### PR TITLE
evalengine: some last fixes

### DIFF
--- a/go/vt/vtgate/evalengine/comparisons.go
+++ b/go/vt/vtgate/evalengine/comparisons.go
@@ -202,11 +202,11 @@ func compareAsTuples(lVal, rVal *EvalResult) bool {
 }
 
 func evalCompareNullSafe(lVal, rVal *EvalResult) (bool, error) {
-	if compareAsTuples(lVal, rVal) {
-		return evalCompareTuplesNullSafe(lVal, rVal)
-	}
 	if lVal.null() || rVal.null() {
 		return lVal.null() == rVal.null(), nil
+	}
+	if compareAsTuples(lVal, rVal) {
+		return evalCompareTuplesNullSafe(lVal, rVal)
 	}
 	n, err := evalCompare(lVal, rVal)
 	return n == 0, err
@@ -235,11 +235,11 @@ func evalCompareMany(left, right []EvalResult, fulleq bool) (int, bool, error) {
 }
 
 func evalCompareAll(lVal, rVal *EvalResult, fulleq bool) (int, bool, error) {
-	if compareAsTuples(lVal, rVal) {
-		return evalCompareMany(lVal.tuple(), rVal.tuple(), fulleq)
-	}
 	if lVal.null() || rVal.null() {
 		return 0, true, nil
+	}
+	if compareAsTuples(lVal, rVal) {
+		return evalCompareMany(lVal.tuple(), rVal.tuple(), fulleq)
 	}
 	n, err := evalCompare(lVal, rVal)
 	return n, false, err

--- a/go/vt/vtgate/evalengine/comparisons.go
+++ b/go/vt/vtgate/evalengine/comparisons.go
@@ -332,6 +332,10 @@ func (i *InExpr) eval(env *ExpressionEnv, result *EvalResult) {
 	if right.typeof() != querypb.Type_TUPLE {
 		throwEvalError(vterrors.Errorf(vtrpcpb.Code_INTERNAL, "rhs of an In operation should be a tuple"))
 	}
+	if left.null() {
+		result.setNull()
+		return
+	}
 
 	var foundNull, found bool
 	var righttuple = right.tuple()

--- a/go/vt/vtgate/evalengine/comparisons.go
+++ b/go/vt/vtgate/evalengine/comparisons.go
@@ -370,24 +370,14 @@ func (i *InExpr) eval(env *ExpressionEnv, result *EvalResult) {
 		}
 	}
 
-	boolResult := func(b, negate bool, result *EvalResult) {
-		// results from IN operations are always Int64 in MySQL 5.7 and 8+
-		if b == !negate {
-			result.setInt64(1)
-		} else {
-			result.setInt64(0)
-		}
-	}
-
-	if found {
-		boolResult(found, i.Negate, result)
-		return
-	}
-	if foundNull {
+	switch {
+	case found:
+		result.setBool(!i.Negate)
+	case foundNull:
 		result.setNull()
-		return
+	default:
+		result.setBool(i.Negate)
 	}
-	boolResult(found, i.Negate, result)
 }
 
 func (i *InExpr) typeof(env *ExpressionEnv) querypb.Type {

--- a/go/vt/vtgate/evalengine/convert_test.go
+++ b/go/vt/vtgate/evalengine/convert_test.go
@@ -65,7 +65,7 @@ func TestConvertSimplification(t *testing.T) {
 		{"42", ok("INT64(42)"), ok("INT64(42)")},
 		{"1 + (1 + 1) * 8", ok("INT64(1) + ((INT64(1) + INT64(1)) * INT64(8))"), ok("INT64(17)")},
 		{"1.0e0 + (1 + 1) * 8.0e0", ok("FLOAT64(1) + ((INT64(1) + INT64(1)) * FLOAT64(8))"), ok("FLOAT64(17)")},
-		{"'pokemon' LIKE 'poke%'", ok("VARBINARY(\"pokemon\") LIKE VARBINARY(\"poke%\")"), ok("UINT64(1)")},
+		{"'pokemon' LIKE 'poke%'", ok("VARBINARY(\"pokemon\") LIKE VARBINARY(\"poke%\")"), ok("INT64(1)")},
 		{
 			"'foo' COLLATE utf8mb4_general_ci IN ('bar' COLLATE latin1_swedish_ci, 'baz')",
 			ok(`VARBINARY("foo") COLLATE utf8mb4_general_ci IN (VARBINARY("bar") COLLATE latin1_swedish_ci, VARBINARY("baz"))`),
@@ -184,13 +184,13 @@ func TestEvaluate(t *testing.T) {
 		expected:   sqltypes.NewInt64(1),
 	}, {
 		expression: "(1,2) = (1,2)",
-		expected:   sqltypes.NewUint64(1),
+		expected:   sqltypes.NewInt64(1),
 	}, {
 		expression: "1 = 'sad'",
-		expected:   sqltypes.NewUint64(0),
+		expected:   sqltypes.NewInt64(0),
 	}, {
 		expression: "(1,2) = (1,3)",
-		expected:   sqltypes.NewUint64(0),
+		expected:   sqltypes.NewInt64(0),
 	}, {
 		expression: "(1,2) = (1,null)",
 		expected:   NULL,
@@ -202,7 +202,7 @@ func TestEvaluate(t *testing.T) {
 		expected:   NULL,
 	}, {
 		expression: "(1,(1,2,3),(1,(1,2),4),2) = (1,(1,2,3),(1,(1,2),4),2)",
-		expected:   sqltypes.NewUint64(1),
+		expected:   sqltypes.NewInt64(1),
 	}, {
 		expression: "(1,(1,2,3),(1,(1,NULL),4),2) = (1,(1,2,3),(1,(1,2),4),2)",
 		expected:   NULL,

--- a/go/vt/vtgate/evalengine/eval_result.go
+++ b/go/vt/vtgate/evalengine/eval_result.go
@@ -159,15 +159,9 @@ func (er *EvalResult) setNull() {
 	er.collation_ = collationNull
 }
 
-var mysql8 = true
-
 func (er *EvalResult) setBool(b bool) {
 	er.collation_ = collationNumeric
-	if mysql8 {
-		er.type_ = sqltypes.Uint64
-	} else {
-		er.type_ = sqltypes.Int64
-	}
+	er.type_ = sqltypes.Int64
 	if b {
 		er.numeric_ = 1
 	} else {

--- a/go/vt/vtgate/evalengine/integration/comparison_test.go
+++ b/go/vt/vtgate/evalengine/integration/comparison_test.go
@@ -40,8 +40,6 @@ func perm1(a []string, f func([]string), i int) {
 }
 
 func TestAllComparisons(t *testing.T) {
-	t.Skipf("temporarily disabled because of MySQL upgrade")
-
 	var elems = []string{"NULL", "-1", "0", "1"}
 	var operators = []string{"=", "!=", "<=>", "<", "<=", ">", ">="}
 

--- a/go/vt/vtgate/evalengine/integration/fuzz_test.go
+++ b/go/vt/vtgate/evalengine/integration/fuzz_test.go
@@ -75,8 +75,6 @@ func (d dummyCollation) CollationIDLookup(_ sqlparser.Expr) collations.ID {
 }
 
 func TestTypes(t *testing.T) {
-	t.Skipf("temporarily disabled because of MySQL upgrade")
-
 	var conn = mysqlconn(t)
 	defer conn.Close()
 

--- a/go/vt/vtgate/evalengine/integration/fuzz_test.go
+++ b/go/vt/vtgate/evalengine/integration/fuzz_test.go
@@ -115,7 +115,7 @@ func TestTypes(t *testing.T) {
 
 var fuzzMaxTime = flag.Duration("fuzz-duration", 30*time.Second, "maximum time to fuzz for")
 var fuzzMaxFailures = flag.Int("fuzz-total", 0, "maximum number of failures to fuzz for")
-var fuzzSeed = flag.Int64("fuzz-seed", 1234, "RNG seed when generating fuzz expressions")
+var fuzzSeed = flag.Int64("fuzz-seed", time.Now().Unix(), "RNG seed when generating fuzz expressions")
 var extractError = regexp.MustCompile(`(.*?) \(errno (\d+)\) \(sqlstate (\d+)\) during query: (.*?)`)
 
 var knownErrors = []*regexp.Regexp{
@@ -251,6 +251,10 @@ func TestGenerateFuzzCases(t *testing.T) {
 		if time.Since(start) > *fuzzMaxTime {
 			break
 		}
+	}
+
+	if len(failures) == 0 {
+		return
 	}
 
 	type evaltest struct {

--- a/go/vt/vtgate/evalengine/integration/fuzz_test.go
+++ b/go/vt/vtgate/evalengine/integration/fuzz_test.go
@@ -27,14 +27,10 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/vt/vtgate/simplifier"
-
-	"github.com/stretchr/testify/require"
-
 	"vitess.io/vitess/go/mysql/collations"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
+	"vitess.io/vitess/go/vt/vtgate/simplifier"
 )
 
 type (
@@ -117,6 +113,7 @@ func TestTypes(t *testing.T) {
 	}
 }
 
+var fuzzMaxTime = flag.Duration("fuzz-duration", 30*time.Second, "maximum time to fuzz for")
 var fuzzMaxFailures = flag.Int("fuzz-total", 0, "maximum number of failures to fuzz for")
 var fuzzSeed = flag.Int64("fuzz-seed", 1234, "RNG seed when generating fuzz expressions")
 var extractError = regexp.MustCompile(`(.*?) \(errno (\d+)\) \(sqlstate (\d+)\) during query: (.*?)`)
@@ -187,14 +184,6 @@ func TestGenerateFuzzCases(t *testing.T) {
 	if *fuzzMaxFailures <= 0 {
 		t.Skipf("skipping fuzz test generation")
 	}
-
-	type evaltest struct {
-		Query string
-		Value string `json:",omitempty"`
-		Error string `json:",omitempty"`
-	}
-
-	var golden []evaltest
 	var gen = gencase{
 		rand:         rand.New(rand.NewSource(*fuzzSeed)),
 		ratioTuple:   8,
@@ -211,7 +200,7 @@ func TestGenerateFuzzCases(t *testing.T) {
 	var conn = mysqlconn(t)
 	defer conn.Close()
 
-	bothReturnSameResult := func(expr sqlparser.Expr) comparisonResult {
+	compareWithMySQL := func(expr sqlparser.Expr) *mismatch {
 		query := "SELECT " + sqlparser.String(expr)
 
 		eval, evaluated, localErr := safeEvaluate(query)
@@ -225,58 +214,77 @@ func TestGenerateFuzzCases(t *testing.T) {
 			remoteErr = fmt.Errorf(syntaxErr)
 		}
 
-		res := comparisonResult{
+		res := mismatch{
+			expr:      expr,
 			localErr:  localErr,
 			remoteErr: remoteErr,
 			evaluated: evaluated,
 		}
-
 		if evaluated {
 			res.localVal = eval.Value().String()
 		}
-
 		if remoteErr == nil {
 			res.remoteVal = remote.Rows[0][0].String()
 		}
-
-		return res
+		if res.Error() != "" {
+			return &res
+		}
+		return nil
 	}
 
-	for len(golden) < *fuzzMaxFailures {
+	var failures []*mismatch
+	var start = time.Now()
+	for len(failures) < *fuzzMaxFailures {
 		query := "SELECT " + gen.expr()
 		stmt, err := sqlparser.Parse(query)
-		require.NoError(t, err)
-		t.Run(query, func(t *testing.T) {
-			astExpr := stmt.(*sqlparser.Select).SelectExprs[0].(*sqlparser.AliasedExpr).Expr
+		if err != nil {
+			t.Fatal(err)
+		}
 
-			resultCmp := bothReturnSameResult(astExpr)
-			diff := resultCmp.diff()
-			if diff == "" {
-				return
+		astExpr := stmt.(*sqlparser.Select).SelectExprs[0].(*sqlparser.AliasedExpr).Expr
+
+		if fail := compareWithMySQL(astExpr); fail != nil {
+			failures = append(failures, fail)
+			t.Errorf("mismatch: %v", fail.Error())
+		}
+
+		if time.Since(start) > *fuzzMaxTime {
+			break
+		}
+	}
+
+	type evaltest struct {
+		Query string
+		Value string `json:",omitempty"`
+		Error string `json:",omitempty"`
+	}
+	var golden []evaltest
+
+	for _, fail := range failures {
+		failErr := fail.Error()
+		start := time.Now()
+		simplified := simplifier.SimplifyExpr(fail.expr, func(expr sqlparser.Expr) bool {
+			err := compareWithMySQL(expr)
+			if err == nil {
+				return false
 			}
-
-			log.Infof("found inconsistency - will try to simplify: %s", query)
-
-			astExpr = simplifier.SimplifyExpr(astExpr, func(expr sqlparser.Expr) bool {
-				return bothReturnSameResult(expr).diff() == diff
-			})
-
-			query = "SELECT " + sqlparser.String(astExpr)
-
-			log.Infof("simplified to: %s", query)
-			t.Errorf("%s", diff)
-			if resultCmp.remoteErr != nil {
-				golden = append(golden, evaltest{
-					Query: query,
-					Error: resultCmp.remoteErr.Error(),
-				})
-			} else {
-				golden = append(golden, evaltest{
-					Query: query,
-					Value: resultCmp.remoteVal,
-				})
-			}
+			return err.Error() == failErr
 		})
+
+		t.Logf("simplified\n\t%s\n\t%s\n(%v)", sqlparser.String(fail.expr), sqlparser.String(simplified), time.Since(start))
+
+		query := "SELECT " + sqlparser.String(simplified)
+		if fail.remoteErr != nil {
+			golden = append(golden, evaltest{
+				Query: query,
+				Error: fail.remoteErr.Error(),
+			})
+		} else {
+			golden = append(golden, evaltest{
+				Query: query,
+				Value: fail.remoteVal,
+			})
+		}
 	}
 
 	out, err := os.Create(fmt.Sprintf("testdata/mysql_golden_%d.json", time.Now().Unix()))
@@ -287,16 +295,18 @@ func TestGenerateFuzzCases(t *testing.T) {
 
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "    ")
+	enc.SetEscapeHTML(false)
 	enc.Encode(golden)
 }
 
-type comparisonResult struct {
+type mismatch struct {
+	expr                sqlparser.Expr
 	localErr, remoteErr error
 	localVal, remoteVal string
 	evaluated           bool
 }
 
-func (cr comparisonResult) diff() string {
+func (cr *mismatch) Error() string {
 	if cr.localErr != nil {
 		if cr.remoteErr == nil {
 			return fmt.Sprintf("%v (eval=%v); mysql response: %s", cr.localErr, cr.evaluated, cr.remoteVal)

--- a/go/vt/vtgate/evalengine/integration/testdata/mysql_golden_1637776444.json
+++ b/go/vt/vtgate/evalengine/integration/testdata/mysql_golden_1637776444.json
@@ -1,402 +1,402 @@
 [
-    {
-        "Query": "SELECT \"fOo\" / 0",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT -1 IN (\"FOO\", 0, -1, (1, 0, -1, 0))",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT -1 IN (\"FOO\", 0, -1, (1, 0, -1, 0))"
-    },
-    {
-        "Query": "SELECT 1 - \"fOo\"",
-        "Value": "FLOAT64(1)"
-    },
-    {
-        "Query": "SELECT \"fOo\" NOT IN (\"fOo\", -1, NULL, 1)",
-        "Value": "INT64(0)"
-    },
-    {
-        "Query": "SELECT -1 LIKE (0 + NULL)",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT (-1 \u003c -1) = -1",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT \"foo\" IN (0, (\"foo\", -1, (((\"foo\", -1, \"fOo\", 1), ((NULL NOT LIKE (\"FOO\", NULL, NULL, (-1 \u003c= (\"FOO\", \"FOO\", 0, -1)))) NOT IN (\"FOO\", \"fOo\", \"FOO\", (\"foo\" \u003c=\u003e -1))), \"FOO\", -1), \"foo\", 0, 0), \"fOo\"), ((\"fOo\", (\"foo\" \u003e 1), 0, \"FOO\"), (((\"fOo\" \u003e= (NULL * \"fOo\")), \"fOo\", \"fOo\", \"FOO\") - ((\"fOo\", 1, (\"FOO\", NULL, \"fOo\", -1), 1) \u003c=\u003e \"fOo\")), 1, \"foo\"), \"fOo\")",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"foo\" IN (0, (\"foo\", -1, (((\"foo\", -1, \"fOo\", 1), ((NULL NOT LIKE (\"FOO\", NULL, NULL, (-1 \u003c= (\"FOO\", \"FOO\", 0, -1)))) NOT IN (\"FOO\", \"fOo\", \"FOO\", (\"foo\" \u003c=\u003e -1))), \"FOO\", -1), \"foo\", 0, 0), \"fOo\"), ((\"fOo\", (\"foo\" \u003e 1), 0, \"FOO\"), (((\"fOo\" \u003e= (NULL * \"fOo\")), \"fOo\", \"fOo\", \"FOO\") - ((\"fOo\", 1, (\"FOO\", NULL, \"fOo\", -1), 1) \u003c=\u003e \"fOo\")), 1, \"foo\"), \"fOo\")"
-    },
-    {
-        "Query": "SELECT 0 - (1, \"FOO\", \"fOo\", -1)",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT 0 - (1, \"FOO\", \"fOo\", -1)"
-    },
-    {
-        "Query": "SELECT (0 \u003c NULL) IN (\"fOo\", \"FOO\", \"foo\", (((\"foo\", (-1, (-1, (\"fOo\" \u003e= (\"FOO\", (0, (\"FOO\" IN ((1, 1, (\"fOo\", -1, \"fOo\", -1), NULL), \"fOo\", -1, \"FOO\")), \"FOO\", \"FOO\"), \"fOo\", 0)), 1, 1), \"FOO\", \"foo\"), (\"foo\", NULL, (\"foo\", 0, \"fOo\", (0, \"FOO\", \"FOO\", \"fOo\")), (-1, -1, (((NULL, NULL, 0, (NULL, 0, \"foo\", NULL)), -1, 0, NULL), NULL, \"FOO\", 1), (((\"FOO\" LIKE \"FOO\") \u003c ((\"fOo\", 1, NULL, \"fOo\") IN (\"FOO\", 1, NULL, 1))), \"fOo\", -1, ((\"FOO\" != NULL) NOT LIKE \"FOO\")))), \"FOO\"), \"FOO\", (((\"fOo\", 0, NULL, (1, (\"fOo\", \"fOo\", 1, \"foo\"), NULL, 0)) IN (\"fOo\", \"foo\", NULL, 0)) \u003c=\u003e \"foo\"), \"fOo\"), \"fOo\", 0, 0))",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (0 \u003c NULL) IN (\"fOo\", \"FOO\", \"foo\", (((\"foo\", (-1, (-1, (\"fOo\" \u003e= (\"FOO\", (0, (\"FOO\" IN ((1, 1, (\"fOo\", -1, \"fOo\", -1), NULL), \"fOo\", -1, \"FOO\")), \"FOO\", \"FOO\"), \"fOo\", 0)), 1, 1), \"FOO\", \"foo\"), (\"foo\", NULL, (\"foo\", 0, \"fOo\", (0, \"FOO\", \"FOO\", \"fOo\")), (-1, -1, (((NULL, NULL, 0, (NULL, 0, \"foo\", NULL)), -1, 0, NULL), NULL, \"FOO\", 1), (((\"FOO\" LIKE \"FOO\") \u003c ((\"fOo\", 1, NULL, \"fOo\") IN (\"FOO\", 1, NULL, 1))), \"fOo\", -1, ((\"FOO\" != NULL) NOT LIKE \"FOO\")))), \"FOO\"), \"FOO\", (((\"fOo\", 0, NULL, (1, (\"fOo\", \"fOo\", 1, \"foo\"), NULL, 0)) IN (\"fOo\", \"foo\", NULL, 0)) \u003c=\u003e \"foo\"), \"fOo\"), \"fOo\", 0, 0))"
-    },
-    {
-        "Query": "SELECT 0 + (1, NULL, (1 \u003e \"foo\"), \"foo\")",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT 0 + (1, NULL, (1 \u003e \"foo\"), \"foo\")"
-    },
-    {
-        "Query": "SELECT NULL + \"foo\"",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT NULL / NULL",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT (1, NULL, \"fOo\", 1) != ((\"fOo\", (\"FOO\", (0 \u003c= ((-1, 0, \"fOo\", (1 / -1)) IN (NULL, (\"fOo\" \u003c=\u003e -1), -1, \"FOO\"))), NULL, 1), (0, \"FOO\", (\"FOO\", \"FOO\", \"fOo\", \"foo\"), \"fOo\"), 0) NOT IN ((0 != \"FOO\"), \"FOO\", \"fOo\", ((0 \u003e= NULL), 0, \"foo\", ((1, \"foo\", -1, 1), \"foo\", \"FOO\", 0))))",
-        "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (1, NULL, \"fOo\", 1) != ((\"fOo\", (\"FOO\", (0 \u003c= ((-1, 0, \"fOo\", (1 / -1)) IN (NULL, (\"fOo\" \u003c=\u003e -1), -1, \"FOO\"))), NULL, 1), (0, \"FOO\", (\"FOO\", \"FOO\", \"fOo\", \"foo\"), \"fOo\"), 0) NOT IN ((0 != \"FOO\"), \"FOO\", \"fOo\", ((0 \u003e= NULL), 0, \"foo\", ((1, \"foo\", -1, 1), \"foo\", \"FOO\", 0))))"
-    },
-    {
-        "Query": "SELECT 0 LIKE 0",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT \"FOO\" / (\"FOO\", NULL, NULL, 0)",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"FOO\" / (\"FOO\", NULL, NULL, 0)"
-    },
-    {
-        "Query": "SELECT (0 \u003c= \"fOo\") IN (\"fOo\", \"FOO\", 0, (\"FOO\" != \"fOo\"))",
-        "Value": "INT64(0)"
-    },
-    {
-        "Query": "SELECT -1 != 1",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT 1 NOT IN (0, \"foo\", (\"foo\" - (NULL \u003c= 0)), -1)",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT \"foo\" LIKE (-1, \"fOo\", NULL, -1)",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"foo\" LIKE (-1, \"fOo\", NULL, -1)"
-    },
-    {
-        "Query": "SELECT 0 LIKE \"FOO\"",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT (1 * \"FOO\") \u003c=\u003e -1",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT NULL \u003c (\"FOO\", (0 != 1), \"fOo\", \"FOO\")",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT NULL \u003c (\"FOO\", (0 != 1), \"fOo\", \"FOO\")"
-    },
-    {
-        "Query": "SELECT (\"foo\", ((\"fOo\", \"foo\", \"FOO\", (-1, NULL, 1, 0)), \"foo\", \"FOO\", \"FOO\"), NULL, (NULL, \"fOo\", -1, 1)) = NULL",
-        "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"foo\", ((\"fOo\", \"foo\", \"FOO\", (-1, NULL, 1, 0)), \"foo\", \"FOO\", \"FOO\"), NULL, (NULL, \"fOo\", -1, 1)) = NULL"
-    },
-    {
-        "Query": "SELECT \"fOo\" LIKE \"fOo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT 1 \u003e= \"fOo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT (1 LIKE NULL) LIKE -1",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT \"fOo\" IN (\"FOO\", \"fOo\", \"fOo\", 1)",
-        "Value": "INT64(1)"
-    },
-    {
-        "Query": "SELECT \"FOO\" * 0",
-        "Value": "FLOAT64(0)"
-    },
-    {
-        "Query": "SELECT 1 LIKE -1",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT -1 \u003c \"fOo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT (\"fOo\" * (\"fOo\", ((-1, \"FOO\", -1, \"foo\"), \"fOo\", 1, -1), \"FOO\", \"FOO\")) \u003c= 1",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"fOo\" * (\"fOo\", ((-1, \"FOO\", -1, \"foo\"), \"fOo\", 1, -1), \"FOO\", \"FOO\")) \u003c= 1"
-    },
-    {
-        "Query": "SELECT \"foo\" + \"fOo\"",
-        "Value": "FLOAT64(0)"
-    },
-    {
-        "Query": "SELECT (\"fOo\" + (NULL \u003e= -1)) \u003c \"fOo\"",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT \"fOo\" * (\"fOo\" LIKE \"foo\")",
-        "Value": "FLOAT64(0)"
-    },
-    {
-        "Query": "SELECT 1 NOT IN (\"FOO\", -1, -1, \"foo\")",
-        "Value": "INT64(1)"
-    },
-    {
-        "Query": "SELECT (\"foo\", 1, NULL, NULL) LIKE 1",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"foo\", 1, NULL, NULL) LIKE 1"
-    },
-    {
-        "Query": "SELECT (-1, ((0, \"FOO\", \"fOo\", 0) \u003c=\u003e 0), 0, \"FOO\") NOT IN (\"foo\", \"FOO\", \"fOo\", \"FOO\")",
-        "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (-1, ((0, \"FOO\", \"fOo\", 0) \u003c=\u003e 0), 0, \"FOO\") NOT IN (\"foo\", \"FOO\", \"fOo\", \"FOO\")"
-    },
-    {
-        "Query": "SELECT 0 \u003e -1",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT 1 IN (((\"fOo\" / \"FOO\"), \"foo\", (-1 \u003c \"foo\"), \"fOo\"), \"fOo\", 1, (\"foo\", \"fOo\", -1, NULL))",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT 1 IN (((\"fOo\" / \"FOO\"), \"foo\", (-1 \u003c \"foo\"), \"fOo\"), \"fOo\", 1, (\"foo\", \"fOo\", -1, NULL))"
-    },
-    {
-        "Query": "SELECT \"FOO\" / 0",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT \"fOo\" LIKE \"foo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT \"foo\" - \"foo\"",
-        "Value": "FLOAT64(0)"
-    },
-    {
-        "Query": "SELECT (-1, -1, 0, \"fOo\") * \"FOO\"",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (-1, -1, 0, \"fOo\") * \"FOO\""
-    },
-    {
-        "Query": "SELECT (\"fOo\" \u003e= 1) \u003c=\u003e -1",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT -1 \u003e= 0",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT (\"foo\" / NULL) \u003c 1",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT ((\"FOO\", \"foo\", -1, 1), \"foo\", 1, \"fOo\") / 1",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT ((\"FOO\", \"foo\", -1, 1), \"foo\", 1, \"fOo\") / 1"
-    },
-    {
-        "Query": "SELECT \"foo\" / 0",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT 1 \u003c= (((NULL, \"FOO\", ((NULL NOT IN ((((0 \u003c= -1) \u003c NULL) = \"fOo\"), (\"fOo\" * (1 != (\"fOo\" / 1))), \"FOO\", (-1, \"foo\", ((\"foo\", \"foo\", (\"FOO\", (\"foo\" NOT LIKE (\"foo\" \u003e 0)), \"fOo\", \"FOO\"), NULL), -1, (0, (\"foo\", NULL, \"foo\", -1), \"FOO\", \"fOo\"), \"foo\"), (NULL * \"FOO\")))), -1, \"fOo\", 1), \"fOo\") \u003c \"foo\"), \"FOO\", NULL, (((-1, (-1, (1, 0, (((\"fOo\" IN ((0, 0, \"foo\", -1), \"fOo\", \"FOO\", \"foo\")), (1 \u003c ((NULL, ((\"foo\", NULL, \"FOO\", 0) \u003c NULL), (-1, NULL, 0, (0, -1, 1, \"foo\")), 0) != (0, \"fOo\", (\"fOo\" NOT LIKE 0), \"fOo\"))), NULL, \"fOo\") / 1), (-1 != (1, \"foo\", \"FOO\", \"foo\"))), \"fOo\", \"fOo\"), NULL, -1), (\"foo\" = ((NULL = \"foo\") NOT LIKE \"foo\")), -1, (\"foo\", 0, -1, \"fOo\")) \u003c (\"FOO\" = 1)))",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT 1 \u003c= (((NULL, \"FOO\", ((NULL NOT IN ((((0 \u003c= -1) \u003c NULL) = \"fOo\"), (\"fOo\" * (1 != (\"fOo\" / 1))), \"FOO\", (-1, \"foo\", ((\"foo\", \"foo\", (\"FOO\", (\"foo\" NOT LIKE (\"foo\" \u003e 0)), \"fOo\", \"FOO\"), NULL), -1, (0, (\"foo\", NULL, \"foo\", -1), \"FOO\", \"fOo\"), \"foo\"), (NULL * \"FOO\")))), -1, \"fOo\", 1), \"fOo\") \u003c \"foo\"), \"FOO\", NULL, (((-1, (-1, (1, 0, (((\"fOo\" IN ((0, 0, \"foo\", -1), \"fOo\", \"FOO\", \"foo\")), (1 \u003c ((NULL, ((\"foo\", NULL, \"FOO\", 0) \u003c NULL), (-1, NULL, 0, (0, -1, 1, \"foo\")), 0) != (0, \"fOo\", (\"fOo\" NOT LIKE 0), \"fOo\"))), NULL, \"fOo\") / 1), (-1 != (1, \"foo\", \"FOO\", \"foo\"))), \"fOo\", \"fOo\"), NULL, -1), (\"foo\" = ((NULL = \"foo\") NOT LIKE \"foo\")), -1, (\"foo\", 0, -1, \"fOo\")) \u003c (\"FOO\" = 1)))"
-    },
-    {
-        "Query": "SELECT \"foo\" + 1",
-        "Value": "FLOAT64(1)"
-    },
-    {
-        "Query": "SELECT (((NULL, \"FOO\", \"foo\", \"foo\") \u003c=\u003e NULL), -1, (-1 IN (-1, 0, (\"foo\" \u003c=\u003e -1), (\"foo\", 1, \"fOo\", \"fOo\"))), \"FOO\") \u003c=\u003e \"foo\"",
-        "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (((NULL, \"FOO\", \"foo\", \"foo\") \u003c=\u003e NULL), -1, (-1 IN (-1, 0, (\"foo\" \u003c=\u003e -1), (\"foo\", 1, \"fOo\", \"fOo\"))), \"FOO\") \u003c=\u003e \"foo\""
-    },
-    {
-        "Query": "SELECT ((0 * 0), -1, \"FOO\", NULL) = (\"FOO\", \"FOO\", NULL, NULL)",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT 0 / 0",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT 1 / -1",
-        "Value": "DECIMAL(-1.0000)"
-    },
-    {
-        "Query": "SELECT \"fOo\" NOT IN ((1 * 1), \"foo\", 0, \"fOo\")",
-        "Value": "INT64(0)"
-    },
-    {
-        "Query": "SELECT 1 \u003e= (\"FOO\" \u003c=\u003e \"FOO\")",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT 1 NOT LIKE \"FOO\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT (\"fOo\", 1, (0 \u003c (\"foo\" - NULL)), 1) NOT IN (-1, (\"fOo\" \u003e= (\"fOo\" \u003c -1)), ((\"FOO\" NOT LIKE ((\"fOo\" \u003e -1) \u003c= 1)) / (1 * \"fOo\")), \"FOO\")",
-        "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"fOo\", 1, (0 \u003c (\"foo\" - NULL)), 1) NOT IN (-1, (\"fOo\" \u003e= (\"fOo\" \u003c -1)), ((\"FOO\" NOT LIKE ((\"fOo\" \u003e -1) \u003c= 1)) / (1 * \"fOo\")), \"FOO\")"
-    },
-    {
-        "Query": "SELECT 1 = \"FOO\"",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT 0 * \"foo\"",
-        "Value": "FLOAT64(0)"
-    },
-    {
-        "Query": "SELECT \"fOo\" = -1",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT 0 LIKE -1",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT -1 LIKE NULL",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT -1 NOT LIKE \"foo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT -1 \u003c=\u003e 0",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT \"fOo\" - (\"foo\" = \"fOo\")",
-        "Value": "FLOAT64(-1)"
-    },
-    {
-        "Query": "SELECT -1 / \"fOo\"",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT \"foo\" NOT IN (\"fOo\", (\"foo\" + \"foo\"), -1, ((\"fOo\" NOT LIKE ((1 \u003e 1), \"fOo\", 0, \"FOO\")), \"foo\", (1, (((NULL, 1, ((-1, 0, 1, \"fOo\") != (0 - \"fOo\")), \"FOO\"), NULL, (\"fOo\", 0, (\"foo\", (\"foo\" + -1), \"foo\", \"fOo\"), \"fOo\"), \"FOO\") \u003c= 1), \"foo\", \"FOO\"), -1))",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"foo\" NOT IN (\"fOo\", (\"foo\" + \"foo\"), -1, ((\"fOo\" NOT LIKE ((1 \u003e 1), \"fOo\", 0, \"FOO\")), \"foo\", (1, (((NULL, 1, ((-1, 0, 1, \"fOo\") != (0 - \"fOo\")), \"FOO\"), NULL, (\"fOo\", 0, (\"foo\", (\"foo\" + -1), \"foo\", \"fOo\"), \"fOo\"), \"FOO\") \u003c= 1), \"foo\", \"FOO\"), -1))"
-    },
-    {
-        "Query": "SELECT \"FOO\" + ((1, (1 != -1), (\"FOO\", 1, \"fOo\", 0), (NULL, ((-1 \u003c=\u003e 1) * 0), 1, (\"FOO\" \u003c \"FOO\"))), -1, -1, \"FOO\")",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"FOO\" + ((1, (1 != -1), (\"FOO\", 1, \"fOo\", 0), (NULL, ((-1 \u003c=\u003e 1) * 0), 1, (\"FOO\" \u003c \"FOO\"))), -1, -1, \"FOO\")"
-    },
-    {
-        "Query": "SELECT \"fOo\" \u003e 0",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT 0 NOT IN (-1, 1, 1, \"fOo\")",
-        "Value": "INT64(0)"
-    },
-    {
-        "Query": "SELECT \"fOo\" + NULL",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT 0 NOT LIKE \"fOo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT 0 = \"fOo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT \"FOO\" \u003c= (-1 - -1)",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT -1 IN ((0, -1, \"FOO\", \"fOo\"), (0 = NULL), (-1 / 0), (0 != -1))",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT -1 IN ((0, -1, \"FOO\", \"fOo\"), (0 = NULL), (-1 / 0), (0 != -1))"
-    },
-    {
-        "Query": "SELECT \"foo\" / (\"FOO\", 0, 1, (NULL = 0))",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"foo\" / (\"FOO\", 0, 1, (NULL = 0))"
-    },
-    {
-        "Query": "SELECT \"fOo\" \u003c=\u003e \"fOo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT (\"FOO\", 0, (\"fOo\", 0, 0, \"fOo\"), NULL) \u003c=\u003e (1, ((\"foo\", (1, 0, 0, \"FOO\"), \"fOo\", 0) * \"foo\"), NULL, NULL)",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"FOO\", 0, (\"fOo\", 0, 0, \"fOo\"), NULL) \u003c=\u003e (1, ((\"foo\", (1, 0, 0, \"FOO\"), \"fOo\", 0) * \"foo\"), NULL, NULL)"
-    },
-    {
-        "Query": "SELECT (\"foo\" / (((\"fOo\" NOT LIKE 1), (1 \u003e \"fOo\"), (1, NULL, 1, \"FOO\"), 1) \u003c= \"fOo\")) * -1",
-        "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"foo\" / (((\"fOo\" NOT LIKE 1), (1 \u003e \"fOo\"), (1, NULL, 1, \"FOO\"), 1) \u003c= \"fOo\")) * -1"
-    },
-    {
-        "Query": "SELECT 1 \u003e= -1",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT -1 != \"fOo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT \"foo\" * 0",
-        "Value": "FLOAT64(0)"
-    },
-    {
-        "Query": "SELECT \"FOO\" - 1",
-        "Value": "FLOAT64(-1)"
-    },
-    {
-        "Query": "SELECT \"FOO\" \u003c \"foo\"",
-        "Value": "UINT64(0)"
-    },
-    {
-        "Query": "SELECT (-1, (\"foo\", 0, 0, (0 \u003c=\u003e NULL)), -1, \"FOO\") \u003c 1",
-        "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (-1, (\"foo\", 0, 0, (0 \u003c=\u003e NULL)), -1, \"FOO\") \u003c 1"
-    },
-    {
-        "Query": "SELECT \"FOO\" / \"fOo\"",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT (\"fOo\" - NULL) \u003c \"fOo\"",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT \"FOO\" + \"foo\"",
-        "Value": "FLOAT64(0)"
-    },
-    {
-        "Query": "SELECT NULL - (NULL = 1)",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT -1 \u003e= (0 / NULL)",
-        "Value": "NULL"
-    },
-    {
-        "Query": "SELECT \"foo\" \u003c= \"foo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT ((NULL, \"FOO\", \"foo\", (\"FOO\" \u003c=\u003e -1)) + \"foo\") \u003c= NULL",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT ((NULL, \"FOO\", \"foo\", (\"FOO\" \u003c=\u003e -1)) + \"foo\") \u003c= NULL"
-    },
-    {
-        "Query": "SELECT \"foo\" \u003c=\u003e \"fOo\"",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT 0 \u003e= -1",
-        "Value": "UINT64(1)"
-    },
-    {
-        "Query": "SELECT (\"foo\", NULL, 1, (1, NULL, 0, \"foo\")) - \"fOo\"",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"foo\", NULL, 1, (1, NULL, 0, \"foo\")) - \"fOo\""
-    },
-    {
-        "Query": "SELECT (NULL, NULL, -1, -1) / (1, \"fOo\", \"FOO\", -1)",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (NULL, NULL, -1, -1) / (1, \"fOo\", \"FOO\", -1)"
-    },
-    {
-        "Query": "SELECT NULL NOT IN (((\"foo\" NOT LIKE (\"FOO\", (NULL, \"fOo\", 1, \"foo\"), \"fOo\", \"foo\")), \"FOO\", 0, -1), -1, (1, (-1, (\"fOo\", 0, \"fOo\", -1), 1, \"foo\"), 1, 1), -1)",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT NULL NOT IN (((\"foo\" NOT LIKE (\"FOO\", (NULL, \"fOo\", 1, \"foo\"), \"fOo\", \"foo\")), \"FOO\", 0, -1), -1, (1, (-1, (\"fOo\", 0, \"fOo\", -1), 1, \"foo\"), 1, 1), -1)"
-    },
-    {
-        "Query": "SELECT -1 * (\"FOO\", \"FOO\", NULL, (\"fOo\", 0, 0, NULL))",
-        "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT -1 * (\"FOO\", \"FOO\", NULL, (\"fOo\", 0, 0, NULL))"
-    },
-    {
-        "Query": "SELECT (\"fOo\" NOT IN (0, \"foo\", \"FOO\", \"foo\")) \u003e= -1",
-        "Value": "UINT64(1)"
-    }
+  {
+    "Query": "SELECT \"fOo\" / 0",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT -1 IN (\"FOO\", 0, -1, (1, 0, -1, 0))",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT -1 IN (\"FOO\", 0, -1, (1, 0, -1, 0))"
+  },
+  {
+    "Query": "SELECT 1 - \"fOo\"",
+    "Value": "FLOAT64(1)"
+  },
+  {
+    "Query": "SELECT \"fOo\" NOT IN (\"fOo\", -1, NULL, 1)",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT -1 LIKE (0 + NULL)",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT (-1 \u003c -1) = -1",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT \"foo\" IN (0, (\"foo\", -1, (((\"foo\", -1, \"fOo\", 1), ((NULL NOT LIKE (\"FOO\", NULL, NULL, (-1 \u003c= (\"FOO\", \"FOO\", 0, -1)))) NOT IN (\"FOO\", \"fOo\", \"FOO\", (\"foo\" \u003c=\u003e -1))), \"FOO\", -1), \"foo\", 0, 0), \"fOo\"), ((\"fOo\", (\"foo\" \u003e 1), 0, \"FOO\"), (((\"fOo\" \u003e= (NULL * \"fOo\")), \"fOo\", \"fOo\", \"FOO\") - ((\"fOo\", 1, (\"FOO\", NULL, \"fOo\", -1), 1) \u003c=\u003e \"fOo\")), 1, \"foo\"), \"fOo\")",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"foo\" IN (0, (\"foo\", -1, (((\"foo\", -1, \"fOo\", 1), ((NULL NOT LIKE (\"FOO\", NULL, NULL, (-1 \u003c= (\"FOO\", \"FOO\", 0, -1)))) NOT IN (\"FOO\", \"fOo\", \"FOO\", (\"foo\" \u003c=\u003e -1))), \"FOO\", -1), \"foo\", 0, 0), \"fOo\"), ((\"fOo\", (\"foo\" \u003e 1), 0, \"FOO\"), (((\"fOo\" \u003e= (NULL * \"fOo\")), \"fOo\", \"fOo\", \"FOO\") - ((\"fOo\", 1, (\"FOO\", NULL, \"fOo\", -1), 1) \u003c=\u003e \"fOo\")), 1, \"foo\"), \"fOo\")"
+  },
+  {
+    "Query": "SELECT 0 - (1, \"FOO\", \"fOo\", -1)",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT 0 - (1, \"FOO\", \"fOo\", -1)"
+  },
+  {
+    "Query": "SELECT (0 \u003c NULL) IN (\"fOo\", \"FOO\", \"foo\", (((\"foo\", (-1, (-1, (\"fOo\" \u003e= (\"FOO\", (0, (\"FOO\" IN ((1, 1, (\"fOo\", -1, \"fOo\", -1), NULL), \"fOo\", -1, \"FOO\")), \"FOO\", \"FOO\"), \"fOo\", 0)), 1, 1), \"FOO\", \"foo\"), (\"foo\", NULL, (\"foo\", 0, \"fOo\", (0, \"FOO\", \"FOO\", \"fOo\")), (-1, -1, (((NULL, NULL, 0, (NULL, 0, \"foo\", NULL)), -1, 0, NULL), NULL, \"FOO\", 1), (((\"FOO\" LIKE \"FOO\") \u003c ((\"fOo\", 1, NULL, \"fOo\") IN (\"FOO\", 1, NULL, 1))), \"fOo\", -1, ((\"FOO\" != NULL) NOT LIKE \"FOO\")))), \"FOO\"), \"FOO\", (((\"fOo\", 0, NULL, (1, (\"fOo\", \"fOo\", 1, \"foo\"), NULL, 0)) IN (\"fOo\", \"foo\", NULL, 0)) \u003c=\u003e \"foo\"), \"fOo\"), \"fOo\", 0, 0))",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (0 \u003c NULL) IN (\"fOo\", \"FOO\", \"foo\", (((\"foo\", (-1, (-1, (\"fOo\" \u003e= (\"FOO\", (0, (\"FOO\" IN ((1, 1, (\"fOo\", -1, \"fOo\", -1), NULL), \"fOo\", -1, \"FOO\")), \"FOO\", \"FOO\"), \"fOo\", 0)), 1, 1), \"FOO\", \"foo\"), (\"foo\", NULL, (\"foo\", 0, \"fOo\", (0, \"FOO\", \"FOO\", \"fOo\")), (-1, -1, (((NULL, NULL, 0, (NULL, 0, \"foo\", NULL)), -1, 0, NULL), NULL, \"FOO\", 1), (((\"FOO\" LIKE \"FOO\") \u003c ((\"fOo\", 1, NULL, \"fOo\") IN (\"FOO\", 1, NULL, 1))), \"fOo\", -1, ((\"FOO\" != NULL) NOT LIKE \"FOO\")))), \"FOO\"), \"FOO\", (((\"fOo\", 0, NULL, (1, (\"fOo\", \"fOo\", 1, \"foo\"), NULL, 0)) IN (\"fOo\", \"foo\", NULL, 0)) \u003c=\u003e \"foo\"), \"fOo\"), \"fOo\", 0, 0))"
+  },
+  {
+    "Query": "SELECT 0 + (1, NULL, (1 \u003e \"foo\"), \"foo\")",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT 0 + (1, NULL, (1 \u003e \"foo\"), \"foo\")"
+  },
+  {
+    "Query": "SELECT NULL + \"foo\"",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT NULL / NULL",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT (1, NULL, \"fOo\", 1) != ((\"fOo\", (\"FOO\", (0 \u003c= ((-1, 0, \"fOo\", (1 / -1)) IN (NULL, (\"fOo\" \u003c=\u003e -1), -1, \"FOO\"))), NULL, 1), (0, \"FOO\", (\"FOO\", \"FOO\", \"fOo\", \"foo\"), \"fOo\"), 0) NOT IN ((0 != \"FOO\"), \"FOO\", \"fOo\", ((0 \u003e= NULL), 0, \"foo\", ((1, \"foo\", -1, 1), \"foo\", \"FOO\", 0))))",
+    "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (1, NULL, \"fOo\", 1) != ((\"fOo\", (\"FOO\", (0 \u003c= ((-1, 0, \"fOo\", (1 / -1)) IN (NULL, (\"fOo\" \u003c=\u003e -1), -1, \"FOO\"))), NULL, 1), (0, \"FOO\", (\"FOO\", \"FOO\", \"fOo\", \"foo\"), \"fOo\"), 0) NOT IN ((0 != \"FOO\"), \"FOO\", \"fOo\", ((0 \u003e= NULL), 0, \"foo\", ((1, \"foo\", -1, 1), \"foo\", \"FOO\", 0))))"
+  },
+  {
+    "Query": "SELECT 0 LIKE 0",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT \"FOO\" / (\"FOO\", NULL, NULL, 0)",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"FOO\" / (\"FOO\", NULL, NULL, 0)"
+  },
+  {
+    "Query": "SELECT (0 \u003c= \"fOo\") IN (\"fOo\", \"FOO\", 0, (\"FOO\" != \"fOo\"))",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT -1 != 1",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT 1 NOT IN (0, \"foo\", (\"foo\" - (NULL \u003c= 0)), -1)",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT \"foo\" LIKE (-1, \"fOo\", NULL, -1)",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"foo\" LIKE (-1, \"fOo\", NULL, -1)"
+  },
+  {
+    "Query": "SELECT 0 LIKE \"FOO\"",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT (1 * \"FOO\") \u003c=\u003e -1",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT NULL \u003c (\"FOO\", (0 != 1), \"fOo\", \"FOO\")",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT NULL \u003c (\"FOO\", (0 != 1), \"fOo\", \"FOO\")"
+  },
+  {
+    "Query": "SELECT (\"foo\", ((\"fOo\", \"foo\", \"FOO\", (-1, NULL, 1, 0)), \"foo\", \"FOO\", \"FOO\"), NULL, (NULL, \"fOo\", -1, 1)) = NULL",
+    "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"foo\", ((\"fOo\", \"foo\", \"FOO\", (-1, NULL, 1, 0)), \"foo\", \"FOO\", \"FOO\"), NULL, (NULL, \"fOo\", -1, 1)) = NULL"
+  },
+  {
+    "Query": "SELECT \"fOo\" LIKE \"fOo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT 1 \u003e= \"fOo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT (1 LIKE NULL) LIKE -1",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT \"fOo\" IN (\"FOO\", \"fOo\", \"fOo\", 1)",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT \"FOO\" * 0",
+    "Value": "FLOAT64(0)"
+  },
+  {
+    "Query": "SELECT 1 LIKE -1",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT -1 \u003c \"fOo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT (\"fOo\" * (\"fOo\", ((-1, \"FOO\", -1, \"foo\"), \"fOo\", 1, -1), \"FOO\", \"FOO\")) \u003c= 1",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"fOo\" * (\"fOo\", ((-1, \"FOO\", -1, \"foo\"), \"fOo\", 1, -1), \"FOO\", \"FOO\")) \u003c= 1"
+  },
+  {
+    "Query": "SELECT \"foo\" + \"fOo\"",
+    "Value": "FLOAT64(0)"
+  },
+  {
+    "Query": "SELECT (\"fOo\" + (NULL \u003e= -1)) \u003c \"fOo\"",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT \"fOo\" * (\"fOo\" LIKE \"foo\")",
+    "Value": "FLOAT64(0)"
+  },
+  {
+    "Query": "SELECT 1 NOT IN (\"FOO\", -1, -1, \"foo\")",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT (\"foo\", 1, NULL, NULL) LIKE 1",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"foo\", 1, NULL, NULL) LIKE 1"
+  },
+  {
+    "Query": "SELECT (-1, ((0, \"FOO\", \"fOo\", 0) \u003c=\u003e 0), 0, \"FOO\") NOT IN (\"foo\", \"FOO\", \"fOo\", \"FOO\")",
+    "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (-1, ((0, \"FOO\", \"fOo\", 0) \u003c=\u003e 0), 0, \"FOO\") NOT IN (\"foo\", \"FOO\", \"fOo\", \"FOO\")"
+  },
+  {
+    "Query": "SELECT 0 \u003e -1",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT 1 IN (((\"fOo\" / \"FOO\"), \"foo\", (-1 \u003c \"foo\"), \"fOo\"), \"fOo\", 1, (\"foo\", \"fOo\", -1, NULL))",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT 1 IN (((\"fOo\" / \"FOO\"), \"foo\", (-1 \u003c \"foo\"), \"fOo\"), \"fOo\", 1, (\"foo\", \"fOo\", -1, NULL))"
+  },
+  {
+    "Query": "SELECT \"FOO\" / 0",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT \"fOo\" LIKE \"foo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT \"foo\" - \"foo\"",
+    "Value": "FLOAT64(0)"
+  },
+  {
+    "Query": "SELECT (-1, -1, 0, \"fOo\") * \"FOO\"",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (-1, -1, 0, \"fOo\") * \"FOO\""
+  },
+  {
+    "Query": "SELECT (\"fOo\" \u003e= 1) \u003c=\u003e -1",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT -1 \u003e= 0",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT (\"foo\" / NULL) \u003c 1",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT ((\"FOO\", \"foo\", -1, 1), \"foo\", 1, \"fOo\") / 1",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT ((\"FOO\", \"foo\", -1, 1), \"foo\", 1, \"fOo\") / 1"
+  },
+  {
+    "Query": "SELECT \"foo\" / 0",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT 1 \u003c= (((NULL, \"FOO\", ((NULL NOT IN ((((0 \u003c= -1) \u003c NULL) = \"fOo\"), (\"fOo\" * (1 != (\"fOo\" / 1))), \"FOO\", (-1, \"foo\", ((\"foo\", \"foo\", (\"FOO\", (\"foo\" NOT LIKE (\"foo\" \u003e 0)), \"fOo\", \"FOO\"), NULL), -1, (0, (\"foo\", NULL, \"foo\", -1), \"FOO\", \"fOo\"), \"foo\"), (NULL * \"FOO\")))), -1, \"fOo\", 1), \"fOo\") \u003c \"foo\"), \"FOO\", NULL, (((-1, (-1, (1, 0, (((\"fOo\" IN ((0, 0, \"foo\", -1), \"fOo\", \"FOO\", \"foo\")), (1 \u003c ((NULL, ((\"foo\", NULL, \"FOO\", 0) \u003c NULL), (-1, NULL, 0, (0, -1, 1, \"foo\")), 0) != (0, \"fOo\", (\"fOo\" NOT LIKE 0), \"fOo\"))), NULL, \"fOo\") / 1), (-1 != (1, \"foo\", \"FOO\", \"foo\"))), \"fOo\", \"fOo\"), NULL, -1), (\"foo\" = ((NULL = \"foo\") NOT LIKE \"foo\")), -1, (\"foo\", 0, -1, \"fOo\")) \u003c (\"FOO\" = 1)))",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT 1 \u003c= (((NULL, \"FOO\", ((NULL NOT IN ((((0 \u003c= -1) \u003c NULL) = \"fOo\"), (\"fOo\" * (1 != (\"fOo\" / 1))), \"FOO\", (-1, \"foo\", ((\"foo\", \"foo\", (\"FOO\", (\"foo\" NOT LIKE (\"foo\" \u003e 0)), \"fOo\", \"FOO\"), NULL), -1, (0, (\"foo\", NULL, \"foo\", -1), \"FOO\", \"fOo\"), \"foo\"), (NULL * \"FOO\")))), -1, \"fOo\", 1), \"fOo\") \u003c \"foo\"), \"FOO\", NULL, (((-1, (-1, (1, 0, (((\"fOo\" IN ((0, 0, \"foo\", -1), \"fOo\", \"FOO\", \"foo\")), (1 \u003c ((NULL, ((\"foo\", NULL, \"FOO\", 0) \u003c NULL), (-1, NULL, 0, (0, -1, 1, \"foo\")), 0) != (0, \"fOo\", (\"fOo\" NOT LIKE 0), \"fOo\"))), NULL, \"fOo\") / 1), (-1 != (1, \"foo\", \"FOO\", \"foo\"))), \"fOo\", \"fOo\"), NULL, -1), (\"foo\" = ((NULL = \"foo\") NOT LIKE \"foo\")), -1, (\"foo\", 0, -1, \"fOo\")) \u003c (\"FOO\" = 1)))"
+  },
+  {
+    "Query": "SELECT \"foo\" + 1",
+    "Value": "FLOAT64(1)"
+  },
+  {
+    "Query": "SELECT (((NULL, \"FOO\", \"foo\", \"foo\") \u003c=\u003e NULL), -1, (-1 IN (-1, 0, (\"foo\" \u003c=\u003e -1), (\"foo\", 1, \"fOo\", \"fOo\"))), \"FOO\") \u003c=\u003e \"foo\"",
+    "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (((NULL, \"FOO\", \"foo\", \"foo\") \u003c=\u003e NULL), -1, (-1 IN (-1, 0, (\"foo\" \u003c=\u003e -1), (\"foo\", 1, \"fOo\", \"fOo\"))), \"FOO\") \u003c=\u003e \"foo\""
+  },
+  {
+    "Query": "SELECT ((0 * 0), -1, \"FOO\", NULL) = (\"FOO\", \"FOO\", NULL, NULL)",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT 0 / 0",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT 1 / -1",
+    "Value": "DECIMAL(-1.0000)"
+  },
+  {
+    "Query": "SELECT \"fOo\" NOT IN ((1 * 1), \"foo\", 0, \"fOo\")",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT 1 \u003e= (\"FOO\" \u003c=\u003e \"FOO\")",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT 1 NOT LIKE \"FOO\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT (\"fOo\", 1, (0 \u003c (\"foo\" - NULL)), 1) NOT IN (-1, (\"fOo\" \u003e= (\"fOo\" \u003c -1)), ((\"FOO\" NOT LIKE ((\"fOo\" \u003e -1) \u003c= 1)) / (1 * \"fOo\")), \"FOO\")",
+    "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"fOo\", 1, (0 \u003c (\"foo\" - NULL)), 1) NOT IN (-1, (\"fOo\" \u003e= (\"fOo\" \u003c -1)), ((\"FOO\" NOT LIKE ((\"fOo\" \u003e -1) \u003c= 1)) / (1 * \"fOo\")), \"FOO\")"
+  },
+  {
+    "Query": "SELECT 1 = \"FOO\"",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT 0 * \"foo\"",
+    "Value": "FLOAT64(0)"
+  },
+  {
+    "Query": "SELECT \"fOo\" = -1",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT 0 LIKE -1",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT -1 LIKE NULL",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT -1 NOT LIKE \"foo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT -1 \u003c=\u003e 0",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT \"fOo\" - (\"foo\" = \"fOo\")",
+    "Value": "FLOAT64(-1)"
+  },
+  {
+    "Query": "SELECT -1 / \"fOo\"",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT \"foo\" NOT IN (\"fOo\", (\"foo\" + \"foo\"), -1, ((\"fOo\" NOT LIKE ((1 \u003e 1), \"fOo\", 0, \"FOO\")), \"foo\", (1, (((NULL, 1, ((-1, 0, 1, \"fOo\") != (0 - \"fOo\")), \"FOO\"), NULL, (\"fOo\", 0, (\"foo\", (\"foo\" + -1), \"foo\", \"fOo\"), \"fOo\"), \"FOO\") \u003c= 1), \"foo\", \"FOO\"), -1))",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"foo\" NOT IN (\"fOo\", (\"foo\" + \"foo\"), -1, ((\"fOo\" NOT LIKE ((1 \u003e 1), \"fOo\", 0, \"FOO\")), \"foo\", (1, (((NULL, 1, ((-1, 0, 1, \"fOo\") != (0 - \"fOo\")), \"FOO\"), NULL, (\"fOo\", 0, (\"foo\", (\"foo\" + -1), \"foo\", \"fOo\"), \"fOo\"), \"FOO\") \u003c= 1), \"foo\", \"FOO\"), -1))"
+  },
+  {
+    "Query": "SELECT \"FOO\" + ((1, (1 != -1), (\"FOO\", 1, \"fOo\", 0), (NULL, ((-1 \u003c=\u003e 1) * 0), 1, (\"FOO\" \u003c \"FOO\"))), -1, -1, \"FOO\")",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"FOO\" + ((1, (1 != -1), (\"FOO\", 1, \"fOo\", 0), (NULL, ((-1 \u003c=\u003e 1) * 0), 1, (\"FOO\" \u003c \"FOO\"))), -1, -1, \"FOO\")"
+  },
+  {
+    "Query": "SELECT \"fOo\" \u003e 0",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT 0 NOT IN (-1, 1, 1, \"fOo\")",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT \"fOo\" + NULL",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT 0 NOT LIKE \"fOo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT 0 = \"fOo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT \"FOO\" \u003c= (-1 - -1)",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT -1 IN ((0, -1, \"FOO\", \"fOo\"), (0 = NULL), (-1 / 0), (0 != -1))",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT -1 IN ((0, -1, \"FOO\", \"fOo\"), (0 = NULL), (-1 / 0), (0 != -1))"
+  },
+  {
+    "Query": "SELECT \"foo\" / (\"FOO\", 0, 1, (NULL = 0))",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT \"foo\" / (\"FOO\", 0, 1, (NULL = 0))"
+  },
+  {
+    "Query": "SELECT \"fOo\" \u003c=\u003e \"fOo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT (\"FOO\", 0, (\"fOo\", 0, 0, \"fOo\"), NULL) \u003c=\u003e (1, ((\"foo\", (1, 0, 0, \"FOO\"), \"fOo\", 0) * \"foo\"), NULL, NULL)",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"FOO\", 0, (\"fOo\", 0, 0, \"fOo\"), NULL) \u003c=\u003e (1, ((\"foo\", (1, 0, 0, \"FOO\"), \"fOo\", 0) * \"foo\"), NULL, NULL)"
+  },
+  {
+    "Query": "SELECT (\"foo\" / (((\"fOo\" NOT LIKE 1), (1 \u003e \"fOo\"), (1, NULL, 1, \"FOO\"), 1) \u003c= \"fOo\")) * -1",
+    "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"foo\" / (((\"fOo\" NOT LIKE 1), (1 \u003e \"fOo\"), (1, NULL, 1, \"FOO\"), 1) \u003c= \"fOo\")) * -1"
+  },
+  {
+    "Query": "SELECT 1 \u003e= -1",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT -1 != \"fOo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT \"foo\" * 0",
+    "Value": "FLOAT64(0)"
+  },
+  {
+    "Query": "SELECT \"FOO\" - 1",
+    "Value": "FLOAT64(-1)"
+  },
+  {
+    "Query": "SELECT \"FOO\" \u003c \"foo\"",
+    "Value": "INT64(0)"
+  },
+  {
+    "Query": "SELECT (-1, (\"foo\", 0, 0, (0 \u003c=\u003e NULL)), -1, \"FOO\") \u003c 1",
+    "Error": "Operand should contain 4 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (-1, (\"foo\", 0, 0, (0 \u003c=\u003e NULL)), -1, \"FOO\") \u003c 1"
+  },
+  {
+    "Query": "SELECT \"FOO\" / \"fOo\"",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT (\"fOo\" - NULL) \u003c \"fOo\"",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT \"FOO\" + \"foo\"",
+    "Value": "FLOAT64(0)"
+  },
+  {
+    "Query": "SELECT NULL - (NULL = 1)",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT -1 \u003e= (0 / NULL)",
+    "Value": "NULL"
+  },
+  {
+    "Query": "SELECT \"foo\" \u003c= \"foo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT ((NULL, \"FOO\", \"foo\", (\"FOO\" \u003c=\u003e -1)) + \"foo\") \u003c= NULL",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT ((NULL, \"FOO\", \"foo\", (\"FOO\" \u003c=\u003e -1)) + \"foo\") \u003c= NULL"
+  },
+  {
+    "Query": "SELECT \"foo\" \u003c=\u003e \"fOo\"",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT 0 \u003e= -1",
+    "Value": "INT64(1)"
+  },
+  {
+    "Query": "SELECT (\"foo\", NULL, 1, (1, NULL, 0, \"foo\")) - \"fOo\"",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (\"foo\", NULL, 1, (1, NULL, 0, \"foo\")) - \"fOo\""
+  },
+  {
+    "Query": "SELECT (NULL, NULL, -1, -1) / (1, \"fOo\", \"FOO\", -1)",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT (NULL, NULL, -1, -1) / (1, \"fOo\", \"FOO\", -1)"
+  },
+  {
+    "Query": "SELECT NULL NOT IN (((\"foo\" NOT LIKE (\"FOO\", (NULL, \"fOo\", 1, \"foo\"), \"fOo\", \"foo\")), \"FOO\", 0, -1), -1, (1, (-1, (\"fOo\", 0, \"fOo\", -1), 1, \"foo\"), 1, 1), -1)",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT NULL NOT IN (((\"foo\" NOT LIKE (\"FOO\", (NULL, \"fOo\", 1, \"foo\"), \"fOo\", \"foo\")), \"FOO\", 0, -1), -1, (1, (-1, (\"fOo\", 0, \"fOo\", -1), 1, \"foo\"), 1, 1), -1)"
+  },
+  {
+    "Query": "SELECT -1 * (\"FOO\", \"FOO\", NULL, (\"fOo\", 0, 0, NULL))",
+    "Error": "Operand should contain 1 column(s) (errno 1241) (sqlstate 21000) during query: SELECT -1 * (\"FOO\", \"FOO\", NULL, (\"fOo\", 0, 0, NULL))"
+  },
+  {
+    "Query": "SELECT (\"fOo\" NOT IN (0, \"foo\", \"FOO\", \"foo\")) \u003e= -1",
+    "Value": "INT64(1)"
+  }
 ]

--- a/go/vt/vtgate/evalengine/integration/testdata/mysql_golden_1642153591.json
+++ b/go/vt/vtgate/evalengine/integration/testdata/mysql_golden_1642153591.json
@@ -1,0 +1,18 @@
+[
+    {
+        "Query": "SELECT null <= ('f' > -1) * -1",
+        "Value": "NULL"
+    },
+    {
+        "Query": "SELECT null = ('f' like 0) - 1",
+        "Value": "NULL"
+    },
+    {
+        "Query": "SELECT null <= 0 not in (-1, 'fOo' like -1, 'fOo' like -1, 'fOo' like -1)",
+        "Value": "NULL"
+    },
+    {
+        "Query": "SELECT 1 / 1 / 1 not in (0, 0, null, 'f')",
+        "Value": "NULL"
+    }
+]

--- a/go/vt/vtgate/evalengine/integration/testdata/mysql_golden_1642436036.json
+++ b/go/vt/vtgate/evalengine/integration/testdata/mysql_golden_1642436036.json
@@ -1,0 +1,6 @@
+[
+    {
+        "Query": "SELECT null not in ('F', 0, 0, ('f' like 0) - 1)",
+        "Value": "NULL"
+    }
+]

--- a/go/vt/vtgate/evalengine/integration/testdata/mysql_golden_1642499325.json
+++ b/go/vt/vtgate/evalengine/integration/testdata/mysql_golden_1642499325.json
@@ -1,0 +1,6 @@
+[
+    {
+        "Query": "SELECT null in (0 - (1 != 'f'), 'F', 'F')",
+        "Value": "NULL"
+    }
+]


### PR DESCRIPTION
## Description

With this last set of fixes, I can run a random expression fuzzer for 1min+ locally and not find any mismatches between the evaluation results of MySQL and ours. #9153 

I am 100% sure there are still corner cases that we're not handling properly, but we should be wildly more compatible than we were before I started this refactoring project, and I believe the `evalengine` is stable enough now to ship in the next version of Vitess and being enabled by default.

cc @deepthi @systay 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->