### PR TITLE
mysql: Add UnimplementedHandler struct

### DIFF
--- a/go/mysql/conn_flaky_test.go
+++ b/go/mysql/conn_flaky_test.go
@@ -805,6 +805,7 @@ func createSendLongDataPacket(stmtID uint32, paramID uint16, data []byte) []byte
 }
 
 type testRun struct {
+	UnimplementedHandler
 	t              *testing.T
 	err            error
 	expParamCounts int
@@ -813,18 +814,6 @@ type testRun struct {
 }
 
 func (t testRun) ComStmtExecute(c *Conn, prepare *PrepareData, callback func(*sqltypes.Result) error) error {
-	panic("implement me")
-}
-
-func (t testRun) NewConnection(c *Conn) {
-	panic("implement me")
-}
-
-func (t testRun) ConnectionReady(c *Conn) {
-	panic("implement me")
-}
-
-func (t testRun) ConnectionClosed(c *Conn) {
 	panic("implement me")
 }
 
@@ -853,10 +842,6 @@ func (t testRun) ComPrepare(c *Conn, query string, bv map[string]*querypb.BindVa
 
 func (t testRun) WarningCount(c *Conn) uint16 {
 	return 0
-}
-
-func (t testRun) ComResetConnection(c *Conn) {
-	panic("implement me")
 }
 
 var _ Handler = (*testRun)(nil)

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -47,6 +47,8 @@ const appendEntry = -1
 // closed, the client queries will return CRServerGone(2006) when sending
 // the data, as opposed to CRServerLost(2013) when reading the response.
 type DB struct {
+	mysql.UnimplementedHandler
+
 	// Fields set at construction time.
 
 	// t is our testing.TB instance
@@ -308,11 +310,6 @@ func (db *DB) NewConnection(c *mysql.Conn) {
 	db.connections[c.ConnectionID] = c
 }
 
-// ConnectionReady is part of the mysql.Handler interface.
-func (db *DB) ConnectionReady(c *mysql.Conn) {
-
-}
-
 // ConnectionClosed is part of the mysql.Handler interface.
 func (db *DB) ConnectionClosed(c *mysql.Conn) {
 	db.mu.Lock()
@@ -467,11 +464,6 @@ func (db *DB) ComPrepare(c *mysql.Conn, query string, bindVars map[string]*query
 // ComStmtExecute is part of the mysql.Handler interface.
 func (db *DB) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, callback func(*sqltypes.Result) error) error {
 	return nil
-}
-
-// ComResetConnection is part of the mysql.Handler interface.
-func (db *DB) ComResetConnection(c *mysql.Conn) {
-
 }
 
 //

--- a/go/mysql/mysql_fuzzer.go
+++ b/go/mysql/mysql_fuzzer.go
@@ -82,15 +82,8 @@ func createFuzzingSocketPair() (net.Listener, *Conn, *Conn) {
 	return listener, sConn, cConn
 }
 
-type fuzztestRun struct{}
-
-func (t fuzztestRun) NewConnection(c *Conn) {
-}
-
-func (t fuzztestRun) ConnectionReady(c *Conn) {
-}
-
-func (t fuzztestRun) ConnectionClosed(c *Conn) {
+type fuzztestRun struct {
+	UnimplementedHandler
 }
 
 func (t fuzztestRun) ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error {
@@ -107,9 +100,6 @@ func (t fuzztestRun) ComStmtExecute(c *Conn, prepare *PrepareData, callback func
 
 func (t fuzztestRun) WarningCount(c *Conn) uint16 {
 	return 0
-}
-
-func (t fuzztestRun) ComResetConnection(c *Conn) {
 }
 
 var _ Handler = (*fuzztestRun)(nil)
@@ -235,6 +225,8 @@ func FuzzReadQueryResults(data []byte) int {
 }
 
 type fuzzTestHandler struct {
+	UnimplementedHandler
+
 	mu       sync.Mutex
 	lastConn *Conn
 	result   *sqltypes.Result
@@ -276,12 +268,6 @@ func (th *fuzzTestHandler) NewConnection(c *Conn) {
 	th.mu.Lock()
 	defer th.mu.Unlock()
 	th.lastConn = c
-}
-
-func (th *fuzzTestHandler) ConnectionReady(_ *Conn) {
-}
-
-func (th *fuzzTestHandler) ConnectionClosed(_ *Conn) {
 }
 
 func (th *fuzzTestHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error {

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -125,6 +125,17 @@ type Handler interface {
 	ComResetConnection(c *Conn)
 }
 
+// UnimplementedHandler implemnts all of the optional callbacks so as to satisy
+// the Handler interface. Intended to be embedded into your custom Handler
+// implementation without needing to define every callback and to help be forwards
+// compatible when new functions are added.
+type UnimplementedHandler struct{}
+
+func (UnimplementedHandler) NewConnection(*Conn)      {}
+func (UnimplementedHandler) ConnectionReady(*Conn)    {}
+func (UnimplementedHandler) ConnectionClosed(*Conn)   {}
+func (UnimplementedHandler) ComResetConnection(*Conn) {}
+
 // Listener is the MySQL server protocol listener.
 type Listener struct {
 	// Construction parameters, set by NewListener.

--- a/go/mysql/server_flaky_test.go
+++ b/go/mysql/server_flaky_test.go
@@ -67,6 +67,7 @@ var selectRowsResult = &sqltypes.Result{
 }
 
 type testHandler struct {
+	UnimplementedHandler
 	mu       sync.Mutex
 	lastConn *Conn
 	result   *sqltypes.Result
@@ -108,12 +109,6 @@ func (th *testHandler) NewConnection(c *Conn) {
 	th.mu.Lock()
 	defer th.mu.Unlock()
 	th.lastConn = c
-}
-
-func (th *testHandler) ConnectionReady(_ *Conn) {
-}
-
-func (th *testHandler) ConnectionClosed(_ *Conn) {
 }
 
 func (th *testHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error {
@@ -229,10 +224,6 @@ func (th *testHandler) ComPrepare(c *Conn, query string, bindVars map[string]*qu
 
 func (th *testHandler) ComStmtExecute(c *Conn, prepare *PrepareData, callback func(*sqltypes.Result) error) error {
 	return nil
-}
-
-func (th *testHandler) ComResetConnection(c *Conn) {
-
 }
 
 func (th *testHandler) WarningCount(c *Conn) uint16 {

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -83,6 +83,7 @@ var (
 // vtgateHandler implements the Listener interface.
 // It stores the Session in the ClientData of a Connection.
 type vtgateHandler struct {
+	mysql.UnimplementedHandler
 	mu sync.Mutex
 
 	vtg         *VTGate
@@ -101,8 +102,6 @@ func (vh *vtgateHandler) NewConnection(c *mysql.Conn) {
 	defer vh.mu.Unlock()
 	vh.connections[c] = true
 }
-
-func (vh *vtgateHandler) ConnectionReady(_ *mysql.Conn) {}
 
 func (vh *vtgateHandler) numConnections() int {
 	vh.mu.Lock()

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -39,17 +39,12 @@ import (
 )
 
 type testHandler struct {
+	mysql.UnimplementedHandler
 	lastConn *mysql.Conn
 }
 
 func (th *testHandler) NewConnection(c *mysql.Conn) {
 	th.lastConn = c
-}
-
-func (th *testHandler) ConnectionReady(c *mysql.Conn) {
-}
-
-func (th *testHandler) ConnectionClosed(c *mysql.Conn) {
 }
 
 func (th *testHandler) ComQuery(c *mysql.Conn, q string, callback func(*sqltypes.Result) error) error {
@@ -63,9 +58,6 @@ func (th *testHandler) ComQuery(c *mysql.Conn, q string, callback func(*sqltypes
 
 func (th *testHandler) ComPrepare(c *mysql.Conn, q string, b map[string]*querypb.BindVariable) ([]*querypb.Field, error) {
 	return nil, nil
-}
-
-func (th *testHandler) ComResetConnection(c *mysql.Conn) {
 }
 
 func (th *testHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, callback func(*sqltypes.Result) error) error {


### PR DESCRIPTION
This follows the pattern of how a gRPC service is generated via
protobuf.

The idea being, you embed the mysql.UnimplementedHandler struct into
your Handler implementation, and this gives you all of the optional
callbacks without needing to explicitly declare them within your
Handler.

This also allows your Handler to be more forwards compatible with adding
new methods that you may not need or care about.

In this PR, it gives us an opportunity also to clean up a bunch of the
test cases that stub in no-op implementations.

As a note, it'd be nice to have this also stub in _all_ of the methods
and return errors, but that might be a harder sell since it's sorta
required to implement them all or you're going to have a Bad Time. Maybe
if the server.go code would be a little better at handling it, but I
don't think it's truly necessary.

Signed-off-by: Matt Robenolt <matt@ydekproductions.com>


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required