### PR TITLE
Add support for health service in gRPC server

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -26,11 +26,13 @@ import (
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"vitess.io/vitess/go/trace"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 
@@ -227,6 +229,10 @@ func serveGRPC() {
 
 	// register reflection to support list calls :)
 	reflection.Register(GRPCServer)
+
+	// register health service to support health checks
+	healthServer := health.NewServer()
+	healthpb.RegisterHealthServer(GRPCServer, healthServer)
 
 	// listen on the port
 	log.Infof("Listening for gRPC calls on port %v", *GRPCPort)

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -234,6 +234,10 @@ func serveGRPC() {
 	healthServer := health.NewServer()
 	healthpb.RegisterHealthServer(GRPCServer, healthServer)
 
+	for service := range GRPCServer.GetServiceInfo() {
+		healthServer.SetServingStatus(service, healthpb.HealthCheckResponse_SERVING)
+	}
+
 	// listen on the port
 	log.Infof("Listening for gRPC calls on port %v", *GRPCPort)
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", *GRPCPort))


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
* Register gRPC health service to support health checks. See [GRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) and [grpc_health_v1](https://pkg.go.dev/google.golang.org/grpc/health/grpc_health_v1).
* This change affects all use cases of `servenv.GRPCServer`

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #9333

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->