### PR TITLE
SwitchTraffic: check vreplication lag before switching

### DIFF
--- a/go/sqltypes/named_result.go
+++ b/go/sqltypes/named_result.go
@@ -110,6 +110,22 @@ func (r RowNamedValues) AsBool(fieldName string, def bool) bool {
 	return def
 }
 
+// ToBytes returns the named field as a byte array
+func (r RowNamedValues) ToBytes(fieldName string) ([]byte, error) {
+	if v, ok := r[fieldName]; ok {
+		return v.ToBytes()
+	}
+	return nil, ErrNoSuchField
+}
+
+// AsBytes returns the named field as a byte array, or default value if nonexistent/error
+func (r RowNamedValues) AsBytes(fieldName string, def []byte) []byte {
+	if v, err := r.ToBytes(fieldName); err == nil {
+		return v
+	}
+	return def
+}
+
 // NamedResult represents a query result with named values as opposed to ordinal values.
 type NamedResult struct {
 	Fields       []*querypb.Field `json:"fields"`

--- a/go/test/endtoend/tabletgateway/buffer/reshard/sharded_buffer_test.go
+++ b/go/test/endtoend/tabletgateway/buffer/reshard/sharded_buffer_test.go
@@ -19,6 +19,11 @@ package reshard
 import (
 	"fmt"
 	"testing"
+	"time"
+
+	"github.com/buger/jsonparser"
+
+	"vitess.io/vitess/go/vt/log"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,12 +33,42 @@ import (
 	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
+const (
+	maxWait              = 10 * time.Second
+	acceptableLagSeconds = 5
+)
+
+func waitForLowLag(t *testing.T, clusterInstance *cluster.LocalProcessCluster, keyspace, workflow string) {
+	var lagSeconds int64
+	waitDuration := 500 * time.Millisecond
+	duration := maxWait
+	for duration > 0 {
+		output, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("Workflow", fmt.Sprintf("%s.%s", keyspace, workflow), "Show")
+		require.NoError(t, err)
+		lagSeconds, err = jsonparser.GetInt([]byte(output), "MaxVReplicationTransactionLag")
+
+		require.NoError(t, err)
+		if lagSeconds < acceptableLagSeconds {
+			log.Infof("waitForLowLag acceptable for workflow %s, keyspace %s, current lag is %d", workflow, keyspace, lagSeconds)
+			break
+		} else {
+			log.Infof("waitForLowLag too high for workflow %s, keyspace %s, current lag is %d", workflow, keyspace, lagSeconds)
+		}
+		time.Sleep(waitDuration)
+		duration -= waitDuration
+	}
+
+	if duration <= 0 {
+		t.Fatalf("waitForLowLag timed out for workflow %s, keyspace %s, current lag is %d", workflow, keyspace, lagSeconds)
+	}
+}
+
 func reshard02(t *testing.T, clusterInstance *cluster.LocalProcessCluster, keyspaceName string, reads, writes buffer.QueryEngine) {
 	keyspace := &cluster.Keyspace{Name: keyspaceName}
 	err := clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 1, false)
 	require.NoError(t, err)
-
-	workflow := keyspaceName + ".buf2buf"
+	workflowName := "buf2buf"
+	workflow := fmt.Sprintf("%s.%s", keyspaceName, "buf2buf")
 
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("Reshard", "-source_shards", "0", "-target_shards", "-80,80-", "Create", workflow)
 	require.NoError(t, err)
@@ -42,6 +77,7 @@ func reshard02(t *testing.T, clusterInstance *cluster.LocalProcessCluster, keysp
 	reads.ExpectQueries(25)
 	writes.ExpectQueries(25)
 
+	waitForLowLag(t, clusterInstance, keyspaceName, workflowName)
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("Reshard", "-tablet_types=rdonly,replica", "SwitchTraffic", workflow)
 	require.NoError(t, err)
 

--- a/go/test/endtoend/tabletgateway/buffer/reshard/sharded_buffer_test.go
+++ b/go/test/endtoend/tabletgateway/buffer/reshard/sharded_buffer_test.go
@@ -48,7 +48,7 @@ func waitForLowLag(t *testing.T, clusterInstance *cluster.LocalProcessCluster, k
 		lagSeconds, err = jsonparser.GetInt([]byte(output), "MaxVReplicationTransactionLag")
 
 		require.NoError(t, err)
-		if lagSeconds < acceptableLagSeconds {
+		if lagSeconds <= acceptableLagSeconds {
 			log.Infof("waitForLowLag acceptable for workflow %s, keyspace %s, current lag is %d", workflow, keyspace, lagSeconds)
 			break
 		} else {

--- a/go/test/endtoend/vreplication/cluster.go
+++ b/go/test/endtoend/vreplication/cluster.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	debug = false // set to true for local debugging: this uses the local env vtdataroot and does not teardown clusters
+	debugMode = false // set to true for local debugging: this uses the local env vtdataroot and does not teardown clusters
 
 	originalVtdataroot    string
 	vtdataroot            string
@@ -93,7 +93,7 @@ type Tablet struct {
 
 func setTempVtDataRoot() string {
 	dirSuffix := 100000 + rand.Intn(999999-100000) // 6 digits
-	if debug {
+	if debugMode {
 		vtdataroot = originalVtdataroot
 	} else {
 		vtdataroot = path.Join(originalVtdataroot, fmt.Sprintf("vreple2e_%d", dirSuffix))
@@ -139,12 +139,12 @@ func init() {
 	// for local debugging set this variable so that each run uses VTDATAROOT instead of a random dir
 	// and also does not teardown the cluster for inspecting logs and the databases
 	if os.Getenv("VREPLICATION_E2E_DEBUG") != "" {
-		debug = true
+		debugMode = true
 	}
 	rand.Seed(time.Now().UTC().UnixNano())
 	originalVtdataroot = os.Getenv("VTDATAROOT")
 	var mainVtDataRoot string
-	if debug {
+	if debugMode {
 		mainVtDataRoot = originalVtdataroot
 	} else {
 		mainVtDataRoot = setTempVtDataRoot()
@@ -458,7 +458,7 @@ func (vc *VitessCluster) teardown(t testing.TB) {
 
 // TearDown brings down a cluster, deleting processes, removing topo keys
 func (vc *VitessCluster) TearDown(t testing.TB) {
-	if debug {
+	if debugMode {
 		return
 	}
 	done := make(chan bool)

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -438,16 +438,16 @@ func testPartialSwitches(t *testing.T) {
 	nextState = wrangler.WorkflowStateReadsSwitched
 	checkStates(t, currentState, nextState)
 
-	//tstWorkflowSwitchReads(t, "", "")
-	//checkStates(t, nextState, nextState) //idempotency
+	tstWorkflowSwitchReads(t, "", "")
+	checkStates(t, nextState, nextState) //idempotency
 
 	tstWorkflowSwitchWrites(t)
 	currentState = nextState
 	nextState = wrangler.WorkflowStateAllSwitched
 	checkStates(t, currentState, nextState)
 
-	//tstWorkflowSwitchWrites(t)
-	//checkStates(t, nextState, nextState) //idempotency
+	tstWorkflowSwitchWrites(t)
+	checkStates(t, nextState, nextState) //idempotency
 
 	keyspace := "product"
 	if currentWorkflowType == wrangler.ReshardWorkflow {
@@ -485,6 +485,7 @@ func testRestOfWorkflow(t *testing.T) {
 	validateReadsRouteToTarget(t, "replica")
 	validateWritesRouteToTarget(t)
 
+	// this function is called for both MoveTables and Reshard, so the reverse workflows exist in different keyspaces
 	keyspace := "product"
 	if currentWorkflowType == wrangler.ReshardWorkflow {
 		keyspace = "customer"

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -948,7 +948,7 @@ func waitForLowLag(t *testing.T, keyspace, workflow string) {
 		lagSeconds, err = jsonparser.GetInt([]byte(output), "MaxVReplicationTransactionLag")
 
 		require.NoError(t, err)
-		if lagSeconds < acceptableLagSeconds {
+		if lagSeconds <= acceptableLagSeconds {
 			log.Infof("waitForLowLag acceptable for workflow %s, keyspace %s, current lag is %d", workflow, keyspace, lagSeconds)
 			break
 		} else {

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buger/jsonparser"
+
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -62,6 +64,7 @@ const (
 	deleteOpenTxQuery = "delete from customer where name = 'openTxQuery'"
 
 	merchantKeyspace = "merchant-type"
+	maxWait          = 10 * time.Second
 )
 
 func init() {
@@ -933,9 +936,35 @@ func verifyClusterHealth(t *testing.T, cluster *VitessCluster) {
 	iterateTablets(t, cluster, checkTabletHealth)
 }
 
+const acceptableLagSeconds = 5
+
+func waitForLowLag(t *testing.T, keyspace, workflow string) {
+	var lagSeconds int64
+	waitDuration := 500 * time.Millisecond
+	duration := maxWait
+	for duration > 0 {
+		output, err := vc.VtctlClient.ExecuteCommandWithOutput("Workflow", fmt.Sprintf("%s.%s", keyspace, workflow), "Show")
+		require.NoError(t, err)
+		lagSeconds, err = jsonparser.GetInt([]byte(output), "MaxVReplicationTransactionLag")
+
+		require.NoError(t, err)
+		if lagSeconds < acceptableLagSeconds {
+			log.Infof("waitForLowLag acceptable for workflow %s, keyspace %s, current lag is %d", workflow, keyspace, lagSeconds)
+			break
+		} else {
+			log.Infof("waitForLowLag too high for workflow %s, keyspace %s, current lag is %d", workflow, keyspace, lagSeconds)
+		}
+		time.Sleep(waitDuration)
+		duration -= waitDuration
+	}
+
+	if duration <= 0 {
+		t.Fatalf("waitForLowLag timed out for workflow %s, keyspace %s, current lag is %d", workflow, keyspace, lagSeconds)
+	}
+}
+
 func catchup(t *testing.T, vttablet *cluster.VttabletProcess, workflow, info string) {
-	const MaxWait = 10 * time.Second
-	vttablet.WaitForVReplicationToCatchup(t, workflow, fmt.Sprintf("vt_%s", vttablet.Keyspace), MaxWait)
+	vttablet.WaitForVReplicationToCatchup(t, workflow, fmt.Sprintf("vt_%s", vttablet.Keyspace), maxWait)
 }
 
 func moveTables(t *testing.T, cell, workflow, sourceKs, targetKs, tables string) {

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -564,6 +564,9 @@ var AlterVReplicationTable = []string{
 	"ALTER TABLE _vt.vreplication ADD KEY workflow_idx (workflow(64))",
 	"ALTER TABLE _vt.vreplication ADD COLUMN rows_copied BIGINT(20) NOT NULL DEFAULT 0",
 	"ALTER TABLE _vt.vreplication ADD COLUMN tags VARBINARY(1024) NOT NULL DEFAULT ''",
+
+	// records the time of the last heartbeat. Heartbeats are only received if the source has no recent events
+	"ALTER TABLE _vt.vreplication ADD COLUMN time_heartbeat BIGINT(20) NOT NULL DEFAULT 0",
 }
 
 // WithDDLInitialQueries contains the queries to be expected by the mock db client during tests
@@ -638,8 +641,7 @@ func CreateVReplicationState(workflow string, source *binlogdatapb.BinlogSource,
 		encodeString(workflow), encodeString(source.String()), encodeString(position), throttler.MaxRateModuleDisabled, throttler.ReplicationLagModuleDisabled, time.Now().Unix(), state, encodeString(dbName))
 }
 
-// GenerateUpdatePos returns a statement to update a value in the
-// _vt.vreplication table.
+// GenerateUpdatePos returns a statement to record the latest processed gtid in the _vt.vreplication table.
 func GenerateUpdatePos(uid uint32, pos mysql.Position, timeUpdated int64, txTimestamp int64, rowsCopied int64, compress bool) string {
 	strGTID := encodeString(mysql.EncodePosition(pos))
 	if compress {
@@ -659,12 +661,12 @@ func GenerateUpdateRowsCopied(uid uint32, rowsCopied int64) string {
 	return fmt.Sprintf("update _vt.vreplication set rows_copied=%v where id=%v", rowsCopied, uid)
 }
 
-// GenerateUpdateTime returns a statement to update time_updated in the _vt.vreplication table.
-func GenerateUpdateTime(uid uint32, timeUpdated int64) (string, error) {
+// GenerateUpdateHeartbeat returns a statement to record the latest heartbeat in the _vt.vreplication table.
+func GenerateUpdateHeartbeat(uid uint32, timeUpdated int64) (string, error) {
 	if timeUpdated == 0 {
 		return "", fmt.Errorf("timeUpdated cannot be zero")
 	}
-	return fmt.Sprintf("update _vt.vreplication set time_updated=%v where id=%v", timeUpdated, uid), nil
+	return fmt.Sprintf("update _vt.vreplication set time_updated=%v, time_heartbeat=%v where id=%v", timeUpdated, timeUpdated, uid), nil
 }
 
 // StartVReplication returns a statement to start the replication.

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2285,7 +2285,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	const defaultWaitTime = time.Duration(30 * time.Second)
 	// for backward compatibility we default the lag to match the timeout for switching primary traffic
 	// this should probably be much smaller so that target and source are almost in sync before switching traffic
-	const defaultMaxTransactionLagAllowed = defaultWaitTime
+	const defaultMaxReplicationLagAllowed = defaultWaitTime
 
 	cells := subFlags.String("cells", "", "Cell(s) or CellAlias(es) (comma-separated) to replicate from.")
 	tabletTypes := subFlags.String("tablet_types", "primary,replica,rdonly", "Source tablet types to replicate from (e.g. primary, replica, rdonly). Defaults to -vreplication_tablet_type parameter value for the tablet, which has the default value of replica.")
@@ -2296,7 +2296,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	keepRoutingRules := subFlags.Bool("keep_routing_rules", false, "Do not remove the routing rules for the source keyspace.  -keep_routing_rules is only supported for Complete and Cancel.")
 	autoStart := subFlags.Bool("auto_start", true, "If false, streams will start in the Stopped state and will need to be explicitly started")
 	stopAfterCopy := subFlags.Bool("stop_after_copy", false, "Streams will be stopped once the copy phase is completed")
-	maxTransactionLagAllowed := subFlags.Duration("max_transaction_lag_allowed", defaultMaxTransactionLagAllowed, "Allow traffic to be switched only if vreplication lag is below this (in seconds)")
+	maxReplicationLagAllowed := subFlags.Duration("max_replication_lag_allowed", defaultMaxReplicationLagAllowed, "Allow traffic to be switched only if vreplication lag is below this (in seconds)")
 
 	// MoveTables and Migrate params
 	tables := subFlags.String("tables", "", "MoveTables only. A table spec or a list of tables. Either table_specs or -all needs to be specified.")
@@ -2448,7 +2448,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 		}
 		vrwp.Timeout = *timeout
 		vrwp.EnableReverseReplication = *reverseReplication
-		vrwp.MaxAllowedTransactionLagSeconds = int64(math.Ceil(maxTransactionLagAllowed.Seconds()))
+		vrwp.MaxAllowedTransactionLagSeconds = int64(math.Ceil(maxReplicationLagAllowed.Seconds()))
 	case vReplicationWorkflowActionCancel:
 		vrwp.KeepData = *keepData
 	case vReplicationWorkflowActionComplete:

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2291,6 +2291,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	keepRoutingRules := subFlags.Bool("keep_routing_rules", false, "Do not remove the routing rules for the source keyspace.  -keep_routing_rules is only supported for Complete and Cancel.")
 	autoStart := subFlags.Bool("auto_start", true, "If false, streams will start in the Stopped state and will need to be explicitly started")
 	stopAfterCopy := subFlags.Bool("stop_after_copy", false, "Streams will be stopped once the copy phase is completed")
+	maxLagAllowed := subFlags.Duration("max_lag_allowed", 5*time.Second, "Allow traffic to be switched only if vreplication lag is below this")
 
 	// MoveTables and Migrate params
 	tables := subFlags.String("tables", "", "MoveTables only. A table spec or a list of tables. Either table_specs or -all needs to be specified.")
@@ -2442,6 +2443,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 		}
 		vrwp.Timeout = *timeout
 		vrwp.EnableReverseReplication = *reverseReplication
+		vrwp.MaxAllowedLagSeconds = int64(math.Ceil(maxLagAllowed.Seconds()))
 	case vReplicationWorkflowActionCancel:
 		vrwp.KeepData = *keepData
 	case vReplicationWorkflowActionComplete:

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2296,7 +2296,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	keepRoutingRules := subFlags.Bool("keep_routing_rules", false, "Do not remove the routing rules for the source keyspace.  -keep_routing_rules is only supported for Complete and Cancel.")
 	autoStart := subFlags.Bool("auto_start", true, "If false, streams will start in the Stopped state and will need to be explicitly started")
 	stopAfterCopy := subFlags.Bool("stop_after_copy", false, "Streams will be stopped once the copy phase is completed")
-	maxTransactionLagAllowed := subFlags.Duration("max_transaction_lag_allowed", defaultMaxTransactionLagAllowed, "Allow traffic to be switched only if vreplication lag is below this")
+	maxTransactionLagAllowed := subFlags.Duration("max_transaction_lag_allowed", defaultMaxTransactionLagAllowed, "Allow traffic to be switched only if vreplication lag is below this (in seconds)")
 
 	// MoveTables and Migrate params
 	tables := subFlags.String("tables", "", "MoveTables only. A table spec or a list of tables. Either table_specs or -all needs to be specified.")

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -494,16 +494,28 @@ func TestCreateDBAndTable(t *testing.T) {
 
 	expectDDLs := func() {
 		t.Helper()
-		dbClient.ExpectRequest("CREATE DATABASE IF NOT EXISTS _vt", &sqltypes.Result{}, nil)
-		dbClient.ExpectRequest("DROP TABLE IF EXISTS _vt.blp_checkpoint", &sqltypes.Result{}, nil)
-		dbClient.ExpectRequestRE("CREATE TABLE IF NOT EXISTS _vt.vreplication.*", &sqltypes.Result{}, nil)
-		dbClient.ExpectRequestRE("ALTER TABLE _vt.vreplication ADD COLUMN db_name.*", &sqltypes.Result{}, nil)
-		dbClient.ExpectRequestRE("ALTER TABLE _vt.vreplication MODIFY source.*", &sqltypes.Result{}, nil)
-		dbClient.ExpectRequestRE("ALTER TABLE _vt.vreplication ADD KEY.*", &sqltypes.Result{}, nil)
-		dbClient.ExpectRequestRE("ALTER TABLE _vt.vreplication ADD COLUMN rows_copied.*", &sqltypes.Result{}, nil)
-		dbClient.ExpectRequestRE("ALTER TABLE _vt.vreplication ADD COLUMN tags.*", &sqltypes.Result{}, nil)
-		dbClient.ExpectRequestRE("create table if not exists _vt.resharding_journal.*", &sqltypes.Result{}, nil)
-		dbClient.ExpectRequestRE("create table if not exists _vt.copy_state.*", &sqltypes.Result{}, nil)
+		ddls := []string{
+			"CREATE DATABASE IF NOT EXISTS _vt",
+			"DROP TABLE IF EXISTS _vt.blp_checkpoint",
+		}
+		for _, ddl := range ddls {
+			dbClient.ExpectRequest(ddl, &sqltypes.Result{}, nil)
+		}
+
+		ddls = []string{
+			"CREATE TABLE IF NOT EXISTS _vt.vreplication.*",
+			"ALTER TABLE _vt.vreplication ADD COLUMN db_name.*",
+			"ALTER TABLE _vt.vreplication MODIFY source.*",
+			"ALTER TABLE _vt.vreplication ADD KEY.*",
+			"ALTER TABLE _vt.vreplication ADD COLUMN rows_copied.*",
+			"ALTER TABLE _vt.vreplication ADD COLUMN tags.*",
+			"ALTER TABLE _vt.vreplication ADD COLUMN time_heartbeat.*",
+			"create table if not exists _vt.resharding_journal.*",
+			"create table if not exists _vt.copy_state.*",
+		}
+		for _, ddl := range ddls {
+			dbClient.ExpectRequestRE(ddl, &sqltypes.Result{}, nil)
+		}
 	}
 	expectDDLs()
 	dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -476,6 +476,7 @@ func shouldIgnoreQuery(query string) bool {
 	queriesToIgnore := []string{
 		"_vt.vreplication_log", // ignore all selects, updates and inserts into this table
 		"@@session.sql_mode",   // ignore all selects, and sets of this variable
+		", time_heartbeat=",    // update of last heartbeat time, can happen out-of-band, so can't test for it
 	}
 	for _, q := range queriesToIgnore {
 		if strings.Contains(query, q) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -251,8 +251,8 @@ func (vp *vplayer) updatePos(ts int64) (posReached bool, err error) {
 	return posReached, nil
 }
 
-func (vp *vplayer) updateCurrentTime(tm int64) error {
-	update, err := binlogplayer.GenerateUpdateTime(vp.vr.id, tm)
+func (vp *vplayer) updateHeartbeat(tm int64) error {
+	update, err := binlogplayer.GenerateUpdateHeartbeat(vp.vr.id, tm)
 	if err != nil {
 		return err
 	}
@@ -262,7 +262,7 @@ func (vp *vplayer) updateCurrentTime(tm int64) error {
 	return nil
 }
 
-func (vp *vplayer) mustUpdateCurrentTime() bool {
+func (vp *vplayer) mustUpdateHeartbeat() bool {
 	return vp.numAccumulatedHeartbeats >= *vreplicationHeartbeatUpdateInterval ||
 		vp.numAccumulatedHeartbeats >= vreplicationMinimumHeartbeatUpdateInterval
 }
@@ -270,11 +270,11 @@ func (vp *vplayer) mustUpdateCurrentTime() bool {
 func (vp *vplayer) recordHeartbeat() error {
 	tm := time.Now().Unix()
 	vp.vr.stats.RecordHeartbeat(tm)
-	if !vp.mustUpdateCurrentTime() {
+	if !vp.mustUpdateHeartbeat() {
 		return nil
 	}
 	vp.numAccumulatedHeartbeats = 0
-	return vp.updateCurrentTime(tm)
+	return vp.updateHeartbeat(tm)
 }
 
 // applyEvents is the main thread that applies the events. It has the following use
@@ -402,6 +402,7 @@ func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
 				}
 			}
 		}
+
 		if sbm >= 0 {
 			vp.vr.stats.ReplicationLagSeconds.Set(sbm)
 			vp.vr.stats.VReplicationLags.Add(strconv.Itoa(int(vp.vr.id)), time.Duration(sbm)*time.Second)

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -66,7 +66,7 @@ func TestHeartbeatFrequencyFlag(t *testing.T) {
 			*vreplicationHeartbeatUpdateInterval = tcase.interval
 			for _, tcount := range tcase.counts {
 				vp.numAccumulatedHeartbeats = tcount.count
-				require.Equal(t, tcount.mustUpdate, vp.mustUpdateCurrentTime())
+				require.Equal(t, tcount.mustUpdate, vp.mustUpdateHeartbeat())
 			}
 		})
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -74,7 +74,7 @@ var (
 
 const (
 	getSQLModeQuery = `SELECT @@session.sql_mode AS sql_mode`
-	// Use this whenever performing a schema change as part of a vreplication
+	// SQLMode should be used whenever performing a schema change as part of a vreplication
 	// workflow to ensure that you set a permissive SQL mode as defined by
 	// VReplication. We follow MySQL's model for recreating database objects
 	// on a target -- using SQL statements generated from a source -- which

--- a/go/vt/wrangler/doc_test.md
+++ b/go/vt/wrangler/doc_test.md
@@ -1,76 +1,67 @@
 ## Wrangler test framework
 
-Some details on how the tests are setup for unit tests in this directory. Updating tests is currently tedious if sql 
-queries get added/modified. We hope to simplify the framework "soon".
+This document has some initial details on how the wrangler unit tests are setup. Updating tests is currently tedious,
+especially if sql queries get added/modified. We hope to simplify the framework "soon".
 
-We will illustrate with by walking through some tests 
+We will illustrate by walking through a test.
 
 ### TestCanSwitch
 
-The first thing in all tests is to create mock tablets for source and targets 
-and the associated database mocks. `traffic_switcher_env_test.go` and `fake_tablet_test.go` contains the 
-framework code.  `newTestTableMigrater` is called to setup the workflow. `newTestTableMigrater` is just a
-wrapper on `newTestTableMigraterCustom` to create a workflow with two source
-shards "-40", "40-" and two target shards "-80", "80-". The filter it uses is a `select *` 
-signifying MoveTables (instead of a Materialize). 
+We first create mock tablets for source and targets and the associated database mocks. `traffic_switcher_env_test.go`
+and `fake_tablet_test.go` contains the framework code.  `newTestTableMigrater` is called to setup the
+workflow. `newTestTableMigrater` is just a wrapper on `newTestTableMigraterCustom` to create a workflow with two source
+shards "-40", "40-" and two target shards "-80", "80-". The filter it uses is a `select *` signifying MoveTables (rather
+than a Materialize).
 
-#### `newTestTableMigraterCustom` 
-* setups a topo (memorytopo) 
+#### `newTestTableMigraterCustom`
+
+* setups a topo (memorytopo)
 * instantiates a wrangler with this topo, logging to the console
 * instantiates a mock db from `fakesqldb`
 * creates a fake tablet, one (primary) per shard
 * start tablets (see below)
 * creates db clients (the `fakeDBClient` for VR engine queries) and the VR engines using this mock db
-* set starting gtid positions 
-* Mimic a MoveTables: on the targets create vreplication stream entries to mimic MoveTables and also create the reverse
-workflow on the sources. Expected sql queries for the vreplication table are
-also added here. Routing rules are setup for this MoveTables.
+* sets starting gtid positions
+* setups a MoveTables: on the targets create vreplication stream entries for MoveTables and also create the reverse
+  workflow on the sources. Expected sql queries for the vreplication table are also added here. Routing rules are setup.
 
 #### The fake tablet
+
 `go/vt/wrangler/fake_tablet_test.go`
 
-Fake tablets are active in that they run a go routine listening to the tablet grpc 
-port and are registered in the topo. The database however is a mock db and not 
-an actual mysql server. Starting an actual mysql server is very slow and hence 
-we prefer the mock db.
+Fake tablets are "active": they run a goroutine listening to the tablet grpc port and are registered in the topo. The
+database however is a mock db and not an actual mysql server. Starting an actual mysql server is very slow and hence we
+prefer the mock db.
 
-The fake tablet has as attributes the keyspace, shard and tablet uid. The key
-functionality is the action loop which creates listeners on the http and grpc ports
-and instantiates a `TabletManager` using  the test top server and
-fake mysql daemon and registers it with the grpc server.
+The fake tablet has, as attributes, keyspace, shard and tablet uid. The key functionality is the action loop which
+creates listeners on the http and grpc ports and instantiates a `TabletManager` using the test topo server and fake
+mysql daemon and registers it with the grpc server.
 
-This ensures that the grpc calls made during the test are actually handled by
-tablet manager code and any vrengine database calls are intercepted by the mock. 
-This setup is good enough for the tests that just setup the workflow and test
-the workflow state machine and are not dependent on the data being vreplicated.
-
+This ensures that the grpc calls made during the test are actually handled by tablet manager code and any vrengine
+database calls are intercepted by the mock. This setup is good enough for the tests that just setup the workflow and
+test the workflow state machine. There is no actual data being vreplicated.
 
 #### The fake MySQLDaemon
+
 `go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go`
 
-Used to set primary positions to provide/validate gtids
-
+Used to set primary positions to provide/validate gtids.
 
 #### The fake db client
+
 `go/vt/wrangler/fake_dbclient_test.go`
 
-This defines a mock db *only* for the vreplication engine. Hence all queries that
-it mocks related to the `_vt` database only.
-
-
- 
+This defines a mock db which is limited in scope to the vreplication engine. All queries that it mocks are related to
+the `_vt` database only.
 
 ### Pain points / Possible improvements
-* Multiple mock db frameworks used (for wrangler, materialize)
-* sequence of queries matters. This was introduced for precise testing of logic
-when VReplication was first invented and many moving parts had to be validated. We 
-have probably moved past that point and should move to a simpler mock.
 
-Ideally we should just use a mysql-backed test server so that we can test based
-on actual data and also won't have to define the queries each time they change. This
-is done in e2e tests, but it is a bit expensive. Maybe it is worth the price in developer-hours if we create
-a single mysql server for all tests in the wrangler directory.
+* Multiple mock db frameworks are used (different ones for wrangler, materialize) resulting in too many paradigms and
+  duplication of functionality
+* sequence of queries matters. This was introduced for precise testing of logic when VReplication was first invented and
+  many moving parts had to be validated. Do we still need this or can we switch to a query map based mock?
 
-Note
-`fake_dbclient_test.go` is used in materializer/movetables tests and is a separate 
-mock db
+Another option is to use a db server with a mysql API, ideally an in-memory one so that we can test based on actual data.
+We won't have to define the queries each time they change. We can of course just setup a regular mysql server.
+This is done in e2e tests, but it might be unacceptable for unit tests.  
+

--- a/go/vt/wrangler/doc_test.md
+++ b/go/vt/wrangler/doc_test.md
@@ -1,0 +1,76 @@
+## Wrangler test framework
+
+Some details on how the tests are setup for unit tests in this directory. Updating tests is currently tedious if sql 
+queries get added/modified. We hope to simplify the framework "soon".
+
+We will illustrate with by walking through some tests 
+
+### TestCanSwitch
+
+The first thing in all tests is to create mock tablets for source and targets 
+and the associated database mocks. `traffic_switcher_env_test.go` and `fake_tablet_test.go` contains the 
+framework code.  `newTestTableMigrater` is called to setup the workflow. `newTestTableMigrater` is just a
+wrapper on `newTestTableMigraterCustom` to create a workflow with two source
+shards "-40", "40-" and two target shards "-80", "80-". The filter it uses is a `select *` 
+signifying MoveTables (instead of a Materialize). 
+
+#### `newTestTableMigraterCustom` 
+* setups a topo (memorytopo) 
+* instantiates a wrangler with this topo, logging to the console
+* instantiates a mock db from `fakesqldb`
+* creates a fake tablet, one (primary) per shard
+* start tablets (see below)
+* creates db clients (the `fakeDBClient` for VR engine queries) and the VR engines using this mock db
+* set starting gtid positions 
+* Mimic a MoveTables: on the targets create vreplication stream entries to mimic MoveTables and also create the reverse
+workflow on the sources. Expected sql queries for the vreplication table are
+also added here. Routing rules are setup for this MoveTables.
+
+#### The fake tablet
+`go/vt/wrangler/fake_tablet_test.go`
+
+Fake tablets are active in that they run a go routine listening to the tablet grpc 
+port and are registered in the topo. The database however is a mock db and not 
+an actual mysql server. Starting an actual mysql server is very slow and hence 
+we prefer the mock db.
+
+The fake tablet has as attributes the keyspace, shard and tablet uid. The key
+functionality is the action loop which creates listeners on the http and grpc ports
+and instantiates a `TabletManager` using  the test top server and
+fake mysql daemon and registers it with the grpc server.
+
+This ensures that the grpc calls made during the test are actually handled by
+tablet manager code and any vrengine database calls are intercepted by the mock. 
+This setup is good enough for the tests that just setup the workflow and test
+the workflow state machine and are not dependent on the data being vreplicated.
+
+
+#### The fake MySQLDaemon
+`go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go`
+
+Used to set primary positions to provide/validate gtids
+
+
+#### The fake db client
+`go/vt/wrangler/fake_dbclient_test.go`
+
+This defines a mock db *only* for the vreplication engine. Hence all queries that
+it mocks related to the `_vt` database only.
+
+
+ 
+
+### Pain points / Possible improvements
+* Multiple mock db frameworks used (for wrangler, materialize)
+* sequence of queries matters. This was introduced for precise testing of logic
+when VReplication was first invented and many moving parts had to be validated. We 
+have probably moved past that point and should move to a simpler mock.
+
+Ideally we should just use a mysql-backed test server so that we can test based
+on actual data and also won't have to define the queries each time they change. This
+is done in e2e tests, but it is a bit expensive. Maybe it is worth the price in developer-hours if we create
+a single mysql server for all tests in the wrangler directory.
+
+Note
+`fake_dbclient_test.go` is used in materializer/movetables tests and is a separate 
+mock db

--- a/go/vt/wrangler/doc_test.md
+++ b/go/vt/wrangler/doc_test.md
@@ -52,7 +52,10 @@ Used to set primary positions to provide/validate gtids.
 `go/vt/wrangler/fake_dbclient_test.go`
 
 This defines a mock db which is limited in scope to the vreplication engine. All queries that it mocks are related to
-the `_vt` database only.
+the `_vt` database only. The queries specified serve to validate that the expected set of queries were generated. When
+updating/adding tests, you will need to tell each test what queries are valid. For queries that can happen often and
+asynchronously, like updating heartbeats or setting gtid positions, we have the mechanism to ignore them or return a
+fixed result.
 
 ### Pain points / Possible improvements
 
@@ -61,7 +64,7 @@ the `_vt` database only.
 * sequence of queries matters. This was introduced for precise testing of logic when VReplication was first invented and
   many moving parts had to be validated. Do we still need this or can we switch to a query map based mock?
 
-Another option is to use a db server with a mysql API, ideally an in-memory one so that we can test based on actual data.
-We won't have to define the queries each time they change. We can of course just setup a regular mysql server.
+Another option is to use a db server with a mysql API, ideally an in-memory one so that we can test based on actual
+data. We won't have to define the queries each time they change. We can of course just setup a regular mysql server.
 This is done in e2e tests, but it might be unacceptable for unit tests.  
 

--- a/go/vt/wrangler/fake_dbclient_test.go
+++ b/go/vt/wrangler/fake_dbclient_test.go
@@ -29,6 +29,8 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 )
 
+const changeMasterToPrimary = `update _vt.vreplication set tablet_types = replace(lower(convert(tablet_types using utf8mb4)), 'master', 'primary') where instr(convert(tablet_types using utf8mb4), 'master');`
+
 func verifyQueries(t *testing.T, dcs []*fakeDBClient) {
 	t.Helper()
 	for _, dc := range dcs {
@@ -80,6 +82,8 @@ func newFakeDBClient(name string) *fakeDBClient {
 			"select * from _vt.vreplication where db_name='db'":         {},
 			"select id, type, state, message from _vt.vreplication_log": {},
 			"insert into _vt.vreplication_log":                          {},
+			changeMasterToPrimary:                                       {},
+			"SELECT db_name FROM _vt.vreplication LIMIT 0":              {},
 		},
 	}
 }

--- a/go/vt/wrangler/fake_dbclient_test.go
+++ b/go/vt/wrangler/fake_dbclient_test.go
@@ -154,19 +154,16 @@ func (dc *fakeDBClient) id() string {
 }
 
 // ExecuteFetch is part of the DBClient interface
-func (dc *fakeDBClient) ExecuteFetch(query string, maxrows int) (qr *sqltypes.Result, err error) {
-	qr, err = dc.executeFetch(query, maxrows)
+func (dc *fakeDBClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {
+	qr, err := dc.executeFetch(query, maxrows)
 	if testMode == "debug" {
 		log.Infof("%s::ExecuteFetch for >>>%s<<< returns >>>%v<<< error >>>%+v<<< ", dc.id(), query, qr, err)
-	}
-	if qr != nil && qr.Rows != nil {
-		qr.RowsAffected = uint64(len(qr.Rows))
 	}
 	return qr, err
 }
 
 // ExecuteFetch is part of the DBClient interface
-func (dc *fakeDBClient) executeFetch(query string, maxrows int) (qr *sqltypes.Result, err error) {
+func (dc *fakeDBClient) executeFetch(query string, maxrows int) (*sqltypes.Result, error) {
 	if dbrs := dc.queries[query]; dbrs != nil {
 		return dbrs.next(query)
 	}

--- a/go/vt/wrangler/fake_dbclient_test.go
+++ b/go/vt/wrangler/fake_dbclient_test.go
@@ -63,14 +63,16 @@ func (dbrs *dbResults) exhausted() bool {
 
 // fakeDBClient fakes a binlog_player.DBClient.
 type fakeDBClient struct {
+	name       string
 	queries    map[string]*dbResults
 	queriesRE  map[string]*dbResults
 	invariants map[string]*sqltypes.Result
 }
 
 // NewfakeDBClient returns a new DBClientMock.
-func newFakeDBClient() *fakeDBClient {
+func newFakeDBClient(name string) *fakeDBClient {
 	return &fakeDBClient{
+		name:      name,
 		queries:   make(map[string]*dbResults),
 		queriesRE: make(map[string]*dbResults),
 		invariants: map[string]*sqltypes.Result{
@@ -83,6 +85,9 @@ func newFakeDBClient() *fakeDBClient {
 }
 
 func (dc *fakeDBClient) addQuery(query string, result *sqltypes.Result, err error) {
+	if testMode == "debug" {
+		log.Infof("%s::addQuery %s\n\n", dc.id(), query)
+	}
 	dbr := &dbResult{result: result, err: err}
 	if dbrs, ok := dc.queries[query]; ok {
 		dbrs.results = append(dbrs.results, dbr)
@@ -92,6 +97,9 @@ func (dc *fakeDBClient) addQuery(query string, result *sqltypes.Result, err erro
 }
 
 func (dc *fakeDBClient) addQueryRE(query string, result *sqltypes.Result, err error) {
+	if testMode == "debug" {
+		log.Infof("%s::addQueryRE %s\n\n", dc.id(), query)
+	}
 	dbr := &dbResult{result: result, err: err}
 	if dbrs, ok := dc.queriesRE[query]; ok {
 		dbrs.results = append(dbrs.results, dbr)
@@ -106,6 +114,9 @@ func (dc *fakeDBClient) getInvariant(query string) *sqltypes.Result {
 
 // note: addInvariant will replace a previous result for a query with the provided one: this is used in the tests
 func (dc *fakeDBClient) addInvariant(query string, result *sqltypes.Result) {
+	if testMode == "debug" {
+		log.Infof("%s::addInvariant %s\n\n", dc.id(), query)
+	}
 	dc.invariants[query] = result
 }
 
@@ -138,12 +149,24 @@ func (dc *fakeDBClient) Rollback() error {
 func (dc *fakeDBClient) Close() {
 }
 
+func (dc *fakeDBClient) id() string {
+	return fmt.Sprintf("FakeDBClient(%s)", dc.name)
+}
+
 // ExecuteFetch is part of the DBClient interface
 func (dc *fakeDBClient) ExecuteFetch(query string, maxrows int) (qr *sqltypes.Result, err error) {
+	qr, err = dc.executeFetch(query, maxrows)
 	if testMode == "debug" {
-		fmt.Printf("ExecuteFetch: %s\n", query)
+		log.Infof("%s::ExecuteFetch for >>>%s<<< returns >>>%v<<< error >>>%+v<<< ", dc.id(), query, qr, err)
 	}
+	if qr != nil && qr.Rows != nil {
+		qr.RowsAffected = uint64(len(qr.Rows))
+	}
+	return qr, err
+}
 
+// ExecuteFetch is part of the DBClient interface
+func (dc *fakeDBClient) executeFetch(query string, maxrows int) (qr *sqltypes.Result, err error) {
 	if dbrs := dc.queries[query]; dbrs != nil {
 		return dbrs.next(query)
 	}

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -181,7 +181,7 @@ func newTestTableMigraterCustom(ctx context.Context, t *testing.T, sourceShards,
 	tme.startTablets(t)
 	tme.createDBClients(ctx, t)
 	tme.setPrimaryPositions()
-	now := time.Now().UnixNano()
+	now := time.Now().Unix()
 	for i, targetShard := range targetShards {
 		var streamInfoRows []string
 		var streamExtInfoRows []string
@@ -337,7 +337,7 @@ func newTestShardMigrater(ctx context.Context, t *testing.T, sourceShards, targe
 	tme.startTablets(t)
 	tme.createDBClients(ctx, t)
 	tme.setPrimaryPositions()
-	now := time.Now().UnixNano()
+	now := time.Now().Unix()
 	for i, targetShard := range targetShards {
 		var rows, rowsRdOnly []string
 		var streamExtInfoRows []string

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -395,7 +395,7 @@ func (tme *testMigraterEnv) stopTablets(t *testing.T) {
 
 func (tme *testMigraterEnv) createDBClients(ctx context.Context, t *testing.T) {
 	for _, primary := range tme.sourcePrimaries {
-		dbclient := newFakeDBClient()
+		dbclient := newFakeDBClient(primary.Tablet.Alias.String())
 		tme.dbSourceClients = append(tme.dbSourceClients, dbclient)
 		dbClientFactory := func() binlogplayer.DBClient { return dbclient }
 		// Replace existing engine with a new one
@@ -404,7 +404,7 @@ func (tme *testMigraterEnv) createDBClients(ctx context.Context, t *testing.T) {
 	}
 	for _, primary := range tme.targetPrimaries {
 		log.Infof("Adding as targetPrimary %s", primary.Tablet.Alias)
-		dbclient := newFakeDBClient()
+		dbclient := newFakeDBClient(primary.Tablet.Alias.String())
 		tme.dbTargetClients = append(tme.dbTargetClients, dbclient)
 		dbClientFactory := func() binlogplayer.DBClient { return dbclient }
 		// Replace existing engine with a new one

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -56,6 +56,7 @@ var (
 
 	streamExtInfoKs2        = fmt.Sprintf(streamExtInfoQuery, "ks2", "test")
 	reverseStreamExtInfoKs2 = fmt.Sprintf(streamExtInfoQuery, "ks2", "test_reverse")
+	reverseStreamExtInfoKs1 = fmt.Sprintf(streamExtInfoQuery, "ks1", "test_reverse")
 	streamExtInfoKs         = fmt.Sprintf(streamExtInfoQuery, "ks", "test")
 )
 
@@ -236,6 +237,7 @@ func newTestTableMigraterCustom(ctx context.Context, t *testing.T, sourceShards,
 			streamInfoRows = append(streamInfoRows, fmt.Sprintf("%d|%v|||", j+1, bls))
 			tme.dbTargetClients[i].addInvariant(fmt.Sprintf(copyStateQuery, j+1), noResult)
 		}
+		log.Infof(">>>>>>>>>>>>> Invariant: %s", reverseStreamExtInfoKs1)
 		tme.dbSourceClients[i].addInvariant(reverseStreamInfoKs1, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 			"id|source|message|cell|tablet_types",
 			"int64|varchar|varchar|varchar|varchar"),

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -44,14 +44,14 @@ import (
 )
 
 const (
-	streamInfoQuery    = "select id, source, message, cell, tablet_types from _vt.vreplication where workflow='test' and db_name='vt_%s'"
+	streamInfoQuery    = "select id, source, message, cell, tablet_types from _vt.vreplication where workflow='%s' and db_name='vt_%s'"
 	streamExtInfoQuery = "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, time_heartbeat, message, tags from _vt.vreplication where db_name = 'vt_ks2' and workflow = 'test'"
 )
 
 var (
-	streamInfoKs  = fmt.Sprintf(streamInfoQuery, "ks")
-	streamInfoKs1 = fmt.Sprintf(streamInfoQuery, "ks1")
-	streamInfoKs2 = fmt.Sprintf(streamInfoQuery, "ks2")
+	streamInfoKs  = fmt.Sprintf(streamInfoQuery, "test", "ks")
+	streamInfoKs1 = fmt.Sprintf(streamInfoQuery, "test_reverse", "ks1")
+	streamInfoKs2 = fmt.Sprintf(streamInfoQuery, "test", "ks2")
 )
 
 type testMigraterEnv struct {

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -237,7 +237,6 @@ func newTestTableMigraterCustom(ctx context.Context, t *testing.T, sourceShards,
 			streamInfoRows = append(streamInfoRows, fmt.Sprintf("%d|%v|||", j+1, bls))
 			tme.dbTargetClients[i].addInvariant(fmt.Sprintf(copyStateQuery, j+1), noResult)
 		}
-		log.Infof(">>>>>>>>>>>>> Invariant: %s", reverseStreamExtInfoKs1)
 		tme.dbSourceClients[i].addInvariant(reverseStreamInfoKs1, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 			"id|source|message|cell|tablet_types",
 			"int64|varchar|varchar|varchar|varchar"),

--- a/go/vt/wrangler/traffic_switcher_test.go
+++ b/go/vt/wrangler/traffic_switcher_test.go
@@ -1566,12 +1566,12 @@ func TestMigrateFrozen(t *testing.T) {
 			}},
 		},
 	}
-	tme.dbTargetClients[0].addQuery(vreplQueryks2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+	tme.dbTargetClients[0].addQuery(streamInfoKs2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"id|source|message|cell|tablet_types",
 		"int64|varchar|varchar|varchar|varchar"),
 		fmt.Sprintf("1|%v|FROZEN||", bls1),
 	), nil)
-	tme.dbTargetClients[1].addQuery(vreplQueryks2, &sqltypes.Result{}, nil)
+	tme.dbTargetClients[1].addQuery(streamInfoKs2, &sqltypes.Result{}, nil)
 
 	switchWrites(tme)
 	_, _, err = tme.wr.SwitchWrites(ctx, tme.targetKeyspace, "test", 0*time.Second, false, false, true, false)
@@ -1586,8 +1586,8 @@ func TestMigrateNoStreamsFound(t *testing.T) {
 	tme := newTestTableMigrater(ctx, t)
 	defer tme.stopTablets(t)
 
-	tme.dbTargetClients[0].addQuery(vreplQueryks2, &sqltypes.Result{}, nil)
-	tme.dbTargetClients[1].addQuery(vreplQueryks2, &sqltypes.Result{}, nil)
+	tme.dbTargetClients[0].addQuery(streamInfoKs2, &sqltypes.Result{}, nil)
+	tme.dbTargetClients[1].addQuery(streamInfoKs2, &sqltypes.Result{}, nil)
 
 	tme.expectNoPreviousJournals()
 	_, err := tme.wr.SwitchReads(ctx, tme.targetKeyspace, "test", []topodatapb.TabletType{topodatapb.TabletType_RDONLY}, nil, workflow.DirectionForward, false)
@@ -1615,7 +1615,7 @@ func TestMigrateDistinctSources(t *testing.T) {
 			}},
 		},
 	}
-	tme.dbTargetClients[0].addQuery(vreplQueryks2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+	tme.dbTargetClients[0].addQuery(streamInfoKs2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"id|source|message|cell|tablet_types",
 		"int64|varchar|varchar|varchar|varchar"),
 		fmt.Sprintf("1|%v|||", bls),
@@ -1644,7 +1644,7 @@ func TestMigrateMismatchedTables(t *testing.T) {
 			}},
 		},
 	}
-	tme.dbTargetClients[0].addQuery(vreplQueryks2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+	tme.dbTargetClients[0].addQuery(streamInfoKs2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"id|source|message|cell|tablet_types",
 		"int64|varchar|varchar|varchar|varchar"),
 		fmt.Sprintf("1|%v|||", bls)),
@@ -1664,7 +1664,7 @@ func TestTableMigrateAllShardsNotPresent(t *testing.T) {
 	tme := newTestTableMigrater(ctx, t)
 	defer tme.stopTablets(t)
 
-	tme.dbTargetClients[0].addQuery(vreplQueryks2, &sqltypes.Result{}, nil)
+	tme.dbTargetClients[0].addQuery(streamInfoKs2, &sqltypes.Result{}, nil)
 
 	tme.expectNoPreviousJournals()
 	_, err := tme.wr.SwitchReads(ctx, tme.targetKeyspace, "test", []topodatapb.TabletType{topodatapb.TabletType_RDONLY}, nil, workflow.DirectionForward, false)
@@ -1703,7 +1703,7 @@ func TestMigrateNoTableWildcards(t *testing.T) {
 			}},
 		},
 	}
-	tme.dbTargetClients[0].addQuery(vreplQueryks2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+	tme.dbTargetClients[0].addQuery(streamInfoKs2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"id|source|message|cell|tablet_types",
 		"int64|varchar|varchar|varchar|varchar"),
 		fmt.Sprintf("1|%v|||", bls1),
@@ -1719,7 +1719,7 @@ func TestMigrateNoTableWildcards(t *testing.T) {
 			}},
 		},
 	}
-	tme.dbTargetClients[1].addQuery(vreplQueryks2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+	tme.dbTargetClients[1].addQuery(streamInfoKs2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"id|source|message|cell|tablet_types",
 		"int64|varchar|varchar|varchar|varchar"),
 		fmt.Sprintf("1|%v|||", bls3),
@@ -2039,8 +2039,8 @@ func TestShardMigrateNoAvailableTabletsForReverseReplication(t *testing.T) {
 	// Temporarily set tablet types to RDONLY to test that SwitchWrites fails if no tablets of rdonly are available
 	invariants := make(map[string]*sqltypes.Result)
 	for i := range tme.targetShards {
-		invariants[fmt.Sprintf("%s-%d", vreplQueryks, i)] = tme.dbTargetClients[i].getInvariant(vreplQueryks)
-		tme.dbTargetClients[i].addInvariant(vreplQueryks, tme.dbTargetClients[i].getInvariant(vreplQueryks+"-rdonly"))
+		invariants[fmt.Sprintf("%s-%d", streamInfoKs, i)] = tme.dbTargetClients[i].getInvariant(streamInfoKs)
+		tme.dbTargetClients[i].addInvariant(streamInfoKs, tme.dbTargetClients[i].getInvariant(streamInfoKs+"-rdonly"))
 	}
 	_, _, err = tme.wr.SwitchWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, false, true, false)
 	require.Error(t, err)
@@ -2049,7 +2049,7 @@ func TestShardMigrateNoAvailableTabletsForReverseReplication(t *testing.T) {
 	require.True(t, strings.Contains(err.Error(), "80-"))
 	require.False(t, strings.Contains(err.Error(), "40"))
 	for i := range tme.targetShards {
-		tme.dbTargetClients[i].addInvariant(vreplQueryks, invariants[fmt.Sprintf("%s-%d", vreplQueryks, i)])
+		tme.dbTargetClients[i].addInvariant(streamInfoKs, invariants[fmt.Sprintf("%s-%d", streamInfoKs, i)])
 	}
 
 	journalID, _, err := tme.wr.SwitchWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, false, true, false)

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -549,7 +549,7 @@ func (wr *Wrangler) getStreams(ctx context.Context, workflow, keyspace string) (
 				if status.TransactionTimestamp == 0 /* no new events after copy */ {
 					lastTransactionTimestamp = lastHeartbeatTime
 				}
-				transactionReplicationLag := time.Now().UnixNano() - lastTransactionTimestamp
+				transactionReplicationLag := time.Now().Unix() - lastTransactionTimestamp
 				transactionReplicationLag = transactionReplicationLag / 1e9
 				if transactionReplicationLag > rsr.MaxVReplicationTransactionLag {
 					rsr.MaxVReplicationTransactionLag = int64(transactionReplicationLag)

--- a/go/vt/wrangler/vexec_plan.go
+++ b/go/vt/wrangler/vexec_plan.go
@@ -79,7 +79,7 @@ func (p vreplicationPlanner) exec(
 		return nil, err
 	}
 	if qr.RowsAffected == 0 {
-		log.Infof("no matching streams found for workflow %s, tablet %s, query %s", p.vx.workflow, primaryAlias, query)
+		log.Infof("no matching streams found for workflow %s, tablet %s, query %s, qr %+v", p.vx.workflow, primaryAlias, query, qr)
 	}
 	return qr, nil
 }

--- a/go/vt/wrangler/vexec_plan.go
+++ b/go/vt/wrangler/vexec_plan.go
@@ -79,7 +79,7 @@ func (p vreplicationPlanner) exec(
 		return nil, err
 	}
 	if qr.RowsAffected == 0 {
-		log.Infof("no matching streams found for workflow %s, tablet %s, query %s, qr %+v", p.vx.workflow, primaryAlias, query, qr)
+		log.Infof("no matching streams found for workflow %s, tablet %s, query %s", p.vx.workflow, primaryAlias, query)
 	}
 	return qr, nil
 }

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -212,6 +212,7 @@ func TestWorkflowListStreams(t *testing.T) {
 	},
 	"MaxVReplicationLag": 0,
 	"MaxVReplicationTransactionLag": 0,
+	"Frozen": false,
 	"ShardStatuses": {
 		"-80/zone1-0000000200": {
 			"PrimaryReplicationStatuses": [

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -31,7 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 )
 
-func TestVExec2(t *testing.T) {
+func TestVExec(t *testing.T) {
 	ctx := context.Background()
 	workflow := "wrWorkflow"
 	keyspace := "target"

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -211,6 +211,7 @@ func TestWorkflowListStreams(t *testing.T) {
 		]
 	},
 	"MaxVReplicationLag": 0,
+	"MaxVReplicationTransactionLag": 0,
 	"ShardStatuses": {
 		"-80/zone1-0000000200": {
 			"PrimaryReplicationStatuses": [
@@ -235,6 +236,7 @@ func TestWorkflowListStreams(t *testing.T) {
 					"DBName": "vt_target",
 					"TransactionTimestamp": 0,
 					"TimeUpdated": 1234,
+					"TimeHeartbeat": 1234,
 					"Message": "",
 					"Tags": "",
 					"CopyState": [
@@ -271,6 +273,7 @@ func TestWorkflowListStreams(t *testing.T) {
 					"DBName": "vt_target",
 					"TransactionTimestamp": 0,
 					"TimeUpdated": 1234,
+					"TimeHeartbeat": 1234,
 					"Message": "",
 					"Tags": "",
 					"CopyState": [
@@ -292,6 +295,8 @@ func TestWorkflowListStreams(t *testing.T) {
 	// MaxVReplicationLag needs to be reset. This can't be determinable in this kind of a test because time.Now() is constantly shifting.
 	re := regexp.MustCompile(`"MaxVReplicationLag": \d+`)
 	got = re.ReplaceAllLiteralString(got, `"MaxVReplicationLag": 0`)
+	re = regexp.MustCompile(`"MaxVReplicationTransactionLag": \d+`)
+	got = re.ReplaceAllLiteralString(got, `"MaxVReplicationTransactionLag": 0`)
 	require.Equal(t, want, got)
 
 	results, err := wr.execWorkflowAction(ctx, workflow, keyspace, "stop", false)

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -474,9 +474,6 @@ func (vrw *VReplicationWorkflow) canSwitch(workflowName string) (reason string, 
 	if err != nil {
 		return "", err
 	}
-	if result.MaxVReplicationTransactionLag >= vrw.params.MaxAllowedTransactionLagSeconds {
-		return fmt.Sprintf(cannotSwitchHighLag, result.MaxVReplicationTransactionLag, vrw.params.MaxAllowedTransactionLagSeconds), nil
-	}
 	for ksShard := range result.ShardStatuses {
 		statuses := result.ShardStatuses[ksShard].PrimaryReplicationStatuses
 		for _, st := range statuses {
@@ -487,6 +484,9 @@ func (vrw *VReplicationWorkflow) canSwitch(workflowName string) (reason string, 
 				return cannotSwitchError, nil
 			}
 		}
+	}
+	if result.MaxVReplicationTransactionLag >= vrw.params.MaxAllowedTransactionLagSeconds {
+		return fmt.Sprintf(cannotSwitchHighLag, result.MaxVReplicationTransactionLag, vrw.params.MaxAllowedTransactionLagSeconds), nil
 	}
 	return "", nil
 }

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -64,7 +64,7 @@ type VReplicationWorkflowParams struct {
 	KeepRoutingRules                  bool
 	Timeout                           time.Duration
 	Direction                         workflow.TrafficSwitchDirection
-	MaxAllowedLagSeconds              int64
+	MaxAllowedTransactionLagSeconds   int64
 
 	// MoveTables specific
 	SourceKeyspace, Tables  string
@@ -474,8 +474,8 @@ func (vrw *VReplicationWorkflow) canSwitch(workflowName string) (reason string, 
 	if err != nil {
 		return "", err
 	}
-	if result.MaxVReplicationLag >= vrw.params.MaxAllowedLagSeconds {
-		return fmt.Sprintf(cannotSwitchHighLag, result.MaxVReplicationLag, vrw.params.MaxAllowedLagSeconds), nil
+	if result.MaxVReplicationTransactionLag >= vrw.params.MaxAllowedTransactionLagSeconds {
+		return fmt.Sprintf(cannotSwitchHighLag, result.MaxVReplicationTransactionLag, vrw.params.MaxAllowedTransactionLagSeconds), nil
 	}
 	for ksShard := range result.ShardStatuses {
 		statuses := result.ShardStatuses[ksShard].PrimaryReplicationStatuses

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -485,7 +485,7 @@ func (vrw *VReplicationWorkflow) canSwitch(workflowName string) (reason string, 
 			}
 		}
 	}
-	if result.MaxVReplicationTransactionLag >= vrw.params.MaxAllowedTransactionLagSeconds {
+	if result.MaxVReplicationTransactionLag > vrw.params.MaxAllowedTransactionLagSeconds {
 		return fmt.Sprintf(cannotSwitchHighLag, result.MaxVReplicationTransactionLag, vrw.params.MaxAllowedTransactionLagSeconds), nil
 	}
 	return "", nil

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -102,8 +102,8 @@ func expectExtInfo(t *testing.T, tme *testMigraterEnv, keyspace, state string, c
 	)
 
 	for _, db := range tme.dbTargetClients {
-		db.addInvariant(streamExtInfoQuery, replicationResult)
-		copyStateQuery := "select table_name, lastpk from _vt.copy_state where vrepl_id = %d"
+		db.addInvariant(streamExtInfoKs2, replicationResult)
+
 		if state == "Copying" {
 			db.addInvariant(fmt.Sprintf(copyStateQuery, 1), copyStateResult)
 		} else {

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -120,11 +120,6 @@ func TestCopyProgress(t *testing.T) {
 	require.Equal(t, int64(400), (*cp)["t2"].TargetRowCount)
 	require.Equal(t, int64(4000), (*cp)["t2"].SourceTableSize)
 	require.Equal(t, int64(1000), (*cp)["t2"].TargetTableSize)
-
-	var isCopyInProgress bool
-	isCopyInProgress, err = wf.IsCopyInProgress()
-	require.NoError(t, err)
-	require.True(t, isCopyInProgress)
 }
 
 func expectCopyProgressQueries(t *testing.T, tme *testMigraterEnv) {
@@ -196,7 +191,6 @@ func TestMoveTablesV2(t *testing.T) {
 
 func validateRoutingRuleCount(ctx context.Context, t *testing.T, ts *topo.Server, cnt int) {
 	rr, err := ts.GetRoutingRules(ctx)
-	fmt.Printf("Rules %+v\n", rr.Rules)
 	require.NoError(t, err)
 	require.NotNil(t, rr)
 	rules := rr.Rules

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -88,7 +88,7 @@ func TestReshardingWorkflowErrorsAndMisc(t *testing.T) {
 }
 
 func expectExtInfo(t *testing.T, tme *testMigraterEnv, keyspace, state string, currentLag int64) {
-	now := int64(time.Now().UnixNano())
+	now := int64(time.Now().Unix())
 	rowTemplate := "1|||||%s|vt_%s|%d|%d|0||"
 	row := fmt.Sprintf(rowTemplate, state, keyspace, now, now-(currentLag*1e9))
 	replicationResult := sqltypes.MakeTestResult(sqltypes.MakeTestFields(

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -87,10 +87,10 @@ func TestReshardingWorkflowErrorsAndMisc(t *testing.T) {
 	require.True(t, hasPrimary)
 }
 
-func expectExtInfo(t *testing.T, tme *testMigraterEnv, keyspace, state string, currentLag int64) {
-	now := int64(time.Now().Unix())
+func expectCanSwitchQueries(t *testing.T, tme *testMigraterEnv, keyspace, state string, currentLag int64) {
+	now := time.Now().Unix()
 	rowTemplate := "1|||||%s|vt_%s|%d|%d|0||"
-	row := fmt.Sprintf(rowTemplate, state, keyspace, now, now-(currentLag*1e9))
+	row := fmt.Sprintf(rowTemplate, state, keyspace, now, now-currentLag)
 	replicationResult := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"id|source|pos|stop_pos|max_replication_lag|state|db_name|time_updated|transaction_timestamp|time_heartbeat|message|tags",
 		"int64|varchar|int64|int64|int64|varchar|varchar|int64|int64|int64|varchar|varchar"),
@@ -146,7 +146,7 @@ func TestCanSwitch(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			expectExtInfo(t, tme, "ks2", tc.state, tc.streamLag)
+			expectCanSwitchQueries(t, tme, "ks2", tc.state, tc.streamLag)
 			p.MaxAllowedTransactionLagSeconds = tc.allowedLag
 			reason, err := wf.canSwitch(workflowName)
 			require.NoError(t, err)

--- a/go/vt/wrangler/wrangler_env_test.go
+++ b/go/vt/wrangler/wrangler_env_test.go
@@ -143,11 +143,11 @@ func newWranglerTestEnv(sourceShards, targetShards []string, query string, posit
 		env.tmc.setVRResults(primary.tablet, "insert into _vt.vreplication(state, workflow, db_name) values ('Running', 'wk1', 'ks1'), ('Stopped', 'wk1', 'ks1')", &sqltypes.Result{RowsAffected: 2})
 
 		result := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-			"id|source|pos|stop_pos|max_replication_lag|state|db_name|time_updated|transaction_timestamp|message|tags",
-			"int64|varchar|varchar|varchar|int64|varchar|varchar|int64|int64|varchar|varchar"),
-			fmt.Sprintf("1|%v|MySQL56/14b68925-696a-11ea-aee7-fec597a91f5e:1-3||0|Running|vt_target|%d|0||", bls, timeUpdated),
+			"id|source|pos|stop_pos|max_replication_lag|state|db_name|time_updated|transaction_timestamp|time_heartbeat|message|tags",
+			"int64|varchar|varchar|varchar|int64|varchar|varchar|int64|int64|int64|varchar|varchar"),
+			fmt.Sprintf("1|%v|MySQL56/14b68925-696a-11ea-aee7-fec597a91f5e:1-3||0|Running|vt_target|%d|0|%d||", bls, timeUpdated, timeUpdated),
 		)
-		env.tmc.setVRResults(primary.tablet, "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication where db_name = 'vt_target' and workflow = 'wrWorkflow'", result)
+		env.tmc.setVRResults(primary.tablet, "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, time_heartbeat, message, tags from _vt.vreplication where db_name = 'vt_target' and workflow = 'wrWorkflow'", result)
 		env.tmc.setVRResults(
 			primary.tablet,
 			"select source, pos from _vt.vreplication where db_name='vt_target' and workflow='wrWorkflow'",
@@ -172,7 +172,7 @@ func newWranglerTestEnv(sourceShards, targetShards []string, query string, posit
 
 		env.tmc.setVRResults(primary.tablet, "select table_name, lastpk from _vt.copy_state where vrepl_id = 1", result)
 
-		env.tmc.setVRResults(primary.tablet, "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication where db_name = 'vt_target' and workflow = 'bad'", result)
+		env.tmc.setVRResults(primary.tablet, "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication where db_name = 'vt_target' and workflow = 'bad'", &sqltypes.Result{})
 
 		env.tmc.setVRResults(primary.tablet, "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message, tags from _vt.vreplication where db_name = 'vt_target' and workflow = 'badwf'", &sqltypes.Result{})
 		env.tmc.vrpos[tabletID] = testSourceGtid


### PR DESCRIPTION
## Description
This PR adds logic to measure the estimated lag between the last transaction at the source and the last transaction seen by the target. The target persists the transaction timestamp of each seen event in `_vt.vreplication`. The target may not receive events from the source in two cases: 
* where there is no activity at the source relevant to the target
* when the source is disconnected from the target (due to a vstreamer error, network issue or source tablets being unavailable). 

To differentiate between this the source starts sending "heartbeats" (special internal VEvents) every second if there are no actual events to be sent. As part of this PR we also start storing the last heartbeat time in `_vt.vreplication`.  

We calculate the transaction lag based on the transaction timestamp and the last heartbeat for each stream and the maximum across streams is used as the workflow lag: https://github.com/vitessio/vitess/blob/dc74ebcc2d1c70f36030ca07ec857c009afd6954/go/vt/wrangler/vexec.go#L536 

We now add a check before switching traffic (both read and write) to ensure:
1. that the lag is within acceptable bounds (defined by the duration flag `-max_transaction_lag_allowed`, default 30s) 
2. that there is no stream that has an error
3. that we are not still in the copy phase (this already exists)

Note that the `Workflow Show` command does already show a MaxVReplicationLag. This was implemented more to determine if there was an issue with the source not being available than measuring transaction lag. Since the name is already in-use, for backward compatibility, a new variable MaxVReplicationTransactionLag has been added for the purposes of this PR.

Other changes:
* Minor refactoring of the test framework for ease of maintenance
* Intial doc to describe the test framework and changes needed for this PR. We will update this in upcoming PRs.

New flag documented in website PR: https://github.com/vitessio/website/pull/957

## Related Issue(s)
https://github.com/vitessio/vitess/issues/9525

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required
