### PR TITLE
Wait for all replicas to reparent when running ERS from vtctl

### DIFF
--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -46,7 +46,7 @@ func TestTrivialERS(t *testing.T) {
 	}
 	// We should do the same for vtctl binary
 	for i := 1; i <= 4; i++ {
-		out, err := utils.ErsWithVtctl(clusterInstance)
+		out, err := utils.ErsWithVtctl(clusterInstance, nil)
 		log.Infof("ERS-vtctl loop %d.  EmergencyReparentShard Output: %v", i, out)
 		require.NoError(t, err)
 		time.Sleep(5 * time.Second)

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -186,7 +186,10 @@ func commandEmergencyReparentShard(ctx context.Context, wr *wrangler.Wrangler, s
 		}
 	}
 	unreachableReplicas := topoproto.ParseTabletSet(*ignoreReplicasList)
-	return wr.EmergencyReparentShard(ctx, keyspace, shard, tabletAlias, *waitReplicasTimeout, unreachableReplicas, *preventCrossCellPromotion)
+	// From the vtctl binary we should be waiting for all the replicas to reparent themselves
+	// since we finish main function execution when ERS ends. We would end up stopping the grpc clients for the replicas which
+	// are still in the process of reparenting themselves if we do not wait for them.
+	return wr.EmergencyReparentShard(ctx, keyspace, shard, tabletAlias, *waitReplicasTimeout, unreachableReplicas, *preventCrossCellPromotion /* waitForReplicasToReparent */, true)
 }
 
 func commandTabletExternallyReparented(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -145,16 +145,17 @@ func (wr *Wrangler) PlannedReparentShard(ctx context.Context, keyspace, shard st
 
 // EmergencyReparentShard will make the provided tablet the primary for
 // the shard, when the old primary is completely unreachable.
-func (wr *Wrangler) EmergencyReparentShard(ctx context.Context, keyspace, shard string, primaryElectTabletAlias *topodatapb.TabletAlias, waitReplicasTimeout time.Duration, ignoredTablets sets.String, preventCrossCellPromotion bool) (err error) {
+func (wr *Wrangler) EmergencyReparentShard(ctx context.Context, keyspace, shard string, primaryElectTabletAlias *topodatapb.TabletAlias, waitReplicasTimeout time.Duration, ignoredTablets sets.String, preventCrossCellPromotion bool, waitForAllReplicasToReparent bool) (err error) {
 	_, err = reparentutil.NewEmergencyReparenter(wr.ts, wr.tmc, wr.logger).ReparentShard(
 		ctx,
 		keyspace,
 		shard,
 		reparentutil.EmergencyReparentOptions{
-			NewPrimaryAlias:           primaryElectTabletAlias,
-			WaitReplicasTimeout:       waitReplicasTimeout,
-			IgnoreReplicas:            ignoredTablets,
-			PreventCrossCellPromotion: preventCrossCellPromotion,
+			NewPrimaryAlias:              primaryElectTabletAlias,
+			WaitReplicasTimeout:          waitReplicasTimeout,
+			IgnoreReplicas:               ignoredTablets,
+			PreventCrossCellPromotion:    preventCrossCellPromotion,
+			WaitForAllReplicasToReparent: waitForAllReplicasToReparent,
 		},
 	)
 

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -270,7 +270,7 @@ func TestEmergencyReparentShardPrimaryElectNotBest(t *testing.T) {
 	defer moreAdvancedReplica.StopActionLoop(t)
 
 	// run EmergencyReparentShard
-	err := wr.EmergencyReparentShard(ctx, newPrimary.Tablet.Keyspace, newPrimary.Tablet.Shard, newPrimary.Tablet.Alias, 10*time.Second, sets.NewString(), false)
+	err := wr.EmergencyReparentShard(ctx, newPrimary.Tablet.Keyspace, newPrimary.Tablet.Shard, newPrimary.Tablet.Alias, 10*time.Second, sets.NewString(), false, false)
 	cancel()
 
 	assert.NoError(t, err)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
When running `EmergencyReparentShard` from the vtctl binary, we used to finish ERS when even 1 replica was successful in reparenting itself to the new primary. When the command finishes, the vtctl binary also finishes execution. This led to the grpc clients for all the other replicas's stopping execution, which in-turn caused the grpc servers to cancel their contexts. In some cases this led to the replication not being setup correctly on some replicas. This PR fixes that issue by adding an additional internal option to running EmergencyReparentShard. When running from vtctl we will wait for all the replicas to return, while we will continue to exit out early for running ERS from vtorc and vtctldserver.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
 - Fixes #9529 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->