### PR TITLE
Faster and safer unsharded query planning

### DIFF
--- a/go/vt/vtgate/planbuilder/gen4_planner.go
+++ b/go/vt/vtgate/planbuilder/gen4_planner.go
@@ -17,18 +17,13 @@ limitations under the License.
 package planbuilder
 
 import (
-	"sort"
-	"strings"
-
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/abstract"
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
-
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/physical"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 )
 
@@ -144,14 +139,7 @@ func newBuildSelectPlan(selStmt sqlparser.SelectStatement, reservedVars *sqlpars
 	vschema.PlannerWarning(semTable.Warning)
 
 	if ks := semTable.SingleUnshardedKeyspace(); ks != nil {
-		plan, err := unshardedShortcut(selStmt, ks, semTable)
-		if err != nil {
-			return nil, err
-		}
-		if err := plan.WireupGen4(semTable); err != nil {
-			return nil, err
-		}
-		return plan, err
+		return unshardedShortcut(selStmt, ks, semTable)
 	}
 
 	err = queryRewrite(semTable, reservedVars, selStmt)
@@ -201,56 +189,6 @@ func newBuildSelectPlan(selStmt sqlparser.SelectStatement, reservedVars *sqlpars
 	}
 
 	return plan, nil
-}
-
-func unshardedShortcut(stmt sqlparser.SelectStatement, ks *vindexes.Keyspace, semTable *semantics.SemTable) (logicalPlan, error) {
-	// this method is used when the query we are handling has all tables in the same unsharded keyspace
-	sqlparser.Rewrite(stmt, func(cursor *sqlparser.Cursor) bool {
-		switch node := cursor.Node().(type) {
-		case sqlparser.SelectExpr:
-			removeKeyspaceFromSelectExpr(node)
-		case sqlparser.TableName:
-			cursor.Replace(sqlparser.TableName{
-				Name: node.Name,
-			})
-		}
-		return true
-	}, nil)
-
-	tableNames, err := getTableNames(semTable)
-	if err != nil {
-		return nil, err
-	}
-	return &routeGen4{
-		eroute: &engine.Route{
-			Opcode:    engine.SelectUnsharded,
-			TableName: strings.Join(tableNames, ", "),
-			Keyspace:  ks,
-		},
-		Select: stmt,
-	}, nil
-}
-
-func getTableNames(semTable *semantics.SemTable) ([]string, error) {
-	tableNameMap := map[string]interface{}{}
-
-	for _, tableInfo := range semTable.Tables {
-		tblObj := tableInfo.GetVindexTable()
-		var name string
-		if tableInfo.IsInfSchema() {
-			name = "tableName"
-		} else {
-			name = sqlparser.String(tblObj.Name)
-		}
-		tableNameMap[name] = nil
-	}
-
-	var tableNames []string
-	for name := range tableNameMap {
-		tableNames = append(tableNames, name)
-	}
-	sort.Strings(tableNames)
-	return tableNames, nil
 }
 
 func planLimit(limit *sqlparser.Limit, plan logicalPlan) (logicalPlan, error) {

--- a/go/vt/vtgate/planbuilder/simplifier_test.go
+++ b/go/vt/vtgate/planbuilder/simplifier_test.go
@@ -36,7 +36,7 @@ import (
 // TestSimplifyBuggyQuery should be used to whenever we get a planner bug reported
 // It will try to minimize the query to make it easier to understand and work with the bug.
 func TestSimplifyBuggyQuery(t *testing.T) {
-	query := "(select id from unsharded union select id from unsharded_auto) union (select id from unsharded_auto union select name from unsharded)"
+	query := "(select id from unsharded union select id from unsharded_auto) union (select id from user union select name from unsharded)"
 	vschema := &vschemaWrapper{
 		v:       loadSchema(t, "schema_test.json", true),
 		version: Gen4,

--- a/go/vt/vtgate/planbuilder/single_sharded_shortcut.go
+++ b/go/vt/vtgate/planbuilder/single_sharded_shortcut.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"sort"
+	"strings"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/semantics"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+func unshardedShortcut(stmt sqlparser.SelectStatement, ks *vindexes.Keyspace, semTable *semantics.SemTable) (logicalPlan, error) {
+	// this method is used when the query we are handling has all tables in the same unsharded keyspace
+	sqlparser.Rewrite(stmt, func(cursor *sqlparser.Cursor) bool {
+		switch node := cursor.Node().(type) {
+		case sqlparser.SelectExpr:
+			removeKeyspaceFromSelectExpr(node)
+		case sqlparser.TableName:
+			cursor.Replace(sqlparser.TableName{
+				Name: node.Name,
+			})
+		}
+		return true
+	}, nil)
+
+	tableNames, err := getTableNames(semTable)
+	if err != nil {
+		return nil, err
+	}
+	plan := &routeGen4{
+		eroute: &engine.Route{
+			Opcode:    engine.SelectUnsharded,
+			TableName: strings.Join(tableNames, ", "),
+			Keyspace:  ks,
+		},
+		Select: stmt,
+	}
+	if err := plan.WireupGen4(semTable); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func getTableNames(semTable *semantics.SemTable) ([]string, error) {
+	tableNameMap := map[string]interface{}{}
+
+	for _, tableInfo := range semTable.Tables {
+		tblObj := tableInfo.GetVindexTable()
+		var name string
+		if tableInfo.IsInfSchema() {
+			name = "tableName"
+		} else {
+			name = sqlparser.String(tblObj.Name)
+		}
+		tableNameMap[name] = nil
+	}
+
+	var tableNames []string
+	for name := range tableNameMap {
+		tableNames = append(tableNames, name)
+	}
+	sort.Strings(tableNames)
+	return tableNames, nil
+}

--- a/go/vt/vtgate/planbuilder/testdata/ddl_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/ddl_cases.txt
@@ -312,7 +312,7 @@ Gen4 plan same as above
     "Query": "create view view_a as select id from unsharded union select id from unsharded_auto union select id from unsharded_auto union select `name` from unsharded"
   }
 }
-Gen4 error: nesting of unions at the right-hand side is not yet supported
+Gen4 plan same as above
 
 # Alter View
 "alter view user.user_extra as select* from user.user"

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -2474,7 +2474,21 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
-Gen4 plan same as above
+{
+  "QueryType": "SELECT",
+  "Original": "select unsharded.id from unsharded where unsharded.name in (select name from unsharded_a)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
+    "Query": "select unsharded.id from unsharded where unsharded.`name` in (select `name` from unsharded_a)",
+    "Table": "unsharded, unsharded_a"
+  }
+}
 
 # in subquery the id will be scoped to local table as there is no qualifier associated with it.
 "select id from user where id in (select col from unsharded where col = id)"
@@ -3912,4 +3926,4 @@ Gen4 plan same as above
     "Table": "unsharded_a, unsharded_b"
   }
 }
-Gen4 error: expr cannot be converted, not supported: coalesce(unsharded_b.col, 4) = 5
+Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -218,21 +218,7 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select m1.col from unsharded as m1 join unsharded as m2",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectUnsharded",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
-    "FieldQuery": "select m1.col from unsharded as m1, unsharded as m2 where 1 != 1",
-    "Query": "select m1.col from unsharded as m1, unsharded as m2",
-    "Table": "unsharded"
-  }
-}
+Gen4 plan same as above
 
 # Multi-table, multi-chunk
 "select music.col from user join music"
@@ -865,7 +851,21 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
-Gen4 plan same as above
+{
+  "QueryType": "SELECT",
+  "Original": "select m1.col from unsharded as m1 right join unsharded as m2 on m1.a=m2.b",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select m1.col from unsharded as m1 right join unsharded as m2 on m1.a = m2.b where 1 != 1",
+    "Query": "select m1.col from unsharded as m1 right join unsharded as m2 on m1.a = m2.b",
+    "Table": "unsharded"
+  }
+}
 
 # Right join with a join LHS
 "select m1.col from unsharded as m1 join unsharded as m2 right join unsharded as m3 on m1.a=m2.b"
@@ -894,8 +894,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": false
     },
-    "FieldQuery": "select m1.col from unsharded as m3 left join (unsharded as m1, unsharded as m2) on m1.a = m2.b where 1 != 1",
-    "Query": "select m1.col from unsharded as m3 left join (unsharded as m1, unsharded as m2) on m1.a = m2.b",
+    "FieldQuery": "select m1.col from unsharded as m1 join unsharded as m2 right join unsharded as m3 on m1.a = m2.b where 1 != 1",
+    "Query": "select m1.col from unsharded as m1 join unsharded as m2 right join unsharded as m3 on m1.a = m2.b",
     "Table": "unsharded"
   }
 }
@@ -927,8 +927,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": false
     },
-    "FieldQuery": "select m1.col from unsharded as m1, unsharded as m2 where 1 != 1",
-    "Query": "select m1.col from unsharded as m1, unsharded as m2",
+    "FieldQuery": "select m1.col from unsharded as m1 join unsharded as m2 where 1 != 1",
+    "Query": "select m1.col from unsharded as m1 join unsharded as m2",
     "Table": "unsharded"
   }
 }
@@ -3441,21 +3441,7 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select u1.a from unsharded u1 join unsharded u2 on database()",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectUnsharded",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
-    "FieldQuery": "select u1.a from unsharded as u1, unsharded as u2 where 1 != 1",
-    "Query": "select u1.a from unsharded as u1, unsharded as u2 where database()",
-    "Table": "unsharded"
-  }
-}
+Gen4 plan same as above
 
 # last_insert_id for dual
 "select last_insert_id()"
@@ -3749,21 +3735,7 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select m1.col from (unsharded as m1, unsharded as m2)",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectUnsharded",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
-    "FieldQuery": "select m1.col from unsharded as m1, unsharded as m2 where 1 != 1",
-    "Query": "select m1.col from unsharded as m1, unsharded as m2",
-    "Table": "unsharded"
-  }
-}
+Gen4 plan same as above
 
 # gen4 - optimise plan by merging user_extra and music first, and then querying for user info
 "select 1 from user u join user_extra ue on ue.id = u.id join music m on m.user_id = ue.user_id"

--- a/go/vt/vtgate/planbuilder/testdata/onecase.txt
+++ b/go/vt/vtgate/planbuilder/testdata/onecase.txt
@@ -1,1 +1,19 @@
 # Add your test case here for debugging and run go test -run=One.
+# SelectDBA with uncorrelated subqueries
+"select t.table_schema from information_schema.tables as t where t.table_schema in (select c.column_name from information_schema.columns as c)"
+{
+  "QueryType": "SELECT",
+  "Original": "select t.table_schema from information_schema.tables as t where t.table_schema in (select c.column_name from information_schema.columns as c)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select t.table_schema from information_schema.`tables` as t where 1 != 1",
+    "Query": "select t.table_schema from information_schema.`tables` as t where t.table_schema in (select c.column_name from information_schema.`columns` as c)",
+    "Table": "information_schema.`tables`"
+  }
+}
+Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/onecase.txt
+++ b/go/vt/vtgate/planbuilder/testdata/onecase.txt
@@ -1,19 +1,1 @@
 # Add your test case here for debugging and run go test -run=One.
-# SelectDBA with uncorrelated subqueries
-"select t.table_schema from information_schema.tables as t where t.table_schema in (select c.column_name from information_schema.columns as c)"
-{
-  "QueryType": "SELECT",
-  "Original": "select t.table_schema from information_schema.tables as t where t.table_schema in (select c.column_name from information_schema.columns as c)",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectDBA",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
-    "FieldQuery": "select t.table_schema from information_schema.`tables` as t where 1 != 1",
-    "Query": "select t.table_schema from information_schema.`tables` as t where t.table_schema in (select c.column_name from information_schema.`columns` as c)",
-    "Table": "information_schema.`tables`"
-  }
-}
-Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -1514,7 +1514,21 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
-Gen4 plan same as above
+{
+  "QueryType": "SELECT",
+  "Original": "(select id from unsharded) union (select id from unsharded_auto) order by id limit 5",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select id from unsharded where 1 != 1 union select id from unsharded_auto where 1 != 1",
+    "Query": "select id from unsharded union select id from unsharded_auto order by id asc limit 5",
+    "Table": "unsharded, unsharded_auto"
+  }
+}
 
 # unsharded union
 "select id from unsharded union select id from unsharded_auto union select id from unsharded_auto where id in (132)"
@@ -1543,9 +1557,9 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": false
     },
-    "FieldQuery": "select id from unsharded where 1 != 1 union all select id from unsharded_auto where 1 != 1 union select id from unsharded_auto where 1 != 1",
-    "Query": "select id from unsharded union all select id from unsharded_auto union select id from unsharded_auto where id in (132)",
-    "Table": "unsharded"
+    "FieldQuery": "select id from unsharded where 1 != 1 union select id from unsharded_auto where 1 != 1 union select id from unsharded_auto where 1 != 1",
+    "Query": "select id from unsharded union select id from unsharded_auto union select id from unsharded_auto where id in (132)",
+    "Table": "unsharded, unsharded_auto"
   }
 }
 
@@ -1566,7 +1580,21 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
-Gen4 error: nesting of unions at the right-hand side is not yet supported
+{
+  "QueryType": "SELECT",
+  "Original": "(select id from unsharded union select id from unsharded_auto) union (select id from unsharded_auto union select name from unsharded)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select id from unsharded where 1 != 1 union select id from unsharded_auto where 1 != 1 union select id from unsharded_auto where 1 != 1 union select `name` from unsharded where 1 != 1",
+    "Query": "select id from unsharded union select id from unsharded_auto union select id from unsharded_auto union select `name` from unsharded",
+    "Table": "unsharded, unsharded_auto"
+  }
+}
 
 # unsharded nested union with limit
 "(select id from unsharded order by id asc limit 1) union (select id from unsharded order by id desc limit 1) order by id asc limit 1"

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -1360,20 +1360,20 @@ func parseAndAnalyze(t *testing.T, query, dbName string) (sqlparser.Statement, *
 func TestSingleUnshardedKeyspace(t *testing.T) {
 	tests := []struct {
 		query     string
-		unsharded bool
+		unsharded *vindexes.Keyspace
 	}{
 		{
 			query:     "select 1 from t, t1",
-			unsharded: false, // both tables are unsharded, but from different keyspaces
+			unsharded: nil, // both tables are unsharded, but from different keyspaces
 		}, {
 			query:     "select 1 from t2",
-			unsharded: false,
+			unsharded: nil,
 		}, {
 			query:     "select 1 from t, t2",
-			unsharded: false,
+			unsharded: nil,
 		}, {
 			query:     "select 1 from t as A, t as B",
-			unsharded: true,
+			unsharded: ks1,
 		},
 	}
 
@@ -1383,6 +1383,19 @@ func TestSingleUnshardedKeyspace(t *testing.T) {
 			assert.Equal(t, test.unsharded, semTable.SingleUnshardedKeyspace())
 		})
 	}
+}
+
+var ks1 = &vindexes.Keyspace{
+	Name:    "ks1",
+	Sharded: false,
+}
+var ks2 = &vindexes.Keyspace{
+	Name:    "ks2",
+	Sharded: false,
+}
+var ks3 = &vindexes.Keyspace{
+	Name:    "ks3",
+	Sharded: true,
 }
 
 func fakeSchemaInfo() *FakeSI {
@@ -1397,19 +1410,6 @@ func fakeSchemaInfo() *FakeSI {
 		Name: sqlparser.NewColIdent("name"),
 		Type: querypb.Type_VARCHAR,
 	}}
-
-	ks1 := &vindexes.Keyspace{
-		Name:    "ks1",
-		Sharded: false,
-	}
-	ks2 := &vindexes.Keyspace{
-		Name:    "ks2",
-		Sharded: false,
-	}
-	ks3 := &vindexes.Keyspace{
-		Name:    "ks3",
-		Sharded: true,
-	}
 
 	si := &FakeSI{
 		Tables: map[string]*vindexes.Table{


### PR DESCRIPTION
## Description
During semantic analysis, which happens very early in the query planning process, we have enough information to know that the query is only addressing a single, unsharded keyspace.

In this situation, we can just clean up the query minimally and then send it to the tablet. This way any shortcomings in the rest of the planner does not have to impact these type of queries.

Fixes #9509