### PR TITLE
Fix panic in vtorc tests

### DIFF
--- a/go/test/endtoend/vtorc/general/main_test.go
+++ b/go/test/endtoend/vtorc/general/main_test.go
@@ -49,18 +49,20 @@ func TestMain(m *testing.M) {
 
 	cluster.PanicHandler(nil)
 
-	// stop vtorc first otherwise its logs get polluted
-	// with instances being unreachable triggering unnecessary operations
-	if clusterInfo.ClusterInstance.VtorcProcess != nil {
-		_ = clusterInfo.ClusterInstance.VtorcProcess.TearDown()
-	}
+	if clusterInfo != nil {
+		// stop vtorc first otherwise its logs get polluted
+		// with instances being unreachable triggering unnecessary operations
+		if clusterInfo.ClusterInstance.VtorcProcess != nil {
+			_ = clusterInfo.ClusterInstance.VtorcProcess.TearDown()
+		}
 
-	for _, cellInfo := range clusterInfo.CellInfos {
-		utils.KillTablets(cellInfo.ReplicaTablets)
-		utils.KillTablets(cellInfo.RdonlyTablets)
+		for _, cellInfo := range clusterInfo.CellInfos {
+			utils.KillTablets(cellInfo.ReplicaTablets)
+			utils.KillTablets(cellInfo.RdonlyTablets)
+		}
+		clusterInfo.ClusterInstance.Keyspaces[0].Shards[0].Vttablets = nil
+		clusterInfo.ClusterInstance.Teardown()
 	}
-	clusterInfo.ClusterInstance.Keyspaces[0].Shards[0].Vttablets = nil
-	clusterInfo.ClusterInstance.Teardown()
 
 	if err != nil {
 		fmt.Printf("%v\n", err)

--- a/go/test/endtoend/vtorc/gracefultakeover/main_test.go
+++ b/go/test/endtoend/vtorc/gracefultakeover/main_test.go
@@ -55,18 +55,20 @@ func TestMain(m *testing.M) {
 
 	cluster.PanicHandler(nil)
 
-	// stop vtorc first otherwise its logs get polluted
-	// with instances being unreachable triggering unnecessary operations
-	if clusterInfo.ClusterInstance.VtorcProcess != nil {
-		_ = clusterInfo.ClusterInstance.VtorcProcess.TearDown()
-	}
+	if clusterInfo != nil {
+		// stop vtorc first otherwise its logs get polluted
+		// with instances being unreachable triggering unnecessary operations
+		if clusterInfo.ClusterInstance.VtorcProcess != nil {
+			_ = clusterInfo.ClusterInstance.VtorcProcess.TearDown()
+		}
 
-	for _, cellInfo := range clusterInfo.CellInfos {
-		utils.KillTablets(cellInfo.ReplicaTablets)
-		utils.KillTablets(cellInfo.RdonlyTablets)
+		for _, cellInfo := range clusterInfo.CellInfos {
+			utils.KillTablets(cellInfo.ReplicaTablets)
+			utils.KillTablets(cellInfo.RdonlyTablets)
+		}
+		clusterInfo.ClusterInstance.Keyspaces[0].Shards[0].Vttablets = nil
+		clusterInfo.ClusterInstance.Teardown()
 	}
-	clusterInfo.ClusterInstance.Keyspaces[0].Shards[0].Vttablets = nil
-	clusterInfo.ClusterInstance.Teardown()
 
 	if err != nil {
 		fmt.Printf("%v\n", err)

--- a/go/test/endtoend/vtorc/primaryfailure/main_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/main_test.go
@@ -56,18 +56,20 @@ func TestMain(m *testing.M) {
 
 	cluster.PanicHandler(nil)
 
-	// stop vtorc first otherwise its logs get polluted
-	// with instances being unreachable triggering unnecessary operations
-	if clusterInfo.ClusterInstance.VtorcProcess != nil {
-		_ = clusterInfo.ClusterInstance.VtorcProcess.TearDown()
-	}
+	if clusterInfo != nil {
+		// stop vtorc first otherwise its logs get polluted
+		// with instances being unreachable triggering unnecessary operations
+		if clusterInfo.ClusterInstance.VtorcProcess != nil {
+			_ = clusterInfo.ClusterInstance.VtorcProcess.TearDown()
+		}
 
-	for _, cellInfo := range clusterInfo.CellInfos {
-		utils.KillTablets(cellInfo.ReplicaTablets)
-		utils.KillTablets(cellInfo.RdonlyTablets)
+		for _, cellInfo := range clusterInfo.CellInfos {
+			utils.KillTablets(cellInfo.ReplicaTablets)
+			utils.KillTablets(cellInfo.RdonlyTablets)
+		}
+		clusterInfo.ClusterInstance.Keyspaces[0].Shards[0].Vttablets = nil
+		clusterInfo.ClusterInstance.Teardown()
 	}
-	clusterInfo.ClusterInstance.Keyspaces[0].Shards[0].Vttablets = nil
-	clusterInfo.ClusterInstance.Teardown()
 
 	if err != nil {
 		fmt.Printf("%v\n", err)


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
In the vtorc test suite, if the cluster isn't setup properly and errors out, we should not be calling teardown on it since it leads to panic. This prevents the actual error to be logged. This PR fixes this issue.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->