### PR TITLE
Support sanitizing potentially sensitive information in log messages

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -648,7 +648,7 @@ func (qre *QueryExecutor) verifyRowCount(count, maxrows int64) error {
 	if warnThreshold > 0 && count > warnThreshold {
 		callerID := callerid.ImmediateCallerIDFromContext(qre.ctx)
 		qre.tsv.Stats().Warnings.Add("ResultsExceeded", 1)
-		log.Warningf("caller id: %s row count %v exceeds warning threshold %v: %q", callerID.Username, count, warnThreshold, queryAsString(qre.plan.FullQuery.Query, qre.bindVars))
+		log.Warningf("caller id: %s row count %v exceeds warning threshold %v: %q", callerID.Username, count, warnThreshold, queryAsString(qre.plan.FullQuery.Query, qre.bindVars, qre.tsv.Config().SanitizeLogMessages))
 	}
 	return nil
 }

--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -175,11 +175,11 @@ func (sc *StatefulConnection) Renew() error {
 }
 
 // String returns a printable version of the connection info.
-func (sc *StatefulConnection) String() string {
+func (sc *StatefulConnection) String(sanitize bool) string {
 	return fmt.Sprintf(
 		"%v\t%s",
 		sc.ConnID,
-		sc.txProps.String(),
+		sc.txProps.String(sanitize),
 	)
 }
 
@@ -268,7 +268,7 @@ func (sc *StatefulConnection) LogTransaction(reason tx.ReleaseReason) {
 	sc.Stats().UserTransactionTimesNs.Add([]string{username, reason.Name()}, int64(duration))
 	sc.txProps.Stats.Add(reason.Name(), duration)
 	if sc.txProps.LogToFile {
-		log.Infof("Logged transaction: %s", sc.String())
+		log.Infof("Logged transaction: %s", sc.String(sc.env.Config().SanitizeLogMessages))
 	}
 	tabletenv.TxLogger.Send(sc)
 }

--- a/go/vt/vttablet/tabletserver/stateful_connection_pool.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection_pool.go
@@ -93,7 +93,7 @@ func (sf *StatefulConnectionPool) Close() {
 		if conn.IsInTransaction() {
 			thing = "transaction"
 		}
-		log.Warningf("killing %s for shutdown: %s", thing, conn.String())
+		log.Warningf("killing %s for shutdown: %s", thing, conn.String(sf.env.Config().SanitizeLogMessages))
 		sf.env.Stats().InternalErrors.Add("StrayTransactions", 1)
 		conn.Close()
 		conn.Releasef("pool closed")

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -121,7 +121,7 @@ func init() {
 	flag.BoolVar(&currentConfig.StrictTableACL, "queryserver-config-strict-table-acl", defaultConfig.StrictTableACL, "only allow queries that pass table acl checks")
 	flag.BoolVar(&currentConfig.EnableTableACLDryRun, "queryserver-config-enable-table-acl-dry-run", defaultConfig.EnableTableACLDryRun, "If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results")
 	flag.StringVar(&currentConfig.TableACLExemptACL, "queryserver-config-acl-exempt-acl", defaultConfig.TableACLExemptACL, "an acl that exempt from table acl checking (this acl is free to access any vitess tables).")
-	flag.BoolVar(&currentConfig.TerseErrors, "queryserver-config-terse-errors", defaultConfig.TerseErrors, "prevent bind vars from escaping in returned or logged errors")
+	flag.BoolVar(&currentConfig.TerseErrors, "queryserver-config-terse-errors", defaultConfig.TerseErrors, "prevent bind vars from escaping in client error messages")
 	flag.BoolVar(&currentConfig.AnnotateQueries, "queryserver-config-annotate-queries", defaultConfig.AnnotateQueries, "prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type")
 	flag.StringVar(&deprecatedPoolNamePrefix, "pool-name-prefix", "", "Deprecated")
 	flag.BoolVar(&currentConfig.WatchReplication, "watch_replication_stream", false, "When enabled, vttablet will stream the MySQL replication stream from the local server, and use it to update schema when it sees a DDL.")
@@ -164,7 +164,7 @@ func init() {
 
 	flag.BoolVar(&enableReplicationReporter, "enable_replication_reporter", false, "Use polling to track replication lag.")
 	flag.BoolVar(&currentConfig.EnableOnlineDDL, "queryserver_enable_online_ddl", true, "Enable online DDL.")
-	flag.BoolVar(&currentConfig.SanitizeLogMessages, "sanitize_log_messages", false, "Do not log potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.")
+	flag.BoolVar(&currentConfig.SanitizeLogMessages, "sanitize_log_messages", false, "Remove potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.")
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -164,6 +164,7 @@ func init() {
 
 	flag.BoolVar(&enableReplicationReporter, "enable_replication_reporter", false, "Use polling to track replication lag.")
 	flag.BoolVar(&currentConfig.EnableOnlineDDL, "queryserver_enable_online_ddl", true, "Enable online DDL.")
+	flag.BoolVar(&currentConfig.SanitizeLogMessages, "sanitize_log_messages", false, "Do not log potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.")
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.
@@ -268,6 +269,7 @@ type TabletConfig struct {
 
 	ExternalConnections map[string]*dbconfigs.DBConfigs `json:"externalConnections,omitempty"`
 
+	SanitizeLogMessages     bool    `json:"-"`
 	StrictTableACL          bool    `json:"-"`
 	EnableTableACLDryRun    bool    `json:"-"`
 	TableACLExemptACL       string  `json:"-"`

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1417,7 +1417,7 @@ func TestSanitizedMessagesNonSQLError(t *testing.T) {
 	want := "tablet error"
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), want)
-	want = "Sql: \"select * from test_table\", BindVars: {[REDACTED]}"
+	want = "Sql: \"select * from test_table\", BindVars: {}"
 	if !strings.Contains(tl.getLog(0), want) {
 		t.Errorf("error log %s, want '%s'", tl.getLog(0), want)
 	}
@@ -1463,7 +1463,7 @@ func TestSanitizedMessagesNoBindVars(t *testing.T) {
 	want := "sensitive message"
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), want)
-	want = "Sql: \"\", BindVars: {[REDACTED]}"
+	want = "Sql: \"\", BindVars: {}"
 	if !strings.Contains(tl.getLog(0), want) {
 		t.Errorf("error log '%s', want '%s'", tl.getLog(0), want)
 	}
@@ -1496,8 +1496,8 @@ func TestTruncateMessages(t *testing.T) {
 		t.Errorf("error got '%v', want '%s'", err, wantErr)
 	}
 
-	// but log *is* truncated
-	wantLog := "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vt [TRUNCATED]\", BindVars: {vtg1: \"type:VARCHAR value:\\\"t [TRUNCATED]"
+	// but log *is* truncated, and sanitized
+	wantLog := "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vt [TRUNCATED]\", BindVars: {[REDACTED]}"
 	if wantLog != tl.getLog(0) {
 		t.Errorf("log got '%s', want '%s'", tl.getLog(0), wantLog)
 	}
@@ -1517,8 +1517,8 @@ func TestTruncateMessages(t *testing.T) {
 		t.Errorf("error got '%v', want '%s'", err, wantErr)
 	}
 
-	// Log not truncated, since our limit is large enough now
-	wantLog = "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vtg1 order by abc desc\", BindVars: {vtg1: \"type:VARCHAR value:\\\"this is kinda long eh\\\"\"}"
+	// Log not truncated, since our limit is large enough now, but it is still sanitized
+	wantLog = "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vtg1 order by abc desc\", BindVars: {[REDACTED]}"
 	if wantLog != tl.getLog(1) {
 		t.Errorf("log got '%s', want '%s'", tl.getLog(1), wantLog)
 	}

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -123,7 +123,7 @@ func (tp *TxPool) Shutdown(ctx context.Context) {
 func (tp *TxPool) transactionKiller() {
 	defer tp.env.LogError()
 	for _, conn := range tp.scp.GetOutdated(tp.Timeout(), "for tx killer rollback") {
-		log.Warningf("killing transaction (exceeded timeout: %v): %s", tp.Timeout(), conn.String())
+		log.Warningf("killing transaction (exceeded timeout: %v): %s", tp.Timeout(), conn.String(tp.env.Config().SanitizeLogMessages))
 		switch {
 		case conn.IsTainted():
 			conn.Close()


### PR DESCRIPTION
## Description
Add a new `vttablet` flag:
   - Name: `sanitize_log_messages`
   - Default: false (no change in behavior, opt-in)
   - Description: Do not log potentially sensitive information in INFO, WARNING, and ERROR log messages such as query parameters

Use this where we make calls to `log.Info[f]`, `log.Warning[f]`, and `log.Error[f]` (glog) to ensure that we are sanitizing any potentially sensitive information. For example, here as this includes queries in the log message:
```
log.Warningf("killing transaction (exceeded timeout: %v): %s", tp.Timeout(), conn.String(tp.env.Config().SanitizeLogMessages))
```

Initially this will be used primarily to redact query/bind parameters from logged queries but this can be used going forward to sanitize any potentially sensitive information in the log messages.

## Related Issue(s)
Follow-up to: https://github.com/vitessio/vitess/pull/9470
Fixes: https://github.com/vitessio/vitess/issues/9469

## Checklist
- [x] Should this PR be backported? Yes, to release-13.0
- [x] Tests were added/updated
- [x] Documentation PR: https://github.com/vitessio/website/pull/950