### PR TITLE
non-unique vindex routing in update and delete query

### DIFF
--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -78,9 +78,7 @@ func (del *Delete) TryExecute(vcursor VCursor, bindVars map[string]*querypb.Bind
 	switch del.Opcode {
 	case Unsharded:
 		return del.execUnsharded(vcursor, bindVars, rss)
-	case Equal:
-		return del.execEqual(vcursor, bindVars, rss, del.deleteVindexEntries)
-	case IN, Scatter, ByDestination:
+	case Equal, IN, Scatter, ByDestination:
 		return del.execMultiDestination(vcursor, bindVars, rss, del.deleteVindexEntries)
 	default:
 		// Unreachable.

--- a/go/vt/vtgate/engine/dml.go
+++ b/go/vt/vtgate/engine/dml.go
@@ -70,21 +70,10 @@ func (dml *DML) execUnsharded(vcursor VCursor, bindVars map[string]*querypb.Bind
 	return execShard(vcursor, dml.Query, bindVars, rss[0], true, true /* canAutocommit */)
 }
 
-func (dml *DML) execEqual(vcursor VCursor, bindVars map[string]*querypb.BindVariable, rss []*srvtopo.ResolvedShard, dmlSpecialFunc func(VCursor, map[string]*querypb.BindVariable, []*srvtopo.ResolvedShard) error) (*sqltypes.Result, error) {
+func (dml *DML) execMultiDestination(vcursor VCursor, bindVars map[string]*querypb.BindVariable, rss []*srvtopo.ResolvedShard, dmlSpecialFunc func(VCursor, map[string]*querypb.BindVariable, []*srvtopo.ResolvedShard) error) (*sqltypes.Result, error) {
 	if len(rss) == 0 {
 		return &sqltypes.Result{}, nil
 	}
-	if len(rss) != 1 {
-		return nil, fmt.Errorf("ResolveDestinations maps to %v shards", len(rss))
-	}
-	err := dmlSpecialFunc(vcursor, bindVars, rss)
-	if err != nil {
-		return nil, err
-	}
-	return execShard(vcursor, dml.Query, bindVars, rss[0], true /* rollbackOnError */, true /* canAutocommit */)
-}
-
-func (dml *DML) execMultiDestination(vcursor VCursor, bindVars map[string]*querypb.BindVariable, rss []*srvtopo.ResolvedShard, dmlSpecialFunc func(VCursor, map[string]*querypb.BindVariable, []*srvtopo.ResolvedShard) error) (*sqltypes.Result, error) {
 	err := dmlSpecialFunc(vcursor, bindVars, rss)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/engine/update.go
+++ b/go/vt/vtgate/engine/update.go
@@ -88,9 +88,7 @@ func (upd *Update) TryExecute(vcursor VCursor, bindVars map[string]*querypb.Bind
 	switch upd.Opcode {
 	case Unsharded:
 		return upd.execUnsharded(vcursor, bindVars, rss)
-	case Equal:
-		return upd.execEqual(vcursor, bindVars, rss, upd.updateVindexEntries)
-	case IN, Scatter, ByDestination:
+	case Equal, IN, Scatter, ByDestination:
 		return upd.execMultiDestination(vcursor, bindVars, rss, upd.updateVindexEntries)
 	default:
 		// Unreachable.

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -79,9 +79,6 @@ func getDMLRouting(where *sqlparser.Where, table *vindexes.Table) (
 	filters := sqlparser.SplitAndExpression(nil, where.Expr)
 	// go over the vindexes in the order of increasing cost
 	for _, colVindex := range table.Ordered {
-		if !colVindex.IsUnique() {
-			continue
-		}
 		if lu, isLu := colVindex.Vindex.(vindexes.LookupBackfill); isLu && lu.IsBackfilling() {
 			// Checking if the Vindex is currently backfilling or not, if it isn't we can read from the vindex table
 			// and we will be able to do a delete equal. Otherwise, we continue to look for next best vindex.

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -3019,3 +3019,111 @@ Gen4 plan same as above
   }
 }
 Gen4 plan same as above
+
+# delete with routing using non-unique lookup vindex
+"delete from multicol_tbl where name = 'foo'"
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where name = 'foo'",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where `name` = 'foo' for update",
+    "Query": "delete from multicol_tbl where `name` = 'foo'",
+    "Table": "multicol_tbl",
+    "Values": [
+      "VARBINARY(\"foo\")"
+    ],
+    "Vindex": "name_muticoltbl_map"
+  }
+}
+Gen4 plan same as above
+
+# delete with routing using subsharding column
+"delete from multicol_tbl where cola = 1"
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where cola = 1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where cola = 1 for update",
+    "Query": "delete from multicol_tbl where cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# delete with routing using subsharding column with in query
+"delete from multicol_tbl where cola in (1,2)"
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where cola in (1,2)",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where cola in (1, 2) for update",
+    "Query": "delete from multicol_tbl where cola in (1, 2)",
+    "Table": "multicol_tbl",
+    "Values": [
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# delete with routing using subsharding column with in query as lower cost over lookup vindex
+"delete from multicol_tbl where name = 'foo' and cola = 2"
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where name = 'foo' and cola = 2",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where `name` = 'foo' and cola = 2 for update",
+    "Query": "delete from multicol_tbl where `name` = 'foo' and cola = 2",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -2887,3 +2887,135 @@ Gen4 plan same as above
   }
 }
 Gen4 plan same as above
+
+# update with routing using non-unique lookup vindex
+"update multicol_tbl set x = 42 where name = 'foo'"
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set x = 42 where name = 'foo'",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update multicol_tbl set x = 42 where `name` = 'foo'",
+    "Table": "multicol_tbl",
+    "Values": [
+      "VARBINARY(\"foo\")"
+    ],
+    "Vindex": "name_muticoltbl_map"
+  }
+}
+Gen4 plan same as above
+
+# update with routing using subsharding column
+"update multicol_tbl set x = 42 where cola = 1"
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set x = 42 where cola = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update multicol_tbl set x = 42 where cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# update with routing using subsharding column on lookup vindex
+"update multicol_tbl set name = 'bar' where cola = 1"
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set name = 'bar' where cola = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "ChangedVindexValues": [
+      "name_muticoltbl_map:4"
+    ],
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name`, `name` = 'bar' from multicol_tbl where cola = 1 for update",
+    "Query": "update multicol_tbl set `name` = 'bar' where cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# update with routing using subsharding column with in query
+"update multicol_tbl set name = 'bar' where cola in (1,2)"
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set name = 'bar' where cola in (1,2)",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "ChangedVindexValues": [
+      "name_muticoltbl_map:4"
+    ],
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name`, `name` = 'bar' from multicol_tbl where cola in (1, 2) for update",
+    "Query": "update multicol_tbl set `name` = 'bar' where cola in (1, 2)",
+    "Table": "multicol_tbl",
+    "Values": [
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# update with routing using subsharding column with in query as lower cost over lookup vindex
+"update multicol_tbl set x = 1 where name = 'foo' and cola = 2"
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set x = 1 where name = 'foo' and cola = 2",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update multicol_tbl set x = 1 where `name` = 'foo' and cola = 2",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -2761,7 +2761,7 @@ Gen4 plan same as above
     "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where cola = 1 and colb = 2 for update",
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where cola = 1 and colb = 2 for update",
     "Query": "delete from multicol_tbl where cola = 1 and colb = 2",
     "Table": "multicol_tbl",
     "Values": [
@@ -2789,7 +2789,7 @@ Gen4 plan same as above
     "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where colb = 2 and cola = 1 for update",
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where colb = 2 and cola = 1 for update",
     "Query": "delete from multicol_tbl where colb = 2 and cola = 1",
     "Table": "multicol_tbl",
     "Values": [
@@ -2817,7 +2817,7 @@ Gen4 plan same as above
     "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where colb in (1, 2) and cola = 1 for update",
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where colb in (1, 2) and cola = 1 for update",
     "Query": "delete from multicol_tbl where colb in (1, 2) and cola = 1",
     "Table": "multicol_tbl",
     "Values": [
@@ -2845,7 +2845,7 @@ Gen4 plan same as above
     "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where colb in (1, 2) and cola in (3, 4) for update",
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where colb in (1, 2) and cola in (3, 4) for update",
     "Query": "delete from multicol_tbl where colb in (1, 2) and cola in (3, 4)",
     "Table": "multicol_tbl",
     "Values": [
@@ -2871,12 +2871,12 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "ChangedVindexValues": [
-      "colc_map:3"
+      "colc_map:4"
     ],
     "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select cola, colb, colc, colc = 1 from multicol_tbl where cola = 1 and colb = 2 for update",
+    "OwnedVindexQuery": "select cola, colb, colc, `name`, colc = 1 from multicol_tbl where cola = 1 and colb = 2 for update",
     "Query": "update multicol_tbl set colc = 1 where cola = 1 and colb = 2",
     "Table": "multicol_tbl",
     "Values": [

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -91,6 +91,10 @@
         "colc_map": {
           "type": "lookup_test",
           "owner": "multicol_tbl"
+        },
+        "name_muticoltbl_map": {
+          "type": "name_lkp_test",
+          "owner": "multicol_tbl"
         }
       },
       "tables": {
@@ -308,6 +312,10 @@
             {
               "column": "colc",
               "name": "colc_map"
+            },
+            {
+              "column": "name",
+              "name": "name_muticoltbl_map"
             }
           ]
         }

--- a/go/vt/vtgate/vindexes/consistent_lookup.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup.go
@@ -100,7 +100,7 @@ func (lu *ConsistentLookup) Map(vcursor VCursor, ids []sqltypes.Value) ([]key.De
 		return out, nil
 	}
 
-	results, err := lu.lkp.Lookup(vcursor, ids, vtgatepb.CommitOrder_PRE)
+	results, err := lu.lkp.Lookup(vcursor, ids, vcursor.LookupRowLockShardSession())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds supported for extracting routing information from update/delete query and using non-unique lookup vindex if available and having lowest cost among other options.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->