### PR TITLE
mysql: use UTF8mb4 as consistent connection charset

### DIFF
--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -136,7 +136,6 @@ func init() {
 		"Rdonly tablets per shard")
 
 	flag.StringVar(&config.Charset, "charset", "utf8mb4", "MySQL charset")
-	flag.StringVar(&config.Collation, "collation", "", "MySQL collation")
 
 	flag.StringVar(&config.PlannerVersion, "planner_version", "v3", "Sets the default planner to use when the session has not changed it. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. Gen4Fallback tries the new gen4 planner and falls back to the V3 planner if the gen4 fails. All Gen4 versions should be considered experimental!")
 

--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -222,7 +222,7 @@ func (c *Conn) clientHandshake(params *ConnParams) error {
 		c.Capabilities = capabilities & (CapabilityClientDeprecateEOF)
 	}
 
-	charset, err := collations.ParseConnectionCharset(params.Charset)
+	charset, err := collations.Local().ParseConnectionCharset(params.Charset)
 	if err != nil {
 		return err
 	}

--- a/go/mysql/collations/8bit.go
+++ b/go/mysql/collations/8bit.go
@@ -224,8 +224,6 @@ func weightStringPadingSimple(padChar byte, dst []byte, numCodepoints int, padTo
 	return dst
 }
 
-const CollationBinaryID ID = 63
-
 type Collation_binary struct{}
 
 func (c *Collation_binary) Init() {}

--- a/go/mysql/collations/env.go
+++ b/go/mysql/collations/env.go
@@ -236,7 +236,8 @@ const (
 )
 
 func ParseConnectionCharset(csname string) (uint8, error) {
-	switch strings.ToLower(csname) {
+	csname = strings.ToLower(csname)
+	switch csname {
 	case "utf8mb4":
 		return CollationUtf8mb4ID, nil
 	case "utf8":
@@ -246,6 +247,13 @@ func ParseConnectionCharset(csname string) (uint8, error) {
 	case "":
 		return DefaultConnectionCharset, nil
 	default:
+		for id, meta := range globalVersionInfo {
+			for _, alias := range meta.alias {
+				if alias == csname && id < 256 {
+					return uint8(id), nil
+				}
+			}
+		}
 		return 0, fmt.Errorf("unsupported connection charset: %q", csname)
 	}
 }

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -182,17 +182,14 @@ type Conn struct {
 	// by Handler methods.
 	StatusFlags uint16
 
-	// CharacterSet is the character set used by the other side of the
-	// connection.
-	// It is set during the initial handshake.
-	// See the values in constants.go.
-	CharacterSet uint8
-
-	// Collation defines the collation for this connection, it has the same
-	// value as the collation_connection variable of MySQL.
-	// Its value is set after we send the initial "SET collation_connection"
-	// query to MySQL after the handshake is done.
-	Collation collations.ID
+	// CharacterSet is the charset for this connection, as negotiated
+	// in our handshake with the server. Note that although the MySQL protocol lists this
+	// as a "character set", the returned byte value is actually a Collation ID,
+	// and hence it's casted as such here.
+	// If the user has specified a custom Collation in the ConnParams for this
+	// connection, once the CharacterSet has been negotiated, we will override
+	// it via SQL and update this field accordingly.
+	CharacterSet collations.ID
 
 	// Packet encoding variables.
 	sequence uint8

--- a/go/mysql/conn_params.go
+++ b/go/mysql/conn_params.go
@@ -29,7 +29,6 @@ type ConnParams struct {
 	DbName     string `json:"dbname"`
 	UnixSocket string `json:"unix_socket"`
 	Charset    string `json:"charset"`
-	Collation  string `json:"collation"`
 	Flags      uint64 `json:"flags"`
 	Flavor     string `json:"flavor,omitempty"`
 

--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -591,21 +591,6 @@ const (
 	SSQueryInterrupted = "70100"
 )
 
-// A few interesting character set values.
-// See http://dev.mysql.com/doc/internals/en/character-set.html#packet-Protocol::CharacterSet
-const (
-	DefaultCollation = "utf8mb4_general_ci"
-
-	// CharacterSetUtf8 is for UTF8.
-	CharacterSetUtf8 = 33
-
-	// CharacterSetUtf8mb4 is for 4-bytes UTF8.
-	CharacterSetUtf8mb4 = 45
-
-	// CharacterSetBinary is for binary. Use by integer fields for instance.
-	CharacterSetBinary = 63
-)
-
 // CharacterSetEncoding maps a charset name to a golang encoder.
 // golang does not support encoders for all MySQL charsets.
 // A charset not in this map is unsupported.

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -272,8 +272,6 @@ func (db *DB) ConnParams() dbconfigs.Connector {
 		UnixSocket: db.socketFile,
 		Uname:      "user1",
 		Pass:       "password1",
-		Charset:    "utf8mb4",
-		Collation:  "utf8mb4_general_ci",
 	})
 }
 
@@ -283,7 +281,6 @@ func (db *DB) ConnParamsWithUname(uname string) dbconfigs.Connector {
 		UnixSocket: db.socketFile,
 		Uname:      uname,
 		Pass:       "password1",
-		Charset:    "utf8",
 	})
 }
 

--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -131,7 +132,7 @@ var BaseShowTablesFields = []*querypb.Field{{
 	Database:     "information_schema",
 	OrgName:      "TABLE_NAME",
 	ColumnLength: 192,
-	Charset:      CharacterSetUtf8,
+	Charset:      collations.CollationUtf8ID,
 	Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 }, {
 	Name:         "t.table_type",
@@ -141,13 +142,13 @@ var BaseShowTablesFields = []*querypb.Field{{
 	Database:     "information_schema",
 	OrgName:      "TABLE_TYPE",
 	ColumnLength: 192,
-	Charset:      CharacterSetUtf8,
+	Charset:      collations.CollationUtf8ID,
 	Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 }, {
 	Name:         "unix_timestamp(t.create_time)",
 	Type:         querypb.Type_INT64,
 	ColumnLength: 11,
-	Charset:      CharacterSetBinary,
+	Charset:      collations.CollationBinaryID,
 	Flags:        uint32(querypb.MySqlFlag_BINARY_FLAG | querypb.MySqlFlag_NUM_FLAG),
 }, {
 	Name:         "t.table_comment",
@@ -157,19 +158,19 @@ var BaseShowTablesFields = []*querypb.Field{{
 	Database:     "information_schema",
 	OrgName:      "TABLE_COMMENT",
 	ColumnLength: 6144,
-	Charset:      CharacterSetUtf8,
+	Charset:      collations.CollationUtf8ID,
 	Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 }, {
 	Name:         "i.file_size",
 	Type:         querypb.Type_INT64,
 	ColumnLength: 11,
-	Charset:      CharacterSetBinary,
+	Charset:      collations.CollationBinaryID,
 	Flags:        uint32(querypb.MySqlFlag_BINARY_FLAG | querypb.MySqlFlag_NUM_FLAG),
 }, {
 	Name:         "i.allocated_size",
 	Type:         querypb.Type_INT64,
 	ColumnLength: 11,
-	Charset:      CharacterSetBinary,
+	Charset:      collations.CollationBinaryID,
 	Flags:        uint32(querypb.MySqlFlag_BINARY_FLAG | querypb.MySqlFlag_NUM_FLAG),
 }}
 

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -592,7 +592,7 @@ func (c *Conn) writeHandshakeV10(serverVersion string, authServer AuthServer, en
 	pos = writeUint16(data, pos, uint16(capabilities))
 
 	// Character set.
-	pos = writeByte(data, pos, collations.DefaultConnectionCharset)
+	pos = writeByte(data, pos, collations.Local().DefaultConnectionCharset())
 
 	// Status flag.
 	pos = writeUint16(data, pos, c.StatusFlags)

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/vt/servenv"
 
 	"vitess.io/vitess/go/sqlescape"
@@ -591,7 +592,7 @@ func (c *Conn) writeHandshakeV10(serverVersion string, authServer AuthServer, en
 	pos = writeUint16(data, pos, uint16(capabilities))
 
 	// Character set.
-	pos = writeByte(data, pos, CharacterSetUtf8)
+	pos = writeByte(data, pos, collations.DefaultConnectionCharset)
 
 	// Status flag.
 	pos = writeUint16(data, pos, c.StatusFlags)
@@ -670,7 +671,7 @@ func (l *Listener) parseClientHandshakePacket(c *Conn, firstTime bool, data []by
 	if !ok {
 		return "", "", nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "parseClientHandshakePacket: can't read characterSet")
 	}
-	c.CharacterSet = characterSet
+	c.CharacterSet = collations.ID(characterSet)
 
 	// 23x reserved zero bytes.
 	pos += 23

--- a/go/test/endtoend/vtgate/reservedconn/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/main_test.go
@@ -120,7 +120,7 @@ func TestMain(m *testing.M) {
 			SchemaSQL: sqlSchema,
 			VSchema:   vSchema,
 		}
-		clusterInstance.VtTabletExtraArgs = []string{"-queryserver-config-transaction-timeout", "5"}
+		clusterInstance.VtTabletExtraArgs = []string{"-queryserver-config-transaction-timeout", "5", "-mysql_server_version", "5.7.0"}
 		if err := clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 1, false); err != nil {
 			return 1
 		}

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -33,8 +33,9 @@ func TestSetSysVarSingle(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
-		Host: "localhost",
-		Port: clusterInstance.VtgateMySQLPort,
+		Host:    "localhost",
+		Port:    clusterInstance.VtgateMySQLPort,
+		Charset: "utf8mb4",
 	}
 	type queriesWithExpectations struct {
 		name, expr, expected string

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -33,9 +33,8 @@ func TestSetSysVarSingle(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{
-		Host:    "localhost",
-		Port:    clusterInstance.VtgateMySQLPort,
-		Charset: "utf8mb4",
+		Host: "localhost",
+		Port: clusterInstance.VtgateMySQLPort,
 	}
 	type queriesWithExpectations struct {
 		name, expr, expected string

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -75,7 +75,6 @@ type DBConfigs struct {
 	Host                       string        `json:"host,omitempty"`
 	Port                       int           `json:"port,omitempty"`
 	Charset                    string        `json:"charset,omitempty"`
-	Collation                  string        `json:"collation,omitempty"`
 	Flags                      uint64        `json:"flags,omitempty"`
 	Flavor                     string        `json:"flavor,omitempty"`
 	SslMode                    vttls.SslMode `json:"sslMode,omitempty"`
@@ -129,7 +128,6 @@ func registerBaseFlags() {
 	flag.StringVar(&GlobalDBConfigs.Host, "db_host", "", "The host name for the tcp connection.")
 	flag.IntVar(&GlobalDBConfigs.Port, "db_port", 0, "tcp port")
 	flag.StringVar(&GlobalDBConfigs.Charset, "db_charset", "utf8mb4", "Character set used for this tablet.")
-	flag.StringVar(&GlobalDBConfigs.Collation, "db_collation", "", "Collation used for this tablet. If this flag is empty, the default collation for the character set will be used.")
 	flag.Uint64Var(&GlobalDBConfigs.Flags, "db_flags", 0, "Flag values as defined by MySQL.")
 	flag.StringVar(&GlobalDBConfigs.Flavor, "db_flavor", "", "Flavor overrid. Valid value is FilePos.")
 	flag.Var(&GlobalDBConfigs.SslMode, "db_ssl_mode", "SSL mode to connect with. One of disabled, preferred, required, verify_ca & verify_identity.")
@@ -358,18 +356,9 @@ func (dbcfgs *DBConfigs) InitWithSocket(defaultSocketFile string) {
 		}
 
 		// If the connection params has a charset defined, it will not be overridden by the
-		// global configuration, same thing applies to the collation field.
-		// At a later stage, when we establish a connection with MySQL, we will receive the
-		// server name back, and we will be able to create a collation environment which is
-		// required to figure out the default collation of a charset or if a collation is valid.
-		// This collation environment will be stored directly in the connection parameters as
-		// only the individual connection parameters are used to talk with MySQL, not the global
-		// connection parameter (DBConfigs).
+		// global configuration.
 		if dbcfgs.Charset != "" && cp.Charset == "" {
 			cp.Charset = dbcfgs.Charset
-		}
-		if dbcfgs.Collation != "" && cp.Collation == "" {
-			cp.Collation = dbcfgs.Collation
 		}
 
 		if dbcfgs.Flags != 0 {
@@ -444,7 +433,6 @@ func NewTestDBConfigs(genParams, appDebugParams mysql.ConnParams, dbname string)
 		replParams:         genParams,
 		externalReplParams: genParams,
 		DBName:             dbname,
-		Collation:          "utf8mb4_general_ci",
-		Charset:            "utf8mb4",
+		Charset:            "utf8mb4_general_ci",
 	}
 }

--- a/go/vt/dbconfigs/dbconfigs_test.go
+++ b/go/vt/dbconfigs/dbconfigs_test.go
@@ -46,7 +46,6 @@ func TestInit(t *testing.T) {
 		Port:                       1,
 		Socket:                     "b",
 		Charset:                    "utf8mb4",
-		Collation:                  "utf8mb4_general_ci",
 		Flags:                      2,
 		Flavor:                     "flavor",
 		SslCa:                      "d",
@@ -82,7 +81,6 @@ func TestInit(t *testing.T) {
 		Pass:             "apppass",
 		UnixSocket:       "b",
 		Charset:          "utf8mb4",
-		Collation:        "utf8mb4_general_ci",
 		Flags:            2,
 		Flavor:           "flavor",
 		ConnectTimeoutMs: 250,
@@ -94,7 +92,6 @@ func TestInit(t *testing.T) {
 		Port:             1,
 		UnixSocket:       "b",
 		Charset:          "utf8mb4",
-		Collation:        "utf8mb4_general_ci",
 		Flags:            2,
 		Flavor:           "flavor",
 		SslCa:            "d",
@@ -111,7 +108,6 @@ func TestInit(t *testing.T) {
 		Pass:             "dbapass",
 		UnixSocket:       "b",
 		Charset:          "utf8mb4",
-		Collation:        "utf8mb4_general_ci",
 		Flags:            2,
 		Flavor:           "flavor",
 		SslCa:            "d",
@@ -148,7 +144,6 @@ func TestInit(t *testing.T) {
 		appParams: mysql.ConnParams{
 			UnixSocket: "socket",
 			Charset:    "utf8mb4",
-			Collation:  "", // should be transformed to the default collation for its charset
 		},
 		dbaParams: mysql.ConnParams{
 			Host:  "host",
@@ -236,7 +231,6 @@ func TestAccessors(t *testing.T) {
 		replParams:     mysql.ConnParams{},
 		DBName:         "db",
 		Charset:        "utf8",
-		Collation:      "utf8_general_ci",
 	}
 	if got, want := dbc.AppWithDB().connParams.DbName, "db"; got != want {
 		t.Errorf("dbc.AppWithDB().DbName: %v, want %v", got, want)

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -26,6 +26,7 @@ package mysqlctl
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -41,8 +42,6 @@ import (
 	"time"
 
 	rice "github.com/GeertJohan/go.rice"
-
-	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -663,7 +662,6 @@ func (mysqld *Mysqld) Init(ctx context.Context, cnf *Mycnf, initDBSQLFile string
 	// user is created yet.
 	params := &mysql.ConnParams{
 		Uname:      "root",
-		Charset:    "utf8mb4",
 		UnixSocket: cnf.SocketFile,
 	}
 	if err = mysqld.wait(ctx, cnf, params); err != nil {

--- a/go/vt/vtgate/evalengine/convert.go
+++ b/go/vt/vtgate/evalengine/convert.go
@@ -161,8 +161,7 @@ func getCollation(expr sqlparser.Expr, lookup ConverterLookup) collations.TypedC
 	if lookup != nil {
 		collation.Collation = lookup.CollationIDLookup(expr)
 	} else {
-		sysdefault, _ := collations.Local().ResolveCollation("", "")
-		collation.Collation = sysdefault.ID()
+		collation.Collation = collations.DefaultConnectionCharset
 	}
 	return collation
 }

--- a/go/vt/vtgate/evalengine/convert.go
+++ b/go/vt/vtgate/evalengine/convert.go
@@ -161,7 +161,7 @@ func getCollation(expr sqlparser.Expr, lookup ConverterLookup) collations.TypedC
 	if lookup != nil {
 		collation.Collation = lookup.CollationIDLookup(expr)
 	} else {
-		collation.Collation = collations.DefaultConnectionCharset
+		collation.Collation = collations.ID(collations.Local().DefaultConnectionCharset())
 	}
 	return collation
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -35,7 +35,7 @@ import (
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/cache"
 	"vitess.io/vitess/go/hack"
-	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/sync2"
@@ -1544,7 +1544,7 @@ func buildVarCharFields(names ...string) []*querypb.Field {
 		fields[i] = &querypb.Field{
 			Name:    v,
 			Type:    sqltypes.VarChar,
-			Charset: mysql.CharacterSetUtf8,
+			Charset: collations.CollationUtf8ID,
 			Flags:   uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 		}
 	}

--- a/go/vt/vtgate/planbuilder/show.go
+++ b/go/vt/vtgate/planbuilder/show.go
@@ -21,12 +21,12 @@ import (
 	"regexp"
 	"strings"
 
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 
-	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -284,7 +284,7 @@ func buildVarCharFields(names ...string) []*querypb.Field {
 		fields[i] = &querypb.Field{
 			Name:    v,
 			Type:    sqltypes.VarChar,
-			Charset: mysql.CharacterSetUtf8,
+			Charset: collations.CollationUtf8ID,
 			Flags:   uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 		}
 	}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -144,7 +144,6 @@ func newVCursorImpl(
 	}
 
 	// we only support collations for the new TabletGateway implementation
-	collationEnv := collations.Local()
 	var connCollation collations.ID
 	if executor != nil {
 		if gw, isTabletGw := executor.resolver.resolver.GetGateway().(*TabletGateway); isTabletGw {
@@ -152,11 +151,7 @@ func newVCursorImpl(
 		}
 	}
 	if connCollation == collations.Unknown {
-		coll, err := collationEnv.ResolveCollation("", "")
-		if err != nil {
-			panic("should never happen: don't know how to resolve default collation")
-		}
-		connCollation = coll.ID()
+		connCollation = collations.DefaultConnectionCharset
 	}
 
 	return &vcursorImpl{

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -151,7 +151,7 @@ func newVCursorImpl(
 		}
 	}
 	if connCollation == collations.Unknown {
-		connCollation = collations.DefaultConnectionCharset
+		connCollation = collations.ID(collations.Local().DefaultConnectionCharset())
 	}
 
 	return &vcursorImpl{

--- a/go/vt/vttablet/endtoend/connkilling/main_test.go
+++ b/go/vt/vttablet/endtoend/connkilling/main_test.go
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 				},
 			},
 			OnlyMySQL: true,
-			Collation: "utf8mb4_general_ci",
+			Charset:   "utf8mb4_general_ci",
 		}
 		if err := cfg.InitSchemas("vttest", testSchema, nil); err != nil {
 			fmt.Fprintf(os.Stderr, "InitSchemas failed: %v\n", err)

--- a/go/vt/vttablet/endtoend/main_test.go
+++ b/go/vt/vttablet/endtoend/main_test.go
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 				},
 			},
 			OnlyMySQL: true,
-			Collation: "utf8mb4_general_ci",
+			Charset:   "utf8mb4_general_ci",
 		}
 		if err := cfg.InitSchemas("vttest", testSchema, nil); err != nil {
 			fmt.Fprintf(os.Stderr, "InitSchemas failed: %v\n", err)

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -233,12 +233,14 @@ func BuildTabletFromInput(alias *topodatapb.TabletAlias, port, grpcPort int32, d
 		return nil, err
 	}
 
-	var charset uint8 = collations.DefaultConnectionCharset
+	var charset uint8
 	if db != nil && db.Charset != "" {
-		charset, err = collations.ParseConnectionCharset(db.Charset)
+		charset, err = collations.Local().ParseConnectionCharset(db.Charset)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		charset = collations.Local().DefaultConnectionCharset()
 	}
 
 	return &topodatapb.Tablet{

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -234,9 +234,9 @@ func BuildTabletFromInput(alias *topodatapb.TabletAlias, port, grpcPort int32, d
 	}
 
 	var coll collations.ID = collations.DefaultConnectionCharset
-	if db != nil && db.Collation != "" {
+	if db != nil && db.Charset != "" {
 		env := collations.NewEnvironment(dbServerVersion)
-		coll = env.LookupByName(db.Collation).ID()
+		coll = env.LookupByName(db.Charset).ID()
 	}
 
 	return &topodatapb.Tablet{

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -233,10 +233,12 @@ func BuildTabletFromInput(alias *topodatapb.TabletAlias, port, grpcPort int32, d
 		return nil, err
 	}
 
-	var coll collations.ID = collations.DefaultConnectionCharset
+	var charset uint8 = collations.DefaultConnectionCharset
 	if db != nil && db.Charset != "" {
-		env := collations.NewEnvironment(dbServerVersion)
-		coll = env.LookupByName(db.Charset).ID()
+		charset, err = collations.ParseConnectionCharset(db.Charset)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &topodatapb.Tablet{
@@ -253,7 +255,7 @@ func BuildTabletFromInput(alias *topodatapb.TabletAlias, port, grpcPort int32, d
 		DbNameOverride:       *initDbNameOverride,
 		Tags:                 mergeTags(buildTags, initTags),
 		DbServerVersion:      dbServerVersion,
-		DefaultConnCollation: uint32(coll),
+		DefaultConnCollation: uint32(charset),
 	}, nil
 }
 

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -71,7 +71,7 @@ func TestStartBuildTabletFromInput(t *testing.T) {
 		Tags:                 map[string]string{},
 		DbNameOverride:       "aa",
 		DbServerVersion:      dbServerVersion,
-		DefaultConnCollation: 45,
+		DefaultConnCollation: 255,
 	}
 
 	gotTablet, err := BuildTabletFromInput(alias, port, grpcport, dbServerVersion, nil)
@@ -155,7 +155,7 @@ func TestBuildTabletFromInputWithBuildTags(t *testing.T) {
 		Tags:                 servenv.AppVersion.ToStringMap(),
 		DbNameOverride:       "aa",
 		DbServerVersion:      "5.7.0",
-		DefaultConnCollation: 45,
+		DefaultConnCollation: 255,
 	}
 
 	gotTablet, err := BuildTabletFromInput(alias, port, grpcport, dbServerVersion, nil)

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -95,6 +95,7 @@ func Init() (*Env, error) {
 			},
 		},
 		OnlyMySQL: true,
+		Charset:   "utf8mb4_general_ci",
 	}
 	te.cluster = &vttest.LocalCluster{
 		Config: cfg,

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -220,7 +220,9 @@ type LocalCluster struct {
 // This connection should be used for debug/introspection purposes; normal
 // cluster access should be performed through the vtgate port.
 func (db *LocalCluster) MySQLConnParams() mysql.ConnParams {
-	return db.mysql.Params(db.DbName())
+	connParams := db.mysql.Params(db.DbName())
+	connParams.Charset = db.Config.Charset
+	return connParams
 }
 
 // MySQLAppDebugConnParams returns a mysql.ConnParams struct that can be used

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -79,11 +79,6 @@ type Config struct {
 	// Charset is the default charset used by MySQL
 	Charset string
 
-	// Collation is the default collation used by MySQL
-	// If Collation is set and Charset is not set, Collation will be used
-	// to define the value of Charset
-	Collation string
-
 	// PlannerVersion is the planner version to use for the vtgate.
 	// Choose between V3, Gen4, Gen4Greedy and Gen4Fallback
 	PlannerVersion string

--- a/go/vt/vttest/mysqlctl.go
+++ b/go/vt/vttest/mysqlctl.go
@@ -146,8 +146,6 @@ func (ctl *Mysqlctl) TabletDir() string {
 // using Vitess' mysql client.
 func (ctl *Mysqlctl) Params(dbname string) mysql.ConnParams {
 	return mysql.ConnParams{
-		Charset:    DefaultCharset,
-		Collation:  "utf8mb4_general_ci",
 		DbName:     dbname,
 		Uname:      "vt_dba",
 		UnixSocket: ctl.UnixSocket(),

--- a/go/vt/vttest/mysqlctl.go
+++ b/go/vt/vttest/mysqlctl.go
@@ -149,6 +149,5 @@ func (ctl *Mysqlctl) Params(dbname string) mysql.ConnParams {
 		DbName:     dbname,
 		Uname:      "vt_dba",
 		UnixSocket: ctl.UnixSocket(),
-		Charset:    DefaultCharset,
 	}
 }

--- a/go/vt/vttest/mysqlctl.go
+++ b/go/vt/vttest/mysqlctl.go
@@ -149,5 +149,6 @@ func (ctl *Mysqlctl) Params(dbname string) mysql.ConnParams {
 		DbName:     dbname,
 		Uname:      "vt_dba",
 		UnixSocket: ctl.UnixSocket(),
+		Charset:    DefaultCharset,
 	}
 }

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -173,7 +173,7 @@ func (vtp *VtProcess) WaitStart() (err error) {
 
 const (
 	// DefaultCharset is the default charset used by MySQL instances
-	DefaultCharset = "utf8mb4_general_ci"
+	DefaultCharset = "utf8mb4"
 )
 
 // QueryServerArgs are the default arguments passed to all Vitess query servers

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -173,10 +173,7 @@ func (vtp *VtProcess) WaitStart() (err error) {
 
 const (
 	// DefaultCharset is the default charset used by MySQL instances
-	DefaultCharset = "utf8mb4"
-
-	// DefaultCollation is the default collation used between VTTablet and MySQL
-	DefaultCollation = "utf8mb4_general_ci"
+	DefaultCharset = "utf8mb4_general_ci"
 )
 
 // QueryServerArgs are the default arguments passed to all Vitess query servers
@@ -211,15 +208,10 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 	if charset == "" {
 		charset = DefaultCharset
 	}
-	collation := args.Collation
-	if collation == "" {
-		collation = DefaultCollation
-	}
 
 	protoTopo, _ := prototext.Marshal(args.Topology)
 	vt.ExtraArgs = append(vt.ExtraArgs, []string{
 		"-db_charset", charset,
-		"-db_collation", collation,
 		"-db_app_user", user,
 		"-db_app_password", pass,
 		"-db_dba_user", user,


### PR DESCRIPTION
## Description

OK, after a lot of testing I have what I believe is a working solution for the weird collation behavior we've been seeing in Vitess clusters. What I figured out is that the workaround that we implemented in our MySQL connection code to support collations >255 was not really working. As a reminder, when connecting to a MySQL server, a handshake is performed between client and server to agree on a "connection charset" (as defined in the MySQL documentation). Now, two critical facts about this: the wire protocol only has 1 byte for this charset, so it's not possible to use charsets higher than 255; and what the documentation calls "charset" is in fact the ID of a full collation, that can very well go above 255.

This PR hence does the following things:

1. It removes the `db_collation` flag that @frouioui and I introduced a couple months ago. Since this flag never made it to any Vitess releases, there's no deprecation notice needed. As a result of this investigation, we now understand that setting a "charset" and a "collation" for a connection is redundant, as the charset is actually a collation ID. The workaround we had to enforce a custom collation, which was doing it via SQL once the connection was open, is not giving reliable results: we were performing a `SET collation_connection` call, but the semantics of this change are _weird_ and it appears to only apply to some string comparisons in SQL. It's not a wholistic change like what we'd get by passing a charset via the handshake when connecting.

2. It adds support for passing collation names to the `db_charset` flag **as long as those collations have a collation ID <=255**, so that it fits in the handshake packet. This is a non-breaking change that matches the behavior of the commandline flags to `mysql` (the MySQL CLI client). You can pass a charset name like we were doing before, such as `utf8mb4`, but you can also pass a full collation like `utf8m4_general_ci`. Vitess will error out if you attempt to pass a collation that resolves to an ID > 255. Fortunately, all the collation IDs for the default collations for all charsets in all MySQL versions are <=255.

3. It reliably changes the default charset used for Vitess clusters **based on the underlying MySQL server version**. Vitess clusters based on MySQL 5.x will use `utf8mb4_general_ci` by default (unless configured otherwise with the `db_charset` flag). Vitess clusters based on MySQL 8+ will use `utf8mb4_0900_ai_ci`. To note: `utf8mb4_0900_ai_ci` _is_ the default charset for a MySQL 8.0 deployment, and Vitess will not match that behavior. However, `utf8mb4_general_ci` is _not_ the default charset for a MySQL 5.7 deployment: that'd be `utf8_general_ci`. We believe this is a terrible default, particularly since `utf8` is a deprecated charset in MySQL, so we want to enforce all users to use `utf8mb4` charsets even in 5.7 to prevent them from shooting themselves in the foot.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->