### PR TITLE
docker: k8s release process updates

### DIFF
--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/base:${VT_BASE_VER} AS base
 

--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
 
 FROM vitess/base:${VT_BASE_VER} AS base
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 # TODO: remove when https://github.com/vitessio/vitess/issues/3553 is fixed
 RUN apt-get update && \

--- a/docker/k8s/logrotate/Dockerfile
+++ b/docker/k8s/logrotate/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster-slim
+ARG DEBIAN_VER=buster-slim
+
+FROM debian:${DEBIAN_VER}
 
 ADD logrotate.conf /vt/logrotate.conf
 

--- a/docker/k8s/logrotate/Dockerfile
+++ b/docker/k8s/logrotate/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM debian:${DEBIAN_VER}
 

--- a/docker/k8s/logtail/Dockerfile
+++ b/docker/k8s/logtail/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM debian:${DEBIAN_VER}
 

--- a/docker/k8s/logtail/Dockerfile
+++ b/docker/k8s/logtail/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster-slim
+ARG DEBIAN_VER=buster-slim
+
+FROM debian:${DEBIAN_VER}
 
 ENV TAIL_FILEPATH /dev/null
 

--- a/docker/k8s/mysqlctl/Dockerfile
+++ b/docker/k8s/mysqlctl/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/mysqlctl/Dockerfile
+++ b/docker/k8s/mysqlctl/Dockerfile
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/mysqlctld/Dockerfile
+++ b/docker/k8s/mysqlctld/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/mysqlctld/Dockerfile
+++ b/docker/k8s/mysqlctld/Dockerfile
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 RUN apt-get update && \
    apt-get upgrade -qq && \

--- a/docker/k8s/orchestrator/Dockerfile
+++ b/docker/k8s/orchestrator/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/orchestrator/Dockerfile
+++ b/docker/k8s/orchestrator/Dockerfile
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
+
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 ARG ORC_VER='3.2.3'
 
 RUN apt-get update && \

--- a/docker/k8s/pmm-client/Dockerfile
+++ b/docker/k8s/pmm-client/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/pmm-client/Dockerfile
+++ b/docker/k8s/pmm-client/Dockerfile
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
+
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 ARG PMM_CLIENT_VER='1.17.4'
 
 RUN apt-get update && \

--- a/docker/k8s/vtbackup/Dockerfile
+++ b/docker/k8s/vtbackup/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s

--- a/docker/k8s/vtbackup/Dockerfile
+++ b/docker/k8s/vtbackup/Dockerfile
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
+
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/vtctl/Dockerfile
+++ b/docker/k8s/vtctl/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vtctl/Dockerfile
+++ b/docker/k8s/vtctl/Dockerfile
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/vtctlclient/Dockerfile
+++ b/docker/k8s/vtctlclient/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vtctlclient/Dockerfile
+++ b/docker/k8s/vtctlclient/Dockerfile
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 RUN apt-get update && \
    apt-get upgrade -qq && \

--- a/docker/k8s/vtctld/Dockerfile
+++ b/docker/k8s/vtctld/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vtctld/Dockerfile
+++ b/docker/k8s/vtctld/Dockerfile
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/vtexplain/Dockerfile
+++ b/docker/k8s/vtexplain/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/base:${VT_BASE_VER} AS base
 

--- a/docker/k8s/vtexplain/Dockerfile
+++ b/docker/k8s/vtexplain/Dockerfile
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
 
 FROM vitess/base:${VT_BASE_VER} AS base
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/vtgate/Dockerfile
+++ b/docker/k8s/vtgate/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vtgate/Dockerfile
+++ b/docker/k8s/vtgate/Dockerfile
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/vttablet/Dockerfile
+++ b/docker/k8s/vttablet/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vttablet/Dockerfile
+++ b/docker/k8s/vttablet/Dockerfile
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 # TODO: remove when https://github.com/vitessio/vitess/issues/3553 is fixed
 RUN apt-get update && \

--- a/docker/k8s/vtworker/Dockerfile
+++ b/docker/k8s/vtworker/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
-ARG DEBIAN_VER=buster-slim
+ARG DEBIAN_VER=stable-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vtworker/Dockerfile
+++ b/docker/k8s/vtworker/Dockerfile
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 ARG VT_BASE_VER=latest
+ARG DEBIAN_VER=buster-slim
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
-FROM debian:buster-slim
+FROM debian:${DEBIAN_VER}
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/release.sh
+++ b/docker/release.sh
@@ -14,55 +14,55 @@ do
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/k8s:$vt_base_version-$debian_version .
   docker tag vitess/k8s:$vt_base_version-$debian_version vitess/k8s:$vt_base_version
   docker push vitess/k8s:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/k8s:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/k8s:$vt_base_version; fi
 
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtgate:$vt_base_version-$debian_version vtgate
   docker tag vitess/vtgate:$vt_base_version-$debian_version vitess/vtgate:$vt_base_version
   docker push vitess/vtgate:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/vtgate:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/vtgate:$vt_base_version; fi
 
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vttablet:$vt_base_version-$debian_version vttablet
   docker tag vitess/vttablet:$vt_base_version-$debian_version vitess/vttablet:$vt_base_version
   docker push vitess/vttablet:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/vttablet:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/vttablet:$vt_base_version; fi
 
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/mysqlctld:$vt_base_version-$debian_version mysqlctld
   docker tag vitess/mysqlctld:$vt_base_version-$debian_version vitess/mysqlctld:$vt_base_version
   docker push vitess/mysqlctld:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/mysqlctld:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/mysqlctld:$vt_base_version; fi
 
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/mysqlctl:$vt_base_version-$debian_version mysqlctl
   docker tag vitess/mysqlctl:$vt_base_version-$debian_version vitess/mysqlctl:$vt_base_version
   docker push vitess/mysqlctl:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/mysqlctl:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/mysqlctl:$vt_base_version; fi
 
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtctl:$vt_base_version-$debian_version vtctl
   docker tag vitess/vtctl:$vt_base_version-$debian_version vitess/vtctl:$vt_base_version
   docker push vitess/vtctl:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/vtctl:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/vtctl:$vt_base_version; fi
 
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtctlclient:$vt_base_version-$debian_version vtctlclient
   docker tag vitess/vtctlclient:$vt_base_version-$debian_version vitess/vtctlclient:$vt_base_version
   docker push vitess/vtctlclient:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/vtctlclient:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/vtctlclient:$vt_base_version; fi
 
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtctld:$vt_base_version-$debian_version vtctld
   docker tag vitess/vtctld:$vt_base_version-$debian_version vitess/vtctld:$vt_base_version
   docker push vitess/vtctld:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/vtctld:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/vtctld:$vt_base_version; fi
 
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtworker:$vt_base_version-$debian_version vtworker
   docker tag vitess/vtworker:$vt_base_version-$debian_version vitess/vtworker:$vt_base_version
   docker push vitess/vtworker:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/vtworker:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/vtworker:$vt_base_version; fi
 
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/logrotate:$vt_base_version-$debian_version logrotate
   docker tag vitess/logrotate:$vt_base_version-$debian_version vitess/logrotate:$vt_base_version
   docker push vitess/logrotate:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/logrotate:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/logrotate:$vt_base_version; fi
 
   docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/logtail:$vt_base_version-$debian_version logtail
   docker tag vitess/logtail:$vt_base_version-$debian_version vitess/logtail:$vt_base_version
   docker push vitess/logtail:$vt_base_version-$debian_version
-  if [ $debian_version = $default_debian_version ]; then docker push vitess/logtail:$vt_base_version; fi
+  if [[ $debian_version == $default_debian_version ]]; then docker push vitess/logtail:$vt_base_version; fi
 done

--- a/docker/release.sh
+++ b/docker/release.sh
@@ -1,62 +1,68 @@
 #!/bin/bash
 set -ex
 
-vt_base_version='v7.0.2'
+vt_base_version='v12.0.3'
+debian_versions='buster  bullseye'
+default_debian_version='buster'
 
 docker pull vitess/base:$vt_base_version
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/k8s:$vt_base_version-buster .
-docker tag vitess/k8s:$vt_base_version-buster vitess/k8s:$vt_base_version
-docker push vitess/k8s:$vt_base_version-buster
-docker push vitess/k8s:$vt_base_version
+for debian_version in $debian_versions
+do
+  echo "####### Building vitess/vt:$debian_version"
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtgate:$vt_base_version-buster vtgate
-docker tag vitess/vtgate:$vt_base_version-buster vitess/vtgate:$vt_base_version
-docker push vitess/vtgate:$vt_base_version-buster
-docker push vitess/vtgate:$vt_base_version
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/k8s:$vt_base_version-$debian_version .
+  docker tag vitess/k8s:$vt_base_version-$debian_version vitess/k8s:$vt_base_version
+  docker push vitess/k8s:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/k8s:$vt_base_version; fi
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vttablet:$vt_base_version-buster vttablet
-docker tag vitess/vttablet:$vt_base_version-buster vitess/vttablet:$vt_base_version
-docker push vitess/vttablet:$vt_base_version-buster
-docker push vitess/vttablet:$vt_base_version
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtgate:$vt_base_version-$debian_version vtgate
+  docker tag vitess/vtgate:$vt_base_version-$debian_version vitess/vtgate:$vt_base_version
+  docker push vitess/vtgate:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/vtgate:$vt_base_version; fi
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/mysqlctld:$vt_base_version-buster mysqlctld
-docker tag vitess/mysqlctld:$vt_base_version-buster vitess/mysqlctld:$vt_base_version
-docker push vitess/mysqlctld:$vt_base_version-buster
-docker push vitess/mysqlctld:$vt_base_version
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vttablet:$vt_base_version-$debian_version vttablet
+  docker tag vitess/vttablet:$vt_base_version-$debian_version vitess/vttablet:$vt_base_version
+  docker push vitess/vttablet:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/vttablet:$vt_base_version; fi
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/mysqlctl:$vt_base_version-buster mysqlctl
-docker tag vitess/mysqlctl:$vt_base_version-buster vitess/mysqlctl:$vt_base_version
-docker push vitess/mysqlctl:$vt_base_version-buster
-docker push vitess/mysqlctl:$vt_base_version
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/mysqlctld:$vt_base_version-$debian_version mysqlctld
+  docker tag vitess/mysqlctld:$vt_base_version-$debian_version vitess/mysqlctld:$vt_base_version
+  docker push vitess/mysqlctld:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/mysqlctld:$vt_base_version; fi
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtctl:$vt_base_version-buster vtctl
-docker tag vitess/vtctl:$vt_base_version-buster vitess/vtctl:$vt_base_version
-docker push vitess/vtctl:$vt_base_version-buster
-docker push vitess/vtctl:$vt_base_version
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/mysqlctl:$vt_base_version-$debian_version mysqlctl
+  docker tag vitess/mysqlctl:$vt_base_version-$debian_version vitess/mysqlctl:$vt_base_version
+  docker push vitess/mysqlctl:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/mysqlctl:$vt_base_version; fi
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtctlclient:$vt_base_version-buster vtctlclient
-docker tag vitess/vtctlclient:$vt_base_version-buster vitess/vtctlclient:$vt_base_version
-docker push vitess/vtctlclient:$vt_base_version-buster
-docker push vitess/vtctlclient:$vt_base_version
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtctl:$vt_base_version-$debian_version vtctl
+  docker tag vitess/vtctl:$vt_base_version-$debian_version vitess/vtctl:$vt_base_version
+  docker push vitess/vtctl:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/vtctl:$vt_base_version; fi
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtctld:$vt_base_version-buster vtctld
-docker tag vitess/vtctld:$vt_base_version-buster vitess/vtctld:$vt_base_version
-docker push vitess/vtctld:$vt_base_version-buster
-docker push vitess/vtctld:$vt_base_version
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtctlclient:$vt_base_version-$debian_version vtctlclient
+  docker tag vitess/vtctlclient:$vt_base_version-$debian_version vitess/vtctlclient:$vt_base_version
+  docker push vitess/vtctlclient:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/vtctlclient:$vt_base_version; fi
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtworker:$vt_base_version-buster vtworker
-docker tag vitess/vtworker:$vt_base_version-buster vitess/vtworker:$vt_base_version
-docker push vitess/vtworker:$vt_base_version-buster
-docker push vitess/vtworker:$vt_base_version
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtctld:$vt_base_version-$debian_version vtctld
+  docker tag vitess/vtctld:$vt_base_version-$debian_version vitess/vtctld:$vt_base_version
+  docker push vitess/vtctld:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/vtctld:$vt_base_version; fi
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/logrotate:$vt_base_version-buster logrotate
-docker tag vitess/logrotate:$vt_base_version-buster vitess/logrotate:$vt_base_version
-docker push vitess/logrotate:$vt_base_version-buster
-docker push vitess/logrotate:$vt_base_version
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/vtworker:$vt_base_version-$debian_version vtworker
+  docker tag vitess/vtworker:$vt_base_version-$debian_version vitess/vtworker:$vt_base_version
+  docker push vitess/vtworker:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/vtworker:$vt_base_version; fi
 
-docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/logtail:$vt_base_version-buster logtail
-docker tag vitess/logtail:$vt_base_version-buster vitess/logtail:$vt_base_version
-docker push vitess/logtail:$vt_base_version-buster
-docker push vitess/logtail:$vt_base_version
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/logrotate:$vt_base_version-$debian_version logrotate
+  docker tag vitess/logrotate:$vt_base_version-$debian_version vitess/logrotate:$vt_base_version
+  docker push vitess/logrotate:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/logrotate:$vt_base_version; fi
 
+  docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg DEBIAN_VER=$debian_version-slim -t vitess/logtail:$vt_base_version-$debian_version logtail
+  docker tag vitess/logtail:$vt_base_version-$debian_version vitess/logtail:$vt_base_version
+  docker push vitess/logtail:$vt_base_version-$debian_version
+  if [ $debian_version = $default_debian_version ]; then docker push vitess/logtail:$vt_base_version; fi
+done

--- a/docker/release.sh
+++ b/docker/release.sh
@@ -2,8 +2,6 @@
 set -ex
 
 vt_base_version='v7.0.2'
-orchestrator_version='3.2.3'
-pmm_client_version='1.17.4'
 
 docker pull vitess/base:$vt_base_version
 
@@ -62,12 +60,3 @@ docker tag vitess/logtail:$vt_base_version-buster vitess/logtail:$vt_base_versio
 docker push vitess/logtail:$vt_base_version-buster
 docker push vitess/logtail:$vt_base_version
 
-docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg PMM_CLIENT_VER=$pmm_client_version -t vitess/pmm-client:v$pmm_client_version-buster pmm-client
-docker tag vitess/pmm-client:v$pmm_client_version-buster vitess/pmm-client:v$pmm_client_version
-docker push vitess/pmm-client:v$pmm_client_version-buster
-docker push vitess/pmm-client:v$pmm_client_version
-
-docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg ORC_VER=$orchestrator_version -t vitess/orchestrator:v$orchestrator_version-buster orchestrator
-docker tag vitess/orchestrator:v$orchestrator_version-buster vitess/orchestrator:v$orchestrator_version
-docker push vitess/orchestrator:v$orchestrator_version-buster
-docker push vitess/orchestrator:v$orchestrator_version


### PR DESCRIPTION
This is an update to the release process for the `/docker/k8s/...` images for individual binaries. This should all be pushed into Docker Hub configuration, and then `release.sh` can be removed I just haven't had the chance to do it. I still manually build and publish images from my machine for every release.