### PR TITLE
vtctl OnlineDDL show: export all columns, support -json

### DIFF
--- a/doc/releasenotes/13_0_0_summary.md
+++ b/doc/releasenotes/13_0_0_summary.md
@@ -94,6 +94,10 @@ For example:
 vtctlclient OnlineDDL commerce complete d08ffe6b_51c9_11ec_9cf2_0a43f95f28a3
 ```
 
+### vtctl/vtctlclient OnlineDDL -json
+
+The command now accepts an optional `-json` flag. With this flag, the output is a valid JSON listing all columns and rows.
+
 ## Incompatible Changes
 
 ## Deprecations

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -653,7 +653,7 @@ var commands = []commandGroup{
 			{
 				name:   "OnlineDDL",
 				method: commandOnlineDDL,
-				params: "<keyspace> <command> [<migration_uuid>]",
+				params: "[-json] <keyspace> <command> [<migration_uuid>]",
 				help: "Operates on online DDL (migrations). Examples:" +
 					" \nvtctl OnlineDDL test_keyspace show 82fa54ac_e83e_11ea_96b7_f875a4d24e90" +
 					" \nvtctl OnlineDDL test_keyspace show all" +

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3268,6 +3268,7 @@ func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 }
 
 func commandOnlineDDL(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+	json := subFlags.Bool("json", false, "Output JSON instead of human-readable table")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -3311,7 +3312,7 @@ func commandOnlineDDL(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag
 			}
 		}
 		query = fmt.Sprintf(`select
-				shard, mysql_schema, mysql_table, ddl_action, migration_uuid, strategy, started_timestamp, completed_timestamp, migration_status
+				*
 				from _vt.schema_migrations where %s`, condition)
 	case "retry":
 		if arg == "" {
@@ -3346,6 +3347,9 @@ func commandOnlineDDL(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag
 	qr, err := wr.VExecResult(ctx, uuid, keyspace, query, false)
 	if err != nil {
 		return err
+	}
+	if *json {
+		return printJSON(wr.Logger(), qr)
 	}
 	printQueryResult(loggerWriter{wr.Logger()}, qr)
 	return nil


### PR DESCRIPTION

## Description

`vtctl OnlineDDL show ...` command now exports all column of `schema_mgirations` table, instead of selected columns. This is to bring `OnlineDDL show` on par with `SHOW VITESS_MIGRATIONS LIKE ...` output.

Also, the command now supports `-json` flag.

Examples:

```shell
$ vtctlclient OnlineDDL commerce show 9d078a8e_7756_11ec_a656_0a43f95f28a3
+------------------+----+--------------------------------------+----------+-------+--------------+-------------+----------------------------------------+----------+---------+---------------------+---------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------------------+----------+-------------------------------------------------------------+---------+------------------+----------------+----------+-------------------+------------+---------+-------------+-------------+------------+-------------------+---------------------+----------+--------------------------+---------------------+--------------------------+---------------------------------+-----------------------+------------------+------------------+--------------------------------------+
|      Tablet      | id |            migration_uuid            | keyspace | shard | mysql_schema | mysql_table |          migration_statement           | strategy | options |   added_timestamp   | requested_timestamp |   ready_timestamp   |  started_timestamp  | liveness_timestamp  | completed_timestamp |  cleanup_timestamp  | migration_status | log_path |                          artifacts                          | retries |      tablet      | tablet_failure | progress | migration_context | ddl_action | message | eta_seconds | rows_copied | table_rows | added_unique_keys | removed_unique_keys | log_file | retain_artifacts_seconds | postpone_completion | removed_unique_key_names | dropped_no_default_column_names | expanded_column_names | revertible_notes | allow_concurrent |            reverted_uuid             |
+------------------+----+--------------------------------------+----------+-------+--------------+-------------+----------------------------------------+----------+---------+---------------------+---------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------------------+----------+-------------------------------------------------------------+---------+------------------+----------------+----------+-------------------+------------+---------+-------------+-------------+------------+-------------------+---------------------+----------+--------------------------+---------------------+--------------------------+---------------------------------+-----------------------+------------------+------------------+--------------------------------------+
| zone1-0000000100 |  3 | 9d078a8e_7756_11ec_a656_0a43f95f28a3 | commerce |     0 | vt_commerce  | corder      | revert vitess_migration                | online   |         | 2022-01-17 05:30:42 | 0000-00-00 00:00:00 | 2022-01-17 05:30:43 | 2022-01-17 05:30:43 | 2022-01-17 05:30:47 | 2022-01-17 05:30:48 | 2022-01-18 05:31:31 | complete         |          | _80de72df_7756_11ec_a656_0a43f95f28a3_20220117052956_vrepl, |       0 | zone1-0000000100 |              0 |      100 | 1111-2222         | alter      |         |           0 |           0 |          0 |                 0 |                   0 |          |                    86400 |                   0 |                          |                                 |                       |                  |                0 | 80de72df_7756_11ec_a656_0a43f95f28a3 |
|                  |    |                                      |          |       |              |             | '80de72df_7756_11ec_a656_0a43f95f28a3' |          |         |                     |                     |                     |                     |                     |                     |                     |                  |          |                                                             |         |                  |                |          |                   |            |         |             |             |            |                   |                     |          |                          |                     |                          |                                 |                       |                  |                  |                                      |
+------------------+----+--------------------------------------+----------+-------+--------------+-------------+----------------------------------------+----------+---------+---------------------+---------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------------------+----------+-------------------------------------------------------------+---------+------------------+----------------+----------+-------------------+------------+---------+-------------+-------------+------------+-------------------+---------------------+----------+--------------------------+---------------------+--------------------------+---------------------------------+-----------------------+------------------+------------------+--------------------------------------+
```

```shell
$ vtctlclient OnlineDDL -json commerce show 9d078a8e_7756_11ec_a656_0a43f95f28a3
```
```json
{
  "fields": [
    {
      "name": "Tablet",
      "type": 10262
    },
    {
      "name": "id",
      "type": 778,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "id",
      "column_length": 20,
      "charset": 63,
      "flags": 49699
    },
    {
      "name": "migration_uuid",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "migration_uuid",
      "column_length": 256,
      "charset": 45,
      "flags": 20485
    },
    {
      "name": "keyspace",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "keyspace",
      "column_length": 1024,
      "charset": 45,
      "flags": 20489
    },
    {
      "name": "shard",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "shard",
      "column_length": 1020,
      "charset": 45,
      "flags": 20481
    },
    {
      "name": "mysql_schema",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "mysql_schema",
      "column_length": 512,
      "charset": 45,
      "flags": 4097
    },
    {
      "name": "mysql_table",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "mysql_table",
      "column_length": 512,
      "charset": 45,
      "flags": 20481
    },
    {
      "name": "migration_statement",
      "type": 6163,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "migration_statement",
      "column_length": 262140,
      "charset": 45,
      "flags": 4113
    },
    {
      "name": "strategy",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "strategy",
      "column_length": 512,
      "charset": 45,
      "flags": 4097
    },
    {
      "name": "options",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "options",
      "column_length": 32768,
      "charset": 45,
      "flags": 4097
    },
    {
      "name": "added_timestamp",
      "type": 2061,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "added_timestamp",
      "column_length": 19,
      "charset": 63,
      "flags": 1153
    },
    {
      "name": "requested_timestamp",
      "type": 2061,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "requested_timestamp",
      "column_length": 19,
      "charset": 63,
      "flags": 1153
    },
    {
      "name": "ready_timestamp",
      "type": 2061,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "ready_timestamp",
      "column_length": 19,
      "charset": 63,
      "flags": 128
    },
    {
      "name": "started_timestamp",
      "type": 2061,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "started_timestamp",
      "column_length": 19,
      "charset": 63,
      "flags": 128
    },
    {
      "name": "liveness_timestamp",
      "type": 2061,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "liveness_timestamp",
      "column_length": 19,
      "charset": 63,
      "flags": 16512
    },
    {
      "name": "completed_timestamp",
      "type": 2061,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "completed_timestamp",
      "column_length": 19,
      "charset": 63,
      "flags": 16512
    },
    {
      "name": "cleanup_timestamp",
      "type": 2061,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "cleanup_timestamp",
      "column_length": 19,
      "charset": 63,
      "flags": 16520
    },
    {
      "name": "migration_status",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "migration_status",
      "column_length": 512,
      "charset": 45,
      "flags": 20489
    },
    {
      "name": "log_path",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "log_path",
      "column_length": 4096,
      "charset": 45,
      "flags": 4097
    },
    {
      "name": "artifacts",
      "type": 6163,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "artifacts",
      "column_length": 262140,
      "charset": 45,
      "flags": 4113
    },
    {
      "name": "retries",
      "type": 776,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "retries",
      "column_length": 10,
      "charset": 63,
      "flags": 49185
    },
    {
      "name": "tablet",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "tablet",
      "column_length": 512,
      "charset": 45,
      "flags": 1
    },
    {
      "name": "tablet_failure",
      "type": 770,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "tablet_failure",
      "column_length": 3,
      "charset": 63,
      "flags": 49193
    },
    {
      "name": "progress",
      "type": 1035,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "progress",
      "column_length": 12,
      "charset": 63,
      "decimals": 31,
      "flags": 32769
    },
    {
      "name": "migration_context",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "migration_context",
      "column_length": 4096,
      "charset": 45,
      "flags": 16393
    },
    {
      "name": "ddl_action",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "ddl_action",
      "column_length": 64,
      "charset": 45,
      "flags": 1
    },
    {
      "name": "message",
      "type": 6163,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "message",
      "column_length": 262140,
      "charset": 45,
      "flags": 4113
    },
    {
      "name": "eta_seconds",
      "type": 265,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "eta_seconds",
      "column_length": 20,
      "charset": 63,
      "flags": 32769
    },
    {
      "name": "rows_copied",
      "type": 778,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "rows_copied",
      "column_length": 20,
      "charset": 63,
      "flags": 32801
    },
    {
      "name": "table_rows",
      "type": 265,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "table_rows",
      "column_length": 20,
      "charset": 63,
      "flags": 32769
    },
    {
      "name": "added_unique_keys",
      "type": 776,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "added_unique_keys",
      "column_length": 10,
      "charset": 63,
      "flags": 32801
    },
    {
      "name": "removed_unique_keys",
      "type": 776,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "removed_unique_keys",
      "column_length": 10,
      "charset": 63,
      "flags": 32801
    },
    {
      "name": "log_file",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "log_file",
      "column_length": 4096,
      "charset": 45,
      "flags": 1
    },
    {
      "name": "retain_artifacts_seconds",
      "type": 265,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "retain_artifacts_seconds",
      "column_length": 20,
      "charset": 63,
      "flags": 32769
    },
    {
      "name": "postpone_completion",
      "type": 770,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "postpone_completion",
      "column_length": 3,
      "charset": 63,
      "flags": 32801
    },
    {
      "name": "removed_unique_key_names",
      "type": 6163,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "removed_unique_key_names",
      "column_length": 262140,
      "charset": 45,
      "flags": 4113
    },
    {
      "name": "dropped_no_default_column_names",
      "type": 6163,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "dropped_no_default_column_names",
      "column_length": 262140,
      "charset": 45,
      "flags": 4113
    },
    {
      "name": "expanded_column_names",
      "type": 6163,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "expanded_column_names",
      "column_length": 262140,
      "charset": 45,
      "flags": 4113
    },
    {
      "name": "revertible_notes",
      "type": 6163,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "revertible_notes",
      "column_length": 262140,
      "charset": 45,
      "flags": 4113
    },
    {
      "name": "allow_concurrent",
      "type": 770,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "allow_concurrent",
      "column_length": 3,
      "charset": 63,
      "flags": 32801
    },
    {
      "name": "reverted_uuid",
      "type": 6165,
      "table": "schema_migrations",
      "org_table": "schema_migrations",
      "database": "_vt",
      "org_name": "reverted_uuid",
      "column_length": 256,
      "charset": 45,
      "flags": 16393
    }
  ],
  "rows_affected": 0,
  "insert_id": 0,
  "rows": [
    [
      "zone1-0000000100",
      3,
      "9d078a8e_7756_11ec_a656_0a43f95f28a3",
      "commerce",
      "0",
      "vt_commerce",
      "corder",
      "revert vitess_migration '80de72df_7756_11ec_a656_0a43f95f28a3'",
      "online",
      "",
      "2022-01-17 05:30:42",
      "0000-00-00 00:00:00",
      "2022-01-17 05:30:43",
      "2022-01-17 05:30:43",
      "2022-01-17 05:30:47",
      "2022-01-17 05:30:48",
      "2022-01-18 05:31:31",
      "complete",
      "",
      "_80de72df_7756_11ec_a656_0a43f95f28a3_20220117052956_vrepl,",
      0,
      "zone1-0000000100",
      0,
      100,
      "1111-2222",
      "alter",
      "",
      0,
      0,
      0,
      0,
      0,
      "",
      86400,
      0,
      "",
      "",
      "",
      "",
      0,
      "80de72df_7756_11ec_a656_0a43f95f28a3"
    ]
  ],
  "session_state_changes": "",
  "status_flags": 0
}
```

## Related Issue(s)

- tracking: #6926 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

cc @mscoutermarsh
