### PR TITLE
Add 30 second wait timeout in mysql stop for cluster Teardown

### DIFF
--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -28,6 +28,7 @@ import (
 	"path"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -731,6 +732,7 @@ func (cluster *LocalProcessCluster) Teardown() {
 	}
 
 	var mysqlctlProcessList []*exec.Cmd
+	var mysqlctlTabletUIDs []int
 	for _, keyspace := range cluster.Keyspaces {
 		for _, shard := range keyspace.Shards {
 			for _, tablet := range shard.Vttablets {
@@ -739,6 +741,7 @@ func (cluster *LocalProcessCluster) Teardown() {
 						log.Errorf("Error in mysqlctl teardown: %v", err)
 					} else {
 						mysqlctlProcessList = append(mysqlctlProcessList, proc)
+						mysqlctlTabletUIDs = append(mysqlctlTabletUIDs, tablet.MysqlctlProcess.TabletUID)
 					}
 				}
 				if tablet.MysqlctldProcess.TabletUID > 0 {
@@ -754,11 +757,11 @@ func (cluster *LocalProcessCluster) Teardown() {
 		}
 	}
 
-	for _, proc := range mysqlctlProcessList {
-		if err := proc.Wait(); err != nil {
-			log.Errorf("Error in mysqlctl teardown wait: %v", err)
-		}
-	}
+	// On the CI it was noticed that MySQL shutdown hangs sometimes and
+	// on local investigation it was waiting on SEMI_SYNC acks for an internal command
+	// of Vitess even after closing the socket file.
+	// To prevent this process for hanging for 5 minutes, we will add a 30-second timeout.
+	cluster.waitForMySQLProcessToExit(mysqlctlProcessList, mysqlctlTabletUIDs)
 
 	if err := cluster.VtctldProcess.TearDown(); err != nil {
 		log.Errorf("Error in vtctld teardown: %v", err)
@@ -772,6 +775,49 @@ func (cluster *LocalProcessCluster) Teardown() {
 	os.Setenv("VTDATAROOT", cluster.OriginalVTDATAROOT)
 
 	cluster.teardownCompleted = true
+}
+
+func (cluster *LocalProcessCluster) waitForMySQLProcessToExit(mysqlctlProcessList []*exec.Cmd, mysqlctlTabletUIDs []int) {
+	wg := sync.WaitGroup{}
+	for i, cmd := range mysqlctlProcessList {
+		wg.Add(1)
+		go func(cmd *exec.Cmd, tabletUID int) {
+			defer func() {
+				wg.Done()
+			}()
+			exit := make(chan error)
+			go func() {
+				exit <- cmd.Wait()
+			}()
+			select {
+			case <-time.After(30 * time.Second):
+				break
+			case err := <-exit:
+				if err == nil {
+					return
+				}
+				log.Errorf("Error in mysqlctl teardown wait: %v", err)
+				break
+			}
+			pidFile := path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/mysql.pid", tabletUID))
+			pidBytes, err := os.ReadFile(pidFile)
+			if err != nil {
+				// We can't read the file which means the PID file does not exist
+				// The server must have stopped
+				return
+			}
+			pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+			if err != nil {
+				log.Errorf("Error in conversion to integer: %v", err)
+				return
+			}
+			err = syscall.Kill(pid, syscall.SIGKILL)
+			if err != nil {
+				log.Errorf("Error in killing process: %v", err)
+			}
+		}(cmd, mysqlctlTabletUIDs[i])
+	}
+	wg.Wait()
 }
 
 // StartVtworker starts a vtworker


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
The 5 minute timeout seen in #9507 is also affecting the Teardown method of the cluster. The same fix has been applied to this function to reduce the CI flakiness.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->