### PR TITLE
Add durability flag in local examples

### DIFF
--- a/examples/legacy_local/scripts/vtctld-up.sh
+++ b/examples/legacy_local/scripts/vtctld-up.sh
@@ -33,6 +33,7 @@ vtctld \
  -file_backup_storage_root $VTDATAROOT/backups \
  -log_dir $VTDATAROOT/tmp \
  -port $vtctld_web_port \
+ -durability_policy 'semi_sync' \
  -grpc_port $grpc_port \
  -pid_file $VTDATAROOT/tmp/vtctld.pid \
   > $VTDATAROOT/tmp/vtctld.out 2>&1 &

--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -38,7 +38,7 @@ for i in 100 101 102; do
 done
 
 # set one of the replicas to primary
-vtctldclient InitShardPrimary --force commerce/0 zone1-100
+vtctldclient PlannedReparentShard commerce/0 --new-primary zone1-100
 
 # create the schema
 vtctlclient ApplySchema -sql-file create_commerce_schema.sql commerce

--- a/examples/local/scripts/vtctld-up.sh
+++ b/examples/local/scripts/vtctld-up.sh
@@ -33,6 +33,7 @@ vtctld \
  -file_backup_storage_root $VTDATAROOT/backups \
  -log_dir $VTDATAROOT/tmp \
  -port $vtctld_web_port \
+ -durability_policy 'semi_sync' \
  -grpc_port $grpc_port \
  -pid_file $VTDATAROOT/tmp/vtctld.pid \
   > $VTDATAROOT/tmp/vtctld.out 2>&1 &


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
A new flag `-durability_policy` for vtctld was introduced and it should now be provided in the local examples. This PR accomplishes that change of adding the new flag to vtctld-up.sh in all the examples which are using semi-sync. 

We also start using PlannedReparentShard for cluster initialisation in the example.

The changes to the scripts have been tested locally by inserting data, reading it, performing failovers (both planned and emergency) and inserting and reading data again. I have also checked the logs and verified that everything is in order.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #9533 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->