### PR TITLE
Add warning to vtctl binary

### DIFF
--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -85,7 +85,7 @@ func main() {
 	args := servenv.ParseFlagsWithArgs("vtctl")
 	action := args[0]
 
-	log.Warningf("WARNING: vtctl should only be used for VDiff workflows. Consider using vtctld and vtctlclient for all other commands.")
+	log.Warningf("WARNING: vtctl should only be used for VDiff workflows. Consider using vtctldclient for all other commands.")
 
 	startMsg := fmt.Sprintf("USER=%v SUDO_USER=%v %v", os.Getenv("USER"), os.Getenv("SUDO_USER"), strings.Join(os.Args, " "))
 

--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -85,6 +85,8 @@ func main() {
 	args := servenv.ParseFlagsWithArgs("vtctl")
 	action := args[0]
 
+	log.Warningf("WARNING: vtctl should only be used for VDiff workflows. Consider using vtctld and vtctlclient for all other commands.")
+
 	startMsg := fmt.Sprintf("USER=%v SUDO_USER=%v %v", os.Getenv("USER"), os.Getenv("SUDO_USER"), strings.Join(os.Args, " "))
 
 	if syslogger, err := syslog.New(syslog.LOG_INFO, "vtctl "); err == nil {

--- a/go/test/endtoend/cluster/cluster_util.go
+++ b/go/test/endtoend/cluster/cluster_util.go
@@ -178,6 +178,18 @@ func getTablet(tabletGrpcPort int, hostname string) *tabletpb.Tablet {
 	return &tabletpb.Tablet{Hostname: hostname, PortMap: portMap}
 }
 
+func filterResultForWarning(input string) string {
+	lines := strings.Split(input, "\n")
+	var result string
+	for _, line := range lines {
+		if strings.Contains(line, "WARNING: vtctl should only be used for VDiff workflows") {
+			continue
+		}
+		result = result + line + "\n"
+	}
+	return result
+}
+
 func filterResultWhenRunsForCoverage(input string) string {
 	if !*isCoverage {
 		return input

--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -83,7 +83,7 @@ func (vtctl *VtctlProcess) ExecuteCommandWithOutput(args ...string) (result stri
 	)
 	log.Info(fmt.Sprintf("Executing vtctlclient with arguments %v", strings.Join(tmpProcess.Args, " ")))
 	resultByte, err := tmpProcess.CombinedOutput()
-	return filterResultWhenRunsForCoverage(string(resultByte)), err
+	return filterResultForWarning(filterResultWhenRunsForCoverage(string(resultByte))), err
 }
 
 // ExecuteCommand executes any vtctlclient command


### PR DESCRIPTION
<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds a warning to the vtctl binary stating that it should only be used for VDiff workflows and vtctld with vtctlclient should be preferred for everything else.

After this change running the vtctl binary looks like this - 
```sh
 ~/vitess: vtctl ListAllTablets
W0129 06:00:35.034992   59439 vtctl.go:88] WARNING: vtctl should only be used for VDiff workflows. Consider using vtctldclient for all other commands.
F0129 06:00:35.035721   59439 server.go:224] topo_global_server_address must be configured

```

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #9529 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->