### PR TITLE
Changed vitess operator examples to use `latest` on main

### DIFF
--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -8,12 +8,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v12.0.0
-    vtgate: vitess/lite:v12.0.0
-    vttablet: vitess/lite:v12.0.0
-    vtbackup: vitess/lite:v12.0.0
+    vtctld: vitess/lite:latest
+    vtgate: vitess/lite:latest
+    vttablet: vitess/lite:latest
+    vtbackup: vitess/lite:latest
     mysqld:
-      mysql56Compatible: vitess/lite:v12.0.0
+      mysql56Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v12.0.0
-    vtgate: vitess/lite:v12.0.0
-    vttablet: vitess/lite:v12.0.0
-    vtbackup: vitess/lite:v12.0.0
+    vtctld: vitess/lite:latest
+    vtgate: vitess/lite:latest
+    vttablet: vitess/lite:latest
+    vtbackup: vitess/lite:latest
     mysqld:
-      mysql56Compatible: vitess/lite:v12.0.0
+      mysql56Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v12.0.0
-    vtgate: vitess/lite:v12.0.0
-    vttablet: vitess/lite:v12.0.0
-    vtbackup: vitess/lite:v12.0.0
+    vtctld: vitess/lite:latest
+    vtgate: vitess/lite:latest
+    vttablet: vitess/lite:latest
+    vtbackup: vitess/lite:latest
     mysqld:
-      mysql56Compatible: vitess/lite:v12.0.0
+      mysql56Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v12.0.0
-    vtgate: vitess/lite:v12.0.0
-    vttablet: vitess/lite:v12.0.0
-    vtbackup: vitess/lite:v12.0.0
+    vtctld: vitess/lite:latest
+    vtgate: vitess/lite:latest
+    vttablet: vitess/lite:latest
+    vtbackup: vitess/lite:latest
     mysqld:
-      mysql56Compatible: vitess/lite:v12.0.0
+      mysql56Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/README.md
+++ b/examples/operator/README.md
@@ -11,12 +11,12 @@ kubectl apply -f operator.yaml
 # NOTE: If you are using MySQL 8, update the images section to use mysql80 images
 # Example:
 #  images:
-#    vtctld: vitess/lite:v12.0.0-mysql80
-#    vtgate: vitess/lite:v12.0.0-mysql80
-#    vttablet: vitess/lite:v12.0.0-mysql80
-#    vtbackup: vitess/lite:v12.0.0-mysql80
+#    vtctld: vitess/lite:mysql80
+#    vtgate: vitess/lite:mysql80
+#    vttablet: vitess/lite:mysql80
+#    vtbackup: vitess/lite:mysql80
 #    mysqld:
-#      mysql80Compatible: vitess/lite:v12.0.0-mysql80
+#      mysql80Compatible: vitess/lite:mysql80
 
 kubectl apply -f 101_initial_cluster.yaml
 

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -5691,7 +5691,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: vitess-operator
-        image: planetscale/vitess-operator:v2.5.0
+        image: planetscale/vitess-operator:latest
         name: vitess-operator
         resources:
           limits:


### PR DESCRIPTION
## Description

This pull request changes the Docker tag used in the vitess operator examples. Previously, they were using `v12.0.0` on `main` which is incorrect, we want people using `main` to use the latest builds of Vitess.

## Related Issue(s)
- Contributes to https://github.com/vitessio/vitess/issues/9566


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
