### PR TITLE
Automatically update vitess-operator example during a release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,53 +328,8 @@ release: docker_base
 	echo "git push origin v$(VERSION)"
 	echo "Also, don't forget the upload releases/v$(VERSION).tar.gz file to GitHub releases"
 
-do_release_2:
-	./tools/do_release.sh
-
 do_release:
-ifndef RELEASE_VERSION
-		echo "Set the env var RELEASE_VERSION with the release version"
-		exit 1
-endif
-ifndef DEV_VERSION
-		echo "Set the env var DEV_VERSION with the version the dev branch should have after release"
-		exit 1
-endif
-ifeq ($(strip $(GIT_STATUS)),)
-	echo so much clean
-else
-	echo cannot do release with dirty git state
-	exit 1
-	echo so much win
-endif
-# Pre checks passed. Let's change the current version
-	cd java && mvn versions:set -DnewVersion=$(RELEASE_VERSION)
-	echo package servenv > go/vt/servenv/version.go
-	echo  >> go/vt/servenv/version.go
-	echo const versionName = \"$(RELEASE_VERSION)\" >> go/vt/servenv/version.go
-	echo -n Pausing so relase notes can be added. Press enter to continue
-	read line
-	git add --all
-	git commit -n -s -m "Release commit for $(RELEASE_VERSION)"
-	git tag -m Version\ $(RELEASE_VERSION) v$(RELEASE_VERSION)
-ifdef GODOC_RELEASE_VERSION
-	git tag -a v$(GODOC_RELEASE_VERSION) -m "Tagging $(RELEASE_VERSION) also as $(GODOC_RELEASE_VERSION) for godoc/go modules"
-endif
-	cd java && mvn versions:set -DnewVersion=$(DEV_VERSION)
-	echo package servenv > go/vt/servenv/version.go
-	echo  >> go/vt/servenv/version.go
-	echo const versionName = \"$(DEV_VERSION)\" >> go/vt/servenv/version.go
-	git add --all
-	git commit -n -s -m "Back to dev mode"
-	echo "Release preparations successful"
-ifdef GODOC_RELEASE_VERSION
-	echo "Two git tags were created, you can push them with:"
-	echo "   git push upstream v$(RELEASE_VERSION) && git push upstream v$(GODOC_RELEASE_VERSION)"
-else
-	echo "One git tag was created, you can push it with:"
-	echo "   git push upstream v$(RELEASE_VERSION)"
-endif
-	echo "The git branch has also been updated. You need to push it and get it merged"
+	./tools/do_release.sh
 
 tools:
 	echo $$(date): Installing dependencies

--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,9 @@ release: docker_base
 	echo "git push origin v$(VERSION)"
 	echo "Also, don't forget the upload releases/v$(VERSION).tar.gz file to GitHub releases"
 
+do_release_2:
+	./tools/do_release.sh
+
 do_release:
 ifndef RELEASE_VERSION
 		echo "Set the env var RELEASE_VERSION with the release version"

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -53,8 +53,9 @@ function updateJava () {
 }
 
 function updateVitessOperatorExample () {
-  vtop_example_files=$(find -E $ROOT/examples/operator -regex ".*.(md|yaml)")
-  sed -i.bak -E "s/vitess\/lite:(.*)(-mysql80)?/vitess\/lite:$RELEASE_VERSION/g" $vtop_example_files
+  vtop_example_files=$(find -E $ROOT/examples/operator -name "*.yaml")
+  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:$RELEASE_VERSION/g" $vtop_example_files
+  sed -i.bak -E "s/vitess\/lite:(.*)-mysql80/vitess\/lite:$RELEASE_VERSION-mysql80/g" $(find -E $ROOT/examples/operator -name "*.md")
   if [ "$VTOP_VERSION" != "" ]; then
   		sed -i.bak -E "s/planetscale\/vitess-operator:(.*)/planetscale\/vitess-operator:$VTOP_VERSION/g" $vtop_example_files
   fi

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Copyright 2022 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "$RELEASE_VERSION" == "" ]; then
+		echo "Set the env var RELEASE_VERSION with the release version"
+		exit 1
+fi
+
+if [ "$DEV_VERSION" == "" ]; then
+		echo "Set the env var DEV_VERSION with the version the dev branch should have after release"
+		exit 1
+fi
+
+git_status_output=$(git status --porcelain)
+if [ "$git_status_output" == "" ]; then
+  	echo so much clean
+else
+    echo cannot do release with dirty git state
+    exit 1
+    echo so much win
+fi
+
+cd java && mvn versions:set -DnewVersion=$RELEASE_VERSION
+echo package servenv > go/vt/servenv/version.go
+echo  >> go/vt/servenv/version.go
+echo const versionName = \"$RELEASE_VERSION\" >> go/vt/servenv/version.go
+echo -n Pausing so relase notes can be added. Press enter to continue
+read line
+git add --all
+git commit -n -s -m "Release commit for $RELEASE_VERSION"
+git tag -m Version\ $RELEASE_VERSION v$RELEASE_VERSION
+
+if [ "$GODOC_RELEASE_VERSION" != "" ]; then
+    git tag -a v$GODOC_RELEASE_VERSION -m "Tagging $RELEASE_VERSION also as $GODOC_RELEASE_VERSION for godoc/go modules"
+fi
+
+cd java && mvn versions:set -DnewVersion=$DEV_VERSION
+echo package servenv > go/vt/servenv/version.go
+echo  >> go/vt/servenv/version.go
+echo const versionName = \"$DEV_VERSION)\" >> go/vt/servenv/version.go
+git add --all
+git commit -n -s -m "Back to dev mode"
+echo "Release preparations successful"
+
+if [ "$GODOC_RELEASE_VERSION" != "" ]; then
+	echo "One git tag was created, you can push it with:"
+	echo "   git push upstream v$RELEASE_VERSION"
+else
+  echo "Two git tags were created, you can push them with:"
+  echo "   git push upstream v$RELEASE_VERSION && git push upstream v$GODOC_RELEASE_VERSION"
+fi
+
+echo "The git branch has also been updated. You need to push it and get it merged"

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -53,12 +53,12 @@ function updateJava () {
 }
 
 function updateVitessOperatorExample () {
-  vtop_example_files=$(find $ROOT/examples/operator -name "*.yaml")
-  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:$RELEASE_VERSION/g" $vtop_example_files
+  vtop_example_files=$(find -E $ROOT/examples/operator -regex ".*.(md|yaml)")
+  sed -i.bak -E "s/vitess\/lite:(.*)(-mysql80)?/vitess\/lite:$RELEASE_VERSION/g" $vtop_example_files
   if [ "$VTOP_VERSION" != "" ]; then
   		sed -i.bak -E "s/planetscale\/vitess-operator:(.*)/planetscale\/vitess-operator:$VTOP_VERSION/g" $vtop_example_files
   fi
-  rm -f $(find $ROOT/examples/operator -name "*.yaml.bak")
+  rm -f $(find -E $ROOT/examples/operator -regex ".*.(md|yaml).bak")
 }
 
 git_status_output=$(git status --porcelain)

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -20,25 +20,25 @@ if [ "$VTROOT" != "" ]; then
 fi
 
 if [ "$RELEASE_VERSION" == "" ]; then
-		echo "Set the env var RELEASE_VERSION with the release version"
-		exit 1
+  echo "Set the env var RELEASE_VERSION with the release version"
+  exit 1
 fi
 
 if [ "$DEV_VERSION" == "" ]; then
-		echo "Set the env var DEV_VERSION with the version the dev branch should have after release"
-		exit 1
+  echo "Set the env var DEV_VERSION with the version the dev branch should have after release"
+  exit 1
 fi
 
 if [ "$VTOP_VERSION" == "" ]; then
-		echo "Warning: The VTOP_VERSION env var is not set, the Docker tag of the vitess-operator image will not be changed."
-		echo -n "If you wish to continue anyhow press enter, otherwise CTRL+C to cancel."
-    read line
+  echo "Warning: The VTOP_VERSION env var is not set, the Docker tag of the vitess-operator image will not be changed."
+  echo -n "If you wish to continue anyhow press enter, otherwise CTRL+C to cancel."
+  read line
 fi
 
 if [ "$GODOC_RELEASE_VERSION" == "" ]; then
-		echo "Warning: The GODOC_RELEASE_VERSION env var is not set, no go doc tag will be created."
-		echo -n "If you wish to continue anyhow press enter, otherwise CTRL+C to cancel."
-    read line
+  echo "Warning: The GODOC_RELEASE_VERSION env var is not set, no go doc tag will be created."
+  echo -n "If you wish to continue anyhow press enter, otherwise CTRL+C to cancel."
+  read line
 fi
 
 function updateVersionGo () {
@@ -100,8 +100,8 @@ if [ "$GODOC_RELEASE_VERSION" != "" ]; then
   echo "Two git tags were created, you can push them with:"
   echo "   git push upstream v$RELEASE_VERSION && git push upstream v$GODOC_RELEASE_VERSION"
 else
-	echo "One git tag was created, you can push it with:"
-	echo "   git push upstream v$RELEASE_VERSION"
+  echo "One git tag was created, you can push it with:"
+  echo "   git push upstream v$RELEASE_VERSION"
 fi
 
 echo "The git branch has also been updated. You need to push it and get it merged"

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
-
 ROOT=$(pwd)
 if [ "$VTROOT" != "" ]; then
     ROOT=$VTROOT

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -54,9 +54,9 @@ function updateJava () {
 
 function updateVitessOperatorExample () {
   vtop_example_files=$(find $ROOT/examples/operator -name "*.yaml")
-  sed -i.bak -E 's/vitess\/lite:(.*)/vitess\/lite:$RELEASE_VERSION/g' $vtop_example_files
+  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:$RELEASE_VERSION/g" $vtop_example_files
   if [ "$VTOP_VERSION" != "" ]; then
-  		sed -i.bak -E 's/planetscale\/vitess-operator:(.*)/planetscale\/vitess-operator:$VTOP_VERSION/g' $vtop_example_files
+  		sed -i.bak -E "s/planetscale\/vitess-operator:(.*)/planetscale\/vitess-operator:$VTOP_VERSION/g" $vtop_example_files
   fi
   rm -f $(find $ROOT/examples/operator -name "*.yaml.bak")
 }
@@ -67,7 +67,6 @@ if [ "$git_status_output" == "" ]; then
 else
     echo cannot do release with dirty git state
     exit 1
-    echo so much win
 fi
 
 # Preparing the release commit
@@ -98,11 +97,11 @@ git commit -n -s -m "Back to dev mode"
 echo "Release preparations successful"
 
 if [ "$GODOC_RELEASE_VERSION" != "" ]; then
-	echo "One git tag was created, you can push it with:"
-	echo "   git push upstream v$RELEASE_VERSION"
-else
   echo "Two git tags were created, you can push them with:"
   echo "   git push upstream v$RELEASE_VERSION && git push upstream v$GODOC_RELEASE_VERSION"
+else
+	echo "One git tag was created, you can push it with:"
+	echo "   git push upstream v$RELEASE_VERSION"
 fi
 
 echo "The git branch has also been updated. You need to push it and get it merged"

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -52,12 +52,14 @@ function updateJava () {
   mvn versions:set -DnewVersion=$1
 }
 
+# First argument is the Release Version (for instance: v12.0.0)
+# Second argument is the Vitess Operator version
 function updateVitessOperatorExample () {
   vtop_example_files=$(find -E $ROOT/examples/operator -name "*.yaml")
-  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:$RELEASE_VERSION/g" $vtop_example_files
-  sed -i.bak -E "s/vitess\/lite:(.*)-mysql80/vitess\/lite:$RELEASE_VERSION-mysql80/g" $(find -E $ROOT/examples/operator -name "*.md")
-  if [ "$VTOP_VERSION" != "" ]; then
-  		sed -i.bak -E "s/planetscale\/vitess-operator:(.*)/planetscale\/vitess-operator:$VTOP_VERSION/g" $vtop_example_files
+  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:$1/g" $vtop_example_files
+  sed -i.bak -E "s/vitess\/lite:(.*)-mysql80/vitess\/lite:$1-mysql80/g" $(find -E $ROOT/examples/operator -name "*.md")
+  if [ "$2" != "" ]; then
+  		sed -i.bak -E "s/planetscale\/vitess-operator:(.*)/planetscale\/vitess-operator:$2/g" $vtop_example_files
   fi
   rm -f $(find -E $ROOT/examples/operator -regex ".*.(md|yaml).bak")
 }
@@ -71,7 +73,7 @@ else
 fi
 
 # Preparing the release commit
-updateVitessOperatorExample
+updateVitessOperatorExample $RELEASE_VERSION $VTOP_VERSION
 updateJava $RELEASE_VERSION
 updateVersionGo $RELEASE_VERSION
 


### PR DESCRIPTION
## Description

This pull request adds some logic to `do_release` to automatically update the vitess-operator example during a release.

In the `./examples/operator`, both the Kubernetes YAML files and the README are updated during the release. The `vitess/lite` Docker image will be tagged to the new release (`$RELEASE_VERSION`), and the `planetscale/vitess-operator` image will use the value of `$VTOP_VERSION` as a tag. Note that `$VTOP_VERSION` is not required to run `do_release`, if no value is passed, the `planetscale/vitess-operator` image will remain the same.

## Related Issue(s)
- Contributes to https://github.com/vitessio/vitess/issues/9566

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
