### PR TITLE
tests: fix CI failure

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -2905,7 +2905,7 @@ Gen4 plan same as above
     "Query": "update multicol_tbl set x = 42 where `name` = 'foo'",
     "Table": "multicol_tbl",
     "Values": [
-      "VARBINARY(\"foo\")"
+      "VARCHAR(\"foo\")"
     ],
     "Vindex": "name_muticoltbl_map"
   }
@@ -3040,7 +3040,7 @@ Gen4 plan same as above
     "Query": "delete from multicol_tbl where `name` = 'foo'",
     "Table": "multicol_tbl",
     "Values": [
-      "VARBINARY(\"foo\")"
+      "VARCHAR(\"foo\")"
     ],
     "Vindex": "name_muticoltbl_map"
   }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
CI is currently failing with
```
--- FAIL: TestPlan (0.12s)
    --- FAIL: TestPlan/dml_cases.txt (0.01s)
        --- FAIL: TestPlan/dml_cases.txt/2913_V3:_#_update_with_routing_using_non-unique_lookup_vindex_ (0.00s)
            plan_test.go:603: V3 - dml_cases.txt:2913
                Diff:
                  strings.Join({
                  	... // 302 identical bytes
                  	"lse,\n    \"Query\": \"update multicol_tbl set x = 42 where `name` =",
                  	" 'foo'\",\n    \"Table\": \"multicol_tbl\",\n    \"Values\": [\n      \"VAR",
                - 	"BINARY",
                + 	"CHAR",
                  	"(\\\"foo\\\")\"\n    ],\n    \"Vindex\": \"name_muticoltbl_map\"\n  }\n}",
                  }, "")

                [{
                  "QueryType": "UPDATE",
                  "Original": "update multicol_tbl set x = 42 where name = 'foo'",
                  "Instructions": {
                    "OperatorType": "Update",
                    "Variant": "Equal",
                    "Keyspace": {
                      "Name": "user",
                      "Sharded": true
                    },
                    "TargetTabletType": "PRIMARY",
                    "MultiShardAutocommit": false,
                    "Query": "update multicol_tbl set x = 42 where `name` = 'foo'",
                    "Table": "multicol_tbl",
                    "Values": [
                      "VARBINARY(\"foo\")"
                    ],
                    "Vindex": "name_muticoltbl_map"
                  }
                }]
                [{
                  "QueryType": "UPDATE",
                  "Original": "update multicol_tbl set x = 42 where name = 'foo'",
                  "Instructions": {
                    "OperatorType": "Update",
                    "Variant": "Equal",
                    "Keyspace": {
                      "Name": "user",
                      "Sharded": true
                    },
                    "TargetTabletType": "PRIMARY",
                    "MultiShardAutocommit": false,
                    "Query": "update multicol_tbl set x = 42 where `name` = 'foo'",
                    "Table": "multicol_tbl",
                    "Values": [
                      "VARCHAR(\"foo\")"
                    ],
                    "Vindex": "name_muticoltbl_map"
                  }
                }]
        --- FAIL: TestPlan/dml_cases.txt/2913_Gen4:_#_update_with_routing_using_non-unique_lookup_vindex_ (0.00s)
            plan_test.go:630: Gen4 - dml_cases.txt:2913
                Diff:
                  strings.Join({
                  	... // 302 identical bytes
                  	"lse,\n    \"Query\": \"update multicol_tbl set x = 42 where `name` =",
                  	" 'foo'\",\n    \"Table\": \"multicol_tbl\",\n    \"Values\": [\n      \"VAR",
                - 	"BINARY",
                + 	"CHAR",
                  	"(\\\"foo\\\")\"\n    ],\n    \"Vindex\": \"name_muticoltbl_map\"\n  }\n}",
                  }, "")

                [{
                  "QueryType": "UPDATE",
                  "Original": "update multicol_tbl set x = 42 where name = 'foo'",
                  "Instructions": {
                    "OperatorType": "Update",
                    "Variant": "Equal",
                    "Keyspace": {
                      "Name": "user",
                      "Sharded": true
                    },
                    "TargetTabletType": "PRIMARY",
                    "MultiShardAutocommit": false,
                    "Query": "update multicol_tbl set x = 42 where `name` = 'foo'",
                    "Table": "multicol_tbl",
                    "Values": [
                      "VARBINARY(\"foo\")"
                    ],
                    "Vindex": "name_muticoltbl_map"
                  }
                }]
                [{
                  "QueryType": "UPDATE",
                  "Original": "update multicol_tbl set x = 42 where name = 'foo'",
                  "Instructions": {
                    "OperatorType": "Update",
                    "Variant": "Equal",
                    "Keyspace": {
                      "Name": "user",
                      "Sharded": true
                    },
                    "TargetTabletType": "PRIMARY",
                    "MultiShardAutocommit": false,
                    "Query": "update multicol_tbl set x = 42 where `name` = 'foo'",
                    "Table": "multicol_tbl",
                    "Values": [
                      "VARCHAR(\"foo\")"
                    ],
                    "Vindex": "name_muticoltbl_map"
                  }
                }]
        --- FAIL: TestPlan/dml_cases.txt/3048_V3:_#_delete_with_routing_using_non-unique_lookup_vindex_ (0.00s)
            plan_test.go:603: V3 - dml_cases.txt:3048
                Diff:
                  strings.Join({
                  	... // 453 identical bytes
                  	"r update\",\n    \"Query\": \"delete from multicol_tbl where `name` =",
                  	" 'foo'\",\n    \"Table\": \"multicol_tbl\",\n    \"Values\": [\n      \"VAR",
                - 	"BINARY",
                + 	"CHAR",
                  	"(\\\"foo\\\")\"\n    ],\n    \"Vindex\": \"name_muticoltbl_map\"\n  }\n}",
                  }, "")

                [{
                  "QueryType": "DELETE",
                  "Original": "delete from multicol_tbl where name = 'foo'",
                  "Instructions": {
                    "OperatorType": "Delete",
                    "Variant": "Equal",
                    "Keyspace": {
                      "Name": "user",
                      "Sharded": true
                    },
                    "TargetTabletType": "PRIMARY",
                    "KsidLength": 2,
                    "KsidVindex": "multicolIdx",
                    "MultiShardAutocommit": false,
                    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where `name` = 'foo' for update",
                    "Query": "delete from multicol_tbl where `name` = 'foo'",
                    "Table": "multicol_tbl",
                    "Values": [
                      "VARBINARY(\"foo\")"
                    ],
                    "Vindex": "name_muticoltbl_map"
                  }
                }]
                [{
                  "QueryType": "DELETE",
                  "Original": "delete from multicol_tbl where name = 'foo'",
                  "Instructions": {
                    "OperatorType": "Delete",
                    "Variant": "Equal",
                    "Keyspace": {
                      "Name": "user",
                      "Sharded": true
                    },
                    "TargetTabletType": "PRIMARY",
                    "KsidLength": 2,
                    "KsidVindex": "multicolIdx",
                    "MultiShardAutocommit": false,
                    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where `name` = 'foo' for update",
                    "Query": "delete from multicol_tbl where `name` = 'foo'",
                    "Table": "multicol_tbl",
                    "Values": [
                      "VARCHAR(\"foo\")"
                    ],
                    "Vindex": "name_muticoltbl_map"
                  }
                }]
        --- FAIL: TestPlan/dml_cases.txt/3048_Gen4:_#_delete_with_routing_using_non-unique_lookup_vindex_ (0.00s)
            plan_test.go:630: Gen4 - dml_cases.txt:3048
                Diff:
                  strings.Join({
                  	... // 453 identical bytes
                  	"r update\",\n    \"Query\": \"delete from multicol_tbl where `name` =",
                  	" 'foo'\",\n    \"Table\": \"multicol_tbl\",\n    \"Values\": [\n      \"VAR",
                - 	"BINARY",
                + 	"CHAR",
                  	"(\\\"foo\\\")\"\n    ],\n    \"Vindex\": \"name_muticoltbl_map\"\n  }\n}",
                  }, "")

                [{
                  "QueryType": "DELETE",
                  "Original": "delete from multicol_tbl where name = 'foo'",
                  "Instructions": {
                    "OperatorType": "Delete",
                    "Variant": "Equal",
                    "Keyspace": {
                      "Name": "user",
                      "Sharded": true
                    },
                    "TargetTabletType": "PRIMARY",
                    "KsidLength": 2,
                    "KsidVindex": "multicolIdx",
                    "MultiShardAutocommit": false,
                    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where `name` = 'foo' for update",
                    "Query": "delete from multicol_tbl where `name` = 'foo'",
                    "Table": "multicol_tbl",
                    "Values": [
                      "VARBINARY(\"foo\")"
                    ],
                    "Vindex": "name_muticoltbl_map"
                  }
                }]
                [{
                  "QueryType": "DELETE",
                  "Original": "delete from multicol_tbl where name = 'foo'",
                  "Instructions": {
                    "OperatorType": "Delete",
                    "Variant": "Equal",
                    "Keyspace": {
                      "Name": "user",
                      "Sharded": true
                    },
                    "TargetTabletType": "PRIMARY",
                    "KsidLength": 2,
                    "KsidVindex": "multicolIdx",
                    "MultiShardAutocommit": false,
                    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where `name` = 'foo' for update",
                    "Query": "delete from multicol_tbl where `name` = 'foo'",
                    "Table": "multicol_tbl",
                    "Values": [
                      "VARCHAR(\"foo\")"
                    ],
                    "Vindex": "name_muticoltbl_map"
                  }
                }]
```

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->