### PR TITLE
Update 13.0 release notes to mention vtadmin-web node LTS requirement

### DIFF
--- a/doc/releasenotes/13_0_0_summary.md
+++ b/doc/releasenotes/13_0_0_summary.md
@@ -102,6 +102,10 @@ vtctlclient OnlineDDL commerce complete d08ffe6b_51c9_11ec_9cf2_0a43f95f28a3
 
 The command now accepts an optional `-json` flag. With this flag, the output is a valid JSON listing all columns and rows.
 
+## vtadmin-web updated to node v16.13.0 (LTS)
+
+Building vtadmin-web now requires node >= v16.13.0 (LTS). Upgrade notes are given in https://github.com/vitessio/vitess/pull/9136. 
+
 ## Incompatible Changes
 
 ## Deprecations


### PR DESCRIPTION
## Description

The only notable change I have for the Vitess 13 release. :) Happy to expand if this isn't verbose enough.

## Related Issue(s)

Mentions the node upgrade in https://github.com/vitessio/vitess/pull/9136. 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
N/A