### PR TITLE
tests: change the way we call net.Listen to avoid annoying popups on macOS

### DIFF
--- a/go/netutil/conn_test.go
+++ b/go/netutil/conn_test.go
@@ -23,7 +23,7 @@ import (
 
 func createSocketPair(t *testing.T) (net.Listener, net.Conn, net.Conn) {
 	// Create a listener.
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Listen failed: %v", err)
 	}

--- a/go/test/fuzzing/tablet_manager_fuzzer.go
+++ b/go/test/fuzzing/tablet_manager_fuzzer.go
@@ -33,7 +33,7 @@ func initTesting() {
 	testing.Init()
 }
 
-func FuzzTabletManager_ExecuteFetchAsDba(data []byte) int {
+func FuzzTabletManagerExecuteFetchAsDba(data []byte) int {
 	fuzzInitter.Do(initTesting)
 	t := &testing.T{}
 	ctx := context.Background()

--- a/go/test/fuzzing/vtctl_fuzzer.go
+++ b/go/test/fuzzing/vtctl_fuzzer.go
@@ -179,15 +179,15 @@ func Fuzz(data []byte) int {
 		// Index of command in getCommandType():
 		commandIndex := int(commandPart[command]) % 68
 		vtCommand := getCommandType(commandIndex)
-		command_slice := []string{vtCommand}
+		commandSlice := []string{vtCommand}
 		args := strings.Split(string(restOfArray[from:to]), " ")
 
 		// Add params to the command
 		for i := range args {
-			command_slice = append(command_slice, args[i])
+			commandSlice = append(commandSlice, args[i])
 		}
 
-		_ = vtctl.RunCommand(ctx, wrangler.New(logger, topo, tmc), command_slice)
+		_ = vtctl.RunCommand(ctx, wrangler.New(logger, topo, tmc), commandSlice)
 		command++
 	}
 

--- a/go/test/fuzzing/vttablet_fuzzer.go
+++ b/go/test/fuzzing/vttablet_fuzzer.go
@@ -692,7 +692,7 @@ func FuzzGRPCTMServer(data []byte) int {
 	t := &testing.T{}
 
 	// Listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0
 	}

--- a/go/vt/binlog/grpcbinlogplayer/player_test.go
+++ b/go/vt/binlog/grpcbinlogplayer/player_test.go
@@ -33,7 +33,7 @@ import (
 // implementation, and runs the test suite against the setup.
 func TestGRPCBinlogStreamer(t *testing.T) {
 	// Listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/grpcoptionaltls/server_test.go
+++ b/go/vt/grpcoptionaltls/server_test.go
@@ -82,7 +82,7 @@ func TestOptionalTLS(t *testing.T) {
 		t.Fatalf("failed to create credentials %v", err)
 	}
 
-	lis, err := net.Listen("tcp", "")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen %v", err)
 	}
@@ -114,12 +114,12 @@ func TestOptionalTLS(t *testing.T) {
 	}
 
 	t.Run("Plain2TLS", func(t *testing.T) {
-		for i := 0; i < 5; i += 1 {
+		for i := 0; i < 5; i++ {
 			testFunc(t, grpc.WithInsecure())
 		}
 	})
 	t.Run("TLS2TLS", func(t *testing.T) {
-		for i := 0; i < 5; i += 1 {
+		for i := 0; i < 5; i++ {
 			testFunc(t, grpc.WithTransportCredentials(tc.client))
 		}
 	})

--- a/go/vt/servenv/exporter_test.go
+++ b/go/vt/servenv/exporter_test.go
@@ -37,7 +37,7 @@ func TestURLPrefix(t *testing.T) {
 
 func TestHandleFunc(t *testing.T) {
 	// Listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient_test.go
+++ b/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient_test.go
@@ -62,7 +62,7 @@ func TestThrottlerServerPanics(t *testing.T) {
 
 func startGRPCServer(t *testing.T, m throttler.Manager) int {
 	// Listen on a random port.
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/tlstest/tlstest_test.go
+++ b/go/vt/tlstest/tlstest_test.go
@@ -84,7 +84,7 @@ func testClientServer(t *testing.T, combineCerts bool) {
 	}
 
 	// Create a TLS server listener.
-	listener, err := tls.Listen("tcp", ":0", serverConfig)
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", serverConfig)
 	if err != nil {
 		t.Fatalf("Listen failed: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestNumberOfCertsWithCombining(t *testing.T) {
 
 func assertTLSHandshakeFails(t *testing.T, serverConfig, clientConfig *tls.Config) {
 	// Create a TLS server listener.
-	listener, err := tls.Listen("tcp", ":0", serverConfig)
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", serverConfig)
 	if err != nil {
 		t.Fatalf("Listen failed: %v", err)
 	}

--- a/go/vt/vitessdriver/driver_test.go
+++ b/go/vt/vitessdriver/driver_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 	service := CreateFakeServer()
 
 	// listen on a random port.
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(fmt.Sprintf("Cannot listen: %v", err))
 	}

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -35,7 +35,7 @@ type fakeVtctld struct {
 }
 
 func TestDial(t *testing.T) {
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	defer listener.Close()

--- a/go/vt/vtctl/grpcvtctlclient/client_test.go
+++ b/go/vt/vtctl/grpcvtctlclient/client_test.go
@@ -39,7 +39,7 @@ func TestVtctlServer(t *testing.T) {
 	ts := vtctlclienttest.CreateTopoServer(t)
 
 	// Listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestVtctlAuthClient(t *testing.T) {
 	ts := vtctlclienttest.CreateTopoServer(t)
 
 	// Listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/vtgate/grpc_discovery_test.go
+++ b/go/vt/vtgate/grpc_discovery_test.go
@@ -46,7 +46,7 @@ func TestGRPCDiscovery(t *testing.T) {
 	service, ts, cell := CreateFakeServers(t)
 
 	// Tablet: listen on a random port.
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
@@ -38,7 +38,7 @@ func TestGRPCVTGateConn(t *testing.T) {
 	service := CreateFakeServer(t)
 
 	// listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestGRPCVTGateConnAuth(t *testing.T) {
 	service := CreateFakeServer(t)
 
 	// listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/vtgate/grpcvtgateconn/fuzz_flaky_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/fuzz_flaky_test.go
@@ -54,7 +54,7 @@ func Fuzz(data []byte) int {
 	service := CreateFakeServer(t)
 
 	// listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		fmt.Println("Cannot listen")
 		return -1

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -85,7 +85,7 @@ func StartCustomServer(connParams, connAppDebugParams mysql.ConnParams, dbName s
 	}
 
 	// Start http service.
-	ln, err := net.Listen("tcp", ":0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return vterrors.Wrap(err, "could not start listener")
 	}

--- a/go/vt/vttablet/grpctabletconn/conn_benchmark_test.go
+++ b/go/vt/vttablet/grpctabletconn/conn_benchmark_test.go
@@ -274,7 +274,7 @@ func BenchmarkGRPCTabletConn(b *testing.B) {
 	}
 
 	// listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		b.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/vttablet/grpctabletconn/conn_test.go
+++ b/go/vt/vttablet/grpctabletconn/conn_test.go
@@ -37,7 +37,7 @@ func TestGRPCTabletConn(t *testing.T) {
 	service := tabletconntest.CreateFakeServer(t)
 
 	// listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestGRPCTabletAuthConn(t *testing.T) {
 	service := tabletconntest.CreateFakeServer(t)
 
 	// listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/vttablet/grpctmserver/server_test.go
+++ b/go/vt/vttablet/grpctmserver/server_test.go
@@ -33,7 +33,7 @@ import (
 // implementation, and runs the test suite against the setup.
 func TestGRPCTMServer(t *testing.T) {
 	// Listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/worker/grpcvtworkerclient/client_test.go
+++ b/go/vt/worker/grpcvtworkerclient/client_test.go
@@ -38,7 +38,7 @@ func TestVtworkerServer(t *testing.T) {
 	wi := vtworkerclienttest.CreateWorkerInstance(t)
 
 	// Listen on a random port.
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestVtworkerServerAuth(t *testing.T) {
 	wi := vtworkerclienttest.CreateWorkerInstance(t)
 
 	// Listen on a random port.
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/workflow/long_polling_test.go
+++ b/go/vt/workflow/long_polling_test.go
@@ -35,7 +35,7 @@ func TestLongPolling(t *testing.T) {
 
 	// Register the manager to a web handler, start a web server.
 	m.HandleHTTPLongPolling("/workflow")
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/workflow/websocket_test.go
+++ b/go/vt/workflow/websocket_test.go
@@ -35,7 +35,7 @@ func TestWebSocket(t *testing.T) {
 
 	// Register the manager to a web handler, start a web server.
 	m.HandleHTTPWebSocket("/workflow")
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/wrangler/testlib/throttler_test.go
+++ b/go/vt/wrangler/testlib/throttler_test.go
@@ -36,7 +36,7 @@ import (
 // "Resharding Throttler" group.
 func TestVtctlThrottlerCommands(t *testing.T) {
 	// Run a throttler server using the default process throttle manager.
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}

--- a/go/vt/wrangler/testlib/vtctl_pipe.go
+++ b/go/vt/wrangler/testlib/vtctl_pipe.go
@@ -64,7 +64,7 @@ func NewVtctlPipe(t *testing.T, ts *topo.Server) *VtctlPipe {
 	})
 
 	// Listen on a random port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Cannot listen: %v", err)
 	}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Running the unit tests on macOS produces a bunch of popups asking whether .test executables should be allowed to accept incoming network connections.
It is annoying because they steal the focus, and it is not desirable to turn off the firewall to avoid them.
This PR attempts to fix _most_ of these warnings/errors. There are still a few that I couldn't trace to the source and some that I couldn't change without causing tests to fail.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->