### PR TITLE
Update web/vtctld2 to use node v8.17 

### DIFF
--- a/tools/web_bootstrap.sh
+++ b/tools/web_bootstrap.sh
@@ -21,10 +21,10 @@ set -euo pipefail
 
 web_dir="$VTROOT/web/vtctld2"
 
-TARGET_NODE_VERSION="v8.0.0"
+TARGET_NODE_VERSION="v8.17.0"
 node_version=$(node -v)
 
-TARGET_NPM_VERSION="5.0.0"
+TARGET_NPM_VERSION="6.13.4"
 npm_version=$(npm -v)
 
 if [[ -z ${node_version+x} || -z ${npm_version+x} ]]; then 

--- a/web/vtctld2/README.md
+++ b/web/vtctld2/README.md
@@ -52,8 +52,10 @@ make web_build
 
 This will regenerate a bunch of files in the `web/vtctld2/dist/` directory, as well as update the embedded files in `rice-box.go`. Make sure you commit these generated files to your branch when opening your pull request.
 
-To verify your changes, run Vitess locally. It is recommended to [use Docker](https://vitess.io/docs/get-started/local-docker/), which will make the vtctld UI accessible at `http://localhost:15000/app`.
-
+To then verify your changes using the built files:
+- Rebuild the vtctld with `make build`
+- Run Vitess locally following the [Local Install guide](https://vitess.io/docs/get-started/local/) 
+- Verify your changes on `http://localhost:15000/app`
 
 ## Troubleshooting
 

--- a/web/vtctld2/README.md
+++ b/web/vtctld2/README.md
@@ -11,15 +11,15 @@ This project was generated with [angular-cli](https://github.com/angular/angular
 You will need (very old!) installations of npm and node to run the front-end dev server. To check your versions:
 
 ```bash
-node -v # v8.0.0 required
-npm -v # 5.0.0 required
+node -v # v8.17.0 required
+npm -v # 6.13.4 required
 ```
 
 Using a node version manager like [nvm](https://github.com/nvm-sh/nvm) is strongly recommended, as the versions required by this project are several years out of date.
 
 1. Install nvm using the [installation guide](https://github.com/nvm-sh/nvm#installing-and-updating).
-1. Install node (and npm): `nvm install 8.0.0`
-1. In the shell you're using for vtctld UI development: `nvm use 8.0.0`
+1. Install node (and npm): `nvm install 8.17.0`
+1. In the shell you're using for vtctld UI development: `nvm use 8.17.0`
 
 ### Starting the dev server
 

--- a/web/vtctld2/package-lock.json
+++ b/web/vtctld2/package-lock.json
@@ -2,18 +2,28 @@
   "name": "vtctld2",
   "version": "0.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@angular-cli/ast-tools": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/@angular-cli/ast-tools/-/ast-tools-1.0.16.tgz",
       "integrity": "sha1-YxmULBol+4TjKUID6fejJmMvzlA=",
       "dev": true,
+      "requires": {
+        "@angular/tsc-wrapped": "^0.5.0",
+        "denodeify": "^1.2.1",
+        "rxjs": "^5.0.1",
+        "typescript": "~2.0.3"
+      },
       "dependencies": {
         "@angular/tsc-wrapped": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-0.5.2.tgz",
           "integrity": "sha1-Lt30csRn/LM06pTe3aqnGZDFpII=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "tsickle": "^0.2"
+          }
         },
         "denodeify": {
           "version": "1.2.1",
@@ -32,6 +42,9 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
@@ -45,7 +58,10 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.1.0.tgz",
           "integrity": "sha1-CqkBi39EC1BfpCvXQrZzi+VQ5yA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "symbol-observable": "^1.0.1"
+          }
         },
         "source-map": {
           "version": "0.5.6",
@@ -57,7 +73,10 @@
           "version": "0.4.11",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.11.tgz",
           "integrity": "sha1-ZH+TmXizhTWQlTCIUwPa8jJ58yI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-map": "^0.5.3"
+          }
         },
         "symbol-observable": {
           "version": "1.0.4",
@@ -69,7 +88,13 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.2.5.tgz",
           "integrity": "sha1-YNjhJGLm+PvayS1fX+rSv0kIXYI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map": "^0.5.6",
+            "source-map-support": "^0.4.2"
+          }
         },
         "typescript": {
           "version": "2.0.10",
@@ -94,6 +119,12 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-0.5.0.tgz",
       "integrity": "sha1-f6reGgCEqKWOXgNpBVe4AJvqPbg=",
       "dev": true,
+      "requires": {
+        "@angular/tsc-wrapped": "^0.2.0",
+        "minimist": "^1.2.0",
+        "parse5": "1.3.2",
+        "reflect-metadata": "^0.1.2"
+      },
       "dependencies": {
         "parse5": {
           "version": "1.3.2",
@@ -137,7 +168,10 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-0.2.2.tgz",
       "integrity": "sha1-bsyax97/4kqZRQWiWjXaPb+3EiA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tsickle": "0.1.6"
+      }
     },
     "@angular2-material/button": {
       "version": "2.0.0-alpha.7-2",
@@ -198,6 +232,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@vaadin/angular2-polymer/-/angular2-polymer-1.0.0.tgz",
       "integrity": "sha1-CTXYm8DpAksTJgBCYfo8DeGqUWM=",
+      "requires": {
+        "@angular/common": "^2.0.0",
+        "@angular/core": "^2.0.0",
+        "@angular/forms": "^2.0.0",
+        "@angular/platform-browser": "^2.0.0",
+        "rxjs": "5.0.0-rc.4",
+        "zone.js": "^0.7.2"
+      },
       "dependencies": {
         "@angular/common": {
           "version": "2.4.10",
@@ -222,7 +264,10 @@
         "rxjs": {
           "version": "5.0.0-rc.4",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-rc.4.tgz",
-          "integrity": "sha1-pNCLxdfzDUjtcTDimVSQwyajJcQ="
+          "integrity": "sha1-pNCLxdfzDUjtcTDimVSQwyajJcQ=",
+          "requires": {
+            "symbol-observable": "^1.0.1"
+          }
         },
         "zone.js": {
           "version": "0.7.8",
@@ -241,7 +286,11 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      }
     },
     "acorn": {
       "version": "5.7.1",
@@ -266,6 +315,10 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
+      "requires": {
+        "extend": "~3.0.0",
+        "semver": "~5.0.1"
+      },
       "dependencies": {
         "semver": {
           "version": "5.0.3",
@@ -279,13 +332,24 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
     },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -297,13 +361,19 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
       "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "stable": "~0.1.3"
+      }
     },
     "amd-name-resolver": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.5.tgz",
       "integrity": "sha1-dpYtrIdu0zEbBdKcaljBTh7zMEs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ensure-posix-path": "^1.0.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -316,12 +386,85 @@
       "resolved": "https://registry.npmjs.org/angular-cli/-/angular-cli-1.0.0-beta.11-webpack.8.tgz",
       "integrity": "sha1-6YkmRjQObEndBVCuOkyf4bH5xFQ=",
       "dev": true,
+      "requires": {
+        "@angular-cli/ast-tools": "^1.0.0",
+        "@angular/compiler": "^2.0.0-rc.5",
+        "@angular/compiler-cli": "^0.5.0",
+        "@angular/core": "^2.0.0-rc.5",
+        "@angular/tsc-wrapped": "^0.2.2",
+        "angular2-template-loader": "^0.5.0",
+        "awesome-typescript-loader": "^2.2.1",
+        "chalk": "^1.1.3",
+        "common-tags": "^1.3.1",
+        "compression-webpack-plugin": "^0.3.1",
+        "copy-webpack-plugin": "^3.0.1",
+        "core-js": "^2.4.0",
+        "css-loader": "^0.23.1",
+        "denodeify": "^1.2.1",
+        "ember-cli": "2.5.0",
+        "ember-cli-string-utils": "^1.0.0",
+        "enhanced-resolve": "^2.2.2",
+        "exit": "^0.1.2",
+        "exports-loader": "^0.6.3",
+        "expose-loader": "^0.7.1",
+        "file-loader": "^0.8.5",
+        "fs-extra": "^0.30.0",
+        "glob": "^7.0.3",
+        "handlebars": "^4.0.5",
+        "html-webpack-plugin": "^2.19.0",
+        "istanbul-instrumenter-loader": "^0.2.0",
+        "json-loader": "^0.5.4",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-webpack": "^1.8.0",
+        "leek": "0.0.21",
+        "less": "^2.7.1",
+        "less-loader": "^2.2.3",
+        "lodash": "^4.11.1",
+        "node-sass": "^3.7.0",
+        "npm": "3.10.2",
+        "npm-run-all": "^3.0.0",
+        "offline-plugin": "^3.4.1",
+        "opn": "4.0.1",
+        "parse5": "^2.1.5",
+        "phantomjs-polyfill": "0.0.2",
+        "phantomjs-prebuilt": "^2.1.7",
+        "postcss-loader": "^0.9.1",
+        "protractor": "^3.3.0",
+        "raw-loader": "^0.5.1",
+        "remap-istanbul": "^0.6.4",
+        "resolve": "^1.1.7",
+        "rimraf": "^2.5.3",
+        "rxjs": "^5.0.0-beta.11",
+        "sass-loader": "^3.2.0",
+        "script-loader": "^0.7.0",
+        "shelljs": "^0.7.0",
+        "silent-error": "^1.0.0",
+        "source-map-loader": "^0.1.5",
+        "sourcemap-istanbul-instrumenter-loader": "^0.2.0",
+        "string-replace-loader": "^1.0.3",
+        "style-loader": "^0.13.1",
+        "stylus": "^0.54.5",
+        "stylus-loader": "^2.1.0",
+        "symlink-or-copy": "^1.0.3",
+        "ts-loader": "^0.8.2",
+        "tslint-loader": "^2.1.4",
+        "typedoc": "^0.4.2",
+        "typescript": "^2.0.0",
+        "url-loader": "^0.5.7",
+        "webpack": "2.1.0-beta.21",
+        "webpack-dev-server": "2.1.0-beta.0",
+        "webpack-md5-hash": "0.0.5",
+        "webpack-merge": "^0.14.0"
+      },
       "dependencies": {
         "rxjs": {
           "version": "5.5.11",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
           "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
         },
         "symbol-observable": {
           "version": "1.0.1",
@@ -335,7 +478,11 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/angular2-template-loader/-/angular2-template-loader-0.5.0.tgz",
       "integrity": "sha1-oW2xkPqvn46OlBDzxGg3DedRJ6Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "codecov": "^1.0.1",
+        "loader-utils": "^0.2.15"
+      }
     },
     "ansi": {
       "version": "0.3.1",
@@ -353,7 +500,10 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
       "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -389,7 +539,11 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
+      }
     },
     "aproba": {
       "version": "1.2.0",
@@ -401,13 +555,20 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
     },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "argv": {
       "version": "0.0.2",
@@ -419,7 +580,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -467,7 +631,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
       "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "es6-symbol": "^3.0.2"
+      }
     },
     "array-map": {
       "version": "0.0.0",
@@ -491,7 +659,10 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-to-error/-/array-to-error-1.1.1.tgz",
       "integrity": "sha1-1ogSkm0UCXogVXmmZ+6vGFakTAc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-to-sentence": "^1.1.0"
+      }
     },
     "array-to-sentence": {
       "version": "1.1.0",
@@ -540,13 +711,21 @@
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
     },
     "assert": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -558,7 +737,10 @@
           "version": "0.10.3",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
         }
       }
     },
@@ -596,7 +778,16 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
       "integrity": "sha1-YEBIZmCzcOQFHNn6n+4nXh+uNyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "2.1.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
+        "username-sync": "1.0.1"
+      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -615,12 +806,19 @@
       "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
       "integrity": "sha1-MIuq+8dK/2agu25/ShjU/oQ0RAw=",
       "dev": true,
+      "requires": {
+        "async": "^2.4.1",
+        "debug": "^2.6.8"
+      },
       "dependencies": {
         "async": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
         }
       }
     },
@@ -640,13 +838,29 @@
       "version": "6.7.7",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "^1.7.6",
+        "caniuse-db": "^1.0.30000634",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^5.2.16",
+        "postcss-value-parser": "^3.2.3"
+      }
     },
     "awesome-typescript-loader": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-2.2.4.tgz",
       "integrity": "sha1-QYXWDANcJVFfnCp0f6X2myoAHp4=",
       "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "enhanced-resolve": "^2.2.2",
+        "loader-utils": "^0.2.6",
+        "lodash": "^4.13.1",
+        "object-assign": "^4.1.0",
+        "source-map-support": "^0.4.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
@@ -658,7 +872,10 @@
           "version": "0.4.18",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
           "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-map": "^0.5.6"
+          }
         }
       }
     },
@@ -679,6 +896,54 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
       "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
       "dev": true,
+      "requires": {
+        "babel-plugin-constant-folding": "^1.0.1",
+        "babel-plugin-dead-code-elimination": "^1.0.2",
+        "babel-plugin-eval": "^1.0.1",
+        "babel-plugin-inline-environment-variables": "^1.0.1",
+        "babel-plugin-jscript": "^1.0.4",
+        "babel-plugin-member-expression-literals": "^1.0.1",
+        "babel-plugin-property-literals": "^1.0.1",
+        "babel-plugin-proto-to-assign": "^1.0.3",
+        "babel-plugin-react-constant-elements": "^1.0.3",
+        "babel-plugin-react-display-name": "^1.0.3",
+        "babel-plugin-remove-console": "^1.0.1",
+        "babel-plugin-remove-debugger": "^1.0.1",
+        "babel-plugin-runtime": "^1.0.7",
+        "babel-plugin-undeclared-variables-check": "^1.0.2",
+        "babel-plugin-undefined-to-void": "^1.1.6",
+        "babylon": "^5.8.38",
+        "bluebird": "^2.9.33",
+        "chalk": "^1.0.0",
+        "convert-source-map": "^1.1.0",
+        "core-js": "^1.0.0",
+        "debug": "^2.1.1",
+        "detect-indent": "^3.0.0",
+        "esutils": "^2.0.0",
+        "fs-readdir-recursive": "^0.1.0",
+        "globals": "^6.4.0",
+        "home-or-tmp": "^1.0.0",
+        "is-integer": "^1.0.4",
+        "js-tokens": "1.0.1",
+        "json5": "^0.4.0",
+        "lodash": "^3.10.0",
+        "minimatch": "^2.0.3",
+        "output-file-sync": "^1.1.0",
+        "path-exists": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "private": "^0.1.6",
+        "regenerator": "0.8.40",
+        "regexpu": "^1.3.0",
+        "repeating": "^1.1.2",
+        "resolve": "^1.1.6",
+        "shebang-regex": "^1.0.0",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.0",
+        "source-map-support": "^0.2.10",
+        "to-fast-properties": "^1.0.0",
+        "trim-right": "^1.0.0",
+        "try-resolve": "^1.0.0"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -702,7 +967,10 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
         },
         "source-map": {
           "version": "0.5.7",
@@ -715,12 +983,18 @@
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
+          "requires": {
+            "source-map": "0.1.32"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
             }
           }
         }
@@ -773,6 +1047,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
       "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
       "dev": true,
+      "requires": {
+        "lodash": "^3.9.3"
+      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -816,7 +1093,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
       "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "leven": "^1.0.2"
+      }
     },
     "babel-plugin-undefined-to-void": {
       "version": "1.1.6",
@@ -834,7 +1114,10 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
       "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "underscore": ">=1.8.3"
+      }
     },
     "backo2": {
       "version": "1.0.2",
@@ -853,6 +1136,15 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -864,25 +1156,39 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
         },
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
         },
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
         },
         "isobject": {
           "version": "3.0.1",
@@ -921,6 +1227,9 @@
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
       "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
       "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      },
       "dependencies": {
         "safe-buffer": {
           "version": "5.1.1",
@@ -941,7 +1250,10 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "beeper": {
       "version": "1.1.1",
@@ -953,7 +1265,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
+      }
     },
     "big.js": {
       "version": "3.2.0",
@@ -978,6 +1293,9 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
       "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
       "dev": true,
+      "requires": {
+        "readable-stream": "~2.0.5"
+      },
       "dependencies": {
         "process-nextick-args": {
           "version": "1.0.7",
@@ -989,7 +1307,15 @@
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -1015,7 +1341,10 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
     },
     "bluebird": {
       "version": "2.11.0",
@@ -1034,6 +1363,18 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "~1.6.15"
+      },
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.19",
@@ -1059,7 +1400,10 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
     },
     "bower": {
       "version": "1.8.4",
@@ -1072,6 +1416,13 @@
       "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
       "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.3",
+        "mout": "^1.0.0",
+        "optimist": "^0.6.1",
+        "osenv": "^0.1.3",
+        "untildify": "^2.1.0"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -1091,13 +1442,22 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      }
     },
     "breakable": {
       "version": "1.0.0",
@@ -1110,6 +1470,18 @@
       "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
       "integrity": "sha1-KwYRzp5dmLjY0rSa4SGa8vUnZ+M=",
       "dev": true,
+      "requires": {
+        "babel-core": "^5.0.0",
+        "broccoli-funnel": "^1.0.0",
+        "broccoli-merge-trees": "^1.0.0",
+        "broccoli-persistent-filter": "^1.4.2",
+        "clone": "^0.2.0",
+        "hash-for-dep": "^1.0.2",
+        "heimdalljs-logger": "^0.1.7",
+        "json-stable-stringify": "^1.0.0",
+        "rsvp": "^3.5.0",
+        "workerpool": "^2.3.0"
+      },
       "dependencies": {
         "clone": {
           "version": "0.2.0",
@@ -1124,24 +1496,49 @@
       "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz",
       "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
       "dev": true,
+      "requires": {
+        "broccoli-kitchen-sink-helpers": "^0.2.5",
+        "broccoli-plugin": "1.1.0",
+        "debug": "^2.1.1",
+        "rimraf": "^2.2.8",
+        "rsvp": "^3.0.17",
+        "walk-sync": "^0.2.5"
+      },
       "dependencies": {
         "broccoli-kitchen-sink-helpers": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
           "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "^5.0.10",
+            "mkdirp": "^0.5.1"
+          }
         },
         "broccoli-plugin": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
           "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.0.1"
+          }
         },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         }
       }
     },
@@ -1149,31 +1546,62 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-clean-css/-/broccoli-clean-css-1.1.0.tgz",
       "integrity": "sha1-nbFD2a9+CuecJuOsWpuy1yDqGfo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "broccoli-persistent-filter": "^1.1.6",
+        "clean-css-promise": "^0.1.0",
+        "inline-source-map-comment": "^1.0.5",
+        "json-stable-stringify": "^1.0.0"
+      }
     },
     "broccoli-concat": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-2.3.8.tgz",
       "integrity": "sha1-WQzcwCG7kFtsEh2HwtHVffRKKkg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "broccoli-caching-writer": "^2.3.1",
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "broccoli-stew": "^1.3.3",
+        "fast-sourcemap-concat": "^1.0.1",
+        "fs-extra": "^0.30.0",
+        "lodash.merge": "^4.3.0",
+        "lodash.omit": "^4.1.0",
+        "lodash.uniq": "^4.2.0"
+      }
     },
     "broccoli-config-loader": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-config-loader/-/broccoli-config-loader-1.0.1.tgz",
       "integrity": "sha1-0QqvjrwMtFwdpbqoJyDh2I0oyAo=",
       "dev": true,
+      "requires": {
+        "broccoli-caching-writer": "^3.0.3"
+      },
       "dependencies": {
         "broccoli-caching-writer": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-3.0.3.tgz",
           "integrity": "sha1-C9LJapc41qarWQ8HujXFFX19tHY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "broccoli-plugin": "^1.2.1",
+            "debug": "^2.1.1",
+            "rimraf": "^2.2.8",
+            "rsvp": "^3.0.17",
+            "walk-sync": "^0.3.0"
+          }
         },
         "walk-sync": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
           "integrity": "sha1-SCcoCvxC0OA1NnxKTjHurA0Tb3U=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
+          }
         }
       }
     },
@@ -1182,12 +1610,24 @@
       "resolved": "https://registry.npmjs.org/broccoli-config-replace/-/broccoli-config-replace-1.1.2.tgz",
       "integrity": "sha1-bqh52SpbrWNNETKbUfxfSq/anAA=",
       "dev": true,
+      "requires": {
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "broccoli-plugin": "^1.2.0",
+        "debug": "^2.2.0",
+        "fs-extra": "^0.24.0"
+      },
       "dependencies": {
         "fs-extra": {
           "version": "0.24.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
           "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -1202,12 +1642,26 @@
       "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
       "integrity": "sha1-mG6z0gBeAOO7kfnQoQqxNyEM0VA=",
       "dev": true,
+      "requires": {
+        "broccoli-plugin": "^1.2.1",
+        "fs-tree-diff": "^0.5.2",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "symlink-or-copy": "^1.1.8",
+        "tree-sync": "^1.2.2"
+      },
       "dependencies": {
         "fs-tree-diff": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
           "integrity": "sha1-MV4rCY1f5/YiiArJZbGwUYaKyHE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
         }
       }
     },
@@ -1216,6 +1670,22 @@
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
       "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
       "dev": true,
+      "requires": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "exists-sync": "0.0.4",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
       "dependencies": {
         "exists-sync": {
           "version": "0.0.4",
@@ -1227,13 +1697,23 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
           "integrity": "sha1-MV4rCY1f5/YiiArJZbGwUYaKyHE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
         },
         "walk-sync": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
           "integrity": "sha1-SCcoCvxC0OA1NnxKTjHurA0Tb3U=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
+          }
         }
       }
     },
@@ -1248,12 +1728,23 @@
       "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
       "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
       "dev": true,
+      "requires": {
+        "glob": "^5.0.10",
+        "mkdirp": "^0.5.1"
+      },
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         }
       }
     },
@@ -1262,12 +1753,28 @@
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
       "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
       "dev": true,
+      "requires": {
+        "broccoli-plugin": "^1.3.0",
+        "can-symlink": "^1.0.0",
+        "fast-ordered-set": "^1.0.2",
+        "fs-tree-diff": "^0.5.4",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0"
+      },
       "dependencies": {
         "fs-tree-diff": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
           "integrity": "sha1-MV4rCY1f5/YiiArJZbGwUYaKyHE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
         }
       }
     },
@@ -1276,18 +1783,43 @@
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
       "integrity": "sha1-NRG8UvxTdAzaUWIfWKKBUtmRG8E=",
       "dev": true,
+      "requires": {
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^0.5.2",
+        "hash-for-dep": "^1.0.2",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^3.0.18",
+        "symlink-or-copy": "^1.0.1",
+        "walk-sync": "^0.3.1"
+      },
       "dependencies": {
         "fs-tree-diff": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
           "integrity": "sha1-MV4rCY1f5/YiiArJZbGwUYaKyHE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
         },
         "walk-sync": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
           "integrity": "sha1-SCcoCvxC0OA1NnxKTjHurA0Tb3U=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
+          }
         }
       }
     },
@@ -1295,13 +1827,25 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
       "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
     },
     "broccoli-sane-watcher": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/broccoli-sane-watcher/-/broccoli-sane-watcher-1.1.5.tgz",
       "integrity": "sha1-8rCvnPCvt0x6Sc2I6xHGhp7owMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "broccoli-slow-trees": "^1.1.0",
+        "debug": "^2.1.0",
+        "rsvp": "^3.0.18",
+        "sane": "^1.1.1"
+      }
     },
     "broccoli-slow-trees": {
       "version": "1.1.0",
@@ -1320,12 +1864,32 @@
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.5.0.tgz",
       "integrity": "sha1-16+MGFEdzlEOSdMIpi5Zd/RhiDw=",
       "dev": true,
+      "requires": {
+        "broccoli-debug": "^0.6.1",
+        "broccoli-funnel": "^1.0.1",
+        "broccoli-merge-trees": "^1.0.0",
+        "broccoli-persistent-filter": "^1.1.6",
+        "broccoli-plugin": "^1.3.0",
+        "chalk": "^1.1.3",
+        "debug": "^2.4.0",
+        "ensure-posix-path": "^1.0.1",
+        "fs-extra": "^2.0.0",
+        "minimatch": "^3.0.2",
+        "resolve": "^1.1.6",
+        "rsvp": "^3.0.16",
+        "symlink-or-copy": "^1.1.8",
+        "walk-sync": "^0.3.0"
+      },
       "dependencies": {
         "fs-extra": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -1337,7 +1901,11 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
           "integrity": "sha1-SCcoCvxC0OA1NnxKTjHurA0Tb3U=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
+          }
         }
       }
     },
@@ -1357,55 +1925,101 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "browserify-cipher": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
     },
     "browserify-des": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
       "integrity": "sha1-M0MSTbbXrVPiaogmMYcSvchFD5w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      }
     },
     "browserify-rsa": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      }
     },
     "browserify-sign": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      }
     },
     "browserify-zlib": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pako": "~0.2.0"
+      }
     },
     "browserslist": {
       "version": "1.7.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caniuse-db": "^1.0.30000639",
+        "electron-to-chromium": "^1.2.7"
+      }
     },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
     },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
     },
     "buffer-from": {
       "version": "1.1.0",
@@ -1454,6 +2068,17 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -1479,7 +2104,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
     },
     "camelcase": {
       "version": "1.2.1",
@@ -1492,6 +2121,10 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
@@ -1505,13 +2138,22 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
       "integrity": "sha1-l7YH2KhLtsbiKLkC2GTstZS50hk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tmp": "0.0.28"
+      }
     },
     "caniuse-api": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "^1.3.6",
+        "caniuse-db": "^1.0.30000529",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
+      }
     },
     "caniuse-db": {
       "version": "1.0.30000856",
@@ -1523,7 +2165,11 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
       "integrity": "sha1-ANX2YdvUqr/ffUHOSKWlm8o1opE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansicolors": "~0.2.1",
+        "redeyed": "~0.5.0"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -1535,13 +2181,24 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
     },
     "charenc": {
       "version": "0.0.2",
@@ -1553,19 +2210,41 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
       "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1"
+      }
     },
     "chokidar": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
       "integrity": "sha1-NW/04rDo5D4yLRijckYLvPOszSY=",
       "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.5"
+      },
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
         },
         "arr-diff": {
           "version": "4.0.0",
@@ -1584,12 +2263,27 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
           "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
             }
           }
         },
@@ -1598,28 +2292,51 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
             },
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
                 }
               }
             },
@@ -1627,23 +2344,38 @@
               "version": "0.1.4",
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
                 }
               }
             },
             "is-descriptor": {
               "version": "0.1.6",
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg=="
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
             },
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+              "dev": true
             }
           }
         },
@@ -1652,18 +2384,34 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
           "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
             },
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
             }
           }
         },
@@ -1672,12 +2420,21 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
             }
           }
         },
@@ -1686,30 +2443,50 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
             }
           }
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY="
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
         },
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc="
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
         },
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
         },
         "is-extglob": {
           "version": "2.1.1",
@@ -1721,18 +2498,28 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
         },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
             }
           }
         },
@@ -1758,7 +2545,22 @@
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
         }
       }
     },
@@ -1766,25 +2568,41 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
       "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3"
+      }
     },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
         },
         "isobject": {
           "version": "3.0.1",
@@ -1805,12 +2623,19 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
       "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
       "dev": true,
+      "requires": {
+        "commander": "2.8.x",
+        "source-map": "0.4.x"
+      },
       "dependencies": {
         "commander": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
         }
       }
     },
@@ -1818,13 +2643,21 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/clean-css-promise/-/clean-css-promise-0.1.1.tgz",
       "integrity": "sha1-Q/PSyN/LK/BxSBJSzZt2QzwI7ss=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-to-error": "^1.0.0",
+        "clean-css": "^3.4.5",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
     },
     "cli-spinners": {
       "version": "0.1.2",
@@ -1837,6 +2670,9 @@
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
       "dev": true,
+      "requires": {
+        "colors": "1.0.3"
+      },
       "dependencies": {
         "colors": {
           "version": "1.0.3",
@@ -1857,6 +2693,11 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -1888,7 +2729,10 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "^1.1.2"
+      }
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1900,31 +2744,52 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/codecov/-/codecov-1.0.1.tgz",
       "integrity": "sha1-lyYM6sDpa47ajVYgBlWKU6E53/0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argv": ">=0.0.2",
+        "execSync": "1.0.2",
+        "request": ">=2.42.0",
+        "urlgrey": ">=0.4.0"
+      }
     },
     "codelyzer": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/codelyzer/-/codelyzer-0.0.28.tgz",
       "integrity": "sha1-KU0xIk+Z9SaKteQLfnEGDduUL6M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "^1.0.3"
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
     },
     "color": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2",
+        "color-convert": "^1.3.0",
+        "color-string": "^0.3.0"
+      }
     },
     "color-convert": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
       "integrity": "sha1-SYgbj7pn3xKpa98/VsCqueeRMUc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.1"
+      }
     },
     "color-name": {
       "version": "1.1.1",
@@ -1936,7 +2801,10 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0"
+      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -1948,7 +2816,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color": "^0.11.0",
+        "css-color-names": "0.0.4",
+        "has": "^1.0.1"
+      }
     },
     "colors": {
       "version": "1.3.0",
@@ -1960,7 +2833,10 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "2.15.1",
@@ -1979,6 +2855,17 @@
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "dev": true,
+      "requires": {
+        "commander": "^2.5.0",
+        "detective": "^4.3.1",
+        "glob": "^5.0.15",
+        "graceful-fs": "^4.1.2",
+        "iconv-lite": "^0.4.5",
+        "mkdirp": "^0.5.0",
+        "private": "^0.1.6",
+        "q": "^1.1.2",
+        "recast": "^0.11.17"
+      },
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
@@ -1990,7 +2877,14 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -2002,7 +2896,13 @@
           "version": "0.11.23",
           "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
           "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ast-types": "0.9.6",
+            "esprima": "~3.1.0",
+            "private": "~0.1.5",
+            "source-map": "~0.5.0"
+          }
         },
         "source-map": {
           "version": "0.5.7",
@@ -2035,6 +2935,9 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "dev": true,
+      "requires": {
+        "mime-db": ">= 1.34.0 < 2"
+      },
       "dependencies": {
         "mime-db": {
           "version": "1.34.0",
@@ -2049,6 +2952,15 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.13",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "~1.1.2"
+      },
       "dependencies": {
         "safe-buffer": {
           "version": "5.1.1",
@@ -2062,7 +2974,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-0.3.2.tgz",
       "integrity": "sha1-Ht+w50nXNm0+cBZwxGM1mywM9wQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "0.2.x",
+        "node-zopfli": "^2.0.0",
+        "webpack-sources": "^0.1.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2074,13 +2991,30 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "configstore": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
       "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
       "dev": true,
+      "requires": {
+        "dot-prop": "^3.0.0",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.1",
+        "os-tmpdir": "^1.0.0",
+        "osenv": "^0.1.0",
+        "uuid": "^2.0.1",
+        "write-file-atomic": "^1.1.2",
+        "xdg-basedir": "^2.0.0"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -2100,7 +3034,13 @@
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
       "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "parseurl": "~1.3.2",
+        "utils-merge": "1.0.1"
+      }
     },
     "connect-history-api-fallback": {
       "version": "1.5.0",
@@ -2112,7 +3052,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -2125,6 +3068,9 @@
       "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
       "dev": true,
+      "requires": {
+        "bluebird": "^3.1.1"
+      },
       "dependencies": {
         "bluebird": {
           "version": "3.5.1",
@@ -2187,18 +3133,40 @@
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-3.0.1.tgz",
       "integrity": "sha1-m7Pp1sYGTeZcW85EzyNrTQd6ITE=",
       "dev": true,
+      "requires": {
+        "bluebird": "^2.10.2",
+        "fs-extra": "^0.26.4",
+        "glob": "^6.0.4",
+        "lodash": "^4.3.0",
+        "minimatch": "^3.0.0",
+        "node-dir": "^0.1.10"
+      },
       "dependencies": {
         "fs-extra": {
           "version": "0.26.7",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
         },
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -2217,7 +3185,10 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/core-object/-/core-object-0.0.2.tgz",
       "integrity": "sha1-yab+6PcS4oH6n2+6ECQ0Ceot68M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash-node": "^2.4.1"
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2230,12 +3201,24 @@
       "resolved": "https://registry.npmjs.org/cpr/-/cpr-0.4.2.tgz",
       "integrity": "sha1-zFCD5tL6MfUrv+765QikRf5hgPI=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "~4.1.2",
+        "mkdirp": "~0.5.0",
+        "rimraf": "~2.4.3"
+      },
       "dependencies": {
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -2247,7 +3230,10 @@
           "version": "2.4.5",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
         }
       }
     },
@@ -2255,25 +3241,49 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      }
     },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
     },
     "create-hmac": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
     },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
     },
     "crypt": {
       "version": "0.0.2",
@@ -2285,13 +3295,29 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x"
+      }
     },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      }
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -2303,7 +3329,20 @@
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
       "integrity": "sha1-n6I/K1wJZSNZEK1ezvO4o2OQ/lA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.5.1",
+        "cssnano": ">=2.6.1 <4",
+        "loader-utils": "~0.2.2",
+        "lodash.camelcase": "^3.0.1",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.6",
+        "postcss-modules-extract-imports": "^1.0.0",
+        "postcss-modules-local-by-default": "^1.0.1",
+        "postcss-modules-scope": "^1.0.0",
+        "postcss-modules-values": "^1.1.0",
+        "source-list-map": "^0.1.4"
+      }
     },
     "css-parse": {
       "version": "1.7.0",
@@ -2315,13 +3354,23 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
     },
     "css-selector-tokenizer": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
       "integrity": "sha1-E5uv00o1/QwUKEhwSeBpnm9qLCE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1"
+      }
     },
     "css-what": {
       "version": "2.1.0",
@@ -2339,13 +3388,51 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "autoprefixer": "^6.3.1",
+        "decamelize": "^1.1.2",
+        "defined": "^1.0.0",
+        "has": "^1.0.1",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.14",
+        "postcss-calc": "^5.2.0",
+        "postcss-colormin": "^2.1.8",
+        "postcss-convert-values": "^2.3.4",
+        "postcss-discard-comments": "^2.0.4",
+        "postcss-discard-duplicates": "^2.0.1",
+        "postcss-discard-empty": "^2.0.1",
+        "postcss-discard-overridden": "^0.1.1",
+        "postcss-discard-unused": "^2.2.1",
+        "postcss-filter-plugins": "^2.0.0",
+        "postcss-merge-idents": "^2.1.5",
+        "postcss-merge-longhand": "^2.0.1",
+        "postcss-merge-rules": "^2.0.3",
+        "postcss-minify-font-values": "^1.0.2",
+        "postcss-minify-gradients": "^1.0.1",
+        "postcss-minify-params": "^1.0.4",
+        "postcss-minify-selectors": "^2.0.4",
+        "postcss-normalize-charset": "^1.1.0",
+        "postcss-normalize-url": "^3.0.7",
+        "postcss-ordered-values": "^2.1.0",
+        "postcss-reduce-idents": "^2.2.2",
+        "postcss-reduce-initial": "^1.0.0",
+        "postcss-reduce-transforms": "^1.0.3",
+        "postcss-svgo": "^2.1.1",
+        "postcss-unique-selectors": "^2.0.2",
+        "postcss-value-parser": "^3.2.3",
+        "postcss-zindex": "^2.0.1"
+      }
     },
     "csso": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "dev": true,
+      "requires": {
+        "clap": "^1.0.9",
+        "source-map": "^0.5.3"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
@@ -2359,7 +3446,10 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
     },
     "custom-event": {
       "version": "1.0.1",
@@ -2371,13 +3461,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "date-now": {
       "version": "0.1.4",
@@ -2389,13 +3485,20 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
+      }
     },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -2426,37 +3529,59 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
     },
     "define-properties": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
+      }
     },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
         },
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
         },
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
         },
         "isobject": {
           "version": "3.0.1",
@@ -2483,6 +3608,18 @@
       "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
       "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
       "dev": true,
+      "requires": {
+        "alter": "~0.2.0",
+        "ast-traverse": "~0.1.1",
+        "breakable": "~1.0.0",
+        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+        "simple-fmt": "~0.1.0",
+        "simple-is": "~0.2.0",
+        "stringmap": "~0.2.2",
+        "stringset": "~0.2.1",
+        "tryor": "~0.1.2",
+        "yargs": "~3.27.0"
+      },
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
@@ -2520,7 +3657,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
     },
     "destroy": {
       "version": "1.0.4",
@@ -2532,7 +3673,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
       "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1",
+        "minimist": "^1.1.0",
+        "repeating": "^1.1.0"
+      }
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -2545,7 +3691,11 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
       "integrity": "sha1-DspzFDOEQv67bWXaVMELscgrJG4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
+      }
     },
     "di": {
       "version": "0.0.1",
@@ -2563,13 +3713,21 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
     },
     "dom-converter": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
+      "requires": {
+        "utila": "~0.3"
+      },
       "dependencies": {
         "utila": {
           "version": "0.3.3",
@@ -2583,13 +3741,23 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
+      }
     },
     "dom-serializer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
+      "requires": {
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
+      },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
@@ -2615,19 +3783,29 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
       "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
     },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
     },
     "dot-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -2640,6 +3818,9 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
+      "requires": {
+        "readable-stream": "~1.1.9"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -2651,7 +3832,13 @@
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -2666,7 +3853,10 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
     },
     "editions": {
       "version": "1.3.4",
@@ -2696,25 +3886,133 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
     },
     "ember-cli": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.5.0.tgz",
       "integrity": "sha1-METP1JnSYLn00BRZHuTfdRt0y5E=",
       "dev": true,
+      "requires": {
+        "amd-name-resolver": "0.0.5",
+        "bower": "^1.3.12",
+        "bower-config": "^1.3.0",
+        "bower-endpoint-parser": "0.2.2",
+        "broccoli-babel-transpiler": "^5.4.5",
+        "broccoli-concat": "^2.0.4",
+        "broccoli-config-loader": "^1.0.0",
+        "broccoli-config-replace": "^1.1.2",
+        "broccoli-funnel": "^1.0.0",
+        "broccoli-funnel-reducer": "^1.0.0",
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "broccoli-merge-trees": "^1.0.0",
+        "broccoli-plugin": "^1.2.0",
+        "broccoli-sane-watcher": "^1.1.1",
+        "broccoli-source": "^1.1.0",
+        "broccoli-viz": "^2.0.1",
+        "chalk": "^1.1.1",
+        "clean-base-url": "^1.0.0",
+        "compression": "^1.4.4",
+        "configstore": "^2.0.0",
+        "core-object": "0.0.2",
+        "cpr": "0.4.2",
+        "debug": "^2.1.3",
+        "diff": "^2.2.2",
+        "ember-cli-broccoli": "0.16.9",
+        "ember-cli-get-component-path-option": "^1.0.0",
+        "ember-cli-is-package-missing": "^1.0.0",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-path-utils": "^1.0.0",
+        "ember-cli-preprocess-registry": "^2.0.0",
+        "ember-cli-string-utils": "^1.0.0",
+        "ember-cli-test-info": "^1.0.0",
+        "ember-cli-valid-component-name": "^1.0.0",
+        "ember-router-generator": "^1.0.0",
+        "escape-string-regexp": "^1.0.3",
+        "exists-sync": "0.0.3",
+        "exit": "^0.1.2",
+        "express": "^4.12.3",
+        "filesize": "^3.1.3",
+        "findup": "0.1.5",
+        "findup-sync": "^0.2.1",
+        "fs-extra": "0.26.7",
+        "fs-monitor-stack": "^1.0.2",
+        "fs-tree-diff": "^0.4.4",
+        "get-caller-file": "^1.0.0",
+        "git-repo-info": "^1.0.4",
+        "glob": "7.0.3",
+        "http-proxy": "^1.9.0",
+        "inflection": "^1.7.0",
+        "inquirer": "^0.12.0",
+        "is-git-url": "^0.2.0",
+        "isbinaryfile": "^2.0.3",
+        "leek": "0.0.21",
+        "lodash": "^4.6.1",
+        "markdown-it": "4.3.0",
+        "markdown-it-terminal": "0.0.3",
+        "merge-defaults": "^0.2.1",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "morgan": "^1.5.2",
+        "node-modules-path": "^1.0.0",
+        "node-uuid": "^1.4.3",
+        "nopt": "^3.0.1",
+        "npm": "2.14.21",
+        "ora": "^0.2.0",
+        "portfinder": "^1.0.3",
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "0.1.5",
+        "readline2": "0.1.1",
+        "resolve": "^1.1.6",
+        "rimraf": "^2.4.4",
+        "rsvp": "^3.0.17",
+        "sane": "^1.1.1",
+        "semver": "^5.1.0",
+        "silent-error": "^1.0.0",
+        "symlink-or-copy": "^1.0.1",
+        "temp": "0.8.3",
+        "testem": "^1.6.0",
+        "through": "^2.3.6",
+        "tiny-lr": "0.2.1",
+        "tree-sync": "^1.1.0",
+        "walk-sync": "^0.2.6",
+        "yam": "0.0.18"
+      },
       "dependencies": {
         "fs-extra": {
           "version": "0.26.7",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
         },
         "glob": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -2732,13 +4030,89 @@
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
         },
         "npm": {
           "version": "2.14.21",
           "resolved": "https://registry.npmjs.org/npm/-/npm-2.14.21.tgz",
           "integrity": "sha1-S+iAc9XrlYZPyEwd8sdDv97e1w4=",
           "dev": true,
+          "requires": {
+            "abbrev": "~1.0.7",
+            "ansi": "~0.3.1",
+            "ansi-regex": "*",
+            "ansicolors": "~0.3.2",
+            "ansistyles": "~0.1.3",
+            "archy": "~1.0.0",
+            "async-some": "~1.0.2",
+            "block-stream": "0.0.8",
+            "char-spinner": "~1.0.1",
+            "chmodr": "~1.0.2",
+            "chownr": "~1.0.1",
+            "cmd-shim": "~2.0.2",
+            "columnify": "~1.5.4",
+            "config-chain": "~1.1.10",
+            "dezalgo": "~1.0.3",
+            "editor": "~1.0.0",
+            "fs-vacuum": "~1.2.7",
+            "fs-write-stream-atomic": "~1.0.8",
+            "fstream": "~1.0.8",
+            "fstream-npm": "~1.0.7",
+            "github-url-from-git": "~1.4.0",
+            "github-url-from-username-repo": "~1.0.2",
+            "glob": "~5.0.15",
+            "graceful-fs": "~4.1.3",
+            "hosted-git-info": "~2.1.4",
+            "imurmurhash": "*",
+            "inflight": "~1.0.4",
+            "inherits": "~2.0.1",
+            "ini": "~1.3.4",
+            "init-package-json": "~1.9.3",
+            "lockfile": "~1.0.1",
+            "lru-cache": "~3.2.0",
+            "minimatch": "~3.0.0",
+            "mkdirp": "~0.5.1",
+            "node-gyp": "~3.3.0",
+            "nopt": "~3.0.6",
+            "normalize-git-url": "~3.0.1",
+            "normalize-package-data": "~2.3.5",
+            "npm-cache-filename": "~1.0.2",
+            "npm-install-checks": "~1.0.7",
+            "npm-package-arg": "~4.1.0",
+            "npm-registry-client": "~7.0.9",
+            "npm-user-validate": "~0.1.2",
+            "npmlog": "~2.0.2",
+            "once": "~1.3.3",
+            "opener": "~1.4.1",
+            "osenv": "~0.1.3",
+            "path-is-inside": "~1.0.0",
+            "read": "~1.0.7",
+            "read-installed": "~4.0.3",
+            "read-package-json": "~2.0.3",
+            "readable-stream": "~1.1.13",
+            "realize-package-specifier": "~3.0.1",
+            "request": "~2.69.0",
+            "retry": "~0.9.0",
+            "rimraf": "~2.5.2",
+            "semver": "~5.1.0",
+            "sha": "~2.0.1",
+            "slide": "~1.1.6",
+            "sorted-object": "~1.0.0",
+            "spdx-license-ids": "~1.2.0",
+            "strip-ansi": "*",
+            "tar": "~2.2.1",
+            "text-table": "~0.2.0",
+            "uid-number": "0.0.6",
+            "umask": "~1.1.0",
+            "validate-npm-package-license": "~3.0.1",
+            "validate-npm-package-name": "~2.2.2",
+            "which": "~1.2.4",
+            "wrappy": "~1.0.1",
+            "write-file-atomic": "~1.1.4"
+          },
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
@@ -2773,12 +4147,18 @@
             "async-some": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "dezalgo": "^1.0.2"
+              }
             },
             "block-stream": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "inherits": "~2.0.0"
+              }
             },
             "char-spinner": {
               "version": "1.0.1",
@@ -2798,22 +4178,36 @@
             "cmd-shim": {
               "version": "2.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "~0.5.0"
+              }
             },
             "columnify": {
               "version": "1.5.4",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "strip-ansi": "^3.0.0",
+                "wcwidth": "^1.0.0"
+              },
               "dependencies": {
                 "wcwidth": {
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "defaults": "^1.0.0"
+                  },
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "clone": "^1.0.2"
+                      },
                       "dependencies": {
                         "clone": {
                           "version": "1.0.2",
@@ -2830,6 +4224,10 @@
               "version": "1.1.10",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+              },
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
@@ -2842,6 +4240,10 @@
               "version": "1.0.3",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+              },
               "dependencies": {
                 "asap": {
                   "version": "2.0.3",
@@ -2858,12 +4260,23 @@
             "fs-vacuum": {
               "version": "1.2.7",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "path-is-inside": "^1.0.1",
+                "rimraf": "^2.2.8"
+              }
             },
             "fs-write-stream-atomic": {
               "version": "1.0.8",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
+              },
               "dependencies": {
                 "iferr": {
                   "version": "0.1.5",
@@ -2875,17 +4288,32 @@
             "fstream": {
               "version": "1.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+              }
             },
             "fstream-npm": {
               "version": "1.0.7",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "fstream-ignore": "^1.0.0",
+                "inherits": "2"
+              },
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.3",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "fstream": "^1.0.0",
+                    "inherits": "2",
+                    "minimatch": "^3.0.0"
+                  }
                 }
               }
             },
@@ -2903,6 +4331,13 @@
               "version": "5.0.15",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              },
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
@@ -2929,7 +4364,11 @@
             "inflight": {
               "version": "1.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
             },
             "inherits": {
               "version": "2.0.1",
@@ -2945,11 +4384,28 @@
               "version": "1.9.3",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "glob": "^6.0.0",
+                "npm-package-arg": "^4.0.0",
+                "promzard": "^0.3.0",
+                "read": "~1.0.1",
+                "read-package-json": "1 || 2",
+                "semver": "2.x || 3.x || 4 || 5",
+                "validate-npm-package-license": "^3.0.1",
+                "validate-npm-package-name": "^2.0.1"
+              },
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
+                  },
                   "dependencies": {
                     "path-is-absolute": {
                       "version": "1.0.0",
@@ -2961,7 +4417,10 @@
                 "promzard": {
                   "version": "0.3.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "read": "1"
+                  }
                 }
               }
             },
@@ -2974,6 +4433,9 @@
               "version": "3.2.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "pseudomap": "^1.0.1"
+              },
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.1",
@@ -2986,11 +4448,18 @@
               "version": "3.0.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "brace-expansion": "^1.0.0"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "balanced-match": "^0.2.0",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.1",
@@ -3010,6 +4479,9 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
@@ -3022,21 +4494,50 @@
               "version": "3.3.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "fstream": "^1.0.0",
+                "glob": "3 || 4",
+                "graceful-fs": "^4.1.2",
+                "minimatch": "1",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2",
+                "osenv": "0",
+                "path-array": "^1.0.0",
+                "request": "2",
+                "rimraf": "2",
+                "semver": "2.x || 3.x || 4 || 5",
+                "tar": "^2.0.0",
+                "which": "1"
+              },
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^2.0.1",
+                    "once": "^1.3.0"
+                  },
                   "dependencies": {
                     "minimatch": {
                       "version": "2.0.10",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "brace-expansion": "^1.0.0"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "balanced-match": "^0.3.0",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
@@ -3058,6 +4559,10 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "lru-cache": "2",
+                    "sigmund": "~1.0.0"
+                  },
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
@@ -3075,16 +4580,26 @@
                   "version": "1.0.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "array-index": "^1.0.0"
+                  },
                   "dependencies": {
                     "array-index": {
                       "version": "1.0.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "debug": "^2.2.0",
+                        "es6-symbol": "^3.0.2"
+                      },
                       "dependencies": {
                         "debug": {
                           "version": "2.2.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "ms": "0.7.1"
+                          },
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
@@ -3097,21 +4612,37 @@
                           "version": "3.0.2",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "d": "~0.1.1",
+                            "es5-ext": "~0.10.10"
+                          },
                           "dependencies": {
                             "d": {
                               "version": "0.1.1",
                               "bundled": true,
-                              "dev": true
+                              "dev": true,
+                              "requires": {
+                                "es5-ext": "~0.10.2"
+                              }
                             },
                             "es5-ext": {
                               "version": "0.10.11",
                               "bundled": true,
                               "dev": true,
+                              "requires": {
+                                "es6-iterator": "2",
+                                "es6-symbol": "~3.0.2"
+                              },
                               "dependencies": {
                                 "es6-iterator": {
                                   "version": "2.0.0",
                                   "bundled": true,
-                                  "dev": true
+                                  "dev": true,
+                                  "requires": {
+                                    "d": "^0.1.1",
+                                    "es5-ext": "^0.10.7",
+                                    "es6-symbol": "3"
+                                  }
                                 }
                               }
                             }
@@ -3126,7 +4657,10 @@
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "abbrev": "1"
+              }
             },
             "normalize-git-url": {
               "version": "3.0.1",
@@ -3137,11 +4671,20 @@
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              },
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "builtin-modules": "^1.0.0"
+                  },
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.0",
@@ -3160,27 +4703,63 @@
             "npm-install-checks": {
               "version": "1.0.7",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "npmlog": "0.1 || 1 || 2",
+                "semver": "^2.3.0 || 3.x || 4 || 5"
+              }
             },
             "npm-package-arg": {
               "version": "4.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "semver": "4 || 5"
+              }
             },
             "npm-registry-client": {
               "version": "7.0.9",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "concat-stream": "^1.4.6",
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "normalize-package-data": "~1.0.1 || ^2.0.0",
+                "npm-package-arg": "^3.0.0 || ^4.0.0",
+                "npmlog": "~2.0.0",
+                "once": "^1.3.0",
+                "request": "^2.47.0",
+                "retry": "^0.8.0",
+                "rimraf": "2",
+                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+                "slide": "^1.1.3"
+              },
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "inherits": "~2.0.1",
+                    "readable-stream": "~2.0.0",
+                    "typedarray": "~0.0.5"
+                  },
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.4",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "process-nextick-args": "~1.0.0",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
+                      },
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -3232,11 +4811,20 @@
               "version": "2.0.2",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "ansi": "~0.3.1",
+                "are-we-there-yet": "~1.0.6",
+                "gauge": "~1.2.5"
+              },
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.0.6",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "delegates": "^1.0.0",
+                    "readable-stream": "^2.0.0 || ^1.1.13"
+                  },
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
@@ -3249,6 +4837,13 @@
                   "version": "1.2.5",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "ansi": "^0.3.0",
+                    "has-unicode": "^2.0.0",
+                    "lodash.pad": "^3.0.0",
+                    "lodash.padleft": "^3.0.0",
+                    "lodash.padright": "^3.0.0"
+                  },
                   "dependencies": {
                     "has-unicode": {
                       "version": "2.0.0",
@@ -3263,27 +4858,44 @@
                     "lodash._createpadding": {
                       "version": "3.6.1",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "lodash.repeat": "^3.0.0"
+                      }
                     },
                     "lodash.pad": {
                       "version": "3.2.2",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "lodash.repeat": "^3.0.0"
+                      }
                     },
                     "lodash.padleft": {
                       "version": "3.1.1",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "lodash._basetostring": "^3.0.0",
+                        "lodash._createpadding": "^3.0.0"
+                      }
                     },
                     "lodash.padright": {
                       "version": "3.1.1",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "lodash._basetostring": "^3.0.0",
+                        "lodash._createpadding": "^3.0.0"
+                      }
                     },
                     "lodash.repeat": {
                       "version": "3.2.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "lodash._root": "^3.0.0"
+                      },
                       "dependencies": {
                         "lodash._root": {
                           "version": "3.0.1",
@@ -3299,7 +4911,10 @@
             "once": {
               "version": "1.3.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
             },
             "opener": {
               "version": "1.4.1",
@@ -3310,6 +4925,10 @@
               "version": "0.1.3",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              },
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.0",
@@ -3332,6 +4951,9 @@
               "version": "1.0.7",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "mute-stream": "~0.0.4"
+              },
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.5",
@@ -3344,6 +4966,15 @@
               "version": "4.0.3",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "debuglog": "^1.0.1",
+                "graceful-fs": "^4.1.2",
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "slide": "~1.1.3",
+                "util-extend": "^1.0.1"
+              },
               "dependencies": {
                 "debuglog": {
                   "version": "1.0.1",
@@ -3353,7 +4984,13 @@
                 "readdir-scoped-modules": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "debuglog": "^1.0.1",
+                    "dezalgo": "^1.0.0",
+                    "graceful-fs": "^4.1.2",
+                    "once": "^1.3.0"
+                  }
                 },
                 "util-extend": {
                   "version": "1.0.1",
@@ -3366,11 +5003,24 @@
               "version": "2.0.3",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "glob": "^6.0.0",
+                "graceful-fs": "^4.1.2",
+                "json-parse-helpfulerror": "^1.0.2",
+                "normalize-package-data": "^2.0.0"
+              },
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
+                  },
                   "dependencies": {
                     "path-is-absolute": {
                       "version": "1.0.0",
@@ -3383,6 +5033,9 @@
                   "version": "1.0.3",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "jju": "^1.1.0"
+                  },
                   "dependencies": {
                     "jju": {
                       "version": "1.2.1",
@@ -3397,6 +5050,12 @@
               "version": "1.1.13",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
@@ -3418,12 +5077,39 @@
             "realize-package-specifier": {
               "version": "3.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "dezalgo": "^1.0.1",
+                "npm-package-arg": "^4.0.0"
+              }
             },
             "request": {
               "version": "2.69.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "bl": "~1.0.0",
+                "caseless": "~0.11.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~1.0.0-rc3",
+                "har-validator": "~2.0.6",
+                "hawk": "~3.1.0",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "node-uuid": "~1.4.7",
+                "oauth-sign": "~0.8.0",
+                "qs": "~6.0.2",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.2.0",
+                "tunnel-agent": "~0.4.1"
+              },
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
@@ -3434,6 +5120,9 @@
                   "version": "1.2.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "lru-cache": "^2.6.5"
+                  },
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
@@ -3446,11 +5135,22 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "readable-stream": "~2.0.5"
+                  },
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.5",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
+                      },
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -3490,6 +5190,9 @@
                   "version": "1.0.5",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "delayed-stream": "~1.0.0"
+                  },
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
@@ -3512,6 +5215,11 @@
                   "version": "1.0.0-rc3",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "async": "^1.4.0",
+                    "combined-stream": "^1.0.5",
+                    "mime-types": "^2.1.3"
+                  },
                   "dependencies": {
                     "async": {
                       "version": "1.5.2",
@@ -3524,11 +5232,24 @@
                   "version": "2.0.6",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "chalk": "^1.1.1",
+                    "commander": "^2.9.0",
+                    "is-my-json-valid": "^2.12.4",
+                    "pinkie-promise": "^2.0.0"
+                  },
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.1",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "ansi-styles": "^2.1.0",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                      },
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.1.0",
@@ -3543,7 +5264,10 @@
                         "has-ansi": {
                           "version": "2.0.0",
                           "bundled": true,
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "ansi-regex": "^2.0.0"
+                          }
                         },
                         "supports-color": {
                           "version": "2.0.0",
@@ -3556,6 +5280,9 @@
                       "version": "2.9.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "graceful-readlink": ">= 1.0.0"
+                      },
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
@@ -3568,6 +5295,12 @@
                       "version": "2.12.4",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "generate-function": "^2.0.0",
+                        "generate-object-property": "^1.1.0",
+                        "jsonpointer": "2.0.0",
+                        "xtend": "^4.0.0"
+                      },
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
@@ -3578,6 +5311,9 @@
                           "version": "1.2.0",
                           "bundled": true,
                           "dev": true,
+                          "requires": {
+                            "is-property": "^1.0.0"
+                          },
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
@@ -3602,6 +5338,9 @@
                       "version": "2.0.0",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "pinkie": "^2.0.0"
+                      },
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
@@ -3616,16 +5355,28 @@
                   "version": "3.1.3",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "boom": "2.x.x",
+                    "cryptiles": "2.x.x",
+                    "hoek": "2.x.x",
+                    "sntp": "1.x.x"
+                  },
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.x.x"
+                      }
                     },
                     "cryptiles": {
                       "version": "2.0.5",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "boom": "2.x.x"
+                      }
                     },
                     "hoek": {
                       "version": "2.16.3",
@@ -3635,7 +5386,10 @@
                     "sntp": {
                       "version": "1.0.9",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.x.x"
+                      }
                     }
                   }
                 },
@@ -3643,6 +5397,11 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "assert-plus": "^0.2.0",
+                    "jsprim": "^1.2.2",
+                    "sshpk": "^1.7.0"
+                  },
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
@@ -3653,6 +5412,11 @@
                       "version": "1.2.2",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.2",
+                        "verror": "1.3.6"
+                      },
                       "dependencies": {
                         "extsprintf": {
                           "version": "1.0.2",
@@ -3667,7 +5431,10 @@
                         "verror": {
                           "version": "1.3.6",
                           "bundled": true,
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
                         }
                       }
                     },
@@ -3675,6 +5442,15 @@
                       "version": "1.7.3",
                       "bundled": true,
                       "dev": true,
+                      "requires": {
+                        "asn1": ">=0.2.3 <0.3.0",
+                        "assert-plus": ">=0.2.0 <0.3.0",
+                        "dashdash": ">=1.10.1 <2.0.0",
+                        "ecc-jsbn": ">=0.0.1 <1.0.0",
+                        "jodid25519": ">=1.0.0 <2.0.0",
+                        "jsbn": ">=0.1.0 <0.2.0",
+                        "tweetnacl": ">=0.13.0 <1.0.0"
+                      },
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
@@ -3684,19 +5460,28 @@
                         "dashdash": {
                           "version": "1.12.2",
                           "bundled": true,
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "assert-plus": "^0.2.0"
+                          }
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
                           "bundled": true,
                           "dev": true,
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "~0.1.0"
+                          }
                         },
                         "jodid25519": {
                           "version": "1.0.2",
                           "bundled": true,
                           "dev": true,
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "~0.1.0"
+                          }
                         },
                         "jsbn": {
                           "version": "0.1.0",
@@ -3733,6 +5518,9 @@
                   "version": "2.1.9",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "mime-db": "~1.21.0"
+                  },
                   "dependencies": {
                     "mime-db": {
                       "version": "1.21.0",
@@ -3782,11 +5570,21 @@
               "version": "2.5.2",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "glob": "^7.0.0"
+              },
               "dependencies": {
                 "glob": {
                   "version": "7.0.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
+                  },
                   "dependencies": {
                     "path-is-absolute": {
                       "version": "1.0.0",
@@ -3806,11 +5604,23 @@
               "version": "2.0.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "readable-stream": "^2.0.2"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.2",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
+                    "isarray": "0.0.1",
+                    "process-nextick-args": "~1.0.0",
+                    "string_decoder": "~0.10.x",
+                    "util-deprecate": "~1.0.1"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
@@ -3859,12 +5669,20 @@
             "strip-ansi": {
               "version": "3.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
             },
             "tar": {
               "version": "2.2.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
+              }
             },
             "text-table": {
               "version": "0.2.0",
@@ -3885,16 +5703,27 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "spdx-correct": "~1.0.0",
+                "spdx-expression-parse": "~1.0.0"
+              },
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "spdx-license-ids": "^1.0.2"
+                  }
                 },
                 "spdx-expression-parse": {
                   "version": "1.0.2",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "spdx-exceptions": "^1.0.4",
+                    "spdx-license-ids": "^1.0.0"
+                  },
                   "dependencies": {
                     "spdx-exceptions": {
                       "version": "1.0.4",
@@ -3909,6 +5738,9 @@
               "version": "2.2.2",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "builtins": "0.0.7"
+              },
               "dependencies": {
                 "builtins": {
                   "version": "0.0.7",
@@ -3921,11 +5753,18 @@
               "version": "1.2.4",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "is-absolute": "^0.1.7",
+                "isexe": "^1.1.1"
+              },
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "is-relative": "^0.1.0"
+                  },
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
@@ -3949,7 +5788,12 @@
             "write-file-atomic": {
               "version": "1.1.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
+              }
             }
           }
         },
@@ -3958,6 +5802,10 @@
           "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
           "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
           "dev": true,
+          "requires": {
+            "os-tmpdir": "^1.0.0",
+            "rimraf": "~2.2.6"
+          },
           "dependencies": {
             "rimraf": {
               "version": "2.2.8",
@@ -3974,18 +5822,43 @@
       "resolved": "https://registry.npmjs.org/ember-cli-broccoli/-/ember-cli-broccoli-0.16.9.tgz",
       "integrity": "sha1-TpEo9Z/67plwXAHppEppGgrhmds=",
       "dev": true,
+      "requires": {
+        "broccoli-kitchen-sink-helpers": "^0.2.5",
+        "broccoli-slow-trees": "^1.0.0",
+        "commander": "^2.5.0",
+        "connect": "^3.3.3",
+        "copy-dereference": "^1.0.0",
+        "findup-sync": "^0.2.1",
+        "handlebars": "^4.0.4",
+        "mime": "^1.2.11",
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.2",
+        "rimraf": "^2.2.8",
+        "rsvp": "^3.0.17"
+      },
       "dependencies": {
         "broccoli-kitchen-sink-helpers": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
           "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "^5.0.10",
+            "mkdirp": "^0.5.1"
+          }
         },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         }
       }
     },
@@ -4005,7 +5878,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz",
       "integrity": "sha1-CxT3vLxZmqEXtf3cgeT9A8S61bc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "silent-error": "^1.0.0"
+      }
     },
     "ember-cli-path-utils": {
       "version": "1.0.0",
@@ -4018,6 +5894,16 @@
       "resolved": "https://registry.npmjs.org/ember-cli-preprocess-registry/-/ember-cli-preprocess-registry-2.0.0.tgz",
       "integrity": "sha1-Rci5heuga7RDs6vOHDxiIP3LgJQ=",
       "dev": true,
+      "requires": {
+        "broccoli-clean-css": "^1.1.0",
+        "broccoli-funnel": "^1.0.0",
+        "broccoli-merge-trees": "^1.0.0",
+        "debug": "^2.2.0",
+        "exists-sync": "0.0.3",
+        "lodash": "^3.10.0",
+        "process-relative-require": "^1.0.0",
+        "silent-error": "^1.0.0"
+      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -4037,19 +5923,28 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-test-info/-/ember-cli-test-info-1.0.0.tgz",
       "integrity": "sha1-7U6WDySel1I8+JHkrtIHLOhFd7Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ember-cli-string-utils": "^1.0.0"
+      }
     },
     "ember-cli-valid-component-name": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-valid-component-name/-/ember-cli-valid-component-name-1.0.0.tgz",
       "integrity": "sha1-cVUM44fgIzBl8wswsVEKot++h+8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "silent-error": "^1.0.0"
+      }
     },
     "ember-router-generator": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-1.2.3.tgz",
       "integrity": "sha1-jtLKhv8yM2MSD8FCeBkeno8TFe4=",
       "dev": true,
+      "requires": {
+        "recast": "^0.11.3"
+      },
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
@@ -4061,7 +5956,13 @@
           "version": "0.11.23",
           "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
           "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ast-types": "0.9.6",
+            "esprima": "~3.1.0",
+            "private": "~0.1.5",
+            "source-map": "~0.5.0"
+          }
         },
         "source-map": {
           "version": "0.5.7",
@@ -4088,18 +5989,33 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
       "integrity": "sha1-PutfJky3XbvsG6rqJtYfWk6s4qo=",
       "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "base64id": "0.1.0",
+        "cookie": "0.3.1",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.1",
+        "ws": "1.1.1"
+      },
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-types": "~2.1.11",
+            "negotiator": "0.6.1"
+          }
         },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -4114,6 +6030,20 @@
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
       "integrity": "sha1-e3MOQSdBQIdZbZvjyI0rxf22z1w=",
       "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.1",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "1.1.1",
+        "xmlhttprequest-ssl": "1.5.3",
+        "yeast": "0.1.2"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -4125,7 +6055,10 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -4140,12 +6073,23 @@
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
       "integrity": "sha1-lVTxrjMQfW+9FwylRm0vgz9qB88=",
       "dev": true,
+      "requires": {
+        "after": "0.8.1",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary": "0.1.6",
+        "wtf-8": "1.0.0"
+      },
       "dependencies": {
         "has-binary": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
           "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -4160,6 +6104,12 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-2.3.0.tgz",
       "integrity": "sha1-oRXDJQS2MC6Fp2Jp16V8zdli41k=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.3.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.3"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -4191,37 +6141,65 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prr": "~1.0.1"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "es-abstract": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity": "sha1-nbvdJ8aFbwABQhyhh4LXhr+KYWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      }
     },
     "es-to-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.45",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
       "integrity": "sha1-C/33tHPaWRnVrfO9Jc63VPzMNlM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "es6-promise": {
       "version": "3.3.1",
@@ -4233,7 +6211,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -4252,13 +6234,23 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
         }
       }
     },
@@ -4290,7 +6282,16 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
     },
     "eventemitter3": {
       "version": "3.1.0",
@@ -4314,25 +6315,38 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "original": ">=0.0.5"
+      }
     },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "exec-sh": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
       "integrity": "sha1-FjuYpuiea2W0fCoo0hW8H2OYnDg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "merge": "^1.1.3"
+      }
     },
     "execSync": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/execSync/-/execSync-1.0.2.tgz",
       "integrity": "sha1-H0LtpYIiUYAFMiTs3T/Rlg/bMTk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "temp": "~0.5.1"
+      }
     },
     "exists-sync": {
       "version": "0.0.3",
@@ -4357,18 +6371,30 @@
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
+      "requires": {
+        "array-slice": "^0.2.3",
+        "array-unique": "^0.2.1",
+        "braces": "^0.1.2"
+      },
       "dependencies": {
         "braces": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "expand-range": "^0.1.0"
+          }
         },
         "expand-range": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "^0.1.1",
+            "repeat-string": "^0.2.2"
+          }
         },
         "is-number": {
           "version": "0.1.1",
@@ -4388,25 +6414,40 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "^0.1.0"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "^2.1.0"
+      }
     },
     "exports-loader": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.4.tgz",
       "integrity": "sha1-1w/GEhl1s1/BKDDPUnVL4nQPyIY=",
       "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "source-map": "0.5.x"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
+          }
         },
         "source-map": {
           "version": "0.5.7",
@@ -4427,12 +6468,53 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
       "dependencies": {
         "finalhandler": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha1-7r9O2EAHnIP0JJA4ydcDAIMBsQU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.4.0",
+            "unpipe": "~1.0.0"
+          }
         },
         "qs": {
           "version": "6.5.1",
@@ -4465,12 +6547,19 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
         }
       }
     },
@@ -4478,13 +6567,22 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
     },
     "extract-zip": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
       "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -4497,6 +6595,11 @@
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
+      "requires": {
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "time-stamp": "^1.0.0"
+      },
       "dependencies": {
         "time-stamp": {
           "version": "1.1.0",
@@ -4528,25 +6631,46 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
       "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "blank-object": "^1.0.1"
+      }
     },
     "fast-sourcemap-concat": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-1.3.0.tgz",
       "integrity": "sha1-zGGOTW9oEGtZilMuF0B2B1u4JAA=",
       "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "fs-extra": "^0.30.0",
+        "heimdalljs-logger": "^0.1.7",
+        "memory-streams": "^0.1.0",
+        "mkdirp": "^0.5.0",
+        "source-map": "^0.4.2",
+        "source-map-url": "^0.3.0",
+        "sourcemap-validator": "^1.0.5"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         },
         "has-flag": {
           "version": "3.0.0",
@@ -4558,7 +6682,10 @@
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -4572,31 +6699,47 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
     },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bser": "^2.0.0"
+      }
     },
     "fd-slicer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
     },
     "file-loader": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
       "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "~0.2.5"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -4609,18 +6752,32 @@
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
       "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
       "dev": true,
+      "requires": {
+        "glob": "5.x",
+        "minimatch": "2.x"
+      },
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
         }
       }
     },
@@ -4634,25 +6791,48 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      }
     },
     "finalhandler": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      }
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
       "dependencies": {
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
         }
       }
     },
@@ -4661,6 +6841,10 @@
       "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
       "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
       "dev": true,
+      "requires": {
+        "colors": "~0.6.0-1",
+        "commander": "~2.1.0"
+      },
       "dependencies": {
         "colors": {
           "version": "0.6.2",
@@ -4681,18 +6865,30 @@
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
       "integrity": "sha1-4KkKRQB1xJRm7lE3MgV1FLgeh4w=",
       "dev": true,
+      "requires": {
+        "glob": "~4.3.0"
+      },
       "dependencies": {
         "glob": {
           "version": "4.3.5",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
           "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
+          }
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
         }
       }
     },
@@ -4700,7 +6896,14 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.7.1.tgz",
       "integrity": "sha1-zPIPeUHxCIg/zduZOD2+bhhhx1g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "~0.2.9",
+        "is-type": "0.0.1",
+        "lodash.debounce": "^3.1.1",
+        "lodash.flatten": "^3.0.2",
+        "minimatch": "^3.0.2"
+      }
     },
     "flatten": {
       "version": "1.0.2",
@@ -4713,12 +6916,18 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
       "integrity": "sha1-I09Jz3cLfzW0DnkPY2zroMOgq3c=",
       "dev": true,
+      "requires": {
+        "debug": "^3.1.0"
+      },
       "dependencies": {
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -4737,7 +6946,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -4755,7 +6967,12 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
+      }
     },
     "forwarded": {
       "version": "0.1.2",
@@ -4767,7 +6984,10 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
     },
     "fresh": {
       "version": "0.5.2",
@@ -4785,13 +7005,23 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "null-check": "^1.0.0"
+      }
     },
     "fs-extra": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -4817,7 +7047,11 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
       "integrity": "sha1-9rddcNsiwfOwXVkicPTtbJwvgt0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.2"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -4831,6 +7065,10 @@
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
       "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
@@ -4841,7 +7079,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4853,17 +7092,27 @@
           "version": "1.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
         },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
         },
         "chownr": {
           "version": "1.0.1",
@@ -4874,17 +7123,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4896,7 +7148,10 @@
           "version": "2.6.9",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "deep-extend": {
           "version": "0.5.1",
@@ -4920,7 +7175,10 @@
           "version": "1.2.5",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -4932,13 +7190,31 @@
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -4950,24 +7226,35 @@
           "version": "0.4.21",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safer-buffer": "^2.1.0"
+          }
         },
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
         },
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4978,7 +7265,11 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "isarray": {
           "version": "1.0.0",
@@ -4989,28 +7280,45 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
+          }
         },
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -5022,19 +7330,40 @@
           "version": "2.2.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
         },
         "node-pre-gyp": {
           "version": "0.10.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
         },
         "npm-bundled": {
           "version": "1.0.3",
@@ -5046,18 +7375,29 @@
           "version": "1.1.10",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5068,7 +7408,11 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "wrappy": "1"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -5086,7 +7430,11 @@
           "version": "0.1.5",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -5105,6 +7453,12 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -5118,18 +7472,31 @@
           "version": "2.3.6",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
         },
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5161,21 +7528,34 @@
           "dev": true,
           "optional": true
         },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -5187,7 +7567,16 @@
           "version": "4.4.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
+          }
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -5199,17 +7588,22 @@
           "version": "1.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5218,6 +7612,12 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -5231,7 +7631,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
       "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "inherits": "2",
+        "minimatch": "^3.0.0"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -5243,13 +7648,26 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
     },
     "gaze": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
       "integrity": "sha1-xEFzPhO5J6yMD/C0w7Az8ogSkko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globule": "^1.0.0"
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -5261,7 +7679,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -5285,7 +7706,10 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "git-repo-info": {
       "version": "1.4.1",
@@ -5297,19 +7721,34 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "^2.0.0"
+      }
     },
     "globals": {
       "version": "6.4.1",
@@ -5321,13 +7760,21 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
       "integrity": "sha1-Xf+xsZHyLSB5epNptJ6rTpg5aW0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
+      }
     },
     "glogg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
       "integrity": "sha1-3PdY5EeJzD89MsHzVio2duajSBA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "^1.0.0"
+      }
     },
     "graceful-fs": {
       "version": "1.2.3",
@@ -5353,6 +7800,26 @@
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
       "dev": true,
+      "requires": {
+        "array-differ": "^1.0.0",
+        "array-uniq": "^1.0.2",
+        "beeper": "^1.0.0",
+        "chalk": "^1.0.0",
+        "dateformat": "^1.0.11",
+        "fancy-log": "^1.1.0",
+        "gulplog": "^1.0.0",
+        "has-gulplog": "^0.1.0",
+        "lodash._reescape": "^3.0.0",
+        "lodash._reevaluate": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.template": "^3.0.0",
+        "minimist": "^1.1.0",
+        "multipipe": "^0.1.2",
+        "object-assign": "^3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "^2.0.0",
+        "vinyl": "^0.5.0"
+      },
       "dependencies": {
         "lodash._reinterpolate": {
           "version": "3.0.0",
@@ -5364,25 +7831,48 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
           "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._root": "^3.0.0"
+          }
         },
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
         },
         "lodash.template": {
           "version": "3.6.2",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._basecopy": "^3.0.0",
+            "lodash._basetostring": "^3.0.0",
+            "lodash._basevalues": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0",
+            "lodash._reinterpolate": "^3.0.0",
+            "lodash.escape": "^3.0.0",
+            "lodash.keys": "^3.0.0",
+            "lodash.restparam": "^3.0.0",
+            "lodash.templatesettings": "^3.0.0"
+          }
         },
         "lodash.templatesettings": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
           "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "^3.0.0",
+            "lodash.escape": "^3.0.0"
+          }
         },
         "object-assign": {
           "version": "3.0.0",
@@ -5396,13 +7886,22 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glogg": "^1.0.0"
+      }
     },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
+      "requires": {
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -5422,25 +7921,38 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
     },
     "has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
       "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -5472,7 +7984,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "^1.0.0"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -5485,6 +8000,11 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -5499,18 +8019,28 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
             }
           }
         },
@@ -5518,7 +8048,10 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
         }
       }
     },
@@ -5526,31 +8059,55 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "hash-for-dep": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
       "integrity": "sha1-XsafyjLCNSOXLVKstbtl/8NmTKs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "heimdalljs": "^0.2.3",
+        "heimdalljs-logger": "^0.1.7",
+        "resolve": "^1.4.0"
+      }
     },
     "hash.js": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
       "integrity": "sha1-i1Dh811RvQHl7Z7OTb41Scz6Cjw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      }
     },
     "hasha": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
     },
     "he": {
       "version": "1.1.1",
@@ -5563,6 +8120,9 @@
       "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
       "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
       "dev": true,
+      "requires": {
+        "rsvp": "~3.2.1"
+      },
       "dependencies": {
         "rsvp": {
           "version": "3.2.1",
@@ -5576,7 +8136,11 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
       "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "heimdalljs": "^0.2.0"
+      }
     },
     "highlight.js": {
       "version": "9.12.0",
@@ -5588,7 +8152,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -5600,7 +8169,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
       "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "^1.0.1",
+        "user-home": "^1.1.1"
+      }
     },
     "hosted-git-info": {
       "version": "2.6.0",
@@ -5619,12 +8192,24 @@
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.16.tgz",
       "integrity": "sha1-OfWquveL38BX/mczQibv1/OFEXU=",
       "dev": true,
+      "requires": {
+        "camel-case": "3.0.x",
+        "clean-css": "4.1.x",
+        "commander": "2.15.x",
+        "he": "1.1.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.3.x"
+      },
       "dependencies": {
         "clean-css": {
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
           "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.x"
+          }
         },
         "source-map": {
           "version": "0.5.7",
@@ -5637,6 +8222,10 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.28.tgz",
           "integrity": "sha1-DvuaE4UOETAzYcEFH2TS7GjZvgY=",
           "dev": true,
+          "requires": {
+            "commander": "~2.15.0",
+            "source-map": "~0.6.1"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
@@ -5653,6 +8242,14 @@
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
       "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
       "dev": true,
+      "requires": {
+        "bluebird": "^3.4.7",
+        "html-minifier": "^3.2.3",
+        "loader-utils": "^0.2.16",
+        "lodash": "^4.17.3",
+        "pretty-error": "^2.0.2",
+        "toposort": "^1.0.0"
+      },
       "dependencies": {
         "bluebird": {
           "version": "3.5.1",
@@ -5667,12 +8264,21 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "dev": true,
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.1",
+        "domutils": "1.1",
+        "readable-stream": "1.0"
+      },
       "dependencies": {
         "domutils": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "domelementtype": "1"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -5684,7 +8290,13 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -5699,6 +8311,12 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
       "dependencies": {
         "statuses": {
           "version": "1.5.0",
@@ -5718,19 +8336,35 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha1-etOElGWPhGBeL220Q230EPTlvpo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
     },
     "http-proxy-middleware": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.15.2.tgz",
       "integrity": "sha1-4cabiUj7BOKEbuIvOLZQ5PCcAn8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "http-proxy": "^1.13.2",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.11.2",
+        "micromatch": "^2.3.8"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "https-browserify": {
       "version": "0.0.1",
@@ -5742,13 +8376,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "agent-base": "2",
+        "debug": "2",
+        "extend": "3"
+      }
     },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -5786,12 +8428,18 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      },
       "dependencies": {
         "repeating": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
         }
       }
     },
@@ -5817,7 +8465,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -5836,19 +8488,46 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/inline-source-map-comment/-/inline-source-map-comment-1.0.5.tgz",
       "integrity": "sha1-UKikTCp5DfrEQbXJTszVRiY1+vY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "minimist": "^1.1.1",
+        "sum-up": "^1.0.1",
+        "xtend": "^4.0.0"
+      }
     },
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      },
       "dependencies": {
         "readline2": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
           "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "mute-stream": "0.0.5"
+          }
         }
       }
     },
@@ -5880,7 +8559,10 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -5892,18 +8574,25 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
     },
     "is-callable": {
       "version": "1.1.3",
@@ -5915,7 +8604,10 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
     },
     "is-date-object": {
       "version": "1.0.1",
@@ -5928,6 +8620,11 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
@@ -5947,7 +8644,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "^2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -5965,13 +8665,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
     },
     "is-git-url": {
       "version": "0.2.3",
@@ -5983,13 +8689,19 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
     },
     "is-integer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
       "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
@@ -6001,13 +8713,23 @@
       "version": "2.17.2",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
       "integrity": "sha1-ayEDoojpTvPeXPFdKd2F/Et41lw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
     },
     "is-obj": {
       "version": "1.0.1",
@@ -6020,6 +8742,9 @@
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
       "integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
       "dev": true,
+      "requires": {
+        "is-number": "^4.0.0"
+      },
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
@@ -6040,6 +8765,9 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -6071,7 +8799,10 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -6083,7 +8814,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "^1.1.0"
+      }
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -6095,7 +8829,10 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/is-type/-/is-type-0.0.1.tgz",
       "integrity": "sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -6137,7 +8874,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -6150,6 +8890,22 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
@@ -6167,13 +8923,23 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "nopt": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
         },
         "resolve": {
           "version": "1.1.7",
@@ -6185,7 +8951,10 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
         },
         "wordwrap": {
           "version": "1.0.0",
@@ -6199,25 +8968,44 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-0.2.0.tgz",
       "integrity": "sha1-ZD5OXk6PlGaGOimpd9KDqzcsAZw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "istanbul": "0.x.x",
+        "loader-utils": "0.x.x",
+        "object-assign": "4.x.x"
+      }
     },
     "istextorbinary": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
+      }
     },
     "jasmine": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.4.1.tgz",
       "integrity": "sha1-kBbdpFMhPSesbUPcTqlzFaGJCF4=",
       "dev": true,
+      "requires": {
+        "exit": "^0.1.2",
+        "glob": "^3.2.11",
+        "jasmine-core": "~2.4.0"
+      },
       "dependencies": {
         "glob": {
           "version": "3.2.11",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2",
+            "minimatch": "0.3"
+          }
         },
         "lru-cache": {
           "version": "2.7.3",
@@ -6229,7 +9017,11 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
         }
       }
     },
@@ -6244,6 +9036,9 @@
       "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-2.5.0.tgz",
       "integrity": "sha1-EuR4LmRFwN+ruN70xS7dMPY2LUI=",
       "dev": true,
+      "requires": {
+        "colors": "1.1.2"
+      },
       "dependencies": {
         "colors": {
           "version": "1.1.2",
@@ -6281,7 +9076,11 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -6306,7 +9105,10 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
       "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jju": "^1.1.0"
+      }
     },
     "json-schema": {
       "version": "0.2.3",
@@ -6324,7 +9126,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -6349,6 +9154,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -6375,13 +9183,44 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "karma": {
       "version": "0.13.22",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.22.tgz",
       "integrity": "sha1-B3ULG9Bj1+fnuRvNLmNU2PKqh0Q=",
       "dev": true,
+      "requires": {
+        "batch": "^0.5.3",
+        "bluebird": "^2.9.27",
+        "body-parser": "^1.12.4",
+        "chokidar": "^1.4.1",
+        "colors": "^1.1.0",
+        "connect": "^3.3.5",
+        "core-js": "^2.1.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.0",
+        "expand-braces": "^0.1.1",
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.2",
+        "http-proxy": "^1.13.0",
+        "isbinaryfile": "^3.0.0",
+        "lodash": "^3.8.0",
+        "log4js": "^0.6.31",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.0",
+        "optimist": "^0.6.1",
+        "rimraf": "^2.3.3",
+        "socket.io": "^1.4.5",
+        "source-map": "^0.5.3",
+        "useragent": "^2.1.6"
+      },
       "dependencies": {
         "batch": {
           "version": "0.5.3",
@@ -6393,7 +9232,18 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -6425,7 +9275,11 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.3.tgz",
       "integrity": "sha1-TG1wDRY6nTTGGO/YeRi+SeekqMk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs-access": "^1.0.0",
+        "which": "^1.2.1"
+      }
     },
     "karma-jasmine": {
       "version": "0.3.8",
@@ -6438,6 +9292,9 @@
       "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz",
       "integrity": "sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -6452,6 +9309,13 @@
       "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-1.8.1.tgz",
       "integrity": "sha1-OdX9Lt7qPMPvW0BZibN9Ww5qO04=",
       "dev": true,
+      "requires": {
+        "async": "~0.9.0",
+        "loader-utils": "^0.2.5",
+        "lodash": "^3.8.0",
+        "source-map": "^0.1.41",
+        "webpack-dev-middleware": "^1.0.11"
+      },
       "dependencies": {
         "async": {
           "version": "0.9.2",
@@ -6469,7 +9333,10 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
         }
       }
     },
@@ -6483,13 +9350,19 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
     },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -6510,39 +9383,75 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
     },
     "leek": {
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/leek/-/leek-0.0.21.tgz",
       "integrity": "sha1-CYBL9w+K77unRfXVbSpN6/InEf8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "^2.1.0",
+        "lodash.assign": "^3.2.0",
+        "request": "^2.27.0",
+        "rsvp": "^3.0.21"
+      }
     },
     "less": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/less/-/less-2.7.3.tgz",
       "integrity": "sha1-zBJg9RyQCp7A2R+2mYE54CUHtjs=",
       "dev": true,
+      "requires": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "mime": "^1.2.11",
+        "mkdirp": "^0.5.0",
+        "promise": "^7.1.1",
+        "request": "2.81.0",
+        "source-map": "^0.5.3"
+      },
       "dependencies": {
         "ajv": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
+          }
         },
         "assert-plus": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true,
+          "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true,
+          "optional": true
         },
         "form-data": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -6554,34 +9463,77 @@
         "har-schema": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "dev": true,
+          "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
+          }
         },
         "http-signature": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
         },
         "performance-now": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "dev": true,
+          "optional": true
         },
         "qs": {
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true,
+          "optional": true
         },
         "request": {
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
+          }
         },
         "source-map": {
           "version": "0.5.7",
@@ -6596,7 +9548,10 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-2.2.3.tgz",
       "integrity": "sha1-ttj4E5yEk98J2ZKpOgBzSwj4RSg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "^0.2.5"
+      }
     },
     "leven": {
       "version": "1.0.2",
@@ -6608,13 +9563,20 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "linkify-it": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.4.tgz",
       "integrity": "sha1-B3NSbDF8j9E71TTuHRgP+Iq/iBo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
     },
     "livereload-js": {
       "version": "2.3.0",
@@ -6627,6 +9589,13 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -6646,7 +9615,13 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      }
     },
     "lodash": {
       "version": "4.17.10",
@@ -6677,12 +9652,21 @@
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
         }
       }
     },
@@ -6690,13 +9674,24 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.3.0.tgz",
       "integrity": "sha1-K1vEUqDhBhQ7IYafIzvbWHQX0kg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecreate": "~2.3.0",
+        "lodash._setbinddata": "~2.3.0",
+        "lodash.isobject": "~2.3.0"
+      }
     },
     "lodash._basecallback": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
       "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseisequal": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
+      }
     },
     "lodash._baseclone": {
       "version": "4.5.7",
@@ -6714,37 +9709,65 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz",
       "integrity": "sha1-m4ioak3P97fzxh2Dovz8BnHsneA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._renative": "~2.3.0",
+        "lodash.isobject": "~2.3.0",
+        "lodash.noop": "~2.3.0"
+      }
     },
     "lodash._basecreatecallback": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.3.0.tgz",
       "integrity": "sha1-N7KrF1kaM56YjbMln81GAZ16w2I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._setbinddata": "~2.3.0",
+        "lodash.bind": "~2.3.0",
+        "lodash.identity": "~2.3.0",
+        "lodash.support": "~2.3.0"
+      }
     },
     "lodash._basecreatewrapper": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.3.0.tgz",
       "integrity": "sha1-qgxhrZYETDkzN2ExSDqXWcNlEkc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecreate": "~2.3.0",
+        "lodash._setbinddata": "~2.3.0",
+        "lodash._slice": "~2.3.0",
+        "lodash.isobject": "~2.3.0"
+      }
     },
     "lodash._basedifference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-4.5.0.tgz",
       "integrity": "sha1-Vup9YBNnv6Rs194RXcPa6xiDeTg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "~3.0.0"
+      }
     },
     "lodash._baseeach": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
       "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
       "dev": true,
+      "requires": {
+        "lodash.keys": "^3.0.0"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
         }
       }
     },
@@ -6764,7 +9787,11 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
     },
     "lodash._basefor": {
       "version": "3.0.3",
@@ -6777,12 +9804,22 @@
       "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
       "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
       "dev": true,
+      "requires": {
+        "lodash.isarray": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
         }
       }
     },
@@ -6808,13 +9845,22 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
+      }
     },
     "lodash._createcompounder": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
       "integrity": "sha1-XdLLVTctbnDg4jkvsjBNZjEJEHU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.deburr": "^3.0.0",
+        "lodash.words": "^3.0.0"
+      }
     },
     "lodash._createset": {
       "version": "4.0.3",
@@ -6826,13 +9872,21 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.3.0.tgz",
       "integrity": "sha1-0arhEC2t9EDo4G/BM6bt1/4UYHU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basebind": "~2.3.0",
+        "lodash._basecreatewrapper": "~2.3.0",
+        "lodash.isfunction": "~2.3.0"
+      }
     },
     "lodash._escapehtmlchar": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.3.0.tgz",
       "integrity": "sha1-0D2mvYLu3zjcCltQPXQOzQ6JRZI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._htmlescapes": "~2.3.0"
+      }
     },
     "lodash._escapestringchar": {
       "version": "2.3.0",
@@ -6892,7 +9946,11 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.3.0.tgz",
       "integrity": "sha1-25ILVax/P/glk5rOubosIxcT0k0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._htmlescapes": "~2.3.0",
+        "lodash.keys": "~2.3.0"
+      }
     },
     "lodash._root": {
       "version": "3.0.1",
@@ -6904,13 +9962,20 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz",
       "integrity": "sha1-5WEEkKzRMnfVmFjZW18nJ/FQjwQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._renative": "~2.3.0",
+        "lodash.noop": "~2.3.0"
+      }
     },
     "lodash._shimkeys": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.3.0.tgz",
       "integrity": "sha1-YR+TFJ4+bHIQlrSHae8pU3rai6k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._objecttypes": "~2.3.0"
+      }
     },
     "lodash._slice": {
       "version": "2.3.0",
@@ -6923,12 +9988,22 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
       "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
       "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._createassigner": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
         }
       }
     },
@@ -6942,13 +10017,21 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.3.0.tgz",
       "integrity": "sha1-wqjhi2jl7MFS4rFoJmEW/qWwFsw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._createwrapper": "~2.3.0",
+        "lodash._renative": "~2.3.0",
+        "lodash._slice": "~2.3.0"
+      }
     },
     "lodash.camelcase": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
       "integrity": "sha1-kyyLh/ikN3iXxnGXUzKC+Xrqwpg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._createcompounder": "^3.0.0"
+      }
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -6960,25 +10043,40 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
       "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0"
+      }
     },
     "lodash.deburr": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
       "integrity": "sha1-baj1QzSjZqfPTEx2742Aqhs2XtU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "^3.0.0"
+      }
     },
     "lodash.defaults": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.3.0.tgz",
       "integrity": "sha1-qDKwAfE487uXIcKBmip8xa4h7SU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._objecttypes": "~2.3.0",
+        "lodash.keys": "~2.3.0"
+      }
     },
     "lodash.escape": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.3.0.tgz",
       "integrity": "sha1-hEw4xY+EThNi6+lnJhWbYs9fKlg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._escapehtmlchar": "~2.3.0",
+        "lodash._reunescapedhtml": "~2.3.0",
+        "lodash.keys": "~2.3.0"
+      }
     },
     "lodash.find": {
       "version": "4.6.0",
@@ -6990,19 +10088,32 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-3.0.2.tgz",
       "integrity": "sha1-3hz1d1j49EeTGdNcPpzGDEUBk4w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseflatten": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
     },
     "lodash.foreach": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.3.0.tgz",
       "integrity": "sha1-CDQEyR6EbudyRf3512UZxosq8Wg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecreatecallback": "~2.3.0",
+        "lodash.forown": "~2.3.0"
+      }
     },
     "lodash.forown": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.3.0.tgz",
       "integrity": "sha1-JPtKr4ANRfwtxgv+w84EyDajrX8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecreatecallback": "~2.3.0",
+        "lodash._objecttypes": "~2.3.0",
+        "lodash.keys": "~2.3.0"
+      }
     },
     "lodash.identity": {
       "version": "2.3.0",
@@ -7038,13 +10149,21 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz",
       "integrity": "sha1-LhbT/Fg9qYMZaJU/LY5tc0NPZ5k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._objecttypes": "~2.3.0"
+      }
     },
     "lodash.isplainobject": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
       "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
     },
     "lodash.istypedarray": {
       "version": "3.0.6",
@@ -7056,13 +10175,22 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz",
       "integrity": "sha1-s1D0+Syqn0WkouzwGEVM8vKK4lM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._renative": "~2.3.0",
+        "lodash._shimkeys": "~2.3.0",
+        "lodash.isobject": "~2.3.0"
+      }
     },
     "lodash.keysin": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
       "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -7111,12 +10239,20 @@
       "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
       "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
       "dev": true,
+      "requires": {
+        "lodash.keys": "^3.0.0"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
         }
       }
     },
@@ -7136,25 +10272,45 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.3.0.tgz",
       "integrity": "sha1-fq8DivTw1qq3drRKptz8gDNMm/0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._renative": "~2.3.0"
+      }
     },
     "lodash.template": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.3.0.tgz",
       "integrity": "sha1-Tj4pxDO0z+pnXsg15vEjkcYf0is=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._escapestringchar": "~2.3.0",
+        "lodash._reinterpolate": "~2.3.0",
+        "lodash.defaults": "~2.3.0",
+        "lodash.escape": "~2.3.0",
+        "lodash.keys": "~2.3.0",
+        "lodash.templatesettings": "~2.3.0",
+        "lodash.values": "~2.3.0"
+      }
     },
     "lodash.templatesettings": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.3.0.tgz",
       "integrity": "sha1-MD0TLDQnEAQNWhjvqi1XL9A/jNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~2.3.0",
+        "lodash.escape": "~2.3.0"
+      }
     },
     "lodash.toplainobject": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
       "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -7172,19 +10328,29 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.3.0.tgz",
       "integrity": "sha1-ypb75gogsLDsK6K6X8anZb0Uo7o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.keys": "~2.3.0"
+      }
     },
     "lodash.words": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
       "integrity": "sha1-TiqGSbwIdFsXxpWxo86P7llmI7M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "^3.0.0"
+      }
     },
     "log4js": {
       "version": "0.6.38",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
       "dev": true,
+      "requires": {
+        "readable-stream": "~1.0.2",
+        "semver": "~4.3.3"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -7196,7 +10362,13 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
         },
         "semver": {
           "version": "4.3.6",
@@ -7222,7 +10394,11 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
     },
     "lower-case": {
       "version": "1.1.4",
@@ -7234,7 +10410,11 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "make-error": {
       "version": "1.3.4",
@@ -7246,7 +10426,10 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.x"
+      }
     },
     "map-cache": {
       "version": "0.2.2",
@@ -7270,37 +10453,79 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
     },
     "markdown-it": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-4.3.0.tgz",
       "integrity": "sha1-DuKwckB50Yaz8EtzRc45WuR8xHQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "~1.0.2",
+        "entities": "~1.1.1",
+        "linkify-it": "~1.2.0",
+        "mdurl": "~1.0.0",
+        "uc.micro": "^1.0.0"
+      }
     },
     "markdown-it-terminal": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/markdown-it-terminal/-/markdown-it-terminal-0.0.3.tgz",
       "integrity": "sha1-x3qFM8IXC0bSqQejw0UtTX9Kpds=",
       "dev": true,
+      "requires": {
+        "ansi-styles": "^2.1.0",
+        "cardinal": "^0.5.0",
+        "cli-table": "^0.3.1",
+        "lodash.merge": "^3.3.2",
+        "markdown-it": "^4.4.0"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
         },
         "lodash.merge": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
           "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._arraycopy": "^3.0.0",
+            "lodash._arrayeach": "^3.0.0",
+            "lodash._createassigner": "^3.0.0",
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.isplainobject": "^3.0.0",
+            "lodash.istypedarray": "^3.0.0",
+            "lodash.keys": "^3.0.0",
+            "lodash.keysin": "^3.0.0",
+            "lodash.toplainobject": "^3.0.0"
+          }
         },
         "markdown-it": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-4.4.0.tgz",
           "integrity": "sha1-PfNz2+pYepp/7z5WMRtokI91xBQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "argparse": "~1.0.2",
+            "entities": "~1.1.1",
+            "linkify-it": "~1.2.0",
+            "mdurl": "~1.0.0",
+            "uc.micro": "^1.0.0"
+          }
         }
       }
     },
@@ -7314,7 +10539,10 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
       "integrity": "sha1-LuCVQ4Nyy4iE8FgjQTjAXGROwzk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -7332,13 +10560,22 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
     },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
     },
     "mdurl": {
       "version": "1.0.1",
@@ -7356,29 +10593,44 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      }
     },
     "memory-streams": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
       "integrity": "sha1-2bABe0uH8dkvVfJ0XJyqyx3JPOs=",
       "dev": true,
+      "requires": {
+        "readable-stream": "~1.0.2"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         }
       }
     },
@@ -7386,7 +10638,19 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      }
     },
     "merge": {
       "version": "1.2.0",
@@ -7399,6 +10663,9 @@
       "resolved": "https://registry.npmjs.org/merge-defaults/-/merge-defaults-0.2.1.tgz",
       "integrity": "sha1-3UIkjrlrtqUVIXJDIccv+Vg93oA=",
       "dev": true,
+      "requires": {
+        "lodash": "~2.4.1"
+      },
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
@@ -7424,13 +10691,32 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      }
     },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -7448,7 +10734,10 @@
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.33.0"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -7466,7 +10755,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -7479,12 +10771,19 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
       "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
         }
       }
     },
@@ -7493,6 +10792,9 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -7512,7 +10814,14 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
       "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "basic-auth": "~2.0.0",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
+      }
     },
     "mout": {
       "version": "1.1.0",
@@ -7530,7 +10839,10 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2"
+      }
     },
     "mustache": {
       "version": "2.3.0",
@@ -7555,6 +10867,20 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
       "integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
       "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
@@ -7604,25 +10930,49 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
     },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
     },
     "node-gyp": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
       "integrity": "sha1-eJR46PbEXid6oBTz4o+VjyhvkgM=",
       "dev": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": ">=2.9.0 <2.82.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
       "dependencies": {
         "ajv": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
+          }
         },
         "assert-plus": {
           "version": "0.2.0",
@@ -7640,7 +10990,12 @@
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -7658,19 +11013,31 @@
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
+          }
         },
         "http-signature": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
         },
         "nopt": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
         },
         "performance-now": {
           "version": "0.2.0",
@@ -7688,7 +11055,31 @@
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
+          }
         },
         "semver": {
           "version": "5.3.0",
@@ -7709,6 +11100,31 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-1.1.1.tgz",
       "integrity": "sha1-KjgkOr7dff/NB6l8mspWaJdab+o=",
       "dev": true,
+      "requires": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^1.4.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
       "dependencies": {
         "string_decoder": {
           "version": "0.10.31",
@@ -7728,7 +11144,13 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
       "integrity": "sha1-+jE90I9VF9sOJQLldY1mSsafneo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "growly": "^1.3.0",
+        "semver": "^5.4.1",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
+      }
     },
     "node-pre-gyp": {
       "version": "0.6.39",
@@ -7736,13 +11158,30 @@
       "integrity": "sha1-wA6WhgsjwOFCCse+/FBE4deNhkk=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "hawk": "3.1.3",
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "npmlog": "^4.0.2",
+        "rc": "^1.1.7",
+        "request": "2.81.0",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^2.2.1",
+        "tar-pack": "^3.4.0"
+      },
       "dependencies": {
         "ajv": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
+          }
         },
         "assert-plus": {
           "version": "0.2.0",
@@ -7763,7 +11202,12 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          }
         },
         "har-schema": {
           "version": "1.0.5",
@@ -7777,14 +11221,23 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
+          }
         },
         "http-signature": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
         },
         "performance-now": {
           "version": "0.2.0",
@@ -7805,7 +11258,31 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
+          }
         }
       }
     },
@@ -7814,12 +11291,34 @@
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
       "integrity": "sha1-ckD7v/I5YwS0IjUn7TAgWJwAT8I=",
       "dev": true,
+      "requires": {
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.3.2",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "^2.61.0",
+        "sass-graph": "^2.1.1"
+      },
       "dependencies": {
         "cross-spawn": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
         },
         "lodash.assign": {
           "version": "4.2.0",
@@ -7834,26 +11333,45 @@
       "resolved": "https://registry.npmjs.org/node-zopfli/-/node-zopfli-2.0.2.tgz",
       "integrity": "sha1-p6RzrpKq6oXUxo1Fu/LJRMRhFrg=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "commander": "^2.8.1",
+        "defaults": "^1.0.2",
+        "nan": "^2.0.0",
+        "node-pre-gyp": "^0.6.4"
+      }
     },
     "nopt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -7865,13 +11383,103 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
+      }
     },
     "npm": {
       "version": "3.10.2",
       "resolved": "https://registry.npmjs.org/npm/-/npm-3.10.2.tgz",
       "integrity": "sha1-ShtWvTOxlxgDQ27bvEVjQS+SpDQ=",
       "dev": true,
+      "requires": {
+        "abbrev": "~1.0.9",
+        "ansi-regex": "*",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "~1.0.3",
+        "archy": "~1.0.0",
+        "asap": "~2.0.4",
+        "chownr": "~1.0.1",
+        "cmd-shim": "~2.0.2",
+        "columnify": "~1.5.4",
+        "config-chain": "~1.1.10",
+        "debuglog": "*",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "fs-vacuum": "~1.2.9",
+        "fs-write-stream-atomic": "~1.0.8",
+        "fstream": "~1.0.10",
+        "fstream-npm": "~1.1.0",
+        "glob": "~7.0.4",
+        "graceful-fs": "~4.1.4",
+        "has-unicode": "~2.0.0",
+        "hosted-git-info": "~2.1.5",
+        "iferr": "~0.1.5",
+        "imurmurhash": "*",
+        "inflight": "~1.0.5",
+        "inherits": "~2.0.1",
+        "ini": "~1.3.4",
+        "init-package-json": "~1.9.4",
+        "lockfile": "~1.0.1",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.3.2",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.4.0",
+        "lodash.uniq": "~4.3.0",
+        "lodash.without": "~4.2.0",
+        "mkdirp": "~0.5.1",
+        "node-gyp": "~3.3.1",
+        "nopt": "~3.0.6",
+        "normalize-git-url": "~3.0.2",
+        "normalize-package-data": "~2.3.5",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "~3.0.0",
+        "npm-package-arg": "~4.2.0",
+        "npm-registry-client": "~7.1.2",
+        "npm-user-validate": "~0.1.4",
+        "npmlog": "~3.1.2",
+        "once": "~1.3.3",
+        "opener": "~1.4.1",
+        "osenv": "~0.1.3",
+        "path-is-inside": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "~1.0.1",
+        "read-installed": "~4.0.3",
+        "read-package-json": "~2.0.4",
+        "read-package-tree": "~5.1.4",
+        "readable-stream": "~2.1.4",
+        "readdir-scoped-modules": "*",
+        "realize-package-specifier": "~3.0.3",
+        "request": "~2.72.0",
+        "retry": "~0.9.0",
+        "rimraf": "~2.5.2",
+        "semver": "~5.1.0",
+        "sha": "~2.0.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.0",
+        "strip-ansi": "~3.0.1",
+        "tar": "~2.2.1",
+        "text-table": "~0.2.0",
+        "uid-number": "0.0.6",
+        "umask": "~1.1.0",
+        "unique-filename": "~1.1.0",
+        "unpipe": "~1.0.0",
+        "validate-npm-package-license": "*",
+        "validate-npm-package-name": "~2.2.2",
+        "which": "~1.2.10",
+        "wrappy": "~1.0.2",
+        "write-file-atomic": "~1.1.4"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
@@ -7918,13 +11526,17 @@
         "assert-plus": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
         },
         "async": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
         },
         "aws-sign2": {
           "version": "0.6.0",
@@ -7937,12 +11549,23 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
           "dev": true,
+          "requires": {
+            "readable-stream": "~2.0.5"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              }
             }
           }
         },
@@ -7962,19 +11585,31 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
           "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
+          }
         },
         "columnify": {
           "version": "1.5.4",
           "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
           "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
+          }
         },
         "config-chain": {
           "version": "1.1.10",
           "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
           "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
+          }
         },
         "debuglog": {
           "version": "1.0.1",
@@ -8002,13 +11637,23 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "async": "^2.0.1",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
+          }
         },
         "fs-vacuum": {
           "version": "1.2.9",
           "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
           "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
+          }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.8",
@@ -8026,25 +11671,50 @@
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
           "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
+          }
         },
         "fstream-npm": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.0.tgz",
           "integrity": "sha1-gOCXQ0heqnDVfonR/4+vo2bN7+o=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fstream-ignore": "^1.0.0",
+            "inherits": "2"
+          }
         },
         "gauge": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
           "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi": "^0.3.0",
+            "has-unicode": "^2.0.0",
+            "lodash.pad": "^4.1.0",
+            "lodash.padend": "^4.1.0",
+            "lodash.padstart": "^4.1.0"
+          }
         },
         "glob": {
           "version": "7.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.4.tgz",
           "integrity": "sha1-O0SvoJQ73DGyA3uTR5Hi4IS8t/Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "graceful-fs": {
           "version": "4.1.4",
@@ -8056,7 +11726,13 @@
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
+          }
         },
         "has-unicode": {
           "version": "2.0.0",
@@ -8074,7 +11750,12 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
         },
         "iferr": {
           "version": "0.1.5",
@@ -8092,7 +11773,11 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
           "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
         },
         "inherits": {
           "version": "2.0.1",
@@ -8111,12 +11796,29 @@
           "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
           "integrity": "sha1-tAU9C0Dwz4QqQZZpN8s9wPU06FY=",
           "dev": true,
+          "requires": {
+            "glob": "^6.0.0",
+            "npm-package-arg": "^4.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^2.0.1"
+          },
           "dependencies": {
             "glob": {
               "version": "6.0.4",
               "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
             }
           }
         },
@@ -8148,7 +11850,11 @@
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
           "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
+          }
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
@@ -8166,7 +11872,10 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
           "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0"
+          }
         },
         "lodash._getnative": {
           "version": "3.9.1",
@@ -8178,7 +11887,10 @@
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.3.2.tgz",
           "integrity": "sha1-0BEsAsdrUiODOuvGpLbjNPDQV94=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._baseclone": "~4.5.0"
+          }
         },
         "lodash.restparam": {
           "version": "3.6.1",
@@ -8190,19 +11902,31 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.4.0.tgz",
           "integrity": "sha1-Ir4jtMhLSdBDblc5Sa0dSkjH+jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._baseflatten": "~4.2.0",
+            "lodash._baseuniq": "~4.6.0",
+            "lodash.rest": "^4.0.0"
+          }
         },
         "lodash.uniq": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.3.0.tgz",
           "integrity": "sha1-3K2BCHaEFEfY8+xmIyPIam2Tgic=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._baseuniq": "~4.6.0"
+          }
         },
         "lodash.without": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.2.0.tgz",
           "integrity": "sha1-+J7JqO4tfsFPipytcqP17hLFpKY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._basedifference": "~4.5.0",
+            "lodash.rest": "^4.0.0"
+          }
         },
         "lru-cache": {
           "version": "2.7.3",
@@ -8220,25 +11944,53 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "node-gyp": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.3.1.tgz",
           "integrity": "sha1-gPe218L5wElbpCxRimcMmb325KA=",
           "dev": true,
+          "requires": {
+            "fstream": "^1.0.0",
+            "glob": "3 || 4",
+            "graceful-fs": "^4.1.2",
+            "minimatch": "1",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2",
+            "osenv": "0",
+            "path-array": "^1.0.0",
+            "request": "2",
+            "rimraf": "2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "tar": "^2.0.0",
+            "which": "1"
+          },
           "dependencies": {
             "glob": {
               "version": "4.5.3",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
               "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^2.0.1",
+                "once": "^1.3.0"
+              },
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^1.0.0"
+                  }
                 }
               }
             },
@@ -8246,13 +11998,22 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
+              }
             },
             "npmlog": {
               "version": "2.0.4",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
               "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi": "~0.3.1",
+                "are-we-there-yet": "~1.1.2",
+                "gauge": "~1.2.5"
+              }
             }
           }
         },
@@ -8266,7 +12027,10 @@
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
         },
         "normalize-git-url": {
           "version": "3.0.2",
@@ -8278,7 +12042,13 @@
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
           "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
         },
         "npm-cache-filename": {
           "version": "1.0.2",
@@ -8299,13 +12069,32 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.0.tgz",
           "integrity": "sha1-gJvGHKv1S9X/lPYWXIm6juiMEVw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.5",
+            "semver": "^5.1.0"
+          }
         },
         "npm-registry-client": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.1.2.tgz",
           "integrity": "sha1-3fJDor0UnTUXL+aAr/QN+iAFS8M=",
           "dev": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "concat-stream": "^1.4.6",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "normalize-package-data": "~1.0.1 || ^2.0.0",
+            "npm-package-arg": "^3.0.0 || ^4.0.0",
+            "npmlog": "~2.0.0 || ~3.1.0",
+            "once": "^1.3.0",
+            "request": "^2.47.0",
+            "retry": "^0.8.0",
+            "rimraf": "2",
+            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+            "slide": "^1.1.3"
+          },
           "dependencies": {
             "retry": {
               "version": "0.8.0",
@@ -8326,12 +12115,29 @@
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
           "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
           "dev": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.6.0",
+            "set-blocking": "~2.0.0"
+          },
           "dependencies": {
             "gauge": {
               "version": "2.6.0",
               "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
               "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-color": "^0.1.7",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
             }
           }
         },
@@ -8339,7 +12145,10 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
         },
         "opener": {
           "version": "1.4.1",
@@ -8351,7 +12160,11 @@
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
           "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
         },
         "path-is-inside": {
           "version": "1.0.1",
@@ -8375,31 +12188,59 @@
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
           "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mute-stream": "~0.0.4"
+          }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
           "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2"
+          }
         },
         "read-installed": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
           "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
+          }
         },
         "read-package-json": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
           "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
           "dev": true,
+          "requires": {
+            "glob": "^6.0.0",
+            "graceful-fs": "^4.1.2",
+            "json-parse-helpfulerror": "^1.0.2",
+            "normalize-package-data": "^2.0.0"
+          },
           "dependencies": {
             "glob": {
               "version": "6.0.4",
               "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
             }
           }
         },
@@ -8407,19 +12248,41 @@
           "version": "5.1.4",
           "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.4.tgz",
           "integrity": "sha1-u25GX5E9QlmpU0yHsdXFCP6OsHg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "once": "^1.3.0",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0"
+          }
         },
         "readable-stream": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "integrity": "sha1-cLl5HG/LhIDbRL0VWg9rtY8XJGg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "^1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
           "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
+          }
         },
         "realize-package-specifier": {
           "version": "3.0.3",
@@ -8435,7 +12298,30 @@
           "version": "2.72.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
           "integrity": "sha1-DOOheVEmILEEQfFMguIcEsDdtOE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "bl": "~1.1.2",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~1.0.0-rc3",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.1.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.2.0",
+            "tunnel-agent": "~0.4.1"
+          }
         },
         "retry": {
           "version": "0.9.0",
@@ -8447,7 +12333,10 @@
           "version": "2.5.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
           "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.0"
+          }
         },
         "semver": {
           "version": "5.1.0",
@@ -8459,7 +12348,11 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
           "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "readable-stream": "^2.0.2"
+          }
         },
         "slide": {
           "version": "1.1.6",
@@ -8477,7 +12370,10 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
           "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "^1.0.2"
+          }
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
@@ -8501,13 +12397,21 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         },
         "tar": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
+          }
         },
         "text-table": {
           "version": "0.2.0",
@@ -8543,7 +12447,10 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
           "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "unique-slug": "^2.0.0"
+          }
         },
         "unpipe": {
           "version": "1.0.0",
@@ -8555,19 +12462,29 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
+          }
         },
         "validate-npm-package-name": {
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
           "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "builtins": "0.0.7"
+          }
         },
         "which": {
           "version": "1.2.10",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
           "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isexe": "^1.1.1"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -8593,12 +12510,28 @@
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-3.1.2.tgz",
       "integrity": "sha1-x+P69KoKWb8Nz8EmARZhUWkhcc8=",
       "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cross-spawn": "^4.0.0",
+        "minimatch": "^3.0.2",
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.1",
+        "ps-tree": "^1.0.1",
+        "read-pkg": "^1.1.0",
+        "read-pkg-up": "^1.0.1",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
       "dependencies": {
         "cross-spawn": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
         }
       }
     },
@@ -8606,13 +12539,22 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
     },
     "nth-check": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
     },
     "null-check": {
       "version": "1.0.0",
@@ -8655,12 +12597,20 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
         }
       }
     },
@@ -8675,6 +12625,9 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -8688,13 +12641,20 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
     },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -8709,6 +12669,13 @@
       "resolved": "https://registry.npmjs.org/offline-plugin/-/offline-plugin-3.4.2.tgz",
       "integrity": "sha1-3bue7D6P0FLsUeA8Vq/cM7CjMaI=",
       "dev": true,
+      "requires": {
+        "deep-extend": "^0.4.0",
+        "ejs": "^2.3.4",
+        "es6-promise": "^3.0.2",
+        "loader-utils": "0.2.x",
+        "minimatch": "^3.0.2"
+      },
       "dependencies": {
         "deep-extend": {
           "version": "0.4.2",
@@ -8722,7 +12689,10 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "on-headers": {
       "version": "1.0.1",
@@ -8734,7 +12704,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -8752,13 +12725,21 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.1.tgz",
       "integrity": "sha1-m9MO4+uk/VM74sg9VjKaTliRO/g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
@@ -8773,6 +12754,14 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
@@ -8792,13 +12781,22 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "cli-cursor": "^1.0.2",
+        "cli-spinners": "^0.1.2",
+        "object-assign": "^4.0.1"
+      }
     },
     "original": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.1.tgz",
       "integrity": "sha1-sKU/9Cupl6jJzR+12q60K51pMZA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "url-parse": "~1.4.0"
+      }
     },
     "os-browserify": {
       "version": "0.2.1",
@@ -8816,7 +12814,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -8828,13 +12829,22 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "output-file-sync": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.4",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.0"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -8854,25 +12864,44 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
     },
     "parse-asn1": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha1-9r8pOBgzK9DatU77Fgh3JHRebKg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
     },
     "parse5": {
       "version": "2.2.3",
@@ -8884,19 +12913,28 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
     },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
     },
     "parseuri": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
     },
     "parseurl": {
       "version": "1.3.2",
@@ -8914,7 +12952,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
       "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-index": "^1.0.0"
+      }
     },
     "path-browserify": {
       "version": "0.0.0",
@@ -8963,6 +13004,11 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -8976,13 +13022,23 @@
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
+      }
     },
     "pbkdf2": {
       "version": "3.0.16",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
       "integrity": "sha1-dAQgjsawG2LYW/g4U6gGT42cKlw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
     },
     "pend": {
       "version": "1.2.0",
@@ -9007,6 +13063,17 @@
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
+      },
       "dependencies": {
         "es6-promise": {
           "version": "4.2.4",
@@ -9018,7 +13085,12 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -9044,13 +13116,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -9071,6 +13151,12 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
       "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
       "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "js-base64": "^2.1.9",
+        "source-map": "^0.5.6",
+        "supports-color": "^3.2.3"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
@@ -9082,7 +13168,10 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
         }
       }
     },
@@ -9090,79 +13179,131 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.2",
+        "postcss-message-helpers": "^2.0.0",
+        "reduce-css-calc": "^1.2.6"
+      }
     },
     "postcss-colormin": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "colormin": "^1.0.5",
+        "postcss": "^5.0.13",
+        "postcss-value-parser": "^3.2.3"
+      }
     },
     "postcss-convert-values": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.11",
+        "postcss-value-parser": "^3.1.2"
+      }
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.14"
+      }
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.14"
+      }
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.16"
+      }
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.14",
+        "uniqs": "^2.0.0"
+      }
     },
     "postcss-filter-plugins": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
       "integrity": "sha1-giRf34IzcEFkXkdxFNjlk6oYuOw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
     },
     "postcss-loader": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-0.9.1.tgz",
       "integrity": "sha1-h6PnD1jkbWinW63Gcl2epHc/0dc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loader-utils": "^0.2.14",
+        "postcss": "^5.0.19"
+      }
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1",
+        "postcss": "^5.0.10",
+        "postcss-value-parser": "^3.1.1"
+      }
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "^1.5.2",
+        "caniuse-api": "^1.5.2",
+        "postcss": "^5.0.4",
+        "postcss-selector-parser": "^2.2.2",
+        "vendors": "^1.0.0"
+      }
     },
     "postcss-message-helpers": {
       "version": "2.0.0",
@@ -9174,43 +13315,75 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
+      }
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.12",
+        "postcss-value-parser": "^3.3.0"
+      }
     },
     "postcss-minify-params": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.2",
+        "postcss-value-parser": "^3.0.2",
+        "uniqs": "^2.0.0"
+      }
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.2",
+        "has": "^1.0.1",
+        "postcss": "^5.0.14",
+        "postcss-selector-parser": "^2.0.0"
+      }
     },
     "postcss-modules-extract-imports": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
+      "requires": {
+        "postcss": "^6.0.1"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         },
         "has-flag": {
           "version": "3.0.0",
@@ -9222,7 +13395,12 @@
           "version": "6.0.22",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha1-4jt4MUkFw7kMvWFwISHnp4hI8qM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -9234,7 +13412,10 @@
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -9243,24 +13424,41 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         },
         "css-selector-tokenizer": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
           "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cssesc": "^0.1.0",
+            "fastparse": "^1.1.1",
+            "regexpu-core": "^1.0.0"
+          }
         },
         "has-flag": {
           "version": "3.0.0",
@@ -9272,7 +13470,12 @@
           "version": "6.0.22",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha1-4jt4MUkFw7kMvWFwISHnp4hI8qM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -9284,7 +13487,10 @@
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -9293,24 +13499,41 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         },
         "css-selector-tokenizer": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
           "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cssesc": "^0.1.0",
+            "fastparse": "^1.1.1",
+            "regexpu-core": "^1.0.0"
+          }
         },
         "has-flag": {
           "version": "3.0.0",
@@ -9322,7 +13545,12 @@
           "version": "6.0.22",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha1-4jt4MUkFw7kMvWFwISHnp4hI8qM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -9334,7 +13562,10 @@
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -9343,18 +13574,30 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
+      "requires": {
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         },
         "has-flag": {
           "version": "3.0.0",
@@ -9366,7 +13609,12 @@
           "version": "6.0.22",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha1-4jt4MUkFw7kMvWFwISHnp4hI8qM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -9378,7 +13626,10 @@
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -9386,55 +13637,96 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.5"
+      }
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^1.4.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3"
+      }
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.1"
+      }
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
+      }
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1",
+        "postcss": "^5.0.8",
+        "postcss-value-parser": "^3.0.1"
+      }
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
     },
     "postcss-svgo": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-svg": "^2.0.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3",
+        "svgo": "^0.7.0"
+      }
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
+      }
     },
     "postcss-value-parser": {
       "version": "3.3.0",
@@ -9446,7 +13738,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -9470,7 +13767,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
+      }
     },
     "primeng": {
       "version": "1.0.0-beta.13",
@@ -9510,7 +13811,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-relative-require/-/process-relative-require-1.0.0.tgz",
       "integrity": "sha1-FZDfz1uPKYO6U+OYRGtoJAtMxoo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "node-modules-path": "^1.0.0"
+      }
     },
     "progress": {
       "version": "1.1.8",
@@ -9523,19 +13827,28 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
     },
     "promise-map-series": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "rsvp": "^3.0.14"
+      }
     },
     "promzard": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
       "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "read": "1"
+      }
     },
     "proto-list": {
       "version": "1.2.4",
@@ -9548,6 +13861,19 @@
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-3.3.0.tgz",
       "integrity": "sha1-f0RoMGrCmjFQhtr2SitKFcC8Exc=",
       "dev": true,
+      "requires": {
+        "adm-zip": "0.4.7",
+        "chalk": "^1.1.3",
+        "glob": "~6.0",
+        "jasmine": "2.4.1",
+        "jasminewd2": "0.0.9",
+        "optimist": "~0.6.0",
+        "q": "1.4.1",
+        "request": "~2.67.0",
+        "saucelabs": "~1.0.1",
+        "selenium-webdriver": "2.52.0",
+        "source-map-support": "~0.4.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "0.2.0",
@@ -9559,7 +13885,10 @@
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
         },
         "aws-sign2": {
           "version": "0.6.0",
@@ -9577,25 +13906,48 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "async": "^2.0.1",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
+          }
         },
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "har-validator": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
+          }
         },
         "http-signature": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
         },
         "node-uuid": {
           "version": "1.4.8",
@@ -9619,7 +13971,29 @@
           "version": "2.67.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
           "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "bl": "~1.0.0",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~1.0.0-rc3",
+            "har-validator": "~2.0.2",
+            "hawk": "~3.1.0",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.0",
+            "qs": "~5.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.2.0",
+            "tunnel-agent": "~0.4.1"
+          }
         },
         "source-map": {
           "version": "0.5.7",
@@ -9631,7 +14005,10 @@
           "version": "0.4.18",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
           "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-map": "^0.5.6"
+          }
         },
         "tough-cookie": {
           "version": "2.2.2",
@@ -9651,7 +14028,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
       "integrity": "sha1-NV8mJQWmIWRrMTCnKOtkfiIFU0E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.6.0"
+      }
     },
     "prr": {
       "version": "1.0.1",
@@ -9663,7 +14044,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "event-stream": "~3.3.0"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -9675,7 +14059,14 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha1-RuuRByBr9zSJ+LhbadkTNMZhCZQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -9699,7 +14090,11 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -9724,6 +14119,11 @@
       "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
       "integrity": "sha1-DQ1n8PtqWJoOFC+QmF92zbr0A/c=",
       "dev": true,
+      "requires": {
+        "mktemp": "~0.3.4",
+        "rimraf": "~2.2.6",
+        "underscore.string": "~2.3.3"
+      },
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
@@ -9738,6 +14138,11 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha1-01SQAw6091eN4pLObfsEqRoSiSM=",
       "dev": true,
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
@@ -9757,13 +14162,20 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha1-0wLFIpSFiISKjTAMkytEwkIx2oA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "randomfill": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
     },
     "range-parser": {
       "version": "1.2.0",
@@ -9776,6 +14188,12 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
       "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      },
       "dependencies": {
         "depd": {
           "version": "1.1.1",
@@ -9787,7 +14205,13 @@
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
           "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": ">= 1.3.1 < 2"
+          }
         },
         "iconv-lite": {
           "version": "0.4.19",
@@ -9814,37 +14238,70 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
     },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
     },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -9859,6 +14316,10 @@
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
       "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
       "dev": true,
+      "requires": {
+        "mute-stream": "0.0.4",
+        "strip-ansi": "^2.0.1"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "1.1.1",
@@ -9876,7 +14337,10 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^1.0.0"
+          }
         }
       }
     },
@@ -9885,6 +14349,12 @@
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
       "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
       "dev": true,
+      "requires": {
+        "ast-types": "0.8.12",
+        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+        "private": "~0.1.5",
+        "source-map": "~0.5.0"
+      },
       "dependencies": {
         "ast-types": {
           "version": "0.8.12",
@@ -9910,19 +14380,29 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
     },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
     },
     "redeyed": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
       "integrity": "sha1-erAA5g7jh1rBFdKe2zLBQDxsJdE=",
       "dev": true,
+      "requires": {
+        "esprima-fb": "~12001.1.0-dev-harmony-fb"
+      },
       "dependencies": {
         "esprima-fb": {
           "version": "12001.1.0-dev-harmony-fb",
@@ -9937,6 +14417,11 @@
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
+      "requires": {
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
+      },
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
@@ -9951,6 +14436,9 @@
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
+      "requires": {
+        "balanced-match": "^0.4.2"
+      },
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
@@ -9976,6 +14464,14 @@
       "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
       "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
       "dev": true,
+      "requires": {
+        "commoner": "~0.10.3",
+        "defs": "~1.1.0",
+        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+        "private": "~0.1.5",
+        "recast": "0.10.33",
+        "through": "~2.3.8"
+      },
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
@@ -9989,25 +14485,44 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "^0.1.3"
+      }
     },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
     },
     "regexpu": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
       "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esprima": "^2.6.0",
+        "recast": "^0.10.10",
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
+      }
     },
     "regexpu-core": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
+      }
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -10019,7 +14534,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      }
     },
     "relateurl": {
       "version": "0.2.7",
@@ -10032,6 +14550,13 @@
       "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.6.4.tgz",
       "integrity": "sha1-rFUe/xqmQVBLTzGNAwPdph47tpU=",
       "dev": true,
+      "requires": {
+        "amdefine": "1.0.0",
+        "gulp-util": "3.0.7",
+        "istanbul": "0.4.3",
+        "source-map": ">=0.5.6",
+        "through2": "2.0.1"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
@@ -10055,13 +14580,32 @@
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.3.tgz",
           "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.x",
+            "async": "1.x",
+            "escodegen": "1.8.x",
+            "esprima": "2.7.x",
+            "fileset": "0.2.x",
+            "handlebars": "^4.0.1",
+            "js-yaml": "3.x",
+            "mkdirp": "0.5.x",
+            "nopt": "3.x",
+            "once": "1.x",
+            "resolve": "1.1.x",
+            "supports-color": "^3.1.0",
+            "which": "^1.1.1",
+            "wordwrap": "^1.0.0"
+          }
         },
         "nopt": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
         },
         "resolve": {
           "version": "1.1.7",
@@ -10079,7 +14623,10 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
         },
         "wordwrap": {
           "version": "1.0.0",
@@ -10100,6 +14647,13 @@
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "dev": true,
+      "requires": {
+        "css-select": "^1.1.0",
+        "dom-converter": "~0.1",
+        "htmlparser2": "~3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "~0.3"
+      },
       "dependencies": {
         "utila": {
           "version": "0.3.3",
@@ -10125,7 +14679,10 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
       "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
     },
     "replace-ext": {
       "version": "0.0.1",
@@ -10137,13 +14694,38 @@
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha1-MvACNc0I1IK00NaNuTqCnA7VdW4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
+      }
     },
     "request-progress": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "throttleit": "^1.0.0"
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -10167,7 +14749,10 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha1-gvHsGaQjrB+9CAsLqwa6NuhKeiY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -10179,7 +14764,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
     },
     "ret": {
       "version": "0.1.15",
@@ -10191,19 +14780,29 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "^0.1.1"
+      }
     },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      }
     },
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
     },
     "rsvp": {
       "version": "3.6.2",
@@ -10215,7 +14814,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0"
+      }
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -10238,7 +14840,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -10250,13 +14855,28 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-1.7.0.tgz",
       "integrity": "sha1-s1ebzLRclM8gNVzIESSZDf00bjA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "anymatch": "^1.3.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^2.0.0",
+        "minimatch": "^3.0.2",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.10.0"
+      }
     },
     "sass-graph": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -10268,13 +14888,33 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
         },
         "yargs": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
+          }
         }
       }
     },
@@ -10283,6 +14923,11 @@
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-3.2.3.tgz",
       "integrity": "sha1-dC6B/YFwqHcal54YYiUBZ0qI41U=",
       "dev": true,
+      "requires": {
+        "async": "^1.4.0",
+        "loader-utils": "^0.2.5",
+        "object-assign": "^4.0.1"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -10296,7 +14941,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
       "integrity": "sha1-tQoQDZxaQUB0izUzWm5dcAF9rfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "^1.0.0"
+      }
     },
     "sax": {
       "version": "1.2.4",
@@ -10308,19 +14956,33 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/script-loader/-/script-loader-0.7.2.tgz",
       "integrity": "sha1-IBbbb4byX1z1baOJFdgzeLsWa6c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "raw-loader": "~0.5.1"
+      }
     },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
+      }
     },
     "selenium-webdriver": {
       "version": "2.52.0",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.52.0.tgz",
       "integrity": "sha1-0tyy9RtIcz1sQoKeUnZ+zuK/S2s=",
       "dev": true,
+      "requires": {
+        "adm-zip": "0.4.4",
+        "rimraf": "^2.2.8",
+        "tmp": "0.0.24",
+        "ws": "^1.0.1",
+        "xml2js": "0.4.4"
+      },
       "dependencies": {
         "adm-zip": {
           "version": "0.4.4",
@@ -10347,6 +15009,21 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
       "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      },
       "dependencies": {
         "mime": {
           "version": "1.4.1",
@@ -10366,13 +15043,28 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      }
     },
     "serve-static": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha1-CV6Ecv1bRiN9tQzkhqQ/S4bGzsE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -10391,12 +15083,21 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
       "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
         }
       }
     },
@@ -10410,13 +15111,20 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -10428,13 +15136,24 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
+      }
     },
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -10458,7 +15177,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.0.tgz",
       "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0"
+      }
     },
     "simple-fmt": {
       "version": "0.1.0",
@@ -10489,18 +15211,34 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
         },
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
         },
         "source-map": {
           "version": "0.5.7",
@@ -10515,27 +15253,49 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY="
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
         },
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc="
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
         },
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw="
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
         },
         "isobject": {
           "version": "3.0.1",
@@ -10546,7 +15306,8 @@
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "dev": true
         }
       }
     },
@@ -10554,25 +15315,43 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      }
     },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
     },
     "socket.io": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
       "integrity": "sha1-PkDZMmN+a9kjmBslyvfFPoO24uE=",
       "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "engine.io": "1.8.0",
+        "has-binary": "0.1.7",
+        "object-assign": "4.1.0",
+        "socket.io-adapter": "0.5.0",
+        "socket.io-client": "1.6.0",
+        "socket.io-parser": "2.3.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -10593,12 +15372,19 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
       "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
       "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "socket.io-parser": "2.3.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -10613,6 +15399,19 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
       "integrity": "sha1-W2aPT3cTBN/u0XkGRwg4b6ZxeFM=",
       "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "2.3.3",
+        "engine.io-client": "1.8.0",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "2.3.1",
+        "to-array": "0.1.4"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -10624,7 +15423,10 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -10639,12 +15441,21 @@
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "dev": true,
+      "requires": {
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -10664,19 +15475,34 @@
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
       "integrity": "sha1-2Xa76ACve9IK4IWY1YI5NQiZPA0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.0.1"
+      }
     },
     "sockjs-client": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
       "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
       "dev": true,
+      "requires": {
+        "debug": "^2.6.6",
+        "eventsource": "0.1.6",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.8"
+      },
       "dependencies": {
         "faye-websocket": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
           "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
         }
       }
     },
@@ -10684,7 +15510,10 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
     },
     "source-list-map": {
       "version": "0.1.8",
@@ -10696,13 +15525,21 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
     },
     "source-map-loader": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.1.6.tgz",
       "integrity": "sha1-wJkD2m1zueU7ftjuUkVZcFHpjpE=",
       "dev": true,
+      "requires": {
+        "async": "^0.9.0",
+        "loader-utils": "~0.2.2",
+        "source-map": "~0.1.33"
+      },
       "dependencies": {
         "async": {
           "version": "0.9.2",
@@ -10714,7 +15551,10 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
         }
       }
     },
@@ -10723,6 +15563,13 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
       "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      },
       "dependencies": {
         "source-map-url": {
           "version": "0.4.0",
@@ -10737,12 +15584,18 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
       "integrity": "sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=",
       "dev": true,
+      "requires": {
+        "source-map": "0.1.32"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
         }
       }
     },
@@ -10756,13 +15609,24 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/sourcemap-istanbul-instrumenter-loader/-/sourcemap-istanbul-instrumenter-loader-0.2.0.tgz",
       "integrity": "sha1-j9cuir0W3tWJGKdHTbW7PQ27ys0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "istanbul": "0.x.x",
+        "loader-utils": "0.x.x",
+        "object-assign": "4.x.x"
+      }
     },
     "sourcemap-validator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.1.0.tgz",
       "integrity": "sha1-AEVFR9FoIYbhSYpyCOAi6N+oc48=",
       "dev": true,
+      "requires": {
+        "jsesc": "~0.3.x",
+        "lodash.foreach": "~2.3.x",
+        "lodash.template": "~2.3.x",
+        "source-map": "~0.1.x"
+      },
       "dependencies": {
         "jsesc": {
           "version": "0.3.0",
@@ -10774,7 +15638,10 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
         }
       }
     },
@@ -10794,7 +15661,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
     },
     "spdx-exceptions": {
       "version": "2.1.0",
@@ -10806,7 +15677,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
     },
     "spdx-license-ids": {
       "version": "3.0.0",
@@ -10818,13 +15693,19 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
     },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -10836,7 +15717,18 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
     },
     "stable": {
       "version": "0.1.8",
@@ -10849,12 +15741,19 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
         }
       }
     },
@@ -10868,7 +15767,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
     },
     "stream-cache": {
       "version": "0.0.2",
@@ -10880,13 +15783,23 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
     },
     "stream-http": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -10894,23 +15807,26 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true
-    },
     "string-replace-loader": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string-replace-loader/-/string-replace-loader-1.3.0.tgz",
       "integrity": "sha1-HUBKe/Xi7CGwj/x22JRF++SbwB0=",
       "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "lodash": "^4"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
+          }
         }
       }
     },
@@ -10918,13 +15834,32 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
     },
     "string.prototype.padend": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
       "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "stringmap": {
       "version": "0.2.2",
@@ -10948,19 +15883,28 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
     },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -10973,12 +15917,20 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
       "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
       "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
+          }
         }
       }
     },
@@ -10993,12 +15945,28 @@
       "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
       "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
       "dev": true,
+      "requires": {
+        "css-parse": "1.7.x",
+        "debug": "*",
+        "glob": "7.0.x",
+        "mkdirp": "0.5.x",
+        "sax": "0.5.x",
+        "source-map": "0.1.x"
+      },
       "dependencies": {
         "glob": {
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "sax": {
           "version": "0.5.8",
@@ -11010,7 +15978,10 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
         }
       }
     },
@@ -11019,6 +15990,11 @@
       "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-2.5.1.tgz",
       "integrity": "sha1-1a2KfglYrcErhYHnuxabmmHVQhY=",
       "dev": true,
+      "requires": {
+        "loader-utils": "^0.2.9",
+        "lodash.clonedeep": "^4.5.0",
+        "when": "~3.6.x"
+      },
       "dependencies": {
         "when": {
           "version": "3.6.4",
@@ -11032,7 +16008,10 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0"
+      }
     },
     "supports-color": {
       "version": "2.0.0",
@@ -11045,6 +16024,15 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
+      "requires": {
+        "coa": "~1.0.1",
+        "colors": "~1.1.2",
+        "csso": "~2.3.1",
+        "js-yaml": "~3.7.0",
+        "mkdirp": "~0.5.1",
+        "sax": "~1.2.1",
+        "whet.extend": "~0.9.9"
+      },
       "dependencies": {
         "colors": {
           "version": "1.1.2",
@@ -11068,13 +16056,21 @@
     "systemjs": {
       "version": "0.19.47",
       "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.19.47.tgz",
-      "integrity": "sha1-yMk5NxgPP1SBx2nNJyB2P7SjHG8="
+      "integrity": "sha1-yMk5NxgPP1SBx2nNJyB2P7SjHG8=",
+      "requires": {
+        "when": "^3.7.5"
+      }
     },
     "tap-parser": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
       "integrity": "sha1-aQfolyXXt/pq5B7ixGTD20MYiuw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "events-to-array": "^1.0.1",
+        "js-yaml": "^3.2.7",
+        "readable-stream": "^2"
+      }
     },
     "tapable": {
       "version": "0.2.8",
@@ -11086,26 +16082,47 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
+      }
     },
     "tar-pack": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
       "integrity": "sha1-4dvAOpudO6B+iWrQJzF+tnmhCh8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "fstream": "^1.0.10",
+        "fstream-ignore": "^1.0.5",
+        "once": "^1.3.3",
+        "readable-stream": "^2.1.4",
+        "rimraf": "^2.5.1",
+        "tar": "^2.2.1",
+        "uid-number": "^0.0.6"
+      }
     },
     "temp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.5.1.tgz",
       "integrity": "sha1-d6sZx5qntZPL5PrCRBdoytmHuN8=",
       "dev": true,
+      "requires": {
+        "rimraf": "~2.1.4"
+      },
       "dependencies": {
         "rimraf": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
           "integrity": "sha1-Wm62Lu2gaPUe3lDymz5c0i89m7I=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "~1"
+          }
         }
       }
     },
@@ -11114,6 +16131,34 @@
       "resolved": "https://registry.npmjs.org/testem/-/testem-1.18.5.tgz",
       "integrity": "sha1-kS87/UdzUZ+jzOCo/Q41R2PL1UU=",
       "dev": true,
+      "requires": {
+        "backbone": "^1.1.2",
+        "bluebird": "^3.4.6",
+        "charm": "^1.0.0",
+        "commander": "^2.6.0",
+        "consolidate": "^0.14.0",
+        "cross-spawn": "^5.1.0",
+        "express": "^4.10.7",
+        "fireworm": "^0.7.0",
+        "glob": "^7.0.4",
+        "http-proxy": "^1.13.1",
+        "js-yaml": "^3.2.5",
+        "lodash.assignin": "^4.1.0",
+        "lodash.clonedeep": "^4.4.1",
+        "lodash.find": "^4.5.1",
+        "lodash.uniqby": "^4.7.0",
+        "mkdirp": "^0.5.1",
+        "mustache": "^2.2.1",
+        "node-notifier": "^5.0.1",
+        "npmlog": "^4.0.0",
+        "printf": "^0.2.3",
+        "rimraf": "^2.4.4",
+        "socket.io": "1.6.0",
+        "spawn-args": "^0.2.0",
+        "styled_string": "0.0.1",
+        "tap-parser": "^5.1.0",
+        "xmldom": "^0.1.19"
+      },
       "dependencies": {
         "bluebird": {
           "version": "3.5.1",
@@ -11146,6 +16191,10 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
       "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
       "dev": true,
+      "requires": {
+        "readable-stream": "~2.0.0",
+        "xtend": "~4.0.0"
+      },
       "dependencies": {
         "process-nextick-args": {
           "version": "1.0.7",
@@ -11157,7 +16206,15 @@
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -11177,19 +16234,42 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "process": "~0.11.0"
+      }
     },
     "tiny-lr": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
       "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
       "dev": true,
+      "requires": {
+        "body-parser": "~1.14.0",
+        "debug": "~2.2.0",
+        "faye-websocket": "~0.10.0",
+        "livereload-js": "^2.2.0",
+        "parseurl": "~1.3.0",
+        "qs": "~5.1.0"
+      },
       "dependencies": {
         "body-parser": {
           "version": "1.14.2",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
           "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
           "dev": true,
+          "requires": {
+            "bytes": "2.2.0",
+            "content-type": "~1.0.1",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "http-errors": "~1.3.1",
+            "iconv-lite": "0.4.13",
+            "on-finished": "~2.3.0",
+            "qs": "5.2.0",
+            "raw-body": "~2.1.5",
+            "type-is": "~1.6.10"
+          },
           "dependencies": {
             "qs": {
               "version": "5.2.0",
@@ -11209,13 +16289,20 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "http-errors": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "statuses": "1"
+          }
         },
         "iconv-lite": {
           "version": "0.4.13",
@@ -11240,6 +16327,11 @@
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
           "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
           "dev": true,
+          "requires": {
+            "bytes": "2.4.0",
+            "iconv-lite": "0.4.13",
+            "unpipe": "1.0.0"
+          },
           "dependencies": {
             "bytes": {
               "version": "2.4.0",
@@ -11255,7 +16347,10 @@
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.1"
+      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -11285,25 +16380,41 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
     },
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
     },
     "to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
         }
       }
     },
@@ -11317,19 +16428,35 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "^1.4.1"
+      }
     },
     "tree-sync": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.2.2.tgz",
       "integrity": "sha1-LPdrhYn1n/7bWNtaOsfLAT0BWLc=",
       "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "fs-tree-diff": "^0.5.6",
+        "mkdirp": "^0.5.1",
+        "quick-temp": "^0.1.5",
+        "walk-sync": "^0.2.7"
+      },
       "dependencies": {
         "fs-tree-diff": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
           "integrity": "sha1-MV4rCY1f5/YiiArJZbGwUYaKyHE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
         }
       }
     },
@@ -11367,12 +16494,25 @@
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-0.8.2.tgz",
       "integrity": "sha1-czEpbRPVsxBc2QXOvKORQ+7SslU=",
       "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "colors": "^1.0.3",
+        "enhanced-resolve": "^0.9.0",
+        "loader-utils": "^0.2.6",
+        "object-assign": "^2.0.0",
+        "semver": "^5.0.1"
+      },
       "dependencies": {
         "enhanced-resolve": {
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -11405,6 +16545,18 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-1.2.1.tgz",
       "integrity": "sha1-EI8eQzZuJfUiPoVJ+nxtz3gO2iM=",
       "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "chalk": "^1.1.1",
+        "diff": "^2.1.1",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "pinkie": "^2.0.4",
+        "source-map-support": "^0.4.0",
+        "tsconfig": "^5.0.2",
+        "xtend": "^4.0.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
@@ -11416,7 +16568,10 @@
           "version": "0.4.18",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
           "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-map": "^0.5.6"
+          }
         }
       }
     },
@@ -11424,31 +16579,61 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-5.0.3.tgz",
       "integrity": "sha1-X0J45wGACWeo/Dg/0ZZIh48qbjo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.3.0",
+        "parse-json": "^2.2.0",
+        "strip-bom": "^2.0.0",
+        "strip-json-comments": "^2.0.0"
+      }
     },
     "tsickle": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.1.6.tgz",
       "integrity": "sha1-6UMjRLZh4Dsq7vaVKxbAmqSDaxk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0",
+        "source-map": "^0.4.2",
+        "source-map-support": "^0.3.1"
+      }
     },
     "tslint": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-3.13.0.tgz",
       "integrity": "sha1-xQkarGitYUcRIougIVNx030NH6Q=",
       "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "diff": "^2.2.1",
+        "findup-sync": "~0.3.0",
+        "glob": "^7.0.3",
+        "optimist": "~0.6.0",
+        "resolve": "^1.1.7",
+        "underscore.string": "^3.3.4"
+      },
       "dependencies": {
         "findup-sync": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
           "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
           "dev": true,
+          "requires": {
+            "glob": "~5.0.0"
+          },
           "dependencies": {
             "glob": {
               "version": "5.0.15",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
             }
           }
         },
@@ -11456,7 +16641,11 @@
           "version": "3.3.4",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
           "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "sprintf-js": "^1.0.3",
+            "util-deprecate": "^1.0.2"
+          }
         }
       }
     },
@@ -11465,6 +16654,13 @@
       "resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-2.1.5.tgz",
       "integrity": "sha1-d6vf2b8T1xM6bvpER6FpB4PEu0k=",
       "dev": true,
+      "requires": {
+        "loader-utils": "^0.2.7",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.0.1",
+        "rimraf": "^2.4.4",
+        "strip-json-comments": "^1.0.2"
+      },
       "dependencies": {
         "strip-json-comments": {
           "version": "1.0.4",
@@ -11484,7 +16680,10 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -11497,13 +16696,20 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-is": {
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
       "integrity": "sha1-+JzjQVQcZysl7nrjxz3uOyvlAZQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -11516,6 +16722,18 @@
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.4.5.tgz",
       "integrity": "sha1-0SyO3Gu5e+cZnFba3mXgzBLRLos=",
       "dev": true,
+      "requires": {
+        "fs-extra": "^0.30.0",
+        "handlebars": "4.0.5",
+        "highlight.js": "^9.0.0",
+        "lodash": "^4.13.1",
+        "marked": "^0.3.5",
+        "minimatch": "^3.0.0",
+        "progress": "^1.1.8",
+        "shelljs": "^0.7.0",
+        "typedoc-default-themes": "^0.4.0",
+        "typescript": "1.8.10"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -11527,7 +16745,13 @@
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
           "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          }
         },
         "typescript": {
           "version": "1.8.10",
@@ -11561,6 +16785,11 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
@@ -11581,7 +16810,13 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0"
+          }
         }
       }
     },
@@ -11621,18 +16856,33 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
         },
         "set-value": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
         }
       }
     },
@@ -11652,7 +16902,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
     },
     "unpipe": {
       "version": "1.0.0",
@@ -11665,18 +16918,30 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
             }
           }
         },
@@ -11698,7 +16963,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
     },
     "upath": {
       "version": "1.1.0",
@@ -11723,6 +16991,10 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
@@ -11737,12 +17009,21 @@
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
       "integrity": "sha1-zI/qgse5Bud3cBklCGnlaemVwpU=",
       "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "mime": "1.3.x"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
+          }
         },
         "mime": {
           "version": "1.3.6",
@@ -11756,7 +17037,11 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
       "integrity": "sha1-TeydrT3IWF+GL+1GHS4Zu/Yj3zA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
     },
     "urlgrey": {
       "version": "0.4.4",
@@ -11769,6 +17054,9 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
       "integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
       "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      },
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
@@ -11788,7 +17076,11 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
       "integrity": "sha1-IX+UOtVAyyEoZYqyP8lg9qiMmXI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.x",
+        "tmp": "0.0.x"
+      }
     },
     "username-sync": {
       "version": "1.0.1",
@@ -11800,7 +17092,10 @@
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
       "integrity": "sha1-OqASW/5mikZy3liFfTrOJ+y3aQE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -11836,7 +17131,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "vary": {
       "version": "1.1.2",
@@ -11854,19 +17153,32 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "vinyl": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
+        "replace-ext": "0.0.1"
+      }
     },
     "vm-browserify": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
     },
     "void-elements": {
       "version": "2.0.1",
@@ -11878,13 +17190,20 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
       "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
     },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.x"
+      }
     },
     "watch": {
       "version": "0.10.0",
@@ -11897,6 +17216,11 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
       "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
       "dev": true,
+      "requires": {
+        "chokidar": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -11910,13 +17234,36 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
     },
     "webpack": {
       "version": "2.1.0-beta.21",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.1.0-beta.21.tgz",
       "integrity": "sha1-nuqMc88cExLdXDn6OIQ1AbtfuHI=",
       "dev": true,
+      "requires": {
+        "acorn": "^3.2.0",
+        "async": "^1.3.0",
+        "clone": "^1.0.2",
+        "enhanced-resolve": "^2.2.0",
+        "interpret": "^1.0.0",
+        "loader-runner": "^2.1.0",
+        "loader-utils": "^0.2.11",
+        "memory-fs": "~0.3.0",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "source-map": "^0.5.3",
+        "supports-color": "^3.1.0",
+        "tapable": "~0.2.3",
+        "uglify-js": "~2.6.0",
+        "watchpack": "^1.0.0",
+        "webpack-sources": "^0.1.0",
+        "yargs": "^4.7.1"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -11946,13 +17293,22 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
         },
         "uglify-js": {
           "version": "2.6.4",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
           "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
           "dev": true,
+          "requires": {
+            "async": "~0.2.6",
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
           "dependencies": {
             "async": {
               "version": "0.2.10",
@@ -11964,7 +17320,13 @@
               "version": "3.10.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
             }
           }
         },
@@ -11979,12 +17341,33 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "dev": true,
+          "requires": {
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
+          },
           "dependencies": {
             "cliui": {
               "version": "3.2.0",
               "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
               "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+              }
             },
             "window-size": {
               "version": "0.2.0",
@@ -11999,6 +17382,10 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
+          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
@@ -12015,12 +17402,23 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
       "integrity": "sha1-+PwRIM47T8VoDO7LQ9d3lmshEF4=",
       "dev": true,
+      "requires": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.5.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
+      },
       "dependencies": {
         "memory-fs": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
         }
       }
     },
@@ -12029,6 +17427,21 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.0.tgz",
       "integrity": "sha1-tWBbuNsRxTErDbsUqi0/IFvJtKk=",
       "dev": true,
+      "requires": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.15.0",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -12040,7 +17453,12 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
         },
         "lodash.assign": {
           "version": "4.2.0",
@@ -12052,7 +17470,10 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
         },
         "window-size": {
           "version": "0.2.0",
@@ -12064,13 +17485,33 @@
           "version": "4.8.1",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
+          }
         },
         "yargs-parser": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
+          }
         }
       }
     },
@@ -12078,31 +17519,66 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/webpack-md5-hash/-/webpack-md5-hash-0.0.5.tgz",
       "integrity": "sha1-2fGJnq1mRFndi2sMkmrHHPvXvHo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "md5": "^2.0.0"
+      }
     },
     "webpack-merge": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-0.14.1.tgz",
       "integrity": "sha1-1r/m2TYKAk4ef45jg65zXxc3zSM=",
       "dev": true,
+      "requires": {
+        "lodash.find": "^3.2.1",
+        "lodash.isequal": "^4.2.0",
+        "lodash.isplainobject": "^3.2.0",
+        "lodash.merge": "^3.3.2"
+      },
       "dependencies": {
         "lodash.find": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
           "integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._basecallback": "^3.0.0",
+            "lodash._baseeach": "^3.0.0",
+            "lodash._basefind": "^3.0.0",
+            "lodash._basefindindex": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
         },
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
         },
         "lodash.merge": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
           "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._arraycopy": "^3.0.0",
+            "lodash._arrayeach": "^3.0.0",
+            "lodash._createassigner": "^3.0.0",
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.isplainobject": "^3.0.0",
+            "lodash.istypedarray": "^3.0.0",
+            "lodash.keys": "^3.0.0",
+            "lodash.keysin": "^3.0.0",
+            "lodash.toplainobject": "^3.0.0"
+          }
         }
       }
     },
@@ -12111,6 +17587,10 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
       "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
       "dev": true,
+      "requires": {
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.5.3"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
@@ -12124,7 +17604,11 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
+      }
     },
     "websocket-extensions": {
       "version": "0.1.3",
@@ -12147,7 +17631,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "which-module": {
       "version": "1.0.0",
@@ -12159,7 +17646,10 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
     },
     "window-size": {
       "version": "0.1.4",
@@ -12177,13 +17667,20 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz",
       "integrity": "sha1-hsXL6Ua1Xn3J0SsZNsiAGm4tdE0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1"
+      }
     },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -12196,6 +17693,11 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -12209,7 +17711,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
       "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
+      }
     },
     "wtf-8": {
       "version": "1.0.0",
@@ -12221,13 +17727,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
       "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
     },
     "xml2js": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
       "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
       "dev": true,
+      "requires": {
+        "sax": "0.6.x",
+        "xmlbuilder": ">=1.0.0"
+      },
       "dependencies": {
         "sax": {
           "version": "0.6.1",
@@ -12278,30 +17791,61 @@
       "resolved": "https://registry.npmjs.org/yam/-/yam-0.0.18.tgz",
       "integrity": "sha1-5cq3cfD8gMpZmBTLnCacuL/wDiw=",
       "dev": true,
+      "requires": {
+        "findup": "^0.1.5",
+        "fs-extra": "^0.16.3",
+        "lodash.merge": "^3.0.2"
+      },
       "dependencies": {
         "fs-extra": {
           "version": "0.16.5",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
           "integrity": "sha1-GtZh+myGyWCM0bSe/G/Og0k5p1A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^3.0.5",
+            "jsonfile": "^2.0.0",
+            "rimraf": "^2.2.8"
+          }
         },
         "graceful-fs": {
           "version": "3.0.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "natives": "^1.1.0"
+          }
         },
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
         },
         "lodash.merge": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
           "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._arraycopy": "^3.0.0",
+            "lodash._arrayeach": "^3.0.0",
+            "lodash._createassigner": "^3.0.0",
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.isplainobject": "^3.0.0",
+            "lodash.istypedarray": "^3.0.0",
+            "lodash.keys": "^3.0.0",
+            "lodash.keysin": "^3.0.0",
+            "lodash.toplainobject": "^3.0.0"
+          }
         }
       }
     },
@@ -12309,13 +17853,24 @@
       "version": "3.27.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
       "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase": "^1.2.1",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "os-locale": "^1.4.0",
+        "window-size": "^0.1.2",
+        "y18n": "^3.2.0"
+      }
     },
     "yargs-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
+      "requires": {
+        "camelcase": "^3.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -12329,7 +17884,10 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
     },
     "yeast": {
       "version": "0.1.2",


### PR DESCRIPTION
## Description

Node v8.0.0 was giving me all kinds of trouble with `npm install`. This PR updates vtctld2 to use node v8.17, the last 8.x LTS version prior to the [8.x EOL in 2020](https://blog.risingstack.com/update-nodejs-8-end-of-life-no-support/). 

Having a somewhat-improved version of 8.x will make it easier to upgrade a handful of other vtctld2 dependencies. :) 

I also committed changes to package-lock.json that resulted from `npm install` after the version upgrade. 

I manually validated that the vtctld2 UI still works by running everything locally. 

## Related Issue(s)

N/A


## Checklist
- [x] Should this PR be backported? **No,** since this comes in under the wire for RC1 tomorrow. :) 
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

There is no action required in this PR for Vitess operators. The UI [hosted by the vtctld](https://github.com/vitessio/vitess/blob/411a983/go/vt/vtctld/vtctld.go) service uses static files, which I've rebuilt with `make web_build` in this PR. 

Installing node 8.x is only a requirement for those looking to make changes in the web/vtctld2 codebase. 