### PR TITLE
collations: fix coercion between character sets

### DIFF
--- a/go/vt/vtgate/evalengine/convert.go
+++ b/go/vt/vtgate/evalengine/convert.go
@@ -199,11 +199,7 @@ func convertExpr(e sqlparser.Expr, lookup ConverterLookup) (Expr, error) {
 		collation := getCollation(node, lookup)
 		return NewColumn(idx, collation), nil
 	case *sqlparser.ComparisonExpr:
-		expr, err := convertComparisonExpr(node.Operator, node.Left, node.Right, lookup)
-		if err != nil {
-			return nil, convertNotSupported(e)
-		}
-		return expr, err
+		return convertComparisonExpr(node.Operator, node.Left, node.Right, lookup)
 	case sqlparser.Argument:
 		collation := getCollation(e, lookup)
 		return NewBindVar(string(node), collation), nil

--- a/go/vt/vtgate/evalengine/integration/comparison_test.go
+++ b/go/vt/vtgate/evalengine/integration/comparison_test.go
@@ -62,6 +62,32 @@ func compareRemoteQuery(t *testing.T, conn *mysql.Conn, query string) {
 }
 
 func TestAllComparisons(t *testing.T) {
+	var elems = []string{"NULL", "-1", "0", "1",
+		`'foo'`, `'bar'`, `'FOO'`, `'BAR'`,
+		`'foo' collate utf8mb4_as_cs`, // invalid collation for testing error messages
+		`'foo' collate utf8mb4_cs_as`,
+		`'FOO' collate utf8mb4_cs_as`,
+		`_latin1 'foo'`,
+		`_latin1 'FOO'`,
+	}
+	var operators = []string{"=", "!=", "<=>", "<", "<=", ">", ">="}
+
+	var conn = mysqlconn(t)
+	defer conn.Close()
+
+	for _, op := range operators {
+		t.Run(op, func(t *testing.T) {
+			for i := 0; i < len(elems); i++ {
+				for j := 0; j < len(elems); j++ {
+					query := fmt.Sprintf("SELECT %s %s %s", elems[i], op, elems[j])
+					compareRemoteQuery(t, conn, query)
+				}
+			}
+		})
+	}
+}
+
+func TestAllTupleComparisons(t *testing.T) {
 	var elems = []string{"NULL", "-1", "0", "1"}
 	var operators = []string{"=", "!=", "<=>", "<", "<=", ">", ">="}
 

--- a/go/vt/vtgate/evalengine/integration/fuzz_test.go
+++ b/go/vt/vtgate/evalengine/integration/fuzz_test.go
@@ -79,7 +79,7 @@ func (g *gencase) expr() string {
 var fuzzMaxTime = flag.Duration("fuzz-duration", 30*time.Second, "maximum time to fuzz for")
 var fuzzMaxFailures = flag.Int("fuzz-total", 0, "maximum number of failures to fuzz for")
 var fuzzSeed = flag.Int64("fuzz-seed", time.Now().Unix(), "RNG seed when generating fuzz expressions")
-var extractError = regexp.MustCompile(`(.*?) \(errno (\d+)\) \(sqlstate (\d+)\) during query: (.*?)`)
+var extractError = regexp.MustCompile(`(.*?) \(errno (\d+)\) \(sqlstate (\w+)\) during query: (.*?)`)
 
 var knownErrors = []*regexp.Regexp{
 	regexp.MustCompile(`value is out of range in '(.*?)'`),
@@ -89,7 +89,7 @@ var knownErrors = []*regexp.Regexp{
 func errorsMatch(remote, local error) bool {
 	rem := extractError.FindStringSubmatch(remote.Error())
 	if rem == nil {
-		panic("could not extract error message")
+		panic(fmt.Sprintf("could not extract error message: %q", remote.Error()))
 	}
 
 	remoteMessage := rem[1]

--- a/go/vt/vtgate/evalengine/mysql_test.go
+++ b/go/vt/vtgate/evalengine/mysql_test.go
@@ -118,6 +118,6 @@ func TestMySQLGolden(t *testing.T) {
 
 func TestDebug1(t *testing.T) {
 	// Debug
-	eval, err := testSingle(t, `SELECT LEAST(0.0,'foobar')`)
+	eval, err := testSingle(t, `SELECT 'foo' = _latin1 'foo'`)
 	t.Logf("eval=%s err=%v", eval.Value(), err) // want value=""
 }

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -505,11 +505,11 @@ Gen4 plan same as above
 # TODO this should be planned without using OA and MS
 "select u.id from user u join user_extra ue on ue.id = u.id group by u.id having count(u.name) = 3"
 "unsupported: cross-shard query with aggregates"
-Gen4 error: expr cannot be converted, not supported: count(u.`name`) = 3
+Gen4 error: expr cannot be converted, not supported: count(u.`name`)
 
 "select (select 1 from user u having count(ue.col) > 10) from user_extra ue"
 "symbol ue.col not found in subquery"
-Gen4 error: expr cannot be converted, not supported: count(ue.col) > 10
+Gen4 error: expr cannot be converted, not supported: count(ue.col)
 
 # aggregation filtering by having on a route with no group by
 "select 1 from user having count(id) = 10"
@@ -528,7 +528,7 @@ Gen4 error: expr cannot be converted, not supported: count(ue.col) > 10
     "Table": "`user`"
   }
 }
-Gen4 error: expr cannot be converted, not supported: count(id) = 10
+Gen4 error: expr cannot be converted, not supported: count(id)
 
 # aggregation filtering by having on a route with no group by with non-unique vindex filter
 "select 1 from user having count(id) = 10 and name = 'a'"
@@ -551,7 +551,7 @@ Gen4 error: expr cannot be converted, not supported: count(id) = 10
     "Vindex": "name_user_map"
   }
 }
-Gen4 error: expr cannot be converted, not supported: count(id) = 10
+Gen4 error: expr cannot be converted, not supported: count(id)
 
 # subquery of information_schema with itself and star expression in outer select
 "select a.*, u.id from information_schema.a a, user u where a.id in (select * from information_schema.b)"
@@ -631,7 +631,7 @@ Gen4 plan same as above
 # Equal filter with hexadecimal value
 "select count(*) a from user having a = 0x01"
 "unsupported: filtering on results of aggregates"
-Gen4 error: expr cannot be converted, not supported: a = 0x01
+Gen4 error: expr cannot be converted, not supported: 0x01
 
 # scatter aggregate with complex select list (can't build order by)
 "select distinct a+1 from user"


### PR DESCRIPTION
## Description

No more new features for the `evalengine` but let's get some more fixes in: this fixes a crash when comparing strings that have different explicit vs implicit charsets.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->