### PR TITLE
Store innodbRowsRead in a Counter instead of a Gauge

### DIFF
--- a/go/stats/counter.go
+++ b/go/stats/counter.go
@@ -52,6 +52,11 @@ func (v *Counter) Add(delta int64) {
 	v.i.Add(delta)
 }
 
+// Set overwrites the current value.
+func (v *Counter) Set(value int64) {
+	v.i.Set(value)
+}
+
 // Reset resets the counter value to 0.
 func (v *Counter) Reset() {
 	v.i.Set(int64(0))

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -81,7 +81,7 @@ type Engine struct {
 
 	tableFileSizeGauge      *stats.GaugesWithSingleLabel
 	tableAllocatedSizeGauge *stats.GaugesWithSingleLabel
-	innoDbReadRowsGauge     *stats.Gauge
+	innoDbReadRowsCounter   *stats.Counter
 }
 
 // NewEngine creates a new Engine.
@@ -101,7 +101,7 @@ func NewEngine(env tabletenv.Env) *Engine {
 	_ = env.Exporter().NewGaugeDurationFunc("SchemaReloadTime", "vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time.", se.ticks.Interval)
 	se.tableFileSizeGauge = env.Exporter().NewGaugesWithSingleLabel("TableFileSize", "tracks table file size", "Table")
 	se.tableAllocatedSizeGauge = env.Exporter().NewGaugesWithSingleLabel("TableAllocatedSize", "tracks table allocated size", "Table")
-	se.innoDbReadRowsGauge = env.Exporter().NewGauge("InnodbRowsRead", "number of rows read by mysql")
+	se.innoDbReadRowsCounter = env.Exporter().NewCounter("InnodbRowsRead", "number of rows read by mysql")
 
 	env.Exporter().HandleFunc("/debug/schema", se.handleDebugSchema)
 	env.Exporter().HandleFunc("/schemaz", func(w http.ResponseWriter, r *http.Request) {
@@ -418,7 +418,7 @@ func (se *Engine) updateInnoDBRowsRead(ctx context.Context, conn *connpool.DBCon
 			return err
 		}
 
-		se.innoDbReadRowsGauge.Set(value)
+		se.innoDbReadRowsCounter.Set(value)
 	} else {
 		log.Warningf("got strange results from 'show status': %v", readRowsData.Rows)
 	}

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -92,7 +92,7 @@ func TestOpenAndReload(t *testing.T) {
 		"int64"),
 		"1427325877",
 	))
-	assert.EqualValues(t, firstReadRowsValue, se.innoDbReadRowsGauge.Get())
+	assert.EqualValues(t, firstReadRowsValue, se.innoDbReadRowsCounter.Get())
 
 	// Modify test_table_03
 	// Add test_table_04
@@ -167,7 +167,7 @@ func TestOpenAndReload(t *testing.T) {
 	err := se.Reload(context.Background())
 	require.NoError(t, err)
 
-	assert.EqualValues(t, secondReadRowsValue, se.innoDbReadRowsGauge.Get())
+	assert.EqualValues(t, secondReadRowsValue, se.innoDbReadRowsCounter.Get())
 
 	want["test_table_03"] = &Table{
 		Name: sqlparser.NewTableIdent("test_table_03"),


### PR DESCRIPTION
<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
It makes more sense to store innodbRowsRead in a counter instead of a gauge since Mysql exporter (prometheus) also does so https://github.com/prometheus/mysqld_exporter/blob/c9d7a01501d047ddc3d0c03c33c262e12d28dd59/collector/global_status.go#L163-L166. This PR accomplishes that change.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? No
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->