### PR TITLE
[vtctld] Add 'enable_vtctld_ui' flag to vtctld to explicitly enable (or disable) the vtctld2 UI

### DIFF
--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -41,6 +41,7 @@ import (
 
 var (
 	enableRealtimeStats = flag.Bool("enable_realtime_stats", false, "Required for the Realtime Stats view. If set, vtctld will maintain a streaming RPC to each tablet (in all cells) to gather the realtime health stats.")
+	enableUI            = flag.Bool("enable_vtctld_ui", true, "If true, the vtctld web interface will be enabled. Default is true.")
 	durabilityPolicy    = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
 
 	_ = flag.String("web_dir", "", "NOT USED, here for backward compatibility")
@@ -171,6 +172,11 @@ func InitVtctld(ts *topo.Server) error {
 }
 
 func webAppHandler(w http.ResponseWriter, r *http.Request) {
+	if !*enableUI {
+		http.NotFound(w, r)
+		return
+	}
+
 	// Strip the prefix.
 	parts := strings.SplitN(r.URL.Path, "/", 3)
 	if len(parts) != 3 {

--- a/go/vt/vtctld/vtctld_test.go
+++ b/go/vt/vtctld/vtctld_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtctld
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebApp(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, appPrefix, nil)
+	w := httptest.NewRecorder()
+
+	webAppHandler(w, req)
+	res := w.Result()
+
+	assert.Equal(t, res.StatusCode, http.StatusOK)
+
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "<!doctype html>")
+}

--- a/go/vt/vtctld/vtctld_test.go
+++ b/go/vt/vtctld/vtctld_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtctld
 
 import (
+	"flag"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -32,11 +33,30 @@ func TestWebApp(t *testing.T) {
 	webAppHandler(w, req)
 	res := w.Result()
 
-	assert.Equal(t, res.StatusCode, http.StatusOK)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
 
 	defer res.Body.Close()
 
 	data, err := ioutil.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.Contains(t, string(data), "<!doctype html>")
+}
+
+func TestWebAppDisabled(t *testing.T) {
+	flag.Set("enable_vtctld_ui", "false")
+	defer flag.Set("enable_vtctld_ui", "true")
+
+	req := httptest.NewRequest(http.MethodGet, appPrefix, nil)
+	w := httptest.NewRecorder()
+
+	webAppHandler(w, req)
+	res := w.Result()
+
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "404 page not found\n", string(data))
 }


### PR DESCRIPTION
## Description

This PR closes #9194 by adding a flag to enable/disable the vtctld2 UI. This default value is true, which means that the vtctld2 UI will continue to be enabled by default. In other words, **nothing will change unless operators explicitly opt out**  of the vtctld2 UI. 

With `-enable_vtctld_ui=false`, any requests to any of the following vtctld URLs will 404:
- /app/
- /app/**/*
- Any other unrecognized path, as those all get redirected to /app/ by [this handler](https://github.com/vitessio/vitess/blob/66109e7f240b3fe45e4da2dc0c9db488b14682f9/go/vt/vtctld/vtctld.go#L139-L142)

This flag does not affect the HTTP API that the vtctld serves on /api/ (used by the web app).

### On nomenclature.
I went back and forth for far too long on whether the flag should be `enable_` (and default to true) or `disable_` (and default to false). 

Ultimately, I went with `enable_` given the next step will be to _disable_ the UI by default, meaning this flag will default to `false` and Vitess operators will have to explicitly opt-in to enable the UI. (We can discuss the timing and communication around this next step in the forthcoming RFC for removing the vtctld2 codebase.) 

That said, I'm happy to switch this up if another approach would make more sense. :) 

### What it looks like

An easy way to test this out is to update [examples/local/scripts/vtctld-up.sh](https://github.com/vitessio/vitess/blob/988a839/examples/local/scripts/vtctld-up.sh) with the flag as follows:

```bash
vtctld \
 $TOPOLOGY_FLAGS \
 -enable_vtctld_ui=false \
# ... other vtctld flags go here
```

(Do note there is no space before the `false` value as described in [the flag package](https://pkg.go.dev/flag).)

Then, all requests to http://localhost:15000/app/ (and any subroutes) will 404. 

<img width="2672" alt="Screen Shot 2022-02-02 at 12 18 36 PM" src="https://user-images.githubusercontent.com/855595/152205370-08628eab-363a-47e8-ae28-4b2141257052.png">

One can also verify that /api/ requests still work:

```bash
$ curl http://localhost:15000/api/keyspaces/
[
  "commerce"
]
```

## Related Issue(s)

Closes #9194

## Checklist
- [x] Should this PR be backported? **No,** I think it's fine for this to wait for 14.0 unless folks feel strongly that it should be backported. 
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

Noted above. 