### PR TITLE
demo.go: fix call to ToBytes

### DIFF
--- a/examples/demo/demo.go
+++ b/examples/demo/demo.go
@@ -203,7 +203,12 @@ func resultToMap(title string, qr *sqltypes.Result) map[string]interface{} {
 		srow := make([]string, 0, len(row))
 		for _, value := range row {
 			if value.Type() == sqltypes.VarBinary {
-				srow = append(srow, hex.EncodeToString(value.ToBytes()))
+				bytes, err := value.ToBytes()
+				if err != nil {
+					log.Errorf("Error converting value to bytes: %v", err)
+					return nil
+				}
+				srow = append(srow, hex.EncodeToString(bytes))
 			} else {
 				srow = append(srow, value.ToString())
 			}


### PR DESCRIPTION
The return value was changed from `[]byte` to `([]byte, error)` a little
while ago, making it impossible to run the demo.

This handles the error and returns nil after logging the error in case
the conversion fails.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes: https://github.com/vitessio/vitess/issues/9763#issuecomment-1048419739


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->