### PR TITLE
Add HexVal and HexNum type support to evalengine.Expr

### DIFF
--- a/go/test/endtoend/vtgate/vindex_bindvars/main_test.go
+++ b/go/test/endtoend/vtgate/vindex_bindvars/main_test.go
@@ -44,7 +44,6 @@ var (
     PRIMARY KEY (id)
 ) ENGINE=Innodb;
 
-
 CREATE TABLE lookup1 (
     field BIGINT NOT NULL,
     keyspace_id binary(8),
@@ -56,6 +55,12 @@ CREATE TABLE lookup2 (
     keyspace_id binary(8),
     UNIQUE KEY (field2)
 ) ENGINE=Innodb;
+
+CREATE TABLE thex (
+    id VARBINARY(64) NOT NULL,
+    field BIGINT NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
 `
 
 	VSchema = `
@@ -64,6 +69,18 @@ CREATE TABLE lookup2 (
     "vindexes": {
         "hash": {
             "type": "hash"
+        },
+        "binary_vdx": {
+            "type": "binary"
+        },
+        "binary_md5_vdx": {
+            "type": "binary_md5"
+        },
+        "xxhash_vdx": {
+            "type": "xxhash"
+        },
+        "numeric_vdx": {
+            "type": "numeric"
         },
         "lookup1": {
             "type": "consistent_lookup",
@@ -118,6 +135,14 @@ CREATE TABLE lookup2 (
                     "name": "hash"
                 }
             ]
+        },
+        "thex": {
+            "column_vindexes": [
+                {
+                    "column": "id",
+                    "name": "binary_vdx"
+                }
+            ]
         }
     }
 }`
@@ -160,6 +185,28 @@ func TestMain(m *testing.M) {
 		return m.Run()
 	}()
 	os.Exit(exitCode)
+}
+
+func TestVindexHexTypes(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	exec(t, conn, "INSERT INTO thex (id, field) VALUES "+
+		"(0x01,1), "+
+		"(x'a5',2), "+
+		"(0x48656c6c6f20476f7068657221,3), "+
+		"(x'c26caa1a5eb94096d29a1bec',4)")
+	result := exec(t, conn, "select id, field from thex order by id")
+
+	expected :=
+		"[[HEXNUM(0x01) INT64(1)] " +
+			"[HEXVAL(x'a5') INT64(2)] " +
+			"[HEXNUM(0x48656c6c6f20476f7068657221) INT64(3)] " +
+			"[HEXVAL(x'c3e486fc26caa1a5eb94096d29a1bec') INT64(4)]]"
+	assert.Equal(t, expected, fmt.Sprintf("%v", result.Rows))
 }
 
 func TestVindexBindVarOverlap(t *testing.T) {


### PR DESCRIPTION
## Description
In this commit https://github.com/vitessio/vitess/pull/9351/commits/0d1a5e5e341e50d9b9fbe6b3cddf773c1ad992e2, which was part of https://github.com/vitessio/vitess/pull/9351, we broke `HexVal` and `HexNum` type support with `Vindexes`.

More specifically, `HexVal` and `HexNum` type support in vindex functions was lost in the transition from `sqltypes.PlanValue` to `evalengine.Expr`.

This work aims to add support for the `HexVal` and `HexNum` types in `evalengine.Expr`.

## Related Issue(s)
- https://github.com/vitessio/vitess/pull/9118
- https://github.com/vitessio/vitess/pull/9277

## Checklist
- [x] Should this PR be backported? YES, but ONLY to release-13.0
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required