### PR TITLE
[VTAdmin] Simplify JSON Discovery

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -245,7 +245,7 @@ func (api *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				c, err := cluster.Config{
 					ID:            clusterID,
 					Name:          clusterID,
-					DiscoveryImpl: "json",
+					DiscoveryImpl: "dynamic",
 					DiscoveryFlagsByImpl: cluster.FlagsByImpl{
 						"json": map[string]string{
 							"discovery": string(decoded),

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -247,7 +247,7 @@ func (api *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					Name:          clusterID,
 					DiscoveryImpl: "dynamic",
 					DiscoveryFlagsByImpl: cluster.FlagsByImpl{
-						"json": map[string]string{
+						"dynamic": map[string]string{
 							"discovery": string(decoded),
 						},
 					},

--- a/go/vt/vtadmin/cluster/discovery/discovery.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery.go
@@ -118,5 +118,5 @@ func New(impl string, cluster *vtadminpb.Cluster, args []string) (Discovery, err
 func init() { // nolint:gochecknoinits
 	Register("consul", NewConsul)
 	Register("staticfile", NewStaticFile)
-	Register("json", NewJSON)
+	Register("dynamic", NewDynamic)
 }

--- a/go/vt/vtadmin/cluster/discovery/discovery_dynamic.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_dynamic.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2022 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,17 +18,16 @@ package discovery
 
 import (
 	"errors"
-	"os"
 
 	"github.com/spf13/pflag"
 
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
 
-// StaticFileDiscovery implements the Discovery interface for "discovering"
-// Vitess components hardcoded in a static JSON file. It inherits from JSONDiscovery.
+// DynamicDiscovery implements the Discovery interface for "discovering"
+// Vitess components hardcoded in a json string. It inherits from JSONDiscovery.
 //
-// As an example, here's a minimal JSON file for a single Vitess cluster running locally
+// As an example, here's a minimal Dynamic object for a single Vitess cluster running locally
 // (such as the one described in https://vitess.io/docs/get-started/local-docker):
 //
 // 		{
@@ -42,33 +41,32 @@ import (
 // 		}
 //
 // For more examples of various static file configurations, see the unit tests.
-type StaticFileDiscovery struct {
+// Discovery Dynamic is very similar to static file discovery, but removes the need for a static file in memory.
+// This allows for dynamic cluster discovery after initial vtadmin deploy without a topo.
+
+type DynamicDiscovery struct {
 	JSONDiscovery
 }
 
-// NewStaticFile returns a StaticFileDiscovery for the given cluster.
-func NewStaticFile(cluster *vtadminpb.Cluster, flags *pflag.FlagSet, args []string) (Discovery, error) {
-	disco := &StaticFileDiscovery{
+// NewDynamic returns a DynamicDiscovery for the given cluster.
+func NewDynamic(cluster *vtadminpb.Cluster, flags *pflag.FlagSet, args []string) (Discovery, error) {
+	disco := &DynamicDiscovery{
 		JSONDiscovery: JSONDiscovery{
 			cluster: cluster,
 		},
 	}
 
-	filePath := flags.String("path", "", "path to the service discovery JSON config file")
+	json := flags.String("discovery", "", "the json config object")
 	if err := flags.Parse(args); err != nil {
 		return nil, err
 	}
 
-	if filePath == nil || *filePath == "" {
-		return nil, errors.New("must specify path to the service discovery JSON config file")
+	if json == nil || *json == "" {
+		return nil, errors.New("must pass service discovery json config object")
 	}
 
-	b, err := os.ReadFile(*filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := disco.parseConfig(b); err != nil {
+	bytes := []byte(*json)
+	if err := disco.parseConfig(bytes); err != nil {
 		return nil, err
 	}
 

--- a/go/vt/vtadmin/cluster/discovery/discovery_dynamic_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_dynamic_test.go
@@ -23,11 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/vt/proto/vtadmin"
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
 
-func TestJSONDiscoverVTGate(t *testing.T) {
+func TestDynamicDiscoverVTGate(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -54,7 +53,7 @@ func TestJSONDiscoverVTGate(t *testing.T) {
 					}]
 				}
 			`),
-			expected: &vtadmin.VTGate{
+			expected: &vtadminpb.VTGate{
 				Hostname: "127.0.0.1:12345",
 			},
 		},
@@ -98,7 +97,7 @@ func TestJSONDiscoverVTGate(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			disco := &JSONDiscovery{}
+			disco := &DynamicDiscovery{}
 			err := disco.parseConfig(tt.contents)
 			require.NoError(t, err)
 
@@ -114,7 +113,7 @@ func TestJSONDiscoverVTGate(t *testing.T) {
 	}
 }
 
-func TestJSONDiscoverVTGates(t *testing.T) {
+func TestDynamicDiscoverVTGates(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -243,7 +242,7 @@ func TestJSONDiscoverVTGates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			disco := &JSONDiscovery{}
+			disco := &DynamicDiscovery{}
 
 			err := disco.parseConfig(tt.contents)
 			if tt.shouldErrConfig {
@@ -264,7 +263,7 @@ func TestJSONDiscoverVTGates(t *testing.T) {
 	}
 }
 
-func TestJSONDiscoverVtctld(t *testing.T) {
+func TestDynamicDiscoverVtctld(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -291,7 +290,7 @@ func TestJSONDiscoverVtctld(t *testing.T) {
 					}]
 				}
 			`),
-			expected: &vtadmin.Vtctld{
+			expected: &vtadminpb.Vtctld{
 				Hostname: "127.0.0.1:12345",
 			},
 		},
@@ -336,7 +335,7 @@ func TestJSONDiscoverVtctld(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			disco := &JSONDiscovery{}
+			disco := &DynamicDiscovery{}
 			err := disco.parseConfig(tt.contents)
 			require.NoError(t, err)
 
@@ -352,7 +351,7 @@ func TestJSONDiscoverVtctld(t *testing.T) {
 	}
 }
 
-func TestJSONDiscoverVtctlds(t *testing.T) {
+func TestDynamicDiscoverVtctlds(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -481,7 +480,7 @@ func TestJSONDiscoverVtctlds(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			disco := &JSONDiscovery{}
+			disco := &DynamicDiscovery{}
 
 			err := disco.parseConfig(tt.contents)
 			if tt.shouldErrConfig {

--- a/go/vt/vtadmin/cluster/discovery/discovery_json.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_json.go
@@ -17,15 +17,10 @@ limitations under the License.
 package discovery
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"math/rand"
 
 	"github.com/spf13/pflag"
 
-	"vitess.io/vitess/go/trace"
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
 
@@ -50,41 +45,15 @@ import (
 // This allows for dynamic cluster discovery after initial vtadmin deploy without a topo.
 
 type JSONDiscovery struct {
-	cluster *vtadminpb.Cluster
-	config  *JSONClusterConfig
-	gates   struct {
-		byName map[string]*vtadminpb.VTGate
-		byTag  map[string][]*vtadminpb.VTGate
-	}
-	vtctlds struct {
-		byName map[string]*vtadminpb.Vtctld
-		byTag  map[string][]*vtadminpb.Vtctld
-	}
-}
-
-// JSONClusterConfig configures Vitess components for a single cluster.
-type JSONClusterConfig struct {
-	VTGates []*JSONVTGateConfig `json:"vtgates,omitempty"`
-	Vtctlds []*JSONVtctldConfig `json:"vtctlds,omitempty"`
-}
-
-// JSONVTGateConfig contains host and tag information for a single VTGate in a cluster.
-type JSONVTGateConfig struct {
-	Host *vtadminpb.VTGate `json:"host"`
-	Tags []string          `json:"tags"`
-}
-
-// JSONVtctldConfig contains a host and tag information for a single
-// Vtctld in a cluster.
-type JSONVtctldConfig struct {
-	Host *vtadminpb.Vtctld `json:"host"`
-	Tags []string          `json:"tags"`
+	StaticFileDiscovery
 }
 
 // NewJSON returns a JSONDiscovery for the given cluster.
 func NewJSON(cluster *vtadminpb.Cluster, flags *pflag.FlagSet, args []string) (Discovery, error) {
 	disco := &JSONDiscovery{
-		cluster: cluster,
+		StaticFileDiscovery: StaticFileDiscovery{
+			cluster: cluster,
+		},
 	}
 
 	json := flags.String("discovery", "", "the json config object")
@@ -102,200 +71,4 @@ func NewJSON(cluster *vtadminpb.Cluster, flags *pflag.FlagSet, args []string) (D
 	}
 
 	return disco, nil
-}
-
-func (d *JSONDiscovery) parseConfig(bytes []byte) error {
-	if err := json.Unmarshal(bytes, &d.config); err != nil {
-		return fmt.Errorf("failed to unmarshal staticfile config from json: %w", err)
-	}
-
-	d.gates.byName = make(map[string]*vtadminpb.VTGate, len(d.config.VTGates))
-	d.gates.byTag = make(map[string][]*vtadminpb.VTGate)
-
-	// Index the gates by name and by tag for easier lookups
-	for _, gate := range d.config.VTGates {
-		d.gates.byName[gate.Host.Hostname] = gate.Host
-
-		for _, tag := range gate.Tags {
-			d.gates.byTag[tag] = append(d.gates.byTag[tag], gate.Host)
-		}
-	}
-
-	d.vtctlds.byName = make(map[string]*vtadminpb.Vtctld, len(d.config.Vtctlds))
-	d.vtctlds.byTag = make(map[string][]*vtadminpb.Vtctld)
-
-	// Index the vtctlds by name and by tag for easier lookups
-	for _, vtctld := range d.config.Vtctlds {
-		d.vtctlds.byName[vtctld.Host.Hostname] = vtctld.Host
-
-		for _, tag := range vtctld.Tags {
-			d.vtctlds.byTag[tag] = append(d.vtctlds.byTag[tag], vtctld.Host)
-		}
-	}
-
-	return nil
-}
-
-// DiscoverVTGate is part of the Discovery interface.
-func (d *JSONDiscovery) DiscoverVTGate(ctx context.Context, tags []string) (*vtadminpb.VTGate, error) {
-	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVTGate")
-	defer span.Finish()
-
-	return d.discoverVTGate(ctx, tags)
-}
-
-func (d *JSONDiscovery) discoverVTGate(ctx context.Context, tags []string) (*vtadminpb.VTGate, error) {
-	gates, err := d.discoverVTGates(ctx, tags)
-	if err != nil {
-		return nil, err
-	}
-
-	count := len(gates)
-	if count == 0 {
-		return nil, ErrNoVTGates
-	}
-
-	gate := gates[rand.Intn(len(gates))]
-	return gate, nil
-}
-
-// DiscoverVTGateAddr is part of the Discovery interface.
-func (d *JSONDiscovery) DiscoverVTGateAddr(ctx context.Context, tags []string) (string, error) {
-	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVTGateAddr")
-	defer span.Finish()
-
-	gate, err := d.DiscoverVTGate(ctx, tags)
-	if err != nil {
-		return "", err
-	}
-
-	return gate.Hostname, nil
-}
-
-// DiscoverVTGates is part of the Discovery interface.
-func (d *JSONDiscovery) DiscoverVTGates(ctx context.Context, tags []string) ([]*vtadminpb.VTGate, error) {
-	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVTGates")
-	defer span.Finish()
-
-	return d.discoverVTGates(ctx, tags)
-}
-
-func (d *JSONDiscovery) discoverVTGates(ctx context.Context, tags []string) ([]*vtadminpb.VTGate, error) {
-	if len(tags) == 0 {
-		results := []*vtadminpb.VTGate{}
-		for _, g := range d.gates.byName {
-			results = append(results, g)
-		}
-
-		return results, nil
-	}
-
-	set := d.gates.byName
-
-	for _, tag := range tags {
-		intermediate := map[string]*vtadminpb.VTGate{}
-
-		gates, ok := d.gates.byTag[tag]
-		if !ok {
-			return []*vtadminpb.VTGate{}, nil
-		}
-
-		for _, g := range gates {
-			if _, ok := set[g.Hostname]; ok {
-				intermediate[g.Hostname] = g
-			}
-		}
-
-		set = intermediate
-	}
-
-	results := make([]*vtadminpb.VTGate, 0, len(set))
-
-	for _, gate := range set {
-		results = append(results, gate)
-	}
-
-	return results, nil
-}
-
-// DiscoverVtctld is part of the Discovery interface.
-func (d *JSONDiscovery) DiscoverVtctld(ctx context.Context, tags []string) (*vtadminpb.Vtctld, error) {
-	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVtctld")
-	defer span.Finish()
-
-	return d.discoverVtctld(ctx, tags)
-}
-
-func (d *JSONDiscovery) discoverVtctld(ctx context.Context, tags []string) (*vtadminpb.Vtctld, error) {
-	vtctlds, err := d.discoverVtctlds(ctx, tags)
-	if err != nil {
-		return nil, err
-	}
-
-	count := len(vtctlds)
-	if count == 0 {
-		return nil, ErrNoVtctlds
-	}
-
-	vtctld := vtctlds[rand.Intn(len(vtctlds))]
-	return vtctld, nil
-}
-
-// DiscoverVtctldAddr is part of the Discovery interface.
-func (d *JSONDiscovery) DiscoverVtctldAddr(ctx context.Context, tags []string) (string, error) {
-	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVtctldAddr")
-	defer span.Finish()
-
-	vtctld, err := d.discoverVtctld(ctx, tags)
-	if err != nil {
-		return "", err
-	}
-
-	return vtctld.Hostname, nil
-}
-
-// DiscoverVtctlds is part of the Discovery interface.
-func (d *JSONDiscovery) DiscoverVtctlds(ctx context.Context, tags []string) ([]*vtadminpb.Vtctld, error) {
-	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVtctlds")
-	defer span.Finish()
-
-	return d.discoverVtctlds(ctx, tags)
-}
-
-func (d *JSONDiscovery) discoverVtctlds(ctx context.Context, tags []string) ([]*vtadminpb.Vtctld, error) {
-	if len(tags) == 0 {
-		results := []*vtadminpb.Vtctld{}
-		for _, v := range d.vtctlds.byName {
-			results = append(results, v)
-		}
-
-		return results, nil
-	}
-
-	set := d.vtctlds.byName
-
-	for _, tag := range tags {
-		intermediate := map[string]*vtadminpb.Vtctld{}
-
-		vtctlds, ok := d.vtctlds.byTag[tag]
-		if !ok {
-			return []*vtadminpb.Vtctld{}, nil
-		}
-
-		for _, v := range vtctlds {
-			if _, ok := set[v.Hostname]; ok {
-				intermediate[v.Hostname] = v
-			}
-		}
-
-		set = intermediate
-	}
-
-	results := make([]*vtadminpb.Vtctld, 0, len(set))
-
-	for _, vtctld := range set {
-		results = append(results, vtctld)
-	}
-
-	return results, nil
 }

--- a/go/vt/vtadmin/cluster/discovery/discovery_json.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_json.go
@@ -17,17 +17,22 @@ limitations under the License.
 package discovery
 
 import (
-	"errors"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
 
-	"github.com/spf13/pflag"
-
+	"vitess.io/vitess/go/trace"
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
 
 // JSONDiscovery implements the Discovery interface for "discovering"
-// Vitess components hardcoded in a JSON string.
+// Vitess components hardcoded in a json object.
 //
-// As an example, here's a minimal JSON object for a single Vitess cluster running locally
+// StaticFileDiscovery and DynamicDiscovery inherit from JSONDiscovery because
+// they both read the same JSON object. They only differ in where the JSON object is stored.
+//
+// As an example, here's a minimal JSON file for a single Vitess cluster running locally
 // (such as the one described in https://vitess.io/docs/get-started/local-docker):
 //
 // 		{
@@ -41,34 +46,230 @@ import (
 // 		}
 //
 // For more examples of various static file configurations, see the unit tests.
-// Discovery JSON is very similar to static file discovery, but removes the need for a static file in memory.
-// This allows for dynamic cluster discovery after initial vtadmin deploy without a topo.
-
 type JSONDiscovery struct {
-	StaticFileDiscovery
+	cluster *vtadminpb.Cluster
+	config  *JSONClusterConfig
+	gates   struct {
+		byName map[string]*vtadminpb.VTGate
+		byTag  map[string][]*vtadminpb.VTGate
+	}
+	vtctlds struct {
+		byName map[string]*vtadminpb.Vtctld
+		byTag  map[string][]*vtadminpb.Vtctld
+	}
 }
 
-// NewJSON returns a JSONDiscovery for the given cluster.
-func NewJSON(cluster *vtadminpb.Cluster, flags *pflag.FlagSet, args []string) (Discovery, error) {
-	disco := &JSONDiscovery{
-		StaticFileDiscovery: StaticFileDiscovery{
-			cluster: cluster,
-		},
+// JSONClusterConfig configures Vitess components for a single cluster.
+type JSONClusterConfig struct {
+	VTGates []*JSONVTGateConfig `json:"vtgates,omitempty"`
+	Vtctlds []*JSONVtctldConfig `json:"vtctlds,omitempty"`
+}
+
+// JSONVTGateConfig contains host and tag information for a single VTGate in a cluster.
+type JSONVTGateConfig struct {
+	Host *vtadminpb.VTGate `json:"host"`
+	Tags []string          `json:"tags"`
+}
+
+// JSONVtctldConfig contains a host and tag information for a single
+// Vtctld in a cluster.
+type JSONVtctldConfig struct {
+	Host *vtadminpb.Vtctld `json:"host"`
+	Tags []string          `json:"tags"`
+}
+
+func (d *JSONDiscovery) parseConfig(bytes []byte) error {
+	if err := json.Unmarshal(bytes, &d.config); err != nil {
+		return fmt.Errorf("failed to unmarshal staticfile config from json: %w", err)
 	}
 
-	json := flags.String("discovery", "", "the json config object")
-	if err := flags.Parse(args); err != nil {
+	d.gates.byName = make(map[string]*vtadminpb.VTGate, len(d.config.VTGates))
+	d.gates.byTag = make(map[string][]*vtadminpb.VTGate)
+
+	// Index the gates by name and by tag for easier lookups
+	for _, gate := range d.config.VTGates {
+		d.gates.byName[gate.Host.Hostname] = gate.Host
+
+		for _, tag := range gate.Tags {
+			d.gates.byTag[tag] = append(d.gates.byTag[tag], gate.Host)
+		}
+	}
+
+	d.vtctlds.byName = make(map[string]*vtadminpb.Vtctld, len(d.config.Vtctlds))
+	d.vtctlds.byTag = make(map[string][]*vtadminpb.Vtctld)
+
+	// Index the vtctlds by name and by tag for easier lookups
+	for _, vtctld := range d.config.Vtctlds {
+		d.vtctlds.byName[vtctld.Host.Hostname] = vtctld.Host
+
+		for _, tag := range vtctld.Tags {
+			d.vtctlds.byTag[tag] = append(d.vtctlds.byTag[tag], vtctld.Host)
+		}
+	}
+
+	return nil
+}
+
+// DiscoverVTGate is part of the Discovery interface.
+func (d *JSONDiscovery) DiscoverVTGate(ctx context.Context, tags []string) (*vtadminpb.VTGate, error) {
+	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVTGate")
+	defer span.Finish()
+
+	return d.discoverVTGate(ctx, tags)
+}
+
+func (d *JSONDiscovery) discoverVTGate(ctx context.Context, tags []string) (*vtadminpb.VTGate, error) {
+	gates, err := d.discoverVTGates(ctx, tags)
+	if err != nil {
 		return nil, err
 	}
 
-	if json == nil || *json == "" {
-		return nil, errors.New("must pass service discovery JSON config object")
+	count := len(gates)
+	if count == 0 {
+		return nil, ErrNoVTGates
 	}
 
-	bytes := []byte(*json)
-	if err := disco.parseConfig(bytes); err != nil {
+	gate := gates[rand.Intn(len(gates))]
+	return gate, nil
+}
+
+// DiscoverVTGateAddr is part of the Discovery interface.
+func (d *JSONDiscovery) DiscoverVTGateAddr(ctx context.Context, tags []string) (string, error) {
+	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVTGateAddr")
+	defer span.Finish()
+
+	gate, err := d.DiscoverVTGate(ctx, tags)
+	if err != nil {
+		return "", err
+	}
+
+	return gate.Hostname, nil
+}
+
+// DiscoverVTGates is part of the Discovery interface.
+func (d *JSONDiscovery) DiscoverVTGates(ctx context.Context, tags []string) ([]*vtadminpb.VTGate, error) {
+	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVTGates")
+	defer span.Finish()
+
+	return d.discoverVTGates(ctx, tags)
+}
+
+func (d *JSONDiscovery) discoverVTGates(ctx context.Context, tags []string) ([]*vtadminpb.VTGate, error) {
+	if len(tags) == 0 {
+		results := []*vtadminpb.VTGate{}
+		for _, g := range d.gates.byName {
+			results = append(results, g)
+		}
+
+		return results, nil
+	}
+
+	set := d.gates.byName
+
+	for _, tag := range tags {
+		intermediate := map[string]*vtadminpb.VTGate{}
+
+		gates, ok := d.gates.byTag[tag]
+		if !ok {
+			return []*vtadminpb.VTGate{}, nil
+		}
+
+		for _, g := range gates {
+			if _, ok := set[g.Hostname]; ok {
+				intermediate[g.Hostname] = g
+			}
+		}
+
+		set = intermediate
+	}
+
+	results := make([]*vtadminpb.VTGate, 0, len(set))
+
+	for _, gate := range set {
+		results = append(results, gate)
+	}
+
+	return results, nil
+}
+
+// DiscoverVtctld is part of the Discovery interface.
+func (d *JSONDiscovery) DiscoverVtctld(ctx context.Context, tags []string) (*vtadminpb.Vtctld, error) {
+	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVtctld")
+	defer span.Finish()
+
+	return d.discoverVtctld(ctx, tags)
+}
+
+func (d *JSONDiscovery) discoverVtctld(ctx context.Context, tags []string) (*vtadminpb.Vtctld, error) {
+	vtctlds, err := d.discoverVtctlds(ctx, tags)
+	if err != nil {
 		return nil, err
 	}
 
-	return disco, nil
+	count := len(vtctlds)
+	if count == 0 {
+		return nil, ErrNoVtctlds
+	}
+
+	vtctld := vtctlds[rand.Intn(len(vtctlds))]
+	return vtctld, nil
+}
+
+// DiscoverVtctldAddr is part of the Discovery interface.
+func (d *JSONDiscovery) DiscoverVtctldAddr(ctx context.Context, tags []string) (string, error) {
+	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVtctldAddr")
+	defer span.Finish()
+
+	vtctld, err := d.discoverVtctld(ctx, tags)
+	if err != nil {
+		return "", err
+	}
+
+	return vtctld.Hostname, nil
+}
+
+// DiscoverVtctlds is part of the Discovery interface.
+func (d *JSONDiscovery) DiscoverVtctlds(ctx context.Context, tags []string) ([]*vtadminpb.Vtctld, error) {
+	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVtctlds")
+	defer span.Finish()
+
+	return d.discoverVtctlds(ctx, tags)
+}
+
+func (d *JSONDiscovery) discoverVtctlds(ctx context.Context, tags []string) ([]*vtadminpb.Vtctld, error) {
+	if len(tags) == 0 {
+		results := []*vtadminpb.Vtctld{}
+		for _, v := range d.vtctlds.byName {
+			results = append(results, v)
+		}
+
+		return results, nil
+	}
+
+	set := d.vtctlds.byName
+
+	for _, tag := range tags {
+		intermediate := map[string]*vtadminpb.Vtctld{}
+
+		vtctlds, ok := d.vtctlds.byTag[tag]
+		if !ok {
+			return []*vtadminpb.Vtctld{}, nil
+		}
+
+		for _, v := range vtctlds {
+			if _, ok := set[v.Hostname]; ok {
+				intermediate[v.Hostname] = v
+			}
+		}
+
+		set = intermediate
+	}
+
+	results := make([]*vtadminpb.Vtctld, 0, len(set))
+
+	for _, vtctld := range set {
+		results = append(results, vtctld)
+	}
+
+	return results, nil
 }

--- a/go/vt/vtadmin/cluster/discovery/discovery_json_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_json_test.go
@@ -98,7 +98,6 @@ func TestJSONDiscoverVTGate(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
 			disco := &JSONDiscovery{}
 			err := disco.parseConfig(tt.contents)
 			require.NoError(t, err)


### PR DESCRIPTION
## Description
This PR greatly simplifies JSON discovery by:
- Renaming JSONDiscovery to DynamicDiscovery
- Refactoring out key logic in StaticFileDiscovery to JSONDiscovery
- Embedding JSONDiscovery in both StaticFileDiscovery and DynamicDiscovery, since they are both JSON-based

## Related Issue(s)
N/A

## Checklist
- [x] Should this PR be backported? **No**
- [x] Tests were added or are not required **Tests remain the same for discovery_json_test.go**
- [x] Documentation was added or is not required

## Deployment Notes
N/A