### PR TITLE
Permission fixes for Docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,15 +264,10 @@ docker_bootstrap_pull:
 
 
 define build_docker_image
-	# Fix permissions before copying files, to avoid AUFS bug.
-	# Take permission backup before setting for restore.
-	getfacl -R ./ > /tmp/vitess-permissions.txt
 	${info Building ${2}}
-	chmod -R o=g *;
+	# Fix permissions before copying files, to avoid AUFS bug other must have read/access permissions
+	chmod -R o=rx *;
 	docker build -f ${1} -t ${2} --build-arg bootstrap_version=${BOOTSTRAP_VERSION} .;
-	# Restore permissions from backup
-	setfacl --restore=/tmp/vitess-permissions.txt
-	rm -f /tmp/vitess-permissions.txt
 endef
 
 docker_base:

--- a/Makefile
+++ b/Makefile
@@ -265,9 +265,14 @@ docker_bootstrap_pull:
 
 define build_docker_image
 	# Fix permissions before copying files, to avoid AUFS bug.
+	# Take permission backup before setting for restore.
+	getfacl -R ./ > /tmp/vitess-permissions.txt
 	${info Building ${2}}
 	chmod -R o=g *;
 	docker build -f ${1} -t ${2} --build-arg bootstrap_version=${BOOTSTRAP_VERSION} .;
+	# Restore permissions from backup
+	setfacl --restore=/tmp/vitess-permissions.txt
+	rm -f /tmp/vitess-permissions.txt
 endef
 
 docker_base:

--- a/docker/bootstrap/build.sh
+++ b/docker/bootstrap/build.sh
@@ -43,8 +43,8 @@ if [[ ! -f bootstrap.sh ]]; then
   exit 1
 fi
 
-# To avoid AUFS permission issues, files must allow access by "other"
-chmod -R o=g *
+# Fix permissions before copying files, to avoid AUFS bug other must have read/access permissions
+chmod -R o=rx *;
 
 arch=$(uname -m)
 [ "$arch" == "aarch64" ] && [ $flavor != "common" ] && arch_ext='-arm64v8'

--- a/docker/test/run.sh
+++ b/docker/test/run.sh
@@ -121,9 +121,8 @@ if [[ -n "$existing_cache_image" ]]; then
   image=$existing_cache_image
 fi
 
-# To avoid AUFS permission issues, files must allow access by "other" (permissions rX required).
-# Mirror permissions to "other" from the owning group (for which we assume it has at least rX permissions).
-chmod -R o=g .
+# Fix permissions before copying files, to avoid AUFS bug other must have read/access permissions
+chmod -R o=rx *;
 
 # This is required by the vtctld_web_test.py test.
 # Otherwise, /usr/bin/chromium will crash with the error:


### PR DESCRIPTION
Signed-off-by: FancyFane <fane@planetscale.com>

## Description
This pull request fixes permission changes being set when `make docker_lite` is ran locally. A backup of permissions is made before the offending `chmod` command, and these permissions are restored after the build is complete. Preventing the user from having incorrect permissions in their local Vitess repository. 


## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
n/a