### PR TITLE
Fix output issue in the do_release script

### DIFF
--- a/go/vt/servenv/mysql.go
+++ b/go/vt/servenv/mysql.go
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// THIS FILE IS AUTO-GENERATED DURING NEW RELEASES
-// DO NOT EDIT
-
 package servenv
 
-const versionName = "14.0.0-SNAPSHOT"
+import "flag"
+
+// MySQLServerVersion is what Vitess will present as it's version during the connection handshake,
+// and as the value to the @@version system variable. If nothing is provided, Vitess will report itself as
+// a specific MySQL version with the vitess version appended to it
+var MySQLServerVersion = flag.String("mysql_server_version", "", "MySQL server version to advertise.")

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -42,17 +42,19 @@ if [ "$GODOC_RELEASE_VERSION" == "" ]; then
 fi
 
 function updateVersionGo () {
-  echo "/*
+
+  cat << EOF > ${ROOT}/go/vt/servenv/version.go
+/*
 Copyright 2022 The Vitess Authors.
 
-Licensed under the Apache License, Version 2.0 (the \"License\");
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an \"AS IS\" BASIS,
+distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
@@ -60,13 +62,16 @@ limitations under the License.
 
 package servenv
 
-const versionName = \"$1\"
+// THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY ./tools/do_releases.sh
+// DO NOT EDIT
 
-" > $ROOT/go/vt/servenv/version.go
+const versionName = "${1}"
+EOF
+
 }
 
 function updateJava () {
-  cd $ROOT/java
+  cd $ROOT/java || exit 1
   mvn versions:set -DnewVersion=$1
 }
 
@@ -86,7 +91,7 @@ git_status_output=$(git status --porcelain)
 if [ "$git_status_output" == "" ]; then
   	echo so much clean
 else
-    echo cannot do release with dirty git state
+    echo "cannot do release with dirty git state"
     exit 1
 fi
 

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -44,7 +44,7 @@ fi
 function updateVersionGo () {
   echo package servenv > $ROOT/go/vt/servenv/version.go
   echo  >> $ROOT/go/vt/servenv/version.go
-  echo "const versionName = \"$1)\"" >> $ROOT/go/vt/servenv/version.go
+  echo "const versionName = \"$1\"" >> $ROOT/go/vt/servenv/version.go
 }
 
 function updateJava () {

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -42,9 +42,27 @@ if [ "$GODOC_RELEASE_VERSION" == "" ]; then
 fi
 
 function updateVersionGo () {
-  echo package servenv > $ROOT/go/vt/servenv/version.go
-  echo  >> $ROOT/go/vt/servenv/version.go
-  echo "const versionName = \"$1\"" >> $ROOT/go/vt/servenv/version.go
+  echo "/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servenv
+
+const versionName = \"$1\"
+
+" > $ROOT/go/vt/servenv/version.go
 }
 
 function updateJava () {


### PR DESCRIPTION
## Description

Between v12 and v13, new code was written to the version.go file, however, `do_release` would override the `version.go` file with the latest release's information, removing other code written in that file. This pull request fixes that.

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
