### PR TITLE
Improve performance of hex type decoding

### DIFF
--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -486,8 +485,7 @@ func (v *Value) UnmarshalJSON(b []byte) error {
 // array matching what MySQL would return when querying the column where
 // an INSERT was performed with x'A1' having been specified as a value
 func (v *Value) decodeHexVal() ([]byte, error) {
-	match, err := regexp.Match("^x'.*'$", v.val)
-	if !match || err != nil {
+	if len(v.val) < 3 || (v.val[0] != 'x' && v.val[0] != 'X') || v.val[1] != '\'' || v.val[len(v.val)-1] != '\'' {
 		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid hex value: %v", v.val)
 	}
 	hexBytes := v.val[2 : len(v.val)-1]
@@ -502,8 +500,7 @@ func (v *Value) decodeHexVal() ([]byte, error) {
 // array matching what MySQL would return when querying the column where
 // an INSERT was performed with 0xA1 having been specified as a value
 func (v *Value) decodeHexNum() ([]byte, error) {
-	match, err := regexp.Match("^0x.*$", v.val)
-	if !match || err != nil {
+	if len(v.val) < 3 || v.val[0] != '0' || v.val[1] != 'x' {
 		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid hex number: %v", v.val)
 	}
 	hexBytes := v.val[2:]


### PR DESCRIPTION
## Description
We replace the use of RegExps with Byte comparisons which should be much faster.

It's also simpler to read IMO since we're already using Byte slice indexes in related code.

Finally, it's actually more precise as it:
 1. Allows for X'1' and x'1' (MySQL accepts both)
 2. Requires x0\<byte\> as MySQL does not accept simply `0x` (it does
    accept `x''` though)
```
mysql> select @@version;
+-----------+
| @@version |
+-----------+
| 8.0.27    |
+-----------+
1 row in set (0.00 sec)

mysql> select x'';
+----------+
| x''      |
+----------+
| 0x       |
+----------+
1 row in set (0.00 sec)

mysql> select X'01';
+--------------+
| X'01'        |
+--------------+
| 0x01         |
+--------------+
1 row in set (0.00 sec)

mysql> select 0X01;
ERROR 1054 (42S22): Unknown column '0X01' in 'field list'
mysql> select 0x;
ERROR 1054 (42S22): Unknown column '0x' in 'field list'
```

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? YES, to release-13.0: https://github.com/vitessio/vitess/pull/9627
- [x] Tests were are not required (existing tests for this)
- [x] Documentation is not required (internal cleanup)