### PR TITLE
Improve performance of information schema query.

### DIFF
--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -259,19 +259,28 @@ const TablesWithSize56 = `SELECT table_name, table_type, unix_timestamp(create_t
 		FROM information_schema.tables WHERE table_schema = database() group by table_name`
 
 // TablesWithSize57 is a query to select table along with size for mysql 5.7.
+//
 // It's a little weird, because the JOIN predicate only works if the table and databases do not contain weird characters.
-// As a fallback, we use the mysql 5.6 query, which is not always up to date, but works for all table/db names.
-const TablesWithSize57 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, sum(i.file_size), sum(i.allocated_size) 
-	FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i 
-	WHERE t.table_schema = database() and 
-	(i.name = concat(t.table_schema,'/',t.table_name) or i.name like concat(t.table_schema,'/',t.table_name, '#p#%')) 
-	group by t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size
-UNION ALL
-	SELECT table_name, table_type, unix_timestamp(create_time), table_comment, SUM( data_length + index_length), SUM( data_length + index_length)
-	FROM information_schema.tables t
-	WHERE table_schema = database() AND 
-	NOT EXISTS(SELECT * FROM information_schema.innodb_sys_tablespaces i WHERE i.name = concat(t.table_schema,'/',t.table_name) or i.name like concat(t.table_schema,'/',t.table_name, '#p#%')) 
-	group by table_name, table_type, unix_timestamp(create_time), table_comment
+// If the join does not return any data, we fall back to the same fields as used in the mysql 5.6 query.
+//
+// We join with a subquery that materializes the data from `information_schema.innodb_sys_tablespaces`
+// early for performance reasons. This effectively causes only a single read of `information_schema.innodb_sys_tablespaces`
+// per query.
+const TablesWithSize57 = `SELECT t.table_name,
+	t.table_type,
+	UNIX_TIMESTAMP(t.create_time),
+	t.table_comment,
+	IFNULL(SUM(i.file_size), SUM(t.data_length + t.index_length)),
+	IFNULL(SUM(i.allocated_size), SUM(t.data_length + t.index_length))
+FROM information_schema.tables t
+LEFT OUTER JOIN (
+	SELECT space, file_size, allocated_size, name
+	FROM information_schema.innodb_sys_tablespaces
+	WHERE name LIKE CONCAT(database(), '/%')
+	GROUP BY space, file_size, allocated_size, name
+) i ON i.name = CONCAT(t.table_schema, '/', t.table_name) or i.name LIKE CONCAT(t.table_schema, '/', t.table_name, '#p#%')
+WHERE t.table_schema = database()
+GROUP BY t.table_name, t.table_type, t.create_time, t.table_comment
 `
 
 // TablesWithSize80 is a query to select table along with size for mysql 8.0


### PR DESCRIPTION
## Description

Querying the `information_schema` tables can be quite expensive in MySQL 5.7.

On the test database I'm using (169 tables), each execution of the `TablesWithSize57` query takes multiple seconds, making this query unbearably slow.

But the runtime of this query can be improved with a few tricks.

For reference, here's the original query:

```sql
	SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, sum(i.file_size), sum(i.allocated_size) 
	FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i 
	WHERE t.table_schema = database() and 
	(i.name = concat(t.table_schema,'/',t.table_name) or i.name like concat(t.table_schema,'/',t.table_name, '#p#%')) 
	group by t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size
UNION ALL
	SELECT table_name, table_type, unix_timestamp(create_time), table_comment, SUM( data_length + index_length), SUM( data_length + index_length)
	FROM information_schema.tables t
	WHERE table_schema = database() AND 
	NOT EXISTS(SELECT * FROM information_schema.innodb_sys_tablespaces i WHERE i.name = concat(t.table_schema,'/',t.table_name) or i.name like concat(t.table_schema,'/',t.table_name, '#p#%')) 
	group by table_name, table_type, unix_timestamp(create_time), table_comment
```

```
169 rows in set (5.36 sec)
```

The first improvement is to reduce the number of accesses to the `information_schema.innodb_sys_tablespaces` table by replacing the `NOT EXISTS` part of the query with a `LEFT OUTER JOIN`:

```sql
	SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, sum(i.file_size), sum(i.allocated_size) 
	FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i 
	WHERE t.table_schema = database() and 
	(i.name = concat(t.table_schema,'/',t.table_name) or i.name like concat(t.table_schema,'/',t.table_name, '#p#%')) 
	group by t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size
UNION ALL
	SELECT table_name, table_type, unix_timestamp(create_time), table_comment, SUM( data_length + index_length), SUM( data_length + index_length)
	FROM information_schema.tables t
	LEFT OUTER JOIN information_schema.innodb_sys_tablespaces i ON i.name = concat(t.table_schema,'/',t.table_name) or i.name like concat(t.table_schema,'/',t.table_name, '#p#%')
	WHERE table_schema = database() AND i.name IS NULL
	group by table_name, table_type, unix_timestamp(create_time), table_comment
```

```
169 rows in set (0.74 sec)
```

Next, we can actually replace the `UNION` with a single query:

```sql
	SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, IFNULL(sum(i.file_size), SUM(t.data_length + t.index_length)), IFNULL(sum(i.allocated_size), SUM(t.data_length + t.index_length))
	FROM information_schema.tables t
	LEFT OUTER JOIN information_schema.innodb_sys_tablespaces i ON i.name = concat(t.table_schema,'/',t.table_name) or i.name like concat(t.table_schema,'/',t.table_name, '#p#%')
	WHERE t.table_schema = database()
	GROUP BY t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size
```

```
169 rows in set (0.37 sec)
```

The next optimization is a bit more exotic. I noticed that individual queries on the `information_schema.tables` and `information_schema.innodb_sys_tablespaces` were fairly quick, but joining them together would cause a quite severe degradation in performance:

```sql
SELECT * FROM information_schema.tables WHERE table_schema = database()
```

```
169 rows in set (0.01 sec)
```

```sql
SELECT * FROM information_schema.innodb_sys_tablespaces WHERE name LIKE CONCAT(database(), '/%');
```

```
Empty set (0.03 sec)
```

So this last optimization step forces early materialization of the data we're interested in:

```sql
SELECT
	t.table_name,
	t.table_type,
	UNIX_TIMESTAMP(t.create_time),
	t.table_comment,
	IFNULL(SUM(i.file_size), SUM(t.data_length + t.index_length)),
	IFNULL(SUM(i.allocated_size), SUM(t.data_length + t.index_length))
FROM information_schema.tables t
LEFT OUTER JOIN (
	SELECT * FROM information_schema.innodb_sys_tablespaces WHERE name LIKE CONCAT(database(), '/%') GROUP BY space
) i ON i.name = CONCAT(t.table_schema, '/', t.table_name) or i.name LIKE CONCAT(t.table_schema, '/', t.table_name, '#p#%')
WHERE t.table_schema = database()
GROUP BY t.table_name
```

```
169 rows in set (0.04 sec)
```

This new query takes only a percent of the time that the old query has taken.

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->