### PR TITLE
Add flag to vtcombo to load a json-encoded test topology file

### DIFF
--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -23,12 +23,12 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"os"
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 
@@ -123,9 +123,7 @@ func main() {
 	tpb := &vttestpb.VTTestTopology{}
 	switch {
 	case *jsonTopo != "":
-		decoder := json.NewDecoder(strings.NewReader(*jsonTopo))
-		decoder.DisallowUnknownFields()
-		if err := decoder.Decode(tpb); err != nil {
+		if err := protojson.Unmarshal([]byte(*jsonTopo), tpb); err != nil {
 			log.Errorf("cannot parse topology: %v", err)
 			exit.Return(1)
 		}

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -69,8 +69,8 @@ var (
 )
 
 func init() {
-	flag.Var(vttest.TextTopoFlag(&tpb), "proto_topo", "vttest proto definition of the topology, encoded in compact text format. See vttest.proto for more information.")
-	flag.Var(vttest.JsonTopoFlag(&tpb), "json_topo", "vttest proto definition of the topology, encoded in json format. See vttest.proto for more information.")
+	flag.Var(vttest.TextTopoData(&tpb), "proto_topo", "vttest proto definition of the topology, encoded in compact text format. See vttest.proto for more information.")
+	flag.Var(vttest.JsonTopoData(&tpb), "json_topo", "vttest proto definition of the topology, encoded in json format. See vttest.proto for more information.")
 
 	servenv.RegisterDefaultFlags()
 }

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strings"
 	"time"
+
 	"vitess.io/vitess/go/vt/vttest"
 
 	"google.golang.org/protobuf/proto"

--- a/go/test/endtoend/vtcombo/vttest_sample_test.go
+++ b/go/test/endtoend/vtcombo/vttest_sample_test.go
@@ -46,32 +46,37 @@ var (
 	vtctldAddr   string
 	ks1          = "test_keyspace"
 	redirected   = "redirected"
+	jsonTopo = `
+{
+	"keyspaces": [
+		{
+			"name": "test_keyspace",
+			"shards": [{"name": "-80"}, {"name": "80-"}],
+			"rdonlyCount": 1,
+			"replicaCount": 2
+		},
+		{
+			"name": "redirected",
+			"servedFrom": "test_keyspace"
+		}
+	]
+}`
 )
 
 func TestMain(m *testing.M) {
 	flag.Parse()
 
 	exitcode, err := func() (int, error) {
+		var topology vttestpb.VTTestTopology
 
-		topology := new(vttestpb.VTTestTopology)
-		topology.Keyspaces = []*vttestpb.Keyspace{
-			{
-				Name: ks1,
-				Shards: []*vttestpb.Shard{
-					{Name: "-80"},
-					{Name: "80-"},
-				},
-				RdonlyCount:  1,
-				ReplicaCount: 2,
-			},
-			{
-				Name:       redirected,
-				ServedFrom: ks1,
-			},
+		flag := vttest.JsonTopoFlag(&topology)
+		err := flag.Set(jsonTopo)
+		if err != nil {
+			return 1, err
 		}
 
 		var cfg vttest.Config
-		cfg.Topology = topology
+		cfg.Topology = &topology
 		cfg.SchemaDir = os.Getenv("VTROOT") + "/test/vttest_schema"
 		cfg.DefaultSchemaDir = os.Getenv("VTROOT") + "/test/vttest_schema/default"
 		cfg.PersistentMode = true
@@ -80,7 +85,7 @@ func TestMain(m *testing.M) {
 			Config: cfg,
 		}
 
-		err := localCluster.Setup()
+		err = localCluster.Setup()
 		defer localCluster.TearDown()
 		if err != nil {
 			return 1, err

--- a/go/test/endtoend/vtcombo/vttest_sample_test.go
+++ b/go/test/endtoend/vtcombo/vttest_sample_test.go
@@ -46,7 +46,7 @@ var (
 	vtctldAddr   string
 	ks1          = "test_keyspace"
 	redirected   = "redirected"
-	jsonTopo = `
+	jsonTopo     = `
 {
 	"keyspaces": [
 		{

--- a/go/test/endtoend/vtcombo/vttest_sample_test.go
+++ b/go/test/endtoend/vtcombo/vttest_sample_test.go
@@ -69,8 +69,8 @@ func TestMain(m *testing.M) {
 	exitcode, err := func() (int, error) {
 		var topology vttestpb.VTTestTopology
 
-		flag := vttest.JsonTopoFlag(&topology)
-		err := flag.Set(jsonTopo)
+		data := vttest.JsonTopoData(&topology)
+		err := data.Set(jsonTopo)
 		if err != nil {
 			return 1, err
 		}

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -21,14 +21,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
 	"unicode"
-
 	"vitess.io/vitess/go/vt/proto/logutil"
 	// we need to import the grpcvtctlclient library so the gRPC
 	// vtctl client is registered and can be used.
@@ -192,6 +195,33 @@ func (cfg *Config) DbName() string {
 		return ns[0].Name
 	}
 	return ""
+}
+
+type TopoFlag struct {
+	ptr *vttestpb.VTTestTopology
+	unmarshal func (b []byte, m proto.Message) error
+}
+
+func (tf *TopoFlag) String() string {
+	return "vttestpb.VTTestTopology"
+}
+
+func (tf *TopoFlag) Set(value string) error {
+	return tf.unmarshal([]byte(value), tf.ptr)
+}
+
+func TextTopoFlag(tpb *vttestpb.VTTestTopology) flag.Value {
+	return &TopoFlag {
+		ptr: tpb,
+		unmarshal: prototext.Unmarshal,
+	}
+}
+
+func JsonTopoFlag(tpb *vttestpb.VTTestTopology) flag.Value {
+	return &TopoFlag {
+		ptr: tpb,
+		unmarshal: protojson.Unmarshal,
+	}
 }
 
 // LocalCluster controls a local Vitess setup for testing, containing

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -23,16 +23,19 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/encoding/prototext"
-	"google.golang.org/protobuf/proto"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
 	"unicode"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+
 	"vitess.io/vitess/go/vt/proto/logutil"
+
 	// we need to import the grpcvtctlclient library so the gRPC
 	// vtctl client is registered and can be used.
 	_ "vitess.io/vitess/go/vt/vtctl/grpcvtctlclient"
@@ -198,8 +201,8 @@ func (cfg *Config) DbName() string {
 }
 
 type TopoFlag struct {
-	ptr *vttestpb.VTTestTopology
-	unmarshal func (b []byte, m proto.Message) error
+	ptr       *vttestpb.VTTestTopology
+	unmarshal func(b []byte, m proto.Message) error
 }
 
 func (tf *TopoFlag) String() string {
@@ -211,15 +214,15 @@ func (tf *TopoFlag) Set(value string) error {
 }
 
 func TextTopoFlag(tpb *vttestpb.VTTestTopology) flag.Value {
-	return &TopoFlag {
-		ptr: tpb,
+	return &TopoFlag{
+		ptr:       tpb,
 		unmarshal: prototext.Unmarshal,
 	}
 }
 
 func JsonTopoFlag(tpb *vttestpb.VTTestTopology) flag.Value {
-	return &TopoFlag {
-		ptr: tpb,
+	return &TopoFlag{
+		ptr:       tpb,
 		unmarshal: protojson.Unmarshal,
 	}
 }

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -200,30 +200,30 @@ func (cfg *Config) DbName() string {
 	return ""
 }
 
-type TopoFlag struct {
-	ptr       *vttestpb.VTTestTopology
-	unmarshal func(b []byte, m proto.Message) error
+type TopoData struct {
+	vtTestTopology *vttestpb.VTTestTopology
+	unmarshal      func(b []byte, m proto.Message) error
 }
 
-func (tf *TopoFlag) String() string {
-	return "vttestpb.VTTestTopology"
+func (td *TopoData) String() string {
+	return prototext.Format(td.vtTestTopology)
 }
 
-func (tf *TopoFlag) Set(value string) error {
-	return tf.unmarshal([]byte(value), tf.ptr)
+func (td *TopoData) Set(value string) error {
+	return td.unmarshal([]byte(value), td.vtTestTopology)
 }
 
-func TextTopoFlag(tpb *vttestpb.VTTestTopology) flag.Value {
-	return &TopoFlag{
-		ptr:       tpb,
-		unmarshal: prototext.Unmarshal,
+func TextTopoData(tpb *vttestpb.VTTestTopology) flag.Value {
+	return &TopoData{
+		vtTestTopology: tpb,
+		unmarshal:      prototext.Unmarshal,
 	}
 }
 
-func JsonTopoFlag(tpb *vttestpb.VTTestTopology) flag.Value {
-	return &TopoFlag{
-		ptr:       tpb,
-		unmarshal: protojson.Unmarshal,
+func JsonTopoData(tpb *vttestpb.VTTestTopology) flag.Value {
+	return &TopoData{
+		vtTestTopology: tpb,
+		unmarshal:      protojson.Unmarshal,
 	}
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR introduces a new flag to vtcombo (`-json_topo`) which allows a user to load a topology file from a JSON-encoded document.

In our testing setup we create topology files dynamically. JSON is easier to generate from a range of sources.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

I don't think this applies to vtcombo?