### PR TITLE
Remove queryserver-config-terse-errors impact on log messages

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1298,15 +1298,20 @@ func (tsv *TabletServer) handlePanicAndSendLogStats(
 	logStats *tabletenv.LogStats,
 ) {
 	if x := recover(); x != nil {
-		// TerseErrors should generally NOT impact log messages -- rather client errors -- but keeping
-		// this existing exception in place so as not to change the behavior for users of the flag.
-		errorMessage := fmt.Sprintf(
-			"Uncaught panic for %v:\n%v\n%s",
-			queryAsString(sql, bindVariables, (tsv.TerseErrors || tsv.Config().SanitizeLogMessages)),
-			x,
-			tb.Stack(4) /* Skip the last 4 boiler-plate frames. */)
-		log.Errorf(errorMessage)
-		terr := vterrors.Errorf(vtrpcpb.Code_UNKNOWN, "%s", errorMessage)
+		// Redaction/sanitization of the client error message is controlled by TerseErrors while
+		// the log message is controlled by SanitizeLogMessages.
+		// We are handling an unrecoverable panic, so the cost of the dual message handling is
+		// not a concern.
+		var messagef, errMessage, logMessage string
+		messagef = fmt.Sprintf("Uncaught panic for %%v:\n%v\n%s", x, tb.Stack(4) /* Skip the last 4 boiler-plate frames. */)
+		errMessage = fmt.Sprintf(messagef, queryAsString(sql, bindVariables, tsv.TerseErrors))
+		terr := vterrors.Errorf(vtrpcpb.Code_UNKNOWN, "%s", errMessage)
+		if tsv.TerseErrors == tsv.Config().SanitizeLogMessages {
+			logMessage = errMessage
+		} else {
+			logMessage = fmt.Sprintf(messagef, queryAsString(sql, bindVariables, tsv.Config().SanitizeLogMessages))
+		}
+		log.Error(logMessage)
 		tsv.stats.InternalErrors.Add("Panic", 1)
 		if logStats != nil {
 			logStats.Error = terr
@@ -1367,12 +1372,10 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 		if tsv.TerseErrors && len(bindVariables) != 0 && errCode != vtrpcpb.Code_FAILED_PRECONDITION {
 			err = vterrors.Errorf(errCode, "(errno %d) (sqlstate %s)%s: %s", errnum, sqlState, callerID, queryAsString(sql, bindVariables, tsv.TerseErrors))
 			if logMethod != nil {
-				// TerseErrors should generally NOT impact log messages -- rather client errors -- but keeping
-				// this existing exception in place so as not to change the behavior for users of the flag.
-				message = fmt.Sprintf("(errno %d) (sqlstate %s)%s: %s", errnum, sqlState, callerID, truncateSQLAndBindVars(sql, bindVariables, tsv.TerseErrors))
+				message = fmt.Sprintf("(errno %d) (sqlstate %s)%s: %s", errnum, sqlState, callerID, truncateSQLAndBindVars(sql, bindVariables, tsv.Config().SanitizeLogMessages))
 			}
 		} else {
-			err = vterrors.Errorf(errCode, "%s (errno %d) (sqlstate %s)%s: %s", sqlErr.Message, errnum, sqlState, callerID, queryAsString(sql, bindVariables, tsv.TerseErrors))
+			err = vterrors.Errorf(errCode, "%s (errno %d) (sqlstate %s)%s: %s", sqlErr.Message, errnum, sqlState, callerID, queryAsString(sql, bindVariables, false))
 			if logMethod != nil {
 				message = fmt.Sprintf("%s (errno %d) (sqlstate %s)%s: %s", sqlErr.Message, errnum, sqlState, callerID, truncateSQLAndBindVars(sql, bindVariables, tsv.Config().SanitizeLogMessages))
 			}
@@ -1380,9 +1383,7 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 	} else {
 		err = vterrors.Errorf(errCode, "%v%s", err.Error(), callerID)
 		if logMethod != nil {
-			// TerseErrors should generally NOT impact log messages -- rather client errors -- but keeping
-			// this existing exception in place so as not to change the behavior for users of the flag.
-			message = fmt.Sprintf("%v: %v", err, truncateSQLAndBindVars(sql, bindVariables, (tsv.TerseErrors || tsv.Config().SanitizeLogMessages)))
+			message = fmt.Sprintf("%v: %v", err, truncateSQLAndBindVars(sql, bindVariables, tsv.Config().SanitizeLogMessages))
 		}
 	}
 

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1419,13 +1419,14 @@ func TestTerseErrors(t *testing.T) {
 		nil,
 	)
 
+	// The client error message should be redacted (made terse)
 	wantErr := "(errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vtg1 order by abc desc\", BindVars: {[REDACTED]}"
 	if err == nil || err.Error() != wantErr {
 		t.Errorf("error got '%v', want '%s'", err, wantErr)
 	}
 
-	// Log should be truncated in same way as the error
-	wantLog := wantErr
+	// But the log message should NOT be
+	wantLog := "(errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vtg1 order by abc desc\", BindVars: {vtg1: \"type:VARCHAR value:\\\"this is kinda long eh\\\"\"}"
 	if wantLog != tl.getLog(0) {
 		t.Errorf("log got '%s', want '%s'", tl.getLog(0), wantLog)
 	}


### PR DESCRIPTION
## Description
This effectively reverts https://github.com/vitessio/vitess/pull/9094.

That PR made undocumented behavior changes in a development release: `13.0.0-SNAPSHOT` (never part of a GA/stable release). It added some log message redaction behavior to the `-queryserver-config-terse-errors` flag and altered the meaning/intention of that flag. Additionally, we did not audit the `vttablet` codebase at that time to ensure that sensitive log messages were actually sanitized in all known potential places (it focused on one specific error message location).

In https://github.com/vitessio/vitess/pull/9550 we intended to properly sanitize all potentially sensitive `vttablet` log messages and we added a new flag for this purpose: `-sanitize_log_messages`. That work was complicated, however, by the fact that `-queryserver-config-terse-errors` had an inconsistent and non-uniform impact on log messages.

Given that the changes in https://github.com/vitessio/vitess/pull/9094 were:
1. Never in a GA/stable release
2. Were not documented 
3. Did not actually work as it should have (there were other log messages where the bind variables were not redacted)

We are making the following changes here:
1. `-queryserver-config-terse-errors` goes back to doing what it was intended and documented to do, redacting client error messages. The behavior of this flag then remains the same between 12.0 and 13.0.
2. Log message sanitization is handled exclusively via a dedicated flag now: `-sanitize_log_messages`.

## Related Issue(s)
This effectively reverts: https://github.com/vitessio/vitess/pull/9094
Follow-up to: https://github.com/vitessio/vitess/pull/9550

## Checklist
- [x] Should this PR be backported? YES, to release-13.0 https://github.com/vitessio/vitess/pull/9636
- [x] Tests were updated
- [x] Documentation is not required