### PR TITLE
Backport: Add sanitize_log_messages and remove queryserver-config-terse-errors impact on log messages

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -648,7 +648,7 @@ func (qre *QueryExecutor) verifyRowCount(count, maxrows int64) error {
 	if warnThreshold > 0 && count > warnThreshold {
 		callerID := callerid.ImmediateCallerIDFromContext(qre.ctx)
 		qre.tsv.Stats().Warnings.Add("ResultsExceeded", 1)
-		log.Warningf("caller id: %s row count %v exceeds warning threshold %v: %q", callerID.Username, count, warnThreshold, queryAsString(qre.plan.FullQuery.Query, qre.bindVars))
+		log.Warningf("caller id: %s row count %v exceeds warning threshold %v: %q", callerID.Username, count, warnThreshold, queryAsString(qre.plan.FullQuery.Query, qre.bindVars, qre.tsv.Config().SanitizeLogMessages))
 	}
 	return nil
 }

--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -175,11 +175,11 @@ func (sc *StatefulConnection) Renew() error {
 }
 
 // String returns a printable version of the connection info.
-func (sc *StatefulConnection) String() string {
+func (sc *StatefulConnection) String(sanitize bool) string {
 	return fmt.Sprintf(
 		"%v\t%s",
 		sc.ConnID,
-		sc.txProps.String(),
+		sc.txProps.String(sanitize),
 	)
 }
 
@@ -268,7 +268,7 @@ func (sc *StatefulConnection) LogTransaction(reason tx.ReleaseReason) {
 	sc.Stats().UserTransactionTimesNs.Add([]string{username, reason.Name()}, int64(duration))
 	sc.txProps.Stats.Add(reason.Name(), duration)
 	if sc.txProps.LogToFile {
-		log.Infof("Logged transaction: %s", sc.String())
+		log.Infof("Logged transaction: %s", sc.String(sc.env.Config().SanitizeLogMessages))
 	}
 	tabletenv.TxLogger.Send(sc)
 }

--- a/go/vt/vttablet/tabletserver/stateful_connection_pool.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection_pool.go
@@ -93,7 +93,7 @@ func (sf *StatefulConnectionPool) Close() {
 		if conn.IsInTransaction() {
 			thing = "transaction"
 		}
-		log.Warningf("killing %s for shutdown: %s", thing, conn.String())
+		log.Warningf("killing %s for shutdown: %s", thing, conn.String(sf.env.Config().SanitizeLogMessages))
 		sf.env.Stats().InternalErrors.Add("StrayTransactions", 1)
 		conn.Close()
 		conn.Releasef("pool closed")

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -121,7 +121,7 @@ func init() {
 	flag.BoolVar(&currentConfig.StrictTableACL, "queryserver-config-strict-table-acl", defaultConfig.StrictTableACL, "only allow queries that pass table acl checks")
 	flag.BoolVar(&currentConfig.EnableTableACLDryRun, "queryserver-config-enable-table-acl-dry-run", defaultConfig.EnableTableACLDryRun, "If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results")
 	flag.StringVar(&currentConfig.TableACLExemptACL, "queryserver-config-acl-exempt-acl", defaultConfig.TableACLExemptACL, "an acl that exempt from table acl checking (this acl is free to access any vitess tables).")
-	flag.BoolVar(&currentConfig.TerseErrors, "queryserver-config-terse-errors", defaultConfig.TerseErrors, "prevent bind vars from escaping in returned or logged errors")
+	flag.BoolVar(&currentConfig.TerseErrors, "queryserver-config-terse-errors", defaultConfig.TerseErrors, "prevent bind vars from escaping in client error messages")
 	flag.BoolVar(&currentConfig.AnnotateQueries, "queryserver-config-annotate-queries", defaultConfig.AnnotateQueries, "prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type")
 	flag.StringVar(&deprecatedPoolNamePrefix, "pool-name-prefix", "", "Deprecated")
 	flag.BoolVar(&currentConfig.WatchReplication, "watch_replication_stream", false, "When enabled, vttablet will stream the MySQL replication stream from the local server, and use it to update schema when it sees a DDL.")
@@ -164,6 +164,7 @@ func init() {
 
 	flag.BoolVar(&enableReplicationReporter, "enable_replication_reporter", false, "Use polling to track replication lag.")
 	flag.BoolVar(&currentConfig.EnableOnlineDDL, "queryserver_enable_online_ddl", true, "Enable online DDL.")
+	flag.BoolVar(&currentConfig.SanitizeLogMessages, "sanitize_log_messages", false, "Remove potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.")
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.
@@ -268,6 +269,7 @@ type TabletConfig struct {
 
 	ExternalConnections map[string]*dbconfigs.DBConfigs `json:"externalConnections,omitempty"`
 
+	SanitizeLogMessages     bool    `json:"-"`
 	StrictTableACL          bool    `json:"-"`
 	EnableTableACLDryRun    bool    `json:"-"`
 	TableACLExemptACL       string  `json:"-"`

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1298,22 +1298,20 @@ func (tsv *TabletServer) handlePanicAndSendLogStats(
 	logStats *tabletenv.LogStats,
 ) {
 	if x := recover(); x != nil {
-		var errorMessage string
-		if tsv.TerseErrors && len(bindVariables) != 0 {
-			errorMessage = fmt.Sprintf(
-				"Uncaught panic for %v:\n%v\n%s",
-				queryAsString(sql, nil),
-				x,
-				tb.Stack(4) /* Skip the last 4 boiler-plate frames. */)
+		// Redaction/sanitization of the client error message is controlled by TerseErrors while
+		// the log message is controlled by SanitizeLogMessages.
+		// We are handling an unrecoverable panic, so the cost of the dual message handling is
+		// not a concern.
+		var messagef, errMessage, logMessage string
+		messagef = fmt.Sprintf("Uncaught panic for %%v:\n%v\n%s", x, tb.Stack(4) /* Skip the last 4 boiler-plate frames. */)
+		errMessage = fmt.Sprintf(messagef, queryAsString(sql, bindVariables, tsv.TerseErrors))
+		terr := vterrors.Errorf(vtrpcpb.Code_UNKNOWN, "%s", errMessage)
+		if tsv.TerseErrors == tsv.Config().SanitizeLogMessages {
+			logMessage = errMessage
 		} else {
-			errorMessage = fmt.Sprintf(
-				"Uncaught panic for %v:\n%v\n%s",
-				queryAsString(sql, bindVariables),
-				x,
-				tb.Stack(4) /* Skip the last 4 boiler-plate frames. */)
+			logMessage = fmt.Sprintf(messagef, queryAsString(sql, bindVariables, tsv.Config().SanitizeLogMessages))
 		}
-		log.Errorf(errorMessage)
-		terr := vterrors.Errorf(vtrpcpb.Code_UNKNOWN, "%s", errorMessage)
+		log.Error(logMessage)
 		tsv.stats.InternalErrors.Add("Panic", 1)
 		if logStats != nil {
 			logStats.Error = terr
@@ -1372,26 +1370,20 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 		sqlState := sqlErr.SQLState()
 		errnum := sqlErr.Number()
 		if tsv.TerseErrors && len(bindVariables) != 0 && errCode != vtrpcpb.Code_FAILED_PRECONDITION {
-			err = vterrors.Errorf(errCode, "(errno %d) (sqlstate %s)%s: %s", errnum, sqlState, callerID, queryAsString(sql, nil))
+			err = vterrors.Errorf(errCode, "(errno %d) (sqlstate %s)%s: %s", errnum, sqlState, callerID, queryAsString(sql, bindVariables, tsv.TerseErrors))
 			if logMethod != nil {
-				message = fmt.Sprintf("(errno %d) (sqlstate %s)%s: %s", errnum, sqlState, callerID, truncateSQLAndBindVars(sql, nil))
+				message = fmt.Sprintf("(errno %d) (sqlstate %s)%s: %s", errnum, sqlState, callerID, truncateSQLAndBindVars(sql, bindVariables, tsv.Config().SanitizeLogMessages))
 			}
 		} else {
-			err = vterrors.Errorf(errCode, "%s (errno %d) (sqlstate %s)%s: %s", sqlErr.Message, errnum, sqlState, callerID, queryAsString(sql, bindVariables))
+			err = vterrors.Errorf(errCode, "%s (errno %d) (sqlstate %s)%s: %s", sqlErr.Message, errnum, sqlState, callerID, queryAsString(sql, bindVariables, false))
 			if logMethod != nil {
-				message = fmt.Sprintf("%s (errno %d) (sqlstate %s)%s: %s", sqlErr.Message, errnum, sqlState, callerID, truncateSQLAndBindVars(sql, bindVariables))
+				message = fmt.Sprintf("%s (errno %d) (sqlstate %s)%s: %s", sqlErr.Message, errnum, sqlState, callerID, truncateSQLAndBindVars(sql, bindVariables, tsv.Config().SanitizeLogMessages))
 			}
 		}
 	} else {
 		err = vterrors.Errorf(errCode, "%v%s", err.Error(), callerID)
-		if tsv.TerseErrors && len(bindVariables) != 0 && errCode != vtrpcpb.Code_FAILED_PRECONDITION {
-			if logMethod != nil {
-				message = fmt.Sprintf("%v: %v", err, truncateSQLAndBindVars(sql, nil))
-			}
-		} else {
-			if logMethod != nil {
-				message = fmt.Sprintf("%v: %v", err, truncateSQLAndBindVars(sql, bindVariables))
-			}
+		if logMethod != nil {
+			message = fmt.Sprintf("%v: %v", err, truncateSQLAndBindVars(sql, bindVariables, tsv.Config().SanitizeLogMessages))
 		}
 	}
 
@@ -1407,22 +1399,26 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 }
 
 // truncateSQLAndBindVars calls TruncateForLog which:
-//  splits off trailing comments, truncates the query, and re-adds the trailing comments
-// appends quoted bindvar: value pairs in sorted order
-// truncates the resulting string
-func truncateSQLAndBindVars(sql string, bindVariables map[string]*querypb.BindVariable) string {
+//  splits off trailing comments, truncates the query, re-adds the trailing comments,
+//  if sanitize is false appends quoted bindvar:value pairs in sorted order, and
+//  lastly it truncates the resulting string
+func truncateSQLAndBindVars(sql string, bindVariables map[string]*querypb.BindVariable, sanitize bool) string {
 	truncatedQuery := sqlparser.TruncateForLog(sql)
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(buf, "BindVars: {")
-	var keys []string
-	for key := range bindVariables {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	var valString string
-	for _, key := range keys {
-		valString = fmt.Sprintf("%v", bindVariables[key])
-		fmt.Fprintf(buf, "%s: %q", key, valString)
+	if len(bindVariables) > 0 {
+		if sanitize {
+			fmt.Fprintf(buf, "[REDACTED]")
+		} else {
+			var keys []string
+			for key := range bindVariables {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				fmt.Fprintf(buf, "%s: %q", key, fmt.Sprintf("%v", bindVariables[key]))
+			}
+		}
 	}
 	fmt.Fprintf(buf, "}")
 	bv := buf.String()
@@ -1855,20 +1851,29 @@ func (tsv *TabletServer) ConsolidatorMode() string {
 	return tsv.qe.consolidatorMode.Get()
 }
 
-// queryAsString returns a readable version of query+bind variables.
-func queryAsString(sql string, bindVariables map[string]*querypb.BindVariable) string {
+// queryAsString returns a readable normalized version of the query and if sanitize
+// is false it also includes the bind variables.
+func queryAsString(sql string, bindVariables map[string]*querypb.BindVariable, sanitize bool) string {
 	buf := &bytes.Buffer{}
+	// sql is the normalized query without the bind vars
 	fmt.Fprintf(buf, "Sql: %q", sql)
+	// Add the bind vars unless this needs to be sanitized, e.g. for log messages
 	fmt.Fprintf(buf, ", BindVars: {")
-	var keys []string
-	for key := range bindVariables {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	var valString string
-	for _, key := range keys {
-		valString = fmt.Sprintf("%v", bindVariables[key])
-		fmt.Fprintf(buf, "%s: %q", key, valString)
+	if len(bindVariables) > 0 {
+		if sanitize {
+			fmt.Fprintf(buf, "[REDACTED]")
+		} else {
+			var keys []string
+			for key := range bindVariables {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			var valString string
+			for _, key := range keys {
+				valString = fmt.Sprintf("%v", bindVariables[key])
+				fmt.Fprintf(buf, "%s: %q", key, valString)
+			}
+		}
 	}
 	fmt.Fprintf(buf, "}")
 	return buf.String()

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -123,7 +123,7 @@ func (tp *TxPool) Shutdown(ctx context.Context) {
 func (tp *TxPool) transactionKiller() {
 	defer tp.env.LogError()
 	for _, conn := range tp.scp.GetOutdated(tp.Timeout(), "for tx killer rollback") {
-		log.Warningf("killing transaction (exceeded timeout: %v): %s", tp.Timeout(), conn.String())
+		log.Warningf("killing transaction (exceeded timeout: %v): %s", tp.Timeout(), conn.String(tp.env.Config().SanitizeLogMessages))
 		switch {
 		case conn.IsTainted():
 			conn.Close()


### PR DESCRIPTION
## Description
This backports two related PRs together. Please see https://github.com/vitessio/vitess/pull/9634 for additional details.

This maintains consistent/unchanged behavior for `-queryserver-config-terse-errors` between 12.0 and 13.0 while adding support for sanitizing log messages with the new `-sanitize_log_messages` flag.

## Related Issue(s)
Backports: 
 - https://github.com/vitessio/vitess/pull/9550
 - https://github.com/vitessio/vitess/pull/9634


## Checklist
- [x] Should this PR be backported? NO
- [x] Tests were added
- [x] Documentation PR: https://github.com/vitessio/website/pull/969