### PR TITLE
OnlineDDL: reject duplicate UUID with different migration_context

### DIFF
--- a/doc/releasenotes/10_0_4_release_notes.md
+++ b/doc/releasenotes/10_0_4_release_notes.md
@@ -15,8 +15,6 @@ This patch is providing an update regarding the Apache Log4j security vulnerabil
 ------------
 ## Changelog
 
-- `vtctl ApplySchema -uuid_list='...'` now rejects a migration if an existing migration has the same UUID but with different `migration_context`.
-
 ### Dependabot
 #### Java
 * build(deps): bump log4j-core from 2.15.0 to 2.16.0 in /java  #9394

--- a/doc/releasenotes/10_0_4_release_notes.md
+++ b/doc/releasenotes/10_0_4_release_notes.md
@@ -15,6 +15,8 @@ This patch is providing an update regarding the Apache Log4j security vulnerabil
 ------------
 ## Changelog
 
+- `vtctl ApplySchema -uuid_list='...'` now rejects a migration if an existing migration has the same UUID but with different `migration_context`.
+
 ### Dependabot
 #### Java
 * build(deps): bump log4j-core from 2.15.0 to 2.16.0 in /java  #9394

--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -1,0 +1,5 @@
+## Major Changes
+
+### Behavior changes
+
+- `vtctl ApplySchema -uuid_list='...'` now rejects a migration if an existing migration has the same UUID but with different `migration_context`.

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -246,15 +246,16 @@ func TestSchemaChange(t *testing.T) {
 	}
 
 	providedUUID := ""
+	providedMigrationContext := ""
 	testWithInitialSchema(t)
 	t.Run("alter non_online", func(t *testing.T) {
-		_ = testOnlineDDLStatement(t, alterTableNormalStatement, string(schema.DDLStrategyDirect), providedUUID, "vtctl", "non_online", false)
+		_ = testOnlineDDLStatement(t, alterTableNormalStatement, string(schema.DDLStrategyDirect), providedUUID, providedMigrationContext, "vtctl", "non_online", "", false)
 		insertRows(t, 2)
 		testRows(t)
 	})
 	t.Run("successful online alter, vtgate", func(t *testing.T) {
 		insertRows(t, 2)
-		uuid := testOnlineDDLStatement(t, alterTableSuccessfulStatement, "online", providedUUID, "vtgate", "vrepl_col", false)
+		uuid := testOnlineDDLStatement(t, alterTableSuccessfulStatement, "online", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		testRows(t)
 		testMigrationRowCount(t, uuid)
@@ -280,7 +281,7 @@ func TestSchemaChange(t *testing.T) {
 	})
 	t.Run("successful online alter, vtctl", func(t *testing.T) {
 		insertRows(t, 2)
-		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, "vtctl", "vrepl_col", false)
+		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, providedMigrationContext, "vtctl", "vrepl_col", "", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		testRows(t)
 		testMigrationRowCount(t, uuid)
@@ -291,8 +292,8 @@ func TestSchemaChange(t *testing.T) {
 	t.Run("successful online alter, vtctl, explicit UUID", func(t *testing.T) {
 		insertRows(t, 2)
 		providedUUID = "00000000_51c9_11ec_9cf2_0a43f95f28a3"
-		defer func() { providedUUID = "" }()
-		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, "vtctl", "vrepl_col", false)
+		providedMigrationContext = "endtoend:0000-1111"
+		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, providedMigrationContext, "vtctl", "vrepl_col", "", false)
 		assert.Equal(t, providedUUID, uuid)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		testRows(t)
@@ -301,9 +302,20 @@ func TestSchemaChange(t *testing.T) {
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckMigrationArtifacts(t, &vtParams, shards, uuid, true)
 	})
+	t.Run("duplicate migration, implicitly ignored", func(t *testing.T) {
+		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, providedMigrationContext, "vtctl", "vrepl_col", "", true)
+		assert.Equal(t, providedUUID, uuid)
+		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
+	})
+	t.Run("fail duplicate migration with different context", func(t *testing.T) {
+		_ = testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, "endtoend:different-context-0000", "vtctl", "vrepl_col", "rejected", true)
+	})
+	providedUUID = ""
+	providedMigrationContext = ""
+
 	t.Run("successful online alter, postponed, vtgate", func(t *testing.T) {
 		insertRows(t, 2)
-		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online -postpone-completion", providedUUID, "vtgate", "test_val", false)
+		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online -postpone-completion", providedUUID, providedMigrationContext, "vtgate", "test_val", "", false)
 		// Should be still running!
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning)
 		// Issue a complete and wait for successful completion
@@ -324,7 +336,7 @@ func TestSchemaChange(t *testing.T) {
 			throttleApp(shards[i].Vttablets[0], throttlerAppName)
 			defer unthrottleApp(shards[i].Vttablets[0], throttlerAppName)
 		}
-		uuid := testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, "vtgate", "vrepl_col", true)
+		uuid := testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", true)
 		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 20*time.Second, schema.OnlineDDLStatusRunning)
 		testRows(t)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, true)
@@ -341,7 +353,7 @@ func TestSchemaChange(t *testing.T) {
 
 			defer unthrottleApp(shards[i].Vttablets[0], throttlerAppName)
 		}
-		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, "vtgate", "test_val", true)
+		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, providedMigrationContext, "vtgate", "test_val", "", true)
 		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 20*time.Second, schema.OnlineDDLStatusRunning)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning)
 		testRows(t)
@@ -356,7 +368,7 @@ func TestSchemaChange(t *testing.T) {
 
 	t.Run("failed migration", func(t *testing.T) {
 		insertRows(t, 2)
-		uuid := testOnlineDDLStatement(t, alterTableFailedStatement, "online", providedUUID, "vtgate", "vrepl_col", false)
+		uuid := testOnlineDDLStatement(t, alterTableFailedStatement, "online", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusFailed)
 		testRows(t)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
@@ -383,7 +395,7 @@ func TestSchemaChange(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				_ = testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, "vtgate", "vrepl_col", false)
+				_ = testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", false)
 			}()
 		}
 		wg.Wait()
@@ -401,7 +413,7 @@ func TestSchemaChange(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				_ = testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, "vtgate", "vrepl_col", false)
+				_ = testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", false)
 			}()
 		}
 		wg.Wait()
@@ -433,7 +445,7 @@ func TestSchemaChange(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Contains(t, body, throttlerAppName)
 			}
-			uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, "vtgate", "test_val", true)
+			uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, providedMigrationContext, "vtgate", "test_val", "", true)
 
 			t.Run("wait for migration and vreplication to run", func(t *testing.T) {
 				_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 20*time.Second, schema.OnlineDDLStatusRunning)
@@ -516,19 +528,19 @@ func TestSchemaChange(t *testing.T) {
 		})
 	}
 	t.Run("Online DROP, vtctl", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, onlineDDLDropTableStatement, "online", providedUUID, "vtctl", "", false)
+		uuid := testOnlineDDLStatement(t, onlineDDLDropTableStatement, "online", providedUUID, providedMigrationContext, "vtctl", "", "", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)
 	})
 	t.Run("Online CREATE, vtctl", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, onlineDDLCreateTableStatement, "online", providedUUID, "vtctl", "online_ddl_create_col", false)
+		uuid := testOnlineDDLStatement(t, onlineDDLCreateTableStatement, "online", providedUUID, providedMigrationContext, "vtctl", "online_ddl_create_col", "", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)
 	})
 	t.Run("Online DROP TABLE IF EXISTS, vtgate", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, onlineDDLDropTableIfExistsStatement, "online", providedUUID, "vtgate", "", false)
+		uuid := testOnlineDDLStatement(t, onlineDDLDropTableIfExistsStatement, "online", providedUUID, providedMigrationContext, "vtgate", "", "", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)
@@ -536,7 +548,7 @@ func TestSchemaChange(t *testing.T) {
 		checkTables(t, schema.OnlineDDLToGCUUID(uuid), 1)
 	})
 	t.Run("Online DROP TABLE IF EXISTS for nonexistent table, vtgate", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, onlineDDLDropTableIfExistsStatement, "online", providedUUID, "vtgate", "", false)
+		uuid := testOnlineDDLStatement(t, onlineDDLDropTableIfExistsStatement, "online", providedUUID, providedMigrationContext, "vtgate", "", "", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)
@@ -544,7 +556,7 @@ func TestSchemaChange(t *testing.T) {
 		checkTables(t, schema.OnlineDDLToGCUUID(uuid), 0)
 	})
 	t.Run("Online DROP TABLE IF EXISTS for nonexistent table, postponed", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, onlineDDLDropTableIfExistsStatement, "online -postpone-completion", providedUUID, "vtgate", "", false)
+		uuid := testOnlineDDLStatement(t, onlineDDLDropTableIfExistsStatement, "online -postpone-completion", providedUUID, providedMigrationContext, "vtgate", "", "", false)
 		// Should be still queued, never promoted to 'ready'!
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusQueued)
 		// Issue a complete and wait for successful completion
@@ -559,13 +571,13 @@ func TestSchemaChange(t *testing.T) {
 		checkTables(t, schema.OnlineDDLToGCUUID(uuid), 0)
 	})
 	t.Run("Online DROP TABLE for nonexistent table, expect error, vtgate", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, onlineDDLDropTableStatement, "online", providedUUID, "vtgate", "", false)
+		uuid := testOnlineDDLStatement(t, onlineDDLDropTableStatement, "online", providedUUID, providedMigrationContext, "vtgate", "", "", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusFailed)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, true)
 	})
 	t.Run("Online CREATE, vtctl", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, onlineDDLCreateTableStatement, "online", providedUUID, "vtctl", "online_ddl_create_col", false)
+		uuid := testOnlineDDLStatement(t, onlineDDLCreateTableStatement, "online", providedUUID, providedMigrationContext, "vtctl", "online_ddl_create_col", "", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)
@@ -631,7 +643,7 @@ func testWithInitialSchema(t *testing.T) {
 }
 
 // testOnlineDDLStatement runs an online DDL, ALTER statement
-func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy string, providedUUIDList string, executeStrategy string, expectHint string, skipWait bool) (uuid string) {
+func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy string, providedUUIDList string, providedMigrationContext string, executeStrategy string, expectHint string, expectError string, skipWait bool) (uuid string) {
 	tableName := fmt.Sprintf("vt_onlineddl_test_%02d", 3)
 	sqlQuery := fmt.Sprintf(alterStatement, tableName)
 	if executeStrategy == "vtgate" {
@@ -640,9 +652,15 @@ func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy str
 			uuid = row.AsString("uuid", "")
 		}
 	} else {
-		var err error
-		uuid, err = clusterInstance.VtctlclientProcess.ApplySchemaWithOutput(keyspaceName, sqlQuery, cluster.VtctlClientParams{DDLStrategy: ddlStrategy, UUIDList: providedUUIDList})
-		assert.NoError(t, err)
+		params := cluster.VtctlClientParams{DDLStrategy: ddlStrategy, UUIDList: providedUUIDList, MigrationContext: providedMigrationContext}
+		output, err := clusterInstance.VtctlclientProcess.ApplySchemaWithOutput(keyspaceName, sqlQuery, params)
+		if expectError == "" {
+			assert.NoError(t, err)
+			uuid = output
+		} else {
+			assert.Error(t, err)
+			assert.Contains(t, output, expectError)
+		}
 	}
 	uuid = strings.TrimSpace(uuid)
 	fmt.Println("# Generated UUID (for debug purposes):")
@@ -659,7 +677,7 @@ func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy str
 		fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 	}
 
-	if expectHint != "" {
+	if expectError == "" && expectHint != "" {
 		checkMigratedTable(t, tableName, expectHint)
 	}
 	return uuid


### PR DESCRIPTION
## Description

Followup to https://github.com/vitessio/vitess/pull/9325. In this PR we reject a migration if submitted with same UUID and different `migration_context`.

As reminder, the user is allowed to supply their own migration UUIDs via `vtctl ApplySchema -uuid_list='...'`. This functionality is used to allow the user control and idempotency over their migrations.

UUID is a unique migration identifier. It is impossible to have any two migrations on same shard with same UUID. Hence, when one submits `-uuid_list=...` with an already existing UUID, their submission does not create a new migration. However, it is then also reasonable to expect that the user provides `-migration_context`. If the same migration is submitted twice or more, with same UUID and same `migration_context`, that is fine. The newer submissions are silently ignored, and this is a desired behavior that allows idempotency.

However, if the new submission uses a different `migration_context` (either because the user has specified one, that is different from the original one; or the user has specified none at all, in which case `vtctl` generates a random, unique value), then we consider this as an unintentional duplication, and as of this PR we return an error.

Here is a valid resubmission:

```shell
$ vtctlclient ApplySchema -skip_preflight -ddl_strategy='online' -migration_context="1222-2342342-423423-42" -uuid_list="4b25f49c_8709_11ec_9f54_0a43f95f28a5" -sql "alter table customer engine=innodb" commerce
4b25f49c_8709_11ec_9f54_0a43f95f28a5
$ vtctlclient ApplySchema -skip_preflight -ddl_strategy='online' -migration_context="1222-2342342-423423-42" -uuid_list="4b25f49c_8709_11ec_9f54_0a43f95f28a5" -sql "alter table customer engine=innodb" commerce
4b25f49c_8709_11ec_9f54_0a43f95f28a5
```

Here is an invalid one:
```shell
$ vtctlclient ApplySchema -skip_preflight -ddl_strategy='online' -uuid_list="4b25f49c_8709_11ec_9f54_0a43f95f28a6" -sql "alter table customer engine=innodb" commerce
4b25f49c_8709_11ec_9f54_0a43f95f28a6
$ vtctlclient ApplySchema -skip_preflight -ddl_strategy='online' -uuid_list="4b25f49c_8709_11ec_9f54_0a43f95f28a6" -sql "alter table customer engine=innodb" commerce
E0206 04:59:15.849989  800011 main.go:67] E0206 04:59:15.849210 vtctl.go:3282] schema change failed, ExecuteResult: {
  "FailedShards": [
    {
      "Shard": "0",
      "Err": "rpc error: code = Unknown desc = TabletManager.ExecuteQuery on zone1-0000000100 error: rpc error: code = FailedPrecondition desc = migration rejected: found migration 4b25f49c_8709_11ec_9f54_0a43f95f28a6 with different context: vtctl:84ee1103-8709-11ec-9f54-0a43f95f28a3 than submmitted migration's context: vtctl:88a0f8b4-8709-11ec-9f54-0a43f95f28a3: rpc error: code = FailedPrecondition desc = migration rejected: found migration 4b25f49c_8709_11ec_9f54_0a43f95f28a6 with different context: vtctl:84ee1103-8709-11ec-9f54-0a43f95f28a3 than submmitted migration's context: vtctl:88a0f8b4-8709-11ec-9f54-0a43f95f28a3"
    }
  ],
...
```

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/9325
- #6926 


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required


cc @dbussink @fatih @mavenraven 