### PR TITLE
OnlineDDL: delete _vt.vreplication entry as part of CLEANUP operation

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -616,17 +616,16 @@ func (e *Executor) terminateVReplMigration(ctx context.Context, uuid string) err
 	if err != nil {
 		return err
 	}
-	{
-		query, err := sqlparser.ParseAndBind(sqlStopVReplStream,
-			sqltypes.StringBindVariable(e.dbName),
-			sqltypes.StringBindVariable(uuid),
-		)
-		if err != nil {
-			return err
-		}
-		// silently skip error; stopping the stream is just a graceful act; later deleting it is more important
-		_, _ = tmClient.VReplicationExec(ctx, tablet.Tablet, query)
+	query, err := sqlparser.ParseAndBind(sqlStopVReplStream,
+		sqltypes.StringBindVariable(e.dbName),
+		sqltypes.StringBindVariable(uuid),
+	)
+	if err != nil {
+		return err
 	}
+	// silently skip error; stopping the stream is just a graceful act; later deleting it is more important
+	_, _ = tmClient.VReplicationExec(ctx, tablet.Tablet, query)
+
 	if err := e.deleteVReplicationEntry(ctx, uuid); err != nil {
 		return err
 	}
@@ -2817,7 +2816,7 @@ func (e *Executor) gcArtifacts(ctx context.Context) error {
 			}
 		}
 
-		// while the next fnuction only applies to 'online' strategy ALTER and REVERT, there is no
+		// while the next function only applies to 'online' strategy ALTER and REVERT, there is no
 		// harm in invoking it for other migrations.
 		if err := e.deleteVReplicationEntry(ctx, uuid); err != nil {
 			return err

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -627,18 +627,8 @@ func (e *Executor) terminateVReplMigration(ctx context.Context, uuid string) err
 		// silently skip error; stopping the stream is just a graceful act; later deleting it is more important
 		_, _ = tmClient.VReplicationExec(ctx, tablet.Tablet, query)
 	}
-	{
-		query, err := sqlparser.ParseAndBind(sqlDeleteVReplStream,
-			sqltypes.StringBindVariable(e.dbName),
-			sqltypes.StringBindVariable(uuid),
-		)
-		if err != nil {
-			return err
-		}
-		// silently skip error; stopping the stream is just a graceful act; later deleting it is more important
-		if _, err := tmClient.VReplicationExec(ctx, tablet.Tablet, query); err != nil {
-			return err
-		}
+	if err := e.deleteVReplicationEntry(ctx, uuid); err != nil {
+		return err
 	}
 	return nil
 }
@@ -2734,6 +2724,28 @@ func (e *Executor) retryTabletFailureMigrations(ctx context.Context) error {
 	return err
 }
 
+// deleteVReplicationEntry cleans up a _vt.vreplication entry; this function is called as part of
+// migration termination and as part of artifact cleanup
+func (e *Executor) deleteVReplicationEntry(ctx context.Context, uuid string) error {
+	query, err := sqlparser.ParseAndBind(sqlDeleteVReplStream,
+		sqltypes.StringBindVariable(e.dbName),
+		sqltypes.StringBindVariable(uuid),
+	)
+	if err != nil {
+		return err
+	}
+	tmClient := tmclient.NewTabletManagerClient()
+	tablet, err := e.ts.GetTablet(ctx, e.tabletAlias)
+	if err != nil {
+		return err
+	}
+
+	if _, err := tmClient.VReplicationExec(ctx, tablet.Tablet, query); err != nil {
+		return err
+	}
+	return nil
+}
+
 // gcArtifactTable garbage-collects a single table
 func (e *Executor) gcArtifactTable(ctx context.Context, artifactTable, uuid string, t time.Time) error {
 	tableExists, err := e.tableExists(ctx, artifactTable)
@@ -2804,6 +2816,13 @@ func (e *Executor) gcArtifacts(ctx context.Context) error {
 				return err
 			}
 		}
+
+		// while the next fnuction only applies to 'online' strategy ALTER and REVERT, there is no
+		// harm in invoking it for other migrations.
+		if err := e.deleteVReplicationEntry(ctx, uuid); err != nil {
+			return err
+		}
+
 		if err := e.updateMigrationTimestamp(ctx, "cleanup_timestamp", uuid); err != nil {
 			return err
 		}


### PR DESCRIPTION

## Description

Migration cleanup happens either on:

- explicit `ALTER VITESS_MIGRATION ... CLEANUP` query
- automated migration garbage collection

In either case, migration cleanup now also makes sure to delete any associated `vreplication` workflow used by the migration. There can only be one such workflow, and one exists when the migration is `ALTER` or an `ALTER`'s `REVERT` with 'online' strategy.

## Related Issue(s)

- Tracking: #6926 


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

cc @aquarapid 