### PR TITLE
Check for proto drift in the CI

### DIFF
--- a/.github/workflows/check_make_proto.yml
+++ b/.github/workflows/check_make_proto.yml
@@ -1,0 +1,37 @@
+name: check_make_proto
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Check Make Proto
+    runs-on: ubuntu-latest
+    steps:
+    
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Tune the OS
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y make unzip g++ etcd curl git wget
+        sudo service etcd stop
+        go mod download
+        go install golang.org/x/tools/cmd/goimports@latest
+
+    - name: Run make minimaltools
+      run: |
+        make minimaltools
+
+    - name: check_make_proto
+      run: |
+        tools/check_make_proto.sh
+

--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -639,14 +639,13 @@ func (ExecuteOptions_TransactionIsolation) EnumDescriptor() ([]byte, []int) {
 type ExecuteOptions_PlannerVersion int32
 
 const (
-	ExecuteOptions_DEFAULT_PLANNER   ExecuteOptions_PlannerVersion = 0
-	ExecuteOptions_V3                ExecuteOptions_PlannerVersion = 1
-	ExecuteOptions_Gen4              ExecuteOptions_PlannerVersion = 2
-	ExecuteOptions_Gen4Greedy        ExecuteOptions_PlannerVersion = 3
-	ExecuteOptions_Gen4Left2Right    ExecuteOptions_PlannerVersion = 4
-	ExecuteOptions_Gen4WithFallback  ExecuteOptions_PlannerVersion = 5
-	ExecuteOptions_Gen4CompareV3     ExecuteOptions_PlannerVersion = 6
-	ExecuteOptions_Gen4CompareV3Test ExecuteOptions_PlannerVersion = 7
+	ExecuteOptions_DEFAULT_PLANNER  ExecuteOptions_PlannerVersion = 0
+	ExecuteOptions_V3               ExecuteOptions_PlannerVersion = 1
+	ExecuteOptions_Gen4             ExecuteOptions_PlannerVersion = 2
+	ExecuteOptions_Gen4Greedy       ExecuteOptions_PlannerVersion = 3
+	ExecuteOptions_Gen4Left2Right   ExecuteOptions_PlannerVersion = 4
+	ExecuteOptions_Gen4WithFallback ExecuteOptions_PlannerVersion = 5
+	ExecuteOptions_Gen4CompareV3    ExecuteOptions_PlannerVersion = 6
 )
 
 // Enum value maps for ExecuteOptions_PlannerVersion.
@@ -659,17 +658,15 @@ var (
 		4: "Gen4Left2Right",
 		5: "Gen4WithFallback",
 		6: "Gen4CompareV3",
-		7: "Gen4CompareV3Test",
 	}
 	ExecuteOptions_PlannerVersion_value = map[string]int32{
-		"DEFAULT_PLANNER":   0,
-		"V3":                1,
-		"Gen4":              2,
-		"Gen4Greedy":        3,
-		"Gen4Left2Right":    4,
-		"Gen4WithFallback":  5,
-		"Gen4CompareV3":     6,
-		"Gen4CompareV3Test": 7,
+		"DEFAULT_PLANNER":  0,
+		"V3":               1,
+		"Gen4":             2,
+		"Gen4Greedy":       3,
+		"Gen4Left2Right":   4,
+		"Gen4WithFallback": 5,
+		"Gen4CompareV3":    6,
 	}
 )
 

--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -639,13 +639,14 @@ func (ExecuteOptions_TransactionIsolation) EnumDescriptor() ([]byte, []int) {
 type ExecuteOptions_PlannerVersion int32
 
 const (
-	ExecuteOptions_DEFAULT_PLANNER  ExecuteOptions_PlannerVersion = 0
-	ExecuteOptions_V3               ExecuteOptions_PlannerVersion = 1
-	ExecuteOptions_Gen4             ExecuteOptions_PlannerVersion = 2
-	ExecuteOptions_Gen4Greedy       ExecuteOptions_PlannerVersion = 3
-	ExecuteOptions_Gen4Left2Right   ExecuteOptions_PlannerVersion = 4
-	ExecuteOptions_Gen4WithFallback ExecuteOptions_PlannerVersion = 5
-	ExecuteOptions_Gen4CompareV3    ExecuteOptions_PlannerVersion = 6
+	ExecuteOptions_DEFAULT_PLANNER   ExecuteOptions_PlannerVersion = 0
+	ExecuteOptions_V3                ExecuteOptions_PlannerVersion = 1
+	ExecuteOptions_Gen4              ExecuteOptions_PlannerVersion = 2
+	ExecuteOptions_Gen4Greedy        ExecuteOptions_PlannerVersion = 3
+	ExecuteOptions_Gen4Left2Right    ExecuteOptions_PlannerVersion = 4
+	ExecuteOptions_Gen4WithFallback  ExecuteOptions_PlannerVersion = 5
+	ExecuteOptions_Gen4CompareV3     ExecuteOptions_PlannerVersion = 6
+	ExecuteOptions_Gen4CompareV3Test ExecuteOptions_PlannerVersion = 7
 )
 
 // Enum value maps for ExecuteOptions_PlannerVersion.
@@ -658,15 +659,17 @@ var (
 		4: "Gen4Left2Right",
 		5: "Gen4WithFallback",
 		6: "Gen4CompareV3",
+		7: "Gen4CompareV3Test",
 	}
 	ExecuteOptions_PlannerVersion_value = map[string]int32{
-		"DEFAULT_PLANNER":  0,
-		"V3":               1,
-		"Gen4":             2,
-		"Gen4Greedy":       3,
-		"Gen4Left2Right":   4,
-		"Gen4WithFallback": 5,
-		"Gen4CompareV3":    6,
+		"DEFAULT_PLANNER":   0,
+		"V3":                1,
+		"Gen4":              2,
+		"Gen4Greedy":        3,
+		"Gen4Left2Right":    4,
+		"Gen4WithFallback":  5,
+		"Gen4CompareV3":     6,
+		"Gen4CompareV3Test": 7,
 	}
 )
 

--- a/tools/check_make_proto.sh
+++ b/tools/check_make_proto.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source build.env
+
+first_output=$(git status --porcelain)
+
+make proto
+
+second_output=$(git status --porcelain)
+
+diff=$(diff <( echo "$first_output") <( echo "$second_output"))
+
+if [[ "$diff" != "" ]]; then
+  echo "ERROR: Regenerated proto files do not match the current version."
+  echo -e "List of files containing differences:\n$diff"
+  exit 1
+fi


### PR DESCRIPTION
## Description

This pull request adds the `check_make_proto` workflow to the CI. The workflow checks that the `go/vt/proto/*.pb.go` files are in accordance with the `proto/*.proto` files. This is done by running the `make proto` command and diffing `git status`'s output before and after executing the `make proto`.

If there is a diff (a drift), the workflow lists the files that are not in accordance. A commit that exhibits this behavior can be found [here](https://github.com/vitessio/vitess/pull/9644/commits/a96bb3350591db945bdea182e5cb2f1e7159de47), with its failing `check_make_proto` workflow [here](https://github.com/vitessio/vitess/runs/5095360428?check_suite_focus=true).

## Related Issue(s)

- Solves #9588 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

