### PR TITLE
[backport] Extract collation data to enable distinct aggregation

### DIFF
--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -1084,6 +1084,7 @@ func TestOrderedAggregateCollate(t *testing.T) {
 		}},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
 		Input:       fp,
+		Collations:  map[int]collations.ID{0: collationID},
 	}
 
 	result, err := oa.TryExecute(&noopVCursor{}, nil, false)
@@ -1125,6 +1126,7 @@ func TestOrderedAggregateCollateAS(t *testing.T) {
 			Col:    1,
 		}},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
+		Collations:  map[int]collations.ID{0: collationID},
 		Input:       fp,
 	}
 
@@ -1169,6 +1171,7 @@ func TestOrderedAggregateCollateKS(t *testing.T) {
 			Col:    1,
 		}},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
+		Collations:  map[int]collations.ID{0: collationID},
 		Input:       fp,
 	}
 

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"vitess.io/vitess/go/mysql/collations"
+
 	"vitess.io/vitess/go/sqltypes"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -333,6 +335,18 @@ func (oa *orderedAggregate) Wireup(plan logicalPlan, jt *jointab) error {
 }
 
 func (oa *orderedAggregate) WireupGen4(semTable *semantics.SemTable) error {
+	colls := map[int]collations.ID{}
+	oa.eaggr.Collations = colls
+	for _, key := range oa.eaggr.Aggregates {
+		if key.CollationID != collations.Unknown {
+			colls[key.KeyCol] = key.CollationID
+		}
+	}
+	for _, key := range oa.eaggr.GroupByKeys {
+		if key.CollationID != collations.Unknown {
+			colls[key.KeyCol] = key.CollationID
+		}
+	}
 	return oa.input.WireupGen4(semTable)
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -134,7 +134,7 @@ Gen4 plan same as above
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
     "Aggregates": "count(0) AS count(*)",
-    "GroupBy": "(1|4), (2|5), (3|6)",
+    "GroupBy": "(1|4), (2|5) COLLATE latin1_swedish_ci, (3|6)",
     "ResultColumns": 4,
     "Inputs": [
       {
@@ -253,7 +253,7 @@ Gen4 plan same as above
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "count(0) AS k",
-        "GroupBy": "(1|4), (2|5), (3|6)",
+        "GroupBy": "(1|4), (2|5) COLLATE latin1_swedish_ci, (3|6)",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3059,6 +3059,59 @@ Gen4 plan same as above
             ]
           }
         ]
+      }
+    ]
+  }
+}
+
+# distinct on text column with collation
+"select col, count(distinct textcol1) from user group by col"
+{
+  "QueryType": "SELECT",
+  "Original": "select col, count(distinct textcol1) from user group by col",
+  "Instructions": {
+    "OperatorType": "Aggregate",
+    "Variant": "Ordered",
+    "Aggregates": "count_distinct(1) AS count(distinct textcol1)",
+    "GroupBy": "0",
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select col, textcol1, weight_string(textcol1) from `user` where 1 != 1 group by col, textcol1, weight_string(textcol1)",
+        "OrderBy": "0 ASC, (1|2) ASC",
+        "Query": "select col, textcol1, weight_string(textcol1) from `user` group by col, textcol1, weight_string(textcol1) order by col asc, textcol1 asc",
+        "ResultColumns": 2,
+        "Table": "`user`"
+      }
+    ]
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select col, count(distinct textcol1) from user group by col",
+  "Instructions": {
+    "OperatorType": "Aggregate",
+    "Variant": "Ordered",
+    "Aggregates": "count_distinct(1|2 COLLATE latin1_swedish_ci) AS count(distinct textcol1)",
+    "GroupBy": "0",
+    "ResultColumns": 2,
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select col, textcol1, weight_string(textcol1) from `user` where 1 != 1 group by col, textcol1, weight_string(textcol1)",
+        "OrderBy": "0 ASC, (1|2) ASC COLLATE latin1_swedish_ci",
+        "Query": "select col, textcol1, weight_string(textcol1) from `user` group by col, textcol1, weight_string(textcol1) order by col asc, textcol1 asc",
+        "Table": "`user`"
       }
     ]
   }

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
@@ -241,7 +241,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "count(1) AS k",
-        "GroupBy": "(2|3)",
+        "GroupBy": "(2|3) COLLATE latin1_swedish_ci",
         "Inputs": [
           {
             "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/oltp_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/oltp_cases.txt
@@ -157,7 +157,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "GroupBy": "(0|1)",
+    "GroupBy": "(0|1) COLLATE latin1_swedish_ci",
     "ResultColumns": 1,
     "Inputs": [
       {


### PR DESCRIPTION
## Description
While working on something related, we realized that collations were not being handled correctly on distinct aggregations.

This is a backport of #9639 

Example:

```sql
select foo, count(distinct bar) from tbl group by foo
```

For this query, if `bar` is a text column, we need to store collation information in the plan. Added this information to the plan description to make it easy to test.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
