### PR TITLE
v13 BACKPORT: OnlineDDL: 'vitess' strategy, synonym for 'online'

### DIFF
--- a/doc/releasenotes/13_0_0_release_notes.md
+++ b/doc/releasenotes/13_0_0_release_notes.md
@@ -51,6 +51,14 @@ Behavior of migrations with this flag:
 - an `ALTER` table begins, runs, but does not cut-over.
 - `CREATE` or `DROP` migrations are silently not even scheduled
 
+### ddl_strategy: 'vitess' strategy, synonym to 'online'
+
+`online` strategy is renamed to `vitess`. Both work identically, and going forward `vitess` will be the preferred term. Future versions will implicitly convert `online` to `vitess` and eventually deprecate `online`. Example:
+
+```shell
+$ vtctl ApplySchema -skip_preflight -ddl_strategy='vitess' -sql "alter table example drop column c" commerce
+```
+
 ### alter vitess_migration ... cleanup
 
 A new query is supported:

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -292,7 +292,7 @@ func TestSchemaChange(t *testing.T) {
 		insertRows(t, 2)
 		providedUUID = "00000000_51c9_11ec_9cf2_0a43f95f28a3"
 		defer func() { providedUUID = "" }()
-		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, "vtctl", "vrepl_col", false)
+		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "vitess", providedUUID, "vtctl", "vrepl_col", false)
 		assert.Equal(t, providedUUID, uuid)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		testRows(t)
@@ -303,7 +303,7 @@ func TestSchemaChange(t *testing.T) {
 	})
 	t.Run("successful online alter, postponed, vtgate", func(t *testing.T) {
 		insertRows(t, 2)
-		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online -postpone-completion", providedUUID, "vtgate", "test_val", false)
+		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "vitess -postpone-completion", providedUUID, "vtgate", "test_val", false)
 		// Should be still running!
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning)
 		// Issue a complete and wait for successful completion
@@ -341,7 +341,7 @@ func TestSchemaChange(t *testing.T) {
 
 			defer unthrottleApp(shards[i].Vttablets[0], throttlerAppName)
 		}
-		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, "vtgate", "test_val", true)
+		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "vitess", providedUUID, "vtgate", "test_val", true)
 		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 20*time.Second, schema.OnlineDDLStatusRunning)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning)
 		testRows(t)
@@ -383,7 +383,7 @@ func TestSchemaChange(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				_ = testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, "vtgate", "vrepl_col", false)
+				_ = testOnlineDDLStatement(t, alterTableThrottlingStatement, "vitess", providedUUID, "vtgate", "vrepl_col", false)
 			}()
 		}
 		wg.Wait()
@@ -433,7 +433,7 @@ func TestSchemaChange(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Contains(t, body, throttlerAppName)
 			}
-			uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, "vtgate", "test_val", true)
+			uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "vitess", providedUUID, "vtgate", "test_val", true)
 
 			t.Run("wait for migration and vreplication to run", func(t *testing.T) {
 				_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 20*time.Second, schema.OnlineDDLStatusRunning)
@@ -522,7 +522,7 @@ func TestSchemaChange(t *testing.T) {
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)
 	})
 	t.Run("Online CREATE, vtctl", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, onlineDDLCreateTableStatement, "online", providedUUID, "vtctl", "online_ddl_create_col", false)
+		uuid := testOnlineDDLStatement(t, onlineDDLCreateTableStatement, "vitess", providedUUID, "vtctl", "online_ddl_create_col", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)
@@ -544,7 +544,7 @@ func TestSchemaChange(t *testing.T) {
 		checkTables(t, schema.OnlineDDLToGCUUID(uuid), 0)
 	})
 	t.Run("Online DROP TABLE IF EXISTS for nonexistent table, postponed", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, onlineDDLDropTableIfExistsStatement, "online -postpone-completion", providedUUID, "vtgate", "", false)
+		uuid := testOnlineDDLStatement(t, onlineDDLDropTableIfExistsStatement, "vitess -postpone-completion", providedUUID, "vtgate", "", false)
 		// Should be still queued, never promoted to 'ready'!
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusQueued)
 		// Issue a complete and wait for successful completion
@@ -565,7 +565,7 @@ func TestSchemaChange(t *testing.T) {
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, true)
 	})
 	t.Run("Online CREATE, vtctl", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, onlineDDLCreateTableStatement, "online", providedUUID, "vtctl", "online_ddl_create_col", false)
+		uuid := testOnlineDDLStatement(t, onlineDDLCreateTableStatement, "vitess", providedUUID, "vtctl", "online_ddl_create_col", false)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)

--- a/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
@@ -72,7 +72,7 @@ var (
 	evaluatedMysqlParams *mysql.ConnParams
 
 	directDDLStrategy     = "direct"
-	onlineDDLStrategy     = "online -vreplication-test-suite -skip-topo"
+	onlineDDLStrategy     = "vitess -vreplication-test-suite -skip-topo"
 	hostname              = "localhost"
 	keyspaceName          = "ks"
 	cell                  = "zone1"

--- a/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
@@ -43,7 +43,7 @@ var (
 	clusterInstance         *cluster.LocalProcessCluster
 	vtParams                mysql.ConnParams
 	evaluatedMysqlParams    *mysql.ConnParams
-	ddlStrategy             = "online -vreplication-test-suite"
+	ddlStrategy             = "vitess -vreplication-test-suite"
 	waitForMigrationTimeout = 20 * time.Second
 
 	hostname              = "localhost"

--- a/go/vt/schema/ddl_strategy.go
+++ b/go/vt/schema/ddl_strategy.go
@@ -44,6 +44,8 @@ type DDLStrategy string
 const (
 	// DDLStrategyDirect means not an online-ddl migration. Just a normal MySQL ALTER TABLE
 	DDLStrategyDirect DDLStrategy = "direct"
+	// DDLStrategyVitess requests vreplication to run the migration; new name for DDLStrategyOnline
+	DDLStrategyVitess DDLStrategy = "vitess"
 	// DDLStrategyOnline requests vreplication to run the migration
 	DDLStrategyOnline DDLStrategy = "online"
 	// DDLStrategyGhost requests gh-ost to run the migration
@@ -56,7 +58,7 @@ const (
 // A strategy is direct if it's not explciitly one of the online DDL strategies
 func (s DDLStrategy) IsDirect() bool {
 	switch s {
-	case DDLStrategyOnline, DDLStrategyGhost, DDLStrategyPTOSC:
+	case DDLStrategyVitess, DDLStrategyOnline, DDLStrategyGhost, DDLStrategyPTOSC:
 		return false
 	}
 	return true
@@ -88,7 +90,7 @@ func ParseDDLStrategy(strategyVariable string) (*DDLStrategySetting, error) {
 	switch strategy := DDLStrategy(strategyName); strategy {
 	case "": // backward compatiblity and to handle unspecified values
 		setting.Strategy = DDLStrategyDirect
-	case DDLStrategyOnline, DDLStrategyGhost, DDLStrategyPTOSC, DDLStrategyDirect:
+	case DDLStrategyVitess, DDLStrategyOnline, DDLStrategyGhost, DDLStrategyPTOSC, DDLStrategyDirect:
 		setting.Strategy = strategy
 	default:
 		return nil, fmt.Errorf("Unknown online DDL strategy: '%v'", strategy)

--- a/go/vt/schema/ddl_strategy_test.go
+++ b/go/vt/schema/ddl_strategy_test.go
@@ -25,10 +25,13 @@ import (
 
 func TestIsDirect(t *testing.T) {
 	assert.True(t, DDLStrategyDirect.IsDirect())
+	assert.False(t, DDLStrategyVitess.IsDirect())
 	assert.False(t, DDLStrategyOnline.IsDirect())
 	assert.False(t, DDLStrategyGhost.IsDirect())
 	assert.False(t, DDLStrategyPTOSC.IsDirect())
 	assert.True(t, DDLStrategy("").IsDirect())
+	assert.False(t, DDLStrategy("vitess").IsDirect())
+	assert.False(t, DDLStrategy("online").IsDirect())
 	assert.False(t, DDLStrategy("gh-ost").IsDirect())
 	assert.False(t, DDLStrategy("pt-osc").IsDirect())
 	assert.True(t, DDLStrategy("something").IsDirect())
@@ -49,6 +52,10 @@ func TestParseDDLStrategy(t *testing.T) {
 		{
 			strategyVariable: "direct",
 			strategy:         DDLStrategyDirect,
+		},
+		{
+			strategyVariable: "vitess",
+			strategy:         DDLStrategyVitess,
 		},
 		{
 			strategyVariable: "online",
@@ -103,6 +110,13 @@ func TestParseDDLStrategy(t *testing.T) {
 		{
 			strategyVariable:  "online -allow-concurrent",
 			strategy:          DDLStrategyOnline,
+			options:           "-allow-concurrent",
+			runtimeOptions:    "",
+			isAllowConcurrent: true,
+		},
+		{
+			strategyVariable:  "vitess -allow-concurrent",
+			strategy:          DDLStrategyVitess,
 			options:           "-allow-concurrent",
 			runtimeOptions:    "",
 			isAllowConcurrent: true,

--- a/go/vt/schema/online_ddl_test.go
+++ b/go/vt/schema/online_ddl_test.go
@@ -207,7 +207,7 @@ func TestNewOnlineDDL(t *testing.T) {
 	}
 	strategies := []*DDLStrategySetting{
 		NewDDLStrategySetting(DDLStrategyDirect, ""),
-		NewDDLStrategySetting(DDLStrategyOnline, ""),
+		NewDDLStrategySetting(DDLStrategyVitess, ""),
 		NewDDLStrategySetting(DDLStrategyOnline, "-singleton"),
 	}
 	require.True(t, strategies[0].IsSkipTopo())
@@ -238,18 +238,18 @@ func TestNewOnlineDDL(t *testing.T) {
 		var err error
 		var onlineDDL *OnlineDDL
 
-		onlineDDL, err = NewOnlineDDL("test_ks", "t", "alter table t engine=innodb", NewDDLStrategySetting(DDLStrategyOnline, ""), migrationContext, "")
+		onlineDDL, err = NewOnlineDDL("test_ks", "t", "alter table t engine=innodb", NewDDLStrategySetting(DDLStrategyVitess, ""), migrationContext, "")
 		assert.NoError(t, err)
 		assert.True(t, IsOnlineDDLUUID(onlineDDL.UUID))
 
 		_, err = NewOnlineDDL("test_ks", "t", "alter table t engine=innodb", NewDDLStrategySetting(DDLStrategyOnline, ""), migrationContext, "abc")
 		assert.Error(t, err)
 
-		onlineDDL, err = NewOnlineDDL("test_ks", "t", "alter table t engine=innodb", NewDDLStrategySetting(DDLStrategyOnline, ""), migrationContext, "4e5dcf80_354b_11eb_82cd_f875a4d24e90")
+		onlineDDL, err = NewOnlineDDL("test_ks", "t", "alter table t engine=innodb", NewDDLStrategySetting(DDLStrategyVitess, ""), migrationContext, "4e5dcf80_354b_11eb_82cd_f875a4d24e90")
 		assert.NoError(t, err)
 		assert.Equal(t, "4e5dcf80_354b_11eb_82cd_f875a4d24e90", onlineDDL.UUID)
 
-		_, err = NewOnlineDDL("test_ks", "t", "alter table t engine=innodb", NewDDLStrategySetting(DDLStrategyOnline, ""), migrationContext, " 4e5dcf80_354b_11eb_82cd_f875a4d24e90")
+		_, err = NewOnlineDDL("test_ks", "t", "alter table t engine=innodb", NewDDLStrategySetting(DDLStrategyVitess, ""), migrationContext, " 4e5dcf80_354b_11eb_82cd_f875a4d24e90")
 		assert.Error(t, err)
 	})
 }
@@ -301,7 +301,7 @@ func TestNewOnlineDDLs(t *testing.T) {
 			}
 			assert.True(t, ok)
 
-			onlineDDLs, err := NewOnlineDDLs("test_ks", query, ddlStmt, NewDDLStrategySetting(DDLStrategyOnline, ""), migrationContext, "")
+			onlineDDLs, err := NewOnlineDDLs("test_ks", query, ddlStmt, NewDDLStrategySetting(DDLStrategyVitess, ""), migrationContext, "")
 			if expect.isError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), expect.expectErrorText)

--- a/go/vt/schemamanager/tablet_executor_test.go
+++ b/go/vt/schemamanager/tablet_executor_test.go
@@ -243,6 +243,12 @@ func TestIsOnlineSchemaDDL(t *testing.T) {
 		},
 		{
 			query:       "ALTER TABLE t ADD COLUMN i INT",
+			ddlStrategy: "vitess",
+			isOnlineDDL: true,
+			strategy:    schema.DDLStrategyVitess,
+		},
+		{
+			query:       "ALTER TABLE t ADD COLUMN i INT",
 			ddlStrategy: "",
 			isOnlineDDL: false,
 		},

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1514,7 +1514,7 @@ func (e *Executor) terminateMigration(ctx context.Context, onlineDDL *schema.Onl
 	defer e.ownedRunningMigrations.Delete(onlineDDL.UUID)
 
 	switch onlineDDL.Strategy {
-	case schema.DDLStrategyOnline:
+	case schema.DDLStrategyOnline, schema.DDLStrategyVitess:
 		// migration could have started by a different tablet. We need to actively verify if it is running
 		foundRunning, _, _ = e.isVReplMigrationRunning(ctx, onlineDDL.UUID)
 		if err := e.terminateVReplMigration(ctx, onlineDDL.UUID); err != nil {
@@ -1723,7 +1723,7 @@ func (e *Executor) validateMigrationRevertible(ctx context.Context, revertMigrat
 	}
 	switch action {
 	case sqlparser.AlterDDLAction:
-		if revertMigration.Strategy != schema.DDLStrategyOnline {
+		if revertMigration.Strategy != schema.DDLStrategyOnline && revertMigration.Strategy != schema.DDLStrategyVitess {
 			return fmt.Errorf("can only revert a %s strategy migration. Migration %s has %s strategy", schema.DDLStrategyOnline, revertMigration.UUID, revertMigration.Strategy)
 		}
 	case sqlparser.RevertDDLAction:
@@ -2248,7 +2248,7 @@ func (e *Executor) executeMigration(ctx context.Context, onlineDDL *schema.Onlin
 		}()
 	case sqlparser.AlterDDLAction:
 		switch onlineDDL.Strategy {
-		case schema.DDLStrategyOnline:
+		case schema.DDLStrategyOnline, schema.DDLStrategyVitess:
 			go func() {
 				e.migrationMutex.Lock()
 				defer e.migrationMutex.Unlock()
@@ -2563,7 +2563,7 @@ func (e *Executor) reviewRunningMigrations(ctx context.Context) (countRunnning i
 		uuidsFoundRunning[uuid] = true
 
 		switch onlineDDL.StrategySetting().Strategy {
-		case schema.DDLStrategyOnline:
+		case schema.DDLStrategyOnline, schema.DDLStrategyVitess:
 			{
 				// We check the _vt.vreplication table
 				running, s, err := e.isVReplMigrationRunning(ctx, uuid)


### PR DESCRIPTION
**BACKPORT** of https://github.com/vitessio/vitess/pull/9642

## Description

Naming is hard, and the `online` ddl-strategy was created in the hope/intention that it becomes the one and only (or the default) strategy. This takes longer than hoped for, and the term "online" is confusing.

This PR introduces a `vitess` strategy. It is identical in all functionality to `online`: `vitess` is an online (see the confusion?) strategy that uses VReplication as the underlying backend for `ALTER TABLE` operations; just like `online` strategy.

At this time, the two strategies `vitess` and `online` co-exist side by side. For backwards compatibility, we do not modify one into another at this time. At some point in the future we will implicitly change any `online` strategy into `vitess`. But we're not there yet.

In the meantime, we will start using `vitess` as the preferred strategy in documentation.

Tests are updated to use `vitess` strategy in most cases, but we leave `online` in some cases to validate that both are supported.

## Related Issue(s)

- tracking: #6926 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

cc @deepthi @rbranson 