### PR TITLE
Strip database qualifier from VIEW definitions in GetSchema

### DIFF
--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -25,11 +25,17 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	getSchemaT1Results = "CREATE TABLE `t1` (\n  `id` bigint(20) NOT NULL,\n  `value` varchar(16) DEFAULT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8"
+	getSchemaV1Results = fmt.Sprintf("CREATE ALGORITHM=UNDEFINED DEFINER=`%s`@`%s` SQL SECURITY DEFINER VIEW `v1` AS select `t1`.`id` AS `id`,`t1`.`value` AS `value` from `t1`", username, hostname)
 )
 
 // TabletCommands tests the basic tablet commands
@@ -222,6 +228,20 @@ func TestShardReplicationFix(t *testing.T) {
 	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("GetShardReplication", cell, keyspaceShard)
 	require.Nil(t, err, "error should be Nil")
 	assertNodeCount(t, result, int(3))
+}
+
+func TestGetSchema(t *testing.T) {
+	defer cluster.PanicHandler(t)
+
+	res, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("GetSchema",
+		"-include-views", "-tables", "t1,v1",
+		fmt.Sprintf("%s-%d", clusterInstance.Cell, primaryTablet.TabletUID))
+	require.Nil(t, err)
+
+	t1Create := gjson.Get(res, "table_definitions.0.schema")
+	assert.Equal(t, getSchemaT1Results, t1Create.String())
+	v1Create := gjson.Get(res, "table_definitions.1.schema")
+	assert.Equal(t, getSchemaV1Results, v1Create.String())
 }
 
 func assertNodeCount(t *testing.T, result string, want int) {

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -56,7 +56,8 @@ var (
 		id bigint,
 		value varchar(16),
 		primary key(id)
-	) Engine=InnoDB;
+	) Engine=InnoDB DEFAULT CHARSET=utf8;
+	CREATE VIEW v1 AS SELECT id, value FROM t1;
 `
 
 	vSchema = `

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -244,9 +244,11 @@ func (mysqld *Mysqld) normalizedSchema(ctx context.Context, dbName, tableName, t
 	norm := qr.Rows[0][1].ToString()
 	norm = autoIncr.ReplaceAllLiteralString(norm, "")
 	if tableType == tmutils.TableView {
-		// Views will have the dbname in there, replace it
-		// with {{.DatabaseName}}
-		norm = strings.Replace(norm, backtickDBName, "{{.DatabaseName}}", -1)
+		// Views will have the dbname qualifier in there, we remove it
+		// so that the results for Views match:
+		//   1. The SHOW CREATE VIEW output from MySQL
+		//   2. The CREATE TABLE output in these results, which does not have the DB name qualifier
+		norm = strings.Replace(norm, backtickDBName+".", "", -1)
 	}
 
 	return norm, nil


### PR DESCRIPTION
## Description
The [TabletManager `GetSchema` RPC call](https://github.com/vitessio/vitess/blob/2a4550de4652bb2f8e4a1b81b4a9a7b15976e19f/go/vt/vttablet/tabletmanager/rpc_schema.go#L32-L35) results for SQL Views have the database name replaced by the template notation `{{.DatabaseName}}` when what we should do instead is remove the database name qualifier so that `CREATE VIEW` clauses match `CREATE TABLE` clauses in the results — meaning that they do not have the database name qualifier.
> The difference in the  base output coming from MySQL is due to the difference between what's shown in the `SHOW CREATE VIEW` output and what's in `information_schema.views`.

<details>
<summary>You can see a demonstration here...</summary>

### Here's the basic structures created and viewed from a `vtgate`:
```
mysql> create table t1 (id int)
Query OK, 0 rows affected (0.01 sec)

mysql> create view v1 as select id from t1;
Query OK, 0 rows affected (0.01 sec)

mysql> show create table t1\G
*************************** 1. row ***************************
       Table: t1
Create Table: CREATE TABLE `t1` (
  `id` int DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
1 row in set (0.00 sec)

mysql> show create view v1\G
*************************** 1. row ***************************
                View: v1
         Create View: CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v1` AS select `t1`.`id` AS `id` from `t1`
character_set_client: utf8mb4
collation_connection: utf8mb4_0900_ai_ci
1 row in set (0.00 sec)

mysql> select * from information_schema.views where table_name="v1"\G
*************************** 1. row ***************************
       TABLE_CATALOG: def
        TABLE_SCHEMA: vt_customer
          TABLE_NAME: v1
     VIEW_DEFINITION: select `vt_customer`.`t1`.`id` AS `id` from `vt_customer`.`t1`
        CHECK_OPTION: NONE
        IS_UPDATABLE: YES
             DEFINER: vt_app@localhost
       SECURITY_TYPE: DEFINER
CHARACTER_SET_CLIENT: utf8
COLLATION_CONNECTION: utf8_general_ci
1 row in set (0.00 sec)
```

### Here's what we see in the Vitess schema:
**Before:**
```
$ vtctlclient GetSchema -include-views=true -tables "t1,v1" zone1-200 | jq -r '.table_definitions[].schema'
CREATE TABLE `t1` (
  `id` int(11) DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8
CREATE ALGORITHM=UNDEFINED DEFINER=`vt_app`@`localhost` SQL SECURITY DEFINER VIEW {{.DatabaseName}}.`v1` AS select {{.DatabaseName}}.`t1`.`id` AS `id` from {{.DatabaseName}}.`t1`
```

**After:**
```
$ vtctlclient GetSchema -include-views=true -tables "t1,v1" zone1-200 | jq -r '.table_definitions[].schema'
CREATE TABLE `t1` (
  `id` int(11) DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8
CREATE ALGORITHM=UNDEFINED DEFINER=`vt_app`@`localhost` SQL SECURITY DEFINER VIEW `v1` AS select `t1`.`id` AS `id` from `t1`
```
</details>

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? NO
- [x] Test was added
- [x] Documentation is not required