### PR TITLE
Add e2e test for the TabletManager GetSchema RPC

### DIFF
--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -56,7 +56,8 @@ var (
 		id bigint,
 		value varchar(16),
 		primary key(id)
-	) Engine=InnoDB;
+	) Engine=InnoDB DEFAULT CHARSET=utf8;
+	CREATE VIEW v1 AS SELECT id, value FROM t1;
 `
 
 	vSchema = `


### PR DESCRIPTION
## Description
While working on [something else](https://github.com/vitessio/vitess/pull/9655) (which will be closed, [see here](https://github.com/vitessio/vitess/pull/9655#issuecomment-1033903896) for why), I was surprised to see that we have 0 tests (unit or e2e) for the [TabletManager's `GetSchema` RPC call](https://github.com/vitessio/vitess/blob/2a4550de4652bb2f8e4a1b81b4a9a7b15976e19f/go/vt/proto/tabletmanagerservice/tabletmanagerservice_grpc.pb.go#L148-L155). 

> It is tested indirectly through `MoveTables` and `Reshard` workflow related tests.

This PR adds a dedicated e2e test for it.

## Related Issue(s)
 - https://github.com/vitessio/vitess/pull/9655

## Checklist
- [x] Should this PR be backported? NO
- [x] Tests were added
- [x] Documentation is not required