### PR TITLE
Gen4: make sure to not merge unsharded tables from different keyspaces

### DIFF
--- a/go/vt/vtgate/planbuilder/physical/route_planning.go
+++ b/go/vt/vtgate/planbuilder/physical/route_planning.go
@@ -470,7 +470,7 @@ func tryMerge(
 
 	switch aRoute.RouteOpCode {
 	case engine.Unsharded, engine.DBA:
-		if aRoute.RouteOpCode == bRoute.RouteOpCode {
+		if aRoute.RouteOpCode == bRoute.RouteOpCode && sameKeyspace {
 			return merger(aRoute, bRoute)
 		}
 	case engine.EqualUnique:

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -4532,3 +4532,41 @@ Gen4 plan same as above
     ]
   }
 }
+
+# dont merge unsharded tables from different keyspaces
+"select 1 from main.unsharded join main_2.unsharded_tab"
+{
+  "QueryType": "SELECT",
+  "Original": "select 1 from main.unsharded join main_2.unsharded_tab",
+  "Instructions": {
+    "OperatorType": "Join",
+    "Variant": "Join",
+    "JoinColumnIndexes": "-1",
+    "TableName": "unsharded_unsharded_tab",
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 from unsharded where 1 != 1",
+        "Query": "select 1 from unsharded",
+        "Table": "unsharded"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main_2",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 from unsharded_tab where 1 != 1",
+        "Query": "select 1 from unsharded_tab",
+        "Table": "unsharded_tab"
+      }
+    ]
+  }
+}
+Gen4 plan same as above


### PR DESCRIPTION
## Description
Gen4 was not checking if two tables on unsharded keyspaces where on the same keyspace.

## Related Issue(s)
Fixes #9662

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required