### PR TITLE
Fixes #8277: vtctld logs leak pii http headers

### DIFF
--- a/go/vt/vtgate/planbuilder/physical/route_planning.go
+++ b/go/vt/vtgate/planbuilder/physical/route_planning.go
@@ -470,7 +470,7 @@ func tryMerge(
 
 	switch aRoute.RouteOpCode {
 	case engine.Unsharded, engine.DBA:
-		if aRoute.RouteOpCode == bRoute.RouteOpCode {
+		if aRoute.RouteOpCode == bRoute.RouteOpCode && sameKeyspace {
 			return merger(aRoute, bRoute)
 		}
 	case engine.EqualUnique:

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -4532,3 +4532,41 @@ Gen4 plan same as above
     ]
   }
 }
+
+# dont merge unsharded tables from different keyspaces
+"select 1 from main.unsharded join main_2.unsharded_tab"
+{
+  "QueryType": "SELECT",
+  "Original": "select 1 from main.unsharded join main_2.unsharded_tab",
+  "Instructions": {
+    "OperatorType": "Join",
+    "Variant": "Join",
+    "JoinColumnIndexes": "-1",
+    "TableName": "unsharded_unsharded_tab",
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 from unsharded where 1 != 1",
+        "Query": "select 1 from unsharded",
+        "Table": "unsharded"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main_2",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 from unsharded_tab where 1 != 1",
+        "Query": "select 1 from unsharded_tab",
+        "Table": "unsharded_tab"
+      }
+    ]
+  }
+}
+Gen4 plan same as above

--- a/go/vt/workflow/long_polling_test.go
+++ b/go/vt/workflow/long_polling_test.go
@@ -18,10 +18,12 @@ package workflow
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -131,4 +133,88 @@ func TestLongPolling(t *testing.T) {
 	// Stop the manager.
 	cancel()
 	wg.Wait()
+}
+
+func TestSanitizeRequestHeaderCookie(t *testing.T) {
+	testCases := []struct {
+		name       string
+		debugOn    bool
+		reqMethod  string
+		reqURL     string
+		reqHeader  map[string]string
+		wantHeader http.Header
+	}{
+		{
+			name:      "withCookie-no-Debug",
+			debugOn:   false,
+			reqMethod: "GET",
+			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			reqHeader: map[string]string{
+				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
+				"Cookie":     "_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;",
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36",
+			},
+			wantHeader: map[string][]string{
+				"Accept":     {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp"},
+				"Cookie":     {HTTPHeaderRedactedMessage},
+				"User-Agent": {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36"},
+			},
+		},
+		{
+			name:      "withCookie-with-Debug",
+			debugOn:   true,
+			reqMethod: "GET",
+			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			reqHeader: map[string]string{
+				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
+				"Cookie":     "_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;",
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36",
+			},
+			wantHeader: map[string][]string{
+				"Accept":     {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp"},
+				"Cookie":     {"_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;"},
+				"User-Agent": {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36"},
+			},
+		},
+		{
+			name:      "noCookie-no-Debug",
+			debugOn:   false,
+			reqMethod: "GET",
+			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			reqHeader: map[string]string{
+				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36",
+			},
+			wantHeader: map[string][]string{
+				"Accept":     {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp"},
+				"User-Agent": {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			req, err := http.NewRequestWithContext(ctx, tc.reqMethod, tc.reqURL, nil)
+			if err != nil {
+				t.Fatalf("can't parse test http req: %v", err)
+			}
+
+			for k, v := range tc.reqHeader {
+				req.Header.Set(k, v)
+			}
+			clone := req.Clone(ctx)
+
+			if got := sanitizeRequestHeader(req, tc.debugOn); !reflect.DeepEqual(got.Header, tc.wantHeader) {
+				t.Errorf("sanitizeRequestHeader() failed\nwant: %#v\ngot: %#v", tc.wantHeader, got.Header)
+			}
+
+			if !reflect.DeepEqual(clone, req) {
+				t.Errorf("sanitizeRequestHeader() corrupted original http request\nwant: %#v\ngot: %#v", clone, req)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes vtctld logging which is currently leaking http header values that can contain PII.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #8277

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->