### PR TITLE
Fixes #8277: vtctld logs leak pii http headers

### DIFF
--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -42,7 +42,7 @@ var (
 	enableRealtimeStats = flag.Bool("enable_realtime_stats", false, "Required for the Realtime Stats view. If set, vtctld will maintain a streaming RPC to each tablet (in all cells) to gather the realtime health stats.")
 	enableUI            = flag.Bool("enable_vtctld_ui", true, "If true, the vtctld web interface will be enabled. Default is true.")
 	durabilityPolicy    = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
-	sanitizeLogMessages = flag.Bool("sanitize_log_messages", false, "When true, vtctld sanitizes logging.")
+	sanitizeLogMessages = flag.Bool("vtctld_sanitize_log_messages", false, "When true, vtctld sanitizes logging.")
 
 	_ = flag.String("web_dir", "", "NOT USED, here for backward compatibility")
 	_ = flag.String("web_dir2", "", "NOT USED, here for backward compatibility")

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -19,14 +19,13 @@ limitations under the License.
 package vtctld
 
 import (
+	"context"
 	"flag"
 	"net/http"
 	"strings"
 	"time"
 
 	rice "github.com/GeertJohan/go.rice"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/log"
 

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -42,6 +42,7 @@ var (
 	enableRealtimeStats = flag.Bool("enable_realtime_stats", false, "Required for the Realtime Stats view. If set, vtctld will maintain a streaming RPC to each tablet (in all cells) to gather the realtime health stats.")
 	enableUI            = flag.Bool("enable_vtctld_ui", true, "If true, the vtctld web interface will be enabled. Default is true.")
 	durabilityPolicy    = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
+	sanitizeLogMessages = flag.Bool("sanitize_log_messages", false, "When true, vtctld sanitizes logging.")
 
 	_ = flag.String("web_dir", "", "NOT USED, here for backward compatibility")
 	_ = flag.String("web_dir2", "", "NOT USED, here for backward compatibility")

--- a/go/vt/vtctld/workflow.go
+++ b/go/vt/vtctld/workflow.go
@@ -38,7 +38,7 @@ var (
 	workflowManagerInit                = flag.Bool("workflow_manager_init", false, "Initialize the workflow manager in this vtctld instance.")
 	workflowManagerUseElection         = flag.Bool("workflow_manager_use_election", false, "if specified, will use a topology server-based master election to ensure only one workflow manager is active at a time.")
 	workflowManagerDisable             flagutil.StringListValue
-	workflowManagerSanitizeHTTPHeaders = flag.Bool("workflow_manager_sanitize_http_headers", true, "When false, workflow manager logging (on error) dumps all http headers without sanitizing them.")
+	workflowManagerSanitizeHTTPHeaders = flag.Bool("workflow_manager_sanitize_http_headers", false, "When true, workflow manager logging (on error) sanitizes all http headers.")
 )
 
 func init() {
@@ -68,7 +68,7 @@ func initWorkflowManager(ts *topo.Server) {
 
 		// Create the WorkflowManager.
 		vtctl.WorkflowManager = workflow.NewManager(ts)
-		vtctl.WorkflowManager.SetDebugHTTPHeaders(*workflowManagerSanitizeHTTPHeaders)
+		vtctl.WorkflowManager.SetSanitizeHTTPHeaders(*workflowManagerSanitizeHTTPHeaders)
 
 		// Register the long polling and websocket handlers.
 		vtctl.WorkflowManager.HandleHTTPLongPolling(apiPrefix + "workflow")

--- a/go/vt/vtctld/workflow.go
+++ b/go/vt/vtctld/workflow.go
@@ -35,10 +35,9 @@ import (
 )
 
 var (
-	workflowManagerInit                = flag.Bool("workflow_manager_init", false, "Initialize the workflow manager in this vtctld instance.")
-	workflowManagerUseElection         = flag.Bool("workflow_manager_use_election", false, "if specified, will use a topology server-based master election to ensure only one workflow manager is active at a time.")
-	workflowManagerDisable             flagutil.StringListValue
-	workflowManagerSanitizeHTTPHeaders = flag.Bool("workflow_manager_sanitize_http_headers", false, "When true, workflow manager logging (on error) sanitizes all http headers.")
+	workflowManagerInit        = flag.Bool("workflow_manager_init", false, "Initialize the workflow manager in this vtctld instance.")
+	workflowManagerUseElection = flag.Bool("workflow_manager_use_election", false, "if specified, will use a topology server-based master election to ensure only one workflow manager is active at a time.")
+	workflowManagerDisable     flagutil.StringListValue
 )
 
 func init() {
@@ -68,7 +67,7 @@ func initWorkflowManager(ts *topo.Server) {
 
 		// Create the WorkflowManager.
 		vtctl.WorkflowManager = workflow.NewManager(ts)
-		vtctl.WorkflowManager.SetSanitizeHTTPHeaders(*workflowManagerSanitizeHTTPHeaders)
+		vtctl.WorkflowManager.SetSanitizeHTTPHeaders(*sanitizeLogMessages)
 
 		// Register the long polling and websocket handlers.
 		vtctl.WorkflowManager.HandleHTTPLongPolling(apiPrefix + "workflow")

--- a/go/vt/vtctld/workflow.go
+++ b/go/vt/vtctld/workflow.go
@@ -17,10 +17,9 @@ limitations under the License.
 package vtctld
 
 import (
+	"context"
 	"flag"
 	"time"
-
-	"context"
 
 	"vitess.io/vitess/go/trace"
 
@@ -36,9 +35,10 @@ import (
 )
 
 var (
-	workflowManagerInit        = flag.Bool("workflow_manager_init", false, "Initialize the workflow manager in this vtctld instance.")
-	workflowManagerUseElection = flag.Bool("workflow_manager_use_election", false, "if specified, will use a topology server-based master election to ensure only one workflow manager is active at a time.")
-	workflowManagerDisable     flagutil.StringListValue
+	workflowManagerInit                = flag.Bool("workflow_manager_init", false, "Initialize the workflow manager in this vtctld instance.")
+	workflowManagerUseElection         = flag.Bool("workflow_manager_use_election", false, "if specified, will use a topology server-based master election to ensure only one workflow manager is active at a time.")
+	workflowManagerDisable             flagutil.StringListValue
+	workflowManagerSanitizeHTTPHeaders = flag.Bool("workflow_manager_sanitize_http_headers", true, "When false, workflow manager logging (on error) dumps all http headers without sanitizing them.")
 )
 
 func init() {
@@ -68,6 +68,7 @@ func initWorkflowManager(ts *topo.Server) {
 
 		// Create the WorkflowManager.
 		vtctl.WorkflowManager = workflow.NewManager(ts)
+		vtctl.WorkflowManager.SetDebugHTTPHeaders(*workflowManagerSanitizeHTTPHeaders)
 
 		// Register the long polling and websocket handlers.
 		vtctl.WorkflowManager.HandleHTTPLongPolling(apiPrefix + "workflow")

--- a/go/vt/workflow/long_polling.go
+++ b/go/vt/workflow/long_polling.go
@@ -170,9 +170,9 @@ var allowedHTTPHeadersList = map[string]interface{}{
 	"X-Real-Ip":                 nil,
 }
 
-// sanitizeRequestHeader - (unless debugOn=true) makes a copy of r and returns it with sanitized headers
-func sanitizeRequestHeader(r *http.Request, debugOn bool) *http.Request {
-	if debugOn {
+// sanitizeRequestHeader - (unless sanitizeHTTPHeaders=false) makes a copy of r and returns it with sanitized headers
+func sanitizeRequestHeader(r *http.Request, sanitizeHTTPHeaders bool) *http.Request {
+	if !sanitizeHTTPHeaders {
 		return r
 	}
 
@@ -192,7 +192,7 @@ func (m *Manager) httpErrorf(w http.ResponseWriter, r *http.Request, format stri
 	log.Errorf("HTTP error on %v: %v, request: %#v",
 		r.URL.Path,
 		errMsg,
-		sanitizeRequestHeader(r, m.debugHTTPHeaders),
+		sanitizeRequestHeader(r, m.sanitizeHTTPHeaders),
 	)
 	http.Error(w, errMsg, http.StatusInternalServerError)
 }

--- a/go/vt/workflow/long_polling_test.go
+++ b/go/vt/workflow/long_polling_test.go
@@ -137,18 +137,18 @@ func TestLongPolling(t *testing.T) {
 
 func TestSanitizeRequestHeader(t *testing.T) {
 	testCases := []struct {
-		name       string
-		debugOn    bool
-		reqMethod  string
-		reqURL     string
-		reqHeader  map[string]string
-		wantHeader http.Header
+		name                string
+		sanitizeHTTPHeaders bool
+		reqMethod           string
+		reqURL              string
+		reqHeader           map[string]string
+		wantHeader          http.Header
 	}{
 		{
-			name:      "withCookie-no-Debug",
-			debugOn:   false,
-			reqMethod: "GET",
-			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			name:                "withCookie-and-sanitize",
+			sanitizeHTTPHeaders: true,
+			reqMethod:           "GET",
+			reqURL:              "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
 			reqHeader: map[string]string{
 				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
 				"Cookie":     "_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;",
@@ -161,10 +161,10 @@ func TestSanitizeRequestHeader(t *testing.T) {
 			},
 		},
 		{
-			name:      "withCookie-with-Debug",
-			debugOn:   true,
-			reqMethod: "GET",
-			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			name:                "withCookie-not-sanitize",
+			sanitizeHTTPHeaders: false,
+			reqMethod:           "GET",
+			reqURL:              "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
 			reqHeader: map[string]string{
 				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
 				"Cookie":     "_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;",
@@ -177,10 +177,10 @@ func TestSanitizeRequestHeader(t *testing.T) {
 			},
 		},
 		{
-			name:      "noCookie-no-Debug",
-			debugOn:   false,
-			reqMethod: "GET",
-			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			name:                "noCookie-sanitize",
+			sanitizeHTTPHeaders: true,
+			reqMethod:           "GET",
+			reqURL:              "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
 			reqHeader: map[string]string{
 				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
 				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36",
@@ -208,7 +208,7 @@ func TestSanitizeRequestHeader(t *testing.T) {
 			}
 			clone := req.Clone(ctx)
 
-			if got := sanitizeRequestHeader(req, tc.debugOn); !reflect.DeepEqual(got.Header, tc.wantHeader) {
+			if got := sanitizeRequestHeader(req, tc.sanitizeHTTPHeaders); !reflect.DeepEqual(got.Header, tc.wantHeader) {
 				t.Errorf("sanitizeRequestHeader() failed\nwant: %#v\ngot: %#v", tc.wantHeader, got.Header)
 			}
 

--- a/go/vt/workflow/long_polling_test.go
+++ b/go/vt/workflow/long_polling_test.go
@@ -18,10 +18,12 @@ package workflow
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -131,4 +133,88 @@ func TestLongPolling(t *testing.T) {
 	// Stop the manager.
 	cancel()
 	wg.Wait()
+}
+
+func TestSanitizeRequestHeaderCookie(t *testing.T) {
+	testCases := []struct {
+		name       string
+		debugOn    bool
+		reqMethod  string
+		reqURL     string
+		reqHeader  map[string]string
+		wantHeader http.Header
+	}{
+		{
+			name:      "withCookie-no-Debug",
+			debugOn:   false,
+			reqMethod: "GET",
+			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			reqHeader: map[string]string{
+				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
+				"Cookie":     "_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;",
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36",
+			},
+			wantHeader: map[string][]string{
+				"Accept":     {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp"},
+				"Cookie":     {HTTPHeaderRedactedMessage},
+				"User-Agent": {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36"},
+			},
+		},
+		{
+			name:      "withCookie-with-Debug",
+			debugOn:   true,
+			reqMethod: "GET",
+			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			reqHeader: map[string]string{
+				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
+				"Cookie":     "_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;",
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36",
+			},
+			wantHeader: map[string][]string{
+				"Accept":     {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp"},
+				"Cookie":     {"_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;"},
+				"User-Agent": {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36"},
+			},
+		},
+		{
+			name:      "noCookie-no-Debug",
+			debugOn:   false,
+			reqMethod: "GET",
+			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			reqHeader: map[string]string{
+				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36",
+			},
+			wantHeader: map[string][]string{
+				"Accept":     {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp"},
+				"User-Agent": {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			req, err := http.NewRequestWithContext(ctx, tc.reqMethod, tc.reqURL, nil)
+			if err != nil {
+				t.Fatalf("can't parse test http req: %v", err)
+			}
+
+			for k, v := range tc.reqHeader {
+				req.Header.Set(k, v)
+			}
+			clone := req.Clone(ctx)
+
+			if got := sanitizeRequestHeader(req, tc.debugOn); !reflect.DeepEqual(got.Header, tc.wantHeader) {
+				t.Errorf("sanitizeRequestHeader() failed\nwant: %#v\ngot: %#v", tc.wantHeader, got.Header)
+			}
+
+			if !reflect.DeepEqual(clone, req) {
+				t.Errorf("sanitizeRequestHeader() corrupted original http request\nwant: %#v\ngot: %#v", clone, req)
+			}
+		})
+	}
 }

--- a/go/vt/workflow/long_polling_test.go
+++ b/go/vt/workflow/long_polling_test.go
@@ -135,7 +135,7 @@ func TestLongPolling(t *testing.T) {
 	wg.Wait()
 }
 
-func TestSanitizeRequestHeaderCookie(t *testing.T) {
+func TestSanitizeRequestHeader(t *testing.T) {
 	testCases := []struct {
 		name       string
 		debugOn    bool

--- a/go/vt/workflow/manager.go
+++ b/go/vt/workflow/manager.go
@@ -94,8 +94,8 @@ type Manager struct {
 	started chan struct{}
 	// workflows is a map from job UUID to runningWorkflow.
 	workflows map[string]*runningWorkflow
-	// debugHTTPHeaders toggles sanitizeRequestHeader() behavior to OFF
-	debugHTTPHeaders bool
+	// sanitizeHTTPHeaders toggles sanitizeRequestHeader() behavior
+	sanitizeHTTPHeaders bool
 }
 
 // runningWorkflow holds information about a running workflow.
@@ -135,9 +135,9 @@ func NewManager(ts *topo.Server) *Manager {
 	}
 }
 
-// SetDebugHTTPHeaders - toggles m.debugHTTPHeaders on/off
-func (m *Manager) SetDebugHTTPHeaders(to bool) {
-	m.debugHTTPHeaders = to
+// SetSanitizeHTTPHeaders - toggles m.debugHTTPHeaders on/off
+func (m *Manager) SetSanitizeHTTPHeaders(to bool) {
+	m.sanitizeHTTPHeaders = to
 }
 
 // SetRedirectFunc sets the redirect function to use.

--- a/go/vt/workflow/manager.go
+++ b/go/vt/workflow/manager.go
@@ -135,7 +135,7 @@ func NewManager(ts *topo.Server) *Manager {
 	}
 }
 
-// SetSanitizeHTTPHeaders - toggles m.debugHTTPHeaders on/off
+// SetSanitizeHTTPHeaders - toggles m.sanitizeHTTPHeaders on/off
 func (m *Manager) SetSanitizeHTTPHeaders(to bool) {
 	m.sanitizeHTTPHeaders = to
 }

--- a/go/vt/workflow/manager.go
+++ b/go/vt/workflow/manager.go
@@ -17,13 +17,12 @@ limitations under the License.
 package workflow
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"sync"
 	"time"
-
-	"context"
 
 	gouuid "github.com/pborman/uuid"
 
@@ -95,6 +94,8 @@ type Manager struct {
 	started chan struct{}
 	// workflows is a map from job UUID to runningWorkflow.
 	workflows map[string]*runningWorkflow
+	// debugHTTPHeaders toggles sanitizeRequestHeader() behavior to OFF
+	debugHTTPHeaders bool
 }
 
 // runningWorkflow holds information about a running workflow.
@@ -132,6 +133,11 @@ func NewManager(ts *topo.Server) *Manager {
 		started:     make(chan struct{}),
 		workflows:   make(map[string]*runningWorkflow),
 	}
+}
+
+// SetDebugHTTPHeaders - toggles m.debugHTTPHeaders on/off
+func (m *Manager) SetDebugHTTPHeaders(to bool) {
+	m.debugHTTPHeaders = to
 }
 
 // SetRedirectFunc sets the redirect function to use.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes vtctld logging which is currently leaking http header values that can contain PII.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #8277

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->