### PR TITLE
messaging: support vt_message_cols to limit cols

### DIFF
--- a/go/cmd/vtaclcheck/tableacl2.json
+++ b/go/cmd/vtaclcheck/tableacl2.json
@@ -71,6 +71,20 @@
       "admins": ["dev"]
     },
     {
+      "name": "vitess_message4",
+      "table_names_or_prefixes": ["vitess_message4"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_message5",
+      "table_names_or_prefixes": ["vitess_message5"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
       "name": "vitess_message_auto",
       "table_names_or_prefixes": ["vitess_message_auto"],
       "readers": ["dev"],

--- a/go/test/endtoend/messaging/main_test.go
+++ b/go/test/endtoend/messaging/main_test.go
@@ -22,9 +22,8 @@ import (
 	"os"
 	"testing"
 
-	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
-
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
 )
 
 var (
@@ -98,7 +97,8 @@ var (
 	  "tables": {
 			"unsharded_message": {},
 			"vitess_message": {},
-			"vitess_message3": {}
+			"vitess_message3": {},
+			"vitess_message4": {}
 	  }
 	}`
 )

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -23,10 +23,12 @@ import (
 	"strings"
 	"time"
 
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/mysqlctl"
-
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 )
 
@@ -64,21 +66,6 @@ func fetchColumns(ta *Table, conn *connpool.DBConn, databaseName, sqlTableName s
 }
 
 func loadMessageInfo(ta *Table, comment string) error {
-	hiddenCols := map[string]struct{}{
-		"priority":   {},
-		"time_next":  {},
-		"epoch":      {},
-		"time_acked": {},
-	}
-
-	requiredCols := []string{
-		"id",
-		"priority",
-		"time_next",
-		"epoch",
-		"time_acked",
-	}
-
 	ta.MessageInfo = &MessageInfo{}
 	// Extract keyvalues.
 	keyvals := make(map[string]string)
@@ -117,6 +104,26 @@ func loadMessageInfo(ta *Table, comment string) error {
 
 	ta.MessageInfo.MaxBackoff, _ = getDuration(keyvals, "vt_max_backoff")
 
+	// these columns are required for message manager to function properly, but only
+	// id is required to be streamed to subscribers
+	requiredCols := []string{
+		"id",
+		"priority",
+		"time_next",
+		"epoch",
+		"time_acked",
+	}
+
+	// by default, these columns are loaded for the message manager, but not sent to subscribers
+	// via stream * from msg_tbl
+	hiddenCols := map[string]struct{}{
+		"priority":   {},
+		"time_next":  {},
+		"epoch":      {},
+		"time_acked": {},
+	}
+
+	// make sure required columns exist in the table schema
 	for _, col := range requiredCols {
 		num := ta.FindColumn(sqlparser.NewColIdent(col))
 		if num == -1 {
@@ -124,13 +131,29 @@ func loadMessageInfo(ta *Table, comment string) error {
 		}
 	}
 
-	// Load user-defined columns. Any "unrecognized" column is user-defined.
-	for _, field := range ta.Fields {
-		if _, ok := hiddenCols[strings.ToLower(field.Name)]; ok {
-			continue
+	// check to see if the user has specified columns to stream to subscribers
+	specifiedCols := parseMessageCols(keyvals, "vt_message_cols")
+
+	if len(specifiedCols) > 0 {
+		// make sure that all the specified columns exist in the table schema
+		for _, col := range specifiedCols {
+			num := ta.FindColumn(sqlparser.NewColIdent(col))
+			if num == -1 {
+				return fmt.Errorf("%s missing from message table: %s", col, ta.Name.String())
+			}
 		}
-		ta.MessageInfo.Fields = append(ta.MessageInfo.Fields, field)
+
+		// the original implementation in message_manager assumes id is the first column, as originally users
+		// could not restrict columns. As the PK, id is required, and by requiring it as the first column,
+		// we avoid the need to change the implementation.
+		if specifiedCols[0] != "id" {
+			return fmt.Errorf("vt_message_cols must begin with id: %s", ta.Name.String())
+		}
+		ta.MessageInfo.Fields = getSpecifiedMessageFields(ta.Fields, specifiedCols)
+	} else {
+		ta.MessageInfo.Fields = getDefaultMessageFields(ta.Fields, hiddenCols)
 	}
+
 	return nil
 }
 
@@ -156,4 +179,44 @@ func getNum(in map[string]string, key string) (int, error) {
 		return 0, err
 	}
 	return v, nil
+}
+
+// parseMessageCols parses the vt_message_cols attribute. It doesn't error out if the attribute is not specified
+// because the default behavior is to stream all columns to subscribers, and if done incorrectly, later checks
+// to see if the columns exist in the table schema will fail.
+func parseMessageCols(in map[string]string, key string) []string {
+	sv := in[key]
+	cols := strings.Split(sv, "|")
+	if len(cols) == 1 && strings.TrimSpace(cols[0]) == "" {
+		return nil
+	}
+	return cols
+}
+
+func getDefaultMessageFields(tableFields []*querypb.Field, hiddenCols map[string]struct{}) []*querypb.Field {
+	fields := make([]*querypb.Field, 0, len(tableFields))
+	// Load user-defined columns. Any "unrecognized" column is user-defined.
+	for _, field := range tableFields {
+		if _, ok := hiddenCols[strings.ToLower(field.Name)]; ok {
+			continue
+		}
+
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+// we have already validated that all the specified columns exist in the table schema, so we don't need to
+// check again and possibly return an error here.
+func getSpecifiedMessageFields(tableFields []*querypb.Field, specifiedCols []string) []*querypb.Field {
+	fields := make([]*querypb.Field, 0, len(specifiedCols))
+	for _, col := range specifiedCols {
+		for _, field := range tableFields {
+			if res, _ := evalengine.NullsafeCompare(sqltypes.NewVarChar(field.Name), sqltypes.NewVarChar(strings.TrimSpace(col)), collations.Default()); res == 0 {
+				fields = append(fields, field)
+				break
+			}
+		}
+	}
+	return fields
 }


### PR DESCRIPTION
## Description
this enables users to set an allow-list of columns that will be loaded into memory and streamed to subscribers when they call `stream * from tbl`

## Related Issue(s)
#9666 

## Checklist
- [x] Should this PR be backported? No
- [x] Tests were added
- [ ] Documentation was added or is not required