### PR TITLE
Use the gen4 planner for queries with outer joins

### DIFF
--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -191,13 +191,13 @@ select id from user where not id in (select col from music where music.user_id =
 ----------------------------------------------------------------------
 SELECT user.id, user.name, name_info.info FROM user INNER JOIN music ON (user.id = music.user_id) LEFT OUTER JOIN name_info ON (user.name = name_info.name)
 
-1 ks_sharded/-40: select `user`.id, `user`.`name` from `user` join music on `user`.id = music.user_id limit 10001
-1 ks_sharded/40-80: select `user`.id, `user`.`name` from `user` join music on `user`.id = music.user_id limit 10001
-1 ks_sharded/80-c0: select `user`.id, `user`.`name` from `user` join music on `user`.id = music.user_id limit 10001
-1 ks_sharded/c0-: select `user`.id, `user`.`name` from `user` join music on `user`.id = music.user_id limit 10001
-2 ks_sharded/40-80: select name_info.info from name_info where name_info.`name` = 'name_val_2' limit 10001
-3 ks_sharded/40-80: select name_info.info from name_info where name_info.`name` = 'name_val_2' limit 10001
-4 ks_sharded/40-80: select name_info.info from name_info where name_info.`name` = 'name_val_2' limit 10001
-5 ks_sharded/40-80: select name_info.info from name_info where name_info.`name` = 'name_val_2' limit 10001
+1 ks_sharded/-40: select `user`.`name`, `user`.id from `user`, music where `user`.id = music.user_id limit 10001
+1 ks_sharded/40-80: select `user`.`name`, `user`.id from `user`, music where `user`.id = music.user_id limit 10001
+1 ks_sharded/80-c0: select `user`.`name`, `user`.id from `user`, music where `user`.id = music.user_id limit 10001
+1 ks_sharded/c0-: select `user`.`name`, `user`.id from `user`, music where `user`.id = music.user_id limit 10001
+2 ks_sharded/80-c0: select name_info.info from name_info where name_info.`name` = 'name_val_1' limit 10001
+3 ks_sharded/80-c0: select name_info.info from name_info where name_info.`name` = 'name_val_1' limit 10001
+4 ks_sharded/80-c0: select name_info.info from name_info where name_info.`name` = 'name_val_1' limit 10001
+5 ks_sharded/80-c0: select name_info.info from name_info where name_info.`name` = 'name_val_1' limit 10001
 
 ----------------------------------------------------------------------

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -2028,13 +2028,13 @@ func TestLeftJoin(t *testing.T) {
 	defer QueryLogger.Unsubscribe(logChan)
 	result1 := []*sqltypes.Result{{
 		Fields: []*querypb.Field{
-			{Name: "id", Type: sqltypes.Int32},
 			{Name: "col", Type: sqltypes.Int32},
+			{Name: "id", Type: sqltypes.Int32},
 		},
 		InsertID: 0,
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt32(1),
 			sqltypes.NewInt32(3),
+			sqltypes.NewInt32(1),
 		}},
 	}}
 	emptyResult := []*sqltypes.Result{{
@@ -2060,7 +2060,7 @@ func TestLeftJoin(t *testing.T) {
 		},
 	}
 	if !result.Equal(wantResult) {
-		t.Errorf("result: %+v, want %+v", result, wantResult)
+		t.Errorf("result: \n%+v, want \n%+v", result, wantResult)
 	}
 	testQueryLog(t, logChan, "TestExecute", "SELECT", sql, 2)
 }
@@ -2069,13 +2069,13 @@ func TestLeftJoinStream(t *testing.T) {
 	executor, sbc1, sbc2, _ := createLegacyExecutorEnv()
 	result1 := []*sqltypes.Result{{
 		Fields: []*querypb.Field{
-			{Name: "id", Type: sqltypes.Int32},
 			{Name: "col", Type: sqltypes.Int32},
+			{Name: "id", Type: sqltypes.Int32},
 		},
 		InsertID: 0,
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt32(1),
 			sqltypes.NewInt32(3),
+			sqltypes.NewInt32(1),
 		}},
 	}}
 	emptyResult := []*sqltypes.Result{{

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -671,25 +671,6 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select user_extra.id from `user` left join user_extra on `user`.id = user_extra.user_id where 1 != 1",
-    "Query": "select user_extra.id from `user` left join user_extra on `user`.id = user_extra.user_id where user_extra.user_id = 5",
-    "Table": "`user`, user_extra",
-    "Values": [
-      "INT64(5)"
-    ],
-    "Vindex": "user_index"
-  }
-}
-{
-  "QueryType": "SELECT",
-  "Original": "select user_extra.id from user left join user_extra on user.id = user_extra.user_id where user_extra.user_id = 5",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "EqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
     "FieldQuery": "select user_extra.id from `user`, user_extra where 1 != 1",
     "Query": "select user_extra.id from `user`, user_extra where user_extra.user_id = 5 and `user`.id = user_extra.user_id",
     "Table": "`user`, user_extra",
@@ -699,6 +680,7 @@ Gen4 plan same as above
     "Vindex": "user_index"
   }
 }
+Gen4 plan same as above
 
 # Multi-route unique vindex constraint
 "select user_extra.id from user join user_extra on user.col = user_extra.col where user.id = 5"
@@ -3156,7 +3138,6 @@ Gen4 plan same as above
 
 # left join where clauses where we can optimize into an inner join
 "select user.id from user left join user_extra on user.col = user_extra.col where user_extra.foobar = 5"
-"unsupported: cross-shard left join and where clause"
 {
   "QueryType": "SELECT",
   "Original": "select user.id from user left join user_extra on user.col = user_extra.col where user_extra.foobar = 5",
@@ -3194,15 +3175,15 @@ Gen4 plan same as above
     ]
   }
 }
+Gen4 plan same as above
 
 # this query lead to a nil pointer error
 "select user.id from user left join user_extra on user.col = user_extra.col where foo(user_extra.foobar)"
-"unsupported: cross-shard left join and where clause"
-Gen4 error: expr cannot be converted, not supported: foo(user_extra.foobar)
+"expr cannot be converted, not supported: foo(user_extra.foobar)"
+Gen4 plan same as above
 
 # filter after outer join
 "select user.id from user left join user_extra on user.col = user_extra.col where user_extra.id is null"
-"unsupported: cross-shard left join and where clause"
 {
   "QueryType": "SELECT",
   "Original": "select user.id from user left join user_extra on user.col = user_extra.col where user_extra.id is null",
@@ -3254,6 +3235,7 @@ Gen4 error: expr cannot be converted, not supported: foo(user_extra.foobar)
     ]
   }
 }
+Gen4 plan same as above
 
 #subquery on other table
 "select distinct user.id, user.col from user where user.col in (select id from music where col2 = 'a')"
@@ -3923,6 +3905,39 @@ Gen4 plan same as above
     "FieldQuery": "select 0 from unsharded_a left join unsharded_b on unsharded_a.col = unsharded_b.col where 1 != 1",
     "Query": "select 0 from unsharded_a left join unsharded_b on unsharded_a.col = unsharded_b.col where coalesce(unsharded_b.col, 4) = 5",
     "Table": "unsharded_a, unsharded_b"
+  }
+}
+Gen4 plan same as above
+
+# filter on outer join should not be used for routing
+"select user.col from user_extra left outer join user on user_extra.user_id = user.id WHERE user.id IS NULL"
+{
+  "QueryType": "SELECT",
+  "Original": "select user.col from user_extra left outer join user on user_extra.user_id = user.id WHERE user.id IS NULL",
+  "Instructions": {
+    "OperatorType": "SimpleProjection",
+    "Columns": [
+      1
+    ],
+    "Inputs": [
+      {
+        "OperatorType": "Filter",
+        "Predicate": "`user`.id is null",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select `user`.id, `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where 1 != 1",
+            "Query": "select `user`.id, `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id",
+            "Table": "`user`, user_extra"
+          }
+        ]
+      }
+    ]
   }
 }
 Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -582,43 +582,6 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "LeftJoin",
-    "JoinColumnIndexes": "-1",
-    "JoinVars": {
-      "u_a": 1
-    },
-    "TableName": "`user`_unsharded",
-    "Inputs": [
-      {
-        "OperatorType": "Route",
-        "Variant": "Scatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select u.col, u.a from `user` as u where 1 != 1",
-        "Query": "select u.col, u.a from `user` as u",
-        "Table": "`user`"
-      },
-      {
-        "OperatorType": "Route",
-        "Variant": "Unsharded",
-        "Keyspace": {
-          "Name": "main",
-          "Sharded": false
-        },
-        "FieldQuery": "select 1 from unsharded as m where 1 != 1",
-        "Query": "select 1 from unsharded as m where m.b = :u_a",
-        "Table": "unsharded"
-      }
-    ]
-  }
-}
-{
-  "QueryType": "SELECT",
-  "Original": "select u.col from user u left join unsharded m on u.a = m.b",
-  "Instructions": {
-    "OperatorType": "Join",
-    "Variant": "LeftJoin",
     "JoinColumnIndexes": "-2",
     "JoinVars": {
       "u_a": 0
@@ -650,68 +613,10 @@ Gen4 plan same as above
     ]
   }
 }
+Gen4 plan same as above
 
 # Three-way left join
 "select user.col, m2.foo from user left join unsharded as m1 on user.col = m1.col left join unsharded as m2 on m1.col = m2.col"
-{
-  "QueryType": "SELECT",
-  "Original": "select user.col, m2.foo from user left join unsharded as m1 on user.col = m1.col left join unsharded as m2 on m1.col = m2.col",
-  "Instructions": {
-    "OperatorType": "Join",
-    "Variant": "LeftJoin",
-    "JoinColumnIndexes": "-1,1",
-    "JoinVars": {
-      "m1_col": 1
-    },
-    "TableName": "`user`_unsharded_unsharded",
-    "Inputs": [
-      {
-        "OperatorType": "Join",
-        "Variant": "LeftJoin",
-        "JoinColumnIndexes": "-1,1",
-        "JoinVars": {
-          "user_col": 0
-        },
-        "TableName": "`user`_unsharded",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select `user`.col from `user`",
-            "Table": "`user`"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "Unsharded",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select m1.col from unsharded as m1 where 1 != 1",
-            "Query": "select m1.col from unsharded as m1 where m1.col = :user_col",
-            "Table": "unsharded"
-          }
-        ]
-      },
-      {
-        "OperatorType": "Route",
-        "Variant": "Unsharded",
-        "Keyspace": {
-          "Name": "main",
-          "Sharded": false
-        },
-        "FieldQuery": "select m2.foo from unsharded as m2 where 1 != 1",
-        "Query": "select m2.foo from unsharded as m2 where m2.col = :m1_col",
-        "Table": "unsharded"
-      }
-    ]
-  }
-}
 {
   "QueryType": "SELECT",
   "Original": "select user.col, m2.foo from user left join unsharded as m1 on user.col = m1.col left join unsharded as m2 on m1.col = m2.col",
@@ -771,6 +676,7 @@ Gen4 plan same as above
     ]
   }
 }
+Gen4 plan same as above
 
 # Three-way left join, right-associated
 "select user.col from user left join user_extra as e left join unsharded as m1 on m1.col = e.col on user.col = e.col"
@@ -846,44 +752,15 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": false
     },
-    "FieldQuery": "select m1.col from unsharded as m2 left join unsharded as m1 on m1.a = m2.b where 1 != 1",
-    "Query": "select m1.col from unsharded as m2 left join unsharded as m1 on m1.a = m2.b",
-    "Table": "unsharded"
-  }
-}
-{
-  "QueryType": "SELECT",
-  "Original": "select m1.col from unsharded as m1 right join unsharded as m2 on m1.a=m2.b",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "Unsharded",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
     "FieldQuery": "select m1.col from unsharded as m1 right join unsharded as m2 on m1.a = m2.b where 1 != 1",
     "Query": "select m1.col from unsharded as m1 right join unsharded as m2 on m1.a = m2.b",
     "Table": "unsharded"
   }
 }
+Gen4 plan same as above
 
 # Right join with a join LHS
 "select m1.col from unsharded as m1 join unsharded as m2 right join unsharded as m3 on m1.a=m2.b"
-{
-  "QueryType": "SELECT",
-  "Original": "select m1.col from unsharded as m1 join unsharded as m2 right join unsharded as m3 on m1.a=m2.b",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "Unsharded",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
-    "FieldQuery": "select m1.col from unsharded as m3 left join (unsharded as m1 join unsharded as m2) on m1.a = m2.b where 1 != 1",
-    "Query": "select m1.col from unsharded as m3 left join (unsharded as m1 join unsharded as m2) on m1.a = m2.b",
-    "Table": "unsharded"
-  }
-}
 {
   "QueryType": "SELECT",
   "Original": "select m1.col from unsharded as m1 join unsharded as m2 right join unsharded as m3 on m1.a=m2.b",
@@ -899,6 +776,7 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
+Gen4 plan same as above
 
 # Straight-join (Gen4 ignores the straight_join hint)
 "select m1.col from unsharded as m1 straight_join unsharded as m2"
@@ -3007,61 +2885,6 @@ Gen4 plan same as above
   "QueryType": "SELECT",
   "Original": "select unsharded.col from unsharded left join user on user.col in (select col from user)",
   "Instructions": {
-    "OperatorType": "Join",
-    "Variant": "LeftJoin",
-    "JoinColumnIndexes": "-1",
-    "TableName": "unsharded_`user`",
-    "Inputs": [
-      {
-        "OperatorType": "Route",
-        "Variant": "Unsharded",
-        "Keyspace": {
-          "Name": "main",
-          "Sharded": false
-        },
-        "FieldQuery": "select unsharded.col from unsharded where 1 != 1",
-        "Query": "select unsharded.col from unsharded",
-        "Table": "unsharded"
-      },
-      {
-        "OperatorType": "Subquery",
-        "Variant": "PulloutIn",
-        "PulloutVars": [
-          "__sq_has_values1",
-          "__sq1"
-        ],
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
-            "Table": "`user`"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select 1 from `user` where 1 != 1",
-            "Query": "select 1 from `user` where :__sq_has_values1 = 1 and `user`.col in ::__sq1",
-            "Table": "`user`"
-          }
-        ]
-      }
-    ]
-  }
-}
-{
-  "QueryType": "SELECT",
-  "Original": "select unsharded.col from unsharded left join user on user.col in (select col from user)",
-  "Instructions": {
     "OperatorType": "Subquery",
     "Variant": "PulloutIn",
     "PulloutVars": [
@@ -3113,6 +2936,7 @@ Gen4 plan same as above
     ]
   }
 }
+Gen4 plan same as above
 
 # subquery in ON clause, with join primitives, and join on top
 # The subquery is not pulled all the way out.
@@ -4480,7 +4304,6 @@ Gen4 plan same as above
 
 # left join where clauses #2
 "select user.id from user left join user_extra on user.col = user_extra.col where coalesce(user_extra.col, 4) = 5"
-"unsupported: cross-shard left join and where clause"
 {
   "QueryType": "SELECT",
   "Original": "select user.id from user left join user_extra on user.col = user_extra.col where coalesce(user_extra.col, 4) = 5",
@@ -4532,6 +4355,7 @@ Gen4 plan same as above
     ]
   }
 }
+Gen4 plan same as above
 
 # dont merge unsharded tables from different keyspaces
 "select 1 from main.unsharded join main_2.unsharded_tab"

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
@@ -102,8 +102,8 @@ Gen4 plan same as above
 
 # TPC-H query 13
 "select c_count, count(*) as custdist from ( select c_custkey, count(o_orderkey) from customer left outer join orders on c_custkey = o_custkey and o_comment not like '%special%requests%' group by c_custkey ) as c_orders(c_custkey, c_count) group by c_count order by custdist desc, c_count desc"
-"unsupported: column aliases in derived table"
-Gen4 error: unsupported: cross-shard query with aggregates
+"unsupported: cross-shard query with aggregates"
+Gen4 plan same as above
 
 # TPC-H query 14
 "select 100.00 * sum(case when p_type like 'PROMO%' then l_extendedprice * (1 - l_discount) else 0 end) /  sum(l_extendedprice * (1 - l_discount)) as promo_revenue from lineitem, part where l_partkey = p_partkey and l_shipdate >= date('1995-09-01') and l_shipdate < date('1995-09-01') + interval '1' month"


### PR DESCRIPTION
Routing for queries that contain outer join was not being handled correctly.
It would require a lot of changes to support these queries correctly in V3, so instead this fix makes it so the gen4 planner is used in the presence of outer joins.

If you know that you want to use the v3 planner, that can still be accomplished by using the query hint `/*vt+ PLANNER=v3 */`

## Related Issue(s)
Fixes #7700 
Backport of #9657
