### PR TITLE
Remove the use_super_read_only flag in VTOrc tests

### DIFF
--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -136,7 +136,6 @@ func createVttablets(clusterInstance *cluster.LocalProcessCluster, cellInfos []*
 	clusterInstance.VtTabletExtraArgs = []string{
 		"-lock_tables_timeout", "5s",
 		"-disable_active_reparents",
-		"-use_super_read_only=false",
 	}
 	// Initialize Cluster
 	shard0.Vttablets = tablets
@@ -772,7 +771,6 @@ func SetupNewClusterSemiSync(t *testing.T) *VtOrcClusterInfo {
 	clusterInstance.VtTabletExtraArgs = []string{
 		"-lock_tables_timeout", "5s",
 		"-disable_active_reparents",
-		"-use_super_read_only=false",
 		"-enable_semi_sync",
 	}
 

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -318,8 +318,11 @@ func SetupVttabletsAndVtorc(t *testing.T, clusterInfo *VtOrcClusterInfo, numRepl
 // cleanAndStartVttablet cleans the MySQL instance underneath for running a new test. It also starts the vttablet.
 func cleanAndStartVttablet(t *testing.T, clusterInfo *VtOrcClusterInfo, vttablet *cluster.Vttablet) {
 	t.Helper()
+	// set super-read-only to false
+	_, err := RunSQL(t, "SET GLOBAL super_read_only = OFF", vttablet, "")
+	require.NoError(t, err)
 	// remove the databases if they exist
-	_, err := RunSQL(t, "DROP DATABASE IF EXISTS vt_ks", vttablet, "")
+	_, err = RunSQL(t, "DROP DATABASE IF EXISTS vt_ks", vttablet, "")
 	require.NoError(t, err)
 	_, err = RunSQL(t, "DROP DATABASE IF EXISTS _vt", vttablet, "")
 	require.NoError(t, err)


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR removes the `use_super_read_only_flag` from the VTOrc test suite and instead turns super read only off before cleaning the underlying MySQL instance (removing old databases, etc).

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->