### PR TITLE
Skip repl config in restore when active reparents disabled

### DIFF
--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -721,7 +721,6 @@ func TestDisableActiveReparents(t *testing.T) {
 		"STOP SLAVE",
 		"RESET SLAVE ALL",
 		"FAKE SET SLAVE POSITION",
-		"FAKE SET MASTER",
 	}
 	destTablet.FakeMysqlDaemon.FetchSuperQueryMap = map[string]*sqltypes.Result{
 		"SHOW DATABASES": {},


### PR DESCRIPTION
## Description

Do not attempt to setup replication when [active reparents are disabled](https://github.com/vitessio/vitess/blob/3adcf439960fbbde3d7f82998717a89f6ebcfb60/go/vt/mysqlctl/mysqld.go#L64).

It makes no sense to do any replication configuration related work as part of a [`RestoreFromBackup`](https://github.com/vitessio/vitess/blob/3adcf439960fbbde3d7f82998717a89f6ebcfb60/go/vt/vttablet/tabletmanager/rpc_backup.go#L155) RPC call because[ we do not ever start replication automatically when active reparents are disabled](https://github.com/vitessio/vitess/search?q=disableActiveReparents). We only need to restore the data and save the associated replication state metadata -- then it's up to the operator to (optionally) complete the replication setup if and as needed at a later time.

### An Example Use Case
As a Vitess operator, I need to have a business continuity plan in the event of a regional disaster. To meet this, I want to have an active/passive setup where there's an active Vitess cluster in one infrastructure region and a passive cluster in another sufficiently distant region. In order to do that, we may have a cell local topo service in each region and they are generally isolated from one another. I seed the initial passive region with backups from the active region's keyspace/shards and manage async MySQL replication myself — so active reparents are disabled — in order to support the ability of making this passive Vitess cluster the active one (with minimal potential data loss) in the event of a regional outage where the previous active cluster was running.

In this case, if you're doing a backup restore for a shard that *has* a primary — as seen in the global topo's shard record — but the primary cannot be reached (networking issue, in a different cell local topo server, etc) then the restore will fail.

This PR allows the restore to complete so that the user can finish the replication setup piece at a later time as appropriate. 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? No
- [x] Tests are not required
- [x] Documentation is not required