### PR TITLE
Fix missing time_heartbeat column error

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -569,10 +569,14 @@ var AlterVReplicationTable = []string{
 	"ALTER TABLE _vt.vreplication ADD COLUMN time_heartbeat BIGINT(20) NOT NULL DEFAULT 0",
 }
 
-// WithDDLInitialQueries contains the queries to be expected by the mock db client during tests
+// WithDDLInitialQueries contains the queries that:
+// - are to be expected by the mock db client during tests, or
+// - trigger some of the above _vt.vreplication schema changes to take effect
+//   when the binlogplayer starts up
 var WithDDLInitialQueries = []string{
 	"SELECT db_name FROM _vt.vreplication LIMIT 0",
 	"SELECT rows_copied FROM _vt.vreplication LIMIT 0",
+	"SELECT time_heartbeat FROM _vt.vreplication LIMIT 0",
 }
 
 // VRSettings contains the settings of a vreplication table.


### PR DESCRIPTION
## Description
Seeing errors like the following in VReplication workflows:
```
error Unknown column 'time_heartbeat' in 'field list' (errno 1054) (sqlstate 42S22) during query: update _vt.vreplication set time_updated=1644542766, time_heartbeat=1644542766 where id=14 updating time
```
This column was added in this recent PR: https://github.com/vitessio/vitess/pull/9538/files. The DDL to add the time_heartbeat column is added [here](https://github.com/planetscale/vitess/blob/0bb4b29c7dfccdd8c17e27ad697b662d7faa776d/go/vt/binlog/binlogplayer/binlog_player.go#L569) which is eventually used in the withDDL [here](https://github.com/planetscale/vitess/blob/0bb4b29c7dfccdd8c17e27ad697b662d7faa776d/go/vt/vttablet/tabletmanager/vreplication/engine.go#L66). But the actual heartbeat query done [here](https://github.com/planetscale/vitess/blob/0bb4b29c7dfccdd8c17e27ad697b662d7faa776d/go/vt/vttablet/tabletmanager/vreplication/vplayer.go#L259) doesn't actaully use this withDDL. Instead this withDDL is used when the vreplication controller starts the binlogplayer [here](https://github.com/planetscale/vitess/blob/0bb4b29c7dfccdd8c17e27ad697b662d7faa776d/go/vt/vttablet/tabletmanager/vreplication/controller.go#L201). But the queries that are made here ([WithDDLInitialQueries](https://github.com/planetscale/vitess/blob/0bb4b29c7dfccdd8c17e27ad697b662d7faa776d/go/vt/binlog/binlogplayer/binlog_player.go#L572)) don't actually include one that uses this newly added time_heartbeat column, so the column never gets created. This PR fixes that issue.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? Yes, to release-13.0
- [x] Tests were are not required
- [x] Documentation is not required