### PR TITLE
BACKPORT: Skip repl config in restore when active reparents disabled

### DIFF
--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -721,7 +721,6 @@ func TestDisableActiveReparents(t *testing.T) {
 		"STOP SLAVE",
 		"RESET SLAVE ALL",
 		"FAKE SET SLAVE POSITION",
-		"FAKE SET MASTER",
 	}
 	destTablet.FakeMysqlDaemon.FetchSuperQueryMap = map[string]*sqltypes.Result{
 		"SHOW DATABASES": {},


### PR DESCRIPTION
## Description
This back ports https://github.com/vitessio/vitess/pull/9675 to vitess 13.0. Please see there for more details.

## Related Issue(s)
Backports: https://github.com/vitessio/vitess/pull/9675


## Checklist
- [x] Should this PR be backported? No further
- [x] Tests were updated
- [x] Documentation is not required
