### PR TITLE
Use AllPrivs user for table GC transitions

### DIFF
--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -171,7 +171,7 @@ func (collector *TableGC) Open() (err error) {
 	}
 
 	log.Info("TableGC: opening")
-	collector.pool.Open(collector.env.Config().DB.DbaWithDB(), collector.env.Config().DB.DbaWithDB(), collector.env.Config().DB.AppDebugWithDB())
+	collector.pool.Open(collector.env.Config().DB.AllPrivsWithDB(), collector.env.Config().DB.DbaWithDB(), collector.env.Config().DB.AppDebugWithDB())
 	atomic.StoreInt64(&collector.isOpen, 1)
 
 	for _, t := range collector.tickers {

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -171,7 +171,7 @@ func (collector *TableGC) Open() (err error) {
 	}
 
 	log.Info("TableGC: opening")
-	collector.pool.Open(collector.env.Config().DB.AppWithDB(), collector.env.Config().DB.DbaWithDB(), collector.env.Config().DB.AppDebugWithDB())
+	collector.pool.Open(collector.env.Config().DB.DbaWithDB(), collector.env.Config().DB.DbaWithDB(), collector.env.Config().DB.AppDebugWithDB())
 	atomic.StoreInt64(&collector.isOpen, 1)
 
 	for _, t := range collector.tickers {


### PR DESCRIPTION
Signed-off-by: Ankit Malpani <malpani@stripe.com>

## Description
Use admin user for tablet GC operations.

Context: Currently `vt_app` user is used for internal table GC operations. This however does not have enough privileges (like `alter/drop`) in all setups which results in GC failures. This change moves internal GC operations to be invoked as dba user

## Related Issue(s)
Fixes https://github.com/vitessio/vitess/issues/9689


## Checklist
- Should this PR be backported? - no
- Tests were added or are not required - tablegc unit tests pass but they dont exercise permission changes
- Documentation was added or is not required - not required

## Deployment Notes
n/a