### PR TITLE
vtexplain: added multicol test to show subshard routing

### DIFF
--- a/go/vt/vtexplain/testdata/gen4-queries.sql
+++ b/go/vt/vtexplain/testdata/gen4-queries.sql
@@ -1,0 +1,3 @@
+
+select * from user_region where regionId = 2305843009213693952 and userId = 100 /* exact shard */;
+select * from user_region where regionId = 2305843009213693952 /* subshard */;

--- a/go/vt/vtexplain/testdata/gen4-queries.sql
+++ b/go/vt/vtexplain/testdata/gen4-queries.sql
@@ -1,3 +1,5 @@
 
-select * from user_region where regionId = 2305843009213693952 and userId = 100 /* exact shard */;
-select * from user_region where regionId = 2305843009213693952 /* subshard */;
+select * from user_region where regionId = 4611686018427387904 and userId = 100 /* exact shard */;
+select * from user_region where regionId = 4611686018427387904 /* subshard */;
+select * from user_region where regionId in (4611686018427387903, 4611686018427387904) /* subshard */;
+select * from user_region where userId = 100 /* scatter, needs prefix columns for subshard routing */;

--- a/go/vt/vtexplain/testdata/multi-output/gen4-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/gen4-output.txt
@@ -1,0 +1,13 @@
+----------------------------------------------------------------------
+select * from user_region where regionId = 2305843009213693952 and userId = 100 /* exact shard */
+
+1 ks_sharded/2000-2080: select * from user_region where regionId = 2305843009213693952 and userId = 100 limit 10001 /* exact shard */
+
+----------------------------------------------------------------------
+select * from user_region where regionId = 2305843009213693952 /* subshard */
+
+1 ks_sharded/1f80-2000: select * from user_region where regionId = 2305843009213693952 limit 10001 /* subshard */
+1 ks_sharded/2000-2080: select * from user_region where regionId = 2305843009213693952 limit 10001 /* subshard */
+1 ks_sharded/2080-2100: select * from user_region where regionId = 2305843009213693952 limit 10001 /* subshard */
+
+----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/multi-output/gen4-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/gen4-output.txt
@@ -1,13 +1,25 @@
 ----------------------------------------------------------------------
-select * from user_region where regionId = 2305843009213693952 and userId = 100 /* exact shard */
+select * from user_region where regionId = 4611686018427387904 and userId = 100 /* exact shard */
 
-1 ks_sharded/2000-2080: select * from user_region where regionId = 2305843009213693952 and userId = 100 limit 10001 /* exact shard */
+1 ks_sharded/40-80: select * from user_region where regionId = 4611686018427387904 and userId = 100 limit 10001 /* exact shard */
 
 ----------------------------------------------------------------------
-select * from user_region where regionId = 2305843009213693952 /* subshard */
+select * from user_region where regionId = 4611686018427387904 /* subshard */
 
-1 ks_sharded/1f80-2000: select * from user_region where regionId = 2305843009213693952 limit 10001 /* subshard */
-1 ks_sharded/2000-2080: select * from user_region where regionId = 2305843009213693952 limit 10001 /* subshard */
-1 ks_sharded/2080-2100: select * from user_region where regionId = 2305843009213693952 limit 10001 /* subshard */
+1 ks_sharded/40-80: select * from user_region where regionId = 4611686018427387904 limit 10001 /* subshard */
+
+----------------------------------------------------------------------
+select * from user_region where regionId in (4611686018427387903, 4611686018427387904) /* subshard */
+
+1 ks_sharded/-40: select * from user_region where regionId in (4611686018427387903) limit 10001 /* subshard */
+1 ks_sharded/40-80: select * from user_region where regionId in (4611686018427387904) limit 10001 /* subshard */
+
+----------------------------------------------------------------------
+select * from user_region where userId = 100 /* scatter, needs prefix columns for subshard routing */
+
+1 ks_sharded/-40: select * from user_region where userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
+1 ks_sharded/40-80: select * from user_region where userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
+1 ks_sharded/80-c0: select * from user_region where userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
+1 ks_sharded/c0-: select * from user_region where userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
 
 ----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/test-schema.sql
+++ b/go/vt/vtexplain/testdata/test-schema.sql
@@ -73,3 +73,11 @@ create table email_customer_map (
    user_id bigint,
    primary key (email, user_id)
 ) Engine=InnoDB;
+
+create table user_region (
+   regionId bigint,
+   userId bigint,
+   name varchar(64),
+   email varchar(64),
+   primary key (regionId,userId)
+) Engine=InnoDB;

--- a/go/vt/vtexplain/testdata/test-vschema.json
+++ b/go/vt/vtexplain/testdata/test-vschema.json
@@ -42,6 +42,14 @@
 			},
 			"md5": {
 				"type": "unicode_loose_md5"
+			},
+			"multicol_vdx": {
+				"type": "multicol",
+				"params": {
+					"column_count": "2",
+					"column_bytes": "1,7",
+					"column_vindex": "numeric,xxhash"
+				}
 			}
 		},
 		"tables": {
@@ -121,6 +129,14 @@
 					{
 						"column": "email",
 						"name": "md5"
+					}
+				]
+			},
+			"user_region": {
+				"column_vindexes": [
+					{
+						"columns": ["regionId","userId"],
+						"name": "multicol_vdx"
 					}
 				]
 			}

--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -159,7 +159,7 @@ func TestExplain(t *testing.T) {
 		}},
 		{"gen4", &Options{
 			ReplicationMode: "ROW",
-			NumShards:       512,
+			NumShards:       4,
 			Normalize:       true,
 			PlannerVersion:  querypb.ExecuteOptions_Gen4,
 		}},

--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	querypb "vitess.io/vitess/go/vt/proto/query"
+
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
@@ -154,6 +156,12 @@ func TestExplain(t *testing.T) {
 			NumShards:       4,
 			Normalize:       false,
 			Target:          "ks_sharded/40-80",
+		}},
+		{"gen4", &Options{
+			ReplicationMode: "ROW",
+			NumShards:       512,
+			Normalize:       true,
+			PlannerVersion:  querypb.ExecuteOptions_Gen4,
 		}},
 	}
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds a test in vtexplain to show subshard vindex routing.

The test works locally, but on CI it fails with the error `limit on 8128 simultaneously alive goroutines is exceeded, dying`.
To show subsharding works, I have to create 512 shards.

Below is the test result.

```
----------------------------------------------------------------------
select * from user_region where regionId = 2305843009213693952 /* subshard */

1 ks_sharded/1f80-2000: select * from user_region where regionId = 2305843009213693952 limit 10001 /* subshard */
1 ks_sharded/2000-2080: select * from user_region where regionId = 2305843009213693952 limit 10001 /* subshard */
1 ks_sharded/2080-2100: select * from user_region where regionId = 2305843009213693952 limit 10001 /* subshard */

----------------------------------------------------------------------
```
I will change the test on the PR to have 4 shards only so that it works on CI but it will not reflect the actual value of subshard routing.


## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Closes https://github.com/vitessio/vitess/issues/9652

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->