### PR TITLE
VReplication Workflows: Use WithDDL while updating time_heartbeat to be backwardly compatible with upgrades to existing cluster

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -569,10 +569,14 @@ var AlterVReplicationTable = []string{
 	"ALTER TABLE _vt.vreplication ADD COLUMN time_heartbeat BIGINT(20) NOT NULL DEFAULT 0",
 }
 
-// WithDDLInitialQueries contains the queries to be expected by the mock db client during tests
+// WithDDLInitialQueries contains the queries that:
+// - are to be expected by the mock db client during tests, or
+// - trigger some of the above _vt.vreplication schema changes to take effect
+//   when the binlogplayer starts up
 var WithDDLInitialQueries = []string{
 	"SELECT db_name FROM _vt.vreplication LIMIT 0",
 	"SELECT rows_copied FROM _vt.vreplication LIMIT 0",
+	"SELECT time_heartbeat FROM _vt.vreplication LIMIT 0",
 }
 
 // VRSettings contains the settings of a vreplication table.

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -561,6 +561,7 @@ func expectNontxQueries(t *testing.T, queries []string) {
 	failed := false
 
 	skipQueries := withDDLInitialQueries
+	skipQueries = append(skipQueries, withDDL.DDLs()...)
 	for i, query := range queries {
 		if failed {
 			t.Errorf("no query received, expecting %s", query)

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -256,7 +256,7 @@ func (vp *vplayer) updateHeartbeat(tm int64) error {
 	if err != nil {
 		return err
 	}
-	if _, err := vp.vr.dbClient.Execute(update); err != nil {
+	if _, err := withDDL.Exec(vp.vr.vre.ctx, update, vp.vr.dbClient.ExecuteFetch, vp.vr.dbClient.ExecuteFetch); err != nil {
 		return fmt.Errorf("error %v updating time", err)
 	}
 	return nil

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -132,8 +132,7 @@ func TestVReplicationTimeUpdated(t *testing.T) {
 	// drop time_heartbeat column to test that heartbeat is updated using WithDDL and can self-heal by creating the column again
 	env.Mysqld.ExecuteSuperQuery(ctx, "alter table _vt.vreplication drop column time_heartbeat")
 	time.Sleep(2 * time.Second)
-	timeUpdated3, transactionTimestamp3, timeHeartbeat3 := getTimestamps()
-	_, _, _ = timeUpdated3, transactionTimestamp3, timeHeartbeat3
+	_, _, timeHeartbeat3 := getTimestamps()
 	require.Greater(t, timeHeartbeat3, timeHeartbeat2, "time_heartbeat not updated")
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -104,26 +104,37 @@ func TestVReplicationTimeUpdated(t *testing.T) {
 		"insert into t1 values(1, 'aaa')",
 	})
 
-	var getTimestamps = func() (int64, int64) {
-		qr, err := env.Mysqld.FetchSuperQuery(ctx, "select time_updated, transaction_timestamp from _vt.vreplication")
+	var getTimestamps = func() (int64, int64, int64) {
+		qr, err := env.Mysqld.FetchSuperQuery(ctx, "select time_updated, transaction_timestamp, time_heartbeat from _vt.vreplication")
 		require.NoError(t, err)
 		require.NotNil(t, qr)
 		require.Equal(t, 1, len(qr.Rows))
-		timeUpdated, err := qr.Rows[0][0].ToInt64()
+		row := qr.Named().Row()
+		timeUpdated, err := row.ToInt64("time_updated")
 		require.NoError(t, err)
-		transactionTimestamp, err := qr.Rows[0][1].ToInt64()
+		transactionTimestamp, err := row.ToInt64("transaction_timestamp")
 		require.NoError(t, err)
-		return timeUpdated, transactionTimestamp
+		timeHeartbeat, err := row.ToInt64("time_heartbeat")
+		require.NoError(t, err)
+		return timeUpdated, transactionTimestamp, timeHeartbeat
 	}
 	expectNontxQueries(t, []string{
 		"insert into t1(id,val) values (1,'aaa')",
 	})
 	time.Sleep(1 * time.Second)
-	timeUpdated1, transactionTimestamp1 := getTimestamps()
+	timeUpdated1, transactionTimestamp1, timeHeartbeat1 := getTimestamps()
 	time.Sleep(2 * time.Second)
-	timeUpdated2, _ := getTimestamps()
+	timeUpdated2, _, timeHeartbeat2 := getTimestamps()
 	require.Greater(t, timeUpdated2, timeUpdated1, "time_updated not updated")
 	require.Greater(t, timeUpdated2, transactionTimestamp1, "transaction_timestamp should not be < time_updated")
+	require.Greater(t, timeHeartbeat2, timeHeartbeat1, "time_heartbeat not updated")
+
+	// drop time_heartbeat column to test that heartbeat is updated using WithDDL and can self-heal by creating the column again
+	env.Mysqld.ExecuteSuperQuery(ctx, "alter table _vt.vreplication drop column time_heartbeat")
+	time.Sleep(2 * time.Second)
+	timeUpdated3, transactionTimestamp3, timeHeartbeat3 := getTimestamps()
+	_, _, _ = timeUpdated3, transactionTimestamp3, timeHeartbeat3
+	require.Greater(t, timeHeartbeat3, timeHeartbeat2, "time_heartbeat not updated")
 }
 
 func TestCharPK(t *testing.T) {


### PR DESCRIPTION
## Description

#9538 introduced a regression with existing clusters because a new column `time_heartbeat` was added to `_vt.vreplication` and the `WithDDL` package was not used while updating this new column.  The workflow would stall with these errors 
```
E0215 20:03:45.678794       1 dbclient.go:107] error in stream 14, retrying after 5s: error Unknown column 'time_heartbeat' in 'field list' (errno 1054) (sqlstate 42S22) during query: update _vt.vreplication set time_updated=1644955425, time_heartbeat=1644955425 where id=1 updating time
```

This PR has the following changes:
* the heartbeat update query is modified to use `WithDDL`.
* a test around this change to confirm that the column gets recreated
* a new query added to the `WithDDLInitialQueries` list: it accesses the new  `time_heartbeat` column to force the related ALTER TABLE to run when a vreplication controller starts up


## Checklist
- [X] Should this PR be backported? Yes, to release-13.0
- [X] Tests were updated
- [x] Documentation is not required

