### PR TITLE
OnlineDDL: force (once) vreplication's WithDDL to run before running a vitess migration

### DIFF
--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -489,11 +489,12 @@ const (
 			AND TABLES.TABLE_NAME=%a
 			AND AUTO_INCREMENT IS NOT NULL
 		`
-	sqlAlterTableAutoIncrement = "ALTER TABLE `%s` AUTO_INCREMENT=%a"
-	sqlStartVReplStream        = "UPDATE _vt.vreplication set state='Running' where db_name=%a and workflow=%a"
-	sqlStopVReplStream         = "UPDATE _vt.vreplication set state='Stopped' where db_name=%a and workflow=%a"
-	sqlDeleteVReplStream       = "DELETE FROM _vt.vreplication where db_name=%a and workflow=%a"
-	sqlReadVReplStream         = `SELECT
+	sqlAlterTableAutoIncrement      = "ALTER TABLE `%s` AUTO_INCREMENT=%a"
+	sqlImpossibleSelectVreplication = "SELECT no_such_column__init_ddl FROM _vt.vreplication LIMIT 1"
+	sqlStartVReplStream             = "UPDATE _vt.vreplication set state='Running' where db_name=%a and workflow=%a"
+	sqlStopVReplStream              = "UPDATE _vt.vreplication set state='Stopped' where db_name=%a and workflow=%a"
+	sqlDeleteVReplStream            = "DELETE FROM _vt.vreplication where db_name=%a and workflow=%a"
+	sqlReadVReplStream              = `SELECT
 			id,
 			workflow,
 			source,


### PR DESCRIPTION
## Description

When running `vitess` (formerly known as `online`) migrations, the Online DDL executor initiates a `VReplication` flow. However, it does so via gRPC, since Online DDL runs on tabletserver and VReplication on tabletmanager. So Online DDL doesn't have ownership nor direct access to VReplication's state and flows.

We recently hit an issue where `_vt.vreplication` table was missing a column; `VReplication` did not happen to run a ny query that would cause its own `WithDDL` to upgrade the table and add the new column.

In this PR, the first time (in the process' lifetime) Online DDL attempts to run a vitess (vreplication) migration, it requests vreplication to run an intentionally invalid query: 

```sql
SELECT no_such_column__init_ddl FROM _vt.vreplication LIMIT 1
```

we know this query will fail, since  `no_such_column__init_ddl` column does not exist. However, what will happen is that this query then forces VReplication to run through its `WithDDL` list of DDLs, meaning we force VReplication to upgrade the table schema as needed.

Previously, I tried similar approach in `Open()`, but that hit a race condition where `tmclient` had no one to speak with, yet. Here, in this PR, we run this (in)validation query when we fully expect `VReplication` to be running.

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/9700 as a VReplication specific PR to fix an upgrade issue
- #6926 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

