### PR TITLE
[vtctld] Add 'enable_vtctld_ui' flag to vtctld to explicitly enable (or disable) the vtctld2 UI (backport)

### DIFF
--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -41,6 +41,7 @@ import (
 
 var (
 	enableRealtimeStats = flag.Bool("enable_realtime_stats", false, "Required for the Realtime Stats view. If set, vtctld will maintain a streaming RPC to each tablet (in all cells) to gather the realtime health stats.")
+	enableUI            = flag.Bool("enable_vtctld_ui", true, "If true, the vtctld web interface will be enabled. Default is true.")
 	durabilityPolicy    = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
 
 	_ = flag.String("web_dir", "", "NOT USED, here for backward compatibility")
@@ -171,6 +172,11 @@ func InitVtctld(ts *topo.Server) error {
 }
 
 func webAppHandler(w http.ResponseWriter, r *http.Request) {
+	if !*enableUI {
+		http.NotFound(w, r)
+		return
+	}
+
 	// Strip the prefix.
 	parts := strings.SplitN(r.URL.Path, "/", 3)
 	if len(parts) != 3 {

--- a/go/vt/vtctld/vtctld_test.go
+++ b/go/vt/vtctld/vtctld_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtctld
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebApp(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, appPrefix, nil)
+	w := httptest.NewRecorder()
+
+	webAppHandler(w, req)
+	res := w.Result()
+
+	assert.Equal(t, res.StatusCode, http.StatusOK)
+
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "<!doctype html>")
+}

--- a/go/vt/vtctld/vtctld_test.go
+++ b/go/vt/vtctld/vtctld_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtctld
 
 import (
+	"flag"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -32,11 +33,30 @@ func TestWebApp(t *testing.T) {
 	webAppHandler(w, req)
 	res := w.Result()
 
-	assert.Equal(t, res.StatusCode, http.StatusOK)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
 
 	defer res.Body.Close()
 
 	data, err := ioutil.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.Contains(t, string(data), "<!doctype html>")
+}
+
+func TestWebAppDisabled(t *testing.T) {
+	flag.Set("enable_vtctld_ui", "false")
+	defer flag.Set("enable_vtctld_ui", "true")
+
+	req := httptest.NewRequest(http.MethodGet, appPrefix, nil)
+	w := httptest.NewRecorder()
+
+	webAppHandler(w, req)
+	res := w.Result()
+
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "404 page not found\n", string(data))
 }


### PR DESCRIPTION
## Description

This is a backport of https://github.com/vitessio/vitess/pull/9614. I'll add release notes in a separate PR + link to this one. 

## Related Issue(s)

Backports https://github.com/vitessio/vitess/pull/9614

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

See https://github.com/vitessio/vitess/pull/9614