### PR TITLE
Remove the DurabilityParams argument to the durability interface

### DIFF
--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -95,7 +95,7 @@ func main() {
 		log.Warningf("cannot connect to syslog: %v", err)
 	}
 
-	if err := reparentutil.SetDurabilityPolicy(*durabilityPolicy, nil); err != nil {
+	if err := reparentutil.SetDurabilityPolicy(*durabilityPolicy); err != nil {
 		log.Errorf("error in setting durability policy: %v", err)
 		exit.Return(1)
 	}

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -80,7 +80,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	if err := reparentutil.SetDurabilityPolicy(*durabilityPolicy, nil); err != nil {
+	if err := reparentutil.SetDurabilityPolicy(*durabilityPolicy); err != nil {
 		log.Errorf("error in setting durability policy: %v", err)
 		exit.Return(1)
 	}

--- a/go/test/endtoend/vtorc/utils/test_config_crosscenter_prefer.json
+++ b/go/test/endtoend/vtorc/utils/test_config_crosscenter_prefer.json
@@ -7,8 +7,5 @@
   "RecoveryPeriodBlockSeconds": 1,
   "InstancePollSeconds": 1,
   "LockShardTimeoutSeconds": 5,
-  "Durability": "specified",
-  "DurabilityParams": {
-    "zone2-0000000200": "prefer"
-  }
+  "Durability": "test"
 }

--- a/go/test/endtoend/vtorc/utils/test_config_crosscenter_prefer_prevent.json
+++ b/go/test/endtoend/vtorc/utils/test_config_crosscenter_prefer_prevent.json
@@ -7,9 +7,6 @@
   "RecoveryPeriodBlockSeconds": 1,
   "InstancePollSeconds": 1,
   "LockShardTimeoutSeconds": 5,
-  "Durability": "specified",
-  "DurabilityParams": {
-    "zone2-0000000200": "prefer"
-  },
+  "Durability": "test",
   "PreventCrossDataCenterPrimaryFailover": true
 }

--- a/go/vt/orchestrator/config/config.go
+++ b/go/vt/orchestrator/config/config.go
@@ -62,14 +62,13 @@ const (
 // strictly expected from user.
 // TODO(sougou): change this to yaml parsing, and possible merge with tabletenv.
 type Configuration struct {
-	Debug                                       bool              // set debug mode (similar to --debug option)
-	EnableSyslog                                bool              // Should logs be directed (in addition) to syslog daemon?
-	ListenAddress                               string            // Where orchestrator HTTP should listen for TCP
-	ListenSocket                                string            // Where orchestrator HTTP should listen for unix socket (default: empty; when given, TCP is disabled)
-	HTTPAdvertise                               string            // optional, for raft setups, what is the HTTP address this node will advertise to its peers (potentially use where behind NAT or when rerouting ports; example: "http://11.22.33.44:3030")
-	AgentsServerPort                            string            // port orchestrator agents talk back to
-	Durability                                  string            // The type of durability to enforce. Default is "none". Other values are dictated by registered plugins
-	DurabilityParams                            map[string]string // map for specifying additional parameters for durability plugins. Used by durability mode "specified"
+	Debug                                       bool   // set debug mode (similar to --debug option)
+	EnableSyslog                                bool   // Should logs be directed (in addition) to syslog daemon?
+	ListenAddress                               string // Where orchestrator HTTP should listen for TCP
+	ListenSocket                                string // Where orchestrator HTTP should listen for unix socket (default: empty; when given, TCP is disabled)
+	HTTPAdvertise                               string // optional, for raft setups, what is the HTTP address this node will advertise to its peers (potentially use where behind NAT or when rerouting ports; example: "http://11.22.33.44:3030")
+	AgentsServerPort                            string // port orchestrator agents talk back to
+	Durability                                  string // The type of durability to enforce. Default is "none". Other values are dictated by registered plugins
 	MySQLTopologyUser                           string
 	MySQLTopologyPassword                       string
 	MySQLReplicaUser                            string // If set, use this credential instead of discovering from mysql. TODO(sougou): deprecate this in favor of fetching from vttablet
@@ -256,7 +255,6 @@ func newConfiguration() *Configuration {
 		HTTPAdvertise:                               "",
 		AgentsServerPort:                            ":3001",
 		Durability:                                  "none",
-		DurabilityParams:                            make(map[string]string),
 		StatusEndpoint:                              DefaultStatusAPIEndpoint,
 		StatusOUVerify:                              false,
 		BackendDB:                                   "sqlite",

--- a/go/vt/orchestrator/logic/orchestrator.go
+++ b/go/vt/orchestrator/logic/orchestrator.go
@@ -416,7 +416,7 @@ func ContinuousDiscovery() {
 	go ometrics.InitMetrics()
 	go acceptSignals()
 	go kv.InitKVStores()
-	reparentutil.SetDurabilityPolicy(config.Config.Durability, config.Config.DurabilityParams)
+	reparentutil.SetDurabilityPolicy(config.Config.Durability)
 
 	if *config.RuntimeCLIFlags.GrabElection {
 		process.GrabElection()

--- a/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
@@ -43,7 +43,7 @@ func TestInitShardPrimary(t *testing.T) {
 	ts := memorytopo.NewServer("cell1")
 	tmc := tmclient.NewTabletManagerClient()
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmc)
-	_ = reparentutil.SetDurabilityPolicy("none", nil)
+	_ = reparentutil.SetDurabilityPolicy("none")
 
 	primaryDb := fakesqldb.New(t)
 	primaryDb.AddQuery("create database if not exists `vt_test_keyspace`", &sqltypes.Result{InsertID: 0, RowsAffected: 0})
@@ -103,7 +103,7 @@ func TestInitShardPrimaryNoFormerPrimary(t *testing.T) {
 	ts := memorytopo.NewServer("cell1")
 	tmc := tmclient.NewTabletManagerClient()
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmc)
-	_ = reparentutil.SetDurabilityPolicy("none", nil)
+	_ = reparentutil.SetDurabilityPolicy("none")
 
 	primaryDb := fakesqldb.New(t)
 	primaryDb.AddQuery("create database if not exists `vt_test_keyspace`", &sqltypes.Result{InsertID: 0, RowsAffected: 0})

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -67,7 +67,7 @@ func init() {
 	tmclient.RegisterTabletManagerClientFactory("grpcvtctldserver.test", func() tmclient.TabletManagerClient {
 		return nil
 	})
-	_ = reparentutil.SetDurabilityPolicy("none", nil)
+	_ = reparentutil.SetDurabilityPolicy("none")
 }
 
 func TestAddCellInfo(t *testing.T) {

--- a/go/vt/vtctl/reparentutil/durability.go
+++ b/go/vt/vtctl/reparentutil/durability.go
@@ -32,7 +32,7 @@ import (
 // A newDurabler is a function that creates a new durabler based on the
 // properties specified in the input map. Every durabler must
 // register a newDurabler function.
-type newDurabler func(map[string]string) durabler
+type newDurabler func() durabler
 
 var (
 	// durabilityPolicies is a map that stores the functions needed to create a new durabler
@@ -45,16 +45,18 @@ var (
 
 func init() {
 	// register all the durability rules with their functions to create them
-	registerDurability("none", func(map[string]string) durabler {
+	registerDurability("none", func() durabler {
 		return &durabilityNone{}
 	})
-	registerDurability("semi_sync", func(map[string]string) durabler {
+	registerDurability("semi_sync", func() durabler {
 		return &durabilitySemiSync{}
 	})
-	registerDurability("cross_cell", func(map[string]string) durabler {
+	registerDurability("cross_cell", func() durabler {
 		return &durabilityCrossCell{}
 	})
-	registerDurability("specified", newDurabilitySpecified)
+	registerDurability("test", func() durabler {
+		return &durabilityTest{}
+	})
 }
 
 // durabler is the interface which is used to get the promotion rules for candidates and the semi sync setup
@@ -74,7 +76,7 @@ func registerDurability(name string, newDurablerFunc newDurabler) {
 //=======================================================================
 
 // SetDurabilityPolicy is used to set the durability policy from the registered policies
-func SetDurabilityPolicy(name string, durabilityParams map[string]string) error {
+func SetDurabilityPolicy(name string) error {
 	newDurabilityCreationFunc, found := durabilityPolicies[name]
 	if !found {
 		return fmt.Errorf("durability policy %v not found", name)
@@ -82,7 +84,7 @@ func SetDurabilityPolicy(name string, durabilityParams map[string]string) error 
 	log.Infof("Setting durability policy to %v", name)
 	curDurabilityPolicyMutex.Lock()
 	defer curDurabilityPolicyMutex.Unlock()
-	curDurabilityPolicy = newDurabilityCreationFunc(durabilityParams)
+	curDurabilityPolicy = newDurabilityCreationFunc()
 	return nil
 }
 
@@ -189,16 +191,12 @@ func (d *durabilityCrossCell) isReplicaSemiSync(primary, replica *topodatapb.Tab
 
 //=======================================================================
 
-// durabilitySpecified is like durabilityNone. It has an additional map which it first queries with the tablet alias as the key
-// If a CandidatePromotionRule is found in that map, then that is used as the promotion rule. Otherwise, it reverts to the same logic as durabilityNone
-type durabilitySpecified struct {
-	promotionRules map[string]promotionrule.CandidatePromotionRule
-}
+// durabilityTest is like durabilityNone. It overrides the type for a specific tablet to prefer. It is only meant to be used for testing purposes!
+type durabilityTest struct{}
 
-func (d *durabilitySpecified) promotionRule(tablet *topodatapb.Tablet) promotionrule.CandidatePromotionRule {
-	promoteRule, isFound := d.promotionRules[topoproto.TabletAliasString(tablet.Alias)]
-	if isFound {
-		return promoteRule
+func (d *durabilityTest) promotionRule(tablet *topodatapb.Tablet) promotionrule.CandidatePromotionRule {
+	if topoproto.TabletAliasString(tablet.Alias) == "zone2-0000000200" {
+		return promotionrule.Prefer
 	}
 
 	switch tablet.Type {
@@ -208,31 +206,10 @@ func (d *durabilitySpecified) promotionRule(tablet *topodatapb.Tablet) promotion
 	return promotionrule.MustNot
 }
 
-func (d *durabilitySpecified) semiSyncAckers(tablet *topodatapb.Tablet) int {
+func (d *durabilityTest) semiSyncAckers(tablet *topodatapb.Tablet) int {
 	return 0
 }
 
-func (d *durabilitySpecified) isReplicaSemiSync(primary, replica *topodatapb.Tablet) bool {
+func (d *durabilityTest) isReplicaSemiSync(primary, replica *topodatapb.Tablet) bool {
 	return false
-}
-
-// newDurabilitySpecified is a function that is used to create a new durabilitySpecified struct
-func newDurabilitySpecified(m map[string]string) durabler {
-	promotionRules := map[string]promotionrule.CandidatePromotionRule{}
-	// range over the map given by the user
-	for tabletAliasStr, promotionRuleStr := range m {
-		// parse the promotion rule
-		promotionRule, err := promotionrule.Parse(promotionRuleStr)
-		// if parsing is not successful, skip over this rule
-		if err != nil {
-			log.Errorf("invalid promotion rule %s found, received error - %v", promotionRuleStr, err)
-			continue
-		}
-		// set the promotion rule in the map at the given tablet alias
-		promotionRules[tabletAliasStr] = promotionRule
-	}
-
-	return &durabilitySpecified{
-		promotionRules: promotionRules,
-	}
 }

--- a/go/vt/vtctl/reparentutil/durability_test.go
+++ b/go/vt/vtctl/reparentutil/durability_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestDurabilityNone(t *testing.T) {
-	err := SetDurabilityPolicy("none", nil)
+	err := SetDurabilityPolicy("none")
 	require.NoError(t, err)
 
 	promoteRule := PromotionRule(&topodatapb.Tablet{
@@ -56,7 +56,7 @@ func TestDurabilityNone(t *testing.T) {
 }
 
 func TestDurabilitySemiSync(t *testing.T) {
-	err := SetDurabilityPolicy("semi_sync", nil)
+	err := SetDurabilityPolicy("semi_sync")
 	require.NoError(t, err)
 
 	promoteRule := PromotionRule(&topodatapb.Tablet{
@@ -88,7 +88,7 @@ func TestDurabilitySemiSync(t *testing.T) {
 }
 
 func TestDurabilityCrossCell(t *testing.T) {
-	err := SetDurabilityPolicy("cross_cell", nil)
+	err := SetDurabilityPolicy("cross_cell")
 	require.NoError(t, err)
 
 	promoteRule := PromotionRule(&topodatapb.Tablet{
@@ -147,20 +147,13 @@ func TestDurabilityCrossCell(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	err := SetDurabilityPolicy("unknown", nil)
+	err := SetDurabilityPolicy("unknown")
 	assert.EqualError(t, err, "durability policy unknown not found")
 }
 
-func TestDurabilitySpecified(t *testing.T) {
-	cellName := "cell"
-	durabilityRules := newDurabilitySpecified(
-		map[string]string{
-			"cell-0000000000": string(promotionrule.Must),
-			"cell-0000000001": string(promotionrule.Prefer),
-			"cell-0000000002": string(promotionrule.Neutral),
-			"cell-0000000003": string(promotionrule.PreferNot),
-			"cell-0000000004": string(promotionrule.MustNot),
-		})
+func TestDurabilityTest(t *testing.T) {
+	cellName := "zone2"
+	durabilityRules := &durabilityTest{}
 
 	testcases := []struct {
 		tablet        *topodatapb.Tablet
@@ -172,13 +165,14 @@ func TestDurabilitySpecified(t *testing.T) {
 					Cell: cellName,
 					Uid:  0,
 				},
+				Type: topodatapb.TabletType_SPARE,
 			},
 			promotionRule: promotionrule.MustNot,
 		}, {
 			tablet: &topodatapb.Tablet{
 				Alias: &topodatapb.TabletAlias{
 					Cell: cellName,
-					Uid:  1,
+					Uid:  200,
 				},
 			},
 			promotionRule: promotionrule.Prefer,
@@ -188,22 +182,16 @@ func TestDurabilitySpecified(t *testing.T) {
 					Cell: cellName,
 					Uid:  2,
 				},
+				Type: topodatapb.TabletType_PRIMARY,
 			},
 			promotionRule: promotionrule.Neutral,
 		}, {
 			tablet: &topodatapb.Tablet{
 				Alias: &topodatapb.TabletAlias{
 					Cell: cellName,
-					Uid:  3,
-				},
-			},
-			promotionRule: promotionrule.PreferNot,
-		}, {
-			tablet: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: cellName,
 					Uid:  4,
 				},
+				Type: topodatapb.TabletType_BACKUP,
 			},
 			promotionRule: promotionrule.MustNot,
 		},

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -1371,7 +1371,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 		},
 	}
 
-	_ = SetDurabilityPolicy("none", nil)
+	_ = SetDurabilityPolicy("none")
 	for _, tt := range tests {
 		tt := tt
 
@@ -2207,7 +2207,7 @@ func TestEmergencyReparenterCounters(t *testing.T) {
 	ersCounter.Set(0)
 	ersSuccessCounter.Set(0)
 	ersFailureCounter.Set(0)
-	_ = SetDurabilityPolicy("none", nil)
+	_ = SetDurabilityPolicy("none")
 
 	emergencyReparentOps := EmergencyReparentOptions{}
 	tmc := &testutil.TabletManagerClient{
@@ -2600,7 +2600,7 @@ func TestEmergencyReparenter_findMostAdvanced(t *testing.T) {
 		},
 	}
 
-	_ = SetDurabilityPolicy("none", nil)
+	_ = SetDurabilityPolicy("none")
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -2691,7 +2691,7 @@ func TestEmergencyReparenter_checkIfConstraintsSatisfied(t *testing.T) {
 		},
 	}
 
-	_ = SetDurabilityPolicy("none", nil)
+	_ = SetDurabilityPolicy("none")
 	erp := NewEmergencyReparenter(nil, nil, nil)
 
 	for _, testcase := range testcases {
@@ -3740,7 +3740,7 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_ = SetDurabilityPolicy("none", nil)
+			_ = SetDurabilityPolicy("none")
 			logger := logutil.NewMemoryLogger()
 
 			erp := NewEmergencyReparenter(nil, nil, logger)

--- a/go/vt/vtctl/reparentutil/reparent_sorter_test.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter_test.go
@@ -122,7 +122,7 @@ func TestReparentSorter(t *testing.T) {
 		},
 	}
 
-	err := SetDurabilityPolicy("none", nil)
+	err := SetDurabilityPolicy("none")
 	require.NoError(t, err)
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -54,7 +54,7 @@ const (
 
 // InitVtctld initializes all the vtctld functionality.
 func InitVtctld(ts *topo.Server) error {
-	err := reparentutil.SetDurabilityPolicy(*durabilityPolicy, nil)
+	err := reparentutil.SetDurabilityPolicy(*durabilityPolicy)
 	if err != nil {
 		log.Errorf("error in setting durability policy: %v", err)
 		return err

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -58,7 +58,7 @@ func createVerticalSplitCloneDestinationFakeDb(t *testing.T, name string, insert
 }
 
 func init() {
-	_ = reparentutil.SetDurabilityPolicy("none", nil)
+	_ = reparentutil.SetDurabilityPolicy("none")
 }
 
 // TestVerticalSplitClone will run VerticalSplitClone in the combined

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -44,7 +44,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 		discovery.SetTabletPickerRetryDelay(delay)
 	}()
 	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
-	_ = reparentutil.SetDurabilityPolicy("none", nil)
+	_ = reparentutil.SetDurabilityPolicy("none")
 
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
@@ -194,7 +194,7 @@ func TestEmergencyReparentShardPrimaryElectNotBest(t *testing.T) {
 		discovery.SetTabletPickerRetryDelay(delay)
 	}()
 	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
-	_ = reparentutil.SetDurabilityPolicy("none", nil)
+	_ = reparentutil.SetDurabilityPolicy("none")
 
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
The DurabilityParams argument was added to the Durability interface for testing purposes. Currently we are in a state wherein we have can specify that map from vtorc but not from any other place. Therefore we are removing this parameter.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? I think so
- [X] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->