### PR TITLE
Hack to allow `bootstrap.sh` to run cleanly on fresh M1

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -105,18 +105,44 @@ install_protoc() {
   case $(get_arch) in
       aarch64)  local target=aarch_64;;
       x86_64)  local target=x86_64;;
-      arm64) case "$platform" in # TODO (ajm188): remove after protoc includes signed protoc binaries for M1 Macs.
-          osx) echo "WARN: Installing x86_64 protoc on arm macos; This will work if you have Rosetta installed. See https://github.com/protocolbuffers/protobuf/issues/9397." >&2;
-               local target=x86_64;;
+      arm64) case "$platform" in
+          osx) local use_homebrew=1;;
           *) echo "ERROR: unsupported architecture"; exit 1;;
-          esac;;
+      esac;;
       *)   echo "ERROR: unsupported architecture"; exit 1;;
   esac
 
-  # This is how we'd download directly from source:
-  # wget https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-$platform-${target}.zip
-  $VTROOT/tools/wget-retry "${VITESS_RESOURCES_DOWNLOAD_URL}/protoc-$version-$platform-${target}.zip"
-  unzip "protoc-$version-$platform-${target}.zip"
+  # TODO (ajm188): remove this branch after protoc includes signed protoc binaries for M1 Macs.
+  if [[ "$use_homebrew" -eq 1 ]]; then
+    cat >&2 <<WARNING
+WARN: Protobuf does not have a protoc binary for arm64 macos.
+Checking for homebrew installation. Altertatively, you may install the x86-64
+version if you have Rosetta installed; your mileage may vary.
+
+See https://github.com/protocolbuffers/protobuf/issues/9397.
+WARNING
+
+    if [[ -z "$(command -v brew)" ]]; then
+      echo "Could not find \`brew\` command. Please install homebrew and retry." >&2;
+      exit 1;
+    fi
+
+    brew install protobuf;
+    protobuf_base="$(brew list protobuf | grep -E 'LICENSE$' | sed 's:/LICENSE$::')"
+    if [[ -z "$protobuf_base" ]]; then
+      echo "Could not find \`protobuf\` directory after installing. Please verify the output of \`brew info protobuf\`" >&2;
+      exit 1;
+    fi
+
+    ln -snf "${protobuf_base}/bin" "${dist}/bin"
+    ln -snf "${protobuf_base}/include" "${dist}/include"
+  else
+    # This is how we'd download directly from source:
+    # wget https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-$platform-${target}.zip
+    $VTROOT/tools/wget-retry "${VITESS_RESOURCES_DOWNLOAD_URL}/protoc-$version-$platform-${target}.zip"
+    unzip "protoc-$version-$platform-${target}.zip"
+  fi
+
   ln -snf "$dist/bin/protoc" "$VTROOT/bin/protoc"
 }
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -105,6 +105,11 @@ install_protoc() {
   case $(get_arch) in
       aarch64)  local target=aarch_64;;
       x86_64)  local target=x86_64;;
+      arm64) case "$platform" in # TODO (ajm188): remove after protoc includes signed protoc binaries for M1 Macs.
+          osx) echo "WARN: Installing x86_64 protoc on arm macos; This will work if you have Rosetta installed. See https://github.com/protocolbuffers/protobuf/issues/9397." >&2;
+               local target=x86_64;;
+          *) echo "ERROR: unsupported architecture"; exit 1;;
+          esac;;
       *)   echo "ERROR: unsupported architecture"; exit 1;;
   esac
 


### PR DESCRIPTION
## Description

Currently, we don't provide a `protoc` binary for osx/arm64
combinations (i.e. "M1 Macs"), and neither does upstream
protobuf.

The current upstream suggested workaround is to build from source or use
unsigned binaries.

Luckily, if you have Rosetta installed on your machine (which for a while
was required to [run `man` without errors](https://apple.stackexchange.com/questions/430310/apple-silicon-usr-bin-mandoc-bad-cpu-type-in-executable/430311#430311), it's actually totally fine to run the x86-64 version.

So, we just warn the user we're doing this and install the other binary.

### Testing

```
➜  vitess git:(andrew/protoc-m1) ✗ rm -rf dist/vt-protoc-*    
➜  vitess git:(andrew/protoc-m1) ✗ 
➜  vitess git:(andrew/protoc-m1) ✗ make minimaltools >/dev/null
WARN: Installing x86_64 protoc on arm macos; This will work if you have Rosetta installed. See https://github.com/protocolbuffers/protobuf/issues/9397.
--2022-02-17 06:08:00--  https://github.com/vitessio/vitess-resources/releases/download/v1.0/protoc-3.19.4-osx-x86_64.zip
Resolving github.com (github.com)...
[wget output elided]
Saving to: ‘protoc-3.19.4-osx-x86_64.zip’

protoc-3.19.4-osx-x86_64.zip       100%[================================================================>]   2.55M  12.0MB/s    in 0.2s    

2022-02-17 06:08:01 (12.0 MB/s) - ‘protoc-3.19.4-osx-x86_64.zip’ saved [2676128/2676128]
```

## Related Issue(s)

Fixes #9722


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required **n/a**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->