### PR TITLE
Fix `make embed_config` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,8 @@ export CGO_CFLAGS := -O1
 
 # regenerate rice-box.go when any of the .cnf files change
 embed_config:
-	cd go/vt/mysqlctl
-	go run github.com/GeertJohan/go.rice/rice embed-go
-	go build .
+	cd go/vt/mysqlctl && go run github.com/GeertJohan/go.rice/rice embed-go
+	cd go/vt/mysqlctl && go build .
 
 # build the vitess binaries with dynamic dependency on libc
 build-dyn:


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Make executes each line in its own shell, so the `cd` had no effect on
the subsequent `go` invocations. Fix this by making each line `cd`
individually.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
none

## Checklist
- [x] Should this PR be backported? - NO, only relevant for development
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
None – development workflow fix only