### PR TITLE
sqlparser: Adding IsText field to ~ColumnDefinition~ ColumnType

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -1593,6 +1593,8 @@ type ColumnType struct {
 	Scale    *Literal
 
 	// Text field options
+	// IsText indicates whether the column has textual properties, thus if it is capable fo having a charset (irrespective of having or not having a declared charset)
+	IsText  bool
 	Charset string
 
 	// Enum values

--- a/go/vt/sqlparser/ast_equals.go
+++ b/go/vt/sqlparser/ast_equals.go
@@ -1303,6 +1303,7 @@ func EqualsRefOfColumnType(a, b *ColumnType) bool {
 	return a.Type == b.Type &&
 		a.Unsigned == b.Unsigned &&
 		a.Zerofill == b.Zerofill &&
+		a.IsText == b.IsText &&
 		a.Charset == b.Charset &&
 		EqualsRefOfColumnTypeOptions(a.Options, b.Options) &&
 		EqualsRefOfLiteral(a.Length, b.Length) &&
@@ -4062,6 +4063,7 @@ func EqualsColumnType(a, b ColumnType) bool {
 	return a.Type == b.Type &&
 		a.Unsigned == b.Unsigned &&
 		a.Zerofill == b.Zerofill &&
+		a.IsText == b.IsText &&
 		a.Charset == b.Charset &&
 		EqualsRefOfColumnTypeOptions(a.Options, b.Options) &&
 		EqualsRefOfLiteral(a.Length, b.Length) &&

--- a/go/vt/sqlparser/cached_size.go
+++ b/go/vt/sqlparser/cached_size.go
@@ -509,7 +509,7 @@ func (cached *ColumnDefinition) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(128)
+		size += int64(144)
 	}
 	// field Name vitess.io/vitess/go/vt/sqlparser.ColIdent
 	size += cached.Name.CachedSize(false)

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -8522,13 +8522,13 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line sql.y:1752
 		{
-			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Length: yyDollar[2].literalUnion(), Charset: yyDollar[3].str}
+			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Length: yyDollar[2].literalUnion(), Charset: yyDollar[3].str, IsText: true}
 		}
 	case 286:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line sql.y:1756
 		{
-			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Length: yyDollar[2].literalUnion(), Charset: yyDollar[3].str}
+			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Length: yyDollar[2].literalUnion(), Charset: yyDollar[3].str, IsText: true}
 		}
 	case 287:
 		yyDollar = yyS[yypt-2 : yypt+1]
@@ -8546,25 +8546,25 @@ yydefault:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line sql.y:1768
 		{
-			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Charset: yyDollar[2].str}
+			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Charset: yyDollar[2].str, IsText: true}
 		}
 	case 290:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line sql.y:1772
 		{
-			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Charset: yyDollar[2].str}
+			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Charset: yyDollar[2].str, IsText: true}
 		}
 	case 291:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line sql.y:1776
 		{
-			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Charset: yyDollar[2].str}
+			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Charset: yyDollar[2].str, IsText: true}
 		}
 	case 292:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line sql.y:1780
 		{
-			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Charset: yyDollar[2].str}
+			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), Charset: yyDollar[2].str, IsText: true}
 		}
 	case 293:
 		yyDollar = yyS[yypt-1 : yypt+1]
@@ -8594,19 +8594,19 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line sql.y:1800
 		{
-			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str)}
+			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), IsText: true}
 		}
 	case 298:
 		yyDollar = yyS[yypt-5 : yypt+1]
 //line sql.y:1804
 		{
-			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), EnumValues: yyDollar[3].strs, Charset: yyDollar[5].str}
+			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), EnumValues: yyDollar[3].strs, Charset: yyDollar[5].str, IsText: true}
 		}
 	case 299:
 		yyDollar = yyS[yypt-5 : yypt+1]
 //line sql.y:1809
 		{
-			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), EnumValues: yyDollar[3].strs, Charset: yyDollar[5].str}
+			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].str), EnumValues: yyDollar[3].strs, Charset: yyDollar[5].str, IsText: true}
 		}
 	case 300:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -1750,11 +1750,11 @@ time_type:
 char_type:
   CHAR length_opt charset_opt
   {
-    $$ = ColumnType{Type: string($1), Length: $2, Charset: $3}
+    $$ = ColumnType{Type: string($1), Length: $2, Charset: $3, IsText: true}
   }
 | VARCHAR length_opt charset_opt
   {
-    $$ = ColumnType{Type: string($1), Length: $2, Charset: $3}
+    $$ = ColumnType{Type: string($1), Length: $2, Charset: $3, IsText: true}
   }
 | BINARY length_opt
   {
@@ -1766,19 +1766,19 @@ char_type:
   }
 | TEXT charset_opt
   {
-    $$ = ColumnType{Type: string($1), Charset: $2}
+    $$ = ColumnType{Type: string($1), Charset: $2, IsText: true}
   }
 | TINYTEXT charset_opt
   {
-    $$ = ColumnType{Type: string($1), Charset: $2}
+    $$ = ColumnType{Type: string($1), Charset: $2, IsText: true}
   }
 | MEDIUMTEXT charset_opt
   {
-    $$ = ColumnType{Type: string($1), Charset: $2}
+    $$ = ColumnType{Type: string($1), Charset: $2, IsText: true}
   }
 | LONGTEXT charset_opt
   {
-    $$ = ColumnType{Type: string($1), Charset: $2}
+    $$ = ColumnType{Type: string($1), Charset: $2, IsText: true}
   }
 | BLOB
   {
@@ -1798,16 +1798,16 @@ char_type:
   }
 | JSON
   {
-    $$ = ColumnType{Type: string($1)}
+    $$ = ColumnType{Type: string($1), IsText: true}
   }
 | ENUM '(' enum_values ')' charset_opt
   {
-    $$ = ColumnType{Type: string($1), EnumValues: $3, Charset: $5}
+    $$ = ColumnType{Type: string($1), EnumValues: $3, Charset: $5, IsText: true}
   }
 // need set_values / SetValues ?
 | SET '(' enum_values ')' charset_opt
   {
-    $$ = ColumnType{Type: string($1), EnumValues: $3, Charset: $5}
+    $$ = ColumnType{Type: string($1), EnumValues: $3, Charset: $5, IsText: true}
   }
 
 spatial_type:


### PR DESCRIPTION
## Description

When parsing ~~`ColumnDefinition`~~ `ColumnType`, the parser parses and assigns the `Charset` value, if present. However, there is some loss of information. Some columns types are not at all textual (like numbers: they don't have charsets), while others are textual but happen to have no `charset` in their definition (ie `c char(10) not null`).

~~`ColumnDefinition`~~ `ColumnType` has a `Charset string` field, which is populated when charset is defined. But when the field is empty, it is impossible to determine whether this was because there isn't any charset clause in the definition, or whether there _can't be_ any charset clause.

This PR adds a `IsText bool` (maybe better called `IsTextual`? whichever), that indicates "yes, this column could potentially have a charset" (chars, varchars, json, enum, set) or "no, there cannot be a charset" (numeric, temporal, etc.).

The parser is responsible to populate `IsText`.

This information is later useful when investigating a table schema (I have a use case for `schemadiff`).

Is this approach acceptable?

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->