### PR TITLE
Backport: fix semi-sync for Backup and RestoreFromBackup commands by calling SetReplicationSource RPC

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -680,12 +680,16 @@ func (tm *TabletManager) setReplicationSourceLocked(ctx context.Context, parentA
 			}
 		}
 	} else if shouldbeReplicating {
-		// The address is correct. Just start replication if needed.
-		if !status.ReplicationRunning() {
-			if err := tm.MysqlDaemon.StartReplication(tm.hookExtraEnv()); err != nil {
-				if err := tm.handleRelayLogError(err); err != nil {
-					return err
-				}
+		// The address is correct. We need to restart replication so that any semi-sync changes if any
+		// are taken into account
+		if err := tm.MysqlDaemon.StopReplication(tm.hookExtraEnv()); err != nil {
+			if err := tm.handleRelayLogError(err); err != nil {
+				return err
+			}
+		}
+		if err := tm.MysqlDaemon.StartReplication(tm.hookExtraEnv()); err != nil {
+			if err := tm.handleRelayLogError(err); err != nil {
+				return err
 			}
 		}
 	}

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -127,30 +127,48 @@ func (wr *Wrangler) StartReplication(ctx context.Context, tablet *topodatapb.Tab
 	return wr.TabletManagerClient().StartReplication(ctx, tablet, semiSync)
 }
 
+// SetReplicationSource is used to set the replication source on the specified tablet
+// It also finds out if the tablet should be sending semi-sync ACKs or not. It does not start the replication forcefully
+func (wr *Wrangler) SetReplicationSource(ctx context.Context, tablet *topodatapb.Tablet) error {
+	shardPrimary, err := wr.getShardPrimaryForTablet(ctx, tablet)
+	if err != nil {
+		return nil
+	}
+	semiSync := reparentutil.IsReplicaSemiSync(shardPrimary.Tablet, tablet)
+	return wr.TabletManagerClient().SetReplicationSource(ctx, tablet, shardPrimary.Alias, 0, "", false, semiSync)
+}
+
 func (wr *Wrangler) shouldSendSemiSyncAck(ctx context.Context, tablet *topodatapb.Tablet) (bool, error) {
-	shard, err := wr.ts.GetShard(ctx, tablet.Keyspace, tablet.Shard)
+	shardPrimary, err := wr.getShardPrimaryForTablet(ctx, tablet)
 	if err != nil {
 		return false, err
 	}
+	return reparentutil.IsReplicaSemiSync(shardPrimary.Tablet, tablet), nil
+}
+
+func (wr *Wrangler) getShardPrimaryForTablet(ctx context.Context, tablet *topodatapb.Tablet) (*topo.TabletInfo, error) {
+	shard, err := wr.ts.GetShard(ctx, tablet.Keyspace, tablet.Shard)
+	if err != nil {
+		return nil, err
+	}
 
 	if !shard.HasPrimary() {
-		return false, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no primary tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
+		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no primary tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
 	}
 
 	shardPrimary, err := wr.ts.GetTablet(ctx, shard.PrimaryAlias)
 	if err != nil {
-		return false, fmt.Errorf("cannot lookup primary tablet %v for shard %v/%v: %w", topoproto.TabletAliasString(shard.PrimaryAlias), tablet.Keyspace, tablet.Shard, err)
+		return nil, fmt.Errorf("cannot lookup primary tablet %v for shard %v/%v: %w", topoproto.TabletAliasString(shard.PrimaryAlias), tablet.Keyspace, tablet.Shard, err)
 	}
 
 	if shardPrimary.Type != topodatapb.TabletType_PRIMARY {
-		return false, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "TopologyServer has incosistent state for shard primary %v", topoproto.TabletAliasString(shard.PrimaryAlias))
+		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "TopologyServer has inconsistent state for shard primary %v", topoproto.TabletAliasString(shard.PrimaryAlias))
 	}
 
 	if shardPrimary.Keyspace != tablet.Keyspace || shardPrimary.Shard != tablet.Shard {
-		return false, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary %v and potential replica %v not in same keypace shard (%v/%v)", topoproto.TabletAliasString(shard.PrimaryAlias), topoproto.TabletAliasString(tablet.Alias), tablet.Keyspace, tablet.Shard)
+		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary %v and potential replica %v not in same keyspace shard (%v/%v)", topoproto.TabletAliasString(shard.PrimaryAlias), topoproto.TabletAliasString(tablet.Alias), tablet.Keyspace, tablet.Shard)
 	}
-
-	return reparentutil.IsReplicaSemiSync(shardPrimary.Tablet, tablet), nil
+	return shardPrimary, nil
 }
 
 // RefreshTabletState refreshes tablet state

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -127,8 +127,9 @@ func (wr *Wrangler) StartReplication(ctx context.Context, tablet *topodatapb.Tab
 	return wr.TabletManagerClient().StartReplication(ctx, tablet, semiSync)
 }
 
-// SetReplicationSource is used to set the replication source on the specified tablet
-// It also finds out if the tablet should be sending semi-sync ACKs or not. It does not start the replication forcefully
+// SetReplicationSource is used to set the replication source on the specified tablet to the current shard primary (if available).
+// It also figures out if the tablet should be sending semi-sync ACKs or not and passes that to the tabletmanager RPC.
+// It does not start the replication forcefully
 func (wr *Wrangler) SetReplicationSource(ctx context.Context, tablet *topodatapb.Tablet) error {
 	shardPrimary, err := wr.getShardPrimaryForTablet(ctx, tablet)
 	if err != nil {

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testlib
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -40,6 +41,7 @@ import (
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 	"vitess.io/vitess/go/vt/wrangler"
 
@@ -47,6 +49,7 @@ import (
 )
 
 func TestBackupRestore(t *testing.T) {
+	_ = reparentutil.SetDurabilityPolicy("none")
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -120,6 +123,7 @@ func TestBackupRestore(t *testing.T) {
 	sourceTablet := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, db)
 	sourceTablet.FakeMysqlDaemon.ReadOnly = true
 	sourceTablet.FakeMysqlDaemon.Replicating = true
+	sourceTablet.FakeMysqlDaemon.SetReplicationSourceInputs = []string{fmt.Sprintf("%s:%d", primary.Tablet.MysqlHostname, primary.Tablet.MysqlPort)}
 	sourceTablet.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
@@ -130,7 +134,15 @@ func TestBackupRestore(t *testing.T) {
 		},
 	}
 	sourceTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// This first set of STOP and START commands come from
+		// the builtinBackupEngine implementation which stops the replication
+		// while taking the backup
 		"STOP SLAVE",
+		"START SLAVE",
+		// These commands come from SetReplicationSource RPC called
+		// to set the correct primary and semi-sync after Backup has concluded
+		"STOP SLAVE",
+		"FAKE SET MASTER",
 		"START SLAVE",
 	}
 	sourceTablet.StartActionLoop(t, wr)
@@ -252,6 +264,7 @@ func TestBackupRestore(t *testing.T) {
 // While doing a backup or a restore, we wait for a change of the replica's position before completing the action
 // This is because otherwise ReplicationLagSeconds is not accurate and the tablet may go into SERVING when it should not
 func TestBackupRestoreLagged(t *testing.T) {
+	_ = reparentutil.SetDurabilityPolicy("none")
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -334,8 +347,17 @@ func TestBackupRestoreLagged(t *testing.T) {
 			},
 		},
 	}
+	sourceTablet.FakeMysqlDaemon.SetReplicationSourceInputs = []string{fmt.Sprintf("%s:%d", primary.Tablet.MysqlHostname, primary.Tablet.MysqlPort)}
 	sourceTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// This first set of STOP and START commands come from
+		// the builtinBackupEngine implementation which stops the replication
+		// while taking the backup
 		"STOP SLAVE",
+		"START SLAVE",
+		// These commands come from SetReplicationSource RPC called
+		// to set the correct primary and semi-sync after Backup has concluded
+		"STOP SLAVE",
+		"FAKE SET MASTER",
 		"START SLAVE",
 	}
 	sourceTablet.StartActionLoop(t, wr)
@@ -449,6 +471,7 @@ func TestBackupRestoreLagged(t *testing.T) {
 }
 
 func TestRestoreUnreachablePrimary(t *testing.T) {
+	_ = reparentutil.SetDurabilityPolicy("none")
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -530,8 +553,17 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 			},
 		},
 	}
+	sourceTablet.FakeMysqlDaemon.SetReplicationSourceInputs = []string{fmt.Sprintf("%s:%d", primary.Tablet.MysqlHostname, primary.Tablet.MysqlPort)}
 	sourceTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// This first set of STOP and START commands come from
+		// the builtinBackupEngine implementation which stops the replication
+		// while taking the backup
 		"STOP SLAVE",
+		"START SLAVE",
+		// These commands come from SetReplicationSource RPC called
+		// to set the correct primary and semi-sync after Backup has concluded
+		"STOP SLAVE",
+		"FAKE SET MASTER",
 		"START SLAVE",
 	}
 	sourceTablet.StartActionLoop(t, wr)
@@ -599,6 +631,7 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 }
 
 func TestDisableActiveReparents(t *testing.T) {
+	_ = reparentutil.SetDurabilityPolicy("none")
 	*mysqlctl.DisableActiveReparents = true
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -44,7 +44,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 		discovery.SetTabletPickerRetryDelay(delay)
 	}()
 	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
-	_ = reparentutil.SetDurabilityPolicy("none")
+	_ = reparentutil.SetDurabilityPolicy("semi_sync")
 
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
@@ -194,7 +194,7 @@ func TestEmergencyReparentShardPrimaryElectNotBest(t *testing.T) {
 		discovery.SetTabletPickerRetryDelay(delay)
 	}()
 	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
-	_ = reparentutil.SetDurabilityPolicy("none")
+	_ = reparentutil.SetDurabilityPolicy("semi_sync")
 
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Backport PR for #9725 
After this change, vtctld will send an additional RPC for `SetReplicationSource` after `Backup` and `RestoreFromBackup` have run. This is needed for maintaining backward compatibility during the upgrade downgrade process.

vtctld from (version 13 and 14) - Will pass the correct semi-sync information in the `SetReplicationSource` RPC
vttablets from version 13 - Will ignore the semi-sync value passed and will use the `enable_semi_sync` flag
vttablets from version 14 - Will use the information passed in the RPC to set the semi-sync correctly.

vttablets from version 13 could have made autonomous decisions on whether semi-sync is supposed to be set or not. But in release 14, `enable_semi_sync` is deprecated, and the only way to know whether to set semi-sync or not will come from durability policies.

Without this backport, vtctld v13 will not issue the SetReplicationSource rpc and vttablets from v14 will not be able to fix semi-sync on its own, so Backups would have incorrect semi-sync settings during the upgrade process. This back port fixes this issue 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->