### PR TITLE
[vtadmin-web] Add REACT_APP_READONLY_MODE flag

### DIFF
--- a/web/vtadmin/src/components/ReadOnlyGate.test.tsx
+++ b/web/vtadmin/src/components/ReadOnlyGate.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { ReadOnlyGate } from './ReadOnlyGate';
+
+// Preserve process.env to restore its original values after each test runs.
+const ORIGINAL_PROCESS_ENV = { ...process.env };
+
+describe('ReadOnlyGate', () => {
+    afterEach(() => {
+        process.env = ORIGINAL_PROCESS_ENV;
+    });
+
+    it('hides children when in read-only mode', () => {
+        (process as any).env.REACT_APP_READONLY_MODE = 'true';
+
+        render(
+            <ReadOnlyGate>
+                <div data-testid="child">🌶🌶🌶</div>
+            </ReadOnlyGate>
+        );
+
+        const child = screen.queryByTestId('child');
+        expect(child).toBeNull();
+    });
+
+    it('shows children when not in read-only mode', () => {
+        render(
+            <ReadOnlyGate>
+                <div data-testid="child">🌶🌶🌶</div>
+            </ReadOnlyGate>
+        );
+
+        const child = screen.queryByTestId('child');
+        expect(child).not.toBeNull();
+        expect(child).toHaveTextContent('🌶🌶🌶');
+    });
+});

--- a/web/vtadmin/src/components/ReadOnlyGate.tsx
+++ b/web/vtadmin/src/components/ReadOnlyGate.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isReadOnlyMode } from '../util/env';
+
+/**
+ * ReadOnlyGate is used to hide child component trees when VTAdmin is running
+ * in read only mode. For example:
+ *
+ *      <ReadOnlyGate>
+ *          <SomeSpicyWriteAction />
+ *      </ReadOnlyGate>
+ */
+export const ReadOnlyGate: React.FunctionComponent = ({ children }) => {
+    if (isReadOnlyMode()) {
+        // Returning `null` here prevents ReadOnlyGate from being used around
+        // <Route> components within a switch statement; returning a fragment
+        // doesn't seem to have this issue.
+        return <></>;
+    }
+
+    return <>{children}</>;
+};

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -36,6 +36,7 @@ import { ExternalTabletLink } from '../links/ExternalTabletLink';
 import { ShardLink } from '../links/ShardLink';
 import InfoDropdown from './tablets/InfoDropdown';
 import { isReadOnlyMode } from '../../util/env';
+import { ReadOnlyGate } from '../ReadOnlyGate';
 
 const COLUMNS = ['Keyspace', 'Shard', 'Alias', 'Type', 'Tablet State', 'Hostname'];
 if (!isReadOnlyMode()) {
@@ -92,11 +93,12 @@ export const Tablets = () => {
                     <DataCell>
                         <ExternalTabletLink fqdn={`//${t._raw.FQDN}`}>{t.hostname}</ExternalTabletLink>
                     </DataCell>
-                    {!isReadOnlyMode() && (
+
+                    <ReadOnlyGate>
                         <DataCell>
                             <InfoDropdown alias={t.alias as string} clusterID={t._raw.cluster?.id as string} />
                         </DataCell>
-                    )}
+                    </ReadOnlyGate>
                 </tr>
             ));
         },

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -35,6 +35,12 @@ import { TabletLink } from '../links/TabletLink';
 import { ExternalTabletLink } from '../links/ExternalTabletLink';
 import { ShardLink } from '../links/ShardLink';
 import InfoDropdown from './tablets/InfoDropdown';
+import { isReadOnlyMode } from '../../util/env';
+
+const COLUMNS = ['Keyspace', 'Shard', 'Alias', 'Type', 'Tablet State', 'Hostname'];
+if (!isReadOnlyMode()) {
+    COLUMNS.push('Actions');
+}
 
 export const Tablets = () => {
     useDocumentTitle('Tablets');
@@ -86,9 +92,11 @@ export const Tablets = () => {
                     <DataCell>
                         <ExternalTabletLink fqdn={`//${t._raw.FQDN}`}>{t.hostname}</ExternalTabletLink>
                     </DataCell>
-                    <DataCell>
-                        <InfoDropdown alias={t.alias as string} clusterID={t._raw.cluster?.id as string} />
-                    </DataCell>
+                    {!isReadOnlyMode() && (
+                        <DataCell>
+                            <InfoDropdown alias={t.alias as string} clusterID={t._raw.cluster?.id as string} />
+                        </DataCell>
+                    )}
                 </tr>
             ));
         },
@@ -108,11 +116,7 @@ export const Tablets = () => {
                     placeholder="Filter tablets"
                     value={filter || ''}
                 />
-                <DataTable
-                    columns={['Keyspace', 'Shard', 'Alias', 'Type', 'Tablet State', 'Hostname', 'Actions']}
-                    data={filteredData}
-                    renderRows={renderRows}
-                />
+                <DataTable columns={COLUMNS} data={filteredData} renderRows={renderRows} />
             </ContentContainer>
         </div>
     );

--- a/web/vtadmin/src/components/routes/tablet/Tablet.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Tablet.tsx
@@ -17,7 +17,6 @@
 import { Link, Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom';
 import { useExperimentalTabletDebugVars, useTablet } from '../../../hooks/api';
 import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
-import { isReadOnlyMode } from '../../../util/env';
 import { formatDisplayType, formatState } from '../../../util/tablets';
 import { Code } from '../../Code';
 import { ContentContainer } from '../../layout/ContentContainer';
@@ -26,6 +25,7 @@ import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
 import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
 import { ExternalTabletLink } from '../../links/ExternalTabletLink';
 import { TabletServingPip } from '../../pips/TabletServingPip';
+import { ReadOnlyGate } from '../../ReadOnlyGate';
 import { Tab } from '../../tabs/Tab';
 import { TabContainer } from '../../tabs/TabContainer';
 import Advanced from './Advanced';
@@ -104,7 +104,9 @@ export const Tablet = () => {
                     <Tab text="QPS" to={`${url}/qps`} />
                     <Tab text="JSON" to={`${url}/json`} />
 
-                    {!isReadOnlyMode() && <Tab text="Advanced" to={`${url}/advanced`} />}
+                    <ReadOnlyGate>
+                        <Tab text="Advanced" to={`${url}/advanced`} />
+                    </ReadOnlyGate>
                 </TabContainer>
 
                 <Switch>
@@ -122,12 +124,13 @@ export const Tablet = () => {
                         </div>
                     </Route>
 
-                    {!isReadOnlyMode() && (
+                    <ReadOnlyGate>
                         <Route path={`${path}/advanced`}>
                             <Advanced tablet={tablet} />
                         </Route>
-                    )}
-                    <Redirect from={path} to={`${path}/qps`} />
+                    </ReadOnlyGate>
+
+                    <Redirect to={`${path}/qps`} />
                 </Switch>
             </ContentContainer>
 

--- a/web/vtadmin/src/components/routes/tablet/Tablet.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Tablet.tsx
@@ -17,6 +17,7 @@
 import { Link, Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom';
 import { useExperimentalTabletDebugVars, useTablet } from '../../../hooks/api';
 import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
+import { isReadOnlyMode } from '../../../util/env';
 import { formatDisplayType, formatState } from '../../../util/tablets';
 import { Code } from '../../Code';
 import { ContentContainer } from '../../layout/ContentContainer';
@@ -102,7 +103,8 @@ export const Tablet = () => {
                 <TabContainer>
                     <Tab text="QPS" to={`${url}/qps`} />
                     <Tab text="JSON" to={`${url}/json`} />
-                    <Tab text="Advanced" to={`${url}/advanced`} />
+
+                    {!isReadOnlyMode() && <Tab text="Advanced" to={`${url}/advanced`} />}
                 </TabContainer>
 
                 <Switch>
@@ -119,9 +121,12 @@ export const Tablet = () => {
                             )}
                         </div>
                     </Route>
-                    <Route path={`${path}/advanced`}>
-                        <Advanced tablet={tablet} />
-                    </Route>
+
+                    {!isReadOnlyMode() && (
+                        <Route path={`${path}/advanced`}>
+                            <Advanced tablet={tablet} />
+                        </Route>
+                    )}
                     <Redirect from={path} to={`${path}/qps`} />
                 </Switch>
             </ContentContainer>

--- a/web/vtadmin/src/react-app-env.d.ts
+++ b/web/vtadmin/src/react-app-env.d.ts
@@ -34,6 +34,12 @@ declare namespace NodeJS {
         // Overriding this can be useful to differentiate between multiple VTAdmin deployments,
         // e.g., "VTAdmin (staging)".
         REACT_APP_DOCUMENT_TITLE?: string;
+
+        // Optional. Defaults to "false". If "true", UI controls that correspond to write actions (PUT, POST, DELETE) will be hidden.
+        // Note that this *only* affects the UI. If write actions are a concern, Vitess operators are encouraged
+        // to also configure vtadmin-api for role-based access control (RBAC) if needed;
+        // see https://github.com/vitessio/vitess/blob/main/go/vt/vtadmin/rbac/rbac.go
+        REACT_APP_READONLY_MODE?: string;
     }
 }
 

--- a/web/vtadmin/src/util/env.ts
+++ b/web/vtadmin/src/util/env.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// process.env variables are always strings, hence this tiny helper function
+// to transmute it into a boolean. It is a function, rather than a constant,
+// to support dynamic updates to process.env in tests.
+export const isReadOnlyMode = (): boolean => process.env.REACT_APP_READONLY_MODE === 'true';


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

This adds a new build flag to vtadmin-web: `REACT_APP_READONLY_MODE`. This flag will hide any UI controls that correspond to write actions (i.e., `POST`/`PUT`/`DELETE` request) and, further, will prevent those requests from being sent at all.

As noted in the comments, this flag only affects the UI. If write actions are a concern, Vitess operators are encouraged to also configure vtadmin-api for role-based access control (RBAC) if needed; see https://github.com/vitessio/vitess/blob/main/go/vt/vtadmin/rbac/rbac.go.

And, as noted in https://github.com/vitessio/vitess/issues/9726:

> A more elegant, long-term solution I'd like to consider is to hide or show UI controls based on the user's authorizations, derived from the RBAC configuration. For example, if a user is authorized for PUT actions on tablets but not DELETE actions, we'd show the UI controls for reparenting the tablet but not the UI controls for deleting the tablet.

| `REACT_APP_READONLY_MODE=false` (default) | `REACT_APP_READONLY_MODE=true` |
|--|--|
| <img width="1598" alt="tablet-false" src="https://user-images.githubusercontent.com/855595/154711311-ee802f97-928b-4527-a19c-12624db75da7.png"> | <img width="1598" alt="detail-false" src="https://user-images.githubusercontent.com/855595/154711254-64816ea8-f45b-4acd-a1c9-71654b206e5d.png"> |
| <img width="1598" alt="tablets-true" src="https://user-images.githubusercontent.com/855595/154711298-f0adc7c7-6534-445f-ad82-98c9c57c6171.png"> | <img width="1598" alt="detail-true" src="https://user-images.githubusercontent.com/855595/154711279-70c3105c-a4f7-47b4-bc6a-42ee6905b5f8.png"> |


## Related Issue(s)

Closes https://github.com/vitessio/vitess/issues/9726. 


## Checklist
- [x] Should this PR be backported? **No**
- [x] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required

## Deployment Notes

Vitess operators wishing to use this flag should use it in their [build flags and/or .env file](https://create-react-app.dev/docs/adding-custom-environment-variables/). For example:

```bash
REACT_APP_VTADMIN_API_ADDRESS="http://localhost:14200"  \
REACT_APP_READONLY_MODE=true \
npm run build
```


