### PR TITLE
Add CI workflow for vtadmin-web unit tests

### DIFF
--- a/.github/workflows/vtadmin_web_build.yml
+++ b/.github/workflows/vtadmin_web_build.yml
@@ -32,3 +32,8 @@ jobs:
 
       - name: Build front-end
         run: npm run build
+
+    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
+    concurrency: 
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/vtadmin_web_build.yml
+++ b/.github/workflows/vtadmin_web_build.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: '16.13.0'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build front-end
         run: npm run build

--- a/.github/workflows/vtadmin_web_lint.yml
+++ b/.github/workflows/vtadmin_web_lint.yml
@@ -49,3 +49,8 @@ jobs:
       - name: Run prettier
         if: always()
         run: npm run lint:prettier
+
+    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
+    concurrency: 
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/vtadmin_web_lint.yml
+++ b/.github/workflows/vtadmin_web_lint.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: '16.13.0'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       # Using "if: always()" means each step will run, even if a previous
       # step fails. This is nice because, for example, we want stylelint and 

--- a/.github/workflows/vtadmin_web_unit_tests.yml
+++ b/.github/workflows/vtadmin_web_unit_tests.yml
@@ -32,3 +32,8 @@ jobs:
 
       - name: Run unit tests
         run: CI=true npm run test
+        
+    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
+    concurrency: 
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/vtadmin_web_unit_tests.yml
+++ b/.github/workflows/vtadmin_web_unit_tests.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: '16.13.0'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run unit tests
         run: CI=true npm run test

--- a/.github/workflows/vtadmin_web_unit_tests.yml
+++ b/.github/workflows/vtadmin_web_unit_tests.yml
@@ -1,0 +1,34 @@
+name: vtadmin-web unit tests
+
+# In specifying the 'paths' property, we need to include the path to this workflow .yml file. 
+# See https://github.community/t/trigger-a-workflow-on-change-to-the-yml-file-itself/17792/4)
+on:
+  push:
+    paths:
+      - '.github/workflows/vtadmin_web_unit_tests.yml'
+      - 'web/vtadmin/**'
+  pull_request:
+    paths:
+      - '.github/workflows/vtadmin_web_unit_tests.yml'
+      - 'web/vtadmin/**'
+
+defaults:
+  run:
+    working-directory: ./web/vtadmin
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          # node-version should match package.json
+          node-version: '16.13.0'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run unit tests
+        run: CI=true npm run test

--- a/web/vtadmin/src/util/__snapshots__/tabletDebugVars.test.ts.snap
+++ b/web/vtadmin/src/util/__snapshots__/tabletDebugVars.test.ts.snap
@@ -2898,7 +2898,7 @@ Object {
 }
 `;
 
-exports[`formatTimeseriesMap timespan < 15 minutes: timespan < 15 minutes 1`] = `
+exports[`formatTimeseriesMap timespan < max span: timespan < max span 1`] = `
 Object {
   "All": Array [
     Object {


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

Well this is an embarrassing oversight! 🤡 Better late than never!

Here's what it looks like when it fails on purpose: https://github.com/tinyspeck/vitess/runs/5254002448?check_suite_focus=true

**Edited to add:** I also switched our CI tests from using `npm install` to using `npm ci`, since... this is the exact use case for `npm ci`. :) 

## Related Issue(s)

N/A

## Checklist
- [x] Should this PR be backported? **No**
- [x] Tests were added or are not required **Many tests were added!**
- [x] Documentation was added or is not required 

## Deployment Notes
N/A