### PR TITLE
Improve explanation of MySQLTopologyUser and MySQLReplicaUser so that their difference is clearer

### DIFF
--- a/go/vt/orchestrator/config/config.go
+++ b/go/vt/orchestrator/config/config.go
@@ -69,10 +69,10 @@ type Configuration struct {
 	HTTPAdvertise                               string // optional, for raft setups, what is the HTTP address this node will advertise to its peers (potentially use where behind NAT or when rerouting ports; example: "http://11.22.33.44:3030")
 	AgentsServerPort                            string // port orchestrator agents talk back to
 	Durability                                  string // The type of durability to enforce. Default is "none". Other values are dictated by registered plugins
-	MySQLTopologyUser                           string
-	MySQLTopologyPassword                       string
-	MySQLReplicaUser                            string // If set, use this credential instead of discovering from mysql. TODO(sougou): deprecate this in favor of fetching from vttablet
-	MySQLReplicaPassword                        string
+	MySQLTopologyUser                           string // The user VTOrc will use to connect to MySQL instances
+	MySQLTopologyPassword                       string // The password VTOrc will use to connect to MySQL instances
+	MySQLReplicaUser                            string // User to set on replica MySQL instances while configuring replication settings on them. If set, use this credential instead of discovering from mysql. TODO(sougou): deprecate this in favor of fetching from vttablet
+	MySQLReplicaPassword                        string // Password to set on replica MySQL instances while configuring replication settings on them.
 	MySQLTopologyCredentialsConfigFile          string // my.cnf style configuration file from where to pick credentials. Expecting `user`, `password` under `[client]` section
 	MySQLTopologySSLPrivateKeyFile              string // Private key file used to authenticate with a Topology mysql instance with TLS
 	MySQLTopologySSLCertFile                    string // Certificate PEM file used to authenticate with a Topology mysql instance with TLS


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR just adds 2 comments explaining MySQLTopologyUser and MySQLReplicaUser parameters for VTOrc, so that the difference between the two is clearer.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? *No*
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->