### PR TITLE
Improve upgrade downgrade workflows' strategy

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -25,14 +25,13 @@ jobs:
           label: Skip Upgrade Downgrade
 
   get_latest_release:
-    timeout-minutes: 10
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
     name: Get latest release
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
     outputs:
-      latest_release: ${{ steps.set-outpout.outputs.matrix }}
+      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
 
     steps:
       - name: Check out to HEAD
@@ -40,15 +39,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get latest major release of Vitess
+      - name: Set output with latest release branch
+        id: output-latest-release-branch
         run: |
-          last_major_releases=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.0$' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)
-          echo "latest_releases=$(echo "$last_major_releases" | awk ' BEGIN { ORS = ""; print "["; } { print "\/\@{\\\"project\\\":\\\"v"$0"\\\"}\/\@"; } END { print "]"; }' | sed "s^\/\@\/\@^, ^g;s^\/\@^^g")" >> $GITHUB_ENV
-
-      - name: Set output
-        id: set-outpout
-        run: |
-          echo "::set-output name=matrix::{\"include\":${{ env.latest_releases }} }"
+          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
+          echo $latest_release_branch
+          echo "::set-output name=latest_release_branch::${latest_release_branch}"
 
   upgrade_downgrade_test_e2e:
     timeout-minutes: 60
@@ -58,9 +54,6 @@ jobs:
     needs:
       - get_upgrade_downgrade_label
       - get_latest_release
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJSON(needs.get_latest_release.outputs.latest_release)}}
 
     steps:
     - name: Set up Go
@@ -98,10 +91,10 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     # Checkout to the last release of Vitess
-    - name: Check out other version's code (${{ matrix.project }})
+    - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
       uses: actions/checkout@v2
       with:
-        ref: ${{ matrix.project }}
+        ref: ${{ needs.get_latest_release.outputs.latest_release }}
 
     - name: Get dependencies for the last release
       run: |

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -25,14 +25,13 @@ jobs:
           label: Skip Upgrade Downgrade
 
   get_latest_release:
-    timeout-minutes: 5
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
     name: Get latest release
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
     outputs:
-      latest_release: ${{ steps.set-outpout.outputs.matrix }}
+      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
 
     steps:
       - name: Check out to HEAD
@@ -40,15 +39,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get latest major release of Vitess
+      - name: Set output with latest release branch
+        id: output-latest-release-branch
         run: |
-          last_major_releases=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.0$' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)
-          echo "latest_releases=$(echo "$last_major_releases" | awk ' BEGIN { ORS = ""; print "["; } { print "\/\@{\\\"project\\\":\\\"v"$0"\\\"}\/\@"; } END { print "]"; }' | sed "s^\/\@\/\@^, ^g;s^\/\@^^g")" >> $GITHUB_ENV
-
-      - name: Set output
-        id: set-outpout
-        run: |
-          echo "::set-output name=matrix::{\"include\":${{ env.latest_releases }} }"
+          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
+          echo $latest_release_branch
+          echo "::set-output name=latest_release_branch::${latest_release_branch}"
 
   # This job usually execute in ± 20 minutes
   upgrade_downgrade_test_manual:
@@ -59,9 +55,6 @@ jobs:
     needs:
       - get_upgrade_downgrade_label
       - get_latest_release
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJSON(needs.get_latest_release.outputs.latest_release)}}
 
     steps:
     - name: Set up Go
@@ -118,10 +111,10 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     # Checkout to the last release of Vitess
-    - name: Checkout to the other version's code (${{ matrix.project }})
+    - name: Checkout to the other version's code (${{ needs.get_latest_release.outputs.latest_release }})
       uses: actions/checkout@v2
       with:
-        ref: ${{ matrix.project }}
+        ref: ${{ needs.get_latest_release.outputs.latest_release }}
 
     - name: Get dependencies for the last release
       run: |

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -33,7 +33,7 @@ jobs:
     needs:
       - get_upgrade_downgrade_label
     outputs:
-      latest_release: ${{ steps.set-outpout.outputs.matrix }}
+      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
 
     steps:
       - name: Check out to HEAD
@@ -41,15 +41,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get latest major release of Vitess
+      - name: Set output with latest release branch
+        id: output-latest-release-branch
         run: |
-          last_major_releases=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.0$' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)
-          echo "latest_releases=$(echo "$last_major_releases" | awk ' BEGIN { ORS = ""; print "["; } { print "\/\@{\\\"project\\\":\\\"v"$0"\\\"}\/\@"; } END { print "]"; }' | sed "s^\/\@\/\@^, ^g;s^\/\@^^g")" >> $GITHUB_ENV
-
-      - name: Set output
-        id: set-outpout
-        run: |
-          echo "::set-output name=matrix::{\"include\":${{ env.latest_releases }} }"
+          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
+          echo "::set-output name=latest_release_branch::${latest_release_branch}"
 
   upgrade_downgrade_test:
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'false')
@@ -58,9 +54,6 @@ jobs:
     needs:
       - get_upgrade_downgrade_label
       - get_latest_release
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJSON(needs.get_latest_release.outputs.latest_release)}}
 
     steps:
     - name: Set up Go
@@ -111,10 +104,10 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     # Checkout to the last release of Vitess
-    - name: Check out other version's code (${{ matrix.project }})
+    - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
       uses: actions/checkout@v2
       with:
-        ref: ${{ matrix.project }}
+        ref: ${{ needs.get_latest_release.outputs.latest_release }}
 
     - name: Get dependencies for the last release
       run: |

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -45,6 +45,7 @@ jobs:
         id: output-latest-release-branch
         run: |
           latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
+          echo $latest_release_branch
           echo "::set-output name=latest_release_branch::${latest_release_branch}"
 
   upgrade_downgrade_test:

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -33,7 +33,7 @@ jobs:
     needs:
       - get_upgrade_downgrade_label
     outputs:
-      latest_release: ${{ steps.set-outpout.outputs.matrix }}
+      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
 
     steps:
       - name: Check out to HEAD
@@ -41,15 +41,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get latest major release of Vitess
+      - name: Set output with latest release branch
+        id: output-latest-release-branch
         run: |
-          last_major_releases=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.0$' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)
-          echo "latest_releases=$(echo "$last_major_releases" | awk ' BEGIN { ORS = ""; print "["; } { print "\/\@{\\\"project\\\":\\\"v"$0"\\\"}\/\@"; } END { print "]"; }' | sed "s^\/\@\/\@^, ^g;s^\/\@^^g")" >> $GITHUB_ENV
-
-      - name: Set output
-        id: set-outpout
-        run: |
-          echo "::set-output name=matrix::{\"include\":${{ env.latest_releases }} }"
+          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
+          echo $latest_release_branch
+          echo "::set-output name=latest_release_branch::${latest_release_branch}"
 
   upgrade_downgrade_test:
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'false')
@@ -58,9 +55,6 @@ jobs:
     needs:
       - get_upgrade_downgrade_label
       - get_latest_release
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJSON(needs.get_latest_release.outputs.latest_release)}}
 
     steps:
     - name: Set up Go
@@ -111,10 +105,10 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     # Checkout to the last release of Vitess
-    - name: Check out other version's code (${{ matrix.project }})
+    - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
       uses: actions/checkout@v2
       with:
-        ref: ${{ matrix.project }}
+        ref: ${{ needs.get_latest_release.outputs.latest_release }}
 
     - name: Get dependencies for the last release
       run: |

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -33,7 +33,7 @@ jobs:
     needs:
       - get_upgrade_downgrade_label
     outputs:
-      latest_release: ${{ steps.set-outpout.outputs.matrix }}
+      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
 
     steps:
       - name: Check out to HEAD
@@ -41,15 +41,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get latest major release of Vitess
+      - name: Set output with latest release branch
+        id: output-latest-release-branch
         run: |
-          last_major_releases=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.0$' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)
-          echo "latest_releases=$(echo "$last_major_releases" | awk ' BEGIN { ORS = ""; print "["; } { print "\/\@{\\\"project\\\":\\\"v"$0"\\\"}\/\@"; } END { print "]"; }' | sed "s^\/\@\/\@^, ^g;s^\/\@^^g")" >> $GITHUB_ENV
-
-      - name: Set output
-        id: set-outpout
-        run: |
-          echo "::set-output name=matrix::{\"include\":${{ env.latest_releases }} }"
+          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
+          echo $latest_release_branch
+          echo "::set-output name=latest_release_branch::${latest_release_branch}"
 
   upgrade_downgrade_test:
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'false')
@@ -58,9 +55,6 @@ jobs:
     needs:
       - get_upgrade_downgrade_label
       - get_latest_release
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJSON(needs.get_latest_release.outputs.latest_release)}}
 
     steps:
     - name: Set up Go
@@ -111,10 +105,10 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     # Checkout to the last release of Vitess
-    - name: Check out other version's code (${{ matrix.project }})
+    - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
       uses: actions/checkout@v2
       with:
-        ref: ${{ matrix.project }}
+        ref: ${{ needs.get_latest_release.outputs.latest_release }}
 
     - name: Get dependencies for the last release
       run: |

--- a/tools/get_latest_release.sh
+++ b/tools/get_latest_release.sh
@@ -27,7 +27,7 @@ if [ "$base_release_branch" != "" ]; then
   major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
   target_release="release-$((${major_release}-1)).0"
 else
-  target_release="release-$(git show-ref --heads | grep -E 'refs/heads/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/heads\/release-//' | sort -nr | head -n1)"
+  target_release="release-$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sort -nr | head -n1)"
 fi
 
 echo $target_release

--- a/tools/get_latest_release.sh
+++ b/tools/get_latest_release.sh
@@ -25,7 +25,8 @@ target_release=""
 base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*.0$')
 if [ "$base_release_branch" != "" ]; then
   major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
-  target_release="release-$((major_release-1)).0"
+  target_major_release=$((major_release-1))
+  target_release=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE=$target_major_release '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
 else
   target_release="release-$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sort -nr | head -n1)"
 fi

--- a/tools/get_latest_release.sh
+++ b/tools/get_latest_release.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2022 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to build and copy the Angular 2 based vtctld UI
+# into the release folder (app) for checkin. Prior to running this script,
+# bootstrap.sh and bootstrap_web.sh should already have been run.
+
+# github.base_ref $1
+
+target_release=""
+
+base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*.0$')
+if [ "$base_release_branch" != "" ]; then
+  major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
+  target_release="release-$((${major_release}-1)).0"
+else
+  target_release="release-$(git show-ref --heads | grep -E 'refs/heads/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/heads\/release-//' | sort -nr | head -n1)"
+fi
+
+echo $target_release

--- a/tools/get_latest_release.sh
+++ b/tools/get_latest_release.sh
@@ -25,9 +25,9 @@ target_release=""
 base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*.0$')
 if [ "$base_release_branch" != "" ]; then
   major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
-  target_release="release-$((${major_release}-1)).0"
+  target_release="release-$((major_release-1)).0"
 else
   target_release="release-$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sort -nr | head -n1)"
 fi
 
-echo $target_release
+echo "$target_release"

--- a/tools/get_latest_release.sh
+++ b/tools/get_latest_release.sh
@@ -28,7 +28,12 @@ if [ "$base_release_branch" != "" ]; then
   target_major_release=$((major_release-1))
   target_release=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE=$target_major_release '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
 else
-  target_release="release-$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sort -nr | head -n1)"
+  target_major_release=$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sed 's/\.0//' | sort -nr | head -n1)
+  target_release=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE=$target_major_release '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
+  if [ -z "$target_release" ]
+  then
+    target_release="release-$target_major_release.0"
+  fi
 fi
 
 echo "$target_release"

--- a/tools/get_latest_release.sh
+++ b/tools/get_latest_release.sh
@@ -26,11 +26,13 @@ base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*.0$')
 if [ "$base_release_branch" != "" ]; then
   major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
   target_major_release=$((major_release-1))
-  target_release=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
+  target_release_number=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
+  target_release="v$target_release_number"
 else
   target_major_release=$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sed 's/\.0//' | sort -nr | head -n1)
-  target_release=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
-  if [ -z "$target_release" ]
+  target_release_number=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
+  target_release="v$target_release_number"
+  if [ -z "$target_release_number" ]
   then
     target_release="release-$target_major_release.0"
   fi

--- a/tools/get_latest_release.sh
+++ b/tools/get_latest_release.sh
@@ -26,10 +26,10 @@ base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*.0$')
 if [ "$base_release_branch" != "" ]; then
   major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
   target_major_release=$((major_release-1))
-  target_release=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE=$target_major_release '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
+  target_release=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
 else
   target_major_release=$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sed 's/\.0//' | sort -nr | head -n1)
-  target_release=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE=$target_major_release '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
+  target_release=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
   if [ -z "$target_release" ]
   then
     target_release="release-$target_major_release.0"


### PR DESCRIPTION
## Description

@GuptaManan100 and I paired up on this pull request to improve the upgrade downgrade testing workflows by choosing the latest release in a better way.

Before, every commit would be tested against the last major release, even if this commit is made on, for instance, the `release-12.0` branch. ~~Now, commits made against a release branch are tested against the previous release branch (commits to `release-13.0` will be tested against `release-12.0`) ; and commits made to `main` and other branches are tested against the latest release branch.~~
Now, commits made against a release branch are tested against the previous releases' latest patch release and commits made to `main` and other branches are tested against the last major release tag unless a new release brach has been created without a tag, in which case that is used.

For example - 
| PR head | Tested against |
| ------- | ------- |
| `release-13.0` | `v12.0.3` |
| `release-12.0` | `v11.0.4` |
| `main` | `v13.0.0` | 
| `main` (after we create `release-14.0` but before creating `v14.0.0`) | `release-14.0` |

Needs to be backported to all three latest releases, but does not need to make it to `v13.0.0 GA`.

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
