### PR TITLE
Query plan/rules: apply for multi-table statement

### DIFF
--- a/go/vt/vttablet/tabletserver/planbuilder/builder.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/builder.go
@@ -32,10 +32,10 @@ import (
 func analyzeSelect(sel *sqlparser.Select, tables map[string]*schema.Table) (plan *Plan, err error) {
 	plan = &Plan{
 		PlanID:     PlanSelect,
-		Table:      lookupTable(sel.From, tables),
 		FieldQuery: GenerateFieldQuery(sel),
 		FullQuery:  GenerateLimitQuery(sel),
 	}
+	plan.Table, plan.AllTables = lookupTables(sel.From, tables)
 
 	if sel.Where != nil {
 		comp, ok := sel.Where.Expr.(*sqlparser.ComparisonExpr)
@@ -66,8 +66,8 @@ func analyzeSelect(sel *sqlparser.Select, tables map[string]*schema.Table) (plan
 func analyzeUpdate(upd *sqlparser.Update, tables map[string]*schema.Table) (plan *Plan, err error) {
 	plan = &Plan{
 		PlanID: PlanUpdate,
-		Table:  lookupTable(upd.TableExprs, tables),
 	}
+	plan.Table, plan.AllTables = lookupTables(upd.TableExprs, tables)
 
 	// Store the WHERE clause as string for the hot row protection (txserializer).
 	if upd.Where != nil {
@@ -96,8 +96,8 @@ func analyzeUpdate(upd *sqlparser.Update, tables map[string]*schema.Table) (plan
 func analyzeDelete(del *sqlparser.Delete, tables map[string]*schema.Table) (plan *Plan, err error) {
 	plan = &Plan{
 		PlanID: PlanDelete,
-		Table:  lookupTable(del.TableExprs, tables),
 	}
+	plan.Table, plan.AllTables = lookupTables(del.TableExprs, tables)
 
 	if del.Where != nil {
 		buf := sqlparser.NewTrackedBuffer(nil)
@@ -176,11 +176,19 @@ func analyzeSet(set *sqlparser.Set) (plan *Plan) {
 	}
 }
 
-func lookupTable(tableExprs sqlparser.TableExprs, tables map[string]*schema.Table) *schema.Table {
-	if len(tableExprs) > 1 {
-		return nil
+func lookupTables(tableExprs sqlparser.TableExprs, tables map[string]*schema.Table) (singleTable *schema.Table, allTables []*schema.Table) {
+	for _, tableExpr := range tableExprs {
+		t := lookupSingleTable(tableExpr, tables)
+		allTables = append(allTables, t)
 	}
-	aliased, ok := tableExprs[0].(*sqlparser.AliasedTableExpr)
+	if len(allTables) == 1 {
+		singleTable = allTables[0]
+	}
+	return singleTable, allTables
+}
+
+func lookupSingleTable(tableExpr sqlparser.TableExpr, tables map[string]*schema.Table) *schema.Table {
+	aliased, ok := tableExpr.(*sqlparser.AliasedTableExpr)
 	if !ok {
 		return nil
 	}

--- a/go/vt/vttablet/tabletserver/planbuilder/builder.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/builder.go
@@ -178,8 +178,9 @@ func analyzeSet(set *sqlparser.Set) (plan *Plan) {
 
 func lookupTables(tableExprs sqlparser.TableExprs, tables map[string]*schema.Table) (singleTable *schema.Table, allTables []*schema.Table) {
 	for _, tableExpr := range tableExprs {
-		t := lookupSingleTable(tableExpr, tables)
-		allTables = append(allTables, t)
+		if t := lookupSingleTable(tableExpr, tables); t != nil {
+			allTables = append(allTables, t)
+		}
 	}
 	if len(allTables) == 1 {
 		singleTable = allTables[0]

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -152,7 +152,10 @@ func (pt PlanType) MarshalJSON() ([]byte, error) {
 // Plan contains the parameters for executing a request.
 type Plan struct {
 	PlanID PlanType
-	Table  *schema.Table
+	// When the query indicates a single table
+	Table *schema.Table
+	// SELECT, UPDATE, DELETE statements may list multiple tables
+	AllTables []*schema.Table
 
 	// Permissions stores the permissions for the tables accessed in the query.
 	Permissions []Permission
@@ -181,6 +184,14 @@ func (plan *Plan) TableName() sqlparser.TableIdent {
 		tableName = plan.Table.Name
 	}
 	return tableName
+}
+
+// TableNames returns the table names for all tables in the plan.
+func (plan *Plan) TableNames() (names []string) {
+	for _, table := range plan.AllTables {
+		names = append(names, table.Name.String())
+	}
+	return names
 }
 
 // Build builds a plan based on the schema.
@@ -278,7 +289,7 @@ func BuildStreaming(sql string, tables map[string]*schema.Table, isReservedConn 
 		if stmt.Lock != sqlparser.NoLock {
 			return nil, vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "select with lock not allowed for streaming")
 		}
-		plan.Table = lookupTable(stmt.From, tables)
+		plan.Table, plan.AllTables = lookupTables(stmt.From, tables)
 	case *sqlparser.OtherRead, *sqlparser.Show, *sqlparser.Union, *sqlparser.CallProc, sqlparser.Explain:
 		// pass
 	default:

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -188,6 +188,10 @@ func (plan *Plan) TableName() sqlparser.TableIdent {
 
 // TableNames returns the table names for all tables in the plan.
 func (plan *Plan) TableNames() (names []string) {
+	if len(plan.AllTables) == 0 {
+		tableName := plan.TableName()
+		return []string{tableName.String()}
+	}
 	for _, table := range plan.AllTables {
 		names = append(names, table.Name.String())
 	}

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -313,7 +313,7 @@ func (qe *QueryEngine) GetPlan(ctx context.Context, logStats *tabletenv.LogStats
 		return nil, err
 	}
 	plan := &TabletPlan{Plan: splan, Original: sql}
-	plan.Rules = qe.queryRuleSources.FilterByPlan(sql, plan.PlanID, plan.TableName().String())
+	plan.Rules = qe.queryRuleSources.FilterByPlan(sql, plan.PlanID, plan.TableNames()...)
 	plan.buildAuthorized()
 	if plan.PlanID.IsSelect() {
 		if !skipQueryPlanCache && qe.enableQueryPlanFieldCaching && plan.FieldQuery != nil {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -758,7 +758,6 @@ func (qre *QueryExecutor) generateFinalSQL(parsedQuery *sqlparser.ParsedQuery, b
 	if err != nil {
 		return "", "", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%s", err)
 	}
-
 	if qre.tsv.config.AnnotateQueries {
 		username := callerid.GetPrincipal(callerid.EffectiveCallerIDFromContext(qre.ctx))
 		if username == "" {

--- a/go/vt/vttablet/tabletserver/rules/map.go
+++ b/go/vt/vttablet/tabletserver/rules/map.go
@@ -86,12 +86,12 @@ func (qri *Map) Get(ruleSource string) (*Rules, error) {
 
 // FilterByPlan creates a new Rules by prefiltering on all query rules that are contained in internal
 // Rules structures, in other words, query rules from all predefined sources will be applied.
-func (qri *Map) FilterByPlan(query string, planid planbuilder.PlanType, tableName string) (newqrs *Rules) {
+func (qri *Map) FilterByPlan(query string, planid planbuilder.PlanType, tableNames ...string) (newqrs *Rules) {
 	qri.mu.Lock()
 	defer qri.mu.Unlock()
 	newqrs = New()
 	for _, rules := range qri.queryRulesMap {
-		newqrs.Append(rules.FilterByPlan(query, planid, tableName))
+		newqrs.Append(rules.FilterByPlan(query, planid, tableNames...))
 	}
 	return newqrs
 }

--- a/go/vt/vttablet/tabletserver/rules/rules_test.go
+++ b/go/vt/vttablet/tabletserver/rules/rules_test.go
@@ -181,6 +181,43 @@ func TestFilterByPlan(t *testing.T) {
 	if got != want {
 		t.Errorf("qrs1:\n%s, want\n%s", got, want)
 	}
+	{
+		// test multiple tables:
+		qrs1 := qrs.FilterByPlan("insert", planbuilder.PlanSelect, "a", "other_table")
+		want := compacted(`[{
+			"Description":"rule 2",
+			"Name":"r2",
+			"BindVarConds":[{
+				"Name":"a",
+				"OnAbsent":true,
+				"Operator":""
+			}],
+			"Action":"FAIL"
+		}]`)
+		got = marshalled(qrs1)
+		if got != want {
+			t.Errorf("qrs1:\n%s, want\n%s", got, want)
+		}
+
+	}
+	{
+		// test multiple tables:
+		qrs1 := qrs.FilterByPlan("insert", planbuilder.PlanSelect, "other_table", "a")
+		want := compacted(`[{
+			"Description":"rule 2",
+			"Name":"r2",
+			"BindVarConds":[{
+				"Name":"a",
+				"OnAbsent":true,
+				"Operator":""
+			}],
+			"Action":"FAIL"
+		}]`)
+		got = marshalled(qrs1)
+		if got != want {
+			t.Errorf("qrs1:\n%s, want\n%s", got, want)
+		}
+	}
 
 	qrs1 = qrs.FilterByPlan("insert", planbuilder.PlanSelect, "a")
 	got = marshalled(qrs1)


### PR DESCRIPTION
## Description

Issue found: when query rules are applied to a table (e.g. `UpdateSourceDeniedTables`), query executor still lets some queries run and operate on the applied table. Specifically, it allows `SELECT`/`UPDATE`/`DELETE` queries that reference multiple tables to go unchecked.

Say table `corder` is denied. the following query gets rejected:
```sql
select * from corder;
ERROR 1105 (HY000) at line 1: target: commerce.0.primary: vttablet: rpc error: code = FailedPrecondition desc = disallowed due to rule: enforce denied tables (CallerID: userData1)
```
while the following query is allowed:
```sql
select * from corder, customer
```

As it turns out, the plan completely ignores the rules if it does not have exactly one referenced table. This is a bug and the behavior is undesired.

In this PR the query executor checks all plan's tables against all rules. It's enough that one rule conflicts with one table, and the query gets rejected.

The code affected by this PR is used in many places. To make the changes minimal, I kept backward-compatibility. Specifically, you will find that:

- `Plan` keeps the old `Table` field, and we add `AllTables` on top.

```golang
type Plan struct {
	// When the query indicates a single table
	Table *schema.Table
	// SELECT, UPDATE, DELETE statements may list multiple tables
	AllTables []*schema.Table
...
```

- I used variadic variables (`tableNames ...string`) as opposed to a slice, so that most existing code can keep calling functions with a single table name

```golang
func (qri *Map) FilterByPlan(query string, planid planbuilder.PlanType, tableNames ...string) (newqrs *Rules) {
```

This bug affects `vitess` migrations: the cut-over step marks the migrated table as denied; there must not be any `insert`s, `delete`s or `update`s to the table during the cut-over time. But the bug allows multi-table `update`s and `delete`s to pass through.

## Related Issue(s)

- #6926 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
