### PR TITLE
Fixed tagged images in vitess-operator examples

### DIFF
--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -8,12 +8,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:13.0.0-rc1
-    vtgate: vitess/lite:13.0.0-rc1
-    vttablet: vitess/lite:13.0.0-rc1
-    vtbackup: vitess/lite:13.0.0-rc1
+    vtctld: vitess/lite:v13.0.0-rc1
+    vtgate: vitess/lite:v13.0.0-rc1
+    vttablet: vitess/lite:v13.0.0-rc1
+    vtbackup: vitess/lite:v13.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:13.0.0-rc1
+      mysql56Compatible: vitess/lite:v13.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:13.0.0-rc1
-    vtgate: vitess/lite:13.0.0-rc1
-    vttablet: vitess/lite:13.0.0-rc1
-    vtbackup: vitess/lite:13.0.0-rc1
+    vtctld: vitess/lite:v13.0.0-rc1
+    vtgate: vitess/lite:v13.0.0-rc1
+    vttablet: vitess/lite:v13.0.0-rc1
+    vtbackup: vitess/lite:v13.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:13.0.0-rc1
+      mysql56Compatible: vitess/lite:v13.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:13.0.0-rc1
-    vtgate: vitess/lite:13.0.0-rc1
-    vttablet: vitess/lite:13.0.0-rc1
-    vtbackup: vitess/lite:13.0.0-rc1
+    vtctld: vitess/lite:v13.0.0-rc1
+    vtgate: vitess/lite:v13.0.0-rc1
+    vttablet: vitess/lite:v13.0.0-rc1
+    vtbackup: vitess/lite:v13.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:13.0.0-rc1
+      mysql56Compatible: vitess/lite:v13.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:13.0.0-rc1
-    vtgate: vitess/lite:13.0.0-rc1
-    vttablet: vitess/lite:13.0.0-rc1
-    vtbackup: vitess/lite:13.0.0-rc1
+    vtctld: vitess/lite:v13.0.0-rc1
+    vtgate: vitess/lite:v13.0.0-rc1
+    vttablet: vitess/lite:v13.0.0-rc1
+    vtbackup: vitess/lite:v13.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:13.0.0-rc1
+      mysql56Compatible: vitess/lite:v13.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1


### PR DESCRIPTION
## Description

This pull request updates the tag used by the vitess-operator Docker image. There was a typo, the `v` of `v13.0.0-rc1` was missing.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
