### PR TITLE
Use latest vitess-operator example CRDs

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -1,9 +1,8 @@
-# Version: v2.5.0
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: etcdlockservers.planetscale.com
 spec:
@@ -13,584 +12,115 @@ spec:
     listKind: EtcdLockserverList
     plural: etcdlockservers
     shortNames:
-    - etcdls
+      - etcdls
     singular: etcdlockserver
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
           properties:
-            advertisePeerURLs:
-              items:
-                type: string
-              maxItems: 3
-              minItems: 3
-              type: array
-            affinity:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
               type: object
-              x-kubernetes-preserve-unknown-fields: true
-            annotations:
-              additionalProperties:
-                type: string
-              type: object
-            clientService:
+            spec:
               properties:
+                advertisePeerURLs:
+                  items:
+                    type: string
+                  maxItems: 3
+                  minItems: 3
+                  type: array
+                affinity:
+                  x-kubernetes-preserve-unknown-fields: true
                 annotations:
                   additionalProperties:
                     type: string
                   type: object
-                clusterIP:
-                  type: string
-              type: object
-            createClientService:
-              type: boolean
-            createPDB:
-              type: boolean
-            createPeerService:
-              type: boolean
-            dataVolumeClaimTemplate:
-              properties:
-                accessModes:
-                  items:
-                    type: string
-                  type: array
-                resources:
+                clientService:
                   properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                  type: object
-                selector:
-                  properties:
-                    matchExpressions:
-                      items:
-                        properties:
-                          key:
-                            type: string
-                          operator:
-                            type: string
-                          values:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                    matchLabels:
+                    annotations:
                       additionalProperties:
                         type: string
                       type: object
+                    clusterIP:
+                      type: string
                   type: object
-                storageClassName:
-                  type: string
-                volumeMode:
-                  type: string
-                volumeName:
-                  type: string
-              type: object
-            extraEnv:
-              items:
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-                  valueFrom:
-                    properties:
-                      configMapKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                      fieldRef:
-                        properties:
-                          apiVersion:
-                            type: string
-                          fieldPath:
-                            type: string
-                        required:
-                        - fieldPath
-                        type: object
-                      resourceFieldRef:
-                        properties:
-                          containerName:
-                            type: string
-                          divisor:
+                createClientService:
+                  type: boolean
+                createPDB:
+                  type: boolean
+                createPeerService:
+                  type: boolean
+                dataVolumeClaimTemplate:
+                  properties:
+                    accessModes:
+                      items:
+                        type: string
+                      type: array
+                    dataSource:
+                      properties:
+                        apiGroup:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                        - kind
+                        - name
+                      type: object
+                    resources:
+                      properties:
+                        limits:
+                          additionalProperties:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          resource:
-                            type: string
-                        required:
-                        - resource
-                        type: object
-                      secretKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-            extraFlags:
-              additionalProperties:
-                type: string
-              type: object
-            extraLabels:
-              additionalProperties:
-                type: string
-              type: object
-            extraVolumeMounts:
-              items:
-                properties:
-                  mountPath:
-                    type: string
-                  mountPropagation:
-                    type: string
-                  name:
-                    type: string
-                  readOnly:
-                    type: boolean
-                  subPath:
-                    type: string
-                  subPathExpr:
-                    type: string
-                required:
-                - mountPath
-                - name
-                type: object
-              type: array
-            extraVolumes:
-              items:
-                required:
-                - name
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              type: array
-            image:
-              type: string
-            imagePullPolicy:
-              type: string
-            imagePullSecrets:
-              items:
-                properties:
-                  name:
-                    type: string
-                type: object
-              type: array
-            initContainers:
-              items:
-                required:
-                - name
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              type: array
-            localMemberIndex:
-              format: int32
-              maximum: 3
-              minimum: 1
-              type: integer
-            peerService:
-              properties:
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                clusterIP:
-                  type: string
-              type: object
-            resources:
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  type: object
-              type: object
-            sidecarContainers:
-              items:
-                required:
-                - name
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              type: array
-            tolerations:
-              items:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              type: array
-            zone:
-              type: string
-          type: object
-        status:
-          properties:
-            available:
-              type: string
-            clientServiceName:
-              type: string
-            observedGeneration:
-              format: int64
-              type: integer
-          type: object
-      type: object
-  version: v2
-  versions:
-  - name: v2
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
-  name: vitessbackups.planetscale.com
-spec:
-  group: planetscale.com
-  names:
-    kind: VitessBackup
-    listKind: VitessBackupList
-    plural: vitessbackups
-    shortNames:
-    - vtb
-    singular: vitessbackup
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          type: object
-        status:
-          properties:
-            complete:
-              type: boolean
-            engine:
-              type: string
-            finishedTime:
-              format: date-time
-              type: string
-            position:
-              type: string
-            startTime:
-              format: date-time
-              type: string
-            storageDirectory:
-              type: string
-            storageName:
-              type: string
-          type: object
-      type: object
-  version: v2
-  versions:
-  - name: v2
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
-  name: vitessbackupstorages.planetscale.com
-spec:
-  group: planetscale.com
-  names:
-    kind: VitessBackupStorage
-    listKind: VitessBackupStorageList
-    plural: vitessbackupstorages
-    shortNames:
-    - vtbs
-    singular: vitessbackupstorage
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            location:
-              properties:
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                azblob:
-                  properties:
-                    account:
-                      minLength: 1
-                      type: string
-                    authSecret:
-                      properties:
-                        key:
-                          type: string
-                        name:
-                          type: string
-                        volumeName:
-                          type: string
-                      required:
-                      - key
-                      type: object
-                    container:
-                      minLength: 1
-                      type: string
-                    keyPrefix:
-                      maxLength: 256
-                      pattern: ^[^\r\n]*$
-                      type: string
-                  required:
-                  - account
-                  - authSecret
-                  - container
-                  type: object
-                ceph:
-                  properties:
-                    authSecret:
-                      properties:
-                        key:
-                          type: string
-                        name:
-                          type: string
-                        volumeName:
-                          type: string
-                      required:
-                      - key
-                      type: object
-                  required:
-                  - authSecret
-                  type: object
-                gcs:
-                  properties:
-                    authSecret:
-                      properties:
-                        key:
-                          type: string
-                        name:
-                          type: string
-                        volumeName:
-                          type: string
-                      required:
-                      - key
-                      type: object
-                    bucket:
-                      minLength: 1
-                      type: string
-                    keyPrefix:
-                      maxLength: 256
-                      pattern: ^[^\r\n]*$
-                      type: string
-                  required:
-                  - bucket
-                  type: object
-                name:
-                  maxLength: 63
-                  pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
-                  type: string
-                s3:
-                  properties:
-                    authSecret:
-                      properties:
-                        key:
-                          type: string
-                        name:
-                          type: string
-                        volumeName:
-                          type: string
-                      required:
-                      - key
-                      type: object
-                    bucket:
-                      minLength: 1
-                      type: string
-                    endpoint:
-                      type: string
-                    keyPrefix:
-                      maxLength: 256
-                      pattern: ^[^\r\n]*$
-                      type: string
-                    region:
-                      minLength: 1
-                      type: string
-                  required:
-                  - bucket
-                  - region
-                  type: object
-                volume:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                volumeSubPath:
-                  type: string
-              type: object
-            subcontroller:
-              properties:
-                serviceAccountName:
-                  type: string
-              type: object
-          required:
-          - location
-          type: object
-        status:
-          properties:
-            observedGeneration:
-              format: int64
-              type: integer
-            totalBackupCount:
-              format: int32
-              type: integer
-          type: object
-      type: object
-  version: v2
-  versions:
-  - name: v2
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
-  name: vitesscells.planetscale.com
-spec:
-  group: planetscale.com
-  names:
-    kind: VitessCell
-    listKind: VitessCellList
-    plural: vitesscells
-    shortNames:
-    - vtc
-    singular: vitesscell
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            allCells:
-              items:
-                type: string
-              type: array
-            extraVitessFlags:
-              additionalProperties:
-                type: string
-              type: object
-            gateway:
-              properties:
-                affinity:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                authentication:
-                  properties:
-                    static:
-                      properties:
-                        secret:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                          - key
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           type: object
                       type: object
+                    selector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    storageClassName:
+                      type: string
+                    volumeMode:
+                      type: string
+                    volumeName:
+                      type: string
                   type: object
                 extraEnv:
                   items:
@@ -610,7 +140,7 @@ spec:
                               optional:
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                           fieldRef:
                             properties:
@@ -619,7 +149,7 @@ spec:
                               fieldPath:
                                 type: string
                             required:
-                            - fieldPath
+                              - fieldPath
                             type: object
                           resourceFieldRef:
                             properties:
@@ -627,14 +157,14 @@ spec:
                                 type: string
                               divisor:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
                               resource:
                                 type: string
                             required:
-                            - resource
+                              - resource
                             type: object
                           secretKeyRef:
                             properties:
@@ -645,11 +175,11 @@ spec:
                               optional:
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                         type: object
                     required:
-                    - name
+                      - name
                     type: object
                   type: array
                 extraFlags:
@@ -676,89 +206,31 @@ spec:
                       subPathExpr:
                         type: string
                     required:
-                    - mountPath
-                    - name
+                      - mountPath
+                      - name
                     type: object
                   type: array
                 extraVolumes:
+                  x-kubernetes-preserve-unknown-fields: true
+                image:
+                  type: string
+                imagePullPolicy:
+                  type: string
+                imagePullSecrets:
                   items:
-                    required:
-                    - name
+                    properties:
+                      name:
+                        type: string
                     type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   type: array
                 initContainers:
-                  items:
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                replicas:
+                  x-kubernetes-preserve-unknown-fields: true
+                localMemberIndex:
                   format: int32
-                  minimum: 0
+                  maximum: 3
+                  minimum: 1
                   type: integer
-                resources:
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                  type: object
-                secureTransport:
-                  properties:
-                    required:
-                      type: boolean
-                    tls:
-                      properties:
-                        certSecret:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                          - key
-                          type: object
-                        clientCACertSecret:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                          - key
-                          type: object
-                        keySecret:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                          - key
-                          type: object
-                      type: object
-                  type: object
-                service:
+                peerService:
                   properties:
                     annotations:
                       additionalProperties:
@@ -767,156 +239,345 @@ spec:
                     clusterIP:
                       type: string
                   type: object
-                sidecarContainers:
-                  items:
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                tolerations:
-                  items:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                topologySpreadConstraints:
-                  items:
-                    required:
-                    - maxSkew
-                    - topologyKey
-                    - whenUnsatisfiable
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-              type: object
-            globalLockserver:
-              properties:
-                address:
-                  type: string
-                implementation:
-                  type: string
-                rootPath:
-                  type: string
-              required:
-              - address
-              - implementation
-              - rootPath
-              type: object
-            imagePullPolicies:
-              properties:
-                mysqld:
-                  type: string
-                mysqldExporter:
-                  type: string
-                vtbackup:
-                  type: string
-                vtctld:
-                  type: string
-                vtgate:
-                  type: string
-                vtorc:
-                  type: string
-                vttablet:
-                  type: string
-              type: object
-            imagePullSecrets:
-              items:
-                properties:
-                  name:
-                    type: string
-                type: object
-              type: array
-            images:
-              properties:
-                vtgate:
-                  type: string
-              type: object
-            lockserver:
-              properties:
-                etcd:
+                resources:
                   properties:
-                    advertisePeerURLs:
-                      items:
-                        type: string
-                      maxItems: 3
-                      minItems: 3
-                      type: array
-                    affinity:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                       type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                sidecarContainers:
+                  x-kubernetes-preserve-unknown-fields: true
+                tolerations:
+                  x-kubernetes-preserve-unknown-fields: true
+                zone:
+                  type: string
+              type: object
+            status:
+              properties:
+                available:
+                  type: string
+                clientServiceName:
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: vitessbackups.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessBackup
+    listKind: VitessBackupList
+    plural: vitessbackups
+    shortNames:
+      - vtb
+    singular: vitessbackup
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+            status:
+              properties:
+                complete:
+                  type: boolean
+                engine:
+                  type: string
+                finishedTime:
+                  format: date-time
+                  type: string
+                position:
+                  type: string
+                startTime:
+                  format: date-time
+                  type: string
+                storageDirectory:
+                  type: string
+                storageName:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: vitessbackupstorages.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessBackupStorage
+    listKind: VitessBackupStorageList
+    plural: vitessbackupstorages
+    shortNames:
+      - vtbs
+    singular: vitessbackupstorage
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                location:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    azblob:
+                      properties:
+                        account:
+                          minLength: 1
+                          type: string
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        container:
+                          minLength: 1
+                          type: string
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                      required:
+                        - account
+                        - authSecret
+                        - container
+                      type: object
+                    ceph:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                            - key
+                          type: object
+                      required:
+                        - authSecret
+                      type: object
+                    gcs:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        bucket:
+                          minLength: 1
+                          type: string
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                      required:
+                        - bucket
+                      type: object
+                    name:
+                      maxLength: 63
+                      pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                      type: string
+                    s3:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        bucket:
+                          minLength: 1
+                          type: string
+                        endpoint:
+                          type: string
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                        region:
+                          minLength: 1
+                          type: string
+                      required:
+                        - bucket
+                        - region
+                      type: object
+                    volume:
+                      x-kubernetes-preserve-unknown-fields: true
+                    volumeSubPath:
+                      type: string
+                  type: object
+                subcontroller:
+                  properties:
+                    serviceAccountName:
+                      type: string
+                  type: object
+              required:
+                - location
+              type: object
+            status:
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                totalBackupCount:
+                  format: int32
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: vitesscells.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessCell
+    listKind: VitessCellList
+    plural: vitesscells
+    shortNames:
+      - vtc
+    singular: vitesscell
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                allCells:
+                  items:
+                    type: string
+                  type: array
+                extraVitessFlags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                gateway:
+                  properties:
+                    affinity:
                       x-kubernetes-preserve-unknown-fields: true
                     annotations:
                       additionalProperties:
                         type: string
                       type: object
-                    clientService:
+                    authentication:
                       properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        clusterIP:
-                          type: string
-                      type: object
-                    createClientService:
-                      type: boolean
-                    createPDB:
-                      type: boolean
-                    createPeerService:
-                      type: boolean
-                    dataVolumeClaimTemplate:
-                      properties:
-                        accessModes:
-                          items:
-                            type: string
-                          type: array
-                        resources:
+                        static:
                           properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              type: object
-                          type: object
-                        selector:
-                          properties:
-                            matchExpressions:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
+                            secret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
                                 - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
                               type: object
                           type: object
-                        storageClassName:
-                          type: string
-                        volumeMode:
-                          type: string
-                        volumeName:
-                          type: string
                       type: object
                     extraEnv:
                       items:
@@ -936,7 +597,7 @@ spec:
                                   optional:
                                     type: boolean
                                 required:
-                                - key
+                                  - key
                                 type: object
                               fieldRef:
                                 properties:
@@ -945,7 +606,7 @@ spec:
                                   fieldPath:
                                     type: string
                                 required:
-                                - fieldPath
+                                  - fieldPath
                                 type: object
                               resourceFieldRef:
                                 properties:
@@ -953,14 +614,14 @@ spec:
                                     type: string
                                   divisor:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
                                     type: string
                                 required:
-                                - resource
+                                  - resource
                                 type: object
                               secretKeyRef:
                                 properties:
@@ -971,11 +632,11 @@ spec:
                                   optional:
                                     type: boolean
                                 required:
-                                - key
+                                  - key
                                 type: object
                             type: object
                         required:
-                        - name
+                          - name
                         type: object
                       type: array
                     extraFlags:
@@ -1002,41 +663,79 @@ spec:
                           subPathExpr:
                             type: string
                         required:
-                        - mountPath
-                        - name
+                          - mountPath
+                          - name
                         type: object
                       type: array
                     extraVolumes:
-                      items:
-                        required:
-                        - name
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      type: array
-                    image:
-                      type: string
-                    imagePullPolicy:
-                      type: string
-                    imagePullSecrets:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                        type: object
-                      type: array
+                      x-kubernetes-preserve-unknown-fields: true
                     initContainers:
-                      items:
-                        required:
-                        - name
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      type: array
-                    localMemberIndex:
+                      x-kubernetes-preserve-unknown-fields: true
+                    replicas:
                       format: int32
-                      maximum: 3
-                      minimum: 1
+                      minimum: 0
                       type: integer
-                    peerService:
+                    resources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    secureTransport:
+                      properties:
+                        required:
+                          type: boolean
+                        tls:
+                          properties:
+                            certSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                            clientCACertSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                            keySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                          type: object
+                      type: object
+                    service:
                       properties:
                         annotations:
                           additionalProperties:
@@ -1045,39 +744,14 @@ spec:
                         clusterIP:
                           type: string
                       type: object
-                    resources:
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                      type: object
                     sidecarContainers:
-                      items:
-                        required:
-                        - name
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      type: array
+                      x-kubernetes-preserve-unknown-fields: true
                     tolerations:
-                      items:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      type: array
+                      x-kubernetes-preserve-unknown-fields: true
+                    topologySpreadConstraints:
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
-                external:
+                globalLockserver:
                   properties:
                     address:
                       type: string
@@ -1086,80 +760,360 @@ spec:
                     rootPath:
                       type: string
                   required:
-                  - address
-                  - implementation
-                  - rootPath
+                    - address
+                    - implementation
+                    - rootPath
                   type: object
-              type: object
-            name:
-              maxLength: 63
-              minLength: 1
-              pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
-              type: string
-            topologyReconciliation:
-              properties:
-                pruneCells:
-                  type: boolean
-                pruneKeyspaces:
-                  type: boolean
-                pruneShardCells:
-                  type: boolean
-                pruneShards:
-                  type: boolean
-                pruneSrvKeyspaces:
-                  type: boolean
-                pruneTablets:
-                  type: boolean
-                registerCells:
-                  type: boolean
-                registerCellsAliases:
-                  type: boolean
-              type: object
-            zone:
-              type: string
-          required:
-          - allCells
-          - globalLockserver
-          - name
-          type: object
-        status:
-          properties:
-            gateway:
-              properties:
-                available:
+                imagePullPolicies:
+                  properties:
+                    mysqld:
+                      type: string
+                    mysqldExporter:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtctld:
+                      type: string
+                    vtgate:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                imagePullSecrets:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  type: array
+                images:
+                  properties:
+                    vtgate:
+                      type: string
+                  type: object
+                lockserver:
+                  properties:
+                    etcd:
+                      properties:
+                        advertisePeerURLs:
+                          items:
+                            type: string
+                          maxItems: 3
+                          minItems: 3
+                          type: array
+                        affinity:
+                          x-kubernetes-preserve-unknown-fields: true
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clientService:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            clusterIP:
+                              type: string
+                          type: object
+                        createClientService:
+                          type: boolean
+                        createPDB:
+                          type: boolean
+                        createPeerService:
+                          type: boolean
+                        dataVolumeClaimTemplate:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                        extraEnv:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        extraFlags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        extraLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        extraVolumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                        extraVolumes:
+                          x-kubernetes-preserve-unknown-fields: true
+                        image:
+                          type: string
+                        imagePullPolicy:
+                          type: string
+                        imagePullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        initContainers:
+                          x-kubernetes-preserve-unknown-fields: true
+                        localMemberIndex:
+                          format: int32
+                          maximum: 3
+                          minimum: 1
+                          type: integer
+                        peerService:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            clusterIP:
+                              type: string
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        sidecarContainers:
+                          x-kubernetes-preserve-unknown-fields: true
+                        tolerations:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    external:
+                      properties:
+                        address:
+                          type: string
+                        implementation:
+                          type: string
+                        rootPath:
+                          type: string
+                      required:
+                        - address
+                        - implementation
+                        - rootPath
+                      type: object
+                  type: object
+                name:
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
                   type: string
-                serviceName:
+                topologyReconciliation:
+                  properties:
+                    pruneCells:
+                      type: boolean
+                    pruneKeyspaces:
+                      type: boolean
+                    pruneShardCells:
+                      type: boolean
+                    pruneShards:
+                      type: boolean
+                    pruneSrvKeyspaces:
+                      type: boolean
+                    pruneTablets:
+                      type: boolean
+                    registerCells:
+                      type: boolean
+                    registerCellsAliases:
+                      type: boolean
+                  type: object
+                zone:
                   type: string
+              required:
+                - allCells
+                - globalLockserver
+                - name
               type: object
-            idle:
-              type: string
-            keyspaces:
-              additionalProperties:
-                type: object
-              type: object
-            lockserver:
+            status:
               properties:
-                etcd:
+                gateway:
                   properties:
                     available:
                       type: string
-                    clientServiceName:
+                    serviceName:
                       type: string
-                    observedGeneration:
-                      format: int64
-                      type: integer
                   type: object
+                idle:
+                  type: string
+                keyspaces:
+                  additionalProperties:
+                    type: object
+                  type: object
+                lockserver:
+                  properties:
+                    etcd:
+                      properties:
+                        available:
+                          type: string
+                        clientServiceName:
+                          type: string
+                        observedGeneration:
+                          format: int64
+                          type: integer
+                      type: object
+                  type: object
+                observedGeneration:
+                  format: int64
+                  type: integer
               type: object
-            observedGeneration:
-              format: int64
-              type: integer
           type: object
-      type: object
-  version: v2
-  versions:
-  - name: v2
-    served: true
-    storage: true
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -1167,11 +1121,11 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: vitessclusters.planetscale.com
 spec:
@@ -1181,464 +1135,178 @@ spec:
     listKind: VitessClusterList
     plural: vitessclusters
     shortNames:
-    - vt
+      - vt
     singular: vitesscluster
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
           properties:
-            backup:
-              properties:
-                engine:
-                  enum:
-                  - builtin
-                  - xtrabackup
-                  type: string
-                locations:
-                  items:
-                    properties:
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      azblob:
-                        properties:
-                          account:
-                            minLength: 1
-                            type: string
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                            - key
-                            type: object
-                          container:
-                            minLength: 1
-                            type: string
-                          keyPrefix:
-                            maxLength: 256
-                            pattern: ^[^\r\n]*$
-                            type: string
-                        required:
-                        - account
-                        - authSecret
-                        - container
-                        type: object
-                      ceph:
-                        properties:
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                            - key
-                            type: object
-                        required:
-                        - authSecret
-                        type: object
-                      gcs:
-                        properties:
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                            - key
-                            type: object
-                          bucket:
-                            minLength: 1
-                            type: string
-                          keyPrefix:
-                            maxLength: 256
-                            pattern: ^[^\r\n]*$
-                            type: string
-                        required:
-                        - bucket
-                        type: object
-                      name:
-                        maxLength: 63
-                        pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
-                        type: string
-                      s3:
-                        properties:
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                            - key
-                            type: object
-                          bucket:
-                            minLength: 1
-                            type: string
-                          endpoint:
-                            type: string
-                          keyPrefix:
-                            maxLength: 256
-                            pattern: ^[^\r\n]*$
-                            type: string
-                          region:
-                            minLength: 1
-                            type: string
-                        required:
-                        - bucket
-                        - region
-                        type: object
-                      volume:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      volumeSubPath:
-                        type: string
-                    type: object
-                  minItems: 1
-                  type: array
-                subcontroller:
-                  properties:
-                    serviceAccountName:
-                      type: string
-                  type: object
-              required:
-              - locations
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
               type: object
-            cells:
-              items:
-                properties:
-                  gateway:
-                    properties:
-                      affinity:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      authentication:
-                        properties:
-                          static:
-                            properties:
-                              secret:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  volumeName:
-                                    type: string
-                                required:
-                                - key
-                                type: object
-                            type: object
-                        type: object
-                      extraEnv:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      extraFlags:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      extraLabels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      extraVolumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      extraVolumes:
-                        items:
-                          required:
-                          - name
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
-                      initContainers:
-                        items:
-                          required:
-                          - name
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
-                      replicas:
-                        format: int32
-                        minimum: 0
-                        type: integer
-                      resources:
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                      secureTransport:
-                        properties:
-                          required:
-                            type: boolean
-                          tls:
-                            properties:
-                              certSecret:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  volumeName:
-                                    type: string
-                                required:
-                                - key
-                                type: object
-                              clientCACertSecret:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  volumeName:
-                                    type: string
-                                required:
-                                - key
-                                type: object
-                              keySecret:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  volumeName:
-                                    type: string
-                                required:
-                                - key
-                                type: object
-                            type: object
-                        type: object
-                      service:
+            spec:
+              properties:
+                backup:
+                  properties:
+                    engine:
+                      enum:
+                        - builtin
+                        - xtrabackup
+                      type: string
+                    locations:
+                      items:
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
                             type: object
-                          clusterIP:
+                          azblob:
+                            properties:
+                              account:
+                                minLength: 1
+                                type: string
+                              authSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                              container:
+                                minLength: 1
+                                type: string
+                              keyPrefix:
+                                maxLength: 256
+                                pattern: ^[^\r\n]*$
+                                type: string
+                            required:
+                              - account
+                              - authSecret
+                              - container
+                            type: object
+                          ceph:
+                            properties:
+                              authSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                            required:
+                              - authSecret
+                            type: object
+                          gcs:
+                            properties:
+                              authSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                              bucket:
+                                minLength: 1
+                                type: string
+                              keyPrefix:
+                                maxLength: 256
+                                pattern: ^[^\r\n]*$
+                                type: string
+                            required:
+                              - bucket
+                            type: object
+                          name:
+                            maxLength: 63
+                            pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                            type: string
+                          s3:
+                            properties:
+                              authSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                              bucket:
+                                minLength: 1
+                                type: string
+                              endpoint:
+                                type: string
+                              keyPrefix:
+                                maxLength: 256
+                                pattern: ^[^\r\n]*$
+                                type: string
+                              region:
+                                minLength: 1
+                                type: string
+                            required:
+                              - bucket
+                              - region
+                            type: object
+                          volume:
+                            x-kubernetes-preserve-unknown-fields: true
+                          volumeSubPath:
                             type: string
                         type: object
-                      sidecarContainers:
-                        items:
-                          required:
-                          - name
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
-                      tolerations:
-                        items:
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
-                      topologySpreadConstraints:
-                        items:
-                          required:
-                          - maxSkew
-                          - topologyKey
-                          - whenUnsatisfiable
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
-                    type: object
-                  lockserver:
+                      minItems: 1
+                      type: array
+                    subcontroller:
+                      properties:
+                        serviceAccountName:
+                          type: string
+                      type: object
+                  required:
+                    - locations
+                  type: object
+                cells:
+                  items:
                     properties:
-                      etcd:
+                      gateway:
                         properties:
-                          advertisePeerURLs:
-                            items:
-                              type: string
-                            maxItems: 3
-                            minItems: 3
-                            type: array
                           affinity:
-                            type: object
                             x-kubernetes-preserve-unknown-fields: true
                           annotations:
                             additionalProperties:
                               type: string
                             type: object
-                          clientService:
+                          authentication:
                             properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              clusterIP:
-                                type: string
-                            type: object
-                          createClientService:
-                            type: boolean
-                          createPDB:
-                            type: boolean
-                          createPeerService:
-                            type: boolean
-                          dataVolumeClaimTemplate:
-                            properties:
-                              accessModes:
-                                items:
-                                  type: string
-                                type: array
-                              resources:
+                              static:
                                 properties:
-                                  limits:
-                                    additionalProperties:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    type: object
-                                  requests:
-                                    additionalProperties:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    type: object
-                                type: object
-                              selector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
+                                  secret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
                                       - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
                                     type: object
                                 type: object
-                              storageClassName:
-                                type: string
-                              volumeMode:
-                                type: string
-                              volumeName:
-                                type: string
                             type: object
                           extraEnv:
                             items:
@@ -1658,7 +1326,7 @@ spec:
                                         optional:
                                           type: boolean
                                       required:
-                                      - key
+                                        - key
                                       type: object
                                     fieldRef:
                                       properties:
@@ -1667,7 +1335,7 @@ spec:
                                         fieldPath:
                                           type: string
                                       required:
-                                      - fieldPath
+                                        - fieldPath
                                       type: object
                                     resourceFieldRef:
                                       properties:
@@ -1675,14 +1343,14 @@ spec:
                                           type: string
                                         divisor:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
                                           type: string
                                       required:
-                                      - resource
+                                        - resource
                                       type: object
                                     secretKeyRef:
                                       properties:
@@ -1693,11 +1361,11 @@ spec:
                                         optional:
                                           type: boolean
                                       required:
-                                      - key
+                                        - key
                                       type: object
                                   type: object
                               required:
-                              - name
+                                - name
                               type: object
                             type: array
                           extraFlags:
@@ -1724,41 +1392,79 @@ spec:
                                 subPathExpr:
                                   type: string
                               required:
-                              - mountPath
-                              - name
+                                - mountPath
+                                - name
                               type: object
                             type: array
                           extraVolumes:
-                            items:
-                              required:
-                              - name
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          image:
-                            type: string
-                          imagePullPolicy:
-                            type: string
-                          imagePullSecrets:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
                           initContainers:
-                            items:
-                              required:
-                              - name
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          localMemberIndex:
+                            x-kubernetes-preserve-unknown-fields: true
+                          replicas:
                             format: int32
-                            maximum: 3
-                            minimum: 1
+                            minimum: 0
                             type: integer
-                          peerService:
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          secureTransport:
+                            properties:
+                              required:
+                                type: boolean
+                              tls:
+                                properties:
+                                  certSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                      - key
+                                    type: object
+                                  clientCACertSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                      - key
+                                    type: object
+                                  keySecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            type: object
+                          service:
                             properties:
                               annotations:
                                 additionalProperties:
@@ -1767,163 +1473,1509 @@ spec:
                               clusterIP:
                                 type: string
                             type: object
-                          resources:
-                            properties:
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type: object
-                            type: object
                           sidecarContainers:
-                            items:
-                              required:
-                              - name
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
                           tolerations:
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                          topologySpreadConstraints:
+                            x-kubernetes-preserve-unknown-fields: true
                         type: object
-                      external:
+                      lockserver:
                         properties:
-                          address:
-                            type: string
-                          implementation:
-                            type: string
-                          rootPath:
-                            type: string
-                        required:
-                        - address
-                        - implementation
-                        - rootPath
+                          etcd:
+                            properties:
+                              advertisePeerURLs:
+                                items:
+                                  type: string
+                                maxItems: 3
+                                minItems: 3
+                                type: array
+                              affinity:
+                                x-kubernetes-preserve-unknown-fields: true
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              clientService:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  clusterIP:
+                                    type: string
+                                type: object
+                              createClientService:
+                                type: boolean
+                              createPDB:
+                                type: boolean
+                              createPeerService:
+                                type: boolean
+                              dataVolumeClaimTemplate:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                              extraEnv:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                        secretKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                      type: object
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                              extraFlags:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              extraLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              extraVolumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                    - mountPath
+                                    - name
+                                  type: object
+                                type: array
+                              extraVolumes:
+                                x-kubernetes-preserve-unknown-fields: true
+                              image:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              initContainers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              localMemberIndex:
+                                format: int32
+                                maximum: 3
+                                minimum: 1
+                                type: integer
+                              peerService:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  clusterIP:
+                                    type: string
+                                type: object
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              sidecarContainers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              tolerations:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          external:
+                            properties:
+                              address:
+                                type: string
+                              implementation:
+                                type: string
+                              rootPath:
+                                type: string
+                            required:
+                              - address
+                              - implementation
+                              - rootPath
+                            type: object
                         type: object
+                      name:
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                        type: string
+                      zone:
+                        type: string
+                    required:
+                      - name
                     type: object
-                  name:
-                    maxLength: 63
-                    minLength: 1
-                    pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
-                    type: string
-                  zone:
-                    type: string
-                required:
-                - name
-                type: object
-              type: array
-            extraVitessFlags:
-              additionalProperties:
-                type: string
-              type: object
-            gatewayService:
-              properties:
-                annotations:
+                  type: array
+                extraVitessFlags:
                   additionalProperties:
                     type: string
                   type: object
-                clusterIP:
-                  type: string
-              type: object
-            globalLockserver:
-              properties:
-                etcd:
+                gatewayService:
                   properties:
-                    advertisePeerURLs:
-                      items:
-                        type: string
-                      maxItems: 3
-                      minItems: 3
-                      type: array
-                    affinity:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
                     annotations:
                       additionalProperties:
                         type: string
                       type: object
-                    clientService:
+                    clusterIP:
+                      type: string
+                  type: object
+                globalLockserver:
+                  properties:
+                    etcd:
                       properties:
+                        advertisePeerURLs:
+                          items:
+                            type: string
+                          maxItems: 3
+                          minItems: 3
+                          type: array
+                        affinity:
+                          x-kubernetes-preserve-unknown-fields: true
                         annotations:
                           additionalProperties:
                             type: string
                           type: object
-                        clusterIP:
-                          type: string
-                      type: object
-                    createClientService:
-                      type: boolean
-                    createPDB:
-                      type: boolean
-                    createPeerService:
-                      type: boolean
-                    dataVolumeClaimTemplate:
-                      properties:
-                        accessModes:
+                        clientService:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            clusterIP:
+                              type: string
+                          type: object
+                        createClientService:
+                          type: boolean
+                        createPDB:
+                          type: boolean
+                        createPeerService:
+                          type: boolean
+                        dataVolumeClaimTemplate:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                        extraEnv:
                           items:
-                            type: string
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
                           type: array
+                        extraFlags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        extraLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        extraVolumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                        extraVolumes:
+                          x-kubernetes-preserve-unknown-fields: true
+                        image:
+                          type: string
+                        imagePullPolicy:
+                          type: string
+                        imagePullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        initContainers:
+                          x-kubernetes-preserve-unknown-fields: true
+                        localMemberIndex:
+                          format: int32
+                          maximum: 3
+                          minimum: 1
+                          type: integer
+                        peerService:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            clusterIP:
+                              type: string
+                          type: object
                         resources:
                           properties:
                             limits:
                               additionalProperties:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
                               type: object
                             requests:
                               additionalProperties:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
-                        selector:
-                          properties:
-                            matchExpressions:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                        storageClassName:
+                        sidecarContainers:
+                          x-kubernetes-preserve-unknown-fields: true
+                        tolerations:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    external:
+                      properties:
+                        address:
                           type: string
-                        volumeMode:
+                        implementation:
                           type: string
-                        volumeName:
+                        rootPath:
+                          type: string
+                      required:
+                        - address
+                        - implementation
+                        - rootPath
+                      type: object
+                  type: object
+                imagePullPolicies:
+                  properties:
+                    mysqld:
+                      type: string
+                    mysqldExporter:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtctld:
+                      type: string
+                    vtgate:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                imagePullSecrets:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  type: array
+                images:
+                  properties:
+                    mysqld:
+                      properties:
+                        mariadb103Compatible:
+                          type: string
+                        mariadbCompatible:
+                          type: string
+                        mysql56Compatible:
+                          type: string
+                        mysql80Compatible:
                           type: string
                       type: object
+                    mysqldExporter:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtctld:
+                      type: string
+                    vtgate:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                keyspaces:
+                  items:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      databaseName:
+                        type: string
+                      name:
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                        type: string
+                      partitionings:
+                        items:
+                          properties:
+                            custom:
+                              properties:
+                                shards:
+                                  items:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      databaseInitScriptSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                        type: object
+                                      keyRange:
+                                        properties:
+                                          end:
+                                            pattern: ^([0-9a-f][0-9a-f])*$
+                                            type: string
+                                          start:
+                                            pattern: ^([0-9a-f][0-9a-f])*$
+                                            type: string
+                                        type: object
+                                      replication:
+                                        properties:
+                                          enforceSemiSync:
+                                            type: boolean
+                                          initializeBackup:
+                                            type: boolean
+                                          initializeMaster:
+                                            type: boolean
+                                          recoverRestartedMaster:
+                                            type: boolean
+                                        type: object
+                                      tabletPools:
+                                        items:
+                                          properties:
+                                            affinity:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            backupLocationName:
+                                              type: string
+                                            cell:
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              properties:
+                                                accessModes:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dataSource:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - kind
+                                                    - name
+                                                  type: object
+                                                resources:
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                          - key
+                                                          - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                storageClassName:
+                                                  type: string
+                                                volumeMode:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              type: object
+                                            externalDatastore:
+                                              properties:
+                                                credentialsSecret:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                database:
+                                                  type: string
+                                                host:
+                                                  type: string
+                                                port:
+                                                  format: int32
+                                                  maximum: 65535
+                                                  minimum: 1
+                                                  type: integer
+                                                serverCACertSecret:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                user:
+                                                  type: string
+                                              required:
+                                                - credentialsSecret
+                                                - database
+                                                - host
+                                                - port
+                                                - user
+                                              type: object
+                                            extraEnv:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                          - key
+                                                        type: object
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        required:
+                                                          - fieldPath
+                                                        type: object
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          resource:
+                                                            type: string
+                                                        required:
+                                                          - resource
+                                                        type: object
+                                                      secretKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                          - key
+                                                        type: object
+                                                    type: object
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
+                                            extraLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            extraVolumeMounts:
+                                              items:
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                                required:
+                                                  - mountPath
+                                                  - name
+                                                type: object
+                                              type: array
+                                            extraVolumes:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            initContainers:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            mysqld:
+                                              properties:
+                                                configOverrides:
+                                                  type: string
+                                                resources:
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                              required:
+                                                - resources
+                                              type: object
+                                            replicas:
+                                              format: int32
+                                              minimum: 0
+                                              type: integer
+                                            sidecarContainers:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            tolerations:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            topologySpreadConstraints:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type:
+                                              enum:
+                                                - replica
+                                                - rdonly
+                                                - externalmaster
+                                                - externalreplica
+                                                - externalrdonly
+                                              type: string
+                                            vttablet:
+                                              properties:
+                                                extraFlags:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                lifecycle:
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                resources:
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                              required:
+                                                - resources
+                                              type: object
+                                          required:
+                                            - cell
+                                            - replicas
+                                            - type
+                                            - vttablet
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - type
+                                          - cell
+                                        x-kubernetes-list-type: map
+                                    required:
+                                      - databaseInitScriptSecret
+                                      - keyRange
+                                    type: object
+                                  type: array
+                              required:
+                                - shards
+                              type: object
+                            equal:
+                              properties:
+                                parts:
+                                  format: int32
+                                  minimum: 1
+                                  type: integer
+                                shardTemplate:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    databaseInitScriptSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    replication:
+                                      properties:
+                                        enforceSemiSync:
+                                          type: boolean
+                                        initializeBackup:
+                                          type: boolean
+                                        initializeMaster:
+                                          type: boolean
+                                        recoverRestartedMaster:
+                                          type: boolean
+                                      type: object
+                                    tabletPools:
+                                      items:
+                                        properties:
+                                          affinity:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          backupLocationName:
+                                            type: string
+                                          cell:
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                                            type: string
+                                          dataVolumeClaimTemplate:
+                                            properties:
+                                              accessModes:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              dataSource:
+                                                properties:
+                                                  apiGroup:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                required:
+                                                  - kind
+                                                  - name
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                type: object
+                                              selector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              storageClassName:
+                                                type: string
+                                              volumeMode:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            type: object
+                                          externalDatastore:
+                                            properties:
+                                              credentialsSecret:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                  - key
+                                                type: object
+                                              database:
+                                                type: string
+                                              host:
+                                                type: string
+                                              port:
+                                                format: int32
+                                                maximum: 65535
+                                                minimum: 1
+                                                type: integer
+                                              serverCACertSecret:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                  - key
+                                                type: object
+                                              user:
+                                                type: string
+                                            required:
+                                              - credentialsSecret
+                                              - database
+                                              - host
+                                              - port
+                                              - user
+                                            type: object
+                                          extraEnv:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                                valueFrom:
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                        - fieldPath
+                                                      type: object
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                        - resource
+                                                      type: object
+                                                    secretKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                  type: object
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                          extraLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          extraVolumeMounts:
+                                            items:
+                                              properties:
+                                                mountPath:
+                                                  type: string
+                                                mountPropagation:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                subPath:
+                                                  type: string
+                                                subPathExpr:
+                                                  type: string
+                                              required:
+                                                - mountPath
+                                                - name
+                                              type: object
+                                            type: array
+                                          extraVolumes:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          initContainers:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          mysqld:
+                                            properties:
+                                              configOverrides:
+                                                type: string
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                type: object
+                                            required:
+                                              - resources
+                                            type: object
+                                          replicas:
+                                            format: int32
+                                            minimum: 0
+                                            type: integer
+                                          sidecarContainers:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          tolerations:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          topologySpreadConstraints:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type:
+                                            enum:
+                                              - replica
+                                              - rdonly
+                                              - externalmaster
+                                              - externalreplica
+                                              - externalrdonly
+                                            type: string
+                                          vttablet:
+                                            properties:
+                                              extraFlags:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              lifecycle:
+                                                x-kubernetes-preserve-unknown-fields: true
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                type: object
+                                            required:
+                                              - resources
+                                            type: object
+                                        required:
+                                          - cell
+                                          - replicas
+                                          - type
+                                          - vttablet
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - type
+                                        - cell
+                                      x-kubernetes-list-type: map
+                                  required:
+                                    - databaseInitScriptSecret
+                                  type: object
+                              required:
+                                - parts
+                              type: object
+                          type: object
+                        maxItems: 2
+                        minItems: 1
+                        type: array
+                      turndownPolicy:
+                        enum:
+                          - RequireIdle
+                          - Immediate
+                        type: string
+                      vitessOrchestrator:
+                        properties:
+                          affinity:
+                            x-kubernetes-preserve-unknown-fields: true
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          configSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          extraEnv:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                  type: object
+                              required:
+                                - name
+                              type: object
+                            type: array
+                          extraFlags:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          extraLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          extraVolumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                          extraVolumes:
+                            x-kubernetes-preserve-unknown-fields: true
+                          initContainers:
+                            x-kubernetes-preserve-unknown-fields: true
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          service:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              clusterIP:
+                                type: string
+                            type: object
+                          sidecarContainers:
+                            x-kubernetes-preserve-unknown-fields: true
+                          tolerations:
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                          - configSecret
+                        type: object
+                    required:
+                      - name
+                      - partitionings
+                    type: object
+                  type: array
+                tabletService:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    clusterIP:
+                      type: string
+                  type: object
+                topologyReconciliation:
+                  properties:
+                    pruneCells:
+                      type: boolean
+                    pruneKeyspaces:
+                      type: boolean
+                    pruneShardCells:
+                      type: boolean
+                    pruneShards:
+                      type: boolean
+                    pruneSrvKeyspaces:
+                      type: boolean
+                    pruneTablets:
+                      type: boolean
+                    registerCells:
+                      type: boolean
+                    registerCellsAliases:
+                      type: boolean
+                  type: object
+                updateStrategy:
+                  properties:
+                    external:
+                      properties:
+                        allowResourceChanges:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type:
+                      enum:
+                        - External
+                        - Immediate
+                      type: string
+                  type: object
+                vitessDashboard:
+                  properties:
+                    affinity:
+                      x-kubernetes-preserve-unknown-fields: true
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    cells:
+                      items:
+                        type: string
+                      type: array
                     extraEnv:
                       items:
                         properties:
@@ -1942,7 +2994,7 @@ spec:
                                   optional:
                                     type: boolean
                                 required:
-                                - key
+                                  - key
                                 type: object
                               fieldRef:
                                 properties:
@@ -1951,7 +3003,7 @@ spec:
                                   fieldPath:
                                     type: string
                                 required:
-                                - fieldPath
+                                  - fieldPath
                                 type: object
                               resourceFieldRef:
                                 properties:
@@ -1959,14 +3011,14 @@ spec:
                                     type: string
                                   divisor:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
                                     type: string
                                 required:
-                                - resource
+                                  - resource
                                 type: object
                               secretKeyRef:
                                 properties:
@@ -1977,11 +3029,11 @@ spec:
                                   optional:
                                     type: boolean
                                 required:
-                                - key
+                                  - key
                                 type: object
                             type: object
                         required:
-                        - name
+                          - name
                         type: object
                       type: array
                     extraFlags:
@@ -2008,41 +3060,37 @@ spec:
                           subPathExpr:
                             type: string
                         required:
-                        - mountPath
-                        - name
+                          - mountPath
+                          - name
                         type: object
                       type: array
                     extraVolumes:
-                      items:
-                        required:
-                        - name
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      type: array
-                    image:
-                      type: string
-                    imagePullPolicy:
-                      type: string
-                    imagePullSecrets:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                        type: object
-                      type: array
+                      x-kubernetes-preserve-unknown-fields: true
                     initContainers:
-                      items:
-                        required:
-                        - name
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      type: array
-                    localMemberIndex:
+                      x-kubernetes-preserve-unknown-fields: true
+                    replicas:
                       format: int32
-                      maximum: 3
-                      minimum: 1
                       type: integer
-                    peerService:
+                    resources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    service:
                       properties:
                         annotations:
                           additionalProperties:
@@ -2051,39 +3099,278 @@ spec:
                         clusterIP:
                           type: string
                       type: object
-                    resources:
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                      type: object
                     sidecarContainers:
-                      items:
-                        required:
-                        - name
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      type: array
+                      x-kubernetes-preserve-unknown-fields: true
                     tolerations:
-                      items:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      type: array
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
-                external:
+              required:
+                - cells
+              type: object
+            status:
+              properties:
+                cells:
+                  additionalProperties:
+                    properties:
+                      gatewayAvailable:
+                        type: string
+                      pendingChanges:
+                        type: string
+                    type: object
+                  type: object
+                gatewayServiceName:
+                  type: string
+                globalLockserver:
+                  properties:
+                    etcd:
+                      properties:
+                        available:
+                          type: string
+                        clientServiceName:
+                          type: string
+                        observedGeneration:
+                          format: int64
+                          type: integer
+                      type: object
+                  type: object
+                keyspaces:
+                  additionalProperties:
+                    properties:
+                      cells:
+                        items:
+                          type: string
+                        type: array
+                      desiredShards:
+                        format: int32
+                        type: integer
+                      desiredTablets:
+                        format: int32
+                        type: integer
+                      pendingChanges:
+                        type: string
+                      readyShards:
+                        format: int32
+                        type: integer
+                      readyTablets:
+                        format: int32
+                        type: integer
+                      shards:
+                        format: int32
+                        type: integer
+                      tablets:
+                        format: int32
+                        type: integer
+                      updatedShards:
+                        format: int32
+                        type: integer
+                      updatedTablets:
+                        format: int32
+                        type: integer
+                    type: object
+                  type: object
+                observedGeneration:
+                  format: int64
+                  type: integer
+                orphanedCells:
+                  additionalProperties:
+                    properties:
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                    required:
+                      - message
+                      - reason
+                    type: object
+                  type: object
+                orphanedKeyspaces:
+                  additionalProperties:
+                    properties:
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                    required:
+                      - message
+                      - reason
+                    type: object
+                  type: object
+                vitessDashboard:
+                  properties:
+                    available:
+                      type: string
+                    serviceName:
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: vitesskeyspaces.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessKeyspace
+    listKind: VitessKeyspaceList
+    plural: vitesskeyspaces
+    shortNames:
+      - vtk
+    singular: vitesskeyspace
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                backupEngine:
+                  type: string
+                backupLocations:
+                  items:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      azblob:
+                        properties:
+                          account:
+                            minLength: 1
+                            type: string
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          container:
+                            minLength: 1
+                            type: string
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                        required:
+                          - account
+                          - authSecret
+                          - container
+                        type: object
+                      ceph:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                        required:
+                          - authSecret
+                        type: object
+                      gcs:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          bucket:
+                            minLength: 1
+                            type: string
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                        required:
+                          - bucket
+                        type: object
+                      name:
+                        maxLength: 63
+                        pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                        type: string
+                      s3:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          bucket:
+                            minLength: 1
+                            type: string
+                          endpoint:
+                            type: string
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                          region:
+                            minLength: 1
+                            type: string
+                        required:
+                          - bucket
+                          - region
+                        type: object
+                      volume:
+                        x-kubernetes-preserve-unknown-fields: true
+                      volumeSubPath:
+                        type: string
+                    type: object
+                  type: array
+                databaseName:
+                  type: string
+                extraVitessFlags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                globalLockserver:
                   properties:
                     address:
                       type: string
@@ -2092,446 +3379,68 @@ spec:
                     rootPath:
                       type: string
                   required:
-                  - address
-                  - implementation
-                  - rootPath
+                    - address
+                    - implementation
+                    - rootPath
                   type: object
-              type: object
-            imagePullPolicies:
-              properties:
-                mysqld:
-                  type: string
-                mysqldExporter:
-                  type: string
-                vtbackup:
-                  type: string
-                vtctld:
-                  type: string
-                vtgate:
-                  type: string
-                vtorc:
-                  type: string
-                vttablet:
-                  type: string
-              type: object
-            imagePullSecrets:
-              items:
-                properties:
-                  name:
-                    type: string
-                type: object
-              type: array
-            images:
-              properties:
-                mysqld:
+                imagePullPolicies:
                   properties:
-                    mariadb103Compatible:
+                    mysqld:
                       type: string
-                    mariadbCompatible:
+                    mysqldExporter:
                       type: string
-                    mysql56Compatible:
+                    vtbackup:
                       type: string
-                    mysql80Compatible:
+                    vtctld:
+                      type: string
+                    vtgate:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
                       type: string
                   type: object
-                mysqldExporter:
-                  type: string
-                vtbackup:
-                  type: string
-                vtctld:
-                  type: string
-                vtgate:
-                  type: string
-                vtorc:
-                  type: string
-                vttablet:
-                  type: string
-              type: object
-            keyspaces:
-              items:
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
+                imagePullSecrets:
+                  items:
+                    properties:
+                      name:
+                        type: string
                     type: object
-                  databaseName:
-                    type: string
-                  name:
-                    maxLength: 63
-                    minLength: 1
-                    pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
-                    type: string
-                  partitionings:
-                    items:
+                  type: array
+                images:
+                  properties:
+                    mysqld:
                       properties:
-                        custom:
-                          properties:
-                            shards:
-                              items:
-                                properties:
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  databaseInitScriptSecret:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      volumeName:
-                                        type: string
-                                    required:
-                                    - key
-                                    type: object
-                                  keyRange:
-                                    properties:
-                                      end:
-                                        pattern: ^([0-9a-f][0-9a-f])*$
-                                        type: string
-                                      start:
-                                        pattern: ^([0-9a-f][0-9a-f])*$
-                                        type: string
-                                    type: object
-                                  replication:
-                                    properties:
-                                      enforceSemiSync:
-                                        type: boolean
-                                      initializeBackup:
-                                        type: boolean
-                                      initializeMaster:
-                                        type: boolean
-                                      recoverRestartedMaster:
-                                        type: boolean
-                                    type: object
-                                  tabletPools:
-                                    items:
-                                      properties:
-                                        affinity:
-                                          type: object
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        annotations:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                        backupLocationName:
-                                          type: string
-                                        cell:
-                                          maxLength: 63
-                                          minLength: 1
-                                          pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
-                                          type: string
-                                        dataVolumeClaimTemplate:
-                                          properties:
-                                            accessModes:
-                                              items:
-                                                type: string
-                                              type: array
-                                            resources:
-                                              properties:
-                                                limits:
-                                                  additionalProperties:
-                                                    anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
-                                                  type: object
-                                                requests:
-                                                  additionalProperties:
-                                                    anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
-                                                  type: object
-                                              type: object
-                                            selector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                    - key
-                                                    - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            storageClassName:
-                                              type: string
-                                            volumeMode:
-                                              type: string
-                                            volumeName:
-                                              type: string
-                                          type: object
-                                        externalDatastore:
-                                          properties:
-                                            credentialsSecret:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                                volumeName:
-                                                  type: string
-                                              required:
-                                              - key
-                                              type: object
-                                            database:
-                                              type: string
-                                            host:
-                                              type: string
-                                            port:
-                                              format: int32
-                                              maximum: 65535
-                                              minimum: 1
-                                              type: integer
-                                            serverCACertSecret:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                                volumeName:
-                                                  type: string
-                                              required:
-                                              - key
-                                              type: object
-                                            user:
-                                              type: string
-                                          required:
-                                          - credentialsSecret
-                                          - database
-                                          - host
-                                          - port
-                                          - user
-                                          type: object
-                                        extraEnv:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                              valueFrom:
-                                                properties:
-                                                  configMapKeyRef:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    required:
-                                                    - key
-                                                    type: object
-                                                  fieldRef:
-                                                    properties:
-                                                      apiVersion:
-                                                        type: string
-                                                      fieldPath:
-                                                        type: string
-                                                    required:
-                                                    - fieldPath
-                                                    type: object
-                                                  resourceFieldRef:
-                                                    properties:
-                                                      containerName:
-                                                        type: string
-                                                      divisor:
-                                                        anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                        x-kubernetes-int-or-string: true
-                                                      resource:
-                                                        type: string
-                                                    required:
-                                                    - resource
-                                                    type: object
-                                                  secretKeyRef:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    required:
-                                                    - key
-                                                    type: object
-                                                type: object
-                                            required:
-                                            - name
-                                            type: object
-                                          type: array
-                                        extraLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                        extraVolumeMounts:
-                                          items:
-                                            properties:
-                                              mountPath:
-                                                type: string
-                                              mountPropagation:
-                                                type: string
-                                              name:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              subPath:
-                                                type: string
-                                              subPathExpr:
-                                                type: string
-                                            required:
-                                            - mountPath
-                                            - name
-                                            type: object
-                                          type: array
-                                        extraVolumes:
-                                          items:
-                                            required:
-                                            - name
-                                            type: object
-                                            x-kubernetes-preserve-unknown-fields: true
-                                          type: array
-                                        initContainers:
-                                          items:
-                                            required:
-                                            - name
-                                            type: object
-                                            x-kubernetes-preserve-unknown-fields: true
-                                          type: array
-                                        mysqld:
-                                          properties:
-                                            configOverrides:
-                                              type: string
-                                            resources:
-                                              properties:
-                                                limits:
-                                                  additionalProperties:
-                                                    anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
-                                                  type: object
-                                                requests:
-                                                  additionalProperties:
-                                                    anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
-                                                  type: object
-                                              type: object
-                                          required:
-                                          - resources
-                                          type: object
-                                        replicas:
-                                          format: int32
-                                          minimum: 0
-                                          type: integer
-                                        sidecarContainers:
-                                          items:
-                                            required:
-                                            - name
-                                            type: object
-                                            x-kubernetes-preserve-unknown-fields: true
-                                          type: array
-                                        tolerations:
-                                          items:
-                                            type: object
-                                            x-kubernetes-preserve-unknown-fields: true
-                                          type: array
-                                        topologySpreadConstraints:
-                                          items:
-                                            required:
-                                            - maxSkew
-                                            - topologyKey
-                                            - whenUnsatisfiable
-                                            type: object
-                                            x-kubernetes-preserve-unknown-fields: true
-                                          type: array
-                                        type:
-                                          enum:
-                                          - replica
-                                          - rdonly
-                                          - externalmaster
-                                          - externalreplica
-                                          - externalrdonly
-                                          type: string
-                                        vttablet:
-                                          properties:
-                                            extraFlags:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                            lifecycle:
-                                              type: object
-                                              x-kubernetes-preserve-unknown-fields: true
-                                            resources:
-                                              properties:
-                                                limits:
-                                                  additionalProperties:
-                                                    anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
-                                                  type: object
-                                                requests:
-                                                  additionalProperties:
-                                                    anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
-                                                  type: object
-                                              type: object
-                                          required:
-                                          - resources
-                                          type: object
-                                      required:
-                                      - cell
-                                      - replicas
-                                      - type
-                                      - vttablet
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-map-keys:
-                                    - type
-                                    - cell
-                                    x-kubernetes-list-type: map
-                                required:
-                                - databaseInitScriptSecret
-                                - keyRange
-                                type: object
-                              type: array
-                          required:
-                          - shards
-                          type: object
-                        equal:
-                          properties:
-                            parts:
-                              format: int32
-                              minimum: 1
-                              type: integer
-                            shardTemplate:
+                        mariadb103Compatible:
+                          type: string
+                        mariadbCompatible:
+                          type: string
+                        mysql56Compatible:
+                          type: string
+                        mysql80Compatible:
+                          type: string
+                      type: object
+                    mysqldExporter:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                name:
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                  type: string
+                partitionings:
+                  items:
+                    properties:
+                      custom:
+                        properties:
+                          shards:
+                            items:
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -2546,7 +3455,16 @@ spec:
                                     volumeName:
                                       type: string
                                   required:
-                                  - key
+                                    - key
+                                  type: object
+                                keyRange:
+                                  properties:
+                                    end:
+                                      pattern: ^([0-9a-f][0-9a-f])*$
+                                      type: string
+                                    start:
+                                      pattern: ^([0-9a-f][0-9a-f])*$
+                                      type: string
                                   type: object
                                 replication:
                                   properties:
@@ -2563,7 +3481,6 @@ spec:
                                   items:
                                     properties:
                                       affinity:
-                                        type: object
                                         x-kubernetes-preserve-unknown-fields: true
                                       annotations:
                                         additionalProperties:
@@ -2582,21 +3499,33 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                          dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
                                           resources:
                                             properties:
                                               limits:
                                                 additionalProperties:
                                                   anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                    - type: integer
+                                                    - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 type: object
                                               requests:
                                                 additionalProperties:
                                                   anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                    - type: integer
+                                                    - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 type: object
@@ -2615,8 +3544,8 @@ spec:
                                                         type: string
                                                       type: array
                                                   required:
-                                                  - key
-                                                  - operator
+                                                    - key
+                                                    - operator
                                                   type: object
                                                 type: array
                                               matchLabels:
@@ -2642,7 +3571,7 @@ spec:
                                               volumeName:
                                                 type: string
                                             required:
-                                            - key
+                                              - key
                                             type: object
                                           database:
                                             type: string
@@ -2662,16 +3591,16 @@ spec:
                                               volumeName:
                                                 type: string
                                             required:
-                                            - key
+                                              - key
                                             type: object
                                           user:
                                             type: string
                                         required:
-                                        - credentialsSecret
-                                        - database
-                                        - host
-                                        - port
-                                        - user
+                                          - credentialsSecret
+                                          - database
+                                          - host
+                                          - port
+                                          - user
                                         type: object
                                       extraEnv:
                                         items:
@@ -2691,7 +3620,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                                 fieldRef:
                                                   properties:
@@ -2700,7 +3629,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 resourceFieldRef:
                                                   properties:
@@ -2708,14 +3637,14 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                                 secretKeyRef:
                                                   properties:
@@ -2726,11 +3655,11 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                               type: object
                                           required:
-                                          - name
+                                            - name
                                           type: object
                                         type: array
                                       extraLabels:
@@ -2753,24 +3682,14 @@ spec:
                                             subPathExpr:
                                               type: string
                                           required:
-                                          - mountPath
-                                          - name
+                                            - mountPath
+                                            - name
                                           type: object
                                         type: array
                                       extraVolumes:
-                                        items:
-                                          required:
-                                          - name
-                                          type: object
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        type: array
+                                        x-kubernetes-preserve-unknown-fields: true
                                       initContainers:
-                                        items:
-                                          required:
-                                          - name
-                                          type: object
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        type: array
+                                        x-kubernetes-preserve-unknown-fields: true
                                       mysqld:
                                         properties:
                                           configOverrides:
@@ -2780,55 +3699,40 @@ spec:
                                               limits:
                                                 additionalProperties:
                                                   anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                    - type: integer
+                                                    - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 type: object
                                               requests:
                                                 additionalProperties:
                                                   anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                    - type: integer
+                                                    - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 type: object
                                             type: object
                                         required:
-                                        - resources
+                                          - resources
                                         type: object
                                       replicas:
                                         format: int32
                                         minimum: 0
                                         type: integer
                                       sidecarContainers:
-                                        items:
-                                          required:
-                                          - name
-                                          type: object
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        type: array
+                                        x-kubernetes-preserve-unknown-fields: true
                                       tolerations:
-                                        items:
-                                          type: object
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        type: array
+                                        x-kubernetes-preserve-unknown-fields: true
                                       topologySpreadConstraints:
-                                        items:
-                                          required:
-                                          - maxSkew
-                                          - topologyKey
-                                          - whenUnsatisfiable
-                                          type: object
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        type: array
+                                        x-kubernetes-preserve-unknown-fields: true
                                       type:
                                         enum:
-                                        - replica
-                                        - rdonly
-                                        - externalmaster
-                                        - externalreplica
-                                        - externalrdonly
+                                          - replica
+                                          - rdonly
+                                          - externalmaster
+                                          - externalreplica
+                                          - externalrdonly
                                         type: string
                                       vttablet:
                                         properties:
@@ -2837,75 +3741,1087 @@ spec:
                                               type: string
                                             type: object
                                           lifecycle:
-                                            type: object
                                             x-kubernetes-preserve-unknown-fields: true
                                           resources:
                                             properties:
                                               limits:
                                                 additionalProperties:
                                                   anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                    - type: integer
+                                                    - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 type: object
                                               requests:
                                                 additionalProperties:
                                                   anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                    - type: integer
+                                                    - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 type: object
                                             type: object
                                         required:
-                                        - resources
+                                          - resources
                                         type: object
                                     required:
+                                      - cell
+                                      - replicas
+                                      - type
+                                      - vttablet
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - type
+                                    - cell
+                                  x-kubernetes-list-type: map
+                              required:
+                                - databaseInitScriptSecret
+                                - keyRange
+                              type: object
+                            type: array
+                        required:
+                          - shards
+                        type: object
+                      equal:
+                        properties:
+                          parts:
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          shardTemplate:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              databaseInitScriptSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                              replication:
+                                properties:
+                                  enforceSemiSync:
+                                    type: boolean
+                                  initializeBackup:
+                                    type: boolean
+                                  initializeMaster:
+                                    type: boolean
+                                  recoverRestartedMaster:
+                                    type: boolean
+                                type: object
+                              tabletPools:
+                                items:
+                                  properties:
+                                    affinity:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    backupLocationName:
+                                      type: string
+                                    cell:
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                                      type: string
+                                    dataVolumeClaimTemplate:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                    externalDatastore:
+                                      properties:
+                                        credentialsSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          required:
+                                            - key
+                                          type: object
+                                        database:
+                                          type: string
+                                        host:
+                                          type: string
+                                        port:
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        serverCACertSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          required:
+                                            - key
+                                          type: object
+                                        user:
+                                          type: string
+                                      required:
+                                        - credentialsSecret
+                                        - database
+                                        - host
+                                        - port
+                                        - user
+                                      type: object
+                                    extraEnv:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                  - key
+                                                type: object
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                  - fieldPath
+                                                type: object
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                  - resource
+                                                type: object
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                  - key
+                                                type: object
+                                            type: object
+                                        required:
+                                          - name
+                                        type: object
+                                      type: array
+                                    extraLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    extraVolumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                          - mountPath
+                                          - name
+                                        type: object
+                                      type: array
+                                    extraVolumes:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    initContainers:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    mysqld:
+                                      properties:
+                                        configOverrides:
+                                          type: string
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                      required:
+                                        - resources
+                                      type: object
+                                    replicas:
+                                      format: int32
+                                      minimum: 0
+                                      type: integer
+                                    sidecarContainers:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    tolerations:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    topologySpreadConstraints:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type:
+                                      enum:
+                                        - replica
+                                        - rdonly
+                                        - externalmaster
+                                        - externalreplica
+                                        - externalrdonly
+                                      type: string
+                                    vttablet:
+                                      properties:
+                                        extraFlags:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        lifecycle:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                      required:
+                                        - resources
+                                      type: object
+                                  required:
                                     - cell
                                     - replicas
                                     - type
                                     - vttablet
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
                                   - type
                                   - cell
-                                  x-kubernetes-list-type: map
-                              required:
+                                x-kubernetes-list-type: map
+                            required:
                               - databaseInitScriptSecret
-                              type: object
-                          required:
+                            type: object
+                        required:
                           - parts
-                          type: object
-                      type: object
-                    maxItems: 2
-                    minItems: 1
-                    type: array
-                  turndownPolicy:
-                    enum:
+                        type: object
+                    type: object
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                topologyReconciliation:
+                  properties:
+                    pruneCells:
+                      type: boolean
+                    pruneKeyspaces:
+                      type: boolean
+                    pruneShardCells:
+                      type: boolean
+                    pruneShards:
+                      type: boolean
+                    pruneSrvKeyspaces:
+                      type: boolean
+                    pruneTablets:
+                      type: boolean
+                    registerCells:
+                      type: boolean
+                    registerCellsAliases:
+                      type: boolean
+                  type: object
+                turndownPolicy:
+                  enum:
                     - RequireIdle
                     - Immediate
+                  type: string
+                updateStrategy:
+                  properties:
+                    external:
+                      properties:
+                        allowResourceChanges:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type:
+                      enum:
+                        - External
+                        - Immediate
+                      type: string
+                  type: object
+                vitessOrchestrator:
+                  properties:
+                    affinity:
+                      x-kubernetes-preserve-unknown-fields: true
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    configSecret:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                        volumeName:
+                          type: string
+                      required:
+                        - key
+                      type: object
+                    extraEnv:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    extraFlags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraVolumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
+                    extraVolumes:
+                      x-kubernetes-preserve-unknown-fields: true
+                    initContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    resources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    service:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clusterIP:
+                          type: string
+                      type: object
+                    sidecarContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    tolerations:
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                    - configSecret
+                  type: object
+                zoneMap:
+                  additionalProperties:
                     type: string
-                  vitessOrchestrator:
+                  type: object
+              required:
+                - globalLockserver
+                - name
+                - partitionings
+                - zoneMap
+              type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                idle:
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+                orphanedShards:
+                  additionalProperties:
+                    properties:
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                    required:
+                      - message
+                      - reason
+                    type: object
+                  type: object
+                partitionings:
+                  items:
+                    properties:
+                      desiredShards:
+                        format: int32
+                        type: integer
+                      desiredTablets:
+                        format: int32
+                        type: integer
+                      readyShards:
+                        format: int32
+                        type: integer
+                      readyTablets:
+                        format: int32
+                        type: integer
+                      servingWrites:
+                        type: string
+                      shardNames:
+                        items:
+                          type: string
+                        type: array
+                      tablets:
+                        format: int32
+                        type: integer
+                      updatedTablets:
+                        format: int32
+                        type: integer
+                    type: object
+                  type: array
+                resharding:
+                  properties:
+                    copyProgress:
+                      type: integer
+                    sourceShards:
+                      items:
+                        type: string
+                      type: array
+                    state:
+                      type: string
+                    targetShards:
+                      items:
+                        type: string
+                      type: array
+                    workflow:
+                      type: string
+                  required:
+                    - state
+                    - workflow
+                  type: object
+                shards:
+                  additionalProperties:
+                    properties:
+                      cells:
+                        items:
+                          type: string
+                        type: array
+                      desiredTablets:
+                        format: int32
+                        type: integer
+                      hasMaster:
+                        type: string
+                      pendingChanges:
+                        type: string
+                      readyTablets:
+                        format: int32
+                        type: integer
+                      servingWrites:
+                        type: string
+                      tablets:
+                        format: int32
+                        type: integer
+                      updatedTablets:
+                        format: int32
+                        type: integer
+                    type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: vitessshards.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessShard
+    listKind: VitessShardList
+    plural: vitessshards
+    shortNames:
+      - vts
+    singular: vitessshard
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                backupEngine:
+                  type: string
+                backupLocations:
+                  items:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      azblob:
+                        properties:
+                          account:
+                            minLength: 1
+                            type: string
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          container:
+                            minLength: 1
+                            type: string
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                        required:
+                          - account
+                          - authSecret
+                          - container
+                        type: object
+                      ceph:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                        required:
+                          - authSecret
+                        type: object
+                      gcs:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          bucket:
+                            minLength: 1
+                            type: string
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                        required:
+                          - bucket
+                        type: object
+                      name:
+                        maxLength: 63
+                        pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                        type: string
+                      s3:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          bucket:
+                            minLength: 1
+                            type: string
+                          endpoint:
+                            type: string
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                          region:
+                            minLength: 1
+                            type: string
+                        required:
+                          - bucket
+                          - region
+                        type: object
+                      volume:
+                        x-kubernetes-preserve-unknown-fields: true
+                      volumeSubPath:
+                        type: string
+                    type: object
+                  type: array
+                databaseInitScriptSecret:
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                    volumeName:
+                      type: string
+                  required:
+                    - key
+                  type: object
+                databaseName:
+                  type: string
+                extraVitessFlags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                globalLockserver:
+                  properties:
+                    address:
+                      type: string
+                    implementation:
+                      type: string
+                    rootPath:
+                      type: string
+                  required:
+                    - address
+                    - implementation
+                    - rootPath
+                  type: object
+                imagePullPolicies:
+                  properties:
+                    mysqld:
+                      type: string
+                    mysqldExporter:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtctld:
+                      type: string
+                    vtgate:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                imagePullSecrets:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  type: array
+                images:
+                  properties:
+                    mysqld:
+                      properties:
+                        mariadb103Compatible:
+                          type: string
+                        mariadbCompatible:
+                          type: string
+                        mysql56Compatible:
+                          type: string
+                        mysql80Compatible:
+                          type: string
+                      type: object
+                    mysqldExporter:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                keyRange:
+                  properties:
+                    end:
+                      pattern: ^([0-9a-f][0-9a-f])*$
+                      type: string
+                    start:
+                      pattern: ^([0-9a-f][0-9a-f])*$
+                      type: string
+                  type: object
+                name:
+                  type: string
+                replication:
+                  properties:
+                    enforceSemiSync:
+                      type: boolean
+                    initializeBackup:
+                      type: boolean
+                    initializeMaster:
+                      type: boolean
+                    recoverRestartedMaster:
+                      type: boolean
+                  type: object
+                tabletPools:
+                  items:
                     properties:
                       affinity:
-                        type: object
                         x-kubernetes-preserve-unknown-fields: true
                       annotations:
                         additionalProperties:
                           type: string
                         type: object
-                      configSecret:
+                      backupLocationName:
+                        type: string
+                      cell:
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                        type: string
+                      dataVolumeClaimTemplate:
                         properties:
-                          key:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          storageClassName:
                             type: string
-                          name:
+                          volumeMode:
                             type: string
                           volumeName:
                             type: string
+                        type: object
+                      externalDatastore:
+                        properties:
+                          credentialsSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          database:
+                            type: string
+                          host:
+                            type: string
+                          port:
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          serverCACertSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          user:
+                            type: string
                         required:
-                        - key
+                          - credentialsSecret
+                          - database
+                          - host
+                          - port
+                          - user
                         type: object
                       extraEnv:
                         items:
@@ -2925,7 +4841,7 @@ spec:
                                     optional:
                                       type: boolean
                                   required:
-                                  - key
+                                    - key
                                   type: object
                                 fieldRef:
                                   properties:
@@ -2934,7 +4850,7 @@ spec:
                                     fieldPath:
                                       type: string
                                   required:
-                                  - fieldPath
+                                    - fieldPath
                                   type: object
                                 resourceFieldRef:
                                   properties:
@@ -2942,14 +4858,14 @@ spec:
                                       type: string
                                     divisor:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
                                       type: string
                                   required:
-                                  - resource
+                                    - resource
                                   type: object
                                 secretKeyRef:
                                   properties:
@@ -2960,17 +4876,13 @@ spec:
                                     optional:
                                       type: boolean
                                   required:
-                                  - key
+                                    - key
                                   type: object
                               type: object
                           required:
-                          - name
+                            - name
                           type: object
                         type: array
-                      extraFlags:
-                        additionalProperties:
-                          type: string
-                        type: object
                       extraLabels:
                         additionalProperties:
                           type: string
@@ -2991,2554 +4903,399 @@ spec:
                             subPathExpr:
                               type: string
                           required:
-                          - mountPath
-                          - name
+                            - mountPath
+                            - name
                           type: object
                         type: array
                       extraVolumes:
-                        items:
-                          required:
-                          - name
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
+                        x-kubernetes-preserve-unknown-fields: true
                       initContainers:
-                        items:
-                          required:
-                          - name
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
-                      resources:
+                        x-kubernetes-preserve-unknown-fields: true
+                      mysqld:
                         properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
+                          configOverrides:
+                            type: string
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
                             type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
+                        required:
+                          - resources
                         type: object
-                      service:
+                      replicas:
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      sidecarContainers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      tolerations:
+                        x-kubernetes-preserve-unknown-fields: true
+                      topologySpreadConstraints:
+                        x-kubernetes-preserve-unknown-fields: true
+                      type:
+                        enum:
+                          - replica
+                          - rdonly
+                          - externalmaster
+                          - externalreplica
+                          - externalrdonly
+                        type: string
+                      vttablet:
                         properties:
-                          annotations:
+                          extraFlags:
                             additionalProperties:
                               type: string
                             type: object
-                          clusterIP:
-                            type: string
+                          lifecycle:
+                            x-kubernetes-preserve-unknown-fields: true
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                        required:
+                          - resources
                         type: object
-                      sidecarContainers:
-                        items:
-                          required:
-                          - name
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
-                      tolerations:
-                        items:
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
                     required:
-                    - configSecret
+                      - cell
+                      - replicas
+                      - type
+                      - vttablet
                     type: object
-                required:
-                - name
-                - partitionings
-                type: object
-              type: array
-            tabletService:
-              properties:
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                clusterIP:
-                  type: string
-              type: object
-            topologyReconciliation:
-              properties:
-                pruneCells:
-                  type: boolean
-                pruneKeyspaces:
-                  type: boolean
-                pruneShardCells:
-                  type: boolean
-                pruneShards:
-                  type: boolean
-                pruneSrvKeyspaces:
-                  type: boolean
-                pruneTablets:
-                  type: boolean
-                registerCells:
-                  type: boolean
-                registerCellsAliases:
-                  type: boolean
-              type: object
-            updateStrategy:
-              properties:
-                external:
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                    - cell
+                  x-kubernetes-list-type: map
+                topologyReconciliation:
                   properties:
-                    allowResourceChanges:
-                      items:
+                    pruneCells:
+                      type: boolean
+                    pruneKeyspaces:
+                      type: boolean
+                    pruneShardCells:
+                      type: boolean
+                    pruneShards:
+                      type: boolean
+                    pruneSrvKeyspaces:
+                      type: boolean
+                    pruneTablets:
+                      type: boolean
+                    registerCells:
+                      type: boolean
+                    registerCellsAliases:
+                      type: boolean
+                  type: object
+                updateStrategy:
+                  properties:
+                    external:
+                      properties:
+                        allowResourceChanges:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type:
+                      enum:
+                        - External
+                        - Immediate
+                      type: string
+                  type: object
+                vitessOrchestrator:
+                  properties:
+                    affinity:
+                      x-kubernetes-preserve-unknown-fields: true
+                    annotations:
+                      additionalProperties:
                         type: string
+                      type: object
+                    configSecret:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                        volumeName:
+                          type: string
+                      required:
+                        - key
+                      type: object
+                    extraEnv:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                            type: object
+                        required:
+                          - name
+                        type: object
                       type: array
+                    extraFlags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraVolumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
+                    extraVolumes:
+                      x-kubernetes-preserve-unknown-fields: true
+                    initContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    resources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    service:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clusterIP:
+                          type: string
+                      type: object
+                    sidecarContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    tolerations:
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                    - configSecret
                   type: object
-                type:
-                  enum:
-                  - External
-                  - Immediate
-                  type: string
-              type: object
-            vitessDashboard:
-              properties:
-                affinity:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                annotations:
+                zoneMap:
                   additionalProperties:
                     type: string
                   type: object
+              required:
+                - databaseInitScriptSecret
+                - globalLockserver
+                - images
+                - keyRange
+                - name
+                - zoneMap
+              type: object
+            status:
+              properties:
+                backupLocations:
+                  items:
+                    properties:
+                      completeBackups:
+                        format: int32
+                        type: integer
+                      incompleteBackups:
+                        format: int32
+                        type: integer
+                      latestCompleteBackupTime:
+                        format: date-time
+                        type: string
+                      name:
+                        type: string
+                    required:
+                      - completeBackups
+                      - incompleteBackups
+                    type: object
+                  type: array
                 cells:
                   items:
                     type: string
                   type: array
-                extraEnv:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      value:
-                        type: string
-                      valueFrom:
-                        properties:
-                          configMapKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                            - key
-                            type: object
-                          fieldRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              fieldPath:
-                                type: string
-                            required:
-                            - fieldPath
-                            type: object
-                          resourceFieldRef:
-                            properties:
-                              containerName:
-                                type: string
-                              divisor:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              resource:
-                                type: string
-                            required:
-                            - resource
-                            type: object
-                          secretKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                            - key
-                            type: object
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  type: array
-                extraFlags:
+                conditions:
                   additionalProperties:
-                    type: string
-                  type: object
-                extraLabels:
-                  additionalProperties:
-                    type: string
-                  type: object
-                extraVolumeMounts:
-                  items:
                     properties:
-                      mountPath:
+                      lastTransitionTime:
+                        format: date-time
                         type: string
-                      mountPropagation:
+                      message:
                         type: string
-                      name:
+                      reason:
                         type: string
-                      readOnly:
-                        type: boolean
-                      subPath:
-                        type: string
-                      subPathExpr:
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
                         type: string
                     required:
-                    - mountPath
-                    - name
+                      - status
                     type: object
-                  type: array
-                extraVolumes:
-                  items:
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                initContainers:
-                  items:
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                replicas:
-                  format: int32
+                  type: object
+                hasInitialBackup:
+                  type: string
+                hasMaster:
+                  type: string
+                idle:
+                  type: string
+                lowestPodGeneration:
+                  format: int64
                   type: integer
-                resources:
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                  type: object
-                service:
-                  properties:
-                    annotations:
-                      additionalProperties:
+                masterAlias:
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+                orphanedTablets:
+                  additionalProperties:
+                    properties:
+                      message:
                         type: string
-                      type: object
-                    clusterIP:
-                      type: string
-                  type: object
-                sidecarContainers:
-                  items:
+                      reason:
+                        type: string
                     required:
-                    - name
+                      - message
+                      - reason
                     type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                tolerations:
-                  items:
+                  type: object
+                servingWrites:
+                  type: string
+                tablets:
+                  additionalProperties:
+                    properties:
+                      available:
+                        type: string
+                      dataVolumeBound:
+                        type: string
+                      index:
+                        format: int32
+                        type: integer
+                      pendingChanges:
+                        type: string
+                      poolType:
+                        type: string
+                      ready:
+                        type: string
+                      running:
+                        type: string
+                      type:
+                        type: string
                     type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-              type: object
-          required:
-          - cells
-          type: object
-        status:
-          properties:
-            cells:
-              additionalProperties:
-                properties:
-                  gatewayAvailable:
-                    type: string
-                  pendingChanges:
-                    type: string
-                type: object
-              type: object
-            gatewayServiceName:
-              type: string
-            globalLockserver:
-              properties:
-                etcd:
+                  type: object
+                vitessOrchestrator:
                   properties:
                     available:
                       type: string
-                    clientServiceName:
+                    serviceName:
                       type: string
-                    observedGeneration:
-                      format: int64
-                      type: integer
                   type: object
-              type: object
-            keyspaces:
-              additionalProperties:
-                properties:
-                  cells:
-                    items:
-                      type: string
-                    type: array
-                  desiredShards:
-                    format: int32
-                    type: integer
-                  desiredTablets:
-                    format: int32
-                    type: integer
-                  pendingChanges:
-                    type: string
-                  readyShards:
-                    format: int32
-                    type: integer
-                  readyTablets:
-                    format: int32
-                    type: integer
-                  shards:
-                    format: int32
-                    type: integer
-                  tablets:
-                    format: int32
-                    type: integer
-                  updatedShards:
-                    format: int32
-                    type: integer
-                  updatedTablets:
-                    format: int32
-                    type: integer
-                type: object
-              type: object
-            observedGeneration:
-              format: int64
-              type: integer
-            orphanedCells:
-              additionalProperties:
-                properties:
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                required:
-                - message
-                - reason
-                type: object
-              type: object
-            orphanedKeyspaces:
-              additionalProperties:
-                properties:
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                required:
-                - message
-                - reason
-                type: object
-              type: object
-            vitessDashboard:
-              properties:
-                available:
-                  type: string
-                serviceName:
-                  type: string
               type: object
           type: object
-      type: object
-  version: v2
-  versions:
-  - name: v2
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
-  name: vitesskeyspaces.planetscale.com
-spec:
-  group: planetscale.com
-  names:
-    kind: VitessKeyspace
-    listKind: VitessKeyspaceList
-    plural: vitesskeyspaces
-    shortNames:
-    - vtk
-    singular: vitesskeyspace
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            annotations:
-              additionalProperties:
-                type: string
-              type: object
-            backupEngine:
-              type: string
-            backupLocations:
-              items:
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  azblob:
-                    properties:
-                      account:
-                        minLength: 1
-                        type: string
-                      authSecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - key
-                        type: object
-                      container:
-                        minLength: 1
-                        type: string
-                      keyPrefix:
-                        maxLength: 256
-                        pattern: ^[^\r\n]*$
-                        type: string
-                    required:
-                    - account
-                    - authSecret
-                    - container
-                    type: object
-                  ceph:
-                    properties:
-                      authSecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - key
-                        type: object
-                    required:
-                    - authSecret
-                    type: object
-                  gcs:
-                    properties:
-                      authSecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - key
-                        type: object
-                      bucket:
-                        minLength: 1
-                        type: string
-                      keyPrefix:
-                        maxLength: 256
-                        pattern: ^[^\r\n]*$
-                        type: string
-                    required:
-                    - bucket
-                    type: object
-                  name:
-                    maxLength: 63
-                    pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
-                    type: string
-                  s3:
-                    properties:
-                      authSecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - key
-                        type: object
-                      bucket:
-                        minLength: 1
-                        type: string
-                      endpoint:
-                        type: string
-                      keyPrefix:
-                        maxLength: 256
-                        pattern: ^[^\r\n]*$
-                        type: string
-                      region:
-                        minLength: 1
-                        type: string
-                    required:
-                    - bucket
-                    - region
-                    type: object
-                  volume:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  volumeSubPath:
-                    type: string
-                type: object
-              type: array
-            databaseName:
-              type: string
-            extraVitessFlags:
-              additionalProperties:
-                type: string
-              type: object
-            globalLockserver:
-              properties:
-                address:
-                  type: string
-                implementation:
-                  type: string
-                rootPath:
-                  type: string
-              required:
-              - address
-              - implementation
-              - rootPath
-              type: object
-            imagePullPolicies:
-              properties:
-                mysqld:
-                  type: string
-                mysqldExporter:
-                  type: string
-                vtbackup:
-                  type: string
-                vtctld:
-                  type: string
-                vtgate:
-                  type: string
-                vtorc:
-                  type: string
-                vttablet:
-                  type: string
-              type: object
-            imagePullSecrets:
-              items:
-                properties:
-                  name:
-                    type: string
-                type: object
-              type: array
-            images:
-              properties:
-                mysqld:
-                  properties:
-                    mariadb103Compatible:
-                      type: string
-                    mariadbCompatible:
-                      type: string
-                    mysql56Compatible:
-                      type: string
-                    mysql80Compatible:
-                      type: string
-                  type: object
-                mysqldExporter:
-                  type: string
-                vtbackup:
-                  type: string
-                vtorc:
-                  type: string
-                vttablet:
-                  type: string
-              type: object
-            name:
-              maxLength: 63
-              minLength: 1
-              pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
-              type: string
-            partitionings:
-              items:
-                properties:
-                  custom:
-                    properties:
-                      shards:
-                        items:
-                          properties:
-                            annotations:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            databaseInitScriptSecret:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                              - key
-                              type: object
-                            keyRange:
-                              properties:
-                                end:
-                                  pattern: ^([0-9a-f][0-9a-f])*$
-                                  type: string
-                                start:
-                                  pattern: ^([0-9a-f][0-9a-f])*$
-                                  type: string
-                              type: object
-                            replication:
-                              properties:
-                                enforceSemiSync:
-                                  type: boolean
-                                initializeBackup:
-                                  type: boolean
-                                initializeMaster:
-                                  type: boolean
-                                recoverRestartedMaster:
-                                  type: boolean
-                              type: object
-                            tabletPools:
-                              items:
-                                properties:
-                                  affinity:
-                                    type: object
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  backupLocationName:
-                                    type: string
-                                  cell:
-                                    maxLength: 63
-                                    minLength: 1
-                                    pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
-                                    type: string
-                                  dataVolumeClaimTemplate:
-                                    properties:
-                                      accessModes:
-                                        items:
-                                          type: string
-                                        type: array
-                                      resources:
-                                        properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                        type: object
-                                      selector:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                      storageClassName:
-                                        type: string
-                                      volumeMode:
-                                        type: string
-                                      volumeName:
-                                        type: string
-                                    type: object
-                                  externalDatastore:
-                                    properties:
-                                      credentialsSecret:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          volumeName:
-                                            type: string
-                                        required:
-                                        - key
-                                        type: object
-                                      database:
-                                        type: string
-                                      host:
-                                        type: string
-                                      port:
-                                        format: int32
-                                        maximum: 65535
-                                        minimum: 1
-                                        type: integer
-                                      serverCACertSecret:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          volumeName:
-                                            type: string
-                                        required:
-                                        - key
-                                        type: object
-                                      user:
-                                        type: string
-                                    required:
-                                    - credentialsSecret
-                                    - database
-                                    - host
-                                    - port
-                                    - user
-                                    type: object
-                                  extraEnv:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                        valueFrom:
-                                          properties:
-                                            configMapKeyRef:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                                optional:
-                                                  type: boolean
-                                              required:
-                                              - key
-                                              type: object
-                                            fieldRef:
-                                              properties:
-                                                apiVersion:
-                                                  type: string
-                                                fieldPath:
-                                                  type: string
-                                              required:
-                                              - fieldPath
-                                              type: object
-                                            resourceFieldRef:
-                                              properties:
-                                                containerName:
-                                                  type: string
-                                                divisor:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                resource:
-                                                  type: string
-                                              required:
-                                              - resource
-                                              type: object
-                                            secretKeyRef:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                                optional:
-                                                  type: boolean
-                                              required:
-                                              - key
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    type: array
-                                  extraLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  extraVolumeMounts:
-                                    items:
-                                      properties:
-                                        mountPath:
-                                          type: string
-                                        mountPropagation:
-                                          type: string
-                                        name:
-                                          type: string
-                                        readOnly:
-                                          type: boolean
-                                        subPath:
-                                          type: string
-                                        subPathExpr:
-                                          type: string
-                                      required:
-                                      - mountPath
-                                      - name
-                                      type: object
-                                    type: array
-                                  extraVolumes:
-                                    items:
-                                      required:
-                                      - name
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    type: array
-                                  initContainers:
-                                    items:
-                                      required:
-                                      - name
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    type: array
-                                  mysqld:
-                                    properties:
-                                      configOverrides:
-                                        type: string
-                                      resources:
-                                        properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                        type: object
-                                    required:
-                                    - resources
-                                    type: object
-                                  replicas:
-                                    format: int32
-                                    minimum: 0
-                                    type: integer
-                                  sidecarContainers:
-                                    items:
-                                      required:
-                                      - name
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    type: array
-                                  tolerations:
-                                    items:
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    type: array
-                                  topologySpreadConstraints:
-                                    items:
-                                      required:
-                                      - maxSkew
-                                      - topologyKey
-                                      - whenUnsatisfiable
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    type: array
-                                  type:
-                                    enum:
-                                    - replica
-                                    - rdonly
-                                    - externalmaster
-                                    - externalreplica
-                                    - externalrdonly
-                                    type: string
-                                  vttablet:
-                                    properties:
-                                      extraFlags:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      lifecycle:
-                                        type: object
-                                        x-kubernetes-preserve-unknown-fields: true
-                                      resources:
-                                        properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                        type: object
-                                    required:
-                                    - resources
-                                    type: object
-                                required:
-                                - cell
-                                - replicas
-                                - type
-                                - vttablet
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                              - type
-                              - cell
-                              x-kubernetes-list-type: map
-                          required:
-                          - databaseInitScriptSecret
-                          - keyRange
-                          type: object
-                        type: array
-                    required:
-                    - shards
-                    type: object
-                  equal:
-                    properties:
-                      parts:
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      shardTemplate:
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          databaseInitScriptSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                            - key
-                            type: object
-                          replication:
-                            properties:
-                              enforceSemiSync:
-                                type: boolean
-                              initializeBackup:
-                                type: boolean
-                              initializeMaster:
-                                type: boolean
-                              recoverRestartedMaster:
-                                type: boolean
-                            type: object
-                          tabletPools:
-                            items:
-                              properties:
-                                affinity:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                annotations:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                backupLocationName:
-                                  type: string
-                                cell:
-                                  maxLength: 63
-                                  minLength: 1
-                                  pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
-                                  type: string
-                                dataVolumeClaimTemplate:
-                                  properties:
-                                    accessModes:
-                                      items:
-                                        type: string
-                                      type: array
-                                    resources:
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                    selector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      type: string
-                                    volumeMode:
-                                      type: string
-                                    volumeName:
-                                      type: string
-                                  type: object
-                                externalDatastore:
-                                  properties:
-                                    credentialsSecret:
-                                      properties:
-                                        key:
-                                          type: string
-                                        name:
-                                          type: string
-                                        volumeName:
-                                          type: string
-                                      required:
-                                      - key
-                                      type: object
-                                    database:
-                                      type: string
-                                    host:
-                                      type: string
-                                    port:
-                                      format: int32
-                                      maximum: 65535
-                                      minimum: 1
-                                      type: integer
-                                    serverCACertSecret:
-                                      properties:
-                                        key:
-                                          type: string
-                                        name:
-                                          type: string
-                                        volumeName:
-                                          type: string
-                                      required:
-                                      - key
-                                      type: object
-                                    user:
-                                      type: string
-                                  required:
-                                  - credentialsSecret
-                                  - database
-                                  - host
-                                  - port
-                                  - user
-                                  type: object
-                                extraEnv:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                      valueFrom:
-                                        properties:
-                                          configMapKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                          secretKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                        type: object
-                                    required:
-                                    - name
-                                    type: object
-                                  type: array
-                                extraLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                extraVolumeMounts:
-                                  items:
-                                    properties:
-                                      mountPath:
-                                        type: string
-                                      mountPropagation:
-                                        type: string
-                                      name:
-                                        type: string
-                                      readOnly:
-                                        type: boolean
-                                      subPath:
-                                        type: string
-                                      subPathExpr:
-                                        type: string
-                                    required:
-                                    - mountPath
-                                    - name
-                                    type: object
-                                  type: array
-                                extraVolumes:
-                                  items:
-                                    required:
-                                    - name
-                                    type: object
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  type: array
-                                initContainers:
-                                  items:
-                                    required:
-                                    - name
-                                    type: object
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  type: array
-                                mysqld:
-                                  properties:
-                                    configOverrides:
-                                      type: string
-                                    resources:
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                  required:
-                                  - resources
-                                  type: object
-                                replicas:
-                                  format: int32
-                                  minimum: 0
-                                  type: integer
-                                sidecarContainers:
-                                  items:
-                                    required:
-                                    - name
-                                    type: object
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  type: array
-                                tolerations:
-                                  items:
-                                    type: object
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  type: array
-                                topologySpreadConstraints:
-                                  items:
-                                    required:
-                                    - maxSkew
-                                    - topologyKey
-                                    - whenUnsatisfiable
-                                    type: object
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  type: array
-                                type:
-                                  enum:
-                                  - replica
-                                  - rdonly
-                                  - externalmaster
-                                  - externalreplica
-                                  - externalrdonly
-                                  type: string
-                                vttablet:
-                                  properties:
-                                    extraFlags:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    lifecycle:
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    resources:
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                  required:
-                                  - resources
-                                  type: object
-                              required:
-                              - cell
-                              - replicas
-                              - type
-                              - vttablet
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - type
-                            - cell
-                            x-kubernetes-list-type: map
-                        required:
-                        - databaseInitScriptSecret
-                        type: object
-                    required:
-                    - parts
-                    type: object
-                type: object
-              maxItems: 2
-              minItems: 1
-              type: array
-            topologyReconciliation:
-              properties:
-                pruneCells:
-                  type: boolean
-                pruneKeyspaces:
-                  type: boolean
-                pruneShardCells:
-                  type: boolean
-                pruneShards:
-                  type: boolean
-                pruneSrvKeyspaces:
-                  type: boolean
-                pruneTablets:
-                  type: boolean
-                registerCells:
-                  type: boolean
-                registerCellsAliases:
-                  type: boolean
-              type: object
-            turndownPolicy:
-              enum:
-              - RequireIdle
-              - Immediate
-              type: string
-            updateStrategy:
-              properties:
-                external:
-                  properties:
-                    allowResourceChanges:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                type:
-                  enum:
-                  - External
-                  - Immediate
-                  type: string
-              type: object
-            vitessOrchestrator:
-              properties:
-                affinity:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                configSecret:
-                  properties:
-                    key:
-                      type: string
-                    name:
-                      type: string
-                    volumeName:
-                      type: string
-                  required:
-                  - key
-                  type: object
-                extraEnv:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      value:
-                        type: string
-                      valueFrom:
-                        properties:
-                          configMapKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                            - key
-                            type: object
-                          fieldRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              fieldPath:
-                                type: string
-                            required:
-                            - fieldPath
-                            type: object
-                          resourceFieldRef:
-                            properties:
-                              containerName:
-                                type: string
-                              divisor:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              resource:
-                                type: string
-                            required:
-                            - resource
-                            type: object
-                          secretKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                            - key
-                            type: object
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  type: array
-                extraFlags:
-                  additionalProperties:
-                    type: string
-                  type: object
-                extraLabels:
-                  additionalProperties:
-                    type: string
-                  type: object
-                extraVolumeMounts:
-                  items:
-                    properties:
-                      mountPath:
-                        type: string
-                      mountPropagation:
-                        type: string
-                      name:
-                        type: string
-                      readOnly:
-                        type: boolean
-                      subPath:
-                        type: string
-                      subPathExpr:
-                        type: string
-                    required:
-                    - mountPath
-                    - name
-                    type: object
-                  type: array
-                extraVolumes:
-                  items:
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                initContainers:
-                  items:
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                resources:
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                  type: object
-                service:
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    clusterIP:
-                      type: string
-                  type: object
-                sidecarContainers:
-                  items:
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                tolerations:
-                  items:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-              required:
-              - configSecret
-              type: object
-            zoneMap:
-              additionalProperties:
-                type: string
-              type: object
-          required:
-          - globalLockserver
-          - name
-          - partitionings
-          - zoneMap
-          type: object
-        status:
-          properties:
-            conditions:
-              items:
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            idle:
-              type: string
-            observedGeneration:
-              format: int64
-              type: integer
-            orphanedShards:
-              additionalProperties:
-                properties:
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                required:
-                - message
-                - reason
-                type: object
-              type: object
-            partitionings:
-              items:
-                properties:
-                  desiredShards:
-                    format: int32
-                    type: integer
-                  desiredTablets:
-                    format: int32
-                    type: integer
-                  readyShards:
-                    format: int32
-                    type: integer
-                  readyTablets:
-                    format: int32
-                    type: integer
-                  servingWrites:
-                    type: string
-                  shardNames:
-                    items:
-                      type: string
-                    type: array
-                  tablets:
-                    format: int32
-                    type: integer
-                  updatedTablets:
-                    format: int32
-                    type: integer
-                type: object
-              type: array
-            resharding:
-              properties:
-                copyProgress:
-                  type: integer
-                sourceShards:
-                  items:
-                    type: string
-                  type: array
-                state:
-                  type: string
-                targetShards:
-                  items:
-                    type: string
-                  type: array
-                workflow:
-                  type: string
-              required:
-              - state
-              - workflow
-              type: object
-            shards:
-              additionalProperties:
-                properties:
-                  cells:
-                    items:
-                      type: string
-                    type: array
-                  desiredTablets:
-                    format: int32
-                    type: integer
-                  hasMaster:
-                    type: string
-                  pendingChanges:
-                    type: string
-                  readyTablets:
-                    format: int32
-                    type: integer
-                  servingWrites:
-                    type: string
-                  tablets:
-                    format: int32
-                    type: integer
-                  updatedTablets:
-                    format: int32
-                    type: integer
-                type: object
-              type: object
-          type: object
-      type: object
-  version: v2
-  versions:
-  - name: v2
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
-  name: vitessshards.planetscale.com
-spec:
-  group: planetscale.com
-  names:
-    kind: VitessShard
-    listKind: VitessShardList
-    plural: vitessshards
-    shortNames:
-    - vts
-    singular: vitessshard
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            annotations:
-              additionalProperties:
-                type: string
-              type: object
-            backupEngine:
-              type: string
-            backupLocations:
-              items:
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  azblob:
-                    properties:
-                      account:
-                        minLength: 1
-                        type: string
-                      authSecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - key
-                        type: object
-                      container:
-                        minLength: 1
-                        type: string
-                      keyPrefix:
-                        maxLength: 256
-                        pattern: ^[^\r\n]*$
-                        type: string
-                    required:
-                    - account
-                    - authSecret
-                    - container
-                    type: object
-                  ceph:
-                    properties:
-                      authSecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - key
-                        type: object
-                    required:
-                    - authSecret
-                    type: object
-                  gcs:
-                    properties:
-                      authSecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - key
-                        type: object
-                      bucket:
-                        minLength: 1
-                        type: string
-                      keyPrefix:
-                        maxLength: 256
-                        pattern: ^[^\r\n]*$
-                        type: string
-                    required:
-                    - bucket
-                    type: object
-                  name:
-                    maxLength: 63
-                    pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
-                    type: string
-                  s3:
-                    properties:
-                      authSecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - key
-                        type: object
-                      bucket:
-                        minLength: 1
-                        type: string
-                      endpoint:
-                        type: string
-                      keyPrefix:
-                        maxLength: 256
-                        pattern: ^[^\r\n]*$
-                        type: string
-                      region:
-                        minLength: 1
-                        type: string
-                    required:
-                    - bucket
-                    - region
-                    type: object
-                  volume:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  volumeSubPath:
-                    type: string
-                type: object
-              type: array
-            databaseInitScriptSecret:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-                volumeName:
-                  type: string
-              required:
-              - key
-              type: object
-            databaseName:
-              type: string
-            extraVitessFlags:
-              additionalProperties:
-                type: string
-              type: object
-            globalLockserver:
-              properties:
-                address:
-                  type: string
-                implementation:
-                  type: string
-                rootPath:
-                  type: string
-              required:
-              - address
-              - implementation
-              - rootPath
-              type: object
-            imagePullPolicies:
-              properties:
-                mysqld:
-                  type: string
-                mysqldExporter:
-                  type: string
-                vtbackup:
-                  type: string
-                vtctld:
-                  type: string
-                vtgate:
-                  type: string
-                vtorc:
-                  type: string
-                vttablet:
-                  type: string
-              type: object
-            imagePullSecrets:
-              items:
-                properties:
-                  name:
-                    type: string
-                type: object
-              type: array
-            images:
-              properties:
-                mysqld:
-                  properties:
-                    mariadb103Compatible:
-                      type: string
-                    mariadbCompatible:
-                      type: string
-                    mysql56Compatible:
-                      type: string
-                    mysql80Compatible:
-                      type: string
-                  type: object
-                mysqldExporter:
-                  type: string
-                vtbackup:
-                  type: string
-                vtorc:
-                  type: string
-                vttablet:
-                  type: string
-              type: object
-            keyRange:
-              properties:
-                end:
-                  pattern: ^([0-9a-f][0-9a-f])*$
-                  type: string
-                start:
-                  pattern: ^([0-9a-f][0-9a-f])*$
-                  type: string
-              type: object
-            name:
-              type: string
-            replication:
-              properties:
-                enforceSemiSync:
-                  type: boolean
-                initializeBackup:
-                  type: boolean
-                initializeMaster:
-                  type: boolean
-                recoverRestartedMaster:
-                  type: boolean
-              type: object
-            tabletPools:
-              items:
-                properties:
-                  affinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  backupLocationName:
-                    type: string
-                  cell:
-                    maxLength: 63
-                    minLength: 1
-                    pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
-                    type: string
-                  dataVolumeClaimTemplate:
-                    properties:
-                      accessModes:
-                        items:
-                          type: string
-                        type: array
-                      resources:
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                      selector:
-                        properties:
-                          matchExpressions:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                operator:
-                                  type: string
-                                values:
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      storageClassName:
-                        type: string
-                      volumeMode:
-                        type: string
-                      volumeName:
-                        type: string
-                    type: object
-                  externalDatastore:
-                    properties:
-                      credentialsSecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - key
-                        type: object
-                      database:
-                        type: string
-                      host:
-                        type: string
-                      port:
-                        format: int32
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                      serverCACertSecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - key
-                        type: object
-                      user:
-                        type: string
-                    required:
-                    - credentialsSecret
-                    - database
-                    - host
-                    - port
-                    - user
-                    type: object
-                  extraEnv:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        value:
-                          type: string
-                        valueFrom:
-                          properties:
-                            configMapKeyRef:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                            fieldRef:
-                              properties:
-                                apiVersion:
-                                  type: string
-                                fieldPath:
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            resourceFieldRef:
-                              properties:
-                                containerName:
-                                  type: string
-                                divisor:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                resource:
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                            secretKeyRef:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  extraLabels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  extraVolumeMounts:
-                    items:
-                      properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                  extraVolumes:
-                    items:
-                      required:
-                      - name
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    type: array
-                  initContainers:
-                    items:
-                      required:
-                      - name
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    type: array
-                  mysqld:
-                    properties:
-                      configOverrides:
-                        type: string
-                      resources:
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                    required:
-                    - resources
-                    type: object
-                  replicas:
-                    format: int32
-                    minimum: 0
-                    type: integer
-                  sidecarContainers:
-                    items:
-                      required:
-                      - name
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    type: array
-                  tolerations:
-                    items:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    type: array
-                  topologySpreadConstraints:
-                    items:
-                      required:
-                      - maxSkew
-                      - topologyKey
-                      - whenUnsatisfiable
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    type: array
-                  type:
-                    enum:
-                    - replica
-                    - rdonly
-                    - externalmaster
-                    - externalreplica
-                    - externalrdonly
-                    type: string
-                  vttablet:
-                    properties:
-                      extraFlags:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      lifecycle:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      resources:
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                    required:
-                    - resources
-                    type: object
-                required:
-                - cell
-                - replicas
-                - type
-                - vttablet
-                type: object
-              type: array
-              x-kubernetes-list-map-keys:
-              - type
-              - cell
-              x-kubernetes-list-type: map
-            topologyReconciliation:
-              properties:
-                pruneCells:
-                  type: boolean
-                pruneKeyspaces:
-                  type: boolean
-                pruneShardCells:
-                  type: boolean
-                pruneShards:
-                  type: boolean
-                pruneSrvKeyspaces:
-                  type: boolean
-                pruneTablets:
-                  type: boolean
-                registerCells:
-                  type: boolean
-                registerCellsAliases:
-                  type: boolean
-              type: object
-            updateStrategy:
-              properties:
-                external:
-                  properties:
-                    allowResourceChanges:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                type:
-                  enum:
-                  - External
-                  - Immediate
-                  type: string
-              type: object
-            vitessOrchestrator:
-              properties:
-                affinity:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                configSecret:
-                  properties:
-                    key:
-                      type: string
-                    name:
-                      type: string
-                    volumeName:
-                      type: string
-                  required:
-                  - key
-                  type: object
-                extraEnv:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      value:
-                        type: string
-                      valueFrom:
-                        properties:
-                          configMapKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                            - key
-                            type: object
-                          fieldRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              fieldPath:
-                                type: string
-                            required:
-                            - fieldPath
-                            type: object
-                          resourceFieldRef:
-                            properties:
-                              containerName:
-                                type: string
-                              divisor:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              resource:
-                                type: string
-                            required:
-                            - resource
-                            type: object
-                          secretKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                            - key
-                            type: object
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  type: array
-                extraFlags:
-                  additionalProperties:
-                    type: string
-                  type: object
-                extraLabels:
-                  additionalProperties:
-                    type: string
-                  type: object
-                extraVolumeMounts:
-                  items:
-                    properties:
-                      mountPath:
-                        type: string
-                      mountPropagation:
-                        type: string
-                      name:
-                        type: string
-                      readOnly:
-                        type: boolean
-                      subPath:
-                        type: string
-                      subPathExpr:
-                        type: string
-                    required:
-                    - mountPath
-                    - name
-                    type: object
-                  type: array
-                extraVolumes:
-                  items:
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                initContainers:
-                  items:
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                resources:
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                  type: object
-                service:
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    clusterIP:
-                      type: string
-                  type: object
-                sidecarContainers:
-                  items:
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                tolerations:
-                  items:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-              required:
-              - configSecret
-              type: object
-            zoneMap:
-              additionalProperties:
-                type: string
-              type: object
-          required:
-          - databaseInitScriptSecret
-          - globalLockserver
-          - images
-          - keyRange
-          - name
-          - zoneMap
-          type: object
-        status:
-          properties:
-            backupLocations:
-              items:
-                properties:
-                  completeBackups:
-                    format: int32
-                    type: integer
-                  incompleteBackups:
-                    format: int32
-                    type: integer
-                  latestCompleteBackupTime:
-                    format: date-time
-                    type: string
-                  name:
-                    type: string
-                required:
-                - completeBackups
-                - incompleteBackups
-                type: object
-              type: array
-            cells:
-              items:
-                type: string
-              type: array
-            conditions:
-              additionalProperties:
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                required:
-                - status
-                type: object
-              type: object
-            hasInitialBackup:
-              type: string
-            hasMaster:
-              type: string
-            idle:
-              type: string
-            lowestPodGeneration:
-              format: int64
-              type: integer
-            masterAlias:
-              type: string
-            observedGeneration:
-              format: int64
-              type: integer
-            orphanedTablets:
-              additionalProperties:
-                properties:
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                required:
-                - message
-                - reason
-                type: object
-              type: object
-            servingWrites:
-              type: string
-            tablets:
-              additionalProperties:
-                properties:
-                  available:
-                    type: string
-                  dataVolumeBound:
-                    type: string
-                  index:
-                    format: int32
-                    type: integer
-                  pendingChanges:
-                    type: string
-                  poolType:
-                    type: string
-                  ready:
-                    type: string
-                  running:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              type: object
-            vitessOrchestrator:
-              properties:
-                available:
-                  type: string
-                serviceName:
-                  type: string
-              type: object
-          type: object
-      type: object
-  version: v2
-  versions:
-  - name: v2
-    served: true
-    storage: true
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -5556,73 +5313,73 @@ kind: Role
 metadata:
   name: vitess-operator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resourceNames:
-  - vitess-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - planetscale.com
-  resources:
-  - vitessclusters
-  - vitessclusters/status
-  - vitessclusters/finalizers
-  - vitesscells
-  - vitesscells/status
-  - vitesscells/finalizers
-  - vitesskeyspaces
-  - vitesskeyspaces/status
-  - vitesskeyspaces/finalizers
-  - vitessshards
-  - vitessshards/status
-  - vitessshards/finalizers
-  - etcdlockservers
-  - etcdlockservers/status
-  - etcdlockservers/finalizers
-  - vitessbackups
-  - vitessbackups/status
-  - vitessbackups/finalizers
-  - vitessbackupstorages
-  - vitessbackupstorages/status
-  - vitessbackupstorages/finalizers
-  verbs:
-  - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resourceNames:
+      - vitess-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - planetscale.com
+    resources:
+      - vitessclusters
+      - vitessclusters/status
+      - vitessclusters/finalizers
+      - vitesscells
+      - vitesscells/status
+      - vitesscells/finalizers
+      - vitesskeyspaces
+      - vitesskeyspaces/status
+      - vitesskeyspaces/finalizers
+      - vitessshards
+      - vitessshards/status
+      - vitessshards/finalizers
+      - etcdlockservers
+      - etcdlockservers/status
+      - etcdlockservers/finalizers
+      - vitessbackups
+      - vitessbackups/status
+      - vitessbackups/finalizers
+      - vitessbackupstorages
+      - vitessbackupstorages/status
+      - vitessbackupstorages/finalizers
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -5633,24 +5390,8 @@ roleRef:
   kind: Role
   name: vitess-operator
 subjects:
-- kind: ServiceAccount
-  name: vitess-operator
----
-apiVersion: scheduling.k8s.io/v1beta1
-description: Vitess components (vttablet, vtgate, vtctld, etcd)
-globalDefault: false
-kind: PriorityClass
-metadata:
-  name: vitess
-value: 1000
----
-apiVersion: scheduling.k8s.io/v1beta1
-description: The vitess-operator control plane.
-globalDefault: false
-kind: PriorityClass
-metadata:
-  name: vitess-operator-control-plane
-value: 5000
+  - kind: ServiceAccount
+    name: vitess-operator
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -5667,37 +5408,53 @@ spec:
         app: vitess-operator
     spec:
       containers:
-      - args:
-        - --logtostderr
-        - -v=4
-        command:
-        - vitess-operator
-        env:
-        - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: PS_OPERATOR_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: PS_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: OPERATOR_NAME
-          value: vitess-operator
-        image: planetscale/vitess-operator:latest
-        name: vitess-operator
-        resources:
-          limits:
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
+        - args:
+            - --logtostderr
+            - -v=4
+          command:
+            - vitess-operator
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: PS_OPERATOR_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PS_OPERATOR_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: vitess-operator
+          image: planetscale/vitess-operator:latest
+          name: vitess-operator
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
       priorityClassName: vitess-operator-control-plane
       serviceAccountName: vitess-operator
+---
+apiVersion: scheduling.k8s.io/v1
+description: The vitess-operator control plane.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: vitess-operator-control-plane
+value: 5000
+---
+apiVersion: scheduling.k8s.io/v1
+description: Vitess components (vttablet, vtgate, vtctld, etcd)
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: vitess
+value: 1000

--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -79,10 +79,10 @@ function updateJava () {
 # Second argument is the Vitess Operator version
 function updateVitessOperatorExample () {
   vtop_example_files=$(find -E $ROOT/examples/operator -name "*.yaml")
-  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:$1/g" $vtop_example_files
-  sed -i.bak -E "s/vitess\/lite:(.*)-mysql80/vitess\/lite:$1-mysql80/g" $(find -E $ROOT/examples/operator -name "*.md")
+  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:v$1/g" $vtop_example_files
+  sed -i.bak -E "s/vitess\/lite:(.*)-mysql80/vitess\/lite:v$1-mysql80/g" $(find -E $ROOT/examples/operator -name "*.md")
   if [ "$2" != "" ]; then
-  		sed -i.bak -E "s/planetscale\/vitess-operator:(.*)/planetscale\/vitess-operator:$2/g" $vtop_example_files
+  		sed -i.bak -E "s/planetscale\/vitess-operator:(.*)/planetscale\/vitess-operator:v$2/g" $vtop_example_files
   fi
   rm -f $(find -E $ROOT/examples/operator -regex ".*.(md|yaml).bak")
 }


### PR DESCRIPTION
## Description

This pull request uses the latest CRDs of the vitess-operator following the recent changes made in vitess-operator. The `operator.yaml` is now usable with the most recent version of Kubernetes that vitess-operator supports `1.22.*` as of today.

Additionally, a minor fix in the `do_release` script is pushed in this pull request. When updating the Docker tag in the vitess-operator examples, the `v` of `vX.X.X` was missing.

The entire vitess-operator example was tested on both `main` and `release-13.0`.

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
