### PR TITLE
Add support for uint32 bind var + test

### DIFF
--- a/go/sqltypes/bind_variables.go
+++ b/go/sqltypes/bind_variables.go
@@ -87,6 +87,11 @@ func Int32BindVariable(v int32) *querypb.BindVariable {
 	return ValueBindVariable(NewInt32(v))
 }
 
+// Uint32BindVariable converts a uint32 to a bind var.
+func Uint32BindVariable(v uint32) *querypb.BindVariable {
+	return ValueBindVariable(NewUint32(v))
+}
+
 // BoolBindVariable converts an bool to a int64 bind var.
 func BoolBindVariable(v bool) *querypb.BindVariable {
 	if v {

--- a/go/vt/vtgate/evalengine/eval_result.go
+++ b/go/vt/vtgate/evalengine/eval_result.go
@@ -733,7 +733,7 @@ func (er *EvalResult) setBindVar1(typ sqltypes.Type, value []byte, collation col
 	case sqltypes.Uint32:
 		ival, err := strconv.ParseUint(string(value), 10, 32)
 		if err != nil {
-			ival = 0
+			throwEvalError(err)
 		}
 		er.setUint64(ival)
 	case sqltypes.Uint64:

--- a/go/vt/vtgate/evalengine/eval_result.go
+++ b/go/vt/vtgate/evalengine/eval_result.go
@@ -730,6 +730,12 @@ func (er *EvalResult) setBindVar1(typ sqltypes.Type, value []byte, collation col
 		}
 		// TODO: type32
 		er.setInt64(ival)
+	case sqltypes.Uint32:
+		ival, err := strconv.ParseUint(string(value), 10, 32)
+		if err != nil {
+			ival = 0
+		}
+		er.setUint64(ival)
 	case sqltypes.Uint64:
 		uval, err := strconv.ParseUint(string(value), 10, 64)
 		if err != nil {

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -159,6 +159,12 @@ func TestEvaluate(t *testing.T) {
 		expression: ":exp",
 		expected:   sqltypes.NewInt64(66),
 	}, {
+		expression: ":int32_bind_variable",
+		expected:   sqltypes.NewInt64(20),
+	}, {
+		expression: ":uint32_bind_variable",
+		expected:   sqltypes.NewUint64(21),
+	}, {
 		expression: ":uint64_bind_variable",
 		expected:   sqltypes.NewUint64(22),
 	}, {
@@ -272,6 +278,8 @@ func TestEvaluate(t *testing.T) {
 				map[string]*querypb.BindVariable{
 					"exp":                  sqltypes.Int64BindVariable(66),
 					"string_bind_variable": sqltypes.StringBindVariable("bar"),
+					"int32_bind_variable":  sqltypes.Int32BindVariable(20),
+					"uint32_bind_variable": sqltypes.Uint32BindVariable(21),
 					"uint64_bind_variable": sqltypes.Uint64BindVariable(22),
 					"float_bind_variable":  sqltypes.Float64BindVariable(2.2),
 				}, 0)


### PR DESCRIPTION
Signed-off-by: Alon Kenneth <11458012+akenneth@users.noreply.github.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Add missing support for `uint32` bindvars mapping.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
* Fixes https://github.com/vitessio/vitess/issues/9756

## Checklist
- [ ] Should this PR be backported? **- akenneth: I don't know!**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required - not required i think?

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->