### PR TITLE
Add unit test for the demo app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,9 @@ vtctldclient: go/vt/proto/vtctlservice/vtctlservice.pb.go
 parser:
 	make -C go/vt/sqlparser
 
+demo:
+	go install ./examples/demo/demo.go
+
 codegen: asthelpergen sizegen parser astfmtgen
 
 visitor: asthelpergen
@@ -171,7 +174,7 @@ cleanall: clean
 	# Remind people to run bootstrap.sh again
 	echo "Please run 'make tools' again to setup your environment"
 
-unit_test: build dependency_check
+unit_test: build dependency_check demo
 	echo $$(date): Running unit tests
 	tools/unit_test_runner.sh
 


### PR DESCRIPTION
## Description

The [example/demo app](https://github.com/vitessio/vitess/tree/main/examples/demo) is apparently used more than we may have thought. [A change in Vitess 13.0](https://github.com/vitessio/vitess/commit/d3dd227c325e6d558c1af6457ee3f0ab5282887d) caused the demo app to break, so this work adds a unit test for it which is simply to ensure that it builds.

## Related Issue(s)
- Related to: https://github.com/vitessio/vitess/pull/9615
- Related to: https://github.com/vitessio/vitess/issues/9763


## Checklist
- [x] Should this PR be backported? No
- [x] Tests were added
- [x] Documentation is not required