### PR TITLE
Externalize Lookup VIndexes properly when not stopping after copy

### DIFF
--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"text/template"
 
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/json2"
@@ -755,7 +756,7 @@ func (wr *Wrangler) ExternalizeVindex(ctx context.Context, qualifiedVindexName s
 		if err != nil {
 			return err
 		}
-		p3qr, err := wr.tmc.VReplicationExec(ctx, targetPrimary.Tablet, fmt.Sprintf("select id, state, message from _vt.vreplication where workflow=%s and db_name=%s", encodeString(workflow), encodeString(targetPrimary.DbName())))
+		p3qr, err := wr.tmc.VReplicationExec(ctx, targetPrimary.Tablet, fmt.Sprintf("select id, state, message, source from _vt.vreplication where workflow=%s and db_name=%s", encodeString(workflow), encodeString(targetPrimary.DbName())))
 		if err != nil {
 			return err
 		}
@@ -767,8 +768,17 @@ func (wr *Wrangler) ExternalizeVindex(ctx context.Context, qualifiedVindexName s
 			}
 			state := row[1].ToString()
 			message := row[2].ToString()
-			if sourceVindex.Owner == "" {
-				// If there's no owner, all streams need to be running.
+			var bls binlogdatapb.BinlogSource
+			sourceBytes, err := row[3].ToBytes()
+			if err != nil {
+				return err
+			}
+			if err := prototext.Unmarshal(sourceBytes, &bls); err != nil {
+				return err
+			}
+			if sourceVindex.Owner == "" || !bls.StopAfterCopy {
+				// If there's no owner or we've requested that the workflow NOT be stopped
+				// after the copy phase completes, then all streams need to be running.
 				if state != binlogplayer.BlpRunning {
 					return fmt.Errorf("stream %d for %v.%v is not in Running state: %v", id, targetShard.Keyspace(), targetShard.ShardName(), state)
 				}


### PR DESCRIPTION
## Description
We did not check for [the saved StopAfterCopy config value](https://github.com/vitessio/vitess/blob/2c0a29df5d513167ac0f600d8916128b15d1063e/go/vt/wrangler/materializer.go#L679) (➡️  [here for the `INSERT` to generate the `_vt.vreplication` row](https://github.com/vitessio/vitess/blob/2c0a29df5d513167ac0f600d8916128b15d1063e/go/vt/wrangler/materializer.go#L1087)) in the workflow [when attempting to externalize it](https://github.com/vitessio/vitess/blob/2c0a29df5d513167ac0f600d8916128b15d1063e/go/vt/wrangler/materializer.go#L758-L782). When the [`-continue_after_copy_with_owner=true`](https://vitess.io/docs/13.0/user-guides/configuration-advanced/createlookupvindex/) flag ([added in v12.0](https://github.com/vitessio/vitess/pull/8572/commits/7e7722ac7b51aa62c42b81a7e679e8acb1c15384)) was used for the [`CreateLookupVindex`](https://vitess.io/docs/13.0/user-guides/configuration-advanced/createlookupvindex/) command — which means that the `_vt.vreplication.source` value  does _*not*_ have `stop_after_copy:true` in it — the workflow state will be `Running` when it's healthy and we should be checking for that.

Instead, before this PR we would fail to externalize the VIndex when `-continue_after_copy_with_owner=true` was used and the workflow was running (as is expected and proper in that case) with an error here: https://github.com/vitessio/vitess/blob/2c0a29df5d513167ac0f600d8916128b15d1063e/go/vt/wrangler/materializer.go#L776-L779

## Related Issue(s)
- Follow-up to: https://github.com/vitessio/vitess/pull/8572


## Checklist
- [x] Should this PR be backported? YES, at least to release-13.0
- [x] Tests were updated
- [x] Documentation is not required