### PR TITLE
Internal cleanup for choosing primary in ERS

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -229,7 +229,7 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 
 	// Check whether the intermediate source candidate selected is ideal or if it can be improved later.
 	// If the intermediateSource is ideal, then we can be certain that it is part of the valid candidates list.
-	isIdeal, err = erp.intermediateSourceIsIdeal(intermediateSource, validCandidateTablets, tabletMap, opts)
+	isIdeal, err = erp.isIntermediateSourceIdeal(intermediateSource, validCandidateTablets, tabletMap, opts)
 	if err != nil {
 		return err
 	}
@@ -601,8 +601,8 @@ func (erp *EmergencyReparenter) reparentReplicas(
 
 }
 
-// intermediateSourceIsIdeal is used to find whether the intermediate source that ERS chose is also the ideal one or not
-func (erp *EmergencyReparenter) intermediateSourceIsIdeal(
+// isIntermediateSourceIdeal is used to find whether the intermediate source that ERS chose is also the ideal one or not
+func (erp *EmergencyReparenter) isIntermediateSourceIdeal(
 	intermediateSource *topodatapb.Tablet,
 	validCandidates []*topodatapb.Tablet,
 	tabletMap map[string]*topo.TabletInfo,

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -674,35 +674,19 @@ func (erp *EmergencyReparenter) identifyPrimaryCandidate(
 
 	// If the user requested for prevention of cross cell promotion then we should only search for valid candidates in the same cell
 	// otherwise we can search in any cell
-	if opts.PreventCrossCellPromotion {
-		// find candidates in the same cell from the preferred candidates list
-		candidate = findCandidateSameCell(intermediateSource, prevPrimary, preferredCandidates)
-		if candidate != nil {
-			return candidate, nil
-		}
-		// we do not have a preferred candidate in the same cell
-	} else {
-		// find candidates in any cell from the preferred candidates list
-		candidate = findCandidateAnyCell(intermediateSource, preferredCandidates)
-		if candidate != nil {
-			return candidate, nil
-		}
+
+	// find candidates in any cell from the preferred candidates list
+	candidate = findCandidateAnyCell(intermediateSource, preferredCandidates)
+	if candidate != nil {
+		return candidate, nil
 	}
 
 	// repeat the same process for the neutral candidates list
-	if opts.PreventCrossCellPromotion {
-		// find candidates in the same cell from the neutral candidates list
-		candidate = findCandidateSameCell(intermediateSource, prevPrimary, neutralReplicas)
-		if candidate != nil {
-			return candidate, nil
-		}
-		// we do not have a neutral candidate in the same cell
-	} else {
-		// find candidates in any cell from the neutral candidates list
-		candidate = findCandidateAnyCell(intermediateSource, neutralReplicas)
-		if candidate != nil {
-			return candidate, nil
-		}
+
+	// find candidates in any cell from the neutral candidates list
+	candidate = findCandidateAnyCell(intermediateSource, neutralReplicas)
+	if candidate != nil {
+		return candidate, nil
 	}
 
 	// return any valid tablet

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -229,7 +229,7 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 
 	// Check whether the intermediate source candidate selected is ideal or if it can be improved later.
 	// If the intermediateSource is ideal, then we can be certain that it is part of the valid candidates list.
-	isIdeal, err = erp.intermediateSourceIsIdeal(intermediateSource, prevPrimary, validCandidateTablets, tabletMap, opts)
+	isIdeal, err = erp.intermediateSourceIsIdeal(intermediateSource, validCandidateTablets, tabletMap, opts)
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		// try to find a better candidate using the list we got back
 		// We prefer to choose a candidate which is in the same cell as our previous primary and of the best possible durability rule.
 		// However, if there is an explicit request from the user to promote a specific tablet, then we choose that tablet.
-		betterCandidate, err = erp.identifyPrimaryCandidate(intermediateSource, prevPrimary, validReplacementCandidates, tabletMap, opts)
+		betterCandidate, err = erp.identifyPrimaryCandidate(intermediateSource, validReplacementCandidates, tabletMap, opts)
 		if err != nil {
 			return err
 		}
@@ -604,13 +604,12 @@ func (erp *EmergencyReparenter) reparentReplicas(
 // intermediateSourceIsIdeal is used to find whether the intermediate source that ERS chose is also the ideal one or not
 func (erp *EmergencyReparenter) intermediateSourceIsIdeal(
 	intermediateSource *topodatapb.Tablet,
-	prevPrimary *topodatapb.Tablet,
 	validCandidates []*topodatapb.Tablet,
 	tabletMap map[string]*topo.TabletInfo,
 	opts EmergencyReparentOptions,
 ) (bool, error) {
 	// we try to find a better candidate with the current list of valid candidates, and if it matches our current primary candidate, then we return true
-	candidate, err := erp.identifyPrimaryCandidate(intermediateSource, prevPrimary, validCandidates, tabletMap, opts)
+	candidate, err := erp.identifyPrimaryCandidate(intermediateSource, validCandidates, tabletMap, opts)
 	if err != nil {
 		return false, err
 	}
@@ -620,7 +619,6 @@ func (erp *EmergencyReparenter) intermediateSourceIsIdeal(
 // identifyPrimaryCandidate is used to find the final candidate for ERS promotion
 func (erp *EmergencyReparenter) identifyPrimaryCandidate(
 	intermediateSource *topodatapb.Tablet,
-	prevPrimary *topodatapb.Tablet,
 	validCandidates []*topodatapb.Tablet,
 	tabletMap map[string]*topo.TabletInfo,
 	opts EmergencyReparentOptions,

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -662,9 +662,9 @@ func (erp *EmergencyReparenter) identifyPrimaryCandidate(
 			return candidate, nil
 		}
 	}
-	// Unreachable
-	// We should have found atleast 1 tablet in the valid list
-	// If the list is empty then we should have errored out much sooner
+	// Unreachable code.
+	// We should have found atleast 1 tablet in the valid list.
+	// If the list is empty, then we should have errored out much sooner.
 	return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "unreachable - did not find a valid primary candidate even though the valid candidate list was non-empty")
 }
 

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -4009,7 +4009,6 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 				Uid:  100,
 			}},
 			intermediateSource: nil,
-			prevPrimary:        nil,
 			validCandidates: []*topodatapb.Tablet{
 				{
 					Alias: &topodatapb.TabletAlias{
@@ -4045,7 +4044,6 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 				Uid:  100,
 			}},
 			intermediateSource: nil,
-			prevPrimary:        nil,
 			validCandidates: []*topodatapb.Tablet{
 				{
 					Alias: &topodatapb.TabletAlias{
@@ -4072,7 +4070,6 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 				Uid:  100,
 			}},
 			intermediateSource: nil,
-			prevPrimary:        nil,
 			validCandidates: []*topodatapb.Tablet{
 				{
 					Alias: &topodatapb.TabletAlias{
@@ -4084,17 +4081,12 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 			tabletMap: map[string]*topo.TabletInfo{},
 			err:       "candidate zone1-0000000100 not found in the tablet map; this an impossible situation",
 		}, {
-			name:                 "preferred candidate in the same cell same as our replica",
-			emergencyReparentOps: EmergencyReparentOptions{PreventCrossCellPromotion: true},
+			name:                 "preferred candidate in the valid list with the best promote rule",
+			emergencyReparentOps: EmergencyReparentOptions{},
 			intermediateSource: &topodatapb.Tablet{
 				Alias: &topodatapb.TabletAlias{
 					Cell: "zone1",
 					Uid:  100,
-				},
-			},
-			prevPrimary: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone1",
 				},
 			},
 			validCandidates: []*topodatapb.Tablet{
@@ -4138,125 +4130,12 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 				},
 			},
 		}, {
-			name:                 "preferred candidate in the same cell different from original replica",
-			emergencyReparentOps: EmergencyReparentOptions{PreventCrossCellPromotion: true},
-			intermediateSource: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone1",
-					Uid:  100,
-				},
-			},
-			prevPrimary: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone1",
-				},
-			},
-			validCandidates: []*topodatapb.Tablet{
-				{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  100,
-					},
-					Type: topodatapb.TabletType_RDONLY,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  101,
-					},
-					Type: topodatapb.TabletType_REPLICA,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  102,
-					},
-					Type: topodatapb.TabletType_RDONLY,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone2",
-						Uid:  100,
-					},
-					Type: topodatapb.TabletType_RDONLY,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone2",
-						Uid:  101,
-					},
-					Type: topodatapb.TabletType_PRIMARY,
-				},
-			},
-			tabletMap: nil,
-			result: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone1",
-					Uid:  101,
-				},
-			},
-		}, {
-			name:                 "preferred candidate in the different cell same as original replica",
+			name:                 "preferred candidate has non optimal promotion rule",
 			emergencyReparentOps: EmergencyReparentOptions{},
 			intermediateSource: &topodatapb.Tablet{
 				Alias: &topodatapb.TabletAlias{
 					Cell: "zone2",
 					Uid:  101,
-				},
-			},
-			prevPrimary: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone1",
-				},
-			},
-			validCandidates: []*topodatapb.Tablet{
-				{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  100,
-					},
-					Type: topodatapb.TabletType_REPLICA,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  102,
-					},
-					Type: topodatapb.TabletType_RDONLY,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone2",
-						Uid:  100,
-					},
-					Type: topodatapb.TabletType_RDONLY,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone2",
-						Uid:  101,
-					},
-					Type: topodatapb.TabletType_PRIMARY,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone2",
-						Uid:  102,
-					},
-					Type: topodatapb.TabletType_PRIMARY,
-				},
-			},
-			tabletMap: nil,
-			result: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone2",
-					Uid:  101,
-				},
-			},
-		}, {
-			name:                 "preferred candidate in the different cell different from original replica",
-			emergencyReparentOps: EmergencyReparentOptions{},
-			intermediateSource: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone2",
-					Uid:  101,
-				},
-			},
-			prevPrimary: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone1",
 				},
 			},
 			validCandidates: []*topodatapb.Tablet{
@@ -4297,60 +4176,6 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 				Alias: &topodatapb.TabletAlias{
 					Cell: "zone2",
 					Uid:  102,
-				},
-			},
-		}, {
-			name:                 "prevent cross cell promotion",
-			emergencyReparentOps: EmergencyReparentOptions{PreventCrossCellPromotion: true},
-			intermediateSource: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone1",
-					Uid:  100,
-				},
-			},
-			prevPrimary: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone1",
-				},
-			},
-			validCandidates: []*topodatapb.Tablet{
-				{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  100,
-					},
-					Type: topodatapb.TabletType_RDONLY,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  102,
-					},
-					Type: topodatapb.TabletType_RDONLY,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone2",
-						Uid:  100,
-					},
-					Type: topodatapb.TabletType_RDONLY,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone2",
-						Uid:  101,
-					},
-					Type: topodatapb.TabletType_RDONLY,
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone2",
-						Uid:  102,
-					},
-					Type: topodatapb.TabletType_PRIMARY,
-				},
-			},
-			tabletMap: nil,
-			result: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone1",
-					Uid:  100,
 				},
 			},
 		},

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -3996,7 +3996,6 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 		name                 string
 		emergencyReparentOps EmergencyReparentOptions
 		intermediateSource   *topodatapb.Tablet
-		prevPrimary          *topodatapb.Tablet
 		validCandidates      []*topodatapb.Tablet
 		tabletMap            map[string]*topo.TabletInfo
 		err                  string
@@ -4187,7 +4186,7 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 			logger := logutil.NewMemoryLogger()
 
 			erp := NewEmergencyReparenter(nil, nil, logger)
-			res, err := erp.identifyPrimaryCandidate(test.intermediateSource, test.prevPrimary, test.validCandidates, test.tabletMap, test.emergencyReparentOps)
+			res, err := erp.identifyPrimaryCandidate(test.intermediateSource, test.validCandidates, test.tabletMap, test.emergencyReparentOps)
 			if test.err != "" {
 				assert.EqualError(t, err, test.err)
 				return

--- a/go/vt/vtctl/reparentutil/promotionrule/promotion_rule.go
+++ b/go/vt/vtctl/reparentutil/promotionrule/promotion_rule.go
@@ -40,6 +40,12 @@ var promotionRuleOrderMap = map[CandidatePromotionRule]int{
 	MustNot:   4,
 }
 
+// AllPromotionRules returns all the CandidatePromotionRules in a list
+// sorted by their priority
+func AllPromotionRules() []CandidatePromotionRule {
+	return []CandidatePromotionRule{Must, Prefer, Neutral, PreferNot, MustNot}
+}
+
 func (this *CandidatePromotionRule) BetterThan(other CandidatePromotionRule) bool {
 	otherOrder, ok := promotionRuleOrderMap[other]
 	if !ok {

--- a/go/vt/vtctl/reparentutil/promotionrule/promotion_rule.go
+++ b/go/vt/vtctl/reparentutil/promotionrule/promotion_rule.go
@@ -41,7 +41,7 @@ var promotionRuleOrderMap = map[CandidatePromotionRule]int{
 }
 
 // AllPromotionRules returns all the CandidatePromotionRules in a list
-// sorted by their priority
+// sorted by their priority.
 func AllPromotionRules() []CandidatePromotionRule {
 	return []CandidatePromotionRule{Must, Prefer, Neutral, PreferNot, MustNot}
 }

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -21,12 +21,11 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/vt/vtctl/reparentutil/promotionrule"
-
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/promotionrule"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 
@@ -245,8 +244,7 @@ func findCandidate(
 }
 
 // getTabletsWithPromotionRules gets the tablets with the given promotion rule from the list of tablets
-func getTabletsWithPromotionRules(tablets []*topodatapb.Tablet, rule promotionrule.CandidatePromotionRule) []*topodatapb.Tablet {
-	var res []*topodatapb.Tablet
+func getTabletsWithPromotionRules(tablets []*topodatapb.Tablet, rule promotionrule.CandidatePromotionRule) (res []*topodatapb.Tablet) {
 	for _, candidate := range tablets {
 		promotionRule := PromotionRule(candidate)
 		if promotionRule == rule {

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -225,31 +225,6 @@ func restrictValidCandidates(validCandidates map[string]mysql.Position, tabletMa
 	return restrictedValidCandidates, nil
 }
 
-func findCandidateSameCell(
-	newPrimary *topodatapb.Tablet,
-	prevPrimary *topodatapb.Tablet,
-	possibleCandidates []*topodatapb.Tablet,
-) *topodatapb.Tablet {
-	// check whether the one we have selected as the source is in the same cell and belongs to the candidate list provided
-	for _, candidate := range possibleCandidates {
-		if !(topoproto.TabletAliasEqual(newPrimary.Alias, candidate.Alias)) {
-			continue
-		}
-		if prevPrimary != nil && !(prevPrimary.Alias.Cell == candidate.Alias.Cell) {
-			continue
-		}
-		return candidate
-	}
-	// check whether there is some other tablet in the same cell belonging to the candidate list provided
-	for _, candidate := range possibleCandidates {
-		if prevPrimary != nil && !(prevPrimary.Alias.Cell == candidate.Alias.Cell) {
-			continue
-		}
-		return candidate
-	}
-	return nil
-}
-
 func findCandidateAnyCell(
 	newPrimary *topodatapb.Tablet,
 	possibleCandidates []*topodatapb.Tablet,

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -228,12 +228,12 @@ func restrictValidCandidates(validCandidates map[string]mysql.Position, tabletMa
 }
 
 func findCandidate(
-	newPrimary *topodatapb.Tablet,
+	intermediateSource *topodatapb.Tablet,
 	possibleCandidates []*topodatapb.Tablet,
 ) *topodatapb.Tablet {
 	// check whether the one we have selected as the source belongs to the candidate list provided
 	for _, candidate := range possibleCandidates {
-		if topoproto.TabletAliasEqual(newPrimary.Alias, candidate.Alias) {
+		if topoproto.TabletAliasEqual(intermediateSource.Alias, candidate.Alias) {
 			return candidate
 		}
 	}

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -22,19 +22,16 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/vt/vtctl/reparentutil/promotionrule"
-
-	"vitess.io/vitess/go/vt/vterrors"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver/testutil"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/promotionrule"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 
 	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -1053,3 +1053,92 @@ func TestRestrictValidCandidates(t *testing.T) {
 		})
 	}
 }
+
+func Test_findCandidate(t *testing.T) {
+	tests := []struct {
+		name               string
+		intermediateSource *topodatapb.Tablet
+		possibleCandidates []*topodatapb.Tablet
+		candidate          *topodatapb.Tablet
+	}{
+		{
+			name:      "empty possible candidates list",
+			candidate: nil,
+		}, {
+			name: "intermediate source in possible candidates list",
+			intermediateSource: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  103,
+				},
+			},
+			possibleCandidates: []*topodatapb.Tablet{
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  101,
+					},
+				}, {
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  103,
+					},
+				}, {
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  102,
+					},
+				},
+			},
+			candidate: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  103,
+				},
+			},
+		}, {
+			name: "intermediate source not in possible candidates list",
+			intermediateSource: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  103,
+				},
+			},
+			possibleCandidates: []*topodatapb.Tablet{
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  101,
+					},
+				}, {
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  104,
+					},
+				}, {
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  102,
+					},
+				},
+			},
+			candidate: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  101,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := findCandidate(tt.intermediateSource, tt.possibleCandidates)
+			if tt.candidate == nil {
+				require.Nil(t, res)
+			} else {
+				require.NotNil(t, res)
+				require.Equal(t, topoproto.TabletAliasString(tt.candidate.Alias), topoproto.TabletAliasString(res.Alias))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

After the changes in #9765, we filter valid candidate list and remove any tablets not from the same cell as the previous primary (when `PreventCrossCellPromotion` is specified), before we choose the primary candidate for promotion. This allows us to simplify the function significantly since it no longer needs to handle the case where `PreventCrossCellPromotion` is specified.

This PR changes the unit tests for the function and simplifies it.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist
- [x] Should this PR be backported? *No*
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->