### PR TITLE
vttestserver: add enable_system_settings option

### DIFF
--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -143,6 +143,8 @@ func init() {
 	flag.StringVar(&config.SnapshotFile, "snapshot_file", "",
 		"A MySQL DB snapshot file")
 
+	flag.BoolVar(&config.EnableSystemSettings, "enable_system_settings", true, "This will enable the system settings to be changed per session at the database connection level")
+
 	flag.StringVar(&config.TransactionMode, "transaction_mode", "MULTI", "Transaction mode MULTI (default), SINGLE or TWOPC ")
 	flag.Float64Var(&config.TransactionTimeout, "queryserver-config-transaction-timeout", 0, "query server transaction timeout (in seconds), a transaction will be killed if it takes longer than this value")
 

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -112,6 +112,9 @@ type Config struct {
 	// do not suppport initialization through snapshot files.
 	SnapshotFile string
 
+	// Enable system settings to be changed per session at the database connection level
+	EnableSystemSettings bool
+
 	// TransactionMode is SINGLE, MULTI or TWOPC
 	TransactionMode string
 

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -234,6 +234,7 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 		"-planner_version", args.PlannerVersion,
 		fmt.Sprintf("-enable_online_ddl=%t", args.EnableOnlineDDL),
 		fmt.Sprintf("-enable_direct_ddl=%t", args.EnableDirectDDL),
+		fmt.Sprintf("-enable_system_settings=%t", args.EnableSystemSettings),
 	}...)
 
 	vt.ExtraArgs = append(vt.ExtraArgs, QueryServerArgs...)


### PR DESCRIPTION
Signed-off-by: Brendan Dougherty <brendan.dougherty@shopify.com>

## Description
Adds the enable_system_settings option to vttestserver so that it can be passed to VTGate via vtcombo.

## Related Issue(s)
N/A

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
N/A