### PR TITLE
[RFC] Add a max-in-use gauge for connection pools

### DIFF
--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -73,6 +73,7 @@ func NewConnectionPool(name string, capacity int, idleTimeout time.Duration, dns
 	stats.NewGaugeFunc(name+"Available", "Connection pool available", cp.Available)
 	stats.NewGaugeFunc(name+"Active", "Connection pool active", cp.Active)
 	stats.NewGaugeFunc(name+"InUse", "Connection pool in-use", cp.InUse)
+	stats.NewGaugeFunc(name+"InUseMax", "Connection pool max in-use per period", cp.ResetInUseMax)
 	stats.NewGaugeFunc(name+"MaxCap", "Connection pool max cap", cp.MaxCap)
 	stats.NewCounterFunc(name+"WaitCount", "Connection pool wait count", cp.WaitCount)
 	stats.NewCounterDurationFunc(name+"WaitTime", "Connection pool wait time", cp.WaitTime)
@@ -235,6 +236,16 @@ func (cp *ConnectionPool) InUse() int64 {
 		return 0
 	}
 	return p.InUse()
+}
+
+// ResetInUseMax returns the maximum value InUse has taken since last called, and
+// resets the gauge to the current value of InUse
+func (cp *ConnectionPool) ResetInUseMax() int64 {
+	p := cp.pool()
+	if p == nil {
+		return 0
+	}
+	return p.ResetInUseMax()
 }
 
 // MaxCap returns the maximum size of the pool


### PR DESCRIPTION
## Description
Proposal to add a gauge which reports the maximum value that InUse has taken for a connection pool over the gauge interval.

The current InUse gauge can hide spiky load, which is something we've seen in practice at Stripe.

It might make sense to also add an AvailableMin gauge, or even just add that since it requires less context to interpret? I'm also pretty unsure if this is the right implementation; it feels like something simpler ought to be possible, but maybe that's just not true with atomics. Looking for feedback!

## Related Issue(s)
n/a

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
n/a