### PR TITLE
Fix upgrade-downgrade CI workflows running even when Skip label specified

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -48,7 +48,7 @@ jobs:
 
   upgrade_downgrade_test_e2e:
     timeout-minutes: 60
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'false')
+    if: always() && (needs.get_latest_release.result == 'success')
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-18.04
     needs:

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -49,7 +49,7 @@ jobs:
   # This job usually execute in ± 20 minutes
   upgrade_downgrade_test_manual:
     timeout-minutes: 40
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'false')
+    if: always() && (needs.get_latest_release.result == 'success')
     name: Run Upgrade Downgrade Test Backup Manual
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -49,7 +49,7 @@ jobs:
           echo "::set-output name=latest_release_branch::${latest_release_branch}"
 
   upgrade_downgrade_test:
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'false')
+    if: always() && (needs.get_latest_release.result == 'success')
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -49,7 +49,7 @@ jobs:
           echo "::set-output name=latest_release_branch::${latest_release_branch}"
 
   upgrade_downgrade_test:
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'false')
+    if: always() && (needs.get_latest_release.result == 'success')
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -49,7 +49,7 @@ jobs:
           echo "::set-output name=latest_release_branch::${latest_release_branch}"
 
   upgrade_downgrade_test:
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'false')
+    if: always() && (needs.get_latest_release.result == 'success')
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Before #9745 we used to build a matrix from the latest releases. So, if the step to get the latest releases was skipped, our matrix used to be empty and no workflow for the upgrade downgrade steps used to run.

In #9745, we moved from a matrix having a single element to a string storing the releaes/tag to run the test against. So, when the step to get latest release was skipped, the output was still a string albeit an empty one. This triggered the next workflow to run with an empty previous release/tag like in https://github.com/vitessio/vitess/runs/5310337523?check_suite_focus=true.

This PR fixes this issue, so that the job to run the upgrade-downgrade test only works when the previous job of getting the release to test against succeeds.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? *Yes* along with #9754 
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->