### PR TITLE
Move deprecation warning to just before we actually invoke the legacy command path

### DIFF
--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -85,8 +85,6 @@ func main() {
 	args := servenv.ParseFlagsWithArgs("vtctl")
 	action := args[0]
 
-	log.Warningf("WARNING: vtctl should only be used for VDiff workflows. Consider using vtctldclient for all other commands.")
-
 	startMsg := fmt.Sprintf("USER=%v SUDO_USER=%v %v", os.Getenv("USER"), os.Getenv("SUDO_USER"), strings.Join(os.Args, " "))
 
 	if syslogger, err := syslog.New(syslog.LOG_INFO, "vtctl "); err == nil {
@@ -152,6 +150,8 @@ func main() {
 		args = args[1:]
 		fallthrough
 	default:
+		log.Warningf("WARNING: vtctl should only be used for VDiff workflows. Consider using vtctldclient for all other commands.")
+
 		if args[0] == "--" {
 			args = args[1:]
 		}


### PR DESCRIPTION
## Description

This removes a warning from the example scripts.

Before:

```
➜  local git:(afe22c6ba3) ✗ ./101_initial_cluster.sh 
add /vitess/global
add /vitess/zone1
add zone1 CellInfo
W0225 12:00:46.596158   80901 vtctl.go:88] WARNING: vtctl should only be used for VDiff workflows. Consider using vtctldclient for all other commands.
```

After:

```
➜  local git:(andrew/better-vtctl-warning-placement) ✗ ./101_initial_cluster.sh 
add /vitess/global
add /vitess/zone1
add zone1 CellInfo
Created cell: zone1
```

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->