### PR TITLE
Add TEXT field comparison support to evalengine (for VDiff)

### DIFF
--- a/go/test/endtoend/vreplication/config.go
+++ b/go/test/endtoend/vreplication/config.go
@@ -24,7 +24,7 @@ create table customer_seq2(id int, next_id bigint, cache bigint, primary key(id)
 create table ` + "`Lead`(`Lead-id`" + ` binary(16), name varbinary(16), date1 datetime not null default '0000-00-00 00:00:00', date2 datetime not null default '2021-00-01 00:00:00', primary key (` + "`Lead-id`" + `));
 create table ` + "`Lead-1`(`Lead`" + ` binary(16), name varbinary(16), date1 datetime not null default '0000-00-00 00:00:00', date2 datetime not null default '2021-00-01 00:00:00', primary key (` + "`Lead`" + `));
 create table _vt_PURGE_4f9194b43b2011eb8a0104ed332e05c2_20221210194431(id int, val varbinary(128), primary key(id));
-create table db_order_test (c_uuid varchar(64) not null default '', created_at datetime not null, dstuff varchar(128), primary key (c_uuid,created_at)) CHARSET=utf8mb4;
+create table db_order_test (c_uuid varchar(64) not null default '', created_at datetime not null, dstuff varchar(128), dtstuff text, dbstuff blob, primary key (c_uuid,created_at)) CHARSET=utf8mb4;
 `
 
 	// These should always be ignored in vreplication

--- a/go/test/endtoend/vreplication/unsharded_init_data.sql
+++ b/go/test/endtoend/vreplication/unsharded_init_data.sql
@@ -15,14 +15,14 @@ insert into customer2(cid, name, typ, sport) values(3, 'Ringo','enterprise','');
 --   1. where inserted binary value is 15 bytes, field is 16, mysql adds a null while storing but binlog returns 15 bytes
 --   2. where mixed case, special characters, or reserved words are used in identifiers
 insert into `Lead`(`Lead-id`, name) values (x'02BD00987932461E8820C908E84BAE', 'abc');
-insert into db_order_test (c_uuid, created_at, dstuff) values ('b169-3ad23512-b003-22000b029685-14e3', '2018-02-16 02:38:00', 'EKiech)uichoo7aen4AiY6oop9OoKee4');
-insert into db_order_test (c_uuid, created_at, dstuff) values ('b169-3ad8fc7a-b289-064d3874effb-14e4', '2018-06-13 14:11:07', 'queen4Uv1Eeshieb6rei3ta1cio[qu6o');
-insert into db_order_test (c_uuid, created_at, dstuff) values ('b169-57d445ba-cc91-22000b048bce-14e3', '2018-04-14 23:56:56', 'aqu3aici9Ish3aiC}oo}laasahdaiMah');
-insert into db_order_test (c_uuid, created_at, dstuff) values ('b169,3ad23512-b003-22000b029685-14e3', '2021-09-15 00:52:55', 'uSh6Roo0iuz.ooqu6aedah1ahk8Aing6');
-insert into db_order_test (c_uuid, created_at, dstuff) values ('b169-da8df852-9bad-22000b029685-14e3', '2020-05-06 07:22:17', 'Va-Sh^ee]s3ighiel:a)x1goh9aephoM');
-insert into db_order_test (c_uuid, created_at, dstuff) values ('b169-c15236c2-c126-0a35b5b9cfad-14e4', '2018-11-23 01:25:09', 'wo9ohphah=g7se-uP7chiuf8noochi?G');
-insert into db_order_test (c_uuid, created_at, dstuff) values ('b169-888dc696-ba7c-1231391275f1-14e2', '2018-10-07 18:52:25', 'ob#iug8zoo2waXa8feu2kaebeebieca5');
-insert into db_order_test (c_uuid, created_at, dstuff) values ('b169-7e6f4774-99e5-22000b010ed3-14e3', '2018-04-02 19:09:00', 'shoo=k3ophujei=fie8ohwahWee!yo3f');
-insert into db_order_test (c_uuid, created_at, dstuff) values ('b169-7359cfb5-9ff5-064d3874effb-14e4', '2018-12-11 01:46:46', 'Fohk0aif4oov!e>ith)eeghoo`Goh)p0');
-insert into db_order_test (c_uuid, created_at, dstuff) values ('b169-a8411858-a983-123139285dbf-14e2', '2020-03-23 04:42:39', 'ooM4pe<chooph2Zoothah>j>eashaeko');
+insert into db_order_test (c_uuid, created_at, dstuff, dtstuff, dbstuff) values ('b169-3ad23512-b003-22000b029685-14e3', '2018-02-16 02:38:00', 'EKiech)uichoo7aen4AiY6oop9OoKee4', 'ohghua7chi5ahPhie2io?S8Pi9dewed8', 'UGhaedai]Yai0Aithoozah$ph9acahjo');
+insert into db_order_test (c_uuid, created_at, dstuff, dtstuff, dbstuff) values ('b169-3ad8fc7a-b289-064d3874effb-14e4', '2018-06-13 14:11:07', 'queen4Uv1Eeshieb6rei3ta1cio[qu6o', 'Athahsea2ahD*u0UKai4aj3ogh0Vou7i', 'jeekiithoo>Ngooze1she0yie8Et1Zie');
+insert into db_order_test (c_uuid, created_at, dstuff, dtstuff, dbstuff) values ('b169-57d445ba-cc91-22000b048bce-14e3', '2018-04-14 23:56:56', 'aqu3aici9Ish3aiC}oo}laasahdaiMah', 'Aa8aeT+ee3hei1quu*aquie4Eexe?i#b', 'doh1ahy@auCie4zie5dod;es8yiekooj');
+insert into db_order_test (c_uuid, created_at, dstuff, dtstuff, dbstuff) values ('b169,3ad23512-b003-22000b029685-14e3', '2021-09-15 00:52:55', 'uSh6Roo0iuz.ooqu6aedah1ahk8Aing6', 'yooF3aex0aegh1saF$ei&noopiy0ojoh', 'eeg1Yaevil&ae0ooBa$quahu^Gh1meiG');
+insert into db_order_test (c_uuid, created_at, dstuff, dtstuff, dbstuff) values ('b169-da8df852-9bad-22000b029685-14e3', '2020-05-06 07:22:17', 'Va-Sh^ee]s3ighiel:a)x1goh9aephoM', 'ahmiut7Ieru8Baz3Moothoh8Ilu:thae', 'egheeshiC9euN1et8aeSh0oohu)hoh7e');
+insert into db_order_test (c_uuid, created_at, dstuff, dtstuff, dbstuff) values ('b169-c15236c2-c126-0a35b5b9cfad-14e4', '2018-11-23 01:25:09', 'wo9ohphah=g7se-uP7chiuf8noochi?G', 'uD9Neesh)eefe0CheeGhetae9aejXoog', 'aiChi3imee{v6aulei6iesh1iTh3hoNe');
+insert into db_order_test (c_uuid, created_at, dstuff, dtstuff, dbstuff) values ('b169-888dc696-ba7c-1231391275f1-14e2', '2018-10-07 18:52:25', 'ob#iug8zoo2waXa8feu2kaebeebieca5', 'cha8Re]Leepheeme,ihooF2iej5coo7e', 'mi0Eijoh1eiChie7jae4Sha=caeD9nu6');
+insert into db_order_test (c_uuid, created_at, dstuff, dtstuff, dbstuff) values ('b169-7e6f4774-99e5-22000b010ed3-14e3', '2018-04-02 19:09:00', 'shoo=k3ophujei=fie8ohwahWee!yo3f', 'ashay]equiel7tho7moh5shem5eiD?ah', 'Eewie-sh3xae8iu3ahth3cohxoo1oohe');
+insert into db_order_test (c_uuid, created_at, dstuff, dtstuff, dbstuff) values ('b169-7359cfb5-9ff5-064d3874effb-14e4', '2018-12-11 01:46:46', 'Fohk0aif4oov!e>ith)eeghoo`Goh)p0', 'shi3ahde9doo5Uph6CeiSheCh/uw0nae', 'audaek{eceenooPh8wichahcheiv9thu');
+insert into db_order_test (c_uuid, created_at, dstuff, dtstuff, dbstuff) values ('b169-a8411858-a983-123139285dbf-14e2', '2020-03-23 04:42:39', 'ooM4pe<chooph2Zoothah>j>eashaeko', 'too$Shei&s2eing3ashoh0Sh9fiey7th', 'Ohx9saf#eiz*echoo0eechSues_u2que');
 

--- a/go/vt/vtgate/evalengine/comparisons.go
+++ b/go/vt/vtgate/evalengine/comparisons.go
@@ -446,7 +446,7 @@ func NullsafeCompare(v1, v2 sqltypes.Value, collationID collations.ID) (int, err
 	}
 
 	switch {
-	case typ == sqltypes.VarChar:
+	case typ == sqltypes.VarChar || typ == sqltypes.Text:
 		v1Bytes := v1.Raw()
 		v2Bytes := v2.Raw()
 


### PR DESCRIPTION
## Description
We switched to using evalengine for `VDiff` comparisons in https://github.com/vitessio/vitess/pull/9679.

What we didn't realize at the time is that evalengine did not support comparing `TEXT` columns. When doing a `VDiff` against a table that has them, you get the following error (you can see a failed test after the test changes [here](https://github.com/vitessio/vitess/runs/5342687212?check_suite_focus=true)):
```
VDiff Error: rpc error: code = Unknown desc = diff: types are not comparable: TEXT vs TEXT
```

There's no logical reason for this as a `TEXT` field for in memory processing is no different from a `VARCHAR`. The main differences are the on disk format which stores the values off page due to the large maximum size for the type. The same is true for `BLOB` and `VARBINARY` fields, but we already treat them the same way in the evalengine. This PR treats `TEXT` fields the same as `VARCHAR` fields for comparisons. 


## Related Issue(s)
- Fixes: ToDo
- Related to: https://github.com/vitessio/vitess/pull/9679


## Checklist
- [x] Should this PR be backported? NO
- [x] Tests were updated
- [x] Documentation is not required