### PR TITLE
evalengine: Support built-in MySQL functions--log(), log2(), log10

### DIFF
--- a/go/vt/vtgate/evalengine/func.go
+++ b/go/vt/vtgate/evalengine/func.go
@@ -36,6 +36,9 @@ var builtinFunctions = map[string]builtin{
 	"collation": builtinCollation{},
 	"bit_count": builtinBitCount{},
 	"hex":       builtinHex{},
+	"log":       builtinLog{},
+	"log2":      builtinLog2{},
+	"log10":     builtinLog10{},
 }
 
 var builtinFunctionsRewrite = map[string]builtinRewrite{
@@ -593,4 +596,75 @@ func aggregatedType(env *ExpressionEnv, expr []Expr) sqltypes.Type {
 		return sqltypes.Blob
 	}
 	return sqltypes.VarChar
+}
+
+type builtinLog struct{}
+
+func (builtinLog) call(_ *ExpressionEnv, args []EvalResult, result *EvalResult) {
+	inarg := &args[0]
+	if inarg.null() {
+		result.setNull()
+		return
+	}
+	inarg.makeFloat()
+	if len(args) < 2 {
+		result.setFloat(math.Log(inarg.float64()))
+	} else {
+		inarg1 := &args[1]
+		inarg1.makeFloat()
+		result.setFloat(math.Log(inarg1.float64()) / math.Log(inarg.float64()))
+	}
+}
+
+func (builtinLog) typeof(env *ExpressionEnv, args []Expr) (sqltypes.Type, flag) {
+	if len(args) < 1 || len(args) > 2 {
+		throwArgError("LOG")
+	}
+
+	tt, f := args[0].typeof(env)
+	return tt, f
+}
+
+type builtinLog2 struct{}
+
+func (builtinLog2) call(_ *ExpressionEnv, args []EvalResult, result *EvalResult) {
+	inarg := &args[0]
+	if inarg.null() {
+		result.setNull()
+		return
+	}
+	inarg.makeFloat()
+	res := math.Log2(inarg.float64())
+	result.setFloat(res)
+}
+
+func (builtinLog2) typeof(env *ExpressionEnv, args []Expr) (sqltypes.Type, flag) {
+	if len(args) < 1 {
+		throwArgError("LOG2")
+	}
+
+	tt, f := args[0].typeof(env)
+	return tt, f
+}
+
+type builtinLog10 struct{}
+
+func (builtinLog10) call(_ *ExpressionEnv, args []EvalResult, result *EvalResult) {
+	inarg := &args[0]
+	if inarg.null() {
+		result.setNull()
+		return
+	}
+	inarg.makeFloat()
+	res := math.Log10(inarg.float64())
+	result.setFloat(res)
+}
+
+func (builtinLog10) typeof(env *ExpressionEnv, args []Expr) (sqltypes.Type, flag) {
+	if len(args) < 1 {
+		throwArgError("LOG10")
+	}
+
+	tt, f := args[0].typeof(env)
+	return tt, f
 }

--- a/go/vt/vtgate/evalengine/integration/comparison_test.go
+++ b/go/vt/vtgate/evalengine/integration/comparison_test.go
@@ -572,3 +572,61 @@ func TestCharsetConversionOperators(t *testing.T) {
 		}
 	}
 }
+
+func TestFunctionLog2(t *testing.T) {
+
+	var charsets = []string{
+		"-2", "-2.0", "-2.2", "0", "2", "2.0", "2.2", "abc", "8.0",
+		"1.0e0", "1.5e0", "-1.5e0", "1.1e0",
+	}
+
+	var conn = mysqlconn(t)
+	defer conn.Close()
+
+	for _, rhs := range charsets {
+		compareRemoteQuery(t, conn, fmt.Sprintf("SELECT log2(%s)", rhs))
+	}
+}
+
+func TestFunctionLog10(t *testing.T) {
+
+	var charsets = []string{
+		"-2", "-2.0", "-2.2", "0", "2", "2.0", "2.2", "abc", "8.0",
+		"1.0e0", "1.5e0", "-1.5e0", "1.1e0",
+	}
+
+	var conn = mysqlconn(t)
+	defer conn.Close()
+
+	for _, rhs := range charsets {
+		compareRemoteQuery(t, conn, fmt.Sprintf("SELECT log10(%s)", rhs))
+	}
+}
+
+func TestFunctionLog(t *testing.T) {
+
+	var charsets = []string{
+		"-2", "2.0", "2.2", "2", "0", "2.0", "-2.2", "abc", "8.0", "1", "8",
+		"1.0e0", "2", "-1.5e0", "1.1e0",
+	}
+
+	var charsets1 = []string{
+		"2", "-2.0", "-2", "0", "2", "2.0", "2.2", "abc", "2", "8", "1",
+		"2", "1.5e0", "-1.5e0", "1.1e0",
+	}
+
+	var conn = mysqlconn(t)
+	defer conn.Close()
+
+	for _, rhs := range charsets {
+		compareRemoteQuery(t, conn, fmt.Sprintf("SELECT log2(%s)", rhs))
+	}
+
+	for pos := 0; pos < len(charsets); pos++ {
+		query := fmt.Sprintf("SELECT log(%s)", charsets[:pos])
+		compareRemoteQuery(t, conn, query)
+
+		query = fmt.Sprintf("SELECT log(%s,%s)", charsets[:pos], charsets1[:pos])
+		compareRemoteQuery(t, conn, query)
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
evalengine: Support built-in MySQL function LOG, LOG2, LOG10.
but In log (0, 8) and log (8, 0), I'm not sure if this is the right way to handle it.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Contributes to #9647 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->