### PR TITLE
Support invisible columns in vreplication

### DIFF
--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -32,9 +32,11 @@ import (
 
 const (
 	// BaseShowPrimary is the base query for fetching primary key info.
-	BaseShowPrimary = "SELECT table_name, column_name FROM information_schema.key_column_usage WHERE table_schema=database() AND constraint_name='PRIMARY' ORDER BY table_name, ordinal_position"
-	// BaseShowTableUniqueKey returns names of colunms covered by a given unique constraint on a given table, in key order
-	BaseShowTableUniqueKey = "SELECT column_name as column_name FROM information_schema.key_column_usage WHERE table_schema=database() AND table_name=%a AND constraint_name=%a ORDER BY ordinal_position"
+	BaseShowPrimary = `SELECT table_name as table_name, COLUMN_NAME as column_name
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = database()
+		AND COLUMN_KEY = 'PRI'
+		ORDER BY table_name, ordinal_position;`
 	// ShowRowsRead is the query used to find the number of rows read.
 	ShowRowsRead = "show status like 'Innodb_rows_read'"
 

--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -113,6 +113,8 @@ order by table_name, ordinal_position`
 from _vt.schemacopy 
 where table_schema = database() 
 order by table_name, ordinal_position`
+
+	GetColumnNamesQueryPatternForTable = `SELECT COLUMN_NAME.*TABLE_NAME.*%s.*`
 )
 
 // VTDatabaseInit contains all the schema creation queries needed to

--- a/go/test/endtoend/vreplication/config.go
+++ b/go/test/endtoend/vreplication/config.go
@@ -14,7 +14,8 @@ var (
 	initialProductSchema = `
 create table product(pid int, description varbinary(128), date1 datetime not null default '0000-00-00 00:00:00', date2 datetime not null default '2021-00-01 00:00:00', primary key(pid)) CHARSET=utf8mb4;
 create table customer(cid int, name varchar(128) collate utf8mb4_bin, meta json default null, typ enum('individual','soho','enterprise'), sport set('football','cricket','baseball'),
-	ts timestamp not null default current_timestamp, bits bit(2) default b'11', date1 datetime not null default '0000-00-00 00:00:00', date2 datetime not null default '2021-00-01 00:00:00', primary key(cid)) CHARSET=utf8mb4;
+	ts timestamp not null default current_timestamp, bits bit(2) default b'11', date1 datetime not null default '0000-00-00 00:00:00', 
+	date2 datetime not null default '2021-00-01 00:00:00', inv1 int invisible default 10, primary key(cid)) CHARSET=utf8mb4;
 create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 create table merchant(mname varchar(128), category varchar(128), primary key(mname)) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 create table orders(oid int, cid int, pid int, mname varchar(128), price int, qty int, total int as (qty * price), total2 int as (qty * price) stored, primary key(oid)) CHARSET=utf8;

--- a/go/test/fuzzing/tabletserver_schema_fuzzer.go
+++ b/go/test/fuzzing/tabletserver_schema_fuzzer.go
@@ -70,5 +70,5 @@ func newTestLoadTable(tableName, comment string, db *fakesqldb.DB) (*schema.Tabl
 	}
 	defer conn.Recycle()
 
-	return schema.LoadTable(conn, tableName, comment)
+	return schema.LoadTable(conn, "fakesqldb", tableName, comment)
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -1440,3 +1440,66 @@ func TestCopyTablesWithInvalidDates(t *testing.T) {
 		"commit",
 	})
 }
+
+func TestCopyInvisibleColumns(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+
+	execStatements(t, []string{
+		"create table src1(id int, id2 int, inv1 int invisible, inv2 int invisible, primary key(id, inv1))",
+		"insert into src1(id, id2, inv1, inv2) values(2, 20, 200, 2000), (1, 10, 100, 1000)",
+		fmt.Sprintf("create table %s.dst1(id int, id2 int, inv1 int invisible, inv2 int invisible, primary key(id, inv1))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table src1",
+		fmt.Sprintf("drop table %s.dst1", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "dst1",
+			Filter: "select * from src1",
+		}},
+	}
+
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	query := binlogplayer.CreateVReplicationState("test", bls, "", binlogplayer.VReplicationInit, playerEngine.dbName)
+	qr, err := playerEngine.Exec(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		query := fmt.Sprintf("delete from _vt.vreplication where id = %d", qr.InsertID)
+		if _, err := playerEngine.Exec(query); err != nil {
+			t.Fatal(err)
+		}
+		expectDeleteQueries(t)
+	}()
+
+	expectNontxQueries(t, []string{
+		// Create the list of tables to copy and transition to Copying state.
+		"/insert into _vt.vreplication",
+		"/update _vt.vreplication set message=",
+		"/insert into _vt.copy_state",
+		"/update _vt.vreplication set state",
+		// The first fast-forward has no starting point. So, it just saves the current position.
+		"insert into dst1(id,id2,inv1,inv2) values (1,10,100,1000), (2,20,200,2000)",
+		`/update _vt.copy_state set lastpk='fields:{name:\\"id\\" type:INT32} fields:{name:\\"inv1\\" type:INT32} rows:{lengths:1 lengths:3 values:\\"2200\\"}' where vrepl_id=.*`,
+		// copy of dst1 is done: delete from copy_state.
+		"/delete from _vt.copy_state.*dst1",
+		"/update _vt.vreplication set state",
+	})
+	expectData(t, "dst1", [][]string{
+		{"1", "10"},
+		{"2", "20"},
+	})
+	expectQueryResult(t, "select id,id2,inv1,inv2 from vrepl.dst1", [][]string{
+		{"1", "10", "100", "1000"},
+		{"2", "20", "200", "2000"},
+	})
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -38,6 +38,77 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
+func TestInvisibleColumns(t *testing.T) {
+
+	if env.DBMajorVersion != 8 && env.DBPatchVersion < 23 {
+		log.Infof("invisible columns not supported in %d:%d:%d", env.DBMajorVersion, env.DBMinorVersion, env.DBPatchVersion)
+		t.Skip()
+	}
+	defer deleteTablet(addTablet(100))
+
+	execStatements(t, []string{
+		"create table t1(id int, val varchar(20), id2 int invisible, pk2 int invisible, primary key(id, pk2))",
+		fmt.Sprintf("create table %s.t1(id int, val varchar(20), id2 int invisible, pk2 int invisible, primary key(id, pk2))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t1",
+		fmt.Sprintf("drop table %s.t1", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "t1",
+			Filter: "select * from t1",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	cancel, _ := startVReplication(t, bls, "")
+	defer cancel()
+
+	testcases := []struct {
+		input       string
+		output      string
+		table       string
+		data        [][]string
+		query       string
+		queryResult [][]string
+	}{{
+		input:  "insert into t1(id,val,id2,pk2) values (1,'aaa',10,100)",
+		output: "insert into t1(id,val,id2,pk2) values (1,'aaa',10,100)",
+		table:  "t1",
+		data: [][]string{
+			{"1", "aaa"},
+		},
+		query: "select id, val, id2, pk2 from t1",
+		queryResult: [][]string{
+			{"1", "aaa", "10", "100"},
+		},
+	}}
+
+	for _, tcases := range testcases {
+		execStatements(t, []string{tcases.input})
+		output := []string{
+			tcases.output,
+		}
+		expectNontxQueries(t, output)
+		time.Sleep(1 * time.Second)
+		log.Flush()
+		if tcases.table != "" {
+			expectData(t, tcases.table, tcases.data)
+		}
+		if tcases.query != "" {
+			expectQueryResult(t, tcases.query, tcases.queryResult)
+		}
+	}
+
+}
+
 func TestHeartbeatFrequencyFlag(t *testing.T) {
 	origVReplicationHeartbeatUpdateInterval := *vreplicationHeartbeatUpdateInterval
 	defer func() {
@@ -2715,6 +2786,7 @@ func TestGeneratedColumns(t *testing.T) {
 		}
 	}
 }
+
 func TestPlayerInvalidDates(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -38,7 +38,7 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
-func TestInvisibleColumns(t *testing.T) {
+func TestPlayerInvisibleColumns(t *testing.T) {
 
 	if env.DBMajorVersion != 8 && env.DBPatchVersion < 23 {
 		log.Infof("invisible columns not supported in %d:%d:%d", env.DBMajorVersion, env.DBMinorVersion, env.DBPatchVersion)

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -54,9 +54,7 @@ import (
 func TestStrictMode(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
+	schematest.AddDefaultQueries(db)
 
 	// Test default behavior.
 	config := tabletenv.NewDefaultConfig()
@@ -99,9 +97,7 @@ func TestStrictMode(t *testing.T) {
 func TestGetPlanPanicDuetoEmptyQuery(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
+	schematest.AddDefaultQueries(db)
 	qe := newTestQueryEngine(10*time.Second, true, newDBConfigs(db))
 	qe.se.Open()
 	qe.Open()
@@ -133,9 +129,7 @@ func addSchemaEngineQueries(db *fakesqldb.DB) {
 func TestGetMessageStreamPlan(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
+	schematest.AddDefaultQueries(db)
 
 	addSchemaEngineQueries(db)
 
@@ -179,9 +173,7 @@ func assertPlanCacheSize(t *testing.T, qe *QueryEngine, expected int) {
 func TestQueryPlanCache(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
+	schematest.AddDefaultQueries(db)
 
 	firstQuery := "select * from test_table_01"
 	secondQuery := "select * from test_table_02"
@@ -224,9 +216,7 @@ func TestQueryPlanCache(t *testing.T) {
 func TestNoQueryPlanCache(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
+	schematest.AddDefaultQueries(db)
 
 	firstQuery := "select * from test_table_01"
 	db.AddQuery("select * from test_table_01 where 1 != 1", &sqltypes.Result{})
@@ -254,9 +244,7 @@ func TestNoQueryPlanCache(t *testing.T) {
 func TestNoQueryPlanCacheDirective(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
+	schematest.AddDefaultQueries(db)
 
 	firstQuery := "select /*vt+ SKIP_QUERY_PLAN_CACHE=1 */ * from test_table_01"
 	db.AddQuery("select /*vt+ SKIP_QUERY_PLAN_CACHE=1 */ * from test_table_01 where 1 != 1", &sqltypes.Result{})
@@ -284,9 +272,7 @@ func TestNoQueryPlanCacheDirective(t *testing.T) {
 func TestStatsURL(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
+	schematest.AddDefaultQueries(db)
 	query := "select * from test_table_01"
 	db.AddQuery("select * from test_table_01 where 1 != 1", &sqltypes.Result{})
 	qe := newTestQueryEngine(1*time.Second, true, newDBConfigs(db))
@@ -387,9 +373,7 @@ func BenchmarkPlanCacheThroughput(b *testing.B) {
 	db := fakesqldb.New(b)
 	defer db.Close()
 
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
+	schematest.AddDefaultQueries(db)
 
 	db.AddQueryPattern(".*", &sqltypes.Result{})
 
@@ -444,9 +428,7 @@ func BenchmarkPlanCacheContention(b *testing.B) {
 	db := fakesqldb.New(b)
 	defer db.Close()
 
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
+	schematest.AddDefaultQueries(db)
 
 	db.AddQueryPattern(".*", &sqltypes.Result{})
 
@@ -473,9 +455,7 @@ func TestPlanCachePollution(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
+	schematest.AddDefaultQueries(db)
 
 	db.AddQueryPattern(".*", &sqltypes.Result{})
 

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -490,7 +490,8 @@ func TestDisableOnlineDDL(t *testing.T) {
 	defer db.Close()
 	query := "ALTER VITESS_MIGRATION CANCEL ALL"
 
-	db.AddQueryPattern(".*", &sqltypes.Result{})
+	db.SetNeverFail(true)
+	defer db.SetNeverFail(false)
 
 	ctx := context.Background()
 	tsv := newTestTabletServer(ctx, noFlags, db)
@@ -1315,9 +1316,7 @@ func setUpQueryExecutorTest(t *testing.T) *fakesqldb.DB {
 const baseShowTablesPattern = `SELECT t\.table_name.*`
 
 func initQueryExecutorTestDB(db *fakesqldb.DB) {
-	for query, result := range getQueryExecutorSupportedQueries() {
-		db.AddQuery(query, result)
-	}
+	addQueryExecutorSupportedQueries(db)
 	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
 		Fields: mysql.BaseShowTablesFields,
 		Rows: [][]sqltypes.Value{
@@ -1341,8 +1340,8 @@ func getTestTableFields() []*querypb.Field {
 	}
 }
 
-func getQueryExecutorSupportedQueries() map[string]*sqltypes.Result {
-	return map[string]*sqltypes.Result{
+func addQueryExecutorSupportedQueries(db *fakesqldb.DB) {
+	queryResultMap := map[string]*sqltypes.Result{
 		// queries for twopc
 		fmt.Sprintf(sqlCreateSidecarDB, "_vt"):          {},
 		fmt.Sprintf(sqlDropLegacy1, "_vt"):              {},
@@ -1419,57 +1418,77 @@ func getQueryExecutorSupportedQueries() map[string]*sqltypes.Result {
 				mysql.ShowPrimaryRow("msg", "id"),
 			},
 		},
-		"select * from test_table where 1 != 1": {
-			Fields: []*querypb.Field{{
-				Name: "pk",
-				Type: sqltypes.Int32,
-			}, {
-				Name: "name",
-				Type: sqltypes.Int32,
-			}, {
-				Name: "addr",
-				Type: sqltypes.Int32,
-			}},
-		},
-		"select * from seq where 1 != 1": {
-			Fields: []*querypb.Field{{
-				Name: "id",
-				Type: sqltypes.Int32,
-			}, {
-				Name: "next_id",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "cache",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "increment",
-				Type: sqltypes.Int64,
-			}},
-		},
-		"select * from msg where 1 != 1": {
-			Fields: []*querypb.Field{{
-				Name: "id",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "priority",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "time_next",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "epoch",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "time_acked",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "message",
-				Type: sqltypes.Int64,
-			}},
-		},
 		"begin":    {},
 		"commit":   {},
 		"rollback": {},
 		fmt.Sprintf(sqlReadAllRedo, "_vt", "_vt"): {},
 	}
+
+	for query, result := range queryResultMap {
+		db.AddQuery(query, result)
+	}
+	addMockQueriesForTable(db, "test_table", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "pk",
+			Type: sqltypes.Int32,
+		}, {
+			Name: "name",
+			Type: sqltypes.Int32,
+		}, {
+			Name: "addr",
+			Type: sqltypes.Int32,
+		}},
+	})
+	addMockQueriesForTable(db, "seq", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "id",
+			Type: sqltypes.Int32,
+		}, {
+			Name: "next_id",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "cache",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "increment",
+			Type: sqltypes.Int64,
+		}},
+	})
+	addMockQueriesForTable(db, "msg", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "id",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "priority",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "time_next",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "epoch",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "time_acked",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "message",
+			Type: sqltypes.Int64,
+		}},
+	})
+}
+
+func addMockQueriesForTable(db *fakesqldb.DB, table string, result *sqltypes.Result) {
+	selectQueryPattern := fmt.Sprintf("select .* from %s where 1 != 1", table)
+	db.AddQueryPattern(selectQueryPattern, result)
+	var cols []string
+	for _, field := range result.Fields {
+		cols = append(cols, field.Name)
+	}
+	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, table), sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"column_name",
+			"varchar",
+		),
+		cols...,
+	))
 }

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -357,7 +357,7 @@ func (se *Engine) reload(ctx context.Context) error {
 		}
 
 		log.V(2).Infof("Reading schema for table: %s", tableName)
-		table, err := LoadTable(conn, tableName, row[3].ToString())
+		table, err := LoadTable(conn, se.cp.DBName(), tableName, row[3].ToString())
 		if err != nil {
 			rec.RecordError(err)
 			continue

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -44,6 +44,7 @@ import (
 )
 
 const baseShowTablesPattern = `SELECT t\.table_name.*`
+const getColumnNamesQueryPattern = `SELECT COLUMN_NAME.*`
 
 var mustMatch = utils.MustMatchFn(".Mutex")
 

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -39,9 +39,7 @@ import (
 func TestLoadTable(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	for query, result := range getTestLoadTableQueries() {
-		db.AddQuery(query, result)
-	}
+	mockLoadTableQueries(db)
 	table, err := newTestLoadTable("USER_TABLE", "test table", db)
 	if err != nil {
 		t.Fatal(err)
@@ -65,9 +63,7 @@ func TestLoadTable(t *testing.T) {
 func TestLoadTableSequence(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	for query, result := range getTestLoadTableQueries() {
-		db.AddQuery(query, result)
-	}
+	mockLoadTableQueries(db)
 	table, err := newTestLoadTable("USER_TABLE", "vitess_sequence", db)
 	if err != nil {
 		t.Fatal(err)
@@ -87,9 +83,7 @@ func TestLoadTableSequence(t *testing.T) {
 func TestLoadTableMessage(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	for query, result := range getMessageTableQueries() {
-		db.AddQuery(query, result)
-	}
+	mockMessageTableQueries(db)
 	table, err := newTestLoadTable("USER_TABLE", "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30", db)
 	if err != nil {
 		t.Fatal(err)
@@ -148,9 +142,7 @@ func TestLoadTableMessage(t *testing.T) {
 		t.Errorf("newTestLoadTable: %v, want %s", err, wanterr)
 	}
 
-	for query, result := range getTestLoadTableQueries() {
-		db.AddQuery(query, result)
-	}
+	mockLoadTableQueries(db)
 	_, err = newTestLoadTable("USER_TABLE", "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30", db)
 	wanterr = "missing from message table: test_table"
 	if err == nil || !strings.Contains(err.Error(), wanterr) {
@@ -173,48 +165,60 @@ func newTestLoadTable(tableType string, comment string, db *fakesqldb.DB) (*Tabl
 	}
 	defer conn.Recycle()
 
-	return LoadTable(conn, "test_table", comment)
+	return LoadTable(conn, "fakesqldb", "test_table", comment)
 }
 
-func getTestLoadTableQueries() map[string]*sqltypes.Result {
-	return map[string]*sqltypes.Result{
-		"select * from test_table where 1 != 1": {
-			Fields: []*querypb.Field{{
-				Name: "pk",
-				Type: sqltypes.Int32,
-			}, {
-				Name: "name",
-				Type: sqltypes.Int32,
-			}, {
-				Name: "addr",
-				Type: sqltypes.Int32,
-			}},
-		},
-	}
+func mockLoadTableQueries(db *fakesqldb.DB) {
+	db.ClearQueryPattern()
+	db.AddQueryPattern("select .* from test_table where 1 != 1", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "pk",
+			Type: sqltypes.Int32,
+		}, {
+			Name: "name",
+			Type: sqltypes.Int32,
+		}, {
+			Name: "addr",
+			Type: sqltypes.Int32,
+		}},
+	})
+	db.AddQueryPattern(getColumnNamesQueryPattern, sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"column_name",
+			"varchar",
+		),
+		"pk", "name", "addr",
+	))
 }
 
-func getMessageTableQueries() map[string]*sqltypes.Result {
-	return map[string]*sqltypes.Result{
-		"select * from test_table where 1 != 1": {
-			Fields: []*querypb.Field{{
-				Name: "id",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "priority",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "time_next",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "epoch",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "time_acked",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "message",
-				Type: sqltypes.VarBinary,
-			}},
-		},
-	}
+func mockMessageTableQueries(db *fakesqldb.DB) {
+	db.ClearQueryPattern()
+	db.AddQueryPattern("select .* from test_table where 1 != 1", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "id",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "priority",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "time_next",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "epoch",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "time_acked",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "message",
+			Type: sqltypes.VarBinary,
+		}},
+	})
+	db.AddQueryPattern(getColumnNamesQueryPattern, sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"column_name",
+			"varchar",
+		),
+		"id", "priority", "time_next", "epoch", "time_acked", "message",
+	))
 }

--- a/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
+++ b/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
@@ -19,113 +19,162 @@ limitations under the License.
 package schematest
 
 import (
+	"fmt"
+
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
-// Queries returns a default set of queries that can
+// AddDefaultQueries returns a default set of queries that can
 // be added to load an initial set of tables into the schema.
-func Queries() map[string]*sqltypes.Result {
-	return map[string]*sqltypes.Result{
-		"select unix_timestamp()": {
-			Fields: []*querypb.Field{{
-				Type: sqltypes.Uint64,
-			}},
-			Rows: [][]sqltypes.Value{
-				{sqltypes.NewInt32(1427325875)},
-			},
+func AddDefaultQueries(db *fakesqldb.DB) {
+	db.ClearQueryPattern()
+	db.AddQuery("select unix_timestamp()", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Type: sqltypes.Uint64,
+		}},
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewInt32(1427325875)},
 		},
-		"select @@global.sql_mode": {
-			Fields: []*querypb.Field{{
-				Type: sqltypes.VarChar,
-			}},
-			Rows: [][]sqltypes.Value{
-				{sqltypes.NewVarBinary("STRICT_TRANS_TABLES")},
-			},
+	})
+	db.AddQuery("select @@global.sql_mode", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Type: sqltypes.VarChar,
+		}},
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewVarBinary("STRICT_TRANS_TABLES")},
 		},
-		"select @@autocommit": {
-			Fields: []*querypb.Field{{
-				Type: sqltypes.Uint64,
-			}},
-			Rows: [][]sqltypes.Value{
-				{sqltypes.NewVarBinary("1")},
-			},
+	})
+	db.AddQuery("select @@autocommit", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Type: sqltypes.Uint64,
+		}},
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewVarBinary("1")},
 		},
-		"select @@sql_auto_is_null": {
-			Fields: []*querypb.Field{{
-				Type: sqltypes.Uint64,
-			}},
-			Rows: [][]sqltypes.Value{
-				{sqltypes.NewVarBinary("0")},
-			},
+	})
+	db.AddQuery("select @@sql_auto_is_null", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Type: sqltypes.Uint64,
+		}},
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewVarBinary("0")},
 		},
-		mysql.BaseShowPrimary: {
-			Fields: mysql.ShowPrimaryFields,
-			Rows: [][]sqltypes.Value{
-				mysql.ShowPrimaryRow("test_table_01", "pk"),
-				mysql.ShowPrimaryRow("test_table_02", "pk"),
-				mysql.ShowPrimaryRow("test_table_03", "pk"),
-				mysql.ShowPrimaryRow("seq", "id"),
-				mysql.ShowPrimaryRow("msg", "id"),
-			},
+	})
+
+	db.AddQuery(mysql.BaseShowPrimary, &sqltypes.Result{
+		Fields: mysql.ShowPrimaryFields,
+		Rows: [][]sqltypes.Value{
+			mysql.ShowPrimaryRow("test_table_01", "pk"),
+			mysql.ShowPrimaryRow("test_table_02", "pk"),
+			mysql.ShowPrimaryRow("test_table_03", "pk"),
+			mysql.ShowPrimaryRow("seq", "id"),
+			mysql.ShowPrimaryRow("msg", "id"),
 		},
-		"select * from test_table_01 where 1 != 1": {
-			Fields: []*querypb.Field{{
-				Name: "pk",
-				Type: sqltypes.Int32,
-			}},
-		},
-		"select * from test_table_02 where 1 != 1": {
-			Fields: []*querypb.Field{{
-				Name: "pk",
-				Type: sqltypes.Int32,
-			}},
-		},
-		"select * from test_table_03 where 1 != 1": {
-			Fields: []*querypb.Field{{
-				Name: "pk",
-				Type: sqltypes.Int32,
-			}},
-		},
-		"select * from seq where 1 != 1": {
-			Fields: []*querypb.Field{{
-				Name: "id",
-				Type: sqltypes.Int32,
-			}, {
-				Name: "next_id",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "cache",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "increment",
-				Type: sqltypes.Int64,
-			}},
-		},
-		"select * from msg where 1 != 1": {
-			Fields: []*querypb.Field{{
-				Name: "id",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "priority",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "time_next",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "epoch",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "time_acked",
-				Type: sqltypes.Int64,
-			}, {
-				Name: "message",
-				Type: sqltypes.Int64,
-			}},
-		},
-		"begin":  {},
-		"commit": {},
-	}
+	})
+
+	db.AddQueryPattern("select .* from test_table_01 where 1 != 1", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "pk",
+			Type: sqltypes.Int32,
+		}},
+	})
+	db.AddQueryPattern(queryForTable("test_table_01"), sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"column_name",
+			"varchar",
+		),
+		"pk",
+	))
+
+	db.AddQueryPattern("select .* from test_table_02 where 1 != 1", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "pk",
+			Type: sqltypes.Int32,
+		}},
+	})
+	db.AddQueryPattern(queryForTable("test_table_02"), sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"column_name",
+			"varchar",
+		),
+		"pk",
+	))
+
+	db.AddQueryPattern("select .* from test_table_03 where 1 != 1", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "pk",
+			Type: sqltypes.Int32,
+		}},
+	})
+	db.AddQueryPattern(queryForTable("test_table_03"), sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"column_name",
+			"varchar",
+		),
+		"pk",
+	))
+
+	db.AddQueryPattern("select .* from seq where 1 != 1", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "id",
+			Type: sqltypes.Int32,
+		}, {
+			Name: "next_id",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "cache",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "increment",
+			Type: sqltypes.Int64,
+		}},
+	})
+	db.AddQueryPattern(queryForTable("seq"), sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"column_name",
+			"varchar",
+		),
+		"id", "next_id", "cache", "increment",
+	))
+
+	db.AddQueryPattern("select .* from msg where 1 != 1", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "id",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "priority",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "time_next",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "epoch",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "time_acked",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "message",
+			Type: sqltypes.Int64,
+		}},
+	})
+	db.AddQueryPattern(queryForTable("msg"), sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"column_name",
+			"varchar",
+		),
+		"id", "priority", "time_next", "epoch", "time_acked", "message",
+	))
+
+	db.AddQuery("begin", &sqltypes.Result{})
+	db.AddQuery("commit", &sqltypes.Result{})
+
+}
+
+func queryForTable(table string) string {
+	return fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, table)
 }

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2161,9 +2161,7 @@ func setupTabletServerTestCustom(t *testing.T, config *tabletenv.TabletConfig, k
 
 func setupFakeDB(t *testing.T) *fakesqldb.DB {
 	db := fakesqldb.New(t)
-	for query, result := range getSupportedQueries() {
-		db.AddQuery(query, result)
-	}
+	addTabletServerSupportedQueries(db)
 	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
 		Fields: mysql.BaseShowTablesFields,
 		Rows: [][]sqltypes.Value{
@@ -2180,8 +2178,8 @@ func setupFakeDB(t *testing.T) *fakesqldb.DB {
 	return db
 }
 
-func getSupportedQueries() map[string]*sqltypes.Result {
-	return map[string]*sqltypes.Result{
+func addTabletServerSupportedQueries(db *fakesqldb.DB) {
+	queryResultMap := map[string]*sqltypes.Result{
 		// Queries for how row protection test (txserializer).
 		"update test_table set name_string = 'tx1' where pk = 1 and `name` = 1 limit 10001": {
 			RowsAffected: 1,
@@ -2306,6 +2304,45 @@ func getSupportedQueries() map[string]*sqltypes.Result {
 		"rollback": {},
 		fmt.Sprintf(sqlReadAllRedo, "_vt", "_vt"): {},
 	}
+	for query, result := range queryResultMap {
+		db.AddQuery(query, result)
+	}
+	addMockQueriesForTable(db, "test_table", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "pk",
+			Type: sqltypes.Int32,
+		}, {
+			Name: "name",
+			Type: sqltypes.Int32,
+		}, {
+			Name: "addr",
+			Type: sqltypes.Int32,
+		}, {
+			Name: "name_string",
+			Type: sqltypes.VarChar,
+		}},
+	})
+	addMockQueriesForTable(db, "msg", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "id",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "priority",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "time_next",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "epoch",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "time_acked",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "message",
+			Type: sqltypes.Int64,
+		}},
+	})
 }
 
 func init() {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -602,7 +602,7 @@ func (vs *vstreamer) buildJournalPlan(id uint64, tm *mysql.TableMap) error {
 	}
 	fields := qr.Fields
 	if len(fields) < len(tm.Types) {
-		return fmt.Errorf("cannot determine table columns for %s: event has %v, schema as %v", tm.Name, tm.Types, fields)
+		return fmt.Errorf("cannot determine table columns for %s: event has %v, schema has %v", tm.Name, tm.Types, fields)
 	}
 	table := &Table{
 		Name:   "_vt.resharding_journal",
@@ -635,7 +635,7 @@ func (vs *vstreamer) buildVersionPlan(id uint64, tm *mysql.TableMap) error {
 	}
 	fields := qr.Fields
 	if len(fields) < len(tm.Types) {
-		return fmt.Errorf("cannot determine table columns for %s: event has %v, schema as %v", tm.Name, tm.Types, fields)
+		return fmt.Errorf("cannot determine table columns for %s: event has %v, schema has %v", tm.Name, tm.Types, fields)
 	}
 	table := &Table{
 		Name:   "_vt.schema_version",
@@ -713,7 +713,7 @@ func (vs *vstreamer) buildTableColumns(tm *mysql.TableMap) ([]*querypb.Field, er
 	if len(st.Fields) < len(tm.Types) {
 		if vs.filter.FieldEventMode == binlogdatapb.Filter_ERR_ON_MISMATCH {
 			log.Infof("Cannot determine columns for table %s", tm.Name)
-			return nil, fmt.Errorf("cannot determine table columns for %s: event has %v, schema as %v", tm.Name, tm.Types, st.Fields)
+			return nil, fmt.Errorf("cannot determine table columns for %s: event has %v, schema has %v", tm.Name, tm.Types, st.Fields)
 		}
 		return fields, nil
 	}


### PR DESCRIPTION
## Description

VReplication used queries like `select * from t1 where 1 = 0` for obtaining the list of columns and the `Fields` structure. This no longer works after invisible columns were introduced in `8.0.23` because `select *` does not return invisible columns. VReplication needs to do faithful copies / stream all data from a table. So it needs to also send the data from invisible columns.

This PR gets the list of all columns, including invisible ones, from `information_schema.columns` and passing on this list explicitly to the `select` clause to get the Fields . It also changes the queries to find primary keys to use `information_schema.columns` instead of `information_schema.key_column_usage`. The latter does not contain info about invisible columns.

The core changes for this PR are in `go/vt/vttablet/tabletserver/schema/load_table.go` and `go/vt/mysqlctl/schema.go`. 

Most of the remaining modifications are related to changes in the existing unit tests for mocking the updated queries, in test frameworks and new tests.


## Related Issue(s)
#9783 

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

