### PR TITLE
Sanitize tx serializer log & error messages

### DIFF
--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
@@ -395,7 +395,8 @@ func newQueueForFirstTransaction(concurrentTransactions int) *queue {
 // sensitive info removed.
 // This is needed because the internal key is e.g. 'tbl1 where col1="foo"'
 // and the WHERE clause can contain sensitive information that should not
-// be shown so we we strip everything after the first WHERE clause.
+// be shown so we we strip everything after the first WHERE keyword.
+// e.g. 'tbl1 where col1="foo" and col2="bar"' -> 'tbl1 ... [REDACTED]'
 func (txs *TxSerializer) sanitizeKey(key string) string {
 	var sanitizedKey string
 	whereLoc := strings.Index(strings.ToLower(key), "where")

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -105,9 +105,17 @@ func TestTxSerializerRedactDebugUI(t *testing.T) {
 func TestKeySanitization(t *testing.T) {
 	config := tabletenv.NewDefaultConfig()
 	txs := New(tabletenv.NewEnv(config, "TxSerializerTest"))
+	// with a where clause
 	key := "t1 where c1='foo'"
 	want := "t1 ... [REDACTED]"
 	got := txs.sanitizeKey(key)
+	if got != want {
+		t.Errorf("Key sanitization error: got = %v, want = %v", got, want)
+	}
+	// without a where clause
+	key = "t1"
+	want = "t1"
+	got = txs.sanitizeKey(key)
 	if got != want {
 		t.Errorf("Key sanitization error: got = %v, want = %v", got, want)
 	}

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -110,14 +110,14 @@ func TestKeySanitization(t *testing.T) {
 	want := "t1 ... [REDACTED]"
 	got := txs.sanitizeKey(key)
 	if got != want {
-		t.Errorf("Key sanitization error: got = %v, want = %v", got, want)
+		t.Errorf("key sanitization error: got = %v, want = %v", got, want)
 	}
 	// without a where clause
 	key = "t1"
 	want = "t1"
 	got = txs.sanitizeKey(key)
 	if got != want {
-		t.Errorf("Key sanitization error: got = %v, want = %v", got, want)
+		t.Errorf("key sanitization error: got = %v, want = %v", got, want)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -102,6 +102,17 @@ func TestTxSerializerRedactDebugUI(t *testing.T) {
 	}
 }
 
+func TestKeySanitization(t *testing.T) {
+	config := tabletenv.NewDefaultConfig()
+	txs := New(tabletenv.NewEnv(config, "TxSerializerTest"))
+	key := "t1 where c1='foo'"
+	want := "t1 ... [REDACTED]"
+	got := txs.sanitizeKey(key)
+	if got != want {
+		t.Errorf("Key sanitization error: got = %v, want = %v", got, want)
+	}
+}
+
 func TestTxSerializer(t *testing.T) {
 	config := tabletenv.NewDefaultConfig()
 	config.HotRowProtection.MaxQueueSize = 2


### PR DESCRIPTION
## Description
The transaction serializer — which offers "hot row protection" that can be enabled in vttablets using the [`-enable_hot_row_protection`](https://vitess.io/docs/14.0/reference/programs/vttablet/) flag — logs the `key` for its map at various times. The key consists of the table name and the `WHERE` clause and the `WHERE` clause can contain sensitive info so we should be sanitizing it for log messages when the vttablet [`-sanitize_log_messages`](https://vitess.io/docs/14.0/reference/programs/vttablet/) flag is enabled. 

We should also be sanitizing the key in the returned error message when the vttablet [`-queryserver-config-terse-errors`](https://vitess.io/docs/14.0/reference/programs/vttablet/) flag is enabled.

## Related Issue(s)
 - Fixes: https://github.com/vitessio/vitess/issues/9801


## Checklist
- [x] Should this PR be backported? No
- [x] Tests were added
- [x] Documentation is not required