### PR TITLE
evalengine: more comprehensive type coverage

### DIFF
--- a/go/sqltypes/type.go
+++ b/go/sqltypes/type.go
@@ -98,24 +98,22 @@ func IsNull(t querypb.Type) bool {
 	return t == Null
 }
 
-// Vitess data types. These are idiomatically
-// named synonyms for the querypb.Type values.
-// Although these constants are interchangeable,
-// they should be treated as different from querypb.Type.
-// Use the synonyms only to refer to the type in Value.
-// For proto variables, use the querypb.Type constants
-// instead.
-// The following conditions are non-overlapping
-// and cover all types: IsSigned(), IsUnsigned(),
-// IsFloat(), IsQuoted(), Null, Decimal, Expression, Bit
-// Also, IsIntegral() == (IsSigned()||IsUnsigned()).
-// TestCategory needs to be updated accordingly if
-// you add a new type.
-// If IsBinary or IsText is true, then IsQuoted is
-// also true. But there are IsQuoted types that are
-// neither binary or text.
-// querypb.Type_TUPLE is not included in this list
-// because it's not a valid Value type.
+// Vitess data types. These are idiomatically named synonyms for the querypb.Type values.
+// Although these constants are interchangeable, they should be treated as different from querypb.Type.
+// Use the synonyms only to refer to the type in Value. For proto variables, use the querypb.Type constants instead.
+// The following is a complete listing of types that match each classification function in this API:
+//
+//    IsSigned(): INT8, INT16, INT24, INT32, INT64
+//    IsFloat(): FLOAT32, FLOAT64
+//    IsUnsigned(): UINT8, UINT16, UINT24, UINT32, UINT64, YEAR
+//    IsIntegral(): INT8, UINT8, INT16, UINT16, INT24, UINT24, INT32, UINT32, INT64, UINT64, YEAR
+//    IsText(): TEXT, VARCHAR, CHAR, HEXNUM, HEXVAL
+//    IsNumber(): INT8, UINT8, INT16, UINT16, INT24, UINT24, INT32, UINT32, INT64, UINT64, FLOAT32, FLOAT64, YEAR, DECIMAL
+//    IsQuoted(): TIMESTAMP, DATE, TIME, DATETIME, TEXT, BLOB, VARCHAR, VARBINARY, CHAR, BINARY, ENUM, SET, GEOMETRY, JSON
+//    IsBinary(): BLOB, VARBINARY, BINARY
+//    IsDate(): TIMESTAMP, DATE, TIME, DATETIME
+//    IsNull(): NULL_TYPE
+//
 // TODO(sougou): provide a categorization function
 // that returns enums, which will allow for cleaner
 // switch statements for those who want to cover types

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sqltypes
 
 import (
+	"strings"
 	"testing"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -439,5 +440,69 @@ func TestTypeEquivalenceCheck(t *testing.T) {
 	}
 	if AreTypesEquivalent(Uint16, Int16) {
 		t.Errorf("Uint16 in binlog and Int16 in schema are not equivalent types.")
+	}
+}
+
+func TestPrintTypeChecks(t *testing.T) {
+	var funcs = []struct {
+		name string
+		f    func(p Type) bool
+	}{
+		{"IsSigned", IsSigned},
+		{"IsFloat", IsFloat},
+		{"IsUnsigned", IsUnsigned},
+		{"IsIntegral", IsIntegral},
+		{"IsText", IsText},
+		{"IsNumber", IsNumber},
+		{"IsQuoted", IsQuoted},
+		{"IsBinary", IsBinary},
+		{"IsDate", IsDate},
+		{"IsNull", IsNull},
+	}
+	var types = []Type{
+		Null,
+		Int8,
+		Uint8,
+		Int16,
+		Uint16,
+		Int24,
+		Uint24,
+		Int32,
+		Uint32,
+		Int64,
+		Uint64,
+		Float32,
+		Float64,
+		Timestamp,
+		Date,
+		Time,
+		Datetime,
+		Year,
+		Decimal,
+		Text,
+		Blob,
+		VarChar,
+		VarBinary,
+		Char,
+		Binary,
+		Bit,
+		Enum,
+		Set,
+		Geometry,
+		TypeJSON,
+		Expression,
+		HexNum,
+		HexVal,
+		Tuple,
+	}
+
+	for _, f := range funcs {
+		var match []string
+		for _, tt := range types {
+			if f.f(tt) {
+				match = append(match, tt.String())
+			}
+		}
+		t.Logf("%s(): %s", f.name, strings.Join(match, ", "))
 	}
 }

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -17,6 +17,8 @@ limitations under the License.
 package evalengine
 
 import (
+	"bytes"
+	"strconv"
 	"strings"
 
 	"vitess.io/vitess/go/hack"
@@ -32,6 +34,28 @@ var zeroBytes = []byte("0")
 
 func dataOutOfRangeError(v1, v2 interface{}, typ, sign string) error {
 	return vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.DataOutOfRange, "%s value is out of range in '(%v %s %v)'", typ, v1, sign, v2)
+}
+
+// FormatFloat formats a float64 as a byte string in a similar way to what MySQL does
+func FormatFloat(typ sqltypes.Type, f float64) []byte {
+	format := byte('g')
+	if typ == sqltypes.Decimal {
+		format = 'f'
+	}
+
+	// the float printer in MySQL does not add a positive sign before
+	// the exponent for positive exponents, but the Golang printer does
+	// do that, and there's no way to customize it, so we must strip the
+	// redundant positive sign manually
+	// e.g. 1.234E+56789 -> 1.234E56789
+	fstr := strconv.AppendFloat(nil, f, format, -1, 64)
+	if idx := bytes.IndexByte(fstr, 'e'); idx >= 0 {
+		if fstr[idx+1] == '+' {
+			fstr = append(fstr[:idx+1], fstr[idx+2:]...)
+		}
+	}
+
+	return fstr
 }
 
 // Add adds two values together

--- a/go/vt/vtgate/evalengine/arithmetic_expr.go
+++ b/go/vt/vtgate/evalengine/arithmetic_expr.go
@@ -46,7 +46,7 @@ func (b *ArithmeticExpr) eval(env *ExpressionEnv, out *EvalResult) {
 	var left, right EvalResult
 	left.init(env, b.Left)
 	right.init(env, b.Right)
-	if left.null() || right.null() {
+	if left.isNull() || right.isNull() {
 		out.setNull()
 		return
 	}

--- a/go/vt/vtgate/evalengine/bit.go
+++ b/go/vt/vtgate/evalengine/bit.go
@@ -59,12 +59,12 @@ func (b *BitwiseNotExpr) eval(env *ExpressionEnv, result *EvalResult) {
 	var inner EvalResult
 	inner.init(env, b.Inner)
 
-	if inner.null() {
+	if inner.isNull() {
 		result.setNull()
 		return
 	}
 
-	if inner.bitwiseBinaryString() {
+	if inner.isBitwiseBinaryString() {
 		in := inner.bytes()
 		out := make([]byte, len(in))
 
@@ -176,7 +176,7 @@ func (bit *BitwiseExpr) eval(env *ExpressionEnv, result *EvalResult) {
 	l.init(env, bit.Left)
 	r.init(env, bit.Right)
 
-	if l.null() || r.null() {
+	if l.isNull() || r.isNull() {
 		result.setNull()
 		return
 	}
@@ -212,7 +212,7 @@ func (bit *BitwiseExpr) eval(env *ExpressionEnv, result *EvalResult) {
 			literal, bit literal, or NULL literal. Numeric evaluation occurs otherwise, with argument conversion to an
 			unsigned 64-bit integer as necessary.
 		*/
-		if l.bitwiseBinaryString() {
+		if l.isBitwiseBinaryString() {
 			r.makeUnsignedIntegral()
 			result.setRaw(sqltypes.VarBinary, op.binary(l.bytes(), r.uint64()), collationBinary)
 		} else {

--- a/go/vt/vtgate/evalengine/collate.go
+++ b/go/vt/vtgate/evalengine/collate.go
@@ -75,8 +75,8 @@ func mergeCollations(left, right *EvalResult) (collations.ID, error) {
 		return lc.Collation, nil
 	}
 
-	lt := left.textual()
-	rt := right.textual()
+	lt := left.isTextual()
+	rt := right.isTextual()
 	if !lt || !rt {
 		if lt {
 			return lc.Collation, nil

--- a/go/vt/vtgate/evalengine/convert.go
+++ b/go/vt/vtgate/evalengine/convert.go
@@ -53,7 +53,7 @@ func (c *ConvertExpr) unsupported() {
 
 func (c *ConvertExpr) eval(env *ExpressionEnv, result *EvalResult) {
 	result.init(env, c.Inner)
-	if result.null() {
+	if result.isNull() {
 		result.resolve()
 		return
 	}
@@ -137,7 +137,7 @@ func (c *ConvertExpr) typeof(env *ExpressionEnv) (sqltypes.Type, flag) {
 
 func (c *ConvertUsingExpr) eval(env *ExpressionEnv, result *EvalResult) {
 	result.init(env, c.Inner)
-	if result.null() {
+	if result.isNull() {
 		result.resolve()
 	} else {
 		result.makeTextualAndConvert(c.Collation)

--- a/go/vt/vtgate/evalengine/eval_result.go
+++ b/go/vt/vtgate/evalengine/eval_result.go
@@ -17,7 +17,6 @@ limitations under the License.
 package evalengine
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -141,8 +140,8 @@ func (er *EvalResult) hasFlag(f flag) bool {
 	return (er.flags_ & f) != 0
 }
 
-func (er *EvalResult) bitwiseBinaryString() bool {
-	return er.typeof() == sqltypes.VarBinary && !er.hasFlag(flagHex|flagBit)
+func (er *EvalResult) clearFlags(f flag) {
+	er.flags_ &= ^f
 }
 
 func (er *EvalResult) collation() collations.TypedCollation {
@@ -186,21 +185,10 @@ func (er *EvalResult) string() string {
 }
 
 func (er *EvalResult) value() sqltypes.Value {
-	if er.null() {
+	if er.isNull() {
 		return sqltypes.NULL
 	}
 	return sqltypes.MakeTrusted(er.typeof(), er.toRawBytes())
-}
-
-func (er *EvalResult) null() bool {
-	if !er.hasFlag(flagNullable) {
-		return false
-	}
-	if er.hasFlag(flagNull) {
-		return true
-	}
-	er.resolve()
-	return er.hasFlag(flagNull)
 }
 
 func (er *EvalResult) setNull() {
@@ -291,6 +279,54 @@ func (er *EvalResult) setTuple(t []EvalResult) {
 	er.collation_ = collations.TypedCollation{}
 }
 
+func (er *EvalResult) isHexLiteral() bool {
+	return sqltypes.IsBinary(er.typeof()) && er.hasFlag(flagHex)
+}
+
+func (er *EvalResult) isNumeric() bool {
+	return sqltypes.IsNumber(er.typeof())
+}
+
+func (er *EvalResult) isBitwiseBinaryString() bool {
+	return sqltypes.IsBinary(er.typeof()) && !er.hasFlag(flagHex|flagBit)
+}
+
+func (er *EvalResult) isNull() bool {
+	if !er.hasFlag(flagNullable) {
+		return false
+	}
+	if er.hasFlag(flagNull) {
+		return true
+	}
+	er.resolve()
+	return er.hasFlag(flagNull)
+}
+
+func (er *EvalResult) isTextual() bool {
+	tt := er.typeof()
+	return sqltypes.IsText(tt) || sqltypes.IsBinary(tt)
+}
+
+func (er *EvalResult) isTruthy() boolean {
+	if er.isNull() {
+		return boolNULL
+	}
+	switch tt := er.typeof(); {
+	case sqltypes.IsIntegral(tt):
+		return makeboolean(er.uint64() != 0)
+	case sqltypes.IsFloat(tt):
+		return makeboolean(er.float64() != 0.0)
+	case tt == sqltypes.Decimal:
+		return makeboolean(!er.decimal().IsZero())
+	case sqltypes.IsBinary(tt) || sqltypes.IsText(tt):
+		return makeboolean(parseStringToFloat(er.string()) != 0.0)
+	case tt == sqltypes.Tuple:
+		panic("did not typecheck tuples")
+	default:
+		return boolTrue
+	}
+}
+
 func (er *EvalResult) makeBinary() {
 	er.resolve()
 	if er.bytes_ == nil {
@@ -299,10 +335,6 @@ func (er *EvalResult) makeBinary() {
 	er.type_ = int16(sqltypes.VarBinary)
 	er.collation_ = collationBinary
 	er.clearFlags(flagBit | flagHex)
-}
-
-func (er *EvalResult) clearFlags(f flag) {
-	er.flags_ &= ^f
 }
 
 func (er *EvalResult) makeTextual(collation collations.ID) {
@@ -339,8 +371,8 @@ func (er *EvalResult) makeTextualAndConvert(collation collations.ID) bool {
 }
 
 func (er *EvalResult) truncate(size int) {
-	switch er.typeof() {
-	case sqltypes.VarBinary:
+	switch tt := er.typeof(); {
+	case sqltypes.IsBinary(tt):
 		if size > len(er.bytes_) {
 			pad := make([]byte, size)
 			copy(pad, er.bytes_)
@@ -348,7 +380,7 @@ func (er *EvalResult) truncate(size int) {
 		} else {
 			er.bytes_ = er.bytes_[:size]
 		}
-	case sqltypes.VarChar:
+	case sqltypes.IsText(tt):
 		collation := collations.Local().LookupByID(er.collation().Collation)
 		er.bytes_ = collations.Slice(collation, er.bytes_, 0, size)
 	default:
@@ -360,132 +392,23 @@ func (er *EvalResult) replaceCollation(collation collations.TypedCollation) {
 	er.collation_ = collation
 }
 
-// Value allows for retrieval of the value we expose for public consumption
-func (er *EvalResult) Value() sqltypes.Value {
-	if er.expr != nil {
-		panic("did not resolve EvalResult after evaluation")
-	}
-	return er.value()
-}
-
-// TupleValues allows for retrieval of the value we expose for public consumption
-func (er *EvalResult) TupleValues() []sqltypes.Value {
-	if er.expr != nil {
-		panic("did not resolve EvalResult after evaluation")
-	}
-	if er.tuple_ == nil {
-		return nil
-	}
-
-	values := *er.tuple_
-	result := make([]sqltypes.Value, 0, len(values))
-	for _, val := range values {
-		result = append(result, val.value())
-	}
-	return result
-}
-
 // debugString prints the entire EvalResult in a debug format
 func (er *EvalResult) debugString() string {
 	return fmt.Sprintf("(%s) 0x%08x %s", sqltypes.Type(er.type_).String(), er.numeric_, er.bytes_)
 }
 
-// ToBooleanStrict is used when the casting to a boolean has to be minimally forgiving,
-// such as when assigning to a system variable that is expected to be a boolean
-func (er *EvalResult) ToBooleanStrict() (bool, error) {
-	if er.expr != nil {
-		panic("did not resolve EvalResult after evaluation")
-	}
-
-	intToBool := func(i uint64) (bool, error) {
-		switch i {
-		case 0:
-			return false, nil
-		case 1:
-			return true, nil
-		default:
-			return false, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%d is not a boolean", i)
-		}
-	}
-
-	switch er.typeof() {
-	case sqltypes.Int8, sqltypes.Int16, sqltypes.Int32, sqltypes.Int64:
-		return intToBool(er.uint64())
-	case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint32, sqltypes.Uint64:
-		return intToBool(er.uint64())
-	case sqltypes.VarBinary, sqltypes.VarChar:
-		lower := strings.ToLower(er.string())
-		switch lower {
-		case "on":
-			return true, nil
-		case "off":
-			return false, nil
-		default:
-			return false, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "'%s' is not a boolean", lower)
-		}
-	}
-	return false, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "'%s' is not a boolean", er.string())
-}
-
-func (er *EvalResult) textual() bool {
-	tt := er.typeof()
-	return sqltypes.IsText(tt) || sqltypes.IsBinary(tt)
-}
-
-func (er *EvalResult) truthy() boolean {
-	if er.null() {
-		return boolNULL
-	}
-	switch er.typeof() {
-	case sqltypes.Int8, sqltypes.Int16, sqltypes.Int32, sqltypes.Int64, sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint32, sqltypes.Uint64:
-		return makeboolean(er.uint64() != 0)
-	case sqltypes.Float64, sqltypes.Float32:
-		return makeboolean(er.float64() != 0.0)
-	case sqltypes.Decimal:
-		return makeboolean(!er.decimal().IsZero())
-	case sqltypes.VarBinary, sqltypes.VarChar:
-		return makeboolean(parseStringToFloat(er.string()) != 0.0)
-	case sqltypes.Tuple:
-		panic("did not typecheck tuples")
-	default:
-		return boolTrue
-	}
-}
-
-// FormatFloat formats a float64 as a byte string in a similar way to what MySQL does
-func FormatFloat(typ sqltypes.Type, f float64) []byte {
-	format := byte('g')
-	if typ == sqltypes.Decimal {
-		format = 'f'
-	}
-
-	// the float printer in MySQL does not add a positive sign before
-	// the exponent for positive exponents, but the Golang printer does
-	// do that, and there's no way to customize it, so we must strip the
-	// redundant positive sign manually
-	// e.g. 1.234E+56789 -> 1.234E56789
-	fstr := strconv.AppendFloat(nil, f, format, -1, 64)
-	if idx := bytes.IndexByte(fstr, 'e'); idx >= 0 {
-		if fstr[idx+1] == '+' {
-			fstr = append(fstr[:idx+1], fstr[idx+2:]...)
-		}
-	}
-
-	return fstr
-}
-
 func (er *EvalResult) toRawBytes() []byte {
-	if er.null() {
+	if er.isNull() {
 		return nil
 	}
-	switch er.typeof() {
-	case sqltypes.Int64, sqltypes.Int32:
+	switch tt := er.typeof(); {
+	case sqltypes.IsSigned(tt):
 		return strconv.AppendInt(nil, er.int64(), 10)
-	case sqltypes.Uint64, sqltypes.Uint32:
+	case sqltypes.IsUnsigned(tt):
 		return strconv.AppendUint(nil, er.uint64(), 10)
-	case sqltypes.Float64, sqltypes.Float32:
+	case sqltypes.IsFloat(tt):
 		return FormatFloat(sqltypes.Float64, er.float64())
-	case sqltypes.Decimal:
+	case tt == sqltypes.Decimal:
 		return er.decimal().FormatMySQL(er.length_)
 	default:
 		return er.bytes()
@@ -495,30 +418,30 @@ func (er *EvalResult) toRawBytes() []byte {
 func (er *EvalResult) toSQLValue(resultType sqltypes.Type) sqltypes.Value {
 	switch {
 	case sqltypes.IsSigned(resultType):
-		switch er.typeof() {
-		case sqltypes.Int64, sqltypes.Int32:
+		switch tt := er.typeof(); {
+		case sqltypes.IsSigned(tt):
 			return sqltypes.MakeTrusted(resultType, strconv.AppendInt(nil, er.int64(), 10))
-		case sqltypes.Uint64, sqltypes.Uint32:
+		case sqltypes.IsUnsigned(tt):
 			return sqltypes.MakeTrusted(resultType, strconv.AppendInt(nil, er.int64(), 10))
-		case sqltypes.Float64, sqltypes.Float32:
+		case sqltypes.IsFloat(tt):
 			return sqltypes.MakeTrusted(resultType, strconv.AppendInt(nil, int64(er.float64()), 10))
 		}
 	case sqltypes.IsUnsigned(resultType):
-		switch er.typeof() {
-		case sqltypes.Uint64, sqltypes.Uint32, sqltypes.Int64, sqltypes.Int32:
+		switch tt := er.typeof(); {
+		case sqltypes.IsIntegral(tt):
 			return sqltypes.MakeTrusted(resultType, strconv.AppendUint(nil, er.uint64(), 10))
-		case sqltypes.Float64, sqltypes.Float32:
+		case sqltypes.IsFloat(tt):
 			return sqltypes.MakeTrusted(resultType, strconv.AppendUint(nil, uint64(er.float64()), 10))
 		}
 	case sqltypes.IsFloat(resultType) || resultType == sqltypes.Decimal:
-		switch er.typeof() {
-		case sqltypes.Int64, sqltypes.Int32:
+		switch tt := er.typeof(); {
+		case sqltypes.IsSigned(tt):
 			return sqltypes.MakeTrusted(resultType, strconv.AppendInt(nil, er.int64(), 10))
-		case sqltypes.Uint64, sqltypes.Uint32:
+		case sqltypes.IsUnsigned(tt):
 			return sqltypes.MakeTrusted(resultType, strconv.AppendUint(nil, er.uint64(), 10))
-		case sqltypes.Float64, sqltypes.Float32:
+		case sqltypes.IsFloat(tt):
 			return sqltypes.MakeTrusted(resultType, FormatFloat(resultType, er.float64()))
-		case sqltypes.Decimal:
+		case tt == sqltypes.Decimal:
 			dec := er.decimal()
 			return sqltypes.MakeTrusted(resultType, dec.FormatMySQL(er.length_))
 		}
@@ -531,19 +454,15 @@ func (er *EvalResult) toSQLValue(resultType sqltypes.Type) sqltypes.Value {
 // HashCode is a type alias to the code easier to read
 type HashCode = uintptr
 
-func (er *EvalResult) numeric() bool {
-	return sqltypes.IsNumber(er.typeof())
-}
-
 func (er *EvalResult) nullSafeHashcode() (HashCode, error) {
 	er.resolve()
 
 	switch {
-	case er.null():
+	case er.isNull():
 		return HashCode(math.MaxUint64), nil
-	case er.numeric():
+	case er.isNumeric():
 		return HashCode(er.uint64()), nil
-	case er.textual():
+	case er.isTextual():
 		coll := collations.Local().LookupByID(er.collation().Collation)
 		if coll == nil {
 			return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "text type with an unknown/unsupported collation cannot be hashed")
@@ -655,68 +574,72 @@ func (er *EvalResult) setValueCast(v sqltypes.Value, typ sqltypes.Type) error {
 func (er *EvalResult) setValueIntegralNumeric(v sqltypes.Value) error {
 	switch {
 	case v.IsSigned():
-		ival, err := strconv.ParseInt(v.RawStr(), 10, 64)
+		ival, err := v.ToInt64()
 		if err != nil {
 			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v", err)
 		}
 		er.setInt64(ival)
 		return nil
 	case v.IsUnsigned():
-		uval, err := strconv.ParseUint(v.RawStr(), 10, 64)
+		var uval uint64
+		uval, err := v.ToUint64()
 		if err != nil {
 			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v", err)
 		}
 		er.setUint64(uval)
 		return nil
+	default:
+		uval, err := strconv.ParseUint(v.RawStr(), 10, 64)
+		if err == nil {
+			er.setUint64(uval)
+			return nil
+		}
+		ival, err := strconv.ParseInt(v.RawStr(), 10, 64)
+		if err == nil {
+			er.setInt64(ival)
+			return nil
+		}
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "could not parse value: '%s'", v.RawStr())
 	}
-
-	// For other types, do best effort.
-	if ival, err := strconv.ParseInt(v.RawStr(), 10, 64); err == nil {
-		er.setInt64(ival)
-		return nil
-	}
-	if uval, err := strconv.ParseUint(v.RawStr(), 10, 64); err == nil {
-		er.setUint64(uval)
-		return nil
-	}
-	return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "could not parse value: '%s'", v.RawStr())
 }
 
 func (er *EvalResult) setValue(value sqltypes.Value, collation collations.TypedCollation) error {
 	var err error
-	switch value.Type() {
-	case sqltypes.Int8, sqltypes.Int16, sqltypes.Int24, sqltypes.Int32, sqltypes.Int64:
+	switch tt := value.Type(); {
+	case sqltypes.IsSigned(tt):
 		var ival int64
 		ival, err = value.ToInt64()
 		er.setInt64(ival)
-	case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint24, sqltypes.Uint32, sqltypes.Uint64:
+	case sqltypes.IsUnsigned(tt):
 		var uval uint64
 		uval, err = value.ToUint64()
 		er.setUint64(uval)
-	case sqltypes.Float32, sqltypes.Float64:
+	case sqltypes.IsFloat(tt):
 		var fval float64
 		fval, err = value.ToFloat64()
 		er.setFloat(fval)
-	case sqltypes.Decimal:
+	case tt == sqltypes.Decimal:
 		var dec decimal.Decimal
 		dec, err = decimal.NewFromMySQL(value.Raw())
 		er.setDecimal(dec, -dec.Exponent())
-	case sqltypes.HexNum:
-		var raw []byte
-		raw, err = parseHexNumber(value.Raw())
-		er.setBinaryHex(raw)
-	case sqltypes.HexVal:
-		var hex = value.Raw()
-		var raw []byte
-		raw, err = parseHexLiteral(hex[2 : len(hex)-1])
-		er.setBinaryHex(raw)
-	case sqltypes.VarChar, sqltypes.Text:
-		er.setRaw(sqltypes.VarChar, value.Raw(), collation)
-	case sqltypes.VarBinary:
+	case sqltypes.IsText(tt):
+		if tt == sqltypes.HexNum {
+			var raw []byte
+			raw, err = parseHexNumber(value.Raw())
+			er.setBinaryHex(raw)
+		} else if tt == sqltypes.HexVal {
+			var hex = value.Raw()
+			var raw []byte
+			raw, err = parseHexLiteral(hex[2 : len(hex)-1])
+			er.setBinaryHex(raw)
+		} else {
+			er.setRaw(sqltypes.VarChar, value.Raw(), collation)
+		}
+	case sqltypes.IsBinary(tt):
 		er.setRaw(sqltypes.VarBinary, value.Raw(), collationBinary)
-	case sqltypes.Time, sqltypes.Datetime, sqltypes.Timestamp, sqltypes.Date:
+	case sqltypes.IsDate(tt):
 		er.setRaw(value.Type(), value.Raw(), collationNumeric)
-	case sqltypes.Null:
+	case sqltypes.IsNull(tt):
 		er.setNull()
 	default:
 		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Type is not supported: %q %s", value, value.Type())
@@ -778,14 +701,14 @@ func NullsafeHashcode(v sqltypes.Value, collation collations.ID, coerceType sqlt
 
 func (er *EvalResult) makeFloat() {
 	er.makeNumeric()
-	switch er.typeof() {
-	case sqltypes.Float64, sqltypes.Float32:
-	case sqltypes.Decimal:
+	switch tt := er.typeof(); {
+	case sqltypes.IsFloat(tt):
+	case tt == sqltypes.Decimal:
 		f, _ := er.coerceDecimalToFloat()
 		er.setFloat(f)
-	case sqltypes.Uint64:
+	case sqltypes.IsUnsigned(tt):
 		er.setFloat(float64(er.uint64()))
-	case sqltypes.Int64:
+	case sqltypes.IsSigned(tt):
 		er.setFloat(float64(er.int64()))
 	}
 }
@@ -794,27 +717,22 @@ func (er *EvalResult) makeDecimal(m, d int32) {
 	er.makeNumeric()
 
 	var dec decimal.Decimal
-	switch er.typeof() {
-	case sqltypes.Decimal:
+	switch tt := er.typeof(); {
+	case tt == sqltypes.Decimal:
 		dec = er.decimal()
-	case sqltypes.Float64, sqltypes.Float32:
+	case sqltypes.IsFloat(tt):
 		dec = decimal.NewFromFloatMySQL(er.float64())
-	case sqltypes.Int64:
+	case sqltypes.IsSigned(tt):
 		dec = decimal.NewFromInt(er.int64())
-	case sqltypes.Uint64:
+	case sqltypes.IsUnsigned(tt):
 		dec = decimal.NewFromUint(er.uint64())
 	}
-
 	er.setDecimal(dec.Clamp(m-d, d), d)
-}
-
-func (er *EvalResult) isHexLiteral() bool {
-	return er.typeof() == sqltypes.VarBinary && er.hasFlag(flagHex)
 }
 
 func (er *EvalResult) makeNumeric() {
 	er.resolve()
-	if er.numeric() {
+	if er.isNumeric() {
 		return
 	}
 	if er.isHexLiteral() {
@@ -838,15 +756,13 @@ func (er *EvalResult) makeNumeric() {
 
 func (er *EvalResult) makeUnsignedIntegral() {
 	er.makeNumeric()
-	switch er.typeof() {
-	case sqltypes.Uint64:
-		// noop
-	case sqltypes.Int64:
+	switch tt := er.typeof(); {
+	case sqltypes.IsIntegral(tt):
 		er.type_ = int16(sqltypes.Uint64)
-	case sqltypes.Float64:
+	case sqltypes.IsFloat(tt):
 		f := math.Round(er.float64())
 		er.setUint64(uint64(f))
-	case sqltypes.Decimal:
+	case tt == sqltypes.Decimal:
 		dec := er.decimal().Round(0)
 		if dec.Sign() < 0 {
 			i, _ := dec.Int64()
@@ -862,15 +778,13 @@ func (er *EvalResult) makeUnsignedIntegral() {
 
 func (er *EvalResult) makeSignedIntegral() {
 	er.makeNumeric()
-	switch er.typeof() {
-	case sqltypes.Int64:
-		// noop
-	case sqltypes.Uint64:
+	switch tt := er.typeof(); {
+	case sqltypes.IsIntegral(tt):
 		er.type_ = int16(sqltypes.Int64)
-	case sqltypes.Float64:
+	case sqltypes.IsFloat(tt):
 		f := math.Round(er.float64())
 		er.setInt64(int64(f))
-	case sqltypes.Decimal:
+	case tt == sqltypes.Decimal:
 		dec := er.decimal().Round(0)
 		i, _ := dec.Int64()
 		er.setInt64(i)
@@ -881,8 +795,8 @@ func (er *EvalResult) makeSignedIntegral() {
 
 func (er *EvalResult) negateNumeric() {
 	er.makeNumeric()
-	switch er.typeof() {
-	case sqltypes.Int8, sqltypes.Int16, sqltypes.Int32, sqltypes.Int64:
+	switch tt := er.typeof(); {
+	case sqltypes.IsSigned(tt):
 		i := er.int64()
 		if er.hasFlag(flagIntegerUdf) {
 			dec := decimal.NewFromInt(i).NegInPlace()
@@ -890,7 +804,7 @@ func (er *EvalResult) negateNumeric() {
 		} else {
 			er.setInt64(-i)
 		}
-	case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint32, sqltypes.Uint64:
+	case sqltypes.IsUnsigned(tt):
 		u := er.uint64()
 		if er.hasFlag(flagHex) {
 			er.setFloat(-float64(u))
@@ -900,9 +814,9 @@ func (er *EvalResult) negateNumeric() {
 		} else {
 			er.setInt64(-int64(u))
 		}
-	case sqltypes.Float32, sqltypes.Float64:
+	case sqltypes.IsFloat(tt):
 		er.setFloat(-er.float64())
-	case sqltypes.Decimal:
+	case tt == sqltypes.Decimal:
 		if !er.decimal_.IsZero() {
 			er.decimal_ = er.decimal_.Neg()
 		}
@@ -914,12 +828,12 @@ func (er *EvalResult) coerceDecimalToFloat() (float64, bool) {
 }
 
 func (er *EvalResult) coerceToFloat() (float64, error) {
-	switch er.typeof() {
-	case sqltypes.Int64:
+	switch tt := er.typeof(); {
+	case sqltypes.IsSigned(tt):
 		return float64(er.int64()), nil
-	case sqltypes.Uint64:
+	case sqltypes.IsUnsigned(tt):
 		return float64(er.uint64()), nil
-	case sqltypes.Decimal:
+	case tt == sqltypes.Decimal:
 		if f, ok := er.coerceDecimalToFloat(); ok {
 			return f, nil
 		}
@@ -930,14 +844,14 @@ func (er *EvalResult) coerceToFloat() (float64, error) {
 }
 
 func (er *EvalResult) coerceToDecimal() decimal.Decimal {
-	switch er.typeof() {
-	case sqltypes.Int64:
+	switch tt := er.typeof(); {
+	case sqltypes.IsSigned(tt):
 		return decimal.NewFromInt(er.int64())
-	case sqltypes.Uint64:
+	case sqltypes.IsUnsigned(tt):
 		return decimal.NewFromUint(er.uint64())
-	case sqltypes.Float64:
+	case sqltypes.IsFloat(tt):
 		panic("should never coerce FLOAT64 to DECIMAL")
-	case sqltypes.Decimal:
+	case tt == sqltypes.Decimal:
 		return er.decimal()
 	default:
 		panic("bad numeric type")
@@ -987,4 +901,59 @@ func (er *EvalResult) unborrow() {
 	er.flags_ = 0
 	er.type_ = 0
 	evalResultPool.Put(er)
+}
+
+// Value allows for retrieval of the value we expose for public consumption
+func (er *EvalResult) Value() sqltypes.Value {
+	if er.expr != nil {
+		panic("did not resolve EvalResult after evaluation")
+	}
+	return er.value()
+}
+
+// TupleValues allows for retrieval of the value we expose for public consumption
+func (er *EvalResult) TupleValues() []sqltypes.Value {
+	if er.expr != nil {
+		panic("did not resolve EvalResult after evaluation")
+	}
+	if er.tuple_ == nil {
+		return nil
+	}
+
+	values := *er.tuple_
+	result := make([]sqltypes.Value, 0, len(values))
+	for _, val := range values {
+		result = append(result, val.value())
+	}
+	return result
+}
+
+// ToBooleanStrict is used when the casting to a boolean has to be minimally forgiving,
+// such as when assigning to a system variable that is expected to be a boolean
+func (er *EvalResult) ToBooleanStrict() (bool, error) {
+	if er.expr != nil {
+		panic("did not resolve EvalResult after evaluation")
+	}
+
+	switch tt := er.typeof(); {
+	case sqltypes.IsIntegral(tt):
+		switch er.uint64() {
+		case 0:
+			return false, nil
+		case 1:
+			return true, nil
+		default:
+			return false, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%d is not a boolean", er.uint64())
+		}
+	case sqltypes.IsText(tt) || sqltypes.IsBinary(tt):
+		switch strings.ToLower(er.string()) {
+		case "on":
+			return true, nil
+		case "off":
+			return false, nil
+		default:
+			return false, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "'%s' is not a boolean", er.string())
+		}
+	}
+	return false, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "'%s' is not a boolean", er.string())
 }

--- a/go/vt/vtgate/evalengine/evalengine.go
+++ b/go/vt/vtgate/evalengine/evalengine.go
@@ -288,7 +288,7 @@ func compareDateAndString(l, r *EvalResult) (int, error) {
 		if err != nil {
 			return 0, err
 		}
-	case l.textual():
+	case l.isTextual():
 		rTime, err = parseDate(r)
 		if err != nil {
 			return 0, err

--- a/go/vt/vtgate/evalengine/func.go
+++ b/go/vt/vtgate/evalengine/func.go
@@ -72,7 +72,7 @@ type builtinCoalesce struct{}
 
 func (builtinCoalesce) call(_ *ExpressionEnv, args []EvalResult, result *EvalResult) {
 	for _, arg := range args {
-		if !arg.null() {
+		if !arg.isNull() {
 			*result = arg
 			result.resolve()
 			return
@@ -107,7 +107,7 @@ func getMultiComparisonFunc(args []EvalResult) multiComparisonFunc {
 
 	for i := range args {
 		arg := &args[i]
-		if arg.null() {
+		if arg.isNull() {
 			return func(args []EvalResult, result *EvalResult, cmp int) {
 				result.setNull()
 			}
@@ -349,7 +349,7 @@ func builtinIsNullRewrite(args []Expr, lookup TranslationLookup) (Expr, error) {
 	return &IsExpr{
 		UnaryExpr: UnaryExpr{args[0]},
 		Op:        sqlparser.IsNullOp,
-		Check:     func(er *EvalResult) bool { return er.null() },
+		Check:     func(er *EvalResult) bool { return er.isNull() },
 	}, nil
 }
 
@@ -359,12 +359,12 @@ func (builtinBitCount) call(_ *ExpressionEnv, args []EvalResult, result *EvalRes
 	var count int
 	inarg := &args[0]
 
-	if inarg.null() {
+	if inarg.isNull() {
 		result.setNull()
 		return
 	}
 
-	if inarg.bitwiseBinaryString() {
+	if inarg.isBitwiseBinaryString() {
 		binary := inarg.bytes()
 		for _, b := range binary {
 			count += bits.OnesCount8(b)

--- a/go/vt/vtgate/evalengine/hex.go
+++ b/go/vt/vtgate/evalengine/hex.go
@@ -61,7 +61,7 @@ type builtinHex struct{}
 
 func (builtinHex) call(env *ExpressionEnv, args []EvalResult, result *EvalResult) {
 	tohex := &args[0]
-	if tohex.null() {
+	if tohex.isNull() {
 		result.setNull()
 	}
 

--- a/go/vt/vtgate/evalengine/logical.go
+++ b/go/vt/vtgate/evalengine/logical.go
@@ -127,7 +127,7 @@ func (left boolean) xor(right boolean) boolean {
 func (n *NotExpr) eval(env *ExpressionEnv, out *EvalResult) {
 	var inner EvalResult
 	inner.init(env, n.Inner)
-	out.setBoolean(inner.truthy().not())
+	out.setBoolean(inner.isTruthy().not())
 }
 
 func (n *NotExpr) typeof(env *ExpressionEnv) (sqltypes.Type, flag) {
@@ -142,7 +142,7 @@ func (l *LogicalExpr) eval(env *ExpressionEnv, out *EvalResult) {
 	if left.typeof() == sqltypes.Tuple || right.typeof() == sqltypes.Tuple {
 		panic("did not typecheck tuples")
 	}
-	out.setBoolean(l.op(left.truthy(), right.truthy()))
+	out.setBoolean(l.op(left.isTruthy(), right.isTruthy()))
 }
 
 func (l *LogicalExpr) typeof(env *ExpressionEnv) (sqltypes.Type, flag) {

--- a/go/vt/vtgate/evalengine/simplify.go
+++ b/go/vt/vtgate/evalengine/simplify.go
@@ -81,7 +81,7 @@ func (expr *LikeExpr) simplify(env *ExpressionEnv) error {
 	}
 
 	lit2, _ := expr.Right.(*Literal)
-	if lit2 != nil && lit2.Val.textual() {
+	if lit2 != nil && lit2.Val.isTextual() {
 		expr.MatchCollation = lit2.Val.collation().Collation
 		coll := collations.Local().LookupByID(expr.MatchCollation)
 		expr.Match = coll.Wildcard(lit2.Val.bytes(), 0, 0, 0)

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -140,17 +140,17 @@ func translateIsExpr(left sqlparser.Expr, op sqlparser.IsExprOperator, lookup Tr
 
 	switch op {
 	case sqlparser.IsNullOp:
-		check = func(er *EvalResult) bool { return er.null() }
+		check = func(er *EvalResult) bool { return er.isNull() }
 	case sqlparser.IsNotNullOp:
-		check = func(er *EvalResult) bool { return !er.null() }
+		check = func(er *EvalResult) bool { return !er.isNull() }
 	case sqlparser.IsTrueOp:
-		check = func(er *EvalResult) bool { return er.truthy() == boolTrue }
+		check = func(er *EvalResult) bool { return er.isTruthy() == boolTrue }
 	case sqlparser.IsNotTrueOp:
-		check = func(er *EvalResult) bool { return er.truthy() != boolTrue }
+		check = func(er *EvalResult) bool { return er.isTruthy() != boolTrue }
 	case sqlparser.IsFalseOp:
-		check = func(er *EvalResult) bool { return er.truthy() == boolFalse }
+		check = func(er *EvalResult) bool { return er.isTruthy() == boolFalse }
 	case sqlparser.IsNotFalseOp:
-		check = func(er *EvalResult) bool { return er.truthy() != boolFalse }
+		check = func(er *EvalResult) bool { return er.isTruthy() != boolFalse }
 	}
 
 	return &IsExpr{


### PR DESCRIPTION
## Description

Since we've started using the evaluation engine for VDiff, @mattlord has found several issues where our type coverage was not good enough and we were failing to operate on types that were (in theory) supported but that we failed to handle because our type checks where too constricted (e.g. `TEXT` vs `CHAR` vs `VARCHAR`).

This PR attempts to fix any further cases that may come up in the future by switching the `evalengine` to using the `sqltypes.IsXXX` category checks instead of explicitly comparing against specific types. It also cleans up some technical debt by renaming some helper methods which were IMO a bit confusing.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->