### PR TITLE
evalengine: Support built-in MySQL function Abs

### DIFF
--- a/go/vt/vtgate/evalengine/comparisons_test.go
+++ b/go/vt/vtgate/evalengine/comparisons_test.go
@@ -18,6 +18,7 @@ package evalengine
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -1302,4 +1303,80 @@ func BenchmarkNullSafeComparison(b *testing.B) {
 			}
 		}
 	})
+}
+
+func TestAbsCall(t *testing.T) {
+	type args struct {
+		env    *ExpressionEnv
+		args   []EvalResult
+		result *EvalResult
+	}
+
+	tests := []struct {
+		name string
+		args args
+		err  string
+	}{
+		{name: "test_int64_(0)", args: args{
+			env: nil,
+			args: []EvalResult{
+				newEvalInt64(0),
+			},
+			result: &EvalResult{},
+		}},
+		{name: "test_int64_(1)", args: args{
+			env: nil,
+			args: []EvalResult{
+				newEvalInt64(1),
+			},
+			result: &EvalResult{},
+		}},
+		{name: "test_int64_(-2)", args: args{
+			env: nil,
+			args: []EvalResult{
+				newEvalInt64(-2),
+			},
+			result: &EvalResult{},
+		}}, {name: "test_int64_(-9223372036854775807)", args: args{
+			env: nil,
+			args: []EvalResult{
+				newEvalInt64(-9223372036854775807),
+			},
+			result: &EvalResult{},
+		},
+		},
+		{name: "test_int64_(math.MinInt64)", args: args{
+			env: nil,
+			args: []EvalResult{
+				newEvalInt64(math.MinInt64),
+			},
+			result: &EvalResult{},
+		},
+		},
+		{name: "test_float_(-1.2)", args: args{
+			env: nil,
+			args: []EvalResult{
+				newEvalFloat(-1.2),
+			},
+			result: &EvalResult{},
+		},
+		}, {name: "test_float_(-1.5e1)", args: args{
+			env: nil,
+			args: []EvalResult{
+				newEvalFloat(-1.5e1),
+			},
+			result: &EvalResult{},
+		},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if err := recover(); err != nil {
+				}
+			}()
+			bu := builtinAbs{}
+			bu.call(tt.args.env, tt.args.args, tt.args.result)
+		})
+	}
 }

--- a/go/vt/vtgate/evalengine/func.go
+++ b/go/vt/vtgate/evalengine/func.go
@@ -398,6 +398,50 @@ func (c *WeightStringCallExpr) typeof(env *ExpressionEnv) (sqltypes.Type, flag) 
 	return sqltypes.VarBinary, f
 }
 
+type builtinAbs struct{}
+
+func (builtinAbs) call(env *ExpressionEnv, args []EvalResult, result *EvalResult) {
+	toabs := &args[0]
+	if toabs.null() {
+		result.setNull()
+		return
+	}
+
+	switch toabs.typeof() {
+	case sqltypes.Int64:
+		res := toabs.int64()
+		if res >= 0 {
+			result.setInt64(res)
+		} else {
+			if res == math.MinInt64 {
+				//Same to mysql, return out of range error
+				throwEvalError(vterrors.Errorf(vtrpcpb.Code_OUT_OF_RANGE, "BIGINT value is out of range in: %s", toabs.String()))
+			} else {
+				result.setInt64(-res)
+			}
+		}
+	case sqltypes.Decimal:
+		res := toabs.decimal()
+		res = res.Abs()
+		result.setDecimal(res, toabs.length_)
+	case sqltypes.Float64:
+		res := toabs.float64()
+		res = math.Abs(res)
+		result.setFloat(res)
+	default:
+		throwEvalError(vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "Unsupported ABS argument: %s", toabs.String()))
+	}
+}
+
+func (builtinAbs) typeof(env *ExpressionEnv, args []Expr) (sqltypes.Type, flag) {
+	if len(args) < 1 {
+		throwArgError("ABS")
+	}
+
+	tt, f := args[0].typeof(env)
+	return tt, f
+}
+
 func (c *WeightStringCallExpr) eval(env *ExpressionEnv, result *EvalResult) {
 	var (
 		str     EvalResult

--- a/go/vt/vtgate/evalengine/internal/decimal/decimal.go
+++ b/go/vt/vtgate/evalengine/internal/decimal/decimal.go
@@ -264,8 +264,8 @@ func (d Decimal) rescale(exp int32) Decimal {
 	return Decimal{value: value, exp: exp}
 }
 
-// abs returns the absolute value of the decimal.
-func (d Decimal) abs() Decimal {
+// Abs returns the absolute value of the decimal.
+func (d Decimal) Abs() Decimal {
 	if d.Sign() >= 0 {
 		return d
 	}
@@ -436,7 +436,7 @@ func (d Decimal) divRound(d2 Decimal, precision int32) Decimal {
 	// now rv2 = abs(r.value) * 2
 	r2 := Decimal{value: &rv2, exp: r.exp + precision}
 	// r2 is now 2 * r * 10 ^ precision
-	var c = r2.Cmp(d2.abs())
+	var c = r2.Cmp(d2.Abs())
 
 	if c < 0 {
 		return q

--- a/go/vt/vtgate/evalengine/internal/decimal/decimal_test.go
+++ b/go/vt/vtgate/evalengine/internal/decimal/decimal_test.go
@@ -761,7 +761,7 @@ func TestDecimal_QuoRem(t *testing.T) {
 			t.Errorf("quotient wrong precision: d=%v, d2= %v, prec=%d, q=%v, r=%v",
 				d, d2, prec, q, r)
 		}
-		if r.abs().Cmp(d2.abs().mul(New(1, -prec))) >= 0 {
+		if r.Abs().Cmp(d2.Abs().mul(New(1, -prec))) >= 0 {
 			t.Errorf("remainder too large: d=%v, d2= %v, prec=%d, q=%v, r=%v",
 				d, d2, prec, q, r)
 		}
@@ -824,8 +824,8 @@ func TestDecimal_QuoRem2(t *testing.T) {
 			t.Errorf("quotient wrong precision, d=%v, d2=%v, prec=%d, q=%v, r=%v",
 				d, d2, prec, q, r)
 		}
-		// rule 3: abs(r)<abs(d) * 10^(-prec)
-		if r.abs().Cmp(d2.abs().mul(New(1, -prec))) >= 0 {
+		// rule 3: Abs(r)<Abs(d) * 10^(-prec)
+		if r.Abs().Cmp(d2.Abs().mul(New(1, -prec))) >= 0 {
 			t.Errorf("remainder too large, d=%v, d2=%v, prec=%d, q=%v, r=%v",
 				d, d2, prec, q, r)
 		}
@@ -879,11 +879,11 @@ func TestDecimal_DivRound(t *testing.T) {
 		if sign(q)*sign(d)*sign(d2) < 0 {
 			t.Errorf("sign of quotient wrong, got: %v/%v is about %v", d, d2, q)
 		}
-		x := q.mul(d2).abs().sub(d.abs()).mul(New(2, 0))
-		if x.Cmp(d2.abs().mul(New(1, -prec))) > 0 {
+		x := q.mul(d2).Abs().sub(d.Abs()).mul(New(2, 0))
+		if x.Cmp(d2.Abs().mul(New(1, -prec))) > 0 {
 			t.Errorf("wrong rounding, got: %v/%v prec=%d is about %v", d, d2, prec, q)
 		}
-		if x.Cmp(d2.abs().mul(New(-1, -prec))) <= 0 {
+		if x.Cmp(d2.Abs().mul(New(-1, -prec))) <= 0 {
 			t.Errorf("wrong rounding, got: %v/%v prec=%d is about %v", d, d2, prec, q)
 		}
 		if !q.Equal(result) {
@@ -904,11 +904,11 @@ func TestDecimal_DivRound2(t *testing.T) {
 		if sign(q)*sign(d)*sign(d2) < 0 {
 			t.Errorf("sign of quotient wrong, got: %v/%v is about %v", d, d2, q)
 		}
-		x := q.mul(d2).abs().sub(d.abs()).mul(New(2, 0))
-		if x.Cmp(d2.abs().mul(New(1, -prec))) > 0 {
+		x := q.mul(d2).Abs().sub(d.Abs()).mul(New(2, 0))
+		if x.Cmp(d2.Abs().mul(New(1, -prec))) > 0 {
 			t.Errorf("wrong rounding, got: %v/%v prec=%d is about %v", d, d2, prec, q)
 		}
-		if x.Cmp(d2.abs().mul(New(-1, -prec))) <= 0 {
+		if x.Cmp(d2.Abs().mul(New(-1, -prec))) <= 0 {
 			t.Errorf("wrong rounding, got: %v/%v prec=%d is about %v", d, d2, prec, q)
 		}
 	}
@@ -973,7 +973,7 @@ func TestDecimal_Abs1(t *testing.T) {
 	a := New(-1234, -4)
 	b := New(1234, -4)
 
-	c := a.abs()
+	c := a.Abs()
 	if c.Cmp(b) != 0 {
 		t.Errorf("error")
 	}
@@ -983,7 +983,7 @@ func TestDecimal_Abs2(t *testing.T) {
 	a := New(-1234, -4)
 	b := New(1234, -4)
 
-	c := b.abs()
+	c := b.Abs()
 	if c.Cmp(a) == 0 {
 		t.Errorf("error")
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
evalengine: Support built-in MySQL function Abs

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
[evalengine: Support all built-in MySQL functions](https://github.com/vitessio/vitess/issues/9647)

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->