### PR TITLE
Add consul-topo for local example

### DIFF
--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -24,6 +24,8 @@ if [ "${TOPO}" = "zk2" ]; then
 	CELL=zone1 ./scripts/zk-up.sh
 elif [ "${TOPO}" = "k8s" ]; then
 	CELL=zone1 ./scripts/k3s-up.sh
+elif [ "${TOPO}" = "consul" ]; then
+	CELL=zone1 ./scripts/consul-up.sh
 else
 	CELL=zone1 ./scripts/etcd-up.sh
 fi

--- a/examples/local/401_teardown.sh
+++ b/examples/local/401_teardown.sh
@@ -40,6 +40,8 @@ if [ "${TOPO}" = "zk2" ]; then
 	CELL=zone1 ./scripts/zk-down.sh
 elif [ "${TOPO}" = "k8s" ]; then
 	CELL=zone1 ./scripts/k3s-down.sh
+elif [ "${TOPO}" = "consul" ]; then
+	CELL=zone1 ./scripts/consul-down.sh
 else
 	CELL=zone1 ./scripts/etcd-down.sh
 fi

--- a/examples/local/env.sh
+++ b/examples/local/env.sh
@@ -61,6 +61,13 @@ elif [ "${TOPO}" = "k8s" ]; then
     K8S_KUBECONFIG=$VTDATAROOT/tmp/k8s.kubeconfig
     # shellcheck disable=SC2034
     TOPOLOGY_FLAGS="-topo_implementation k8s -topo_k8s_kubeconfig ${K8S_KUBECONFIG} -topo_global_server_address ${K8S_ADDR}:${K8S_PORT} -topo_global_root /vitess/global"
+elif [ "${TOPO}" = "consul" ]; then
+    # Set up topology environment parameters.
+    CONSUL_SERVER=127.0.0.1
+    CONSUL_HTTP_PORT=8500
+    CONSUL_SERVER_PORT=8300
+    TOPOLOGY_FLAGS="-topo_implementation consul -topo_global_server_address ${CONSUL_SERVER}:${CONSUL_HTTP_PORT} -topo_global_root vitess/global/"
+    mkdir -p "${VTDATAROOT}/consul"
 else
     ETCD_SERVER="localhost:2379"
     TOPOLOGY_FLAGS="-topo_implementation etcd2 -topo_global_server_address $ETCD_SERVER -topo_global_root /vitess/global"

--- a/examples/local/scripts/consul-down.sh
+++ b/examples/local/scripts/consul-down.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2022 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is an example script that stops the consul server started by consul-up.sh.
+
+source ./env.sh
+
+echo "Stopping consul..."
+kill -9 `cat $VTDATAROOT/tmp/consul.pid` 

--- a/examples/local/scripts/consul-up.sh
+++ b/examples/local/scripts/consul-up.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2022 The Vitess Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is an example script that creates a single-node consul datacenter.
+
+source ./env.sh
+
+cell=${CELL:-'test'}
+consul_http_port=${CONSUL_HTTP_PORT:-'8500'}
+consul_server_port=${CONSUL_SERVER_PORT:-'8300'}
+
+# Check that consul is not already running
+curl "http://${CONSUL_SERVER}:${consul_http_port}" > /dev/null 2>&1 && fail "consul is already running. Exiting."
+
+set -x
+consul agent \
+    -server \
+    -bootstrap-expect=1 \
+    -node=vitess-consul \
+    -bind="${CONSUL_SERVER}" \
+    -server-port="${consul_server_port}" \
+    -data-dir="${VTDATAROOT}/consul/" -ui > "${VTDATAROOT}/tmp/consul.out" 2>&1 &
+
+PID=$!
+echo $PID > "${VTDATAROOT}/tmp/consul.pid"
+sleep 5
+
+# Add the CellInfo description for the cell.
+# If the node already exists, it's fine, means we used existing data.
+echo "add $cell CellInfo"
+set +e
+# shellcheck disable=SC2086
+vtctl $TOPOLOGY_FLAGS VtctldCommand AddCellInfo \
+  --root "vitess/$cell" \
+  --server-address "${CONSUL_SERVER}:${consul_http_port}" \
+  "$cell"
+set -e
+
+echo "consul start done..."


### PR DESCRIPTION
## Description

This is a chunk of work I've broken out from some other work where I needed to troubleshoot some consul-specific behavior. I figured it might be useful to others as well. I only use the local example, so that's all I have, but hopefully someone else will have the time/familiarity to add consul to the other examples as well, but I view this as strictly an improvement.

### Testing

```
➜  local git:(andrew/local-consul-example) TOPO=consul ./101_initial_cluster.sh    
+ PID=46050
+ echo 46050
+ consul agent -server -bootstrap-expect=1 -node=vitess-consul -bind=127.0.0.1 -server-port=8300 -data-dir=<REDACTED> -ui
+ sleep 5
+ echo 'add zone1 CellInfo'
add zone1 CellInfo
+ set +e
+ vtctl -topo_implementation consul -topo_global_server_address 127.0.0.1:8500 -topo_global_root vitess/global/ VtctldCommand AddCellInfo --root vitess/zone1 --server-address 127.0.0.1:8500 zone1
Created cell: zone1
+ set -e
+ echo 'consul start done...'
consul start done...
Starting vtctld...
Starting MySQL for tablet zone1-0000000100...
Starting vttablet for zone1-0000000100...
HTTP/1.1 200 OK
Date: Tue, 01 Mar 2022 17:25:51 GMT
Content-Type: text/html; charset=utf-8

Starting MySQL for tablet zone1-0000000101...
Starting vttablet for zone1-0000000101...
HTTP/1.1 200 OK
Date: Tue, 01 Mar 2022 17:26:00 GMT
Content-Type: text/html; charset=utf-8

Starting MySQL for tablet zone1-0000000102...
Starting vttablet for zone1-0000000102...
HTTP/1.1 200 OK
Date: Tue, 01 Mar 2022 17:26:09 GMT
Content-Type: text/html; charset=utf-8

I0301 17:26:09.544845 planned_reparenter.go:667] populating reparent journal on new primary zone1-0000000100
I0301 17:26:09.544867 planned_reparenter.go:646] setting new primary on replica zone1-0000000102
I0301 17:26:09.544894 planned_reparenter.go:646] setting new primary on replica zone1-0000000101
New VSchema object:
{
  "tables": {
    "corder": {},
    "customer": {},
    "product": {}
  }
}
If this is not what you expected, check the input data (as JSON parsing will skip unexpected fields).
Waiting for vtgate to be up...
vtgate is up!
Access vtgate at http://127.0.0.1:15001/debug/status
```

## Related Issue(s)


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->