### PR TITLE
evalengine: Use field information when doing type calculation on columns

### DIFF
--- a/go/vt/vtgate/engine/filter.go
+++ b/go/vt/vtgate/engine/filter.go
@@ -59,6 +59,7 @@ func (f *Filter) TryExecute(vcursor VCursor, bindVars map[string]*querypb.BindVa
 	}
 	env := evalengine.EnvWithBindVars(bindVars, vcursor.ConnCollation())
 	var rows [][]sqltypes.Value
+	env.Fields = result.Fields
 	for _, row := range result.Rows {
 		env.Row = row
 		evalResult, err := env.Evaluate(f.Predicate)
@@ -82,6 +83,7 @@ func (f *Filter) TryStreamExecute(vcursor VCursor, bindVars map[string]*querypb.
 	env := evalengine.EnvWithBindVars(bindVars, vcursor.ConnCollation())
 	filter := func(results *sqltypes.Result) error {
 		var rows [][]sqltypes.Value
+		env.Fields = results.Fields
 		for _, row := range results.Rows {
 			env.Row = row
 			evalResult, err := env.Evaluate(f.Predicate)

--- a/go/vt/vtgate/engine/set.go
+++ b/go/vt/vtgate/engine/set.go
@@ -123,6 +123,7 @@ func (s *Set) TryExecute(vcursor VCursor, bindVars map[string]*querypb.BindVaria
 	}
 	env := evalengine.EnvWithBindVars(bindVars, vcursor.ConnCollation())
 	env.Row = input.Rows[0]
+	env.Fields = input.Fields
 	for _, setOp := range s.Ops {
 		err := setOp.Execute(vcursor, env)
 		if err != nil {

--- a/go/vt/vtgate/evalengine/comparisons_test.go
+++ b/go/vt/vtgate/evalengine/comparisons_test.go
@@ -59,9 +59,14 @@ func (tc testCase) run(t *testing.T) {
 	if tc.bv == nil {
 		tc.bv = map[string]*querypb.BindVariable{}
 	}
+	fields := make([]*querypb.Field, len(tc.row))
+	for i, value := range tc.row {
+		fields[i] = &querypb.Field{Type: value.Type()}
+	}
 	env := &ExpressionEnv{
 		BindVars: tc.bv,
 		Row:      tc.row,
+		Fields:   fields,
 	}
 	cmp, err := translateComparisonExpr2(tc.op, tc.v1, tc.v2)
 	if err != nil {

--- a/go/vt/vtgate/evalengine/expressions.go
+++ b/go/vt/vtgate/evalengine/expressions.go
@@ -523,19 +523,18 @@ func (t TupleExpr) typeof(*ExpressionEnv) (sqltypes.Type, flag) {
 }
 
 func (c *Column) typeof(env *ExpressionEnv) (sqltypes.Type, flag) {
-	f := flag(0)
-	t := sqltypes.Null
-
 	// we'll try to do the best possible with the information we have
 	if c.Offset < len(env.Row) {
 		value := env.Row[c.Offset]
 		if value.IsNull() {
-			f = flagNull | flagNullable
+			return sqltypes.Null, flagNull | flagNullable
 		}
-		t = value.Type()
+		return value.Type(), flag(0)
 	}
+
 	if c.Offset < len(env.Fields) {
-		t = env.Fields[c.Offset].Type
+		return env.Fields[c.Offset].Type, flagNullable
 	}
-	return t, f
+
+	panic("Column missing both data and field")
 }


### PR DESCRIPTION
## Description
When we need to calculate the type of a column, it's more accurate and safer to use the field information from the incoming result, and not just look at the values.

It's not a problem in `main`, but another [PR](#9643) will push the evalengine to need to do this.
