### PR TITLE
replmanager: Let TabletManger decide if replication needs to be repaired

### DIFF
--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tabletmanager
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"sync"
@@ -90,6 +91,28 @@ func (rm *replManager) SetTabletType(tabletType topodatapb.TabletType) {
 	rm.ticks.Start(rm.check)
 }
 
+func (rm *replManager) checkPrimaryIsSource(status mysql.ReplicationStatus) (bool, error) {
+	tablet := rm.tm.Tablet()
+
+	si, err := rm.tm.TopoServer.GetShard(rm.ctx, tablet.Keyspace, tablet.Shard)
+	if err != nil {
+		return false, err
+	}
+
+	if !si.HasPrimary() {
+		return false, fmt.Errorf("no primary tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
+	}
+
+	primary, err := rm.tm.TopoServer.GetTablet(rm.ctx, si.PrimaryAlias)
+	if err != nil {
+		return false, err
+	}
+	host := primary.Tablet.MysqlHostname
+	port := int(primary.Tablet.MysqlPort)
+
+	return status.SourceHost == host && status.SourcePort == port, nil
+}
+
 func (rm *replManager) check() {
 	// We need to obtain the action lock if we're going to fix
 	// replication, but only if the lock is available to take.
@@ -110,7 +133,10 @@ func (rm *replManager) checkActionLocked() {
 		// If only one of the threads is stopped, it's probably
 		// intentional. So, we don't repair replication.
 		if status.SQLHealthy() || status.IOHealthy() {
-			return
+			// Check if the Primary is still the source though
+			if primaryIsSource, err := rm.checkPrimaryIsSource(status); err != nil || primaryIsSource {
+				return
+			}
 		}
 	}
 

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -148,10 +148,11 @@ func TestReparentTablet(t *testing.T) {
 	// which ends up making this test unpredictable.
 	replica.FakeMysqlDaemon.Replicating = true
 	replica.FakeMysqlDaemon.IOThreadRunning = true
+	replica.FakeMysqlDaemon.CurrentSourceHost = primary.Tablet.MysqlHostname
+	replica.FakeMysqlDaemon.CurrentSourcePort = int(primary.Tablet.MysqlPort)
 	replica.FakeMysqlDaemon.SetReplicationSourceInputs = append(replica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(primary.Tablet))
 	replica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
-		"FAKE SET MASTER",
 		"START SLAVE",
 	}
 	replica.StartActionLoop(t, wr)


### PR DESCRIPTION
Signed-off-by: John Watson <johnw@planetscale.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
If a tablet's Primary's hostname or port changes before the tablet has replicated any data, the tablet will not attempt to repair replication. So this adds a specific check to make sure the tablet's configured source still corresponds to the shard's primary tablet's info.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->