### PR TITLE
Split aggregation in scalar and ordered aggregation

### DIFF
--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -656,92 +656,15 @@ func TestMerge(t *testing.T) {
 		"1|3|2.8|2|bc",
 	)
 
-	merged, _, err := oa.merge(fields, r.Rows[0], r.Rows[1], nil, nil)
+	merged, _, err := merge(fields, r.Rows[0], r.Rows[1], nil, nil, oa.Aggregates)
 	assert.NoError(err)
 	want := sqltypes.MakeTestResult(fields, "1|5|6.0|2|bc").Rows[0]
 	assert.Equal(want, merged)
 
 	// swap and retry
-	merged, _, err = oa.merge(fields, r.Rows[1], r.Rows[0], nil, nil)
+	merged, _, err = merge(fields, r.Rows[1], r.Rows[0], nil, nil, oa.Aggregates)
 	assert.NoError(err)
 	assert.Equal(want, merged)
-}
-
-func TestNoInputAndNoGroupingKeys(outer *testing.T) {
-	testCases := []struct {
-		name        string
-		opcode      AggregateOpcode
-		expectedVal string
-		expectedTyp string
-	}{{
-		"count(distinct col1)",
-		AggregateCountDistinct,
-		"0",
-		"int64",
-	}, {
-		"col1",
-		AggregateCount,
-		"0",
-		"int64",
-	}, {
-		"sum(distinct col1)",
-		AggregateSumDistinct,
-		"null",
-		"decimal",
-	}, {
-		"col1",
-		AggregateSum,
-		"null",
-		"int64",
-	}, {
-		"col1",
-		AggregateMax,
-		"null",
-		"int64",
-	}, {
-		"col1",
-		AggregateMin,
-		"null",
-		"int64",
-	}}
-
-	for _, test := range testCases {
-		outer.Run(test.name, func(t *testing.T) {
-			assert := assert.New(t)
-			fp := &fakePrimitive{
-				results: []*sqltypes.Result{sqltypes.MakeTestResult(
-					sqltypes.MakeTestFields(
-						"col1",
-						"int64",
-					),
-					// Empty input table
-				)},
-			}
-
-			oa := &OrderedAggregate{
-				PreProcess: true,
-				Aggregates: []*AggregateParams{{
-					Opcode: test.opcode,
-					Col:    0,
-					Alias:  test.name,
-				}},
-				GroupByKeys: []*GroupByParams{},
-				Input:       fp,
-			}
-
-			result, err := oa.TryExecute(&noopVCursor{}, nil, false)
-			assert.NoError(err)
-
-			wantResult := sqltypes.MakeTestResult(
-				sqltypes.MakeTestFields(
-					test.name,
-					test.expectedTyp,
-				),
-				test.expectedVal,
-			)
-			assert.Equal(wantResult, result)
-		})
-	}
 }
 
 func TestOrderedAggregateExecuteGtid(t *testing.T) {
@@ -756,7 +679,6 @@ func TestOrderedAggregateExecuteGtid(t *testing.T) {
 		Shard:    "80-",
 		Gtid:     "b",
 	})
-	fmt.Println(vgtid.String())
 
 	fp := &fakePrimitive{
 		results: []*sqltypes.Result{sqltypes.MakeTestResult(
@@ -1079,7 +1001,7 @@ func TestOrderedAggregateCollate(t *testing.T) {
 	collationID, _ := collations.Local().LookupID("utf8mb4_0900_ai_ci")
 	oa := &OrderedAggregate{
 		Aggregates: []*AggregateParams{{
-			Opcode: AggregateCount,
+			Opcode: AggregateSum,
 			Col:    1,
 		}},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
@@ -1122,7 +1044,7 @@ func TestOrderedAggregateCollateAS(t *testing.T) {
 	collationID, _ := collations.Local().LookupID("utf8mb4_0900_as_ci")
 	oa := &OrderedAggregate{
 		Aggregates: []*AggregateParams{{
-			Opcode: AggregateCount,
+			Opcode: AggregateSum,
 			Col:    1,
 		}},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
@@ -1167,7 +1089,7 @@ func TestOrderedAggregateCollateKS(t *testing.T) {
 	collationID, _ := collations.Local().LookupID("utf8mb4_ja_0900_as_cs_ks")
 	oa := &OrderedAggregate{
 		Aggregates: []*AggregateParams{{
-			Opcode: AggregateCount,
+			Opcode: AggregateSum,
 			Col:    1,
 		}},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},

--- a/go/vt/vtgate/engine/scalar_aggregation.go
+++ b/go/vt/vtgate/engine/scalar_aggregation.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+var _ Primitive = (*ScalarAggregate)(nil)
+
+// ScalarAggregate is a primitive used to do aggregations without grouping keys
+type ScalarAggregate struct {
+	// PreProcess is true if one of the aggregates needs preprocessing.
+	PreProcess bool `json:",omitempty"`
+	// Aggregates specifies the aggregation parameters for each
+	// aggregation function: function opcode and input column number.
+	Aggregates []*AggregateParams
+
+	// TruncateColumnCount specifies the number of columns to return
+	// in the final result. Rest of the columns are truncated
+	// from the result received. If 0, no truncation happens.
+	TruncateColumnCount int `json:",omitempty"`
+
+	// Collations stores the collation ID per column offset.
+	// It is used for grouping keys and distinct aggregate functions
+	Collations map[int]collations.ID
+
+	// Input is the primitive that will feed into this Primitive.
+	Input Primitive
+}
+
+// RouteType implements the Primitive interface
+func (sa *ScalarAggregate) RouteType() string {
+	return sa.Input.RouteType()
+}
+
+// GetKeyspaceName implements the Primitive interface
+func (sa *ScalarAggregate) GetKeyspaceName() string {
+	return sa.Input.GetKeyspaceName()
+
+}
+
+// GetTableName implements the Primitive interface
+func (sa *ScalarAggregate) GetTableName() string {
+	return sa.Input.GetTableName()
+}
+
+// GetFields implements the Primitive interface
+func (sa *ScalarAggregate) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	qr, err := sa.Input.GetFields(vcursor, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	qr = &sqltypes.Result{Fields: convertFields(qr.Fields, sa.PreProcess, sa.Aggregates)}
+	return qr.Truncate(sa.TruncateColumnCount), nil
+}
+
+// NeedsTransaction implements the Primitive interface
+func (sa *ScalarAggregate) NeedsTransaction() bool {
+	return sa.Input.NeedsTransaction()
+}
+
+// TryExecute implements the Primitive interface
+func (sa *ScalarAggregate) TryExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	result, err := vcursor.ExecutePrimitive(sa.Input, bindVars, wantfields)
+	if err != nil {
+		return nil, err
+	}
+	out := &sqltypes.Result{
+		Fields: convertFields(result.Fields, sa.PreProcess, sa.Aggregates),
+	}
+
+	var resultRow []sqltypes.Value
+	var curDistincts []sqltypes.Value
+	for _, row := range result.Rows {
+		if resultRow == nil {
+			resultRow, curDistincts = convertRow(row, sa.PreProcess, sa.Aggregates)
+			continue
+		}
+		resultRow, curDistincts, err = merge(result.Fields, resultRow, row, curDistincts, sa.Collations, sa.Aggregates)
+		if err != nil {
+			return nil, err
+		}
+		continue
+	}
+
+	if resultRow == nil {
+		// When doing aggregation without grouping keys, we need to produce a single row containing zero-value for the
+		// different aggregation functions
+		resultRow, err = sa.createEmptyRow()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		resultRow, err = convertFinal(resultRow, sa.Aggregates)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	out.Rows = [][]sqltypes.Value{resultRow}
+	return out, nil
+}
+
+// TryStreamExecute implements the Primitive interface
+func (sa *ScalarAggregate) TryStreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	panic("todo")
+}
+
+// creates the empty row for the case when we are missing grouping keys and have empty input table
+func (sa *ScalarAggregate) createEmptyRow() ([]sqltypes.Value, error) {
+	out := make([]sqltypes.Value, len(sa.Aggregates))
+	for i, aggr := range sa.Aggregates {
+		value, err := createEmptyValueFor(aggr.Opcode)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = value
+	}
+	return out, nil
+}
+
+// Inputs implements the Primitive interface
+func (sa *ScalarAggregate) Inputs() []Primitive {
+	return []Primitive{sa.Input}
+}
+
+// description implements the Primitive interface
+func (sa *ScalarAggregate) description() PrimitiveDescription {
+	aggregates := GenericJoin(sa.Aggregates, aggregateParamsToString)
+	other := map[string]interface{}{
+		"Aggregates": aggregates,
+	}
+	if sa.TruncateColumnCount > 0 {
+		other["ResultColumns"] = sa.TruncateColumnCount
+	}
+	return PrimitiveDescription{
+		OperatorType: "Aggregate",
+		Variant:      "Scalar",
+		Other:        other,
+	}
+
+}

--- a/go/vt/vtgate/engine/scalar_aggregation_test.go
+++ b/go/vt/vtgate/engine/scalar_aggregation_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"vitess.io/vitess/go/sqltypes"
+)
+
+func TestEmptyRows(outer *testing.T) {
+	testCases := []struct {
+		opcode      AggregateOpcode
+		expectedVal string
+		expectedTyp string
+	}{{
+		// 	opcode:      AggregateCountDistinct,
+		// 	expectedVal: "0",
+		// 	expectedTyp: "int64",
+		// }, {
+		opcode:      AggregateCount,
+		expectedVal: "0",
+		expectedTyp: "int64",
+	}, {
+		opcode:      AggregateSumDistinct,
+		expectedVal: "null",
+		expectedTyp: "decimal",
+	}, {
+		opcode:      AggregateSum,
+		expectedVal: "null",
+		expectedTyp: "int64",
+	}, {
+		opcode:      AggregateMax,
+		expectedVal: "null",
+		expectedTyp: "int64",
+	}, {
+		opcode:      AggregateMin,
+		expectedVal: "null",
+		expectedTyp: "int64",
+	}}
+
+	for _, test := range testCases {
+		outer.Run(test.opcode.String(), func(t *testing.T) {
+			assert := assert.New(t)
+			fp := &fakePrimitive{
+				results: []*sqltypes.Result{sqltypes.MakeTestResult(
+					sqltypes.MakeTestFields(
+						test.opcode.String(),
+						"int64",
+					),
+					// Empty input table
+				)},
+			}
+
+			oa := &ScalarAggregate{
+				PreProcess: true,
+				Aggregates: []*AggregateParams{{
+					Opcode: test.opcode,
+					Col:    0,
+					Alias:  test.opcode.String(),
+				}},
+				Input: fp,
+			}
+
+			result, err := oa.TryExecute(&noopVCursor{}, nil, false)
+			assert.NoError(err)
+
+			wantResult := sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields(
+					test.opcode.String(),
+					test.expectedTyp,
+				),
+				test.expectedVal,
+			)
+			assert.Equal(wantResult, result)
+		})
+	}
+}

--- a/go/vt/vtgate/planbuilder/grouping.go
+++ b/go/vt/vtgate/planbuilder/grouping.go
@@ -77,7 +77,7 @@ func planGroupBy(pb *primitiveBuilder, input logicalPlan, groupBy sqlparser.Grou
 			default:
 				return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: in scatter query: only simple references allowed")
 			}
-			node.eaggr.GroupByKeys = append(node.eaggr.GroupByKeys, &engine.GroupByParams{KeyCol: colNumber, WeightStringCol: -1, FromGroupBy: true})
+			node.groupByKeys = append(node.groupByKeys, &engine.GroupByParams{KeyCol: colNumber, WeightStringCol: -1, FromGroupBy: true})
 		}
 		// Append the distinct aggregate if any.
 		if node.extraDistinct != nil {
@@ -110,7 +110,7 @@ func planDistinct(input logicalPlan) (logicalPlan, error) {
 			if rc.column.Origin() == node {
 				return newDistinct(node, nil), nil
 			}
-			node.eaggr.GroupByKeys = append(node.eaggr.GroupByKeys, &engine.GroupByParams{KeyCol: i, WeightStringCol: -1, FromGroupBy: false})
+			node.groupByKeys = append(node.groupByKeys, &engine.GroupByParams{KeyCol: i, WeightStringCol: -1, FromGroupBy: false})
 		}
 		newInput, err := planDistinct(node.input)
 		if err != nil {

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -63,7 +63,19 @@ var _ logicalPlan = (*orderedAggregate)(nil)
 type orderedAggregate struct {
 	resultsBuilder
 	extraDistinct *sqlparser.ColName
-	eaggr         *engine.OrderedAggregate
+
+	// preProcess is true if one of the aggregates needs preprocessing.
+	preProcess bool
+
+	// aggregates specifies the aggregation parameters for each
+	// aggregation function: function opcode and input column number.
+	aggregates []*engine.AggregateParams
+
+	// groupByKeys specifies the input values that must be used for
+	// the aggregation key.
+	groupByKeys []*engine.GroupByParams
+
+	truncateColumnCount int
 }
 
 // checkAggregates analyzes the select expression for aggregates. If it determines
@@ -129,11 +141,9 @@ func (pb *primitiveBuilder) checkAggregates(sel *sqlparser.Select) error {
 	}
 
 	// We need an aggregator primitive.
-	eaggr := &engine.OrderedAggregate{}
-	pb.plan = &orderedAggregate{
-		resultsBuilder: newResultsBuilder(rb, eaggr),
-		eaggr:          eaggr,
-	}
+	oa := &orderedAggregate{}
+	oa.resultsBuilder = newResultsBuilder(rb, oa)
+	pb.plan = oa
 	pb.plan.Reorder(0)
 	return nil
 }
@@ -215,8 +225,36 @@ func findAlias(colname *sqlparser.ColName, selects sqlparser.SelectExprs) sqlpar
 
 // Primitive implements the logicalPlan interface
 func (oa *orderedAggregate) Primitive() engine.Primitive {
-	oa.eaggr.Input = oa.input.Primitive()
-	return oa.eaggr
+	colls := map[int]collations.ID{}
+	for _, key := range oa.aggregates {
+		if key.CollationID != collations.Unknown {
+			colls[key.KeyCol] = key.CollationID
+		}
+	}
+	for _, key := range oa.groupByKeys {
+		if key.CollationID != collations.Unknown {
+			colls[key.KeyCol] = key.CollationID
+		}
+	}
+
+	input := oa.input.Primitive()
+	if len(oa.groupByKeys) == 0 {
+		return &engine.ScalarAggregate{
+			PreProcess:          oa.preProcess,
+			Aggregates:          oa.aggregates,
+			TruncateColumnCount: oa.truncateColumnCount,
+			Collations:          colls,
+			Input:               input,
+		}
+	}
+
+	return &engine.OrderedAggregate{
+		PreProcess:          oa.preProcess,
+		Aggregates:          oa.aggregates,
+		GroupByKeys:         oa.groupByKeys,
+		TruncateColumnCount: oa.truncateColumnCount,
+		Input:               input,
+	}
 }
 
 func (oa *orderedAggregate) pushAggr(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin logicalPlan) (rc *resultColumn, colNumber int, err error) {
@@ -245,7 +283,7 @@ func (oa *orderedAggregate) pushAggr(pb *primitiveBuilder, expr *sqlparser.Alias
 			return nil, 0, err
 		}
 		oa.extraDistinct = col
-		oa.eaggr.PreProcess = true
+		oa.preProcess = true
 		var alias string
 		if expr.As.IsEmpty() {
 			alias = sqlparser.String(expr.Expr)
@@ -258,7 +296,7 @@ func (oa *orderedAggregate) pushAggr(pb *primitiveBuilder, expr *sqlparser.Alias
 		case engine.AggregateSum:
 			opcode = engine.AggregateSumDistinct
 		}
-		oa.eaggr.Aggregates = append(oa.eaggr.Aggregates, &engine.AggregateParams{
+		oa.aggregates = append(oa.aggregates, &engine.AggregateParams{
 			Opcode: opcode,
 			Col:    innerCol,
 			Alias:  alias,
@@ -269,7 +307,7 @@ func (oa *orderedAggregate) pushAggr(pb *primitiveBuilder, expr *sqlparser.Alias
 			return nil, 0, err
 		}
 		pb.plan = newBuilder
-		oa.eaggr.Aggregates = append(oa.eaggr.Aggregates, &engine.AggregateParams{
+		oa.aggregates = append(oa.aggregates, &engine.AggregateParams{
 			Opcode: opcode,
 			Col:    innerCol,
 		})
@@ -314,7 +352,7 @@ func (oa *orderedAggregate) needDistinctHandling(pb *primitiveBuilder, funcExpr 
 // compare those instead. This is because we currently don't have the
 // ability to mimic mysql's collation behavior.
 func (oa *orderedAggregate) Wireup(plan logicalPlan, jt *jointab) error {
-	for i, gbk := range oa.eaggr.GroupByKeys {
+	for i, gbk := range oa.groupByKeys {
 		rc := oa.resultColumns[gbk.KeyCol]
 		if sqltypes.IsText(rc.column.typ) {
 			weightcolNumber, err := oa.input.SupplyWeightString(gbk.KeyCol, gbk.FromGroupBy)
@@ -326,38 +364,31 @@ func (oa *orderedAggregate) Wireup(plan logicalPlan, jt *jointab) error {
 				return err
 			}
 			oa.weightStrings[rc] = weightcolNumber
-			oa.eaggr.GroupByKeys[i].WeightStringCol = weightcolNumber
-			oa.eaggr.GroupByKeys[i].KeyCol = weightcolNumber
-			oa.eaggr.TruncateColumnCount = len(oa.resultColumns)
+			oa.groupByKeys[i].WeightStringCol = weightcolNumber
+			oa.groupByKeys[i].KeyCol = weightcolNumber
+			oa.truncateColumnCount = len(oa.resultColumns)
 		}
 	}
 	return oa.input.Wireup(plan, jt)
 }
 
 func (oa *orderedAggregate) WireupGen4(semTable *semantics.SemTable) error {
-	colls := map[int]collations.ID{}
-	oa.eaggr.Collations = colls
-	for _, key := range oa.eaggr.Aggregates {
-		if key.CollationID != collations.Unknown {
-			colls[key.KeyCol] = key.CollationID
-		}
-	}
-	for _, key := range oa.eaggr.GroupByKeys {
-		if key.CollationID != collations.Unknown {
-			colls[key.KeyCol] = key.CollationID
-		}
-	}
 	return oa.input.WireupGen4(semTable)
 }
 
 // OutputColumns implements the logicalPlan interface
 func (oa *orderedAggregate) OutputColumns() []sqlparser.SelectExpr {
 	outputCols := sqlparser.CloneSelectExprs(oa.input.OutputColumns())
-	for _, aggr := range oa.eaggr.Aggregates {
+	for _, aggr := range oa.aggregates {
 		outputCols[aggr.Col] = &sqlparser.AliasedExpr{Expr: aggr.Expr, As: sqlparser.NewColIdent(aggr.Alias)}
 	}
-	if oa.eaggr.TruncateColumnCount > 0 {
-		return outputCols[:oa.eaggr.TruncateColumnCount]
+	if oa.truncateColumnCount > 0 {
+		return outputCols[:oa.truncateColumnCount]
 	}
 	return outputCols
+}
+
+// SetTruncateColumnCount sets the truncate column count.
+func (oa *orderedAggregate) SetTruncateColumnCount(count int) {
+	oa.truncateColumnCount = count
 }

--- a/go/vt/vtgate/planbuilder/ordering.go
+++ b/go/vt/vtgate/planbuilder/ordering.go
@@ -86,7 +86,7 @@ func planOAOrdering(pb *primitiveBuilder, orderBy v3OrderBy, oa *orderedAggregat
 	}
 
 	// referenced tracks the keys referenced by the order by clause.
-	referenced := make([]bool, len(oa.eaggr.GroupByKeys))
+	referenced := make([]bool, len(oa.groupByKeys))
 	postSort := false
 	selOrderBy := make(v3OrderBy, 0, len(orderBy))
 	for _, order := range orderBy {
@@ -113,7 +113,7 @@ func planOAOrdering(pb *primitiveBuilder, orderBy v3OrderBy, oa *orderedAggregat
 
 		// Match orderByCol against the group by columns.
 		found := false
-		for j, groupBy := range oa.eaggr.GroupByKeys {
+		for j, groupBy := range oa.groupByKeys {
 			if oa.resultColumns[groupBy.KeyCol].column != orderByCol {
 				continue
 			}
@@ -130,7 +130,7 @@ func planOAOrdering(pb *primitiveBuilder, orderBy v3OrderBy, oa *orderedAggregat
 	}
 
 	// Append any unreferenced keys at the end of the order by.
-	for i, groupByKey := range oa.eaggr.GroupByKeys {
+	for i, groupByKey := range oa.groupByKeys {
 		if referenced[i] {
 			continue
 		}

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -280,7 +280,7 @@ Gen4 plan same as above
   "Original": "select count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0)",
     "Inputs": [
       {
@@ -302,7 +302,7 @@ Gen4 plan same as above
   "Original": "select count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0) AS count(*)",
     "Inputs": [
       {
@@ -327,7 +327,7 @@ Gen4 plan same as above
   "Original": "select sum(col) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "sum(0)",
     "Inputs": [
       {
@@ -349,7 +349,7 @@ Gen4 plan same as above
   "Original": "select sum(col) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "sum(0) AS sum(col)",
     "Inputs": [
       {
@@ -374,7 +374,7 @@ Gen4 plan same as above
   "Original": "select min(col) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "min(0)",
     "Inputs": [
       {
@@ -396,7 +396,7 @@ Gen4 plan same as above
   "Original": "select min(col) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "min(0) AS min(col)",
     "Inputs": [
       {
@@ -421,7 +421,7 @@ Gen4 plan same as above
   "Original": "select max(col) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "max(0)",
     "Inputs": [
       {
@@ -443,7 +443,7 @@ Gen4 plan same as above
   "Original": "select max(col) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "max(0) AS max(col)",
     "Inputs": [
       {
@@ -870,7 +870,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0)",
         "Inputs": [
           {
@@ -900,7 +900,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {
@@ -927,7 +927,7 @@ Gen4 plan same as above
   "Original": "select id, count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(1)",
     "Inputs": [
       {
@@ -1130,7 +1130,7 @@ Gen4 plan same as above
   "Original": "select count(distinct col2) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count_distinct(0) AS count(distinct col2)",
     "Inputs": [
       {
@@ -1154,7 +1154,7 @@ Gen4 plan same as above
   "Original": "select count(distinct col2) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count_distinct(0|1) AS count(distinct col2)",
     "ResultColumns": 1,
     "Inputs": [
@@ -1625,7 +1625,7 @@ Gen4 plan same as above
   "Original": "select count(*) from user order by null",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0)",
     "Inputs": [
       {
@@ -1647,7 +1647,7 @@ Gen4 plan same as above
   "Original": "select count(*) from user order by null",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0) AS count(*)",
     "Inputs": [
       {
@@ -2133,7 +2133,7 @@ Gen4 plan same as above
   "Original": "select count(*) from (select user.col, user_extra.extra from user join user_extra on user.id = user_extra.user_id order by user_extra.extra) a",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0) AS count(*)",
     "Inputs": [
       {
@@ -2214,7 +2214,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0)",
         "Inputs": [
           {
@@ -2238,7 +2238,7 @@ Gen4 plan same as above
   "Original": "select distinct count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0) AS count(*)",
     "Inputs": [
       {
@@ -2311,7 +2311,7 @@ Gen4 plan same as above
   "Original": "select count(distinct a), count(distinct b) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count_distinct(0|2) AS count(distinct a), count_distinct(1|3) AS count(distinct b)",
     "ResultColumns": 2,
     "Inputs": [
@@ -2472,7 +2472,7 @@ Gen4 plan same as above
   "Original": "select count(*) from user where exists (select 1 from user_extra where user_id = user.id group by user_id having max(col) \u003e 10)",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0)",
     "Inputs": [
       {
@@ -2494,7 +2494,7 @@ Gen4 plan same as above
   "Original": "select count(*) from user where exists (select 1 from user_extra where user_id = user.id group by user_id having max(col) \u003e 10)",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0) AS count(*)",
     "Inputs": [
       {
@@ -2743,7 +2743,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {
@@ -2775,7 +2775,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {
@@ -2807,7 +2807,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {
@@ -2839,7 +2839,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {
@@ -2871,7 +2871,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {
@@ -2903,7 +2903,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {
@@ -2935,7 +2935,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {
@@ -2967,7 +2967,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -3681,7 +3681,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0)",
         "Inputs": [
           {
@@ -3711,7 +3711,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {

--- a/go/vt/vtgate/planbuilder/testdata/oltp_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/oltp_cases.txt
@@ -47,7 +47,7 @@ Gen4 plan same as above
   "Original": "SELECT SUM(k) FROM sbtest43 WHERE id BETWEEN 90 AND 990",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "sum(0)",
     "Inputs": [
       {
@@ -69,7 +69,7 @@ Gen4 plan same as above
   "Original": "SELECT SUM(k) FROM sbtest43 WHERE id BETWEEN 90 AND 990",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "sum(0) AS SUM(k)",
     "Inputs": [
       {

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -1802,7 +1802,7 @@ Gen4 plan same as above
   "Original": "select count(id), num from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0)",
     "Inputs": [
       {
@@ -1834,7 +1834,7 @@ Gen4 error: In aggregated query without GROUP BY, expression of SELECT list cont
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0)",
         "ResultColumns": 3,
         "Inputs": [
@@ -2236,7 +2236,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS a",
         "Inputs": [
           {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -82,7 +82,7 @@ Gen4 plan same as above
   "Original": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0)",
     "Inputs": [
       {
@@ -105,7 +105,7 @@ Gen4 plan same as above
   "Original": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0) AS count(*)",
     "Inputs": [
       {
@@ -177,7 +177,7 @@ Gen4 plan same as above
   "Original": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0)",
     "Inputs": [
       {
@@ -200,7 +200,7 @@ Gen4 plan same as above
   "Original": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0) AS count(*)",
     "Inputs": [
       {
@@ -226,7 +226,7 @@ Gen4 plan same as above
   "Original": "/*VT_SPAN_CONTEXT=123*/select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0)",
     "Inputs": [
       {
@@ -249,7 +249,7 @@ Gen4 plan same as above
   "Original": "/*VT_SPAN_CONTEXT=123*/select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(0) AS count(*)",
     "Inputs": [
       {
@@ -1766,7 +1766,7 @@ Gen4 plan same as above
       },
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0)",
         "Inputs": [
           {
@@ -1810,7 +1810,7 @@ Gen4 plan same as above
       },
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS count(*)",
         "Inputs": [
           {
@@ -1902,7 +1902,7 @@ Gen4 plan same as above
       },
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0)",
         "Inputs": [
           {
@@ -1948,7 +1948,7 @@ Gen4 plan same as above
       },
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "count(0) AS count(*)",
         "Inputs": [
           {

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
@@ -30,7 +30,7 @@ Gen4 plan same as above
   "Original": "select sum(l_extendedprice * l_discount) as revenue from lineitem where l_shipdate \u003e= date('1994-01-01') and l_shipdate \u003c date('1994-01-01') + interval '1' year and l_discount between 0.06 - 0.01 and 0.06 + 0.01 and l_quantity \u003c 24",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "sum(0)",
     "Inputs": [
       {
@@ -52,7 +52,7 @@ Gen4 plan same as above
   "Original": "select sum(l_extendedprice * l_discount) as revenue from lineitem where l_shipdate \u003e= date('1994-01-01') and l_shipdate \u003c date('1994-01-01') + interval '1' year and l_discount between 0.06 - 0.01 and 0.06 + 0.01 and l_quantity \u003c 24",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "sum(0) AS revenue",
     "Inputs": [
       {
@@ -129,7 +129,7 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "max(0)",
         "Inputs": [
           {
@@ -200,7 +200,7 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
     "Inputs": [
       {
         "OperatorType": "Aggregate",
-        "Variant": "Ordered",
+        "Variant": "Scalar",
         "Aggregates": "max(0) AS max(total_revenue)",
         "Inputs": [
           {
@@ -438,7 +438,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
   "Original": "select sum(l_extendedprice* (1 - l_discount)) as revenue from lineitem, part where ( p_partkey = l_partkey and p_brand = 'Brand#12' and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and l_quantity \u003e= 1 and l_quantity \u003c= 1 + 10 and p_size between 1 and 5 and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON' ) or ( p_partkey = l_partkey and p_brand = 'Brand#23' and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') and l_quantity \u003e= 10 and l_quantity \u003c= 10 + 10 and p_size between 1 and 10 and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON' ) or ( p_partkey = l_partkey and p_brand = 'Brand#34' and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') and l_quantity \u003e= 20 and l_quantity \u003c= 20 + 10 and p_size between 1 and 15 and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON' )",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "sum(0) AS revenue",
     "Inputs": [
       {

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.txt
@@ -1241,7 +1241,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
         "Inputs": [
           {
             "OperatorType": "Aggregate",
-            "Variant": "Ordered",
+            "Variant": "Scalar",
             "Aggregates": "count(0)",
             "Inputs": [
               {
@@ -1259,7 +1259,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           },
           {
             "OperatorType": "Aggregate",
-            "Variant": "Ordered",
+            "Variant": "Scalar",
             "Aggregates": "count(0)",
             "Inputs": [
               {
@@ -1291,7 +1291,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
         "Inputs": [
           {
             "OperatorType": "Aggregate",
-            "Variant": "Ordered",
+            "Variant": "Scalar",
             "Aggregates": "count(0) AS s",
             "Inputs": [
               {
@@ -1309,7 +1309,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           },
           {
             "OperatorType": "Aggregate",
-            "Variant": "Ordered",
+            "Variant": "Scalar",
             "Aggregates": "count(0) AS s",
             "Inputs": [
               {

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -443,7 +443,7 @@ Gen4 plan same as above
   "Original": "select id, count(*) from user",
   "Instructions": {
     "OperatorType": "Aggregate",
-    "Variant": "Ordered",
+    "Variant": "Scalar",
     "Aggregates": "count(1)",
     "Inputs": [
       {


### PR DESCRIPTION
## Description
For aggregations without grouping columns (`select count(*) from tbl`), we could use a simple engine primitive.
This PR implements the scalar aggregation engine primitive, that handles these types of situations.

## Checklist
- [x] Should this PR be backported? *no*
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->