### PR TITLE
Run WithDDL queries on tablet startup

### DIFF
--- a/go/vt/binlog/binlogplayer/mock_dbclient.go
+++ b/go/vt/binlog/binlogplayer/mock_dbclient.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/withddl"
+
 	"vitess.io/vitess/go/sqltypes"
 )
 
@@ -49,7 +51,10 @@ type mockExpect struct {
 
 func getQueriesToIgnore() []*mockExpect {
 	var queriesToIgnore []*mockExpect
-	for _, query := range WithDDLInitialQueries {
+	var queries []string
+	queries = append(queries, WithDDLInitialQueries...)
+	queries = append(queries, withddl.QueryToTriggerWithDDL)
+	for _, query := range queries {
 		exp := &mockExpect{
 			query:  query,
 			re:     nil,

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -69,7 +69,6 @@ var withDDLInitialQueries []string
 const (
 	throttlerAppName      = "vreplication"
 	changeMasterToPrimary = `update _vt.vreplication set tablet_types = replace(lower(convert(tablet_types using utf8mb4)), 'master', 'primary') where instr(convert(tablet_types using utf8mb4), 'master');`
-	queryWillFail         = "SELECT _vt_no_such_column__init_schema FROM _vt.vreplication LIMIT 1"
 )
 
 func init() {
@@ -222,7 +221,7 @@ func (vre *Engine) ensureValidSchema(ctx context.Context) error {
 		return err
 	}
 	defer dbClient.Close()
-	_, _ = withDDL.ExecIgnore(ctx, queryWillFail, dbClient.ExecuteFetch)
+	_, _ = withDDL.ExecIgnore(ctx, withddl.QueryToTriggerWithDDL, dbClient.ExecuteFetch)
 	return nil
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/withddl"
+
 	"vitess.io/vitess/go/vt/log"
 
 	"github.com/stretchr/testify/require"
@@ -489,6 +491,7 @@ func shouldIgnoreQuery(query string) bool {
 func expectDBClientQueries(t *testing.T, queries []string, skippableOnce ...string) {
 	extraQueries := withDDL.DDLs()
 	extraQueries = append(extraQueries, withDDLInitialQueries...)
+	extraQueries = append(extraQueries, withddl.QueryToTriggerWithDDL)
 	// Either 'queries' or 'queriesWithDDLs' must match globalDBQueries
 	t.Helper()
 	failed := false

--- a/go/vt/withddl/withddl.go
+++ b/go/vt/withddl/withddl.go
@@ -29,6 +29,8 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
+const QueryToTriggerWithDDL = "SELECT _vt_no_such_column__init_schema FROM _vt.vreplication LIMIT 1"
+
 // WithDDL allows you to execute statements against
 // tables whose schema may not be up-to-date. If the tables
 // don't exist or result in a schema error, it can apply a series


### PR DESCRIPTION
## Description

This PR runs a "fake" query using WithDDL on tablet startup so that we reach the desired schema right at the start rather than auto-magically during a WithDDL.Exec() invocation.

Since we don't enforce the usage of WithDDL.Exec() statically, it is possible for code to execute queries directly and cause regressions. Example: new code on an existing cluster expects a new column but does not use WithDDL.Exec() and hence that column never gets created.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->