### PR TITLE
mysql: add a flag to handle EnableQueryInfo

### DIFF
--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -198,6 +198,12 @@ func (c *Conn) Ping() error {
 // Note the connection can be closed while this is running.
 // Returns a SQLError.
 func (c *Conn) clientHandshake(params *ConnParams) error {
+	// if EnableQueryInfo is set, make sure that all queries starting with the handshake
+	// will actually process the INFO fields in QUERY_OK packets
+	if params.EnableQueryInfo {
+		c.enableQueryInfo = true
+	}
+
 	// Wait for the server initial handshake packet, and parse it.
 	data, err := c.readPacket()
 	if err != nil {

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -199,12 +199,9 @@ type Conn struct {
 	// See https://dev.mysql.com/doc/internals/en/semi-sync-binlog-event.html
 	ExpectSemiSyncIndicator bool
 
-	// ReturnQueryInfo sets whether the *Result objects from queries performed by this
-	// connection should include the 'info' field that MySQL usually returns. This 'info'
-	// field usually contains a human-readable text description of the executed query
-	// for informative purposes. It has no programmatic value. Returning this field is
-	// disabled by default.
-	ReturnQueryInfo bool
+	// enableQueryInfo controls whether we parse the INFO field in QUERY_OK packets
+	// See: ConnParams.EnableQueryInfo
+	enableQueryInfo bool
 }
 
 // splitStatementFunciton is the function that is used to split the statement in case of a multi-statement query.
@@ -1457,7 +1454,7 @@ func (c *Conn) parseOKPacket(in []byte) (*PacketOK, error) {
 
 	// info
 	info, _ := data.readLenEncInfo()
-	if c.ReturnQueryInfo {
+	if c.enableQueryInfo {
 		packetOK.info = info
 	}
 

--- a/go/mysql/conn_params.go
+++ b/go/mysql/conn_params.go
@@ -54,6 +54,13 @@ type ConnParams struct {
 	// The following is only set to force the client to connect without
 	// using CapabilityClientDeprecateEOF
 	DisableClientDeprecateEOF bool
+
+	// EnableQueryInfo sets whether the results from queries performed by this
+	// connection should include the 'info' field that MySQL usually returns. This 'info'
+	// field usually contains a human-readable text description of the executed query
+	// for informative purposes. It has no programmatic value. Returning this field is
+	// disabled by default.
+	EnableQueryInfo bool
 }
 
 // EnableSSL will set the right flag on the parameters.

--- a/go/mysql/endtoend/client_test.go
+++ b/go/mysql/endtoend/client_test.go
@@ -361,12 +361,12 @@ func TestClientInfo(t *testing.T) {
 	const infoPrepared = "Statement prepared"
 
 	ctx := context.Background()
-	conn, err := mysql.Connect(ctx, &connParams)
+	params := connParams
+	params.EnableQueryInfo = true
+	conn, err := mysql.Connect(ctx, &params)
 	require.NoError(t, err)
 
 	defer conn.Close()
-
-	conn.ReturnQueryInfo = true
 
 	// This is the simplest query that would return some textual data in the 'info' field
 	result, err := conn.ExecuteFetch(`PREPARE stmt1 FROM 'SELECT 1 = 1'`, -1, true)

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -86,6 +86,7 @@ type DBConfigs struct {
 	ServerName                 string        `json:"serverName,omitempty"`
 	ConnectTimeoutMilliseconds int           `json:"connectTimeoutMilliseconds,omitempty"`
 	DBName                     string        `json:"dbName,omitempty"`
+	EnableQueryInfo            bool          `json:"enableQueryInfo,omitempty"`
 
 	App          UserConfig `json:"app,omitempty"`
 	Dba          UserConfig `json:"dba,omitempty"`
@@ -138,6 +139,7 @@ func registerBaseFlags() {
 	flag.StringVar(&GlobalDBConfigs.TLSMinVersion, "db_tls_min_version", "", "Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.")
 	flag.StringVar(&GlobalDBConfigs.ServerName, "db_server_name", "", "server name of the DB we are connecting to.")
 	flag.IntVar(&GlobalDBConfigs.ConnectTimeoutMilliseconds, "db_connect_timeout_ms", 0, "connection timeout to mysqld in milliseconds (0 for no timeout)")
+	flag.BoolVar(&GlobalDBConfigs.EnableQueryInfo, "db_conn_query_info", false, "enable parsing and processing of QUERY_OK info fields")
 }
 
 // The flags will change the global singleton
@@ -368,6 +370,7 @@ func (dbcfgs *DBConfigs) InitWithSocket(defaultSocketFile string) {
 			cp.Flavor = dbcfgs.Flavor
 		}
 		cp.ConnectTimeoutMs = uint64(dbcfgs.ConnectTimeoutMilliseconds)
+		cp.EnableQueryInfo = dbcfgs.EnableQueryInfo
 
 		cp.Uname = uc.User
 		cp.Pass = uc.Password


### PR DESCRIPTION
## Description

We added the functionality to handle processing these fields a while ago, but it was disabled by default. This PR adds a flag, that will make itself available in all VTTablet instances, that lets users control this functionality at launch.

cc @piki @deepthi 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->