### PR TITLE
Check for nil vschema.Table in StreamMigrator

### DIFF
--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -30,7 +30,6 @@ import (
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/key"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -759,9 +758,7 @@ func (sm *StreamMigrator) blsIsReference(bls *binlogdatapb.BinlogSource) (bool, 
 func (sm *StreamMigrator) identifyRuleType(rule *binlogdatapb.Rule) (StreamType, error) {
 	vtable, ok := sm.ts.SourceKeyspaceSchema().Tables[rule.Match]
 	if !ok {
-		if schema.IsInternalOperationTableName(rule.Match) {
-			log.Infof("found internal table %s, ignoring in rule identification", rule.Match)
-		} else {
+		if !schema.IsInternalOperationTableName(rule.Match) {
 			return 0, fmt.Errorf("table %v not found in vschema", rule.Match)
 		}
 	}

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -639,7 +639,7 @@ func (sm *StreamMigrator) templatizeRule(ctx context.Context, rule *binlogdatapb
 		}
 	}
 
-	if vtable.Type == vindexes.TypeReference {
+	if vtable != nil && vtable.Type == vindexes.TypeReference {
 		return StreamTypeReference, nil
 	}
 
@@ -766,7 +766,7 @@ func (sm *StreamMigrator) identifyRuleType(rule *binlogdatapb.Rule) (StreamType,
 		}
 	}
 
-	if vtable.Type == vindexes.TypeReference {
+	if vtable != nil && vtable.Type == vindexes.TypeReference {
 		return StreamTypeReference, nil
 	}
 

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -632,10 +632,8 @@ func (sm *StreamMigrator) templatize(ctx context.Context, tabletStreams []*VRepl
 // This can then be used by go's template package to substitute other keyrange values.
 func (sm *StreamMigrator) templatizeRule(ctx context.Context, rule *binlogdatapb.Rule) (StreamType, error) {
 	vtable, ok := sm.ts.SourceKeyspaceSchema().Tables[rule.Match]
-	if !ok {
-		if !schema.IsInternalOperationTableName(rule.Match) {
-			return StreamTypeUnknown, fmt.Errorf("table %v not found in vschema", rule.Match)
-		}
+	if !ok && !schema.IsInternalOperationTableName(rule.Match) {
+		return StreamTypeUnknown, fmt.Errorf("table %v not found in vschema", rule.Match)
 	}
 
 	if vtable != nil && vtable.Type == vindexes.TypeReference {
@@ -757,10 +755,8 @@ func (sm *StreamMigrator) blsIsReference(bls *binlogdatapb.BinlogSource) (bool, 
 
 func (sm *StreamMigrator) identifyRuleType(rule *binlogdatapb.Rule) (StreamType, error) {
 	vtable, ok := sm.ts.SourceKeyspaceSchema().Tables[rule.Match]
-	if !ok {
-		if !schema.IsInternalOperationTableName(rule.Match) {
-			return 0, fmt.Errorf("table %v not found in vschema", rule.Match)
-		}
+	if !ok && !schema.IsInternalOperationTableName(rule.Match) {
+		return 0, fmt.Errorf("table %v not found in vschema", rule.Match)
 	}
 
 	if vtable != nil && vtable.Type == vindexes.TypeReference {


### PR DESCRIPTION
## Description
We were not checking for this when it can be null due to processing an internal table such as those used for OnlineDDL.

## Related Issue(s)
 - Follow-up to: https://github.com/vitessio/vitess/pull/9578
 - Fixes: https://github.com/vitessio/vitess/issues/9826

## Checklist
- [x] Should this PR be backported? No
- [x] Tests are not required
- [x] Documentation not required