### PR TITLE
Fix rendering type in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,7 +45,6 @@ body:
             ```
         3. Run `SELECT...`
         4. View error
-      render: markdown
     validations:
       required: true
 
@@ -60,7 +59,7 @@ body:
         giaquinti@workspace:~$ vtgate --version
         Version: a95cf5d (Git branch 'HEAD') built on Fri May 18 16:54:26 PDT 2018 by giaquinti@workspace using go1.10 linux/amd64
         ```
-      render: shell
+      render: sh
     validations:
       required: true
 
@@ -74,7 +73,7 @@ body:
         - Operating system (output of `cat /etc/os-release`)
         - Kernel version (output of `uname -sr`)
         - Architecture (output of `uname -m`)
-      render: shell
+      render: sh
     validations:
       required: true
 
@@ -83,4 +82,4 @@ body:
     attributes:
       label: Log Fragments
       description: Include appropriate log fragments. If the log is longer than a few dozen lines, please include the URL to the gist (https://gist.github.com/) of the log instead of posting it in the issue. This will be automatically formatted into code, so no need for backticks.
-      render: shell
+      render: sh

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,7 +13,6 @@ body:
     attributes:
       label: Feature Description
       description: A written overview of the feature
-      render: markdown
     validations:
       required: true
 
@@ -22,6 +21,5 @@ body:
     attributes:
       label: Use Case(s)
       description: Any relevant use-cases that you see.
-      render: markdown
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -15,6 +15,5 @@ body:
     id: question
     attributes:
       label: Question
-      render: markdown
     validations:
       required: true


### PR DESCRIPTION
## Description

This pull request changes the rendering type of the text fields in the issue templates. Some fields were using incoherent types (i.e: `shell` instead of `markdown`).

The templates can be previewed [here](https://github.com/frouioui/issue-template/issues/new/choose).


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required