### PR TITLE
Add help text for LegacyVtctlCommand and VtctldCommand

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -616,13 +616,13 @@ var commands = []commandGroup{
 				name: "VtctldCommand",
 				method: func(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 					subFlags.Usage = func() {
-						fmt.Fprintln(subFlags.Output(), "Runs the vtctl request through the new vtctldclient program syntax. This will become the default in a later version of Vitess.")
+						fmt.Fprintln(subFlags.Output(), "Runs the vtctl request through the new vtctldclient program syntax. This will become the default in a future version of Vitess.")
 					}
 
 					return subFlags.Parse(args)
 				},
 				params: "<command> [args ...]",
-				help:   "Runs the vtctl request through the new vtctldclient program syntax. This will become the default in a later version of Vitess.",
+				help:   "Runs the vtctl request through the new vtctldclient program syntax. This will become the default in a future version of Vitess.",
 			},
 		},
 	},

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -600,6 +600,30 @@ var commands = []commandGroup{
 				help:   "Triggers a panic on the server side, to test the handling.",
 				hidden: true,
 			},
+			{
+				name: "LegacyVtctlCommand",
+				method: func(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+					subFlags.Usage = func() {
+						fmt.Fprintln(subFlags.Output(), "Runs the vtctl request through the legacy vtctlclient program syntax (default).")
+					}
+
+					return subFlags.Parse(args)
+				},
+				params: "<command> [args...]",
+				help:   "Runs the vtctl request through the legacy vtctlclient program syntax (default).",
+			},
+			{
+				name: "VtctldCommand",
+				method: func(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+					subFlags.Usage = func() {
+						fmt.Fprintln(subFlags.Output(), "Runs the vtctl request through the new vtctldclient program syntax. This will become the default in a later version of Vitess.")
+					}
+
+					return subFlags.Parse(args)
+				},
+				params: "<command> [args ...]",
+				help:   "Runs the vtctl request through the new vtctldclient program syntax. This will become the default in a later version of Vitess.",
+			},
 		},
 	},
 	{


### PR DESCRIPTION
## Description

This adds some cursory documentation for the `LegacyVtctlCommand` and `VtctldCommand` modes.

Example:

```
bash-3.2$ vtctl $TOPOLOGY_FLAGS help  | grep "Command"
W0307 11:22:40.763787   10524 vtctl.go:153] WARNING: vtctl should only be used for VDiff workflows. Consider using vtctldclient for all other commands.
  LegacyVtctldCommand <command> [args...]
  VtctldCommand <command> [args ...]
bash-3.2$ vtctl $TOPOLOGY_FLAGS help VtctldCommand
W0307 11:22:57.421730   10534 vtctl.go:153] WARNING: vtctl should only be used for VDiff workflows. Consider using vtctldclient for all other commands.
Runs the vtctl request through the new vtctldclient program syntax. This will become the default in a later version of Vitess.
```

## Related Issue(s)

Closes #9822.


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->