### PR TITLE
sqlescape: Improve performance of EscapeID

### DIFF
--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -14,22 +14,29 @@ limitations under the License.
 package sqlescape
 
 import (
-	"bytes"
+	"strings"
 )
 
 // EscapeID returns a backticked identifier given an input string.
 func EscapeID(in string) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	WriteEscapeID(&buf, in)
 	return buf.String()
 }
 
 // WriteEscapeID writes a backticked identifier from an input string into buf.
-func WriteEscapeID(buf *bytes.Buffer, in string) {
+func WriteEscapeID(buf *strings.Builder, in string) {
+	// growing by 4 more than the length, gives us room
+	// for guaranteed escaping with backticks on each end,
+	// plus a small amount of room just in case there are
+	// backticks within the symbol that needs to be double
+	// escaped. This is an unlikely edge case.
+	buf.Grow(4 + len(in))
+
 	buf.WriteByte('`')
-	for _, c := range in {
-		buf.WriteRune(c)
-		if c == '`' {
+	for i := 0; i < len(in); i++ {
+		buf.WriteByte(in[i])
+		if in[i] == '`' {
 			buf.WriteByte('`')
 		}
 	}

--- a/go/sqlescape/ids_test.go
+++ b/go/sqlescape/ids_test.go
@@ -34,3 +34,22 @@ func TestEscapeID(t *testing.T) {
 		}
 	}
 }
+
+var scratch string
+
+func BenchmarkEscapeID(b *testing.B) {
+	testcases := []string{
+		"aa", "a`a", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+	for _, tc := range testcases {
+		name := tc
+		if len(name) > 10 {
+			name = "long"
+		}
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				scratch = EscapeID(tc)
+			}
+		})
+	}
+}

--- a/go/vt/worker/restartable_result_reader.go
+++ b/go/vt/worker/restartable_result_reader.go
@@ -17,7 +17,6 @@ limitations under the License.
 package worker
 
 import (
-	"bytes"
 	"io"
 	"strings"
 	"time"
@@ -333,7 +332,7 @@ func (r *RestartableResultReader) generateQuery() {
 	if r.lastRow == nil {
 		// Initial query.
 		if !r.chunk.start.IsNull() {
-			var b bytes.Buffer
+			var b strings.Builder
 			sqlescape.WriteEscapeID(&b, r.td.PrimaryKeyColumns[0])
 			b.WriteString(">=")
 			r.chunk.start.EncodeSQL(&b)
@@ -351,7 +350,7 @@ func (r *RestartableResultReader) generateQuery() {
 
 	// end value.
 	if !r.chunk.end.IsNull() {
-		var b bytes.Buffer
+		var b strings.Builder
 		sqlescape.WriteEscapeID(&b, r.td.PrimaryKeyColumns[0])
 		b.WriteString("<")
 		r.chunk.end.EncodeSQL(&b)
@@ -392,14 +391,14 @@ func greaterThanTupleWhereClause(columns []string, row []sqltypes.Value) []strin
 
 	// Additional clause on the first column for multi-columns.
 	if len(columns) > 1 {
-		var b bytes.Buffer
+		var b strings.Builder
 		sqlescape.WriteEscapeID(&b, columns[0])
 		b.WriteString(">=")
 		row[0].EncodeSQL(&b)
 		clauses = append(clauses, b.String())
 	}
 
-	var b bytes.Buffer
+	var b strings.Builder
 	// List of columns.
 	if len(columns) > 1 {
 		b.WriteByte('(')


### PR DESCRIPTION
Using a strings.Builder over a bytes.Buffer yields one less allocation
per call due to the final .String() call requring an allocation with
bytes.Buffer, while strings.Builder is simply a pointer cast to a
string.

Also minor nits:

* Iterating over the string bytes, rather than runes is quite a bit
  faster, and we don't care about runes.

In general there are lots of places just glancing over the codebase that
are using bytes.Buffer in places that I'm pretty confident could/should
be converted over to strings.Builder instead. Constructing SQL strings,
etc. These would all likely benefit from a decent performance boost, but
I'm not entirely qualified to make these sweeping core changes in ways
that I can't easily test. But they should be reasonably easy to audit
and swap. They maintain the same API.

Benchmark against main:

```
goos: linux
goarch: amd64
pkg: vitess.io/vitess/go/sqlescape
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkEscapeID
BenchmarkEscapeID/aa
BenchmarkEscapeID/aa-8          13189527               122.3 ns/op            68 B/op        2 allocs/op
BenchmarkEscapeID/a`a
BenchmarkEscapeID/a`a-8          8941188               130.0 ns/op            72 B/op        2 allocs/op
BenchmarkEscapeID/long
BenchmarkEscapeID/long-8          659671              1661 ns/op             640 B/op        4 allocs/op
PASS
```

Benchmark against my change:

```
goos: linux
goarch: amd64
pkg: vitess.io/vitess/go/sqlescape
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkEscapeID
BenchmarkEscapeID/aa
BenchmarkEscapeID/aa-8          33748676                44.12 ns/op            8 B/op        1 allocs/op
BenchmarkEscapeID/a`a
BenchmarkEscapeID/a`a-8         26893474                48.27 ns/op            8 B/op        1 allocs/op
BenchmarkEscapeID/long
BenchmarkEscapeID/long-8         2717251               482.7 ns/op           160 B/op        1 allocs/op
PASS
```

As we can see, the difference is actually about 3-4x, and on long
strings, significantly better due to the pre-allocation.