### PR TITLE
Force PK index usage in copy table vstreamer and vdiff queries

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -67,7 +67,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"1" type:INT64} pkfields:{name:"id" type:INT32}`,
 		`rows:{lengths:1 values:"1"} rows:{lengths:1 values:"1"} lastpk:{lengths:1 values:"2"}`,
 	}
-	wantQuery := "select id, val from t1 order by id"
+	wantQuery := "select id, val from t1 force index (`PRIMARY`) order by id"
 	checkStream(t, "select 1 from t1", nil, wantQuery, wantStream)
 
 	// t1: simulates rollup, with non-pk column
@@ -75,7 +75,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"1" type:INT64} fields:{name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id" type:INT32}`,
 		`rows:{lengths:1 lengths:3 values:"1aaa"} rows:{lengths:1 lengths:3 values:"1bbb"} lastpk:{lengths:1 values:"2"}`,
 	}
-	wantQuery = "select id, val from t1 order by id"
+	wantQuery = "select id, val from t1 force index (`PRIMARY`) order by id"
 	checkStream(t, "select 1, val from t1", nil, wantQuery, wantStream)
 
 	// t1: simulates rollup, with pk and non-pk column
@@ -83,7 +83,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"1" type:INT64} fields:{name:"id" type:INT32 table:"t1" org_table:"t1" database:"vttest" org_name:"id" column_length:11 charset:63} fields:{name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id" type:INT32}`,
 		`rows:{lengths:1 lengths:1 lengths:3 values:"11aaa"} rows:{lengths:1 lengths:1 lengths:3 values:"12bbb"} lastpk:{lengths:1 values:"2"}`,
 	}
-	wantQuery = "select id, val from t1 order by id"
+	wantQuery = "select id, val from t1 force index (`PRIMARY`) order by id"
 	checkStream(t, "select 1, id, val from t1", nil, wantQuery, wantStream)
 
 	// t1: no pk in select list
@@ -91,7 +91,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id" type:INT32}`,
 		`rows:{lengths:3 values:"aaa"} rows:{lengths:3 values:"bbb"} lastpk:{lengths:1 values:"2"}`,
 	}
-	wantQuery = "select id, val from t1 order by id"
+	wantQuery = "select id, val from t1 force index (`PRIMARY`) order by id"
 	checkStream(t, "select val from t1", nil, wantQuery, wantStream)
 
 	// t1: all rows
@@ -99,7 +99,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"id" type:INT32 table:"t1" org_table:"t1" database:"vttest" org_name:"id" column_length:11 charset:63} fields:{name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id" type:INT32}`,
 		`rows:{lengths:1 lengths:3 values:"1aaa"} rows:{lengths:1 lengths:3 values:"2bbb"} lastpk:{lengths:1 values:"2"}`,
 	}
-	wantQuery = "select id, val from t1 order by id"
+	wantQuery = "select id, val from t1 force index (`PRIMARY`) order by id"
 	checkStream(t, "select * from t1", nil, wantQuery, wantStream)
 
 	// t1: lastpk=1
@@ -107,7 +107,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"id" type:INT32 table:"t1" org_table:"t1" database:"vttest" org_name:"id" column_length:11 charset:63} fields:{name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id" type:INT32}`,
 		`rows:{lengths:1 lengths:3 values:"2bbb"} lastpk:{lengths:1 values:"2"}`,
 	}
-	wantQuery = "select id, val from t1 where (id > 1) order by id"
+	wantQuery = "select id, val from t1 force index (`PRIMARY`) where (id > 1) order by id"
 	checkStream(t, "select * from t1", []sqltypes.Value{sqltypes.NewInt64(1)}, wantQuery, wantStream)
 
 	// t1: different column ordering
@@ -115,7 +115,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63} fields:{name:"id" type:INT32 table:"t1" org_table:"t1" database:"vttest" org_name:"id" column_length:11 charset:63} pkfields:{name:"id" type:INT32}`,
 		`rows:{lengths:3 lengths:1 values:"aaa1"} rows:{lengths:3 lengths:1 values:"bbb2"} lastpk:{lengths:1 values:"2"}`,
 	}
-	wantQuery = "select id, val from t1 order by id"
+	wantQuery = "select id, val from t1 force index (`PRIMARY`) order by id"
 	checkStream(t, "select val, id from t1", nil, wantQuery, wantStream)
 
 	// t2: all rows
@@ -123,7 +123,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"id1" type:INT32 table:"t2" org_table:"t2" database:"vttest" org_name:"id1" column_length:11 charset:63} fields:{name:"id2" type:INT32 table:"t2" org_table:"t2" database:"vttest" org_name:"id2" column_length:11 charset:63} fields:{name:"val" type:VARBINARY table:"t2" org_table:"t2" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id1" type:INT32} pkfields:{name:"id2" type:INT32}`,
 		`rows:{lengths:1 lengths:1 lengths:3 values:"12aaa"} rows:{lengths:1 lengths:1 lengths:3 values:"13bbb"} lastpk:{lengths:1 lengths:1 values:"13"}`,
 	}
-	wantQuery = "select id1, id2, val from t2 order by id1, id2"
+	wantQuery = "select id1, id2, val from t2 force index (`PRIMARY`) order by id1, id2"
 	checkStream(t, "select * from t2", nil, wantQuery, wantStream)
 
 	// t2: lastpk=1,2
@@ -131,7 +131,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"id1" type:INT32 table:"t2" org_table:"t2" database:"vttest" org_name:"id1" column_length:11 charset:63} fields:{name:"id2" type:INT32 table:"t2" org_table:"t2" database:"vttest" org_name:"id2" column_length:11 charset:63} fields:{name:"val" type:VARBINARY table:"t2" org_table:"t2" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id1" type:INT32} pkfields:{name:"id2" type:INT32}`,
 		`rows:{lengths:1 lengths:1 lengths:3 values:"13bbb"} lastpk:{lengths:1 lengths:1 values:"13"}`,
 	}
-	wantQuery = "select id1, id2, val from t2 where (id1 = 1 and id2 > 2) or (id1 > 1) order by id1, id2"
+	wantQuery = "select id1, id2, val from t2 force index (`PRIMARY`) where (id1 = 1 and id2 > 2) or (id1 > 1) order by id1, id2"
 	checkStream(t, "select * from t2", []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)}, wantQuery, wantStream)
 
 	// t3: all rows
@@ -155,7 +155,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"id1" type:INT32 table:"t4" org_table:"t4" database:"vttest" org_name:"id1" column_length:11 charset:63} fields:{name:"id2" type:INT32 table:"t4" org_table:"t4" database:"vttest" org_name:"id2" column_length:11 charset:63} fields:{name:"id3" type:INT32 table:"t4" org_table:"t4" database:"vttest" org_name:"id3" column_length:11 charset:63} fields:{name:"val" type:VARBINARY table:"t4" org_table:"t4" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id1" type:INT32} pkfields:{name:"id2" type:INT32} pkfields:{name:"id3" type:INT32}`,
 		`rows:{lengths:1 lengths:1 lengths:1 lengths:3 values:"123aaa"} rows:{lengths:1 lengths:1 lengths:1 lengths:3 values:"234bbb"} lastpk:{lengths:1 lengths:1 lengths:1 values:"234"}`,
 	}
-	wantQuery = "select id1, id2, id3, val from t4 order by id1, id2, id3"
+	wantQuery = "select id1, id2, id3, val from t4 force index (`PRIMARY`) order by id1, id2, id3"
 	checkStream(t, "select * from t4", nil, wantQuery, wantStream)
 
 	// t4: lastpk: 1,2,3
@@ -163,7 +163,7 @@ func TestStreamRowsScan(t *testing.T) {
 		`fields:{name:"id1" type:INT32 table:"t4" org_table:"t4" database:"vttest" org_name:"id1" column_length:11 charset:63} fields:{name:"id2" type:INT32 table:"t4" org_table:"t4" database:"vttest" org_name:"id2" column_length:11 charset:63} fields:{name:"id3" type:INT32 table:"t4" org_table:"t4" database:"vttest" org_name:"id3" column_length:11 charset:63} fields:{name:"val" type:VARBINARY table:"t4" org_table:"t4" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id1" type:INT32} pkfields:{name:"id2" type:INT32} pkfields:{name:"id3" type:INT32}`,
 		`rows:{lengths:1 lengths:1 lengths:1 lengths:3 values:"234bbb"} lastpk:{lengths:1 lengths:1 lengths:1 values:"234"}`,
 	}
-	wantQuery = "select id1, id2, id3, val from t4 where (id1 = 1 and id2 = 2 and id3 > 3) or (id1 = 1 and id2 > 2) or (id1 > 1) order by id1, id2, id3"
+	wantQuery = "select id1, id2, id3, val from t4 force index (`PRIMARY`) where (id1 = 1 and id2 = 2 and id3 > 3) or (id1 = 1 and id2 > 2) or (id1 > 1) order by id1, id2, id3"
 	checkStream(t, "select * from t4", []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2), sqltypes.NewInt64(3)}, wantQuery, wantStream)
 
 	// t1: test for unsupported integer literal
@@ -258,7 +258,7 @@ func TestStreamRowsKeyRange(t *testing.T) {
 		`fields:{name:"id1" type:INT32 table:"t1" org_table:"t1" database:"vttest" org_name:"id1" column_length:11 charset:63} fields:{name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id1" type:INT32}`,
 		`rows:{lengths:1 lengths:3 values:"1aaa"} lastpk:{lengths:1 values:"6"}`,
 	}
-	wantQuery := "select id1, val from t1 order by id1"
+	wantQuery := "select id1, val from t1 force index (`PRIMARY`) order by id1"
 	checkStream(t, "select * from t1 where in_keyrange('-80')", nil, wantQuery, wantStream)
 }
 
@@ -290,7 +290,7 @@ func TestStreamRowsFilterInt(t *testing.T) {
 		`fields:{name:"id1" type:INT32 table:"t1" org_table:"t1" database:"vttest" org_name:"id1" column_length:11 charset:63} fields:{name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id1" type:INT32}`,
 		`rows:{lengths:1 lengths:3 values:"1aaa"} rows:{lengths:1 lengths:3 values:"4ddd"} lastpk:{lengths:1 values:"5"}`,
 	}
-	wantQuery := "select id1, id2, val from t1 order by id1"
+	wantQuery := "select id1, id2, val from t1 force index (`PRIMARY`) order by id1"
 	checkStream(t, "select id1, val from t1 where id2 = 100", nil, wantQuery, wantStream)
 	require.Equal(t, int64(0), engine.rowStreamerNumPackets.Get())
 	require.Equal(t, int64(2), engine.rowStreamerNumRows.Get())
@@ -323,7 +323,7 @@ func TestStreamRowsFilterVarBinary(t *testing.T) {
 		`fields:{name:"id1" type:INT32 table:"t1" org_table:"t1" database:"vttest" org_name:"id1" column_length:11 charset:63} fields:{name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63} pkfields:{name:"id1" type:INT32}`,
 		`rows:{lengths:1 lengths:6 values:"2newton"} rows:{lengths:1 lengths:6 values:"3newton"} rows:{lengths:1 lengths:6 values:"5newton"} lastpk:{lengths:1 values:"6"}`,
 	}
-	wantQuery := "select id1, val from t1 order by id1"
+	wantQuery := "select id1, val from t1 force index (`PRIMARY`) order by id1"
 	checkStream(t, "select id1, val from t1 where val = 'newton'", nil, wantQuery, wantStream)
 }
 
@@ -351,7 +351,7 @@ func TestStreamRowsMultiPacket(t *testing.T) {
 		`rows:{lengths:1 lengths:10 values:"42345678901"} lastpk:{lengths:1 values:"4"}`,
 		`rows:{lengths:1 lengths:1 values:"52"} lastpk:{lengths:1 values:"5"}`,
 	}
-	wantQuery := "select id, val from t1 order by id"
+	wantQuery := "select id, val from t1 force index (`PRIMARY`) order by id"
 	checkStream(t, "select * from t1", nil, wantQuery, wantStream)
 }
 

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -77,8 +77,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c1, c2 from t1 order by c1 asc",
-			targetExpression: "select c1, c2 from t1 order by c1 asc",
+			sourceExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
+			targetExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -94,8 +94,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c1, c2 from t1 order by c1 asc",
-			targetExpression: "select c1, c2 from t1 order by c1 asc",
+			sourceExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
+			targetExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -111,8 +111,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c1, c2 from t1 order by c1 asc",
-			targetExpression: "select c1, c2 from t1 order by c1 asc",
+			sourceExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
+			targetExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -128,8 +128,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c2, c1 from t1 order by c1 asc",
-			targetExpression: "select c2, c1 from t1 order by c1 asc",
+			sourceExpression: "select c2, c1 from t1 force index (`PRIMARY`) order by c1 asc",
+			targetExpression: "select c2, c1 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), false}, {1, collations.Collation(nil), true}},
 			comparePKs:       []compareColInfo{{1, collations.Collation(nil), true}},
 			pkCols:           []int{1},
@@ -145,8 +145,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c0 as c1, c2 from t2 order by c1 asc",
-			targetExpression: "select c1, c2 from t1 order by c1 asc",
+			sourceExpression: "select c0 as c1, c2 from t2 force index (`PRIMARY`) order by c1 asc",
+			targetExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -163,8 +163,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "nonpktext",
 		td: &tableDiffer{
 			targetTable:      "nonpktext",
-			sourceExpression: "select c1, textcol from nonpktext order by c1 asc",
-			targetExpression: "select c1, textcol from nonpktext order by c1 asc",
+			sourceExpression: "select c1, textcol from nonpktext force index (`PRIMARY`) order by c1 asc",
+			targetExpression: "select c1, textcol from nonpktext force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -181,8 +181,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "nonpktext",
 		td: &tableDiffer{
 			targetTable:      "nonpktext",
-			sourceExpression: "select textcol, c1 from nonpktext order by c1 asc",
-			targetExpression: "select textcol, c1 from nonpktext order by c1 asc",
+			sourceExpression: "select textcol, c1 from nonpktext force index (`PRIMARY`) order by c1 asc",
+			targetExpression: "select textcol, c1 from nonpktext force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), false}, {1, collations.Collation(nil), true}},
 			comparePKs:       []compareColInfo{{1, collations.Collation(nil), true}},
 			pkCols:           []int{1},
@@ -199,8 +199,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "pktext",
 		td: &tableDiffer{
 			targetTable:      "pktext",
-			sourceExpression: "select textcol, c2 from pktext order by textcol asc",
-			targetExpression: "select textcol, c2 from pktext order by textcol asc",
+			sourceExpression: "select textcol, c2 from pktext force index (`PRIMARY`) order by textcol asc",
+			targetExpression: "select textcol, c2 from pktext force index (`PRIMARY`) order by textcol asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -217,8 +217,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "pktext",
 		td: &tableDiffer{
 			targetTable:      "pktext",
-			sourceExpression: "select c2, textcol from pktext order by textcol asc",
-			targetExpression: "select c2, textcol from pktext order by textcol asc",
+			sourceExpression: "select c2, textcol from pktext force index (`PRIMARY`) order by textcol asc",
+			targetExpression: "select c2, textcol from pktext force index (`PRIMARY`) order by textcol asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), false}, {1, collations.Collation(nil), true}},
 			comparePKs:       []compareColInfo{{1, collations.Collation(nil), true}},
 			pkCols:           []int{1},
@@ -235,8 +235,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "pktext",
 		td: &tableDiffer{
 			targetTable:      "pktext",
-			sourceExpression: "select c2, a + b as textcol from pktext order by textcol asc",
-			targetExpression: "select c2, textcol from pktext order by textcol asc",
+			sourceExpression: "select c2, a + b as textcol from pktext force index (`PRIMARY`) order by textcol asc",
+			targetExpression: "select c2, textcol from pktext force index (`PRIMARY`) order by textcol asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), false}, {1, collations.Collation(nil), true}},
 			comparePKs:       []compareColInfo{{1, collations.Collation(nil), true}},
 			pkCols:           []int{1},
@@ -251,8 +251,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "multipk",
 		td: &tableDiffer{
 			targetTable:      "multipk",
-			sourceExpression: "select c1, c2 from multipk order by c1 asc, c2 asc",
-			targetExpression: "select c1, c2 from multipk order by c1 asc, c2 asc",
+			sourceExpression: "select c1, c2 from multipk force index (`PRIMARY`) order by c1 asc, c2 asc",
+			targetExpression: "select c1, c2 from multipk force index (`PRIMARY`) order by c1 asc, c2 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), true}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), true}},
 			pkCols:           []int{0, 1},
@@ -269,8 +269,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c1, c2 from t1 order by c1 asc",
-			targetExpression: "select c1, c2 from t1 order by c1 asc",
+			sourceExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
+			targetExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -288,8 +288,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c1, c2 from t1 where c2 = 2 order by c1 asc",
-			targetExpression: "select c1, c2 from t1 order by c1 asc",
+			sourceExpression: "select c1, c2 from t1 force index (`PRIMARY`) where c2 = 2 order by c1 asc",
+			targetExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -307,8 +307,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c1, c2 from t1 where c2 = 2 order by c1 asc",
-			targetExpression: "select c1, c2 from t1 order by c1 asc",
+			sourceExpression: "select c1, c2 from t1 force index (`PRIMARY`) where c2 = 2 order by c1 asc",
+			targetExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -326,8 +326,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c1, c2 from t1 where c2 = 2 and c1 = 1 order by c1 asc",
-			targetExpression: "select c1, c2 from t1 order by c1 asc",
+			sourceExpression: "select c1, c2 from t1 force index (`PRIMARY`) where c2 = 2 and c1 = 1 order by c1 asc",
+			targetExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -345,8 +345,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c1, c2 from t1 where c2 = 2 order by c1 asc",
-			targetExpression: "select c1, c2 from t1 order by c1 asc",
+			sourceExpression: "select c1, c2 from t1 force index (`PRIMARY`) where c2 = 2 order by c1 asc",
+			targetExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -363,8 +363,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c1, c2 from t1 group by c1 order by c1 asc",
-			targetExpression: "select c1, c2 from t1 order by c1 asc",
+			sourceExpression: "select c1, c2 from t1 force index (`PRIMARY`) group by c1 order by c1 asc",
+			targetExpression: "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -381,8 +381,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "aggr",
 		td: &tableDiffer{
 			targetTable:      "aggr",
-			sourceExpression: "select c1, c2, count(*) as c3, sum(c4) as c4 from t1 group by c1 order by c1 asc",
-			targetExpression: "select c1, c2, c3, c4 from aggr order by c1 asc",
+			sourceExpression: "select c1, c2, count(*) as c3, sum(c4) as c4 from t1 force index (`PRIMARY`) group by c1 order by c1 asc",
+			targetExpression: "select c1, c2, c3, c4 from aggr force index (`PRIMARY`) order by c1 asc",
 			compareCols:      []compareColInfo{{0, collations.Collation(nil), true}, {1, collations.Collation(nil), false}, {2, collations.Collation(nil), false}, {3, collations.Collation(nil), false}},
 			comparePKs:       []compareColInfo{{0, collations.Collation(nil), true}},
 			pkCols:           []int{0},
@@ -716,13 +716,13 @@ func TestVDiffUnsharded(t *testing.T) {
 						"c1": sqltypes.NewInt64(2),
 						"c2": sqltypes.NewInt64(3),
 					},
-						Query: "select c1, c2 from t1 where c1=2;",
+						Query: "select c1, c2 from t1 force index (`PRIMARY`) where c1=2;",
 					},
 					Target: &RowDiff{Row: map[string]sqltypes.Value{
 						"c1": sqltypes.NewInt64(2),
 						"c2": sqltypes.NewInt64(4),
 					},
-						Query: "select c1, c2 from t1 where c1=2;",
+						Query: "select c1, c2 from t1 force index (`PRIMARY`) where c1=2;",
 					},
 				},
 			},
@@ -731,8 +731,8 @@ func TestVDiffUnsharded(t *testing.T) {
 
 	for _, tcase := range testcases {
 		t.Run(tcase.id, func(t *testing.T) {
-			env.tablets[101].setResults("select c1, c2 from t1 order by c1 asc", vdiffSourceGtid, tcase.source)
-			env.tablets[201].setResults("select c1, c2 from t1 order by c1 asc", vdiffTargetPrimaryPosition, tcase.target)
+			env.tablets[101].setResults("select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc", vdiffSourceGtid, tcase.source)
+			env.tablets[201].setResults("select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc", vdiffTargetPrimaryPosition, tcase.target)
 
 			dr, err := env.wr.VDiff(context.Background(), "target", env.workflow, env.cell, env.cell, "replica", 30*time.Second, "", 100, "", tcase.debug, tcase.onlyPks, 100)
 			require.NoError(t, err)
@@ -767,7 +767,7 @@ func TestVDiffSharded(t *testing.T) {
 
 	env.tmc.schema = schm
 
-	query := "select c1, c2 from t1 order by c1 asc"
+	query := "select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc"
 	fields := sqltypes.MakeTestFields(
 		"c1|c2",
 		"int64|int64",
@@ -828,7 +828,7 @@ func TestVDiffAggregates(t *testing.T) {
 	}
 	env.tmc.schema = schm
 
-	sourceQuery := "select c1, count(*) as c2, sum(c3) as c3 from t group by c1 order by c1 asc"
+	sourceQuery := "select c1, count(*) as c2, sum(c3) as c3 from t force index (`PRIMARY`) group by c1 order by c1 asc"
 	fields := sqltypes.MakeTestFields(
 		"c1|c2|c3",
 		"int64|int64|int64",
@@ -852,7 +852,7 @@ func TestVDiffAggregates(t *testing.T) {
 			"5|3|3",
 		),
 	)
-	targetQuery := "select c1, c2, c3 from t1 order by c1 asc"
+	targetQuery := "select c1, c2, c3 from t1 force index (`PRIMARY`) order by c1 asc"
 	env.tablets[201].setResults(
 		targetQuery,
 		vdiffTargetPrimaryPosition,
@@ -907,8 +907,8 @@ func TestVDiffDefaults(t *testing.T) {
 		"3|1",
 	)
 	target := source
-	env.tablets[101].setResults("select c1, c2 from t1 order by c1 asc", vdiffSourceGtid, source)
-	env.tablets[201].setResults("select c1, c2 from t1 order by c1 asc", vdiffTargetPrimaryPosition, target)
+	env.tablets[101].setResults("select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc", vdiffSourceGtid, source)
+	env.tablets[201].setResults("select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc", vdiffTargetPrimaryPosition, target)
 
 	_, err := env.wr.VDiff(context.Background(), "target", env.workflow, "", "", "replica", 30*time.Second, "", 100, "", false /*debug*/, false /*onlyPks*/, 100)
 	require.NoError(t, err)
@@ -960,8 +960,8 @@ func TestVDiffReplicationWait(t *testing.T) {
 		"3|1",
 	)
 	target := source
-	env.tablets[101].setResults("select c1, c2 from t1 order by c1 asc", vdiffSourceGtid, source)
-	env.tablets[201].setResults("select c1, c2 from t1 order by c1 asc", vdiffTargetPrimaryPosition, target)
+	env.tablets[101].setResults("select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc", vdiffSourceGtid, source)
+	env.tablets[201].setResults("select c1, c2 from t1 force index (`PRIMARY`) order by c1 asc", vdiffTargetPrimaryPosition, target)
 
 	_, err := env.wr.VDiff(context.Background(), "target", env.workflow, env.cell, env.cell, "replica", 0*time.Second, "", 100, "", false /*debug*/, false /*onlyPks*/, 100)
 	require.Error(t, err)


### PR DESCRIPTION
## Description
In the vreplication vstreamer and vdiff components we rely on the primary key for uniqueness and ordering. It's possible, however, that the optimizer may choose a secondary index for the queries used to read rows from the source (invalid index stats, etc).

This PK index will always be the best option — when available — given the current ORDER BY PK clauses combined with the fact that we typically select all of the columns. Given that InnoDB uses a clustered index for the PK (index organized tables) this means that we can do a covering index scan and avoid the need for a filesort when using the PK.

To avoid the potential for using a secondary index for any reason when an explicit PK is available, we add a `force index (PRIMARY)` clause to the SELECT queries used on the source for row streaming (copy_table) vstreams and on the source and target for VDiffs.

> ⚠️ NOTE: this work excludes vstreams unrelated to RowStreamer (for copying tables) and should have no impact on materialization and messaging as the optimal key will vary for those streams.

## Related Issue(s)
 - ???


## Checklist
- [x] Should this PR be backported? NO
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required