### PR TITLE
[topo/helpers] Make CopyShardReplications idempotent

### DIFF
--- a/go/vt/topo/helpers/copy_test.go
+++ b/go/vt/topo/helpers/copy_test.go
@@ -140,6 +140,16 @@ func TestBasic(t *testing.T) {
 		t.Fatalf("unexpected ShardReplication: %v", sr)
 	}
 
+	// check ShardReplications is idempotent
+	CopyShardReplications(ctx, fromTS, toTS)
+	sr, err = toTS.GetShardReplication(ctx, "test_cell", "test_keyspace", "0")
+	if err != nil {
+		t.Fatalf("toTS.GetShardReplication failed: %v", err)
+	}
+	if len(sr.Nodes) != 2 {
+		t.Fatalf("unexpected ShardReplication after second copy: %v", sr)
+	}
+
 	// check tablet copy
 	CopyTablets(ctx, fromTS, toTS)
 	tablets, err := toTS.GetTabletAliasesByCell(ctx, "test_cell")


### PR DESCRIPTION
## Description

This updates `helpers.CopyShardReplications` to build a set of tablet aliases in the fromTS topo so that repeated copies are idempotent.

## Related Issue(s)

Fixes #9844 

## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required **n/a**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->