### PR TITLE
Fix `__sq_has_values1` error with `PulloutSubquery`

### DIFF
--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -42,6 +42,18 @@ func TestSubqueriesHasValues(t *testing.T) {
 	utils.AssertMatches(t, conn, `SELECT id2 FROM t1 WHERE id1 NOT IN (SELECT id1 FROM t1 WHERE id1 > 10) ORDER BY id2`, `[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)] [INT64(5)] [INT64(6)]]`)
 }
 
+func TestSubqueriesExists(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	defer utils.Exec(t, conn, `delete from t1`)
+	utils.Exec(t, conn, "insert into t1(id1, id2) values (0,1),(1,2),(2,3),(3,4),(4,5),(5,6)")
+	utils.AssertMatches(t, conn, `SELECT id2 FROM t1 WHERE EXISTS (SELECT id1 FROM t1 WHERE id1 > 0)`, `[[INT64(1)] [INT64(5)] [INT64(2)] [INT64(3)] [INT64(4)] [INT64(6)]]`)
+}
+
 func TestQueryAndSubQWithLimit(t *testing.T) {
 	conn, err := mysql.Connect(context.Background(), &vtParams)
 	require.NoError(t, err)

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -1653,7 +1653,7 @@ func (es *ExtractedSubquery) GetHasValuesArg() string {
 func (es *ExtractedSubquery) updateAlternative() {
 	switch original := es.Original.(type) {
 	case *ExistsExpr:
-		es.alternative = NewArgument(es.argName)
+		es.alternative = NewArgument(es.hasValuesArg)
 	case *Subquery:
 		es.alternative = NewArgument(es.argName)
 	case *ComparisonExpr:

--- a/go/vt/vtgate/planbuilder/rewrite.go
+++ b/go/vt/vtgate/planbuilder/rewrite.go
@@ -147,8 +147,8 @@ func (r *rewriter) rewriteExistsSubquery(cursor *sqlparser.Cursor, node *sqlpars
 	}
 
 	r.inSubquery++
-	argName := r.reservedVars.ReserveHasValuesSubQuery()
-	semTableSQ.SetArgName(argName)
+	hasValuesArg := r.reservedVars.ReserveHasValuesSubQuery()
+	semTableSQ.SetHasValuesArg(hasValuesArg)
 	cursor.Replace(semTableSQ)
 	return nil
 }


### PR DESCRIPTION
## Description

This pull request fixes #9854 by using `HasValues` arguments instead of the regular `Name` argument for `EXISTS` subqueries.

## Related Issue(s)
- Fixes #9854 
- Unblock #9710

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
