### PR TITLE
Change logic to reach desired _vt schema on vreplication startup

### DIFF
--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -234,20 +234,6 @@ func TestCellAliasVreplicationWorkflow(t *testing.T) {
 	shardCustomer(t, true, []*Cell{cell1, cell2}, "alias", false)
 }
 
-/// confirm that WithDDL runs on tablet start and creates the expected _vt.vreplication schema
-func ensureVTSchemaIsUpToDate(t *testing.T) {
-	tablets := vc.getVttabletsInKeyspace(t, defaultCell, "product", "primary")
-	require.Equal(t, 1, len(tablets))
-	for _, tablet := range tablets {
-		qr, err := tablet.QueryTabletWithDB("show create table vreplication", "_vt")
-		require.NoError(t, err)
-		require.Equal(t, int64(1), int64(len(qr.Rows)))
-		// verify that a recently added column exists. ideally this should be the most recent one, but
-		// there is no way for an e2e test to know which column was added last.
-		require.Contains(t, qr.Rows[0][1].ToString(), "time_heartbeat")
-	}
-}
-
 // testVStreamFrom confirms that the "vstream * from" endpoint is serving data
 func testVStreamFrom(t *testing.T, table string, expectedRowCount int) {
 	ctx := context.Background()

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -226,11 +226,29 @@ func TestCellAliasVreplicationWorkflow(t *testing.T) {
 	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
 	defer vtgateConn.Close()
 	verifyClusterHealth(t, vc)
+
+	t.Run("ensure _vt.vreplication table is created", func(t *testing.T) {
+		ensureVTSchemaIsUpToDate(t)
+	})
 	insertInitialData(t)
 	t.Run("VStreamFrom", func(t *testing.T) {
 		testVStreamFrom(t, "product", 2)
 	})
 	shardCustomer(t, true, []*Cell{cell1, cell2}, "alias", false)
+}
+
+/// confirm that WithDDL runs on tablet start and creates the expected _vt.vreplication schema
+func ensureVTSchemaIsUpToDate(t *testing.T) {
+	tablets := vc.getVttabletsInKeyspace(t, defaultCell, "product", "primary")
+	require.Equal(t, 1, len(tablets))
+	for _, tablet := range tablets {
+		qr, err := tablet.QueryTabletWithDB("show create table vreplication", "_vt")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), int64(len(qr.Rows)))
+		// verify that a recently added column exists. ideally this should be the most recent one, but
+		// there is no way for an e2e test to know which column was added last.
+		require.Contains(t, qr.Rows[0][1].ToString(), "time_heartbeat")
+	}
 }
 
 // testVStreamFrom confirms that the "vstream * from" endpoint is serving data

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -227,9 +227,6 @@ func TestCellAliasVreplicationWorkflow(t *testing.T) {
 	defer vtgateConn.Close()
 	verifyClusterHealth(t, vc)
 
-	t.Run("ensure _vt.vreplication table is created", func(t *testing.T) {
-		ensureVTSchemaIsUpToDate(t)
-	})
 	insertInitialData(t)
 	t.Run("VStreamFrom", func(t *testing.T) {
 		testVStreamFrom(t, "product", 2)

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -30,6 +30,8 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/vt/withddl"
+
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -573,10 +575,13 @@ var AlterVReplicationTable = []string{
 // - are to be expected by the mock db client during tests, or
 // - trigger some of the above _vt.vreplication schema changes to take effect
 //   when the binlogplayer starts up
+// todo: cleanup here. QueryToTriggerWithDDL will be enough to ensure vreplication schema gets created/altered correctly.
+//   So do that explicitly and move queries required into the mock code.
 var WithDDLInitialQueries = []string{
 	"SELECT db_name FROM _vt.vreplication LIMIT 0",
 	"SELECT rows_copied FROM _vt.vreplication LIMIT 0",
 	"SELECT time_heartbeat FROM _vt.vreplication LIMIT 0",
+	withddl.QueryToTriggerWithDDL,
 }
 
 // VRSettings contains the settings of a vreplication table.

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1031,12 +1031,6 @@ func (e *Executor) ExecuteWithVReplication(ctx context.Context, onlineDDL *schem
 			return err
 		}
 
-		e.initVreplicationDDLOnce.Do(func() {
-			// Ensure vreplication schema is up-to-date by invoking a query with non-existing columns.
-			// This will make vreplication run through its WithDDL schema changes.
-			_, _ = tmClient.VReplicationExec(ctx, tablet.Tablet, withddl.QueryToTriggerWithDDL)
-		})
-
 		// reload schema before migration
 		if err := tmClient.ReloadSchema(ctx, tablet.Tablet, ""); err != nil {
 			return err

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -500,12 +500,11 @@ const (
 			AND TABLES.TABLE_NAME=%a
 			AND AUTO_INCREMENT IS NOT NULL
 		`
-	sqlAlterTableAutoIncrement      = "ALTER TABLE `%s` AUTO_INCREMENT=%a"
-	sqlImpossibleSelectVreplication = "SELECT no_such_column__init_ddl FROM _vt.vreplication LIMIT 1"
-	sqlStartVReplStream             = "UPDATE _vt.vreplication set state='Running' where db_name=%a and workflow=%a"
-	sqlStopVReplStream              = "UPDATE _vt.vreplication set state='Stopped' where db_name=%a and workflow=%a"
-	sqlDeleteVReplStream            = "DELETE FROM _vt.vreplication where db_name=%a and workflow=%a"
-	sqlReadVReplStream              = `SELECT
+	sqlAlterTableAutoIncrement = "ALTER TABLE `%s` AUTO_INCREMENT=%a"
+	sqlStartVReplStream        = "UPDATE _vt.vreplication set state='Running' where db_name=%a and workflow=%a"
+	sqlStopVReplStream         = "UPDATE _vt.vreplication set state='Stopped' where db_name=%a and workflow=%a"
+	sqlDeleteVReplStream       = "DELETE FROM _vt.vreplication where db_name=%a and workflow=%a"
+	sqlReadVReplStream         = `SELECT
 			id,
 			workflow,
 			source,

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -216,12 +216,12 @@ func (vre *Engine) Open(ctx context.Context) {
 // We plan to refactor so that we remove WithDDL, just define the list of DDLs required to reach the desired
 // and execute vreplication queries normally.
 func (vre *Engine) ensureValidSchema(ctx context.Context) error {
-	dbClient := vre.dbClientFactoryFiltered()
+	dbClient := vre.getDBClient(false)
 	if err := dbClient.Connect(); err != nil {
 		return err
 	}
 	defer dbClient.Close()
-	_, _ = withDDL.ExecIgnore(ctx, withddl.QueryToTriggerWithDDL, dbClient.ExecuteFetch)
+	_, _ = withDDL.Exec(ctx, withddl.QueryToTriggerWithDDL, dbClient.ExecuteFetch, dbClient.ExecuteFetch)
 	return nil
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -210,26 +210,7 @@ func (vre *Engine) Open(ctx context.Context) {
 	}
 }
 
-// ensureValidSchema runs a "fake" query using WithDDL, which always fails, forcing WithDDL to run all its DDLs resulting
-// in the desired schema. This is a workaround, protecting against queries to vreplication tables that
-// don't use the recommended WithDDL.Exec() mechanism. Adding this function makes the use of WithDDL.Exec() unnecessary.
-// We plan to refactor so that we remove WithDDL, just define the list of DDLs required to reach the desired
-// and execute vreplication queries normally.
-func (vre *Engine) ensureValidSchema(ctx context.Context) error {
-	dbClient := vre.getDBClient(false)
-	if err := dbClient.Connect(); err != nil {
-		return err
-	}
-	defer dbClient.Close()
-	_, _ = withDDL.Exec(ctx, withddl.QueryToTriggerWithDDL, dbClient.ExecuteFetch, dbClient.ExecuteFetch)
-	return nil
-}
-
 func (vre *Engine) openLocked(ctx context.Context) error {
-
-	if err := vre.ensureValidSchema(ctx); err != nil {
-		return err
-	}
 
 	rows, err := vre.readAllRows(ctx)
 	if err != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -412,7 +412,8 @@ func (dbc *realDBClient) Close() {
 }
 
 func (dbc *realDBClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {
-	if strings.HasPrefix(query, "use") {
+	if strings.HasPrefix(query, "use") ||
+		query == withddl.QueryToTriggerWithDDL { // this query breaks unit tests since it errors out
 		return nil, nil
 	}
 	qr, err := dbc.conn.ExecuteFetch(query, 10000, true)
@@ -492,7 +493,6 @@ func shouldIgnoreQuery(query string) bool {
 func expectDBClientQueries(t *testing.T, queries []string, skippableOnce ...string) {
 	extraQueries := withDDL.DDLs()
 	extraQueries = append(extraQueries, withDDLInitialQueries...)
-	extraQueries = append(extraQueries, withddl.QueryToTriggerWithDDL)
 	// Either 'queries' or 'queriesWithDDLs' must match globalDBQueries
 	t.Helper()
 	failed := false

--- a/test/region_example.sh
+++ b/test/region_example.sh
@@ -44,6 +44,9 @@ mysql --table < show_initial_data.sql
 ./203_reshard.sh
 
 # SwitchReads
+
+sleep 5 # wait for workflow to run
+
 ./204_switch_reads.sh
 
 # SwitchWrites


### PR DESCRIPTION
## Description

https://github.com/vitessio/vitess/pull/9817 was calling `WithDDL.ExecIgnore()` which _does not_ run the initial WithDDL queries to create the `_vt` schema. We need  to use `WithDDL.Exec()` instead for that.  However after trying that we found that some tests were failing. This happens when a primary is coming up, semi-sync is enabled, but there are no other replicas. This causes the tablet to deadlock and never come up.

So we just add the "impossible" query from the previous PR to the `WithDDLInitialQueries` list so that we will always run all the `_vt` schema queries, when a workflow starts.

We will also need the change in #9861, to handle the code paths using `VReplicationExec`  and `VExec`. This PR was originally supposed to make that redundant (since we planned to create the `_vt` schema on tablet startup.

## Related Issue(s)
#9817
#9861

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required
