### PR TITLE
feat: make the join columns output easier to read

### DIFF
--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -260,7 +260,7 @@ func combineVars(bv1, bv2 map[string]*querypb.BindVariable) map[string]*querypb.
 func (jn *Join) description() PrimitiveDescription {
 	other := map[string]interface{}{
 		"TableName":         jn.GetTableName(),
-		"JoinColumnIndexes": strings.Trim(strings.Join(strings.Fields(fmt.Sprint(jn.Cols)), ","), "[]"),
+		"JoinColumnIndexes": jn.joinColsDescription(),
 	}
 	if len(jn.Vars) > 0 {
 		other["JoinVars"] = orderedStringIntMap(jn.Vars)
@@ -270,4 +270,17 @@ func (jn *Join) description() PrimitiveDescription {
 		Variant:      jn.Opcode.String(),
 		Other:        other,
 	}
+}
+
+func (jn *Join) joinColsDescription() string {
+	var joinCols []string
+	for _, col := range jn.Cols {
+		if col < 0 {
+			joinCols = append(joinCols, fmt.Sprintf("L:%d", -col-1))
+		} else {
+			joinCols = append(joinCols, fmt.Sprintf("R:%d", col-1))
+		}
+	}
+	joinColTxt := strings.Join(joinCols, ",")
+	return joinColTxt
 }

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -520,7 +520,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "`user`_unsharded",
     "Inputs": [
       {
@@ -2307,7 +2307,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -3174,7 +3174,7 @@ Gen4 error: cannot push projections in ordered aggregates
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,1",
+            "JoinColumnIndexes": "L:0,R:0",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -3250,7 +3250,7 @@ Gen4 error: cannot push projections in ordered aggregates
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-2,-3,-1,1",
+            "JoinColumnIndexes": "L:1,L:2,L:0,R:0",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -3308,7 +3308,7 @@ Gen4 error: cannot push projections in ordered aggregates
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-2,-3,-1,1",
+            "JoinColumnIndexes": "L:1,L:2,L:0,R:0",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -3372,7 +3372,7 @@ Gen4 error: cannot push projections in ordered aggregates
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "1,2,-2,3,4,-3,5,6",
+                "JoinColumnIndexes": "R:0,R:1,L:1,R:2,R:3,L:2,R:4,R:5",
                 "JoinVars": {
                   "u_foo": 0
                 },
@@ -3392,7 +3392,7 @@ Gen4 error: cannot push projections in ordered aggregates
                   {
                     "OperatorType": "Join",
                     "Variant": "Join",
-                    "JoinColumnIndexes": "2,3,-2,1,-3,1",
+                    "JoinColumnIndexes": "R:1,R:2,L:1,R:0,L:2,R:0",
                     "JoinVars": {
                       "ue_bar": 0
                     },
@@ -3727,7 +3727,7 @@ Gen4 error: cannot push projections in ordered aggregates
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-3,-4,-6",
+            "JoinColumnIndexes": "L:2,L:3,L:5",
             "JoinVars": {
               "u2_val2": 0
             },
@@ -3736,7 +3736,7 @@ Gen4 error: cannot push projections in ordered aggregates
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "1,1,-3,-1,2,-2",
+                "JoinColumnIndexes": "R:0,R:0,L:2,L:0,R:1,L:1",
                 "JoinVars": {
                   "u_val2": 0
                 },
@@ -3820,7 +3820,7 @@ Gen4 error: cannot push projections in ordered aggregates
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2,-3,1,2",
+            "JoinColumnIndexes": "L:0,L:1,L:2,R:0,R:1",
             "JoinVars": {
               "user_col": 0
             },

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -690,7 +690,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_col": 0
     },
@@ -735,7 +735,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_col": 0
     },
@@ -802,7 +802,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_col": 0
     },
@@ -847,7 +847,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_col": 0
     },
@@ -884,7 +884,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_col": 0
     },
@@ -1081,7 +1081,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -1118,7 +1118,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "unsharded_id": 0
     },
@@ -1185,7 +1185,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_col": 0
     },
@@ -1226,7 +1226,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_col": 0
     },
@@ -1270,7 +1270,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_col": 0
     },
@@ -1311,7 +1311,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_col": 0
     },
@@ -1355,7 +1355,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "user_extra_`user`",
     "Inputs": [
       {
@@ -1393,7 +1393,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "user_extra_`user`",
     "Inputs": [
       {
@@ -1434,7 +1434,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_col": 0
     },
@@ -1475,7 +1475,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_col": 0
     },
@@ -2989,7 +2989,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -3044,7 +3044,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -3081,7 +3081,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_col": 0
     },
@@ -3144,7 +3144,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "user_col": 0
     },
@@ -3200,7 +3200,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Join",
             "Variant": "LeftJoin",
-            "JoinColumnIndexes": "1,-2",
+            "JoinColumnIndexes": "R:0,L:1",
             "JoinVars": {
               "user_col": 0
             },

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -228,7 +228,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "`user`_music",
     "Inputs": [
       {
@@ -402,7 +402,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "music_id": 1
     },
@@ -443,7 +443,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "music_id": 0
     },
@@ -487,7 +487,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "`user`_music",
     "Inputs": [
       {
@@ -582,7 +582,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "LeftJoin",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "u_a": 0
     },
@@ -623,7 +623,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "LeftJoin",
-    "JoinColumnIndexes": "-2,1",
+    "JoinColumnIndexes": "L:1,R:0",
     "JoinVars": {
       "m1_col": 0
     },
@@ -632,7 +632,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "LeftJoin",
-        "JoinColumnIndexes": "1,-1",
+        "JoinColumnIndexes": "R:0,L:0",
         "JoinVars": {
           "user_col": 0
         },
@@ -686,7 +686,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "LeftJoin",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "user_col": 0
     },
@@ -819,13 +819,13 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_unsharded_unsharded",
     "Inputs": [
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "`user`_unsharded",
         "Inputs": [
           {
@@ -872,7 +872,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_unsharded",
     "Inputs": [
       {
@@ -909,7 +909,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_unsharded",
     "Inputs": [
       {
@@ -943,7 +943,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_unsharded",
     "Inputs": [
       {
@@ -980,7 +980,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_`user`_unsharded",
     "Inputs": [
       {
@@ -1032,7 +1032,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "`user`_`user`_unsharded",
     "Inputs": [
       {
@@ -1049,7 +1049,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "`user`_unsharded",
         "Inputs": [
           {
@@ -1299,7 +1299,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "user_id": 1
     },
@@ -1336,7 +1336,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "user_id": 0
     },
@@ -1376,7 +1376,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -1418,7 +1418,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -1460,7 +1460,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "user_id": 1
     },
@@ -1497,7 +1497,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_col": 0
     },
@@ -1541,7 +1541,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_user_id": 0
     },
@@ -1582,7 +1582,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "user_name": 0
     },
@@ -1767,7 +1767,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "unsharded_user_extra",
     "Inputs": [
       {
@@ -1952,7 +1952,7 @@ Gen4 error: Duplicate column name 'id'
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "t_id": 0
     },
@@ -2247,7 +2247,7 @@ Gen4 error: symbol id not found
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "information_schema.a_unsharded",
     "Inputs": [
       {
@@ -2285,7 +2285,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "unsharded_information_schema.a",
     "Inputs": [
       {
@@ -2323,7 +2323,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "t_col1": 0,
       "t_id": 1
@@ -2340,7 +2340,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -2399,7 +2399,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2",
+        "JoinColumnIndexes": "L:0,L:1",
         "JoinVars": {
           "user_col": 2
         },
@@ -2444,7 +2444,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-2,-3",
+        "JoinColumnIndexes": "L:1,L:2",
         "JoinVars": {
           "user_col": 0
         },
@@ -2486,7 +2486,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "unsharded_a_`user`_user_extra",
     "Inputs": [
       {
@@ -2509,7 +2509,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -2552,7 +2552,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "ua_id": 0
     },
@@ -2578,7 +2578,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -2865,7 +2865,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "unsharded_`user`",
         "Inputs": [
           {
@@ -2925,7 +2925,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "LeftJoin",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "unsharded_`user`",
         "Inputs": [
           {
@@ -2966,7 +2966,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "unsharded_`user`_unsharded_a",
     "Inputs": [
       {
@@ -2991,7 +2991,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1",
+            "JoinColumnIndexes": "L:0",
             "TableName": "unsharded_`user`",
             "Inputs": [
               {
@@ -3059,7 +3059,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "1",
+        "JoinColumnIndexes": "R:0",
         "TableName": "`user`_unsharded, unsharded_a",
         "Inputs": [
           {
@@ -3098,7 +3098,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "JoinVars": {
       "user_col2": 1
     },
@@ -3135,7 +3135,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,1",
+    "JoinColumnIndexes": "L:1,R:0",
     "JoinVars": {
       "user_col2": 0
     },
@@ -3234,7 +3234,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
@@ -3351,7 +3351,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -3392,7 +3392,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_assembly_id": 0
     },
@@ -3504,7 +3504,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "ue_user_id": 1
     },
@@ -3513,7 +3513,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,1",
+        "JoinColumnIndexes": "L:0,R:0",
         "JoinVars": {
           "u_id": 1
         },
@@ -3567,7 +3567,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "ue_id": 0
     },
@@ -3611,7 +3611,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "JoinVars": {
       "u_id": 0
     },
@@ -3648,7 +3648,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1,-2",
+    "JoinColumnIndexes": "R:0,L:1",
     "JoinVars": {
       "ue_id": 0
     },
@@ -3781,7 +3781,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2",
+        "JoinColumnIndexes": "L:0,L:1",
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
@@ -3831,7 +3831,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2,-3",
+        "JoinColumnIndexes": "L:0,L:1,L:2",
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
@@ -3923,7 +3923,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2",
+        "JoinColumnIndexes": "L:0,L:1",
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
@@ -4099,7 +4099,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "u_intcol": 1
     },
@@ -4136,7 +4136,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "u_intcol": 0
     },
@@ -4177,7 +4177,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "t_col1": 0
     },
@@ -4193,7 +4193,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_unsharded",
             "Inputs": [
               {
@@ -4255,7 +4255,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Join",
             "Variant": "LeftJoin",
-            "JoinColumnIndexes": "1,-2",
+            "JoinColumnIndexes": "R:0,L:1",
             "JoinVars": {
               "user_col": 0
             },
@@ -4300,7 +4300,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "unsharded_unsharded_tab",
     "Inputs": [
       {

--- a/go/vt/vtgate/planbuilder/testdata/large_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/large_cases.txt
@@ -5,7 +5,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -189,7 +189,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "music, music_extra_`user`, user_extra, user_metadata_unsharded, unsharded_a, unsharded_auto, unsharded_b",
     "Inputs": [
       {
@@ -206,7 +206,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "`user`, user_extra, user_metadata_unsharded, unsharded_a, unsharded_auto, unsharded_b",
         "Inputs": [
           {

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
@@ -280,7 +280,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2,-3",
+            "JoinColumnIndexes": "L:0,L:1,L:2",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -331,7 +331,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2,-3",
+            "JoinColumnIndexes": "L:0,L:1,L:2",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -378,7 +378,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2,1,2",
+        "JoinColumnIndexes": "L:0,L:1,R:0,R:1",
         "JoinVars": {
           "user_id": 2
         },
@@ -431,7 +431,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-2,-3,1,2",
+        "JoinColumnIndexes": "L:1,L:2,R:0,R:1",
         "JoinVars": {
           "user_id": 0
         },
@@ -487,7 +487,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2,1,-3,2,-4",
+        "JoinColumnIndexes": "L:0,L:1,R:0,L:2,R:1,L:3",
         "JoinVars": {
           "user_id": 4
         },
@@ -540,7 +540,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-2,-3,1,-4,2,-5",
+        "JoinColumnIndexes": "L:1,L:2,R:0,L:3,R:1,L:4",
         "JoinVars": {
           "user_id": 0
         },
@@ -596,7 +596,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2,1,-3,2",
+        "JoinColumnIndexes": "L:0,L:1,R:0,L:2,R:1",
         "TableName": "`user`_unsharded",
         "Inputs": [
           {
@@ -638,7 +638,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2,1,-3,2",
+        "JoinColumnIndexes": "L:0,L:1,R:0,L:2,R:1",
         "TableName": "`user`_unsharded",
         "Inputs": [
           {
@@ -683,7 +683,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "1,2,-1,3,-2",
+        "JoinColumnIndexes": "R:0,R:1,L:0,R:2,L:1",
         "TableName": "unsharded_`user`",
         "Inputs": [
           {
@@ -725,7 +725,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "1,2,-1,3,-2",
+        "JoinColumnIndexes": "R:0,R:1,L:0,R:2,L:1",
         "TableName": "unsharded_`user`",
         "Inputs": [
           {
@@ -819,7 +819,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "u_a": 0
     },

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -45,7 +45,7 @@ Gen4 error: Column 'col1' in field list is ambiguous
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -79,7 +79,7 @@ Gen4 error: Column 'col1' in field list is ambiguous
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -116,7 +116,7 @@ Gen4 error: Column 'col1' in field list is ambiguous
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2,1",
+    "JoinColumnIndexes": "L:0,L:1,R:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -150,7 +150,7 @@ Gen4 error: Column 'col1' in field list is ambiguous
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2,1",
+    "JoinColumnIndexes": "L:0,L:1,R:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -644,7 +644,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2,1",
+    "JoinColumnIndexes": "L:0,L:1,R:0",
     "JoinVars": {
       "user_id": 2
     },
@@ -689,7 +689,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,-3,1",
+    "JoinColumnIndexes": "L:1,L:2,R:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -737,7 +737,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2,1",
+    "JoinColumnIndexes": "L:0,L:1,R:0",
     "JoinVars": {
       "user_id": 2
     },
@@ -782,7 +782,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,-3,1",
+    "JoinColumnIndexes": "L:1,L:2,R:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -831,7 +831,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2,1",
+    "JoinColumnIndexes": "L:0,L:1,R:0",
     "JoinVars": {
       "user_id": 2
     },
@@ -876,7 +876,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,-3,1",
+    "JoinColumnIndexes": "L:1,L:2,R:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -1019,7 +1019,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2,1",
+    "JoinColumnIndexes": "L:0,L:1,R:0",
     "JoinVars": {
       "user_id": 2
     },
@@ -1064,7 +1064,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,-3,1",
+    "JoinColumnIndexes": "L:1,L:2,R:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -1221,7 +1221,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "JoinVars": {
       "u_col": 1
     },
@@ -1258,7 +1258,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,1",
+    "JoinColumnIndexes": "L:1,R:0",
     "JoinVars": {
       "u_col": 0
     },
@@ -1516,7 +1516,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
@@ -1763,7 +1763,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_music",
     "Inputs": [
       {
@@ -1799,7 +1799,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_music",
     "Inputs": [
       {
@@ -2019,7 +2019,7 @@ Gen4 error: In aggregated query without GROUP BY, expression of SELECT list cont
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-1",
+    "JoinColumnIndexes": "L:0,L:0",
     "TableName": "`user`_music",
     "Inputs": [
       {
@@ -2086,7 +2086,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
@@ -2128,7 +2128,7 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2",
+        "JoinColumnIndexes": "L:0,L:1",
         "TableName": "`user`_user_extra",
         "Inputs": [
           {

--- a/go/vt/vtgate/planbuilder/testdata/rails_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/rails_cases.txt
@@ -6,7 +6,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2,-3,-4",
+    "JoinColumnIndexes": "L:0,L:1,L:2,L:3",
     "JoinVars": {
       "book6s_supplier5_id": 4
     },
@@ -15,7 +15,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2,-3,-4,-5",
+        "JoinColumnIndexes": "L:0,L:1,L:2,L:3,L:4",
         "JoinVars": {
           "order2s_customer2_id": 5
         },
@@ -24,7 +24,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2,-3,-4,-5,1",
+            "JoinColumnIndexes": "L:0,L:1,L:2,L:3,L:4,R:0",
             "JoinVars": {
               "book6s_order2s_order2_id": 5
             },
@@ -33,7 +33,7 @@
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "-1,-2,-3,-4,-5,1",
+                "JoinColumnIndexes": "L:0,L:1,L:2,L:3,L:4,R:0",
                 "JoinVars": {
                   "book6s_id": 5
                 },
@@ -121,7 +121,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1,2,3,4",
+    "JoinColumnIndexes": "R:0,R:1,R:2,R:3",
     "JoinVars": {
       "order2s_id": 0
     },
@@ -141,7 +141,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-2,-3,-4,-5",
+        "JoinColumnIndexes": "L:1,L:2,L:3,L:4",
         "JoinVars": {
           "book6s_supplier5_id": 0
         },
@@ -150,7 +150,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-2,-3,-4,-5,-6",
+            "JoinColumnIndexes": "L:1,L:2,L:3,L:4,L:5",
             "JoinVars": {
               "book6s_id": 0
             },
@@ -204,4 +204,3 @@
     ]
   }
 }
-

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -520,7 +520,7 @@ Gen4 error: Column 'col' in field list is ambiguous
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -657,7 +657,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -695,7 +695,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -733,7 +733,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -771,7 +771,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1,-2",
+    "JoinColumnIndexes": "L:0,R:0,L:1",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -809,7 +809,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -847,7 +847,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -885,7 +885,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -926,7 +926,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -1373,7 +1373,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,1",
+        "JoinColumnIndexes": "L:0,R:0",
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
@@ -2071,7 +2071,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2",
+    "JoinColumnIndexes": "L:0,L:1",
     "TableName": "`user`, user_extra_unsharded",
     "Inputs": [
       {
@@ -2105,7 +2105,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1,2",
+    "JoinColumnIndexes": "R:0,R:1",
     "TableName": "unsharded_`user`, user_extra",
     "Inputs": [
       {
@@ -2160,7 +2160,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "dual_`user`",
     "Inputs": [
       {
@@ -2212,7 +2212,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "dual_`user`",
     "Inputs": [
       {
@@ -2274,7 +2274,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
@@ -2336,7 +2336,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "`user`_user_extra",
         "Inputs": [
           {
@@ -2406,7 +2406,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1",
+            "JoinColumnIndexes": "L:0",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -2474,7 +2474,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1",
+            "JoinColumnIndexes": "L:0",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -2538,7 +2538,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_id": 0
     },
@@ -2678,7 +2678,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,1,-2",
+        "JoinColumnIndexes": "L:0,R:0,L:1",
         "TableName": "`user`_`user`",
         "Inputs": [
           {
@@ -2816,7 +2816,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_col": 0,
       "user_id": 1
@@ -2854,7 +2854,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "user_extra_col": 1,
       "user_extra_id": 0

--- a/go/vt/vtgate/planbuilder/testdata/symtab_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/symtab_cases.txt
@@ -8,7 +8,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "JoinVars": {
       "predef2": 0
     },

--- a/go/vt/vtgate/planbuilder/testdata/systemtables_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/systemtables_cases.txt
@@ -283,7 +283,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "INFORMATION_SCHEMA.KEY_COLUMN_USAGE, INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS_INFORMATION_SCHEMA.K",
     "Inputs": [
       {
@@ -835,7 +835,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "x_id": 1
     },
@@ -876,7 +876,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "x_id": 0
     },

--- a/go/vt/vtgate/planbuilder/testdata/tpcc_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/tpcc_cases.txt
@@ -884,7 +884,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2",
+        "JoinColumnIndexes": "L:0,L:1",
         "JoinVars": {
           "o_o_c_id": 3,
           "o_o_d_id": 1,

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
@@ -50,7 +50,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "-1,1,2,-3,3,4,-2,5,6",
+                        "JoinColumnIndexes": "L:0,R:0,R:1,L:2,R:2,R:3,L:1,R:4,R:5",
                         "JoinVars": {
                           "l_orderkey": 0
                         },
@@ -70,7 +70,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "-4,-6,-5,-7,-2,1",
+                            "JoinColumnIndexes": "L:3,L:5,L:4,L:6,L:1,R:0",
                             "JoinVars": {
                               "o_custkey": 0
                             },
@@ -219,7 +219,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                   {
                     "OperatorType": "Join",
                     "Variant": "Join",
-                    "JoinColumnIndexes": "1,2,-4,-5,-6,-7,3,4",
+                    "JoinColumnIndexes": "R:0,R:1,L:3,L:4,L:5,L:6,R:2,R:3",
                     "JoinVars": {
                       "s_nationkey": 0
                     },
@@ -228,7 +228,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "1,2,3,-7,-8,4,5",
+                        "JoinColumnIndexes": "R:0,R:1,R:2,L:6,L:7,R:3,R:4",
                         "JoinVars": {
                           "c_nationkey": 1,
                           "o_orderkey": 0
@@ -238,7 +238,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "-2,1,-2,1,-5,3,-3,2",
+                            "JoinColumnIndexes": "L:1,R:0,L:1,R:0,L:4,R:2,L:2,R:1",
                             "JoinVars": {
                               "o_custkey": 0
                             },
@@ -275,7 +275,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "1,1,3,-2,2",
+                            "JoinColumnIndexes": "R:0,R:0,R:2,L:1,R:1",
                             "JoinVars": {
                               "l_suppkey": 0
                             },
@@ -318,7 +318,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "-4,-5,-2,1",
+                        "JoinColumnIndexes": "L:3,L:4,L:1,R:0",
                         "JoinVars": {
                           "n_regionkey": 0
                         },
@@ -480,7 +480,7 @@ Gen4 error: using aggregation on top of a *planbuilder.simpleProjection plan is 
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "1,2,3,4,5,6,7,8,9,10,11,12,13,14,-4,-5,15,16",
+                        "JoinColumnIndexes": "R:0,R:1,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13,L:3,L:4,R:14,R:15",
                         "JoinVars": {
                           "o_custkey": 0
                         },
@@ -489,7 +489,7 @@ Gen4 error: using aggregation on top of a *planbuilder.simpleProjection plan is 
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "-2,-2,-5,-3,1",
+                            "JoinColumnIndexes": "L:1,L:1,L:4,L:2,R:0",
                             "JoinVars": {
                               "o_orderkey": 0
                             },
@@ -526,7 +526,7 @@ Gen4 error: using aggregation on top of a *planbuilder.simpleProjection plan is 
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "-4,-6,-8,-10,2,-12,-14,-5,-7,-9,-11,3,-13,-15,-2,1",
+                            "JoinColumnIndexes": "L:3,L:5,L:7,L:9,R:1,L:11,L:13,L:4,L:6,L:8,L:10,R:2,L:12,L:14,L:1,R:0",
                             "JoinVars": {
                               "c_nationkey": 0
                             },
@@ -613,7 +613,7 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "2,3,-2,1,-3,1",
+                "JoinColumnIndexes": "R:1,R:2,L:1,R:0,L:2,R:0",
                 "JoinVars": {
                   "o_orderkey": 0
                 },
@@ -703,7 +703,7 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2,-3,-4,1",
+        "JoinColumnIndexes": "L:0,L:1,L:2,L:3,R:0",
         "JoinVars": {
           "s_suppkey": 0
         },
@@ -823,7 +823,7 @@ Gen4 error: unsupported: group by on: *planbuilder.joinGen4
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-5,1",
+            "JoinColumnIndexes": "L:4,R:0",
             "JoinVars": {
               "l_partkey": 0,
               "l_quantity": 1,
@@ -905,7 +905,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "1,2,-4,-5,3,4",
+                        "JoinColumnIndexes": "R:0,R:1,L:3,L:4,R:2,R:3",
                         "JoinVars": {
                           "l1_l_suppkey": 0
                         },
@@ -914,7 +914,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "-2,-2,-5,-3,1",
+                            "JoinColumnIndexes": "L:1,L:1,L:4,L:2,R:0",
                             "JoinVars": {
                               "l1_l_orderkey": 0
                             },
@@ -951,7 +951,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "-4,-5,-2,1",
+                            "JoinColumnIndexes": "L:3,L:4,L:1,R:0",
                             "JoinVars": {
                               "s_nationkey": 0
                             },

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.txt
@@ -1016,7 +1016,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -1071,7 +1071,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -1140,7 +1140,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -1195,7 +1195,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -1698,7 +1698,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "tbl1_id": 0
     },

--- a/go/vt/vtgate/planbuilder/testdata/vindex_func_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/vindex_func_cases.txt
@@ -117,7 +117,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "_unsharded",
     "Inputs": [
       {
@@ -152,7 +152,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "TableName": "_unsharded",
     "Inputs": [
       {
@@ -190,7 +190,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1,-1",
+    "JoinColumnIndexes": "R:0,L:0",
     "TableName": "unsharded_",
     "Inputs": [
       {
@@ -225,7 +225,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1,-1",
+    "JoinColumnIndexes": "R:0,L:0",
     "TableName": "unsharded_",
     "Inputs": [
       {
@@ -263,7 +263,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2,1",
+    "JoinColumnIndexes": "L:0,L:1,R:0",
     "JoinVars": {
       "user_index_id": 0
     },
@@ -303,7 +303,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2,1",
+    "JoinColumnIndexes": "L:0,L:1,R:0",
     "JoinVars": {
       "user_index_id": 0
     },
@@ -346,7 +346,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,-2,1",
+    "JoinColumnIndexes": "L:0,L:1,R:0",
     "JoinVars": {
       "user_index_id": 1
     },
@@ -386,7 +386,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,-1,1",
+    "JoinColumnIndexes": "L:1,L:0,R:0",
     "JoinVars": {
       "user_index_id": 0
     },
@@ -429,7 +429,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "JoinVars": {
       "user_index_id": 1
     },
@@ -469,7 +469,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,1",
+    "JoinColumnIndexes": "L:1,R:0",
     "JoinVars": {
       "user_index_id": 0
     },
@@ -512,7 +512,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "JoinVars": {
       "ui_id": 1
     },
@@ -552,7 +552,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,1",
+    "JoinColumnIndexes": "L:1,R:0",
     "JoinVars": {
       "ui_id": 0
     },

--- a/go/vt/vtgate/planbuilder/testdata/wireup_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/wireup_cases.txt
@@ -6,7 +6,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1,-1,2",
+    "JoinColumnIndexes": "R:0,L:0,R:1",
     "JoinVars": {
       "uid": 0
     },
@@ -43,7 +43,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,1,-3",
+    "JoinColumnIndexes": "L:1,R:0,L:2",
     "JoinVars": {
       "e_id": 0
     },
@@ -87,7 +87,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1,-1,2",
+    "JoinColumnIndexes": "R:0,L:0,R:1",
     "JoinVars": {
       "uid1": 0
     },
@@ -124,7 +124,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2,1,-3",
+    "JoinColumnIndexes": "L:1,R:0,L:2",
     "JoinVars": {
       "e_id": 0
     },
@@ -168,7 +168,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "u1_col": 1
     },
@@ -177,7 +177,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2",
+        "JoinColumnIndexes": "L:0,L:1",
         "TableName": "`user`_`user`",
         "Inputs": [
           {
@@ -224,7 +224,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "`user`_`user`_`user`",
     "Inputs": [
       {
@@ -241,7 +241,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-2",
+        "JoinColumnIndexes": "L:1",
         "JoinVars": {
           "u1_col": 0
         },
@@ -283,7 +283,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "u2_col": 1
     },
@@ -292,7 +292,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,1",
+        "JoinColumnIndexes": "L:0,R:0",
         "TableName": "`user`_`user`",
         "Inputs": [
           {
@@ -339,7 +339,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_`user`_`user`",
     "Inputs": [
       {
@@ -397,7 +397,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "u1_col": 1
     },
@@ -406,7 +406,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2",
+        "JoinColumnIndexes": "L:0,L:1",
         "JoinVars": {
           "u1_col": 1
         },
@@ -456,7 +456,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "u3_col": 0
     },
@@ -476,7 +476,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-2",
+        "JoinColumnIndexes": "L:1",
         "JoinVars": {
           "u1_col": 0
         },
@@ -521,7 +521,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "u1_col": 1
     },
@@ -530,7 +530,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2",
+        "JoinColumnIndexes": "L:0,L:1",
         "JoinVars": {
           "u1_col": 1
         },
@@ -539,7 +539,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,-2",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_`user`",
             "Inputs": [
               {
@@ -603,7 +603,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "TableName": "`user`_`user`_`user`_`user`",
     "Inputs": [
       {
@@ -620,7 +620,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "1",
+        "JoinColumnIndexes": "R:0",
         "JoinVars": {
           "u4_col": 0
         },
@@ -640,7 +640,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-2",
+            "JoinColumnIndexes": "L:1",
             "JoinVars": {
               "u1_col": 0
             },
@@ -688,7 +688,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "JoinVars": {
       "u1_col": 1
     },
@@ -751,7 +751,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "u1_col": 0
     },
@@ -760,7 +760,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,-2",
+        "JoinColumnIndexes": "L:0,L:1",
         "JoinVars": {
           "u1_col": 0
         },
@@ -821,7 +821,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1,1",
+    "JoinColumnIndexes": "L:0,R:0",
     "JoinVars": {
       "weird_name_a_b_c": 1
     },
@@ -858,7 +858,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1,-2",
+    "JoinColumnIndexes": "R:0,L:1",
     "JoinVars": {
       "unsharded_id": 0
     },
@@ -902,7 +902,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "1",
+    "JoinColumnIndexes": "R:0",
     "JoinVars": {
       "weird_name_a_b_c": 0
     },
@@ -939,7 +939,7 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-2",
+    "JoinColumnIndexes": "L:1",
     "JoinVars": {
       "unsharded_id": 0
     },
@@ -987,7 +987,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1,1",
+        "JoinColumnIndexes": "L:0,R:0",
         "JoinVars": {
           "u_col": 1
         },
@@ -1030,7 +1030,7 @@
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-2,1",
+        "JoinColumnIndexes": "L:1,R:0",
         "JoinVars": {
           "u_col": 0
         },
@@ -1084,7 +1084,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,1",
+            "JoinColumnIndexes": "L:0,R:0",
             "JoinVars": {
               "u_col": 1
             },
@@ -1152,7 +1152,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-2,1",
+            "JoinColumnIndexes": "L:1,R:0",
             "JoinVars": {
               "u_col": 0
             },
@@ -1234,7 +1234,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-1,1,-2",
+            "JoinColumnIndexes": "L:0,R:0,L:1",
             "JoinVars": {
               "u_col": 2
             },
@@ -1297,7 +1297,7 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "-2,1,-3",
+            "JoinColumnIndexes": "L:1,R:0,L:2",
             "JoinVars": {
               "u_col": 0
             },
@@ -1364,7 +1364,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_`user`",
     "Inputs": [
       {
@@ -1406,7 +1406,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_`user`",
     "Inputs": [
       {
@@ -1476,13 +1476,13 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "-1",
+    "JoinColumnIndexes": "L:0",
     "TableName": "`user`_unsharded_unsharded",
     "Inputs": [
       {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "-1",
+        "JoinColumnIndexes": "L:0",
         "TableName": "`user`_unsharded",
         "Inputs": [
           {

--- a/test/config.json
+++ b/test/config.json
@@ -1026,7 +1026,7 @@
 			"Command": [],
 			"Manual": false,
 			"Shard": "23",
-			"RetryMax": 1,
+			"RetryMax": 3,
 			"Tags": [
 				"worker_test"
 			]


### PR DESCRIPTION
## Description
Small PR that makes the plan descriptions containing join columns slightly easier to read.

Up until now, the list of columns that the join primitive produces has been shown using a list of integers, such as:
```
{
  "QueryType": "SELECT",
  "Original": "select user.name, music.genre from user join music on user.musicId = music.id",
  "Instructions": {
    "OperatorType": "Join",
    "Variant": "Join",
    "JoinColumnIndexes": "-2,1",
    "Inputs": [
      {
        "OperatorType": "Route",
        "Query": "select `user`.musicId, `user`.`name` from `user`",
      },
      {
        "OperatorType": "Route",
        "Query": "select music.genre from music where music.id = :user_musicId",
      }
    ]
  }
}
```

The interesting part here is **"JoinColumnIndexes": "-2,1"**.
Negative numbers come from the left, so -2 here means the second column coming from the left (`user.name`), and 1 means the first column from the right (`music.genre`).

My suggestion is that this field instead should show: **"JoinColumnIndexes": "L:1, R:0"**

## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
