### PR TITLE
VPlayer: use stored/binlogged ENUM index value in WHERE clauses

### DIFF
--- a/go/test/endtoend/vreplication/config.go
+++ b/go/test/endtoend/vreplication/config.go
@@ -4,6 +4,9 @@ package vreplication
 // We violate the NO_ZERO_DATES and NO_ZERO_IN_DATE sql_modes that are enabled by default in
 // MySQL 5.7+ and MariaDB 10.2+ to ensure that vreplication still works everywhere and the
 // permissive sql_mode now used in vreplication causes no unwanted side effects.
+// The customer table also tests two important things:
+//   1. Composite or multi-column primary keys
+//   2. PKs that contain an ENUM column
 // The Lead and Lead-1 tables also allows us to test several things:
 //   1. Mixed case identifiers
 //   2. Column and table names with special characters in them, namely a dash
@@ -15,7 +18,7 @@ var (
 create table product(pid int, description varbinary(128), date1 datetime not null default '0000-00-00 00:00:00', date2 datetime not null default '2021-00-01 00:00:00', primary key(pid)) CHARSET=utf8mb4;
 create table customer(cid int, name varchar(128) collate utf8mb4_bin, meta json default null, typ enum('individual','soho','enterprise'), sport set('football','cricket','baseball'),
 	ts timestamp not null default current_timestamp, bits bit(2) default b'11', date1 datetime not null default '0000-00-00 00:00:00', 
-	date2 datetime not null default '2021-00-01 00:00:00', primary key(cid)) CHARSET=utf8mb4;
+	date2 datetime not null default '2021-00-01 00:00:00', primary key(cid,typ)) CHARSET=utf8mb4;
 create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 create table merchant(mname varchar(128), category varchar(128), primary key(mname)) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 create table orders(oid int, cid int, pid int, mname varchar(128), price int, qty int, total int as (qty * price), total2 int as (qty * price) stored, primary key(oid)) CHARSET=utf8;

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -371,6 +371,28 @@ func testVSchemaForSequenceAfterMoveTables(t *testing.T) {
 	validateQuery(t, vtgateConn, "product", "select max(cid) from customer2", want)
 }
 
+// testReplicatingWithPKEnumCols ensures that we properly apply binlog events
+// in the stream where the PK contains an ENUM column
+func testReplicatingWithPKEnumCols(t *testing.T) {
+	// At this point we have an ongoing MoveTables operation for the customer table
+	// from the product to the customer keyspace. Let's delete and insert a row to
+	// ensure that the PK -- which is on (cid, typ) with typ being an ENUM -- is
+	// managed correctly in the WHERE clause for the delete. The end result is that
+	// we should see the proper deletes propogate and not get a duplicate key error
+	// when we re-insert the same row values and ultimately VDiff shows the table as
+	// being identical in both keyspaces.
+
+	// typ is an enum, with soho having a stored and binlogged value of 2
+	deleteQuery := "delete from customer where cid = 2 and typ = 'soho'"
+	insertQuery := "insert into customer(cid, name, typ, sport, meta) values(2, 'Paül','soho','cricket',convert(x'7b7d' using utf8mb4))"
+	execVtgateQuery(t, vtgateConn, "product", deleteQuery)
+	time.Sleep(2 * time.Second)
+	vdiff(t, ksWorkflow, "")
+	execVtgateQuery(t, vtgateConn, "product", insertQuery)
+	time.Sleep(2 * time.Second)
+	vdiff(t, ksWorkflow, "")
+}
+
 func testReshardV2Workflow(t *testing.T) {
 	currentWorkflowType = wrangler.ReshardWorkflow
 
@@ -412,6 +434,8 @@ func testMoveTablesV2Workflow(t *testing.T) {
 	// Verify that we've properly ignored any internal operational tables
 	// and that they were not copied to the new target keyspace
 	verifyNoInternalTables(t, vtgateConn, targetKs)
+
+	testReplicatingWithPKEnumCols(t)
 
 	testRestOfWorkflow(t)
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -1476,7 +1476,7 @@ func TestPlayerTypes(t *testing.T) {
 		},
 	}, {
 		input:  "insert into vitess_strings values('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a', 'a,b')",
-		output: "insert into vitess_strings(vb,c,vc,b,tb,bl,ttx,tx,en,s) values ('a','b','c','d\\0\\0\\0\\0','e','f','g','h','1','3')",
+		output: "insert into vitess_strings(vb,c,vc,b,tb,bl,ttx,tx,en,s) values ('a','b','c','d\\0\\0\\0\\0','e','f','g','h',1,'3')",
 		table:  "vitess_strings",
 		data: [][]string{
 			{"a", "b", "c", "d\000\000\000\000", "e", "f", "g", "h", "a", "a,b"},


### PR DESCRIPTION
## Description
With MySQL [ENUM types](https://dev.mysql.com/doc/refman/en/enum.html) you define a list of valid values for the column as a list of strings. What MySQL stores in the table[space] and writes to row based binary log events, however, is [the index](https://dev.mysql.com/doc/refman/en/enum.html#enum-indexes) value.

In VReplication's `VPlayer` component — which runs on the target tablet and applies row based binlog events received from the `VStreamer` component on the source tablet — we generate `DELETE` and `UPDATE` statements with a `WHERE` clause that contains the `PRIMARY KEY` columns (or other unique equivalents) so that statement applies to a unique row. When the `PRIMARY KEY` contains an `ENUM` field then that field will always be used in the `WHERE` clause. But because the _**index value**_ is binary logged for the field, e.g. (field 3):
```
## Table structure
CREATE TABLE `jobs_subscriptions` (
  `job_id` varchar(36) NOT NULL,
  `subscription_id` varchar(36) NOT NULL,
  `type` enum('RFS_WEBHOOKS','ESS') NOT NULL,
  `creation_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`job_id`,`type`),
  KEY `subscription_id_idx` (`subscription_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;

## Decoded RBR event resulting from SQL statement deleting a row from the table
#220119 15:07:07 server id 2749805  end_log_pos 788514835 CRC32 0xbd937ca8 	Delete_rows: table id 451 flags: STMT_END_F
### DELETE FROM `vt_main`.`jobs_subscriptions`
### WHERE
###   @1='4ef79a1e-29bf-48a1-8033-4ec8e406e929' /* VARSTRING(108) meta=108 nullable=0 is_null=0 */
###   @2='a0c8d8db-2ea0-495a-98c7-68b5e7926aeb' /* VARSTRING(108) meta=108 nullable=0 is_null=0 */
###   @3=2 /* ENUM(1 byte) meta=63233 nullable=0 is_null=0 */
###   @4=1638266996 /* TIMESTAMP(0) meta=0 nullable=0 is_null=0 */
```

We then end up with a `WHERE` clause that does not match the row because the string '2' is not in the ENUM values list and will thus gets converted to **0**, which is the index for any string specified that's not in the `ENUM` definition:
```
delete from jobs_subscriptions where job_id='4ef79a1e-29bf-48a1-8033-4ec8e406e929' and type='2';
```

While the column type is an `ENUM` which is normally a quoted string value in the parser as we use the string mappings available in the defined schema, we need to treat it as an integer type here or do the index to string value mapping again. But given that doing the mapping here would be completely unnecessary overhead as we already have the index value which is what gets stored, we convert the internal value type to a uint64 and use it directly (2 in the example). 

## Related Issue(s)
- Fixes: https://github.com/vitessio/vitess/issues/9546

## Checklist
- [x] Should this PR be backported? ???
- [x] Tests were added
- [x] Documentation is not required