### PR TITLE
VReplication: Defer execution of `SAVEPOINT` statements until required

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -450,6 +450,72 @@ func TestPlayerSavepoint(t *testing.T) {
 	cancel()
 }
 
+func TestPlayerSavepointsWithoutData(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+	execStatements(t, []string{
+		"create table t1(id int, primary key(id))",
+		fmt.Sprintf("create table %s.t1(id int, primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t1",
+		fmt.Sprintf("drop table %s.t1", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			// No queries made against t2 here
+			Match: "t2",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	cancel, _ := startVReplication(t, bls, "")
+	// Issue a dummy change to ensure vreplication is initialized. Otherwise there
+	// is a race between the DDLs and the schema loader of vstreamer.
+	// Root cause seems to be with MySQL where t1 shows up in information_schema before
+	// the actual table is created.
+	execStatements(t, []string{"insert into t1 values(1)"})
+	expectDBClientQueries(t, []string{
+		"/update _vt.vreplication set pos=",
+		"/update _vt.vreplication set pos=",
+		"/update _vt.vreplication set pos=",
+	})
+
+	execStatements(t, []string{
+		"begin",
+		"savepoint vrepl_a",
+		"insert into t1(id) values (2)",
+		"savepoint vrepl_b",
+		"insert into t1(id) values (3)",
+		"release savepoint vrepl_b",
+		"savepoint vrepl_c",
+		"insert into t1(id) values (4)",
+		"savepoint vrepl_d",
+		"insert into t1(id) values (5)",
+		"savepoint vrepl_e",
+		"savepoint vrepl_f",
+		"insert into t1(id) values (42)",
+		"rollback work to savepoint vrepl_f",
+		"commit",
+	})
+	expectDBClientQueries(t, []string{
+		"begin",
+		"SAVEPOINT `vrepl_b`",
+		"SAVEPOINT `vrepl_c`",
+		"SAVEPOINT `vrepl_d`",
+		"SAVEPOINT `vrepl_e`",
+		"SAVEPOINT `vrepl_f`",
+		"/update _vt.vreplication set pos=",
+		"commit",
+	})
+	cancel()
+}
+
 func TestPlayerStatementModeWithFilter(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 


### PR DESCRIPTION
## Description

On one of our clusters, we're running multiple (36) `CreateLookupVindex` workflows with the `-continue-after-copy` as part of a migration from an unsharded to a sharded cluster.

We noticed that an interaction between savepoints and VReplication caused our MySQL instances to become overloaded, extreme binlog growth and  `vttablet` instances to consume up to 100GB of memory (instead of just ~2GB). In our setup `vttablet` and `mysqld` run on the same machine.

We believe this is due to the fact that VReplication workflows that have a filter defined (as the `CreateLookupVindex` workflows have) would still end up applying transactions and savepoints that were otherwise empty of actual data changes.

https://github.com/vitessio/vitess/commit/b0826701ef29f815f78ecfe9f861cf346946e5e4 contains a test that shows this problematic behaviour. The workflow is set up to filter only changes made to the `t2` table. The actual changes made only affect the `t1` table, but the transaction (and all savepoints) are replicated and executed anyway.

`vplayer` contains logic that skips "empty" transactions, but transactions that only contain savepoint statements are not skipped, and end up causing extreme load and binlog growths on the MySQL instance.

Even worse, if a `CreateLookupVindex` actually ends up writing data of a transaction with savepoints, the transaction will be replicated _again_. In our setup, in the worst case, a transaction containing a mix of writes and savepoints can cause a write amplification of those transactions and savepoints by `2 * 36` times.

## Proposed fix

Inside `vplayer`, we can buffer up and defer savepoint events until the first time an actual data-modifying event (or a `ROLLBACK TO` savepoint event) is encountered. Once we encounter a commit event, all pending savepoint events can be discarded. In the best case, this can lead to a transaction that only contains savepoint events to be completely skipped.

This is a "low complexity" and "low effort" fix for the exact problem we're running into. There will still be cases where more savepoint events than required will be applied.

A further improvement could be to "flatten" savepoint events that come in one after another. This will require keeping a map of "original" savepoint names and the "flattened" savepoint names, and will require re-writing `ROLLBACK TO` savepoint events to use the "flattened" savepoint name, but could further reduce the overhead of savepoint usage.

Another improvement could be to move this logic into the `vstreamer` component. This way, we could remove the overhead of sending savepoint events that are unsued between `vstreamer` and `vplayer`.

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

None.