### PR TITLE
vstreamer: split packets between savepoint events

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
@@ -1416,6 +1416,27 @@ func TestBuffering(t *testing.T) {
 			`commit`,
 		}},
 	}, {
+		input: []string{
+			"begin",
+			"insert into packet_test values (9, '123')",
+			"SAVEPOINT a",
+			"insert into packet_test values (10, '12')",
+			"SAVEPOINT b",
+			"commit",
+		},
+		output: [][]string{{
+			`begin`,
+			`type:ROW row_event:{table_name:"packet_test" row_changes:{after:{lengths:1 lengths:3 values:"9123"}}}`,
+		}, {
+			"type:SAVEPOINT statement:\"SAVEPOINT `a`\"",
+		}, {
+			`type:ROW row_event:{table_name:"packet_test" row_changes:{after:{lengths:2 lengths:2 values:"1012"}}}`,
+		}, {
+			"type:SAVEPOINT statement:\"SAVEPOINT `b`\"",
+			`gtid`,
+			`commit`,
+		}},
+	}, {
 		// DDL is in its own packet
 		input: []string{
 			"alter table packet_test change val val varchar(128)",


### PR DESCRIPTION
## Description

On one of our clusters, `CreateLookupVindex` workflows have run into the following error:
```
vttablet: rpc error: code = ResourceExhausted desc = trying to send message larger than max (111926209 vs. 67108864)
```

We believe the root cause of this error is the same as https://github.com/vitessio/vitess/pull/9881 - vreplication is executing transactions containing many savepoints but no or only a small number of actual data changes.

`vstreamer` tries to send data to vplayer in packets. A packet either contains all binlog events that happened for a single transaction, or for large transactions, the event stream is split along row or statement events, once packet size grows bigger than `vstream_packet_size`.

It looks like savepoint events are ignored in the packet size calculation logic. If a single transaction contains many savepoints, that could lead to packets growing unusually large.

This pull request proposes to fix this by including the statement length of savepoints in the packet size calculation.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

None.