### PR TITLE
Migrate remaining vtctldclient commands in local example

### DIFF
--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -43,10 +43,10 @@ done
 vtctldclient PlannedReparentShard commerce/0 --new-primary zone1-100
 
 # create the schema
-vtctlclient ApplySchema -- --sql-file create_commerce_schema.sql commerce
+vtctldclient ApplySchema --sql-file create_commerce_schema.sql commerce
 
 # create the vschema
-vtctlclient ApplyVSchema -- --vschema_file vschema_commerce_initial.json commerce
+vtctldclient ApplyVSchema --vschema-file vschema_commerce_initial.json commerce
 
 # start vtgate
 CELL=zone1 ./scripts/vtgate-up.sh

--- a/examples/local/301_customer_sharded.sh
+++ b/examples/local/301_customer_sharded.sh
@@ -22,7 +22,7 @@
 
 source ./env.sh
 
-vtctlclient ApplySchema -- --sql-file create_commerce_seq.sql commerce
-vtctlclient ApplyVSchema -- --vschema_file vschema_commerce_seq.json commerce
-vtctlclient ApplyVSchema -- --vschema_file vschema_customer_sharded.json customer
-vtctlclient ApplySchema -- --sql-file create_customer_sharded.sql customer
+vtctldclient ApplySchema --sql-file create_commerce_seq.sql commerce
+vtctldclient ApplyVSchema --vschema-file vschema_commerce_seq.json commerce
+vtctldclient ApplyVSchema --vschema-file vschema_customer_sharded.json customer
+vtctldclient ApplySchema --sql-file create_customer_sharded.sql customer


### PR DESCRIPTION
## Description

```
New VSchema object:
{
  "sharded": false,
  "vindexes": {},
  "tables": {
    "corder": {
      "type": "",
      "column_vindexes": [],
      "auto_increment": null,
      "columns": [],
      "pinned": "",
      "column_list_authoritative": false
    },
    "customer": {
      "type": "",
      "column_vindexes": [],
      "auto_increment": null,
      "columns": [],
      "pinned": "",
      "column_list_authoritative": false
    },
    "product": {
      "type": "",
      "column_vindexes": [],
      "auto_increment": null,
      "columns": [],
      "pinned": "",
      "column_list_authoritative": false
    }
  },
  "require_explicit_routing": false
}
If this is not what you expected, check the input data (as JSON parsing will skip unexpected fields).
Waiting for vtgate to be up...
vtgate is up!
```

## Related Issue(s)

Closes #7219 

## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->