### PR TITLE
[VEP-4, phase 1] Flag cleanup in `go/cmd`

### DIFF
--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -203,17 +203,17 @@ type command struct {
 }
 
 var commands = []command{
-	{"init", initCmd, "[-wait_time=5m] [-init_db_sql_file=]",
+	{"init", initCmd, "[--wait_time=5m] [--init_db_sql_file=]",
 		"Initializes the directory structure and starts mysqld"},
 	{"init_config", initConfigCmd, "",
 		"Initializes the directory structure, creates my.cnf file, but does not start mysqld"},
 	{"reinit_config", reinitConfigCmd, "",
 		"Reinitializes my.cnf file with new server_id"},
-	{"teardown", teardownCmd, "[-wait_time=5m] [-force]",
+	{"teardown", teardownCmd, "[--wait_time=5m] [--force]",
 		"Shuts mysqld down, and removes the directory"},
-	{"start", startCmd, "[-wait_time=5m]",
+	{"start", startCmd, "[--wait_time=5m]",
 		"Starts mysqld on an already 'init'-ed directory"},
-	{"shutdown", shutdownCmd, "[-wait_time=5m]",
+	{"shutdown", shutdownCmd, "[--wait_time=5m]",
 		"Shuts down mysqld, does not remove any file"},
 
 	{"position", positionCmd,

--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -312,7 +312,7 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 	case mysqlctl.ErrNoBackup:
 		// There is no backup found, but we may be taking the initial backup of a shard
 		if !*allowFirstBackup {
-			return fmt.Errorf("no backup found; not starting up empty since -initial_backup flag was not enabled")
+			return fmt.Errorf("no backup found; not starting up empty since --initial_backup flag was not enabled")
 		}
 		restorePos = mysql.Position{}
 	default:
@@ -634,14 +634,14 @@ func shouldBackup(ctx context.Context, topoServer *topo.Server, backupStorage ba
 
 	// We need at least one backup so we can restore first, unless the user explicitly says we don't
 	if len(backups) == 0 && !*allowFirstBackup {
-		return false, fmt.Errorf("no existing backups to restore from; backup is not possible since -initial_backup flag was not enabled")
+		return false, fmt.Errorf("no existing backups to restore from; backup is not possible since --initial_backup flag was not enabled")
 	}
 	if lastBackup == nil {
 		if *allowFirstBackup {
 			// There's no complete backup, but we were told to take one from scratch anyway.
 			return true, nil
 		}
-		return false, fmt.Errorf("no complete backups to restore from; backup is not possible since -initial_backup flag was not enabled")
+		return false, fmt.Errorf("no complete backups to restore from; backup is not possible since --initial_backup flag was not enabled")
 	}
 
 	// Has it been long enough since the last complete backup to need a new one?

--- a/go/cmd/vtbench/vtbench.go
+++ b/go/cmd/vtbench/vtbench.go
@@ -48,36 +48,36 @@ import (
 
   Mysql protocol to vtgate:
   vtbench \
-        -protocol mysql \
-        -host vtgate-host.my.domain \
-        -port 15306 \
-        -user db_username \
-        -db-credentials-file ./vtbench_db_creds.json \
-        -db @replica \
-        -sql "select * from loadtest_table where id=123456789" \
-        -threads 10 \
-        -count 10
+        --protocol mysql \
+        --host vtgate-host.my.domain \
+        --port 15306 \
+        --user db_username \
+        --db-credentials-file ./vtbench_db_creds.json \
+        --db @replica \
+        --sql "select * from loadtest_table where id=123456789" \
+        --threads 10 \
+        --count 10
 
   GRPC to vtgate:
   vtbench \
-        -protocol grpc-vtgate \
-        -host vtgate-host.my.domain \
-        -port 15999 \
-        -db @replica  \
+        --protocol grpc-vtgate \
+        --host vtgate-host.my.domain \
+        --port 15999 \
+        --db @replica  \
         $VTTABLET_GRPC_ARGS \
-        -sql "select * from loadtest_table where id=123456789" \
-        -threads 10 \
-        -count 10
+        --sql "select * from loadtest_table where id=123456789" \
+        --threads 10 \
+        --count 10
 
   GRPC to vttablet:
   vtbench \
-        -protocol grpc-vttablet \
-        -host tablet-loadtest-00-80.my.domain \
-        -port 15999 \
-        -db loadtest/00-80@replica  \
-        -sql "select * from loadtest_table where id=123456789" \
-        -threads 10 \
-        -count 10
+        --protocol grpc-vttablet \
+        --host tablet-loadtest-00-80.my.domain \
+        --port 15999 \
+        --db loadtest/00-80@replica  \
+        --sql "select * from loadtest_table where id=123456789" \
+        --threads 10 \
+        --count 10
 
 */
 

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -56,9 +56,9 @@ in the form of :v1, :v2, etc.
 
 Examples:
 
-  $ vtclient -server vtgate:15991 "SELECT * FROM messages"
+  $ vtclient --server vtgate:15991 "SELECT * FROM messages"
 
-  $ vtclient -server vtgate:15991 -target '@primary' -bind_variables '[ 12345, 1, "msg 12345" ]' "INSERT INTO messages (page,time_created_ns,message) VALUES (:v1, :v2, :v3)"
+  $ vtclient --server vtgate:15991 --target '@primary' --bind_variables '[ 12345, 1, "msg 12345" ]' "INSERT INTO messages (page,time_created_ns,message) VALUES (:v1, :v2, :v3)"
 
 `
 	server        = flag.String("server", "", "vtgate server to connect to")

--- a/go/cmd/vtclient/vtclient_test.go
+++ b/go/cmd/vtclient/vtclient_test.go
@@ -89,27 +89,27 @@ func TestVtclient(t *testing.T) {
 			args: []string{"SELECT * FROM table1"},
 		},
 		{
-			args: []string{"-target", "@primary", "-bind_variables", `[ 1, 100 ]`,
+			args: []string{"--target", "@primary", "--bind_variables", `[ 1, 100 ]`,
 				"INSERT INTO table1 (id, i) VALUES (:v1, :v2)"},
 			rowsAffected: 1,
 		},
 		{
-			args: []string{"-target", "@primary",
+			args: []string{"--target", "@primary",
 				"UPDATE table1 SET i = (i + 1)"},
 			rowsAffected: 1,
 		},
 		{
-			args: []string{"-target", "@primary",
+			args: []string{"--target", "@primary",
 				"SELECT * FROM table1"},
 			rowsAffected: 1,
 		},
 		{
-			args: []string{"-target", "@primary", "-bind_variables", `[ 1 ]`,
+			args: []string{"--target", "@primary", "--bind_variables", `[ 1 ]`,
 				"DELETE FROM table1 WHERE id = :v1"},
 			rowsAffected: 1,
 		},
 		{
-			args: []string{"-target", "@primary",
+			args: []string{"--target", "@primary",
 				"SELECT * FROM table1"},
 			rowsAffected: 0,
 		},
@@ -124,7 +124,7 @@ func TestVtclient(t *testing.T) {
 	for _, q := range queries {
 		// Run main function directly and not as external process. To achieve this,
 		// overwrite os.Args which is used by flag.Parse().
-		os.Args = []string{"vtclient_test.go", "-server", vtgateAddr}
+		os.Args = []string{"vtclient_test.go", "--server", vtgateAddr}
 		os.Args = append(os.Args, q.args...)
 
 		results, err := run()

--- a/go/cmd/vtctldclient/command/legacy_shim.go
+++ b/go/cmd/vtctldclient/command/legacy_shim.go
@@ -70,8 +70,8 @@ LegacyVtctlCommand -- help # displays help for supported legacy vtctl commands
 # before the first flag argument, like in the first example. The double dash may
 # be used, however, at any point after the "LegacyVtctlCommand" string, as in
 # the second example.
-LegacyVtctlCommand AddCellInfo -- -server_address "localhost:1234" -root "/vitess/cell1"
-LegacyVtctlCommand -- AddCellInfo -server_address "localhost:5678" -root "/vitess/cell1"`),
+LegacyVtctlCommand AddCellInfo -- --server_address "localhost:1234" --root "/vitess/cell1"
+LegacyVtctlCommand -- AddCellInfo --server_address "localhost:5678" --root "/vitess/cell1"`),
 	}
 )
 

--- a/go/cmd/vtctldclient/command/root.go
+++ b/go/cmd/vtctldclient/command/root.go
@@ -81,7 +81,7 @@ var (
 	}
 )
 
-var errNoServer = errors.New("please specify -server <vtctld_host:vtctld_port> to specify the vtctld server to connect to")
+var errNoServer = errors.New("please specify --server <vtctld_host:vtctld_port> to specify the vtctld server to connect to")
 
 // ensureServerArg validates that --server was passed to the CLI.
 func ensureServerArg() error {

--- a/go/cmd/vtctldclient/command/vschemas.go
+++ b/go/cmd/vtctldclient/command/vschemas.go
@@ -32,17 +32,19 @@ import (
 var (
 	// GetVSchema makes a GetVSchema gRPC call to a vtctld.
 	GetVSchema = &cobra.Command{
-		Use:  "GetVSchema keyspace",
-		Args: cobra.ExactArgs(1),
-		RunE: commandGetVSchema,
+		Use:                   "GetVSchema <keyspace>",
+		Short:                 "Prints a JSON representation of a keyspace's topo record.",
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		RunE:                  commandGetVSchema,
 	}
 	// ApplyVSchema makes an ApplyVSchema gRPC call to a vtctld.
 	ApplyVSchema = &cobra.Command{
-		Use:                   "ApplyVSchema {-vschema=<vschema> || -vschema-file=<vschema file> || -sql=<sql> || -sql-file=<sql file>} [-cells=c1,c2,...] [-skip-rebuild] [-dry-run] <keyspace>",
-		Args:                  cobra.ExactArgs(1),
-		DisableFlagsInUseLine: true,
-		RunE:                  commandApplyVSchema,
+		Use:                   "ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> || --sql=<sql> || --sql-file=<sql file>} [--cells=c1,c2,...] [--skip-rebuild] [--dry-run] <keyspace>",
 		Short:                 "Applies the VTGate routing schema to the provided keyspace. Shows the result after application.",
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		RunE:                  commandApplyVSchema,
 	}
 )
 

--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -42,7 +42,7 @@ var (
 	vschemaFileFlag    = flag.String("vschema-file", "", "Identifies the VTGate routing schema file")
 	ksShardMapFlag     = flag.String("ks-shard-map", "", "JSON map of keyspace name -> shard name -> ShardReference object. The inner map is the same as the output of FindAllShardsInKeyspace")
 	ksShardMapFileFlag = flag.String("ks-shard-map-file", "", "File containing json blob of keyspace name -> shard name -> ShardReference object")
-	numShards          = flag.Int("shards", 2, "Number of shards per keyspace. Passing -ks-shard-map/-ks-shard-map-file causes this flag to be ignored.")
+	numShards          = flag.Int("shards", 2, "Number of shards per keyspace. Passing --ks-shard-map/--ks-shard-map-file causes this flag to be ignored.")
 	executionMode      = flag.String("execution-mode", "multi", "The execution mode to simulate -- must be set to multi, legacy-autocommit, or twopc")
 	replicationMode    = flag.String("replication-mode", "ROW", "The replication mode to simulate -- must be set to either ROW or STATEMENT")
 	normalize          = flag.Bool("normalize", false, "Whether to enable vtgate normalization")

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -66,11 +66,11 @@ func main() {
 	servenv.Init()
 
 	if *tabletPath == "" {
-		log.Exit("-tablet-path required")
+		log.Exit("--tablet-path required")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(*tabletPath)
 	if err != nil {
-		log.Exitf("failed to parse -tablet-path: %v", err)
+		log.Exitf("failed to parse --tablet-path: %v", err)
 	}
 
 	// config and mycnf initializations are intertwined.
@@ -93,7 +93,7 @@ func main() {
 	}
 	tablet, err := tabletmanager.BuildTabletFromInput(tabletAlias, int32(*servenv.Port), gRPCPort, mysqld.GetVersionString(), config.DB)
 	if err != nil {
-		log.Exitf("failed to parse -tablet-path: %v", err)
+		log.Exitf("failed to parse --tablet-path: %v", err)
 	}
 	tm = &tabletmanager.TabletManager{
 		BatchCtx:            context.Background(),
@@ -107,7 +107,7 @@ func main() {
 		MetadataManager:     &mysqlctl.MetadataManager{},
 	}
 	if err := tm.Start(tablet, config.Healthcheck.IntervalSeconds.Get()); err != nil {
-		log.Exitf("failed to parse -tablet-path or initialize DB credentials: %v", err)
+		log.Exitf("failed to parse --tablet-path or initialize DB credentials: %v", err)
 	}
 	servenv.OnClose(func() {
 		// Close the tm so that our topo entry gets pruned properly and any

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -23,11 +23,12 @@ import (
 	"flag"
 	"os"
 
+	rice "github.com/GeertJohan/go.rice"
+
 	"vitess.io/vitess/go/vt/binlog"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/tableacl"
 	"vitess.io/vitess/go/vt/tableacl/simpleacl"
@@ -40,7 +41,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/yaml2"
 
-	rice "github.com/GeertJohan/go.rice"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 var (

--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -88,8 +88,8 @@ func init() {
 		"If this flag is set, the MySQL data directory is not cleaned up"+
 			" when LocalCluster.TearDown() is called. This is useful for running"+
 			" vttestserver as a database container in local developer environments. Note"+
-			" that db migration files (-schema_dir option) and seeding of"+
-			" random data (-initialize_with_random_data option) will only run during"+
+			" that db migration files (--schema_dir option) and seeding of"+
+			" random data (--initialize_with_random_data option) will only run during"+
 			" cluster startup if the data directory does not already exist. vschema"+
 			" migrations are run every time the cluster starts, since persistence"+
 			" for the topology server has not been implemented yet")

--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -31,8 +31,9 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/vt/log"
-	vttestpb "vitess.io/vitess/go/vt/proto/vttest"
 	"vitess.io/vitess/go/vt/vttest"
+
+	vttestpb "vitess.io/vitess/go/vt/proto/vttest"
 )
 
 type topoFlags struct {

--- a/go/cmd/vttestserver/vttestserver_test.go
+++ b/go/cmd/vttestserver/vttestserver_test.go
@@ -390,7 +390,7 @@ func assertVtGateExecute(t *testing.T, cluster vttest.LocalCluster) {
 	stream, err := client.ExecuteVtctlCommand(
 		context.Background(),
 		[]string{
-			"VtGateExecute", "--",
+			"VtGateExecute",
 			"--server",
 			fmt.Sprintf("localhost:%v", cluster.GrpcPort()),
 			"select 'success';",

--- a/go/cmd/vttestserver/vttestserver_test.go
+++ b/go/cmd/vttestserver/vttestserver_test.go
@@ -130,7 +130,7 @@ func TestForeignKeysAndDDLModes(t *testing.T) {
 	conf := config
 	defer resetFlags(args, conf)
 
-	cluster, err := startCluster("-foreign_key_mode=allow", "-enable_online_ddl=true", "-enable_direct_ddl=true")
+	cluster, err := startCluster("--foreign_key_mode=allow", "--enable_online_ddl=true", "--enable_direct_ddl=true")
 	assert.NoError(t, err)
 	defer cluster.TearDown()
 
@@ -156,7 +156,7 @@ func TestForeignKeysAndDDLModes(t *testing.T) {
 	assert.NoError(t, err)
 
 	cluster.TearDown()
-	cluster, err = startCluster("-foreign_key_mode=disallow", "-enable_online_ddl=false", "-enable_direct_ddl=false")
+	cluster, err = startCluster("--foreign_key_mode=disallow", "--enable_online_ddl=false", "--enable_direct_ddl=false")
 	assert.NoError(t, err)
 	defer cluster.TearDown()
 
@@ -210,8 +210,8 @@ func TestExternalTopoServerConsul(t *testing.T) {
 		}
 	}()
 
-	cluster, err := startCluster("-external_topo_implementation=consul",
-		fmt.Sprintf("-external_topo_global_server_address=%s", serverAddr), "-external_topo_global_root=consul_test/global")
+	cluster, err := startCluster("--external_topo_implementation=consul",
+		fmt.Sprintf("--external_topo_global_server_address=%s", serverAddr), "--external_topo_global_root=consul_test/global")
 	assert.NoError(t, err)
 	defer cluster.TearDown()
 
@@ -245,14 +245,14 @@ func TestMtlsAuth(t *testing.T) {
 	// When cluster starts it will apply SQL and VSchema migrations in the configured schema_dir folder
 	// With mtls authorization enabled, the authorized CN must match the certificate's CN
 	cluster, err := startCluster(
-		"-grpc_auth_mode=mtls",
-		fmt.Sprintf("-grpc_key=%s", key),
-		fmt.Sprintf("-grpc_cert=%s", cert),
-		fmt.Sprintf("-grpc_ca=%s", caCert),
-		fmt.Sprintf("-vtctld_grpc_key=%s", clientKey),
-		fmt.Sprintf("-vtctld_grpc_cert=%s", clientCert),
-		fmt.Sprintf("-vtctld_grpc_ca=%s", caCert),
-		fmt.Sprintf("-grpc_auth_mtls_allowed_substrings=%s", "CN=ClientApp"))
+		"--grpc_auth_mode=mtls",
+		fmt.Sprintf("--grpc_key=%s", key),
+		fmt.Sprintf("--grpc_cert=%s", cert),
+		fmt.Sprintf("--grpc_ca=%s", caCert),
+		fmt.Sprintf("--vtctld_grpc_key=%s", clientKey),
+		fmt.Sprintf("--vtctld_grpc_cert=%s", clientCert),
+		fmt.Sprintf("--vtctld_grpc_ca=%s", caCert),
+		fmt.Sprintf("--grpc_auth_mtls_allowed_substrings=%s", "CN=ClientApp"))
 	assert.NoError(t, err)
 	defer cluster.TearDown()
 
@@ -289,14 +289,14 @@ func TestMtlsAuthUnauthorizedFails(t *testing.T) {
 	// For mtls authorization failure by providing a client certificate with different CN thant the
 	// authorized in the configuration
 	cluster, err := startCluster(
-		"-grpc_auth_mode=mtls",
-		fmt.Sprintf("-grpc_key=%s", key),
-		fmt.Sprintf("-grpc_cert=%s", cert),
-		fmt.Sprintf("-grpc_ca=%s", caCert),
-		fmt.Sprintf("-vtctld_grpc_key=%s", clientKey),
-		fmt.Sprintf("-vtctld_grpc_cert=%s", clientCert),
-		fmt.Sprintf("-vtctld_grpc_ca=%s", caCert),
-		fmt.Sprintf("-grpc_auth_mtls_allowed_substrings=%s", "CN=ClientApp"))
+		"--grpc_auth_mode=mtls",
+		fmt.Sprintf("--grpc_key=%s", key),
+		fmt.Sprintf("--grpc_cert=%s", cert),
+		fmt.Sprintf("--grpc_ca=%s", caCert),
+		fmt.Sprintf("--vtctld_grpc_key=%s", clientKey),
+		fmt.Sprintf("--vtctld_grpc_cert=%s", clientCert),
+		fmt.Sprintf("--vtctld_grpc_ca=%s", caCert),
+		fmt.Sprintf("--grpc_auth_mtls_allowed_substrings=%s", "CN=ClientApp"))
 	defer cluster.TearDown()
 
 	assert.Error(t, err)
@@ -305,20 +305,20 @@ func TestMtlsAuthUnauthorizedFails(t *testing.T) {
 
 func startPersistentCluster(dir string, flags ...string) (vttest.LocalCluster, error) {
 	flags = append(flags, []string{
-		"-persistent_mode",
+		"--persistent_mode",
 		// FIXME: if port is not provided, data_dir is not respected
-		fmt.Sprintf("-port=%d", randomPort()),
-		fmt.Sprintf("-data_dir=%s", dir),
+		fmt.Sprintf("--port=%d", randomPort()),
+		fmt.Sprintf("--data_dir=%s", dir),
 	}...)
 	return startCluster(flags...)
 }
 
 func startCluster(flags ...string) (vttest.LocalCluster, error) {
-	schemaDirArg := "-schema_dir=data/schema"
-	tabletHostname := "-tablet_hostname=localhost"
-	keyspaceArg := "-keyspaces=test_keyspace,app_customer"
-	numShardsArg := "-num_shards=2,2"
-	vschemaDDLAuthorizedUsers := "-vschema_ddl_authorized_users=%"
+	schemaDirArg := "--schema_dir=data/schema"
+	tabletHostname := "--tablet_hostname=localhost"
+	keyspaceArg := "--keyspaces=test_keyspace,app_customer"
+	numShardsArg := "--num_shards=2,2"
+	vschemaDDLAuthorizedUsers := "--vschema_ddl_authorized_users=%"
 	os.Args = append(os.Args, []string{schemaDirArg, keyspaceArg, numShardsArg, tabletHostname, vschemaDDLAuthorizedUsers}...)
 	os.Args = append(os.Args, flags...)
 	return runCluster()
@@ -390,8 +390,8 @@ func assertVtGateExecute(t *testing.T, cluster vttest.LocalCluster) {
 	stream, err := client.ExecuteVtctlCommand(
 		context.Background(),
 		[]string{
-			"VtGateExecute",
-			"-server",
+			"VtGateExecute", "--",
+			"--server",
 			fmt.Sprintf("localhost:%v", cluster.GrpcPort()),
 			"select 'success';",
 		},

--- a/go/cmd/vttestserver/vttestserver_test.go
+++ b/go/cmd/vttestserver/vttestserver_test.go
@@ -29,22 +29,19 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/tlstest"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"vitess.io/vitess/go/mysql"
-
+	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
 	"vitess.io/vitess/go/vt/vttest"
 
-	"vitess.io/vitess/go/vt/proto/logutil"
-	"vitess.io/vitess/go/vt/proto/vschema"
-	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
+	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
 type columnVindex struct {
@@ -355,8 +352,8 @@ func assertColumnVindex(t *testing.T, cluster vttest.LocalCluster, expected colu
 	args := []string{"GetVSchema", expected.keyspace}
 	ctx := context.Background()
 
-	err := vtctlclient.RunCommandAndWait(ctx, server, args, func(e *logutil.Event) {
-		var keyspace vschema.Keyspace
+	err := vtctlclient.RunCommandAndWait(ctx, server, args, func(e *logutilpb.Event) {
+		var keyspace vschemapb.Keyspace
 		if err := protojson.Unmarshal([]byte(e.Value), &keyspace); err != nil {
 			t.Error(err)
 		}

--- a/go/cmd/vttlstest/vttlstest.go
+++ b/go/cmd/vttlstest/vttlstest.go
@@ -34,14 +34,14 @@ var doc = `
 vttlstest is a tool for generating test certificates and keys for TLS tests.
 
 To create a toplevel CA, use:
-  $ vttlstest -root /tmp CreateCA
+  $ vttlstest --root /tmp CreateCA
 
 To create an intermediate or leaf CA, use:
-  $ vttlstest -root /tmp CreateSignedCert servers
-  $ vttlstest -root /tmp CreateSignedCert -parent servers server
+  $ vttlstest --root /tmp CreateSignedCert servers
+  $ vttlstest --root /tmp CreateSignedCert --parent servers server
 
 To get help on a command, use:
-  $ vttlstest <command> -help
+  $ vttlstest <command> --help
 `
 
 type cmdFunc func(subFlags *flag.FlagSet, args []string)

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -200,10 +200,10 @@ func (env *LocalTestEnv) ProcessHealthCheck(name string) HealthChecker {
 // VtcomboArguments implements VtcomboArguments for LocalTestEnv.
 func (env *LocalTestEnv) VtcomboArguments() []string {
 	return []string{
-		"-service_map", strings.Join(
+		"--service_map", strings.Join(
 			[]string{"grpc-vtgateservice", "grpc-vtctl", "grpc-vtctld"}, ",",
 		),
-		"-enable_queries",
+		"--enable_queries",
 	}
 }
 

--- a/go/vt/vttest/environment_test.go
+++ b/go/vt/vttest/environment_test.go
@@ -30,10 +30,10 @@ func TestVtcomboArguments(t *testing.T) {
 	args := env.VtcomboArguments()
 
 	t.Run("service_map flag", func(t *testing.T) {
-		require.Contains(t, args, "-service_map", "vttest.LocalTestEnv must provide `-service_map` flag to vtcombo")
+		require.Contains(t, args, "--service_map", "vttest.LocalTestEnv must provide `--service_map` flag to vtcombo")
 
-		x := sort.SearchStrings(args, "-service_map")
-		require.Less(t, x+1, len(args), "-service_map vtcombo flag (idx = %d) must take an argument. full arg list: %v", x, args)
+		x := sort.SearchStrings(args, "--service_map")
+		require.Less(t, x+1, len(args), "--service_map vtcombo flag (idx = %d) must take an argument. full arg list: %v", x, args)
 
 		expectedServiceList := []string{
 			"grpc-vtgateservice",
@@ -41,6 +41,6 @@ func TestVtcomboArguments(t *testing.T) {
 			"grpc-vtctld",
 		}
 		serviceMapList := strings.Split(args[x+1], ",")
-		assert.ElementsMatch(t, expectedServiceList, serviceMapList, "-service_map list does not contain expected vtcombo services")
+		assert.ElementsMatch(t, expectedServiceList, serviceMapList, "--service_map list does not contain expected vtcombo services")
 	})
 }

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -569,7 +569,7 @@ func (db *LocalCluster) GrpcPort() int {
 
 func (db *LocalCluster) applyVschema(keyspace string, migration string) error {
 	server := fmt.Sprintf("localhost:%v", db.vt.PortGrpc)
-	args := []string{"ApplyVSchema", "--", "--sql", migration, keyspace}
+	args := []string{"ApplyVSchema", "--sql", migration, keyspace}
 	fmt.Printf("Applying vschema %v", args)
 	err := vtctlclient.RunCommandAndWait(context.Background(), server, args, func(e *logutil.Event) {
 		log.Info(e)
@@ -580,7 +580,7 @@ func (db *LocalCluster) applyVschema(keyspace string, migration string) error {
 
 func (db *LocalCluster) reloadSchemaKeyspace(keyspace string) error {
 	server := fmt.Sprintf("localhost:%v", db.vt.PortGrpc)
-	args := []string{"ReloadSchemaKeyspace", "--", "--include_primary=true", keyspace}
+	args := []string{"ReloadSchemaKeyspace", "--include_primary=true", keyspace}
 	fmt.Printf("Reloading keyspace schema %v", args)
 
 	err := vtctlclient.RunCommandAndWait(context.Background(), server, args, func(e *logutil.Event) {

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -569,7 +569,7 @@ func (db *LocalCluster) GrpcPort() int {
 
 func (db *LocalCluster) applyVschema(keyspace string, migration string) error {
 	server := fmt.Sprintf("localhost:%v", db.vt.PortGrpc)
-	args := []string{"ApplyVSchema", "-sql", migration, keyspace}
+	args := []string{"ApplyVSchema", "--", "--sql", migration, keyspace}
 	fmt.Printf("Applying vschema %v", args)
 	err := vtctlclient.RunCommandAndWait(context.Background(), server, args, func(e *logutil.Event) {
 		log.Info(e)
@@ -580,7 +580,7 @@ func (db *LocalCluster) applyVschema(keyspace string, migration string) error {
 
 func (db *LocalCluster) reloadSchemaKeyspace(keyspace string) error {
 	server := fmt.Sprintf("localhost:%v", db.vt.PortGrpc)
-	args := []string{"ReloadSchemaKeyspace", "-include_primary=true", keyspace}
+	args := []string{"ReloadSchemaKeyspace", "--", "--include_primary=true", keyspace}
 	fmt.Printf("Reloading keyspace schema %v", args)
 
 	err := vtctlclient.RunCommandAndWait(context.Background(), server, args, func(e *logutil.Event) {

--- a/go/vt/vttest/mysqlctl.go
+++ b/go/vt/vttest/mysqlctl.go
@@ -61,11 +61,11 @@ func (ctl *Mysqlctl) Setup() error {
 
 	cmd := exec.CommandContext(ctx,
 		ctl.Binary,
-		"-alsologtostderr",
-		"-tablet_uid", fmt.Sprintf("%d", ctl.UID),
-		"-mysql_port", fmt.Sprintf("%d", ctl.Port),
-		"init",
-		"-init_db_sql_file", ctl.InitFile,
+		"--alsologtostderr",
+		"--tablet_uid", fmt.Sprintf("%d", ctl.UID),
+		"--mysql_port", fmt.Sprintf("%d", ctl.Port),
+		"init", "--",
+		"--init_db_sql_file", ctl.InitFile,
 	)
 
 	myCnf := strings.Join(ctl.MyCnf, ":")
@@ -86,9 +86,9 @@ func (ctl *Mysqlctl) Start() error {
 
 	cmd := exec.CommandContext(ctx,
 		ctl.Binary,
-		"-alsologtostderr",
-		"-tablet_uid", fmt.Sprintf("%d", ctl.UID),
-		"-mysql_port", fmt.Sprintf("%d", ctl.Port),
+		"--alsologtostderr",
+		"--tablet_uid", fmt.Sprintf("%d", ctl.UID),
+		"--mysql_port", fmt.Sprintf("%d", ctl.Port),
 		"start",
 	)
 
@@ -109,9 +109,9 @@ func (ctl *Mysqlctl) TearDown() error {
 
 	cmd := exec.CommandContext(ctx,
 		ctl.Binary,
-		"-alsologtostderr",
-		"-tablet_uid", fmt.Sprintf("%d", ctl.UID),
-		"-mysql_port", fmt.Sprintf("%d", ctl.Port),
+		"--alsologtostderr",
+		"--tablet_uid", fmt.Sprintf("%d", ctl.UID),
+		"--mysql_port", fmt.Sprintf("%d", ctl.Port),
 		"shutdown",
 	)
 

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -125,13 +125,13 @@ func (vtp *VtProcess) WaitTerminate() error {
 func (vtp *VtProcess) WaitStart() (err error) {
 	vtp.proc = exec.Command(
 		vtp.Binary,
-		"-port", fmt.Sprintf("%d", vtp.Port),
-		"-log_dir", vtp.LogDirectory,
-		"-alsologtostderr",
+		"--port", fmt.Sprintf("%d", vtp.Port),
+		"--log_dir", vtp.LogDirectory,
+		"--alsologtostderr",
 	)
 
 	if vtp.PortGrpc != 0 {
-		vtp.proc.Args = append(vtp.proc.Args, "-grpc_port")
+		vtp.proc.Args = append(vtp.proc.Args, "--grpc_port")
 		vtp.proc.Args = append(vtp.proc.Args, fmt.Sprintf("%d", vtp.PortGrpc))
 	}
 
@@ -178,13 +178,13 @@ const (
 
 // QueryServerArgs are the default arguments passed to all Vitess query servers
 var QueryServerArgs = []string{
-	"-queryserver-config-pool-size", "4",
-	"-queryserver-config-query-timeout", "300",
-	"-queryserver-config-schema-reload-time", "60",
-	"-queryserver-config-stream-pool-size", "4",
-	"-queryserver-config-transaction-cap", "4",
-	"-queryserver-config-transaction-timeout", "300",
-	"-queryserver-config-txpool-timeout", "300",
+	"--queryserver-config-pool-size", "4",
+	"--queryserver-config-query-timeout", "300",
+	"--queryserver-config-schema-reload-time", "60",
+	"--queryserver-config-stream-pool-size", "4",
+	"--queryserver-config-transaction-cap", "4",
+	"--queryserver-config-transaction-timeout", "300",
+	"--queryserver-config-txpool-timeout", "300",
 }
 
 // VtcomboProcess returns a VtProcess handle for a local `vtcombo` service,
@@ -211,63 +211,63 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 
 	protoTopo, _ := prototext.Marshal(args.Topology)
 	vt.ExtraArgs = append(vt.ExtraArgs, []string{
-		"-db_charset", charset,
-		"-db_app_user", user,
-		"-db_app_password", pass,
-		"-db_dba_user", user,
-		"-db_dba_password", pass,
-		"-proto_topo", string(protoTopo),
-		"-mycnf_server_id", "1",
-		"-mycnf_socket_file", socket,
-		"-normalize_queries",
-		"-enable_query_plan_field_caching=false",
-		"-dbddl_plugin", "vttest",
-		"-foreign_key_mode", args.ForeignKeyMode,
-		"-planner_version", args.PlannerVersion,
-		fmt.Sprintf("-enable_online_ddl=%t", args.EnableOnlineDDL),
-		fmt.Sprintf("-enable_direct_ddl=%t", args.EnableDirectDDL),
-		fmt.Sprintf("-enable_system_settings=%t", args.EnableSystemSettings),
+		"--db_charset", charset,
+		"--db_app_user", user,
+		"--db_app_password", pass,
+		"--db_dba_user", user,
+		"--db_dba_password", pass,
+		"--proto_topo", string(protoTopo),
+		"--mycnf_server_id", "1",
+		"--mycnf_socket_file", socket,
+		"--normalize_queries",
+		"--enable_query_plan_field_caching=false",
+		"--dbddl_plugin", "vttest",
+		"--foreign_key_mode", args.ForeignKeyMode,
+		"--planner_version", args.PlannerVersion,
+		fmt.Sprintf("--enable_online_ddl=%t", args.EnableOnlineDDL),
+		fmt.Sprintf("--enable_direct_ddl=%t", args.EnableDirectDDL),
+		fmt.Sprintf("--enable_system_settings=%t", args.EnableSystemSettings),
 	}...)
 
 	vt.ExtraArgs = append(vt.ExtraArgs, QueryServerArgs...)
 	vt.ExtraArgs = append(vt.ExtraArgs, env.VtcomboArguments()...)
 
 	if args.SchemaDir != "" {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-schema_dir", args.SchemaDir}...)
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--schema_dir", args.SchemaDir}...)
 	}
 	if args.TransactionMode != "" {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-transaction_mode", args.TransactionMode}...)
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--transaction_mode", args.TransactionMode}...)
 	}
 	if args.TransactionTimeout != 0 {
-		vt.ExtraArgs = append(vt.ExtraArgs, "-queryserver-config-transaction-timeout", fmt.Sprintf("%f", args.TransactionTimeout))
+		vt.ExtraArgs = append(vt.ExtraArgs, "--queryserver-config-transaction-timeout", fmt.Sprintf("%f", args.TransactionTimeout))
 	}
 	if args.TabletHostName != "" {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-tablet_hostname", args.TabletHostName}...)
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--tablet_hostname", args.TabletHostName}...)
 	}
 	if *servenv.GRPCAuth == "mtls" {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-grpc_auth_mode", *servenv.GRPCAuth, "-grpc_key", *servenv.GRPCKey, "-grpc_cert", *servenv.GRPCCert, "-grpc_ca", *servenv.GRPCCA, "-grpc_auth_mtls_allowed_substrings", *servenv.ClientCertSubstrings}...)
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--grpc_auth_mode", *servenv.GRPCAuth, "--grpc_key", *servenv.GRPCKey, "--grpc_cert", *servenv.GRPCCert, "--grpc_ca", *servenv.GRPCCA, "--grpc_auth_mtls_allowed_substrings", *servenv.ClientCertSubstrings}...)
 	}
 	if args.InitWorkflowManager {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-workflow_manager_init"}...)
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--workflow_manager_init"}...)
 	}
 	if args.VSchemaDDLAuthorizedUsers != "" {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-vschema_ddl_authorized_users", args.VSchemaDDLAuthorizedUsers}...)
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--vschema_ddl_authorized_users", args.VSchemaDDLAuthorizedUsers}...)
 	}
 	if *servenv.MySQLServerVersion != "" {
-		vt.ExtraArgs = append(vt.ExtraArgs, "-mysql_server_version", *servenv.MySQLServerVersion)
+		vt.ExtraArgs = append(vt.ExtraArgs, "--mysql_server_version", *servenv.MySQLServerVersion)
 	}
 
 	if socket != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{
-			"-db_socket", socket,
+			"--db_socket", socket,
 		}...)
 	} else {
 		hostname, p := mysql.Address()
 		port := fmt.Sprintf("%d", p)
 
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{
-			"-db_host", hostname,
-			"-db_port", port,
+			"--db_host", hostname,
+			"--db_port", port,
 		}...)
 	}
 
@@ -278,17 +278,17 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 	}
 
 	vt.ExtraArgs = append(vt.ExtraArgs, []string{
-		"-mysql_auth_server_impl", "none",
-		"-mysql_server_port", fmt.Sprintf("%d", vtcomboMysqlPort),
-		"-mysql_server_bind_address", vtcomboMysqlBindAddress,
+		"--mysql_auth_server_impl", "none",
+		"--mysql_server_port", fmt.Sprintf("%d", vtcomboMysqlPort),
+		"--mysql_server_bind_address", vtcomboMysqlBindAddress,
 	}...)
 
 	if args.ExternalTopoImplementation != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{
-			"-external_topo_server",
-			"-topo_implementation", args.ExternalTopoImplementation,
-			"-topo_global_server_address", args.ExternalTopoGlobalServerAddress,
-			"-topo_global_root", args.ExternalTopoGlobalRoot,
+			"--external_topo_server",
+			"--topo_implementation", args.ExternalTopoImplementation,
+			"--topo_global_server_address", args.ExternalTopoGlobalServerAddress,
+			"--topo_global_root", args.ExternalTopoGlobalRoot,
 		}...)
 	}
 


### PR DESCRIPTION
## Description

This tidies up flag examples, usages strings, error strings, and tests in `go/cmd` with the exception of `vtorc` because (1) it's under active development, and (2) it doesn't hook through any of the existing deprecation mechanisms/servenv/flag shims.

## Related Issue(s)

#9895 

## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required 
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->