### PR TITLE
Improve network partitions handling

### DIFF
--- a/go/vt/vtgr/controller/diagnose_test.go
+++ b/go/vt/vtgr/controller/diagnose_test.go
@@ -40,7 +40,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgr/db"
 )
 
-const diagnoseGroupSize = 2
+const diagnoseGroupSize = 3
 
 var (
 	testHost, _ = os.Hostname()
@@ -309,6 +309,17 @@ func TestMysqlIssueDiagnoses(t *testing.T) {
 				{MemberHost: "", MemberPort: "", MemberState: "OFFLINE", MemberRole: ""},
 			}, topodatapb.TabletType_REPLICA},
 		}},
+		{name: "fail to bootstrap with incorrect number of nodes", expected: DiagnoseTypeError, errMessage: "fail to diagnose ShardHasNoGroup with 3 nodes", inputs: []data{
+			{alias0, "", true, 0, []db.TestGroupState{
+				{MemberHost: "", MemberPort: "", MemberState: "OFFLINE", MemberRole: ""},
+			}, topodatapb.TabletType_REPLICA},
+			{alias1, "", true, 0, []db.TestGroupState{
+				{MemberHost: "", MemberPort: "", MemberState: "OFFLINE", MemberRole: ""},
+			}, topodatapb.TabletType_REPLICA},
+			{alias2, "", true, 0, []db.TestGroupState{
+				{MemberHost: "", MemberPort: "", MemberState: "OFFLINE", MemberRole: ""},
+			}, topodatapb.TabletType_REPLICA},
+		}, config: &config.VTGRConfig{BootstrapGroupSize: 2, MinNumReplica: 2, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}},
 		{name: "unreachable node", expected: DiagnoseTypeBackoffError, errMessage: "", inputs: []data{
 			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
@@ -668,12 +679,13 @@ func TestDiagnoseWithInactive(t *testing.T) {
 		ttype      topodatapb.TabletType
 	}
 	var sqltests = []struct {
-		name          string
-		expected      DiagnoseType
-		errMessage    string
-		config        *config.VTGRConfig
-		inputs        []data
-		removeTablets []string // to simulate missing tablet in topology
+		name                 string
+		expected             DiagnoseType
+		errMessage           string
+		config               *config.VTGRConfig
+		inputs               []data
+		rebootstrapGroupSize int
+		removeTablets        []string // to simulate missing tablet in topology
 	}{
 		// although mysql and vitess has different primary, but since this is an active shard, VTGR won't fix that
 		{name: "mysql and tablet has different primary", expected: DiagnoseTypeHealthy, errMessage: "", inputs: []data{
@@ -758,6 +770,17 @@ func TestDiagnoseWithInactive(t *testing.T) {
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
+		{name: "error when there are only two nodes", expected: DiagnoseTypeError, errMessage: "fail to diagnose ShardHasInactiveGroup with 3 nodes expecting 2", inputs: []data{
+			{alias0, "group", true, true, []db.TestGroupState{
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "OFFLINE", MemberRole: ""},
+			}, topodatapb.TabletType_REPLICA},
+			{alias1, "group", true, true, []db.TestGroupState{
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "OFFLINE", MemberRole: ""},
+			}, topodatapb.TabletType_REPLICA},
+			{alias2, "group", true, true, []db.TestGroupState{
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "OFFLINE", MemberRole: ""},
+			}, topodatapb.TabletType_REPLICA},
+		}, rebootstrapGroupSize: 2},
 	}
 	for _, tt := range sqltests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -828,6 +851,9 @@ func TestDiagnoseWithInactive(t *testing.T) {
 					AnyTimes()
 			}
 			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, conf, testPort0, false)
+			if tt.rebootstrapGroupSize != 0 {
+				shard.OverrideRebootstrapGroupSize(tt.rebootstrapGroupSize)
+			}
 			shard.refreshTabletsInShardLocked(ctx)
 			diagnose, err := shard.Diagnose(ctx)
 			assert.Equal(t, expected, diagnose)

--- a/go/vt/vtgr/controller/repair_test.go
+++ b/go/vt/vtgr/controller/repair_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const repairGroupSize = 2
+const repairGroupSize = 3
 
 func TestRepairShardHasNoGroup(t *testing.T) {
 	type data struct {
@@ -108,7 +108,7 @@ func TestRepairShardHasNoGroup(t *testing.T) {
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
-		{"raise error without bootstrap with only one reachable node", 0, "vtgr repair: unsafe to bootstrap group", []data{
+		{"raise error without bootstrap with only one reachable node", 0, "vtgr repair: fail to diagnose ShardHasNoGroup with 1 nodes", []data{
 			{"", 0, "group", true, []db.TestGroupState{
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
 			}, topodatapb.TabletType_REPLICA},
@@ -119,7 +119,7 @@ func TestRepairShardHasNoGroup(t *testing.T) {
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
 			}, topodatapb.TabletType_REPLICA},
 		}},
-		{"raise error when there are not enough members", 0, "vtgr repair: unsafe to bootstrap group", []data{
+		{"raise error when there are not enough members", 0, "vtgr repair: fail to diagnose ShardHasNoGroup with 1 nodes", []data{
 			{testHost, testPort0, "", true, []db.TestGroupState{
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
 			}, topodatapb.TabletType_REPLICA},
@@ -300,7 +300,7 @@ func TestRepairShardHasInactiveGroup(t *testing.T) {
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
 			}, true, getMysql56GTIDSet(sid1, "1-9"), topodatapb.TabletType_REPLICA},
 		}},
-		{"error on one unreachable mysql", "invalid mysql instance key", 0, 0, []data{
+		{"error on one unreachable mysql", "vtgr repair: fail to diagnose ShardHasInactiveGroup with 2 nodes expecting 3", 0, 0, []data{
 			{"", 0, "group", []db.TestGroupState{
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
 			}, true, getMysql56GTIDSet(sid1, "1-11"), topodatapb.TabletType_REPLICA},
@@ -344,7 +344,7 @@ func TestRepairShardHasInactiveGroup(t *testing.T) {
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
 			}, true, getMysql56GTIDSet(sid1, "1-9"), topodatapb.TabletType_REPLICA},
 		}},
-		{"error on two unreachable mysql", "invalid mysql instance key", 0, 0, []data{
+		{"error on two unreachable mysql", "vtgr repair: fail to diagnose ShardHasInactiveGroup with 1 nodes expecting 3", 0, 0, []data{
 			{"", 0, "group", []db.TestGroupState{
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
 			}, true, getMysql56GTIDSet(sid1, "1-11"), topodatapb.TabletType_REPLICA},


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This is an improvement on how we handle network partition. VTGR used to rely to "UNREACHABLE" state to determine network partition, it is not always reliable since when a node is really "partitioned", it will also possible to be unreachable. It introduced a race condition when the network is flapping: a partitioned VTGR will see everyone is OFFLINE and try to rebootstrap the group, if network recovered during the rebootstrap, VTGR will stop the functioning group incorrectly.

To address the issue, this PR mainly does two things:
1. Do not allow bootstrap unless we can reach expected number of nodes.
2. Do not allow rebootstrap unless we see all the nodes unless there is an override.

This helps VTGR to avoid some "false positive" diagnoses and hence avoid further incorrect repair operations.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
^

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->