### PR TITLE
[VEP-4, part 1] Flag cleanup in `go/mysql` and some endtoend tests

### DIFF
--- a/go/cmd/tools.go
+++ b/go/cmd/tools.go
@@ -29,8 +29,8 @@ func DetachFromTerminalAndExit() {
 	args := os.Args[1:]
 	i := 0
 	for ; i < len(args); i++ {
-		if strings.HasPrefix(args[i], "-detach") {
-			args[i] = "-detach=false"
+		if strings.HasPrefix(args[i], "-detach") || strings.HasPrefix(args[i], "--detach") {
+			args[i] = "--detach=false"
 			break
 		}
 	}

--- a/go/mysql/vault/auth_server_vault.go
+++ b/go/mysql/vault/auth_server_vault.go
@@ -51,7 +51,7 @@ type AuthServerVault struct {
 	methods []mysql.AuthMethod
 	mu      sync.Mutex
 	// users, passwords and user data
-	// We use the same JSON format as for -mysql_auth_server_static
+	// We use the same JSON format as for --mysql_auth_server_static
 	// Acts as a cache for the in-Vault data
 	entries                map[string][]*mysql.AuthServerStaticEntry
 	vaultCacheExpireTicker *time.Ticker
@@ -66,11 +66,11 @@ type AuthServerVault struct {
 func InitAuthServerVault() {
 	// Check critical parameters.
 	if *vaultAddr == "" {
-		log.Infof("Not configuring AuthServerVault, as -mysql_auth_vault_addr is empty.")
+		log.Infof("Not configuring AuthServerVault, as --mysql_auth_vault_addr is empty.")
 		return
 	}
 	if *vaultPath == "" {
-		log.Exitf("If using Vault auth server, -mysql_auth_vault_path is required.")
+		log.Exitf("If using Vault auth server, --mysql_auth_vault_path is required.")
 	}
 
 	registerAuthServerVault(*vaultAddr, *vaultTimeout, *vaultCACert, *vaultPath, *vaultCacheTTL, *vaultTokenFile, *vaultRoleID, *vaultRoleSecretIDFile, *vaultRoleMountPoint)
@@ -88,11 +88,11 @@ func newAuthServerVault(addr string, timeout time.Duration, caCertPath string, p
 	// Validate more parameters
 	token, err := readFromFile(tokenFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("No Vault token in provided filename for -mysql_auth_vault_tokenfile")
+		return nil, fmt.Errorf("No Vault token in provided filename for --mysql_auth_vault_tokenfile")
 	}
 	secretID, err := readFromFile(secretIDPath)
 	if err != nil {
-		return nil, fmt.Errorf("No Vault secret_id in provided filename for -mysql_auth_vault_role_secretidfile")
+		return nil, fmt.Errorf("No Vault secret_id in provided filename for --mysql_auth_vault_role_secretidfile")
 	}
 
 	config := vaultapi.NewConfig()

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -289,7 +289,7 @@ func primaryBackup(t *testing.T) {
 
 	output, err := localCluster.VtctlclientProcess.ExecuteCommandWithOutput("Backup", primary.Alias)
 	require.Error(t, err)
-	assert.Contains(t, output, "type PRIMARY cannot take backup. if you really need to do this, rerun the backup command with -allow_primary")
+	assert.Contains(t, output, "type PRIMARY cannot take backup. if you really need to do this, rerun the backup command with --allow_primary")
 
 	localCluster.VerifyBackupCount(t, shardKsName, 0)
 

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -130,8 +130,8 @@ func (topo *TopoProcess) SetupZookeeper(cluster *LocalProcessCluster) (err error
 
 	topo.proc = exec.Command(
 		topo.Binary,
-		"-log_dir", topo.LogDirectory,
-		"-zk.cfg", fmt.Sprintf("1@%v:%s", host, topo.ZKPorts),
+		"--log_dir", topo.LogDirectory,
+		"--zk.cfg", fmt.Sprintf("1@%v:%s", host, topo.ZKPorts),
 		"init",
 	)
 
@@ -251,8 +251,8 @@ func (topo *TopoProcess) TearDown(Cell string, originalVtRoot string, currentRoo
 		}
 		topo.proc = exec.Command(
 			topo.Binary,
-			"-log_dir", topo.LogDirectory,
-			"-zk.cfg", fmt.Sprintf("1@%v:%s", topo.Host, topo.ZKPorts),
+			"--log_dir", topo.LogDirectory,
+			"--zk.cfg", fmt.Sprintf("1@%v:%s", topo.Host, topo.ZKPorts),
 			cmd,
 		)
 

--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -47,7 +47,7 @@ func (vtctl *VtctlProcess) AddCellInfo(Cell string) (err error) {
 		"--topo_global_root", vtctl.TopoGlobalRoot,
 	)
 	if *isCoverage {
-		tmpProcess.Args = append(tmpProcess.Args, "-test.coverprofile="+getCoveragePath("vtctl-addcell.out"))
+		tmpProcess.Args = append(tmpProcess.Args, "--test.coverprofile="+getCoveragePath("vtctl-addcell.out"))
 	}
 	tmpProcess.Args = append(tmpProcess.Args,
 		"AddCellInfo", "--",

--- a/go/test/endtoend/cluster/vtgr_process.go
+++ b/go/test/endtoend/cluster/vtgr_process.go
@@ -43,10 +43,10 @@ type VtgrProcess struct {
 // Start starts vtgr process with required arguements
 func (vtgr *VtgrProcess) Start(alias string) (err error) {
 	/* minimal command line arguments:
-	$ vtgr -topo_implementation etcd2 \
-	-topo_global_server_address localhost:2379 \
-	-topo_global_root /vitess/global \
-	-clusters_to_watch ks/0
+	$ vtgr --topo_implementation etcd2 \
+	--topo_global_server_address localhost:2379 \
+	--topo_global_root /vitess/global \
+	--clusters_to_watch ks/0
 	*/
 	vtgr.proc = exec.Command(
 		vtgr.Binary,

--- a/go/test/endtoend/cluster/vtworker_process.go
+++ b/go/test/endtoend/cluster/vtworker_process.go
@@ -71,7 +71,7 @@ func (vtworker *VtworkerProcess) Setup(cell string) (err error) {
 		"--command_display_interval", "10ms",
 	)
 	if *isCoverage {
-		vtworker.proc.Args = append(vtworker.proc.Args, "--test.coverprofile=vtworker.out", "-test.v")
+		vtworker.proc.Args = append(vtworker.proc.Args, "--test.coverprofile=vtworker.out", "--test.v")
 	}
 	vtworker.proc.Args = append(vtworker.proc.Args, vtworker.ExtraArgs...)
 

--- a/go/test/endtoend/encryption/encryptedreplication/encrypted_replication_test.go
+++ b/go/test/endtoend/encryption/encryptedreplication/encrypted_replication_test.go
@@ -101,7 +101,7 @@ func initializeCluster(t *testing.T) (int, error) {
 	err = encryption.ExecuteVttlstestCommand("--root", certDirectory, "CreateSignedCert", "--", "--common_name", "Mysql Server", "--serial", "01", "server")
 	require.NoError(t, err)
 
-	err = encryption.ExecuteVttlstestCommand("-root", certDirectory, "CreateSignedCert", "--", "--common_name", "Mysql Client", "--serial", "02", "client")
+	err = encryption.ExecuteVttlstestCommand("--root", certDirectory, "CreateSignedCert", "--", "--common_name", "Mysql Client", "--serial", "02", "client")
 	require.NoError(t, err)
 
 	extraMyCnf := path.Join(certDirectory, "secure.cnf")

--- a/go/test/endtoend/migration/migration_test.go
+++ b/go/test/endtoend/migration/migration_test.go
@@ -32,6 +32,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
@@ -140,7 +141,7 @@ func TestMigration(t *testing.T) {
 	defer clusterInstance.Teardown()
 
 	tabletConfig := func(vt *cluster.VttabletProcess) {
-		vt.ExtraArgs = append(vt.ExtraArgs, "-tablet_config", yamlFile)
+		vt.ExtraArgs = append(vt.ExtraArgs, "--tablet_config", yamlFile)
 	}
 	createKeyspace(t, commerce, []string{"0"}, tabletConfig)
 	err := clusterInstance.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", "commerce")

--- a/go/test/endtoend/preparestmt/main_test.go
+++ b/go/test/endtoend/preparestmt/main_test.go
@@ -25,10 +25,10 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/test/endtoend/cluster"
-
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 // tableData is a temporary structure to hold selected data.
@@ -204,9 +204,9 @@ func TestMain(m *testing.M) {
 		vtgateInstance.MySQLAuthServerImpl = "static"
 		// add extra arguments
 		vtgateInstance.ExtraArgs = []string{
-			"-mysql_server_query_timeout", "1s",
-			"-mysql_auth_server_static_file", clusterInstance.TmpDirectory + "/" + mysqlAuthServerStatic,
-			"-mysql_server_version", "8.0.16-7",
+			"--mysql_server_query_timeout", "1s",
+			"--mysql_auth_server_static_file", clusterInstance.TmpDirectory + "/" + mysqlAuthServerStatic,
+			"--mysql_server_version", "8.0.16-7",
 		}
 
 		// Start vtgate

--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -22,12 +22,11 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/test/endtoend/reparent/utils"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/reparent/utils"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -149,7 +148,7 @@ func TestReparentAvoid(t *testing.T) {
 	// tablets[1 is in the same cell and tablets[3] is in a different cell, so we must land on tablets[1
 	utils.CheckPrimaryTablet(t, clusterInstance, tablets[1])
 
-	// If we kill the tablet in the same cell as primary then reparent -avoid_tablet will fail.
+	// If we kill the tablet in the same cell as primary then reparent --avoid_tablet will fail.
 	utils.StopTablet(t, tablets[0], true)
 	out, err := utils.PrsAvoid(t, clusterInstance, tablets[1])
 	require.Error(t, err)

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -47,7 +47,7 @@ func (tm *TabletManager) Backup(ctx context.Context, concurrency int, logger log
 	// It is not safe to take backups from tablet in this state
 	currentTablet := tm.Tablet()
 	if !allowPrimary && currentTablet.Type == topodatapb.TabletType_PRIMARY {
-		return fmt.Errorf("type PRIMARY cannot take backup. if you really need to do this, rerun the backup command with -allow_primary")
+		return fmt.Errorf("type PRIMARY cannot take backup. if you really need to do this, rerun the backup command with --allow_primary")
 	}
 	engine, err := mysqlctl.GetBackupEngine()
 	if err != nil {
@@ -59,7 +59,7 @@ func (tm *TabletManager) Backup(ctx context.Context, concurrency int, logger log
 		return err
 	}
 	if !allowPrimary && tablet.Type == topodatapb.TabletType_PRIMARY {
-		return fmt.Errorf("type PRIMARY cannot take backup. if you really need to do this, rerun the backup command with -allow_primary")
+		return fmt.Errorf("type PRIMARY cannot take backup. if you really need to do this, rerun the backup command with --allow_primary")
 	}
 
 	// prevent concurrent backups, and record stats


### PR DESCRIPTION
## Description

More cleanup work for single- to double-dash flags. See [VEP-4](https://github.com/vitessio/enhancements/blob/main/veps/vep-4.md)

## Related Issue(s)

#9895 


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->