### PR TITLE
[vtadmin] Update vtctld dialer to validate connectivity 

### DIFF
--- a/go/vt/vtadmin/cluster/discovery/fakediscovery/discovery.go
+++ b/go/vt/vtadmin/cluster/discovery/fakediscovery/discovery.go
@@ -60,6 +60,18 @@ func New() *Fake {
 	}
 }
 
+func (d *Fake) Clear() {
+	d.gates = &gates{
+		byTag:  map[string][]*vtadminpb.VTGate{},
+		byName: map[string]*vtadminpb.VTGate{},
+	}
+
+	d.vtctlds = &vtctlds{
+		byTag:  map[string][]*vtadminpb.Vtctld{},
+		byName: map[string]*vtadminpb.Vtctld{},
+	}
+}
+
 // AddTaggedGates adds the given gates to the discovery fake, associating each
 // gate with each tag. To tag different gates with multiple tags, call multiple
 // times with the same gates but different tag slices. Gates are uniquely

--- a/go/vt/vtadmin/vtctldclient/config.go
+++ b/go/vt/vtadmin/vtctldclient/config.go
@@ -64,7 +64,7 @@ func Parse(cluster *vtadminpb.Cluster, disco discovery.Discovery, args []string)
 func (c *Config) Parse(args []string) error {
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
 
-	fs.DurationVar(&c.ConnectivityTimeout, "grpc-connectivity-timeout", 2*time.Second, "The maximum duration to wait for a vtctld gRPC connection to be established.")
+	fs.DurationVar(&c.ConnectivityTimeout, "grpc-connectivity-timeout", 2*time.Second, "The maximum duration to wait for a gRPC connection to be established to the vtctld.")
 
 	credentialsTmplStr := fs.String("credentials-path-tmpl", "",
 		"Go template used to specify a path to a credentials file, which is a json file containing "+

--- a/go/vt/vtadmin/vtctldclient/config.go
+++ b/go/vt/vtadmin/vtctldclient/config.go
@@ -18,6 +18,7 @@ package vtctldclient
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/pflag"
 
@@ -36,6 +37,8 @@ type Config struct {
 	CredentialsPath string
 
 	Cluster *vtadminpb.Cluster
+
+	ConnectivityTimeout time.Duration
 }
 
 // Parse returns a new config with the given cluster and discovery, after
@@ -60,6 +63,8 @@ func Parse(cluster *vtadminpb.Cluster, disco discovery.Discovery, args []string)
 // (*cluster.Cluster).New().
 func (c *Config) Parse(args []string) error {
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
+
+	fs.DurationVar(&c.ConnectivityTimeout, "grpc-connectivity-timeout", 2*time.Second, "The maximum duration to wait for a vtctld gRPC connection to be established.")
 
 	credentialsTmplStr := fs.String("credentials-path-tmpl", "",
 		"Go template used to specify a path to a credentials file, which is a json file containing "+

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -105,8 +105,7 @@ func (vtctld *ClientProxy) Dial(ctx context.Context) error {
 
 	if vtctld.VtctldClient != nil {
 		if !vtctld.closed {
-			// TODO add a flag for context timeout
-			waitCtx, waitCancel := context.WithTimeout(ctx, 2*time.Second)
+			waitCtx, waitCancel := context.WithTimeout(ctx, vtctld.cfg.ConnectivityTimeout)
 			defer waitCancel()
 
 			if err := vtctld.VtctldClient.WaitForReady(waitCtx); err == nil {
@@ -161,8 +160,7 @@ func (vtctld *ClientProxy) Dial(ctx context.Context) error {
 	}
 
 	log.Infof("Established gRPC connection to vtctld %s; waiting to transition to READY...\n", addr)
-	// TODO use flag
-	waitCtx, waitCancel := context.WithTimeout(ctx, 2*time.Second)
+	waitCtx, waitCancel := context.WithTimeout(ctx, vtctld.cfg.ConnectivityTimeout)
 	defer waitCancel()
 
 	if err := client.WaitForReady(waitCtx); err != nil {

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -111,7 +111,8 @@ func TestRedial(t *testing.T) {
 			Id:   "test",
 			Name: "testcluster",
 		},
-		Discovery: disco,
+		Discovery:           disco,
+		ConnectivityTimeout: 2 * time.Second,
 	})
 
 	// We don't have a vtctld host until we call Dial

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,4 +67,94 @@ func TestDial(t *testing.T) {
 	err = proxy.Dial(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, listener.Addr().String(), proxy.host)
+}
+
+// TestRedial tests that vtadmin-api is able to recover from a lost connection to
+// a vtctld by rediscovering and redialing a new one.
+func TestRedial(t *testing.T) {
+	// Initialize vtctld #1
+	listener1, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener1.Close()
+
+	vtctld1 := &fakeVtctld{}
+	server1 := grpc.NewServer()
+
+	go server1.Serve(listener1)
+	defer server1.Stop()
+
+	vtctlservicepb.RegisterVtctlServer(server1, vtctld1)
+
+	// Initialize vtctld #2
+	listener2, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener2.Close()
+
+	vtctld2 := &fakeVtctld{}
+	server2 := grpc.NewServer()
+
+	go server2.Serve(listener2)
+	defer server2.Stop()
+
+	vtctlservicepb.RegisterVtctlServer(server2, vtctld2)
+
+	// Register both vtctlds with VTAdmin
+	disco := fakediscovery.New()
+	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
+		Hostname: listener1.Addr().String(),
+	}, &vtadminpb.Vtctld{
+		Hostname: listener2.Addr().String(),
+	})
+
+	proxy := New(&Config{
+		Cluster: &vtadminpb.Cluster{
+			Id:   "test",
+			Name: "testcluster",
+		},
+		Discovery: disco,
+	})
+
+	// We don't have a vtctld host until we call Dial
+	require.Empty(t, proxy.host)
+
+	// Check for a successful connection to whichever vtctld we discover first.
+	err = proxy.Dial(context.Background())
+	assert.NoError(t, err)
+
+	// vtadmin's fakediscovery package discovers vtctlds in random order. Rather
+	// than force some cumbersome sequential logic, we can just do a switcheroo
+	// here in the test to determine our "current" and (expected) "next" vtctlds.
+	var currentVtctld *grpc.Server
+	var nextAddr string
+
+	switch proxy.host {
+	case listener1.Addr().String():
+		currentVtctld = server1
+		nextAddr = listener2.Addr().String()
+
+	case listener2.Addr().String():
+		currentVtctld = server2
+		nextAddr = listener1.Addr().String()
+	default:
+		t.Fatalf("invalid proxy host %s", proxy.host)
+	}
+
+	// Remove the shut down vtctld from VTAdmin's service discovery (clumsily).
+	// Otherwise, when redialing, we may redial the vtctld that we just shut down.
+	// FIXME make this nicer
+	disco.Clear()
+	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
+		Hostname: nextAddr,
+	})
+
+	// Force an ungraceful shutdown of the gRPC server to which we're connected
+	currentVtctld.Stop()
+
+	// FIXME use WaitForReady instead
+	time.Sleep(2 * time.Second)
+
+	// Finally, check that dial + establish a connection to the remaining vtctld.
+	err = proxy.Dial(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, nextAddr, proxy.host)
 }

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -58,7 +58,8 @@ func TestDial(t *testing.T) {
 			Id:   "test",
 			Name: "testcluster",
 		},
-		Discovery: disco,
+		Discovery:           disco,
+		ConnectivityTimeout: 2 * time.Second,
 	})
 
 	// We don't have a vtctld host until we call Dial

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -144,7 +144,6 @@ func TestRedial(t *testing.T) {
 
 	// Remove the shut down vtctld from VTAdmin's service discovery (clumsily).
 	// Otherwise, when redialing, we may redial the vtctld that we just shut down.
-	// FIXME make this nicer
 	disco.Clear()
 	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
 		Hostname: nextAddr,
@@ -153,7 +152,7 @@ func TestRedial(t *testing.T) {
 	// Force an ungraceful shutdown of the gRPC server to which we're connected
 	currentVtctld.Stop()
 
-	// Wait for the client connection to shut down. If we redial too quickly,
+	// Wait for the client connection to shut down. (If we redial too quickly,
 	// we get into a race condition with gRPC's internal retry logic.
 	// (Using WaitForReady here _does_ expose more function internals than is ideal for a unit test,
 	// but it's far less flaky than using time.Sleep.)
@@ -165,7 +164,7 @@ func TestRedial(t *testing.T) {
 		}
 	}
 
-	// Finally, check that dial + establish a connection to the remaining vtctld.
+	// Finally, check that we discover, dial + establish a new connection to the remaining vtctld.
 	err = proxy.Dial(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, nextAddr, proxy.host)

--- a/go/vt/vtctl/grpcvtctldclient/client.go
+++ b/go/vt/vtctl/grpcvtctldclient/client.go
@@ -19,6 +19,8 @@ limitations under the License.
 package grpcvtctldclient
 
 import (
+	"context"
+
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -69,6 +71,7 @@ func NewWithDialOpts(addr string, failFast grpcclient.FailFast, opts ...grpc.Dia
 	}, nil
 }
 
+// Close is part of the vtctldclient.VtctldClient interface.
 func (client *gRPCVtctldClient) Close() error {
 	err := client.cc.Close()
 	if err == nil {
@@ -76,6 +79,11 @@ func (client *gRPCVtctldClient) Close() error {
 	}
 
 	return err
+}
+
+// WaitForReady is part of the vtctldclient.VtctldClient interface.
+func (client *gRPCVtctldClient) WaitForReady(ctx context.Context) error {
+	return nil
 }
 
 func init() {

--- a/go/vt/vtctl/grpcvtctldclient/client.go
+++ b/go/vt/vtctl/grpcvtctldclient/client.go
@@ -104,7 +104,7 @@ func (client *gRPCVtctldClient) WaitForReady(ctx context.Context) error {
 				return nil
 
 			// Per https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md,
-			// a client that enters SHUTDOWN state never leave this state, and all new RPCs should
+			// a client that enters SHUTDOWN state never leaves this state, and all new RPCs should
 			// fail immediately. So, we don't need to waste time by continuing to poll and can
 			// return an error immediately so that the caller can close the connection.
 			case connectivity.Shutdown:

--- a/go/vt/vtctl/grpcvtctldclient/client.go
+++ b/go/vt/vtctl/grpcvtctldclient/client.go
@@ -110,9 +110,9 @@ func (client *gRPCVtctldClient) WaitForReady(ctx context.Context) error {
 				return nil
 
 			// Per https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md,
-			// a client that enters SHUTDOWN state never leaves this state, and all new RPCs should
-			// fail immediately. So, we don't need to waste time by continuing to poll and can
-			// return an error immediately so that the caller can close the connection.
+			// a client that enters the SHUTDOWN state never leaves this state, and all new RPCs should
+			// fail immediately. Further polling is futile, in other words, and so we
+			// return an error immediately to indicate that the caller can close the connection.
 			case connectivity.Shutdown:
 				return ErrConnectionShutdown
 

--- a/go/vt/vtctl/localvtctldclient/client.go
+++ b/go/vt/vtctl/localvtctldclient/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package localvtctldclient
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -36,6 +37,9 @@ type localVtctldClient struct {
 
 // Close is part of the vtctldclient.VtctldClient interface.
 func (client *localVtctldClient) Close() error { return nil }
+
+// WaitForReady is part of the vtctldclient.VtctldClient interface.
+func (client *localVtctldClient) WaitForReady(ctx context.Context) error { return nil }
 
 //go:generate -command localvtctldclient go run ../vtctldclient/codegen
 //go:generate localvtctldclient -targetpkg localvtctldclient -impl localVtctldClient -out client_gen.go -local

--- a/go/vt/vtctl/vtctldclient/client.go
+++ b/go/vt/vtctl/vtctldclient/client.go
@@ -3,16 +3,22 @@
 package vtctldclient
 
 import (
+	"context"
 	"fmt"
 	"log"
 
 	vtctlservicepb "vitess.io/vitess/go/vt/proto/vtctlservice"
 )
 
-// VtctldClient augments the vtctlservicepb.VtctlClient interface with io.Closer.
 type VtctldClient interface {
 	vtctlservicepb.VtctldClient
+
+	// Close augments the vtctlservicepb.VtctlClient interface with io.Closer.
 	Close() error
+
+	// WaitForReady waits until the connection to the vtctld is in a ready state,
+	// or until the context times out.
+	WaitForReady(ctx context.Context) error
 }
 
 // Factory is a function that creates new VtctldClients.


### PR DESCRIPTION
## Description

This fixes https://github.com/vitessio/vitess/issues/9422: prior to this fix, vtadmin-api will hang on to a cached gRPC connection a vtctld even after the gRPC channel is shut down. 

This change updates VTAdmin's vtctld proxy to be "self healing" when its gRPC connection is lost. The `Dial` function, which is called prior to any vtctld request, will now wait until its cached connection is `READY`. If this check fails (for example: the connection is in a `SHUTDOWN` state as mentioned above, or we exceed `grpc-connectivity-timeout`'s worth of waiting), then the proxy will discover a different vtctld in that cluster and attempt to establish (and cache) a new gRPC connection. 

I also added a bunch more logging in the `Dial` function... I've found the added verbosity to be useful, but let me know if I took it too far (lol). 

FWIW we've had this branch running across Slack's Vitess deployments for the past few months and its worked well. 

### Reproduction steps

Some of this is noted in https://github.com/vitessio/vitess/issues/9422, but I'll note it here for posterity anyway. (It's an interesting example of doing mildly nontrivial stuff with VTAdmin + the local example. 🤷)

 1. Parameterize the vtctld-up.sh script and VTAdmin's discovery.json file to make it a lil easier to run a second vtctld
 
    <details>
    <summary>View diff</summary>
    ```bash
    diff --git a/examples/local/scripts/vtctld-up.sh b/examples/local/scripts/vtctld-up.sh
    index db6e544230..b81134c477 100755
    --- a/examples/local/scripts/vtctld-up.sh
    +++ b/examples/local/scripts/vtctld-up.sh
    @@ -18,8 +18,8 @@
    
    source ./env.sh
    
    -cell=${CELL:-'test'}
    -grpc_port=15999
    +grpc_port=${VTCTLD_GRPC_PORT:-'15999'}
    +web_port=${VTCTLD_WEB_PORT:-'15000'}
    
    echo "Starting vtctld..."
    # shellcheck disable=SC2086
    @@ -32,7 +32,7 @@ vtctld \
    --backup_storage_implementation file \
    --file_backup_storage_root $VTDATAROOT/backups \
    --log_dir $VTDATAROOT/tmp \
    - --port $vtctld_web_port \
    + --port $web_port \
    --durability_policy 'semi_sync' \
    --grpc_port $grpc_port \
    --pid_file $VTDATAROOT/tmp/vtctld.pid \
    diff --git a/examples/local/vtadmin/discovery.json b/examples/local/vtadmin/discovery.json
    index def7dd50f8..6b29f0077c 100644
    --- a/examples/local/vtadmin/discovery.json
    +++ b/examples/local/vtadmin/discovery.json
    @@ -5,6 +5,12 @@
                    "fqdn": "localhost:15000",
                    "hostname": "localhost:15999"
                }
    +        },
    +        {
    +            "host": {
    +                "fqdn": "localhost:16000",
    +                "hostname": "localhost:16999"
    +            }
            }
        ],
        "vtgates": [
    ```
    <details>

2. Start up a local cluster as usual, which will start up a single vtctld on http://localhost:15999: `./101_initial_cluster.sh`
3. Start a _second_ vtctld on http://localhost:16999: `VTCTLD_GRPC_PORT=16999 VTCTLD_WEB_PORT=16000 ./scripts/vtctld-up.sh`
4. Start up VTAdmin. (The usual way is `./scripts/vtadmin-up.sh`, which will also start vtadmin-web.)

At this point, we can double check that VTAdmin can "discover" both vtctlds. (Scare quotes since "discovery", in this case, is simply reading from that discovery.json file.)

```
 $ curl "http://localhost:14200/api/vtctlds"

{"result":{"vtctlds":[{"hostname":"localhost:15999","cluster":{"id":"local","name":"local"},"FQDN":"localhost:15000"}]},"ok":true}
```

Now, since VTAdmin lazy-initializes its vtctld connections, we need to trigger a request that traverses the "discover -> dial -> cache" codepath:

```
# We don't really care about the output right now
curl "http://localhost:14200/api/schemas"
```

Examine VTAdmin's `proxy.go` logs to see which of the two local vtctlds it discovered + dialed; in this case, it's the vtcltd on http://localhost:16999. 

```
I0318 12:46:54.444487   43118 config.go:122] [rbac]: loaded authorizer with 1 rules
I0318 12:46:54.444526   43118 config.go:146] [rbac]: no authenticator implementation specified
I0318 12:46:54.449496   43118 server.go:240] server vtadmin listening on :14200
I0318 12:49:37.128481   43118 vtsql.go:175] Dialing localhost:15991 ...
2022-03-18 12:49:37     INFO proxy.go:136] Discovering vtctld to dial...

2022-03-18 12:49:37     INFO proxy.go:156] Discovered vtctld localhost:16999; attempting to establish gRPC connection...

2022-03-18 12:49:37     INFO proxy.go:162] Established gRPC connection to vtctld localhost:16999; waiting to transition to READY...

2022-03-18 12:49:37     INFO proxy.go:175] Established gRPC connection to vtctld localhost:16999

2022-03-18 12:49:37     INFO proxy.go:113] Using cached connection to vtctld localhost:16999
```



## Related Issue(s)

Closes https://github.com/vitessio/vitess/issues/9422

## Checklist
- [x] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

This PR introduces `grpc-connectivity-timeout`, a new per-cluster config option that sets the maxmium wait time to establish a gRPC connection between VTAdmin and the vtctld it queries in that region. The default value is 2 seconds. 