### PR TITLE
[VEP 4, phase 1] Cleanup flags in `endtoend/vault` (and some comments in `endtoend/tabletmanager`)

### DIFF
--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -26,15 +26,14 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/test/endtoend/utils"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
+
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
@@ -156,7 +155,7 @@ func TestHealthCheck(t *testing.T) {
 
 	// stop the replica's source mysqld instance to break replication
 	// and test that the replica tablet becomes unhealthy and non-serving after crossing
-	// the tablet's -unhealthy_threshold and the gateway's -discovery_low_replication_lag
+	// the tablet's --unhealthy_threshold and the gateway's --discovery_low_replication_lag
 	err = primaryTablet.MysqlctlProcess.Stop()
 	require.NoError(t, err)
 

--- a/go/test/endtoend/tabletmanager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_test.go
@@ -61,7 +61,7 @@ func TestEnsureDB(t *testing.T) {
 // TestLocalMetadata tests the contents of local_metadata table after vttablet startup
 func TestLocalMetadata(t *testing.T) {
 	defer cluster.PanicHandler(t)
-	// by default tablets are started with -restore_from_backup
+	// by default tablets are started with --restore_from_backup
 	// so metadata should exist
 	cluster.VerifyLocalMetadata(t, &replicaTablet, keyspaceName, shardName, cell)
 
@@ -88,7 +88,7 @@ func TestLocalMetadata(t *testing.T) {
 	// Create another new tablet
 	rTablet2 := clusterInstance.NewVttabletInstance("replica", 0, "")
 
-	// start with -init_populate_metadata false (default)
+	// start with --init_populate_metadata false (default)
 	clusterInstance.VtTabletExtraArgs = []string{
 		"--lock_tables_timeout", "5s",
 	}

--- a/go/test/endtoend/vault/vault_test.go
+++ b/go/test/endtoend/vault/vault_test.go
@@ -57,46 +57,46 @@ var (
 	vtgateUser      = "vtgate_user"
 	vtgatePassword  = "password123"
 	commonTabletArg = []string{
-		"-vreplication_healthcheck_topology_refresh", "1s",
-		"-vreplication_healthcheck_retry_delay", "1s",
-		"-vreplication_retry_delay", "1s",
-		"-degraded_threshold", "5s",
-		"-lock_tables_timeout", "5s",
-		"-watch_replication_stream",
+		"--vreplication_healthcheck_topology_refresh", "1s",
+		"--vreplication_healthcheck_retry_delay", "1s",
+		"--vreplication_retry_delay", "1s",
+		"--degraded_threshold", "5s",
+		"--lock_tables_timeout", "5s",
+		"--watch_replication_stream",
 		// Frequently reload schema, generating some tablet traffic,
 		//   so we can speed up token refresh
-		"-queryserver-config-schema-reload-time", "5",
-		"-serving_state_grace_period", "1s"}
+		"--queryserver-config-schema-reload-time", "5",
+		"--serving_state_grace_period", "1s"}
 	vaultTabletArg = []string{
-		"-db-credentials-server", "vault",
-		"-db-credentials-vault-timeout", "3s",
-		"-db-credentials-vault-path", "kv/prod/dbcreds",
+		"--db-credentials-server", "vault",
+		"--db-credentials-vault-timeout", "3s",
+		"--db-credentials-vault-path", "kv/prod/dbcreds",
 		// This is overriden by our env VAULT_ADDR
-		"-db-credentials-vault-addr", "https://127.0.0.1:8200",
+		"--db-credentials-vault-addr", "https://127.0.0.1:8200",
 		// This is overriden by our env VAULT_CACERT
-		"-db-credentials-vault-tls-ca", "/path/to/ca.pem",
+		"--db-credentials-vault-tls-ca", "/path/to/ca.pem",
 		// This is provided by our env VAULT_ROLEID
-		//"-db-credentials-vault-roleid", "34644576-9ffc-8bb5-d046-4a0e41194e15",
+		//"--db-credentials-vault-roleid", "34644576-9ffc-8bb5-d046-4a0e41194e15",
 		// Contents of this file provided by our env VAULT_SECRETID
-		//"-db-credentials-vault-secretidfile", "/path/to/file/containing/secret_id",
+		//"--db-credentials-vault-secretidfile", "/path/to/file/containing/secret_id",
 		// Make this small, so we can get a renewal
-		"-db-credentials-vault-ttl", "21s"}
+		"--db-credentials-vault-ttl", "21s"}
 	vaultVTGateArg = []string{
-		"-mysql_auth_server_impl", "vault",
-		"-mysql_auth_vault_timeout", "3s",
-		"-mysql_auth_vault_path", "kv/prod/vtgatecreds",
+		"--mysql_auth_server_impl", "vault",
+		"--mysql_auth_vault_timeout", "3s",
+		"--mysql_auth_vault_path", "kv/prod/vtgatecreds",
 		// This is overriden by our env VAULT_ADDR
-		"-mysql_auth_vault_addr", "https://127.0.0.1:8200",
+		"--mysql_auth_vault_addr", "https://127.0.0.1:8200",
 		// This is overriden by our env VAULT_CACERT
-		"-mysql_auth_vault_tls_ca", "/path/to/ca.pem",
+		"--mysql_auth_vault_tls_ca", "/path/to/ca.pem",
 		// This is provided by our env VAULT_ROLEID
-		//"-mysql_auth_vault_roleid", "34644576-9ffc-8bb5-d046-4a0e41194e15",
+		//"--mysql_auth_vault_roleid", "34644576-9ffc-8bb5-d046-4a0e41194e15",
 		// Contents of this file provided by our env VAULT_SECRETID
-		//"-mysql_auth_vault_role_secretidfile", "/path/to/file/containing/secret_id",
+		//"--mysql_auth_vault_role_secretidfile", "/path/to/file/containing/secret_id",
 		// Make this small, so we can get a renewal
-		"-mysql_auth_vault_ttl", "21s"}
+		"--mysql_auth_vault_ttl", "21s"}
 	mysqlctlArg = []string{
-		"-db_dba_password", mysqlPassword}
+		"--db_dba_password", mysqlPassword}
 	vttabletLogFileName = "vttablet.INFO"
 	tokenRenewalString  = "Vault client status: token renewed"
 )
@@ -218,7 +218,7 @@ func setupVaultServer(t *testing.T, vs *VaultServer) (string, string) {
 func initializeClusterEarly(t *testing.T) {
 	clusterInstance = cluster.NewCluster(cell, hostname)
 
-	clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "-durability_policy=semi_sync")
+	clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 	// Start topo server
 	err := clusterInstance.StartTopo()
 	require.NoError(t, err)


### PR DESCRIPTION


## Description

More VEP-4 tidying.

## Related Issue(s)

#9895 


## Checklist
- [x] Should this PR be backported? -- **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->