### PR TITLE
Improve escape handling for vindex materializer

### DIFF
--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -1436,7 +1436,7 @@ func TestCreateLookupVindexFailures(t *testing.T) {
 				},
 			},
 		},
-		err: "vindex 'table' must be <keyspace>.<table>",
+		err: "vindex table name must be in the form <keyspace>.<table>",
 	}, {
 		description: "unique lookup should have only one from column",
 		input: &vschemapb.Keyspace{
@@ -1698,7 +1698,7 @@ func TestExternalizeVindex(t *testing.T) {
 		err:   "vindex sourceks.absent not found in vschema",
 	}, {
 		input: "sourceks.bad",
-		err:   "table name in vindex should be of the form keyspace.table: unqualified",
+		err:   "vindex table name must be in the form <keyspace>.<table>. Got: unqualified",
 	}, {
 		input:        "sourceks.owned",
 		vrResponse:   running,


### PR DESCRIPTION
In case we handle table names here with for example a dash in them, we should escape it consistently like how we escape values in other parts of the vschema as well.

Additionally, use the proper escape functionality instead of manually putting the string between backticks to ensure consistent behavior.

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes

This would break an existing specific case in a vschema, namely using a table reference to a table that requires escaping. However, I think there's other areas already where this breaks from what I can gather so not sure if that's a practical concern then or not. 