### PR TITLE
[VEP4, phase1] Cleanup flags in `endtoend/vtgate` and `endtoend/vtorc`

### DIFF
--- a/go/test/endtoend/vtgate/schematracker/loadkeyspace/schema_load_keyspace_test.go
+++ b/go/test/endtoend/vtgate/schematracker/loadkeyspace/schema_load_keyspace_test.go
@@ -64,7 +64,7 @@ func TestBlockedLoadKeyspace(t *testing.T) {
 	err = clusterInstance.StartTopo()
 	require.NoError(t, err)
 
-	// Start keyspace without the -queryserver-config-schema-change-signal flag
+	// Start keyspace without the --queryserver-config-schema-change-signal flag
 	keyspace := &cluster.Keyspace{
 		Name:      keyspaceName,
 		SchemaSQL: sqlSchema,

--- a/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
+++ b/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
@@ -159,7 +159,7 @@ func TestHealthCheckCacheWithTabletChurn(t *testing.T) {
 		deleteTablet(t, tablet)
 		expectedTabletHCcacheEntries--
 
-		// We need to sleep for at least vtgate's -tablet_refresh_interval to be sure we
+		// We need to sleep for at least vtgate's --tablet_refresh_interval to be sure we
 		// have resynchronized the healthcheck cache with the topo server via the topology
 		// watcher and pruned the deleted tablet from the healthcheck cache.
 		time.Sleep(tabletRefreshInterval)

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -40,13 +40,13 @@ import (
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	"vitess.io/vitess/go/vt/topo/topoproto"
-
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 const (
@@ -526,7 +526,7 @@ func validateTopology(t *testing.T, clusterInfo *VtOrcClusterInfo, pingTablets b
 				var err error
 				var output string
 				if pingTablets {
-					output, err = clusterInfo.ClusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("Validate", "-ping-tablets=true")
+					output, err = clusterInfo.ClusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("Validate", "--", "--ping-tablets=true")
 				} else {
 					output, err = clusterInfo.ClusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("Validate")
 				}


### PR DESCRIPTION
## Description

More of the same flag cleanup.

## Related Issue(s)
#9895 


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->