### PR TITLE
[vtctl] Deprecate query commands

### DIFF
--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -45,7 +45,7 @@ import (
 const queriesGroupName = "Queries"
 
 var (
-	enableQueries = flag.Bool("enable_queries", false, "if set, allows vtgate and vttablet queries. May have security implications, as the queries will be run from this process.")
+	enableQueries = flag.Bool("enable_queries", false, "[DEPRECATED - query commands via vtctl are being deprecated] if set, allows vtgate and vttablet queries. May have security implications, as the queries will be run from this process.")
 )
 
 func init() {
@@ -53,42 +53,49 @@ func init() {
 
 	// VtGate commands
 	addCommand(queriesGroupName, command{
-		name:   "VtGateExecute",
-		method: commandVtGateExecute,
-		params: "-server <vtgate> [-bind_variables <JSON map>] [-keyspace <default keyspace>] [-tablet_type <tablet type>] [-options <proto text options>] [-json] <sql>",
-		help:   "Executes the given SQL query with the provided bound variables against the vtgate server.",
+		name:       "VtGateExecute",
+		method:     commandVtGateExecute,
+		params:     "-server <vtgate> [-bind_variables <JSON map>] [-keyspace <default keyspace>] [-tablet_type <tablet type>] [-options <proto text options>] [-json] <sql>",
+		help:       "Executes the given SQL query with the provided bound variables against the vtgate server.",
+		deprecated: true,
 	})
 
 	// VtTablet commands
 	addCommand(queriesGroupName, command{
-		name:   "VtTabletExecute",
-		method: commandVtTabletExecute,
-		params: "[-username <TableACL user>] [-transaction_id <transaction_id>] [-options <proto text options>] [-json] <tablet alias> <sql>",
-		help:   "Executes the given query on the given tablet. -transaction_id is optional. Use VtTabletBegin to start a transaction.",
+		name:         "VtTabletExecute",
+		method:       commandVtTabletExecute,
+		params:       "[-username <TableACL user>] [-transaction_id <transaction_id>] [-options <proto text options>] [-json] <tablet alias> <sql>",
+		help:         "Executes the given query on the given tablet. -transaction_id is optional. Use VtTabletBegin to start a transaction.",
+		deprecated:   true,
+		deprecatedBy: "ExecuteFetchAsApp",
 	})
 	addCommand(queriesGroupName, command{
-		name:   "VtTabletBegin",
-		method: commandVtTabletBegin,
-		params: "[-username <TableACL user>] <tablet alias>",
-		help:   "Starts a transaction on the provided server.",
+		name:       "VtTabletBegin",
+		method:     commandVtTabletBegin,
+		params:     "[-username <TableACL user>] <tablet alias>",
+		help:       "Starts a transaction on the provided server.",
+		deprecated: true,
 	})
 	addCommand(queriesGroupName, command{
-		name:   "VtTabletCommit",
-		method: commandVtTabletCommit,
-		params: "[-username <TableACL user>] <transaction_id>",
-		help:   "Commits the given transaction on the provided server.",
+		name:       "VtTabletCommit",
+		method:     commandVtTabletCommit,
+		params:     "[-username <TableACL user>] <transaction_id>",
+		help:       "Commits the given transaction on the provided server.",
+		deprecated: true,
 	})
 	addCommand(queriesGroupName, command{
-		name:   "VtTabletRollback",
-		method: commandVtTabletRollback,
-		params: "[-username <TableACL user>] <tablet alias> <transaction_id>",
-		help:   "Rollbacks the given transaction on the provided server.",
+		name:       "VtTabletRollback",
+		method:     commandVtTabletRollback,
+		params:     "[-username <TableACL user>] <tablet alias> <transaction_id>",
+		help:       "Rollbacks the given transaction on the provided server.",
+		deprecated: true,
 	})
 	addCommand(queriesGroupName, command{
-		name:   "VtTabletStreamHealth",
-		method: commandVtTabletStreamHealth,
-		params: "[-count <count, default 1>] <tablet alias>",
-		help:   "Executes the StreamHealth streaming query to a vttablet process. Will stop after getting <count> answers.",
+		name:       "VtTabletStreamHealth",
+		method:     commandVtTabletStreamHealth,
+		params:     "[-count <count, default 1>] <tablet alias>",
+		help:       "Executes the StreamHealth streaming query to a vttablet process. Will stop after getting <count> answers.",
+		deprecated: true,
 	})
 }
 
@@ -145,7 +152,7 @@ func parseExecuteOptions(value string) (*querypb.ExecuteOptions, error) {
 
 func commandVtGateExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
+		return fmt.Errorf("query commands are disabled (set the --enable_queries flag to enable)")
 	}
 
 	server := subFlags.String("server", "", "VtGate server to connect to")
@@ -190,7 +197,7 @@ func commandVtGateExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 
 func commandVtTabletExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
+		return fmt.Errorf("query commands are disabled (set the --enable_queries flag to enable)")
 	}
 
 	username := subFlags.String("username", "", "If set, value is set as immediate caller id in the request and used by vttablet for TableACL check")
@@ -253,7 +260,7 @@ func commandVtTabletExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags
 
 func commandVtTabletBegin(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
+		return fmt.Errorf("query commands are disabled (set the --enable_queries flag to enable)")
 	}
 
 	username := subFlags.String("username", "", "If set, value is set as immediate caller id in the request and used by vttablet for TableACL check")
@@ -300,7 +307,7 @@ func commandVtTabletBegin(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 
 func commandVtTabletCommit(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
+		return fmt.Errorf("query commands are disabled (set the --enable_queries flag to enable)")
 	}
 
 	username := subFlags.String("username", "", "If set, value is set as immediate caller id in the request and used by vttablet for TableACL check")
@@ -346,7 +353,7 @@ func commandVtTabletCommit(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 
 func commandVtTabletRollback(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
+		return fmt.Errorf("query commands are disabled (set the --enable_queries flag to enable)")
 	}
 
 	username := subFlags.String("username", "", "If set, value is set as immediate caller id in the request and used by vttablet for TableACL check")
@@ -392,7 +399,7 @@ func commandVtTabletRollback(ctx context.Context, wr *wrangler.Wrangler, subFlag
 
 func commandVtTabletStreamHealth(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
+		return fmt.Errorf("query commands are disabled (set the --enable_queries flag to enable)")
 	}
 
 	count := subFlags.Int("count", 1, "number of responses to wait for")


### PR DESCRIPTION
## Description

This deprecates the following commands, to take effect in 14.0:
- `VtGateExecute`
- `VtTabletExecute`
- `VtTabletBegin`
- `VtTabletCommit`
- `VtTabletRollback`
- `VtTabletStreamHealth`

After 14.0, we'll delete the commands, flag, and associated code, which is tracked in #9933.

### Demo

```
➜  local git:(andrew/deprecate-vtctl-querycommands) ✗ vtctlclient --server ":15999" help | grep -E 'Vt(Tablet|Gate)'
  (DEPRECATED) VtGateExecute -server <vtgate> [-bind_variables <JSON map>] [-keyspace <default keyspace>] [-tablet_type <tablet type>] [-options <proto text options>] [-json] <sql>
  (DEPRECATED) VtTabletExecute [-username <TableACL user>] [-transaction_id <transaction_id>] [-options <proto text options>] [-json] <tablet alias> <sql>
  (DEPRECATED) VtTabletBegin [-username <TableACL user>] <tablet alias>
  (DEPRECATED) VtTabletCommit [-username <TableACL user>] <transaction_id>
  (DEPRECATED) VtTabletRollback [-username <TableACL user>] <tablet alias> <transaction_id>
  (DEPRECATED) VtTabletStreamHealth [-count <count, default 1>] <tablet alias>
➜  local git:(andrew/deprecate-vtctl-querycommands) ✗ vtctlclient --server ":15999" VtTabletBegin -- -h             
WARNING: VtTabletBegin is deprecated and will be removed in a future release.
Usage: VtTabletBegin [-username <TableACL user>] <tablet alias>

Starts a transaction on the provided server.

  --username string
        If set, value is set as immediate caller id in the request and used by vttablet for TableACL check
```

## Related Issue(s)

Closes #9932.

## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->