### PR TITLE
region_example: sleep 5s before switching reads to allow copy to finish

### DIFF
--- a/test/region_example.sh
+++ b/test/region_example.sh
@@ -43,6 +43,8 @@ mysql --table < show_initial_data.sql
 # reshard
 ./203_reshard.sh
 
+sleep 5 # Give reshard time to finish copying
+
 # SwitchReads
 ./204_switch_reads.sh
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
After I changed the example to use v2 vreplication commands instead of v1, it started failing on several PRs (though it passed on the original PR #9875)
Temporarily adding a sleep to allow it to finish.
We should investigate whether v2 is slower than v1, keeping in mind that this is a tiny dataset.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#9875 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->