### PR TITLE
fix: allow multiple distinct columns on single shards

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -3856,3 +3856,25 @@ Gen4 error: cannot push projections in ordered aggregates
     ]
   }
 }
+
+"select count(distinct user_id, name) from unsharded"
+{
+  "QueryType": "SELECT",
+  "Original": "select count(distinct user_id, name) from unsharded",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "Unsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select count(distinct user_id, `name`) from unsharded where 1 != 1",
+    "Query": "select count(distinct user_id, `name`) from unsharded",
+    "Table": "unsharded"
+  }
+}
+Gen4 plan same as above
+
+"select count(distinct user_id, name) from user"
+"unsupported: only one expression allowed inside aggregates: count(distinct user_id, `name`)"
+Gen4 error: aggregate functions take a single argument 'count(distinct user_id, `name`)'

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -292,7 +292,7 @@ func (a *analyzer) checkForInvalidConstructs(cursor *sqlparser.Cursor) error {
 
 		if node.Distinct {
 			err := vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "syntax error: %s", sqlparser.String(node))
-			if len(node.Exprs) != 1 {
+			if len(node.Exprs) < 1 {
 				return err
 			} else if _, ok := node.Exprs[0].(*sqlparser.AliasedExpr); !ok {
 				return err


### PR DESCRIPTION
## Description
We don't support multiple distinct columns when aggregating on the vtgate, but there is no reason we should not allow it against single shards.

## Related Issue(s)
Fixes #9927 

## Checklist
- [x] Should this PR be backported? `No, unless, someone asks for it`
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
