### PR TITLE
cache: update Cache implementation to use Generics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,10 @@ issues:
       - errcheck
       - goimports
 
+    - path: '^go/cache/'
+      linters:
+        - structcheck
+
     ### BEGIN: errcheck exclusion rules. Each rule should be considered
     #   a TODO for removal after adding error checks to that package/file/etc,
     #   except where otherwise noted.

--- a/go/cache/cache_test.go
+++ b/go/cache/cache_test.go
@@ -9,25 +9,31 @@ import (
 	"vitess.io/vitess/go/cache/ristretto"
 )
 
+type dummy uint32
+
+func (dummy) CachedSize(bool) int64 {
+	return 1
+}
+
 func TestNewDefaultCacheImpl(t *testing.T) {
-	assertNullCache := func(t *testing.T, cache Cache) {
-		_, ok := cache.(*nullCache)
+	assertNullCache := func(t *testing.T, cache Cache[dummy]) {
+		_, ok := cache.(*nullCache[dummy])
 		require.True(t, ok)
 	}
 
-	assertLFUCache := func(t *testing.T, cache Cache) {
-		_, ok := cache.(*ristretto.Cache)
+	assertLFUCache := func(t *testing.T, cache Cache[dummy]) {
+		_, ok := cache.(*ristretto.Cache[dummy])
 		require.True(t, ok)
 	}
 
-	assertLRUCache := func(t *testing.T, cache Cache) {
-		_, ok := cache.(*LRUCache)
+	assertLRUCache := func(t *testing.T, cache Cache[dummy]) {
+		_, ok := cache.(*LRUCache[dummy])
 		require.True(t, ok)
 	}
 
 	tests := []struct {
 		cfg    *Config
-		verify func(t *testing.T, cache Cache)
+		verify func(t *testing.T, cache Cache[dummy])
 	}{
 		{&Config{MaxEntries: 0, MaxMemoryUsage: 0, LFU: false}, assertNullCache},
 		{&Config{MaxEntries: 0, MaxMemoryUsage: 0, LFU: true}, assertNullCache},
@@ -40,7 +46,7 @@ func TestNewDefaultCacheImpl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%d.%d.%v", tt.cfg.MaxEntries, tt.cfg.MaxMemoryUsage, tt.cfg.LFU), func(t *testing.T) {
-			cache := NewDefaultCacheImpl(tt.cfg)
+			cache := NewDefaultCacheImpl[dummy](tt.cfg)
 			tt.verify(t, cache)
 		})
 	}

--- a/go/cache/null.go
+++ b/go/cache/null.go
@@ -17,57 +17,57 @@ limitations under the License.
 package cache
 
 // nullCache is a no-op cache that does not store items
-type nullCache struct{}
+type nullCache[I any] struct{}
 
 // Get never returns anything on the nullCache
-func (n *nullCache) Get(_ string) (any, bool) {
-	return nil, false
+func (n *nullCache[I]) Get(_ string) (i I, b bool) {
+	return
 }
 
 // Set is a no-op in the nullCache
-func (n *nullCache) Set(_ string, _ any) bool {
+func (n *nullCache[I]) Set(_ string, _ I) bool {
 	return false
 }
 
 // ForEach iterates the nullCache, which is always empty
-func (n *nullCache) ForEach(_ func(any) bool) {}
+func (n *nullCache[I]) ForEach(_ func(I) bool) {}
 
 // Delete is a no-op in the nullCache
-func (n *nullCache) Delete(_ string) {}
+func (n *nullCache[I]) Delete(_ string) {}
 
 // Clear is a no-op in the nullCache
-func (n *nullCache) Clear() {}
+func (n *nullCache[I]) Clear() {}
 
 // Wait is a no-op in the nullcache
-func (n *nullCache) Wait() {}
+func (n *nullCache[I]) Wait() {}
 
-func (n *nullCache) Len() int {
+func (n *nullCache[I]) Len() int {
 	return 0
 }
 
 // Hits returns number of cache hits since creation
-func (n *nullCache) Hits() int64 {
+func (n *nullCache[I]) Hits() int64 {
 	return 0
 }
 
 // Hits returns number of cache misses since creation
-func (n *nullCache) Misses() int64 {
+func (n *nullCache[I]) Misses() int64 {
 	return 0
 }
 
 // Capacity returns the capacity of the nullCache, which is always 0
-func (n *nullCache) UsedCapacity() int64 {
+func (n *nullCache[I]) UsedCapacity() int64 {
 	return 0
 }
 
 // Capacity returns the capacity of the nullCache, which is always 0
-func (n *nullCache) MaxCapacity() int64 {
+func (n *nullCache[I]) MaxCapacity() int64 {
 	return 0
 }
 
 // SetCapacity sets the capacity of the null cache, which is a no-op
-func (n *nullCache) SetCapacity(_ int64) {}
+func (n *nullCache[I]) SetCapacity(_ int64) {}
 
-func (n *nullCache) Evictions() int64 {
+func (n *nullCache[I]) Evictions() int64 {
 	return 0
 }

--- a/go/cache/ristretto.go
+++ b/go/cache/ristretto.go
@@ -4,23 +4,21 @@ import (
 	"vitess.io/vitess/go/cache/ristretto"
 )
 
-var _ Cache = &ristretto.Cache{}
-
 // NewRistrettoCache returns a Cache implementation based on Ristretto
-func NewRistrettoCache(maxEntries, maxCost int64, cost func(any) int64) *ristretto.Cache {
+func NewRistrettoCache[I any](maxEntries, maxCost int64, cost func(I) int64) *ristretto.Cache[I] {
 	// The TinyLFU paper recommends to allocate 10x times the max entries amount as counters
 	// for the admission policy; since our caches are small and we're very interested on admission
 	// accuracy, we're a bit more greedy than 10x
 	const CounterRatio = 12
 
-	config := ristretto.Config{
+	config := ristretto.Config[I]{
 		NumCounters: maxEntries * CounterRatio,
 		MaxCost:     maxCost,
 		BufferItems: 64,
 		Metrics:     true,
 		Cost:        cost,
 	}
-	cache, err := ristretto.NewCache(&config)
+	cache, err := ristretto.NewCache[I](&config)
 	if err != nil {
 		panic(err)
 	}

--- a/go/cache/ristretto/policy_test.go
+++ b/go/cache/ristretto/policy_test.go
@@ -28,18 +28,18 @@ func TestPolicy(t *testing.T) {
 	defer func() {
 		require.Nil(t, recover())
 	}()
-	newPolicy(100, 10)
+	newPolicy[int](100, 10)
 }
 
 func TestPolicyMetrics(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.CollectMetrics(newMetrics())
 	require.NotNil(t, p.metrics)
 	require.NotNil(t, p.evict.metrics)
 }
 
 func TestPolicyProcessItems(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.itemsCh <- []uint64{1, 2, 2}
 	time.Sleep(wait)
 	p.Lock()
@@ -56,7 +56,7 @@ func TestPolicyProcessItems(t *testing.T) {
 }
 
 func TestPolicyPush(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	require.True(t, p.Push([]uint64{}))
 
 	keepCount := 0
@@ -69,7 +69,7 @@ func TestPolicyPush(t *testing.T) {
 }
 
 func TestPolicyAdd(t *testing.T) {
-	p := newDefaultPolicy(1000, 100)
+	p := newDefaultPolicy[int](1000, 100)
 	if victims, added := p.Add(1, 101); victims != nil || added {
 		t.Fatal("can't add an item bigger than entire cache")
 	}
@@ -98,14 +98,14 @@ func TestPolicyAdd(t *testing.T) {
 }
 
 func TestPolicyHas(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.Add(1, 1)
 	require.True(t, p.Has(1))
 	require.False(t, p.Has(2))
 }
 
 func TestPolicyDel(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.Add(1, 1)
 	p.Del(1)
 	p.Del(2)
@@ -114,13 +114,13 @@ func TestPolicyDel(t *testing.T) {
 }
 
 func TestPolicyCap(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.Add(1, 1)
 	require.Equal(t, int64(9), p.MaxCost()-p.Used())
 }
 
 func TestPolicyUpdate(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.Add(1, 1)
 	p.Update(1, 2)
 	p.Lock()
@@ -129,14 +129,14 @@ func TestPolicyUpdate(t *testing.T) {
 }
 
 func TestPolicyCost(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.Add(1, 2)
 	require.Equal(t, int64(2), p.Cost(1))
 	require.Equal(t, int64(-1), p.Cost(2))
 }
 
 func TestPolicyClear(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.Add(1, 1)
 	p.Add(2, 2)
 	p.Add(3, 3)
@@ -152,20 +152,20 @@ func TestPolicyClose(t *testing.T) {
 		require.NotNil(t, recover())
 	}()
 
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.Add(1, 1)
 	p.Close()
 	p.itemsCh <- []uint64{1}
 }
 
 func TestPushAfterClose(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.Close()
 	require.False(t, p.Push([]uint64{1, 2}))
 }
 
 func TestAddAfterClose(t *testing.T) {
-	p := newDefaultPolicy(100, 10)
+	p := newDefaultPolicy[int](100, 10)
 	p.Close()
 	p.Add(1, 1)
 }

--- a/go/cache/ristretto/store_test.go
+++ b/go/cache/ristretto/store_test.go
@@ -25,9 +25,9 @@ import (
 )
 
 func TestStoreSetGet(t *testing.T) {
-	s := newStore()
+	s := newStore[int]()
 	key, conflict := defaultStringHash("1")
-	i := Item{
+	i := Item[int]{
 		Key:      key,
 		Conflict: conflict,
 		Value:    2,
@@ -35,16 +35,16 @@ func TestStoreSetGet(t *testing.T) {
 	s.Set(&i)
 	val, ok := s.Get(key, conflict)
 	require.True(t, ok)
-	require.Equal(t, 2, val.(int))
+	require.Equal(t, 2, val)
 
 	i.Value = 3
 	s.Set(&i)
 	val, ok = s.Get(key, conflict)
 	require.True(t, ok)
-	require.Equal(t, 3, val.(int))
+	require.Equal(t, 3, val)
 
 	key, conflict = defaultStringHash("2")
-	i = Item{
+	i = Item[int]{
 		Key:      key,
 		Conflict: conflict,
 		Value:    2,
@@ -52,13 +52,13 @@ func TestStoreSetGet(t *testing.T) {
 	s.Set(&i)
 	val, ok = s.Get(key, conflict)
 	require.True(t, ok)
-	require.Equal(t, 2, val.(int))
+	require.Equal(t, 2, val)
 }
 
 func TestStoreDel(t *testing.T) {
-	s := newStore()
+	s := newStore[int]()
 	key, conflict := defaultStringHash("1")
-	i := Item{
+	i := Item[int]{
 		Key:      key,
 		Conflict: conflict,
 		Value:    1,
@@ -73,10 +73,10 @@ func TestStoreDel(t *testing.T) {
 }
 
 func TestStoreClear(t *testing.T) {
-	s := newStore()
+	s := newStore[int]()
 	for i := 0; i < 1000; i++ {
 		key, conflict := defaultStringHash(strconv.Itoa(i))
-		it := Item{
+		it := Item[int]{
 			Key:      key,
 			Conflict: conflict,
 			Value:    i,
@@ -93,9 +93,9 @@ func TestStoreClear(t *testing.T) {
 }
 
 func TestStoreUpdate(t *testing.T) {
-	s := newStore()
+	s := newStore[int]()
 	key, conflict := defaultStringHash("1")
-	i := Item{
+	i := Item[int]{
 		Key:      key,
 		Conflict: conflict,
 		Value:    1,
@@ -111,7 +111,7 @@ func TestStoreUpdate(t *testing.T) {
 
 	val, ok = s.Get(key, conflict)
 	require.True(t, ok)
-	require.Equal(t, 2, val.(int))
+	require.Equal(t, 2, val)
 
 	i.Value = 3
 	_, ok = s.Update(&i)
@@ -119,10 +119,10 @@ func TestStoreUpdate(t *testing.T) {
 
 	val, ok = s.Get(key, conflict)
 	require.True(t, ok)
-	require.Equal(t, 3, val.(int))
+	require.Equal(t, 3, val)
 
 	key, conflict = defaultStringHash("2")
-	i = Item{
+	i = Item[int]{
 		Key:      key,
 		Conflict: conflict,
 		Value:    2,
@@ -135,9 +135,9 @@ func TestStoreUpdate(t *testing.T) {
 }
 
 func TestStoreCollision(t *testing.T) {
-	s := newShardedMap()
+	s := newShardedMap[int]()
 	s.shards[1].Lock()
-	s.shards[1].data[1] = storeItem{
+	s.shards[1].data[1] = storeItem[int]{
 		key:      1,
 		conflict: 0,
 		value:    1,
@@ -147,7 +147,7 @@ func TestStoreCollision(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, val)
 
-	i := Item{
+	i := Item[int]{
 		Key:      1,
 		Conflict: 1,
 		Value:    2,
@@ -155,13 +155,13 @@ func TestStoreCollision(t *testing.T) {
 	s.Set(&i)
 	val, ok = s.Get(1, 0)
 	require.True(t, ok)
-	require.NotEqual(t, 2, val.(int))
+	require.NotEqual(t, 2, val)
 
 	_, ok = s.Update(&i)
 	require.False(t, ok)
 	val, ok = s.Get(1, 0)
 	require.True(t, ok)
-	require.NotEqual(t, 2, val.(int))
+	require.NotEqual(t, 2, val)
 
 	s.Del(1, 1)
 	val, ok = s.Get(1, 0)
@@ -170,9 +170,9 @@ func TestStoreCollision(t *testing.T) {
 }
 
 func BenchmarkStoreGet(b *testing.B) {
-	s := newStore()
+	s := newStore[int]()
 	key, conflict := defaultStringHash("1")
-	i := Item{
+	i := Item[int]{
 		Key:      key,
 		Conflict: conflict,
 		Value:    1,
@@ -187,12 +187,12 @@ func BenchmarkStoreGet(b *testing.B) {
 }
 
 func BenchmarkStoreSet(b *testing.B) {
-	s := newStore()
+	s := newStore[int]()
 	key, conflict := defaultStringHash("1")
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			i := Item{
+			i := Item[int]{
 				Key:      key,
 				Conflict: conflict,
 				Value:    1,
@@ -203,9 +203,9 @@ func BenchmarkStoreSet(b *testing.B) {
 }
 
 func BenchmarkStoreUpdate(b *testing.B) {
-	s := newStore()
+	s := newStore[int]()
 	key, conflict := defaultStringHash("1")
-	i := Item{
+	i := Item[int]{
 		Key:      key,
 		Conflict: conflict,
 		Value:    1,
@@ -214,7 +214,7 @@ func BenchmarkStoreUpdate(b *testing.B) {
 	b.SetBytes(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s.Update(&Item{
+			s.Update(&Item[int]{
 				Key:      key,
 				Conflict: conflict,
 				Value:    2,

--- a/go/generics/list/list.go
+++ b/go/generics/list/list.go
@@ -17,6 +17,7 @@
 package list
 
 // Element is an element of a linked list.
+// nolint
 type Element[I any] struct {
 	// Next and previous pointers in the doubly-linked list of elements.
 	// To simplify the implementation, internally a list l is implemented
@@ -50,9 +51,10 @@ func (e *Element[I]) Prev() *Element[I] {
 
 // List represents a doubly linked list.
 // The zero value for List is an empty list ready to use.
+//nolint
 type List[I any] struct {
 	root Element[I] // sentinel list element, only &root, root.prev, and root.next are used
-	len  int     // current list length excluding (this) sentinel element
+	len  int        // current list length excluding (this) sentinel element
 }
 
 // Init initializes or clears list l.
@@ -105,7 +107,7 @@ func (l *List[I]) insert(e, at *Element[I]) *Element[I] {
 }
 
 // insertValue is a convenience wrapper for insert(&Element{Value: v}, at).
-func (l *List[I]) insertValue(v I, at *Element[I]) *Element[I]{
+func (l *List[I]) insertValue(v I, at *Element[I]) *Element[I] {
 	return l.insert(&Element[I]{Value: v}, at)
 }
 

--- a/go/generics/list/list.go
+++ b/go/generics/list/list.go
@@ -1,0 +1,240 @@
+/*
+ Copyright 2022 The Vitess Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package list
+
+// Element is an element of a linked list.
+type Element[I any] struct {
+	// Next and previous pointers in the doubly-linked list of elements.
+	// To simplify the implementation, internally a list l is implemented
+	// as a ring, such that &l.root is both the next element of the last
+	// list element (l.Back()) and the previous element of the first list
+	// element (l.Front()).
+	next, prev *Element[I]
+
+	// The list to which this element belongs.
+	list *List[I]
+
+	// The value stored with this element.
+	Value I
+}
+
+// Next returns the next list element or nil.
+func (e *Element[I]) Next() *Element[I] {
+	if p := e.next; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// Prev returns the previous list element or nil.
+func (e *Element[I]) Prev() *Element[I] {
+	if p := e.prev; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// List represents a doubly linked list.
+// The zero value for List is an empty list ready to use.
+type List[I any] struct {
+	root Element[I] // sentinel list element, only &root, root.prev, and root.next are used
+	len  int     // current list length excluding (this) sentinel element
+}
+
+// Init initializes or clears list l.
+func (l *List[I]) Init() *List[I] {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+	l.len = 0
+	return l
+}
+
+// New returns an initialized list.
+func New[I any]() *List[I] { return new(List[I]).Init() }
+
+// Len returns the number of elements of list l.
+// The complexity is O(1).
+func (l *List[I]) Len() int { return l.len }
+
+// Front returns the first element of list l or nil if the list is empty.
+func (l *List[I]) Front() *Element[I] {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.next
+}
+
+// Back returns the last element of list l or nil if the list is empty.
+func (l *List[I]) Back() *Element[I] {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.prev
+}
+
+// lazyInit lazily initializes a zero List value.
+func (l *List[I]) lazyInit() {
+	if l.root.next == nil {
+		l.Init()
+	}
+}
+
+// insert inserts e after at, increments l.len, and returns e.
+func (l *List[I]) insert(e, at *Element[I]) *Element[I] {
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+	e.list = l
+	l.len++
+	return e
+}
+
+// insertValue is a convenience wrapper for insert(&Element{Value: v}, at).
+func (l *List[I]) insertValue(v I, at *Element[I]) *Element[I]{
+	return l.insert(&Element[I]{Value: v}, at)
+}
+
+// remove removes e from its list, decrements l.len
+func (l *List[I]) remove(e *Element[I]) {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil // avoid memory leaks
+	e.prev = nil // avoid memory leaks
+	e.list = nil
+	l.len--
+}
+
+// move moves e to next to at.
+func (l *List[I]) move(e, at *Element[I]) {
+	if e == at {
+		return
+	}
+	e.prev.next = e.next
+	e.next.prev = e.prev
+
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+}
+
+// Remove removes e from l if e is an element of list l.
+// It returns the element value e.Value.
+// The element must not be nil.
+func (l *List[I]) Remove(e *Element[I]) any {
+	if e.list == l {
+		// if e.list == l, l must have been initialized when e was inserted
+		// in l or l == nil (e is a zero Element) and l.remove will crash
+		l.remove(e)
+	}
+	return e.Value
+}
+
+// PushFront inserts a new element e with value v at the front of list l and returns e.
+func (l *List[I]) PushFront(v I) *Element[I] {
+	l.lazyInit()
+	return l.insertValue(v, &l.root)
+}
+
+// PushBack inserts a new element e with value v at the back of list l and returns e.
+func (l *List[I]) PushBack(v I) *Element[I] {
+	l.lazyInit()
+	return l.insertValue(v, l.root.prev)
+}
+
+// InsertBefore inserts a new element e with value v immediately before mark and returns e.
+// If mark is not an element of l, the list is not modified.
+// The mark must not be nil.
+func (l *List[I]) InsertBefore(v I, mark *Element[I]) *Element[I] {
+	if mark.list != l {
+		return nil
+	}
+	// see comment in List.Remove about initialization of l
+	return l.insertValue(v, mark.prev)
+}
+
+// InsertAfter inserts a new element e with value v immediately after mark and returns e.
+// If mark is not an element of l, the list is not modified.
+// The mark must not be nil.
+func (l *List[I]) InsertAfter(v I, mark *Element[I]) *Element[I] {
+	if mark.list != l {
+		return nil
+	}
+	// see comment in List.Remove about initialization of l
+	return l.insertValue(v, mark)
+}
+
+// MoveToFront moves element e to the front of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *List[I]) MoveToFront(e *Element[I]) {
+	if e.list != l || l.root.next == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.move(e, &l.root)
+}
+
+// MoveToBack moves element e to the back of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *List[I]) MoveToBack(e *Element[I]) {
+	if e.list != l || l.root.prev == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.move(e, l.root.prev)
+}
+
+// MoveBefore moves element e to its new position before mark.
+// If e or mark is not an element of l, or e == mark, the list is not modified.
+// The element and mark must not be nil.
+func (l *List[I]) MoveBefore(e, mark *Element[I]) {
+	if e.list != l || e == mark || mark.list != l {
+		return
+	}
+	l.move(e, mark.prev)
+}
+
+// MoveAfter moves element e to its new position after mark.
+// If e or mark is not an element of l, or e == mark, the list is not modified.
+// The element and mark must not be nil.
+func (l *List[I]) MoveAfter(e, mark *Element[I]) {
+	if e.list != l || e == mark || mark.list != l {
+		return
+	}
+	l.move(e, mark)
+}
+
+// PushBackList inserts a copy of another list at the back of list l.
+// The lists l and other may be the same. They must not be nil.
+func (l *List[I]) PushBackList(other *List[I]) {
+	l.lazyInit()
+	for i, e := other.Len(), other.Front(); i > 0; i, e = i-1, e.Next() {
+		l.insertValue(e.Value, l.root.prev)
+	}
+}
+
+// PushFrontList inserts a copy of another list at the front of list l.
+// The lists l and other may be the same. They must not be nil.
+func (l *List[I]) PushFrontList(other *List[I]) {
+	l.lazyInit()
+	for i, e := other.Len(), other.Back(); i > 0; i, e = i-1, e.Prev() {
+		l.insertValue(e.Value, &l.root)
+	}
+}

--- a/go/sync2/consolidator.go
+++ b/go/sync2/consolidator.go
@@ -89,12 +89,12 @@ func (rs *Result) Wait() {
 // It is also used by the txserializer package to count how often transactions
 // have been queued and had to wait because they targeted the same row (range).
 type ConsolidatorCache struct {
-	*cache.LRUCache
+	*cache.LRUCache[*ccount]
 }
 
 // NewConsolidatorCache creates a new cache with the given capacity.
 func NewConsolidatorCache(capacity int64) *ConsolidatorCache {
-	return &ConsolidatorCache{cache.NewLRUCache(capacity, func(_ any) int64 {
+	return &ConsolidatorCache{cache.NewLRUCache[*ccount](capacity, func(_ *ccount) int64 {
 		return 1
 	})}
 }
@@ -103,7 +103,7 @@ func NewConsolidatorCache(capacity int64) *ConsolidatorCache {
 // If it's not in the cache yet, it will be added.
 func (cc *ConsolidatorCache) Record(query string) {
 	if v, ok := cc.Get(query); ok {
-		v.(*ccount).add(1)
+		v.add(1)
 	} else {
 		c := ccount(1)
 		cc.Set(query, &c)
@@ -121,7 +121,7 @@ func (cc *ConsolidatorCache) Items() []ConsolidatorCacheItem {
 	items := cc.LRUCache.Items()
 	ret := make([]ConsolidatorCacheItem, len(items))
 	for i, v := range items {
-		ret[i] = ConsolidatorCacheItem{Query: v.Key, Count: v.Value.(*ccount).get()}
+		ret[i] = ConsolidatorCacheItem{Query: v.Key, Count: v.Value.get()}
 	}
 	return ret
 }

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -209,8 +209,7 @@ func vtgateExecute(sql string) ([]*engine.Plan, map[string]*TabletActions, error
 	}
 
 	var plans []*engine.Plan
-	planCache.ForEach(func(value any) bool {
-		plan := value.(*engine.Plan)
+	planCache.ForEach(func(plan *engine.Plan) bool {
 		plan.ExecTime = 0
 		plans = append(plans, plan)
 		return true

--- a/go/vt/vtgate/executor_scatter_stats.go
+++ b/go/vt/vtgate/executor_scatter_stats.go
@@ -61,8 +61,7 @@ func (e *Executor) gatherScatterStats() (statsResults, error) {
 	plans := make([]*engine.Plan, 0)
 	routes := make([]*engine.Route, 0)
 	// First we go over all plans and collect statistics and all query plans for scatter queries
-	e.plans.ForEach(func(value any) bool {
-		plan := value.(*engine.Plan)
+	e.plans.ForEach(func(plan *engine.Plan) bool {
 		scatter := engine.Find(findScatter, plan.Instructions)
 		readOnly := !engine.Exists(isUpdating, plan.Instructions)
 		isScatter := scatter != nil

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1612,10 +1612,10 @@ func TestGetPlanUnnormalized(t *testing.T) {
 	}
 }
 
-func assertCacheSize(t *testing.T, c cache.Cache, expected int) {
+func assertCacheSize[I any](t *testing.T, c cache.Cache[I], expected int) {
 	t.Helper()
 	var size int
-	c.ForEach(func(_ any) bool {
+	c.ForEach(func(_ I) bool {
 		size++
 		return true
 	})

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1612,7 +1612,7 @@ func TestGetPlanUnnormalized(t *testing.T) {
 	}
 }
 
-func assertCacheSize[I any](t *testing.T, c cache.Cache[I], expected int) {
+func assertCacheSize[I cache.Cacheable](t *testing.T, c cache.Cache[I], expected int) {
 	t.Helper()
 	var size int
 	c.ForEach(func(_ I) bool {

--- a/go/vt/vtgate/queryz.go
+++ b/go/vt/vtgate/queryz.go
@@ -142,8 +142,7 @@ func queryzHandler(e *Executor, w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	e.plans.ForEach(func(value any) bool {
-		plan := value.(*engine.Plan)
+	e.plans.ForEach(func(plan *engine.Plan) bool {
 		Value := &queryzRow{
 			Query: logz.Wrappable(sqlparser.TruncateForUI(plan.Original)),
 		}

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -161,7 +161,7 @@ func TestGetMessageStreamPlan(t *testing.T) {
 func assertPlanCacheSize(t *testing.T, qe *QueryEngine, expected int) {
 	var size int
 	qe.plans.Wait()
-	qe.plans.ForEach(func(_ any) bool {
+	qe.plans.ForEach(func(_ *TabletPlan) bool {
 		size++
 		return true
 	})

--- a/go/vt/vttablet/tabletserver/queryz.go
+++ b/go/vt/vttablet/tabletserver/queryz.go
@@ -151,8 +151,7 @@ func queryzHandler(qe *QueryEngine, w http.ResponseWriter, r *http.Request) {
 			return row1.timePQ() > row2.timePQ()
 		},
 	}
-	qe.plans.ForEach(func(value any) bool {
-		plan := value.(*TabletPlan)
+	qe.plans.ForEach(func(plan *TabletPlan) bool {
 		if plan == nil {
 			return true
 		}


### PR DESCRIPTION
## Description

It's a brave new world out there! After a lot of research, this is the main refactoring I believe we can make in the codebase to introduce generics without negatively affecting performance.

Porting the `cache` package to use Generics makes the code easier to read and reduces the amount of memory we're using for caching without any measured slowdowns.

The main thing bothering me is that the `structcheck` linter doesn't work with generic code: it marks all fields in a generic struct as unused, so I've had to disable it for the `go/cache/` path.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->