### PR TITLE
Ci: Moves backups manual upgrade downgrade to single self-hosted runner

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -215,6 +215,12 @@ jobs:
         echo "select count(email) from customer;" | mysql 2>&1| grep 6
         echo "select count(sku) from corder;" | mysql 2>&1| grep 6
 
+    - name: Copy the logs to save them
+      if: always()
+      run: |
+        echo "vtdataroot-$GITHUB_SHA-$GITHUB_RUN_ATTEMPT"
+        cp -r vtdataroot ~/savedRuns/vtdataroot-$GITHUB_SHA-$GITHUB_RUN_ATTEMPT
+
     - name: Stop the Vitess cluster
       if: always()
       run: |

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
     if: github.repository == 'vitessio/vitess'
     name: Get the Upgrade Downgrade pull request label
-    runs-on: ubuntu-latest
+    runs-on: single-self-hosted
     outputs:
       hasLabel: ${{ steps.check_label.outputs.hasLabel }}
 
@@ -27,7 +27,7 @@ jobs:
   get_latest_release:
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
     name: Get latest release
-    runs-on: ubuntu-latest
+    runs-on: single-self-hosted
     needs:
       - get_upgrade_downgrade_label
     outputs:
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_latest_release.result == 'success')
     name: Run Upgrade Downgrade Test Backup Manual
-    runs-on: ubuntu-latest
+    runs-on: single-self-hosted
     needs:
       - get_upgrade_downgrade_label
       - get_latest_release

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -62,54 +62,6 @@ jobs:
       with:
         go-version: 1.18
 
-    - name: Set up python
-      uses: actions/setup-python@v2
-
-    - name: Tune the OS
-      run: |
-        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
-
-    # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
-    - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
-      run: |
-        echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
-
-    - name: Get base dependencies
-      run: |
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
-        # Uninstall any previously installed MySQL first
-        sudo systemctl stop apparmor
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
-        sudo apt-get -y autoremove
-        sudo apt-get -y autoclean
-        sudo deluser mysql
-        sudo rm -rf /var/lib/mysql
-        sudo rm -rf /etc/mysql
-        # Install mysql80
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
-        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
-        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
-        sudo apt-get update
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
-        # Install everything else we need, and configure
-        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata grep
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
-
-        # install JUnit report formatter
-        go install github.com/jstemmer/go-junit-report@latest
-
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
-
     # Checkout to the last release of Vitess
     - name: Checkout to the other version's code (${{ needs.get_latest_release.outputs.latest_release }})
       uses: actions/checkout@v2


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR moves the backups manual upgrade downgrade test to the self-hosted runner having a single runner. This will allow us to debug it by looking at the logs and then we can move them back.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->