### PR TITLE
Properly generate vtgate_tablet_healthcheck_cache workflow

### DIFF
--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -28,6 +28,9 @@ jobs:
     - name: Tune the OS
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+        # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
+        echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
+        sudo sysctl -p /etc/sysctl.conf
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -28,6 +28,9 @@ jobs:
     - name: Tune the OS
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+        # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
+        echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
+        sudo sysctl -p /etc/sysctl.conf
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -1,53 +1,85 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
- name: Cluster (vtgate_tablet_healthcheck_cache)
- on: [push, pull_request]
- concurrency:
-   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_tablet_healthcheck_cache)')
-   cancel-in-progress: true
+name: Cluster (vtgate_tablet_healthcheck_cache)
+on: [push, pull_request]
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_tablet_healthcheck_cache)')
+  cancel-in-progress: true
 
- jobs:
-   build:
-     name: Run endtoend tests on Cluster (vtgate_tablet_healthcheck_cache)
-     runs-on: ubuntu-18.04
+env:
+  LAUNCHABLE_ORGANIZATION: "vitess"
+  LAUNCHABLE_WORKSPACE: "vitess-app"
+  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
-     steps:
-     - name: Set up Go
-       uses: actions/setup-go@v2
-       with:
-         go-version: 1.18
+jobs:
+  build:
+    name: Run endtoend tests on Cluster (vtgate_tablet_healthcheck_cache)
+    runs-on: ubuntu-18.04
 
-     - name: Tune the OS
-       run: |
-         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18
 
-     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
-     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
-       run: |
-         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
+    - name: Set up python
+      uses: actions/setup-python@v2
 
-     - name: Check out code
-       uses: actions/checkout@v2
+    - name: Tune the OS
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+        # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
+        echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
+        sudo sysctl -p /etc/sysctl.conf
 
-     - name: Get dependencies
-       run: |
-         sudo apt-get update
-         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
-         sudo service mysql stop
-         sudo service etcd stop
-         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-         go mod download
+    - name: Check out code
+      uses: actions/checkout@v2
 
-         wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-         sudo apt-get install -y gnupg2
-         sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-         sudo apt-get update
-         sudo apt-get install percona-xtrabackup-24
+    - name: Get dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        go mod download
 
-     - name: Run cluster endtoend test
-       timeout-minutes: 30
-       run: |
-         source build.env
-         eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_tablet_healthcheck_cache
+        # install JUnit report formatter
+        go install github.com/jstemmer/go-junit-report@latest
+
+        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get install -y gnupg2
+        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get update
+        sudo apt-get install percona-xtrabackup-24
+
+    - name: Setup launchable dependencies
+      run: |
+        # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
+        pip3 install --user launchable~=1.0 > /dev/null
+
+        # verify that launchable setup is all correct.
+        launchable verify || true
+
+        # Tell Launchable about the build you are producing and testing
+        launchable record build --name "$GITHUB_RUN_ID" --source .
+
+    - name: Run cluster endtoend test
+      timeout-minutes: 30
+      run: |
+        source build.env
+
+        set -x
+
+        # run the tests however you normally do, then produce a JUnit XML file
+        eatmydata -- go run test.go -docker=false -follow -shard vtgate_tablet_healthcheck_cache | tee -a output.txt | go-junit-report -set-exit-code > report.xml
+
+    - name: Print test output and Record test result in launchable
+      run: |
+        # send recorded tests to launchable
+        launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
+
+        # print test output
+        cat output.txt
+      if: always()

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -88,6 +88,7 @@ var (
 		"vtgate_readafterwrite",
 		"vtgate_reservedconn",
 		"vtgate_schema",
+		"vtgate_tablet_healthcheck_cache",
 		"vtgate_topo",
 		"vtgate_topo_consul",
 		"vtgate_topo_etcd",


### PR DESCRIPTION
## Description
When working on https://github.com/vitessio/vitess/pull/9106 I didn't yet understand how the CI workflows were managed and I must have simply copied and edited another existing workflow file rather than using the auto generation tooling.

This PR corrects that mistake and other changes resulting from a subsequent `make generate_ci_workflows` run.

## Related Issue(s)
 - Follow-up to: https://github.com/vitessio/vitess/pull/9106


## Checklist
- [x] Should this PR be backported? NO
- [x] Tests are not required
- [x] Documentation is not required