### PR TITLE
Flakiness fix for Upgrade Downgrade Backup Manual test

### DIFF
--- a/examples/local/backups/restart_tablets.sh
+++ b/examples/local/backups/restart_tablets.sh
@@ -23,19 +23,31 @@ for i in 100 101 102; do
   CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
   CELL=zone1 KEYSPACE=commerce TABLET_UID=$i ./scripts/vttablet-up.sh
 done
-sleep 5
-vtctldclient InitShardPrimary --force commerce/0 zone1-100
 
 for i in 200 201 202; do
   CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
   SHARD=-80 CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
 done
-sleep 5
-vtctldclient InitShardPrimary --force customer/-80 zone1-200
 
 for i in 300 301 302; do
   CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
   SHARD=80- CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 sleep 5
+
+# Wait for all the replica tablets to be in the serving state before initiating
+# InitShardPrimary. This is essential, since we want the RESTORE phase to be
+# complete before we start InitShardPrimary, otherwise we end up reading the
+# tablet type to RESTORE and do not set semi-sync, which leads to the primary
+# hanging on writes.
+for i in 101 201 301; do
+  for _ in $(seq 0 300); do
+   status=$(curl "http://$hostname:15$i/debug/status_details")
+   echo "$status" | grep "REPLICA: Serving" && break
+   sleep 0.1
+  done
+done
+
+vtctldclient InitShardPrimary --force commerce/0 zone1-100
+vtctldclient InitShardPrimary --force customer/-80 zone1-200
 vtctldclient InitShardPrimary --force customer/80- zone1-300


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

The upgrade downgrade backups manual test has been flaky on the ci for a while. On investigation of the same with the help of https://github.com/vitessio/vitess/pull/9944 led to the following discovery - 

While restarting the tablets with a backup, the tablet transitions to `RESTORE` type to restore from the local backup. Without waiting for the backup to finish, we call `InitShardPrimary` which sees the tablet type as `RESTORE` and turns off semi-sync on that tablet.

Later restoration completes and the tablet transitions to `REPLICA`, but its semi-sync settings aren't fixed, which leads to the primary stalling indefinitely on writes.

This PR fixes this issue by first waiting for the restoration phase to finish before calling InitShardPrimary. Earlier we had a 5 second hard wait to ensure that this phase had finished but on the CI it generally takes longer. Locally 5 seconds is sufficient, which made reproducibility a challenge. 

I think it is better to have an explicit check on the tablet type by `curl`ing the tablet server API endpoint instead of any fixed hard time sleep.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? *No*
- [x] Tests were added or are not required Yes, the upgrade downgrade tests for backup
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->