### PR TITLE
[vtctl] Deprecate Throttler RPCs

### DIFF
--- a/go/vt/vtctl/throttler.go
+++ b/go/vt/vtctl/throttler.go
@@ -47,37 +47,47 @@ func init() {
 	addCommandGroup(throttlerGroupName)
 
 	addCommand(throttlerGroupName, command{
-		name:   "ThrottlerMaxRates",
-		method: commandThrottlerMaxRates,
-		params: "-server <vtworker or vttablet>",
-		help:   "Returns the current max rate of all active resharding throttlers on the server.",
+		name:         "ThrottlerMaxRates",
+		method:       commandThrottlerMaxRates,
+		params:       "-server <vtworker or vttablet>",
+		help:         "Returns the current max rate of all active resharding throttlers on the server.",
+		deprecated:   true,
+		deprecatedBy: "the new Reshard/MoveTables workflows",
 	})
 	addCommand(throttlerGroupName, command{
-		name:   "ThrottlerSetMaxRate",
-		method: commandThrottlerSetMaxRate,
-		params: "-server <vtworker or vttablet> <rate>",
-		help:   "Sets the max rate for all active resharding throttlers on the server.",
+		name:         "ThrottlerSetMaxRate",
+		method:       commandThrottlerSetMaxRate,
+		params:       "-server <vtworker or vttablet> <rate>",
+		help:         "Sets the max rate for all active resharding throttlers on the server.",
+		deprecated:   true,
+		deprecatedBy: "the new Reshard/MoveTables workflows",
 	})
 
 	addCommand(throttlerGroupName, command{
-		name:   "GetThrottlerConfiguration",
-		method: commandGetThrottlerConfiguration,
-		params: "-server <vtworker or vttablet> [<throttler name>]",
-		help:   "Returns the current configuration of the MaxReplicationLag module. If no throttler name is specified, the configuration of all throttlers will be returned.",
+		name:         "GetThrottlerConfiguration",
+		method:       commandGetThrottlerConfiguration,
+		params:       "-server <vtworker or vttablet> [<throttler name>]",
+		help:         "Returns the current configuration of the MaxReplicationLag module. If no throttler name is specified, the configuration of all throttlers will be returned.",
+		deprecated:   true,
+		deprecatedBy: "the new Reshard/MoveTables workflows",
 	})
 	addCommand(throttlerGroupName, command{
 		name:   "UpdateThrottlerConfiguration",
 		method: commandUpdateThrottlerConfiguration,
 		// Note: <configuration protobuf text> is put in quotes to tell the user
 		// that the value must be quoted such that it's one argument only.
-		params: `-server <vtworker or vttablet> [-copy_zero_values] "<configuration protobuf text>" [<throttler name>]`,
-		help:   "Updates the configuration of the MaxReplicationLag module. The configuration must be specified as protobuf text. If a field is omitted or has a zero value, it will be ignored unless -copy_zero_values is specified. If no throttler name is specified, all throttlers will be updated.",
+		params:       `-server <vtworker or vttablet> [-copy_zero_values] "<configuration protobuf text>" [<throttler name>]`,
+		help:         "Updates the configuration of the MaxReplicationLag module. The configuration must be specified as protobuf text. If a field is omitted or has a zero value, it will be ignored unless -copy_zero_values is specified. If no throttler name is specified, all throttlers will be updated.",
+		deprecated:   true,
+		deprecatedBy: "the new Reshard/MoveTables workflows",
 	})
 	addCommand(throttlerGroupName, command{
-		name:   "ResetThrottlerConfiguration",
-		method: commandResetThrottlerConfiguration,
-		params: "-server <vtworker or vttablet> [<throttler name>]",
-		help:   "Resets the current configuration of the MaxReplicationLag module. If no throttler name is specified, the configuration of all throttlers will be reset.",
+		name:         "ResetThrottlerConfiguration",
+		method:       commandResetThrottlerConfiguration,
+		params:       "-server <vtworker or vttablet> [<throttler name>]",
+		help:         "Resets the current configuration of the MaxReplicationLag module. If no throttler name is specified, the configuration of all throttlers will be reset.",
+		deprecated:   true,
+		deprecatedBy: "the new Reshard/MoveTables workflows",
 	})
 }
 


### PR DESCRIPTION
## Description

The new VReplication flows do not rely on these, which means we can delete them after vtworker is gone.

### Demo

```
➜  local git:(andrew/vtctldserver-deprecate-throttler) ✗ vtctlclient --server ":15999" help | grep Throttler                  
Resharding Throttler:
  (DEPRECATED) ThrottlerMaxRates -server <vtworker or vttablet>
  (DEPRECATED) ThrottlerSetMaxRate -server <vtworker or vttablet> <rate>
  (DEPRECATED) GetThrottlerConfiguration -server <vtworker or vttablet> [<throttler name>]
  (DEPRECATED) UpdateThrottlerConfiguration -server <vtworker or vttablet> [-copy_zero_values] "<configuration protobuf text>" [<throttler name>]
  (DEPRECATED) ResetThrottlerConfiguration -server <vtworker or vttablet> [<throttler name>]
➜  local git:(andrew/vtctldserver-deprecate-throttler) ✗ vtctlclient --server ":15999" ThrottlerMaxRates -- -h
WARNING: ThrottlerMaxRates is deprecated and will be removed in a future release. Use the new Reshard/MoveTables workflows instead.
Usage: ThrottlerMaxRates -server <vtworker or vttablet>

Returns the current max rate of all active resharding throttlers on the server.

  --server string
        vtworker or vttablet to connect to
➜  local git:(andrew/vtctldserver-deprecate-throttler) ✗ 
```

## Related Issue(s)

Closes #9960


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->