### PR TITLE
Address flakiness of some cluster e2e tests

### DIFF
--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -1,9 +1,9 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
-name: Cluster (16)
+name: Cluster (ers_prs_newfeatures_heavy)
 on: [push, pull_request]
 concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (16)')
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (ers_prs_newfeatures_heavy)')
   cancel-in-progress: true
 
 env:
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    name: Run endtoend tests on Cluster (16)
+    name: Run endtoend tests on Cluster (ers_prs_newfeatures_heavy)
     runs-on: ubuntu-18.04
 
     steps:
@@ -72,8 +72,27 @@ jobs:
 
         set -x
 
+        # Increase our local ephemeral port range as we could exhaust this
+        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+        # Increase our open file descriptor limit as we could hit this
+        ulimit -n 65536
+        cat <<-EOF>>./config/mycnf/mysql57.cnf
+        innodb_buffer_pool_dump_at_shutdown=OFF
+        innodb_buffer_pool_load_at_startup=OFF
+        innodb_buffer_pool_size=64M
+        innodb_doublewrite=OFF
+        innodb_flush_log_at_trx_commit=0
+        innodb_flush_method=O_DIRECT
+        innodb_numa_interleave=ON
+        innodb_adaptive_hash_index=OFF
+        sync_binlog=0
+        sync_relay_log=0
+        performance_schema=OFF
+        slow-query-log=OFF
+        EOF
+        
         # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 16 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
+        eatmydata -- go run test.go -docker=false -follow -shard ers_prs_newfeatures_heavy | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
       run: |

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -1,9 +1,9 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
-name: Cluster (14)
+name: Cluster (shardedrecovery_stress_verticalsplit_heavy)
 on: [push, pull_request]
 concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (14)')
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (shardedrecovery_stress_verticalsplit_heavy)')
   cancel-in-progress: true
 
 env:
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    name: Run endtoend tests on Cluster (14)
+    name: Run endtoend tests on Cluster (shardedrecovery_stress_verticalsplit_heavy)
     runs-on: ubuntu-18.04
 
     steps:
@@ -72,8 +72,27 @@ jobs:
 
         set -x
 
+        # Increase our local ephemeral port range as we could exhaust this
+        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+        # Increase our open file descriptor limit as we could hit this
+        ulimit -n 65536
+        cat <<-EOF>>./config/mycnf/mysql57.cnf
+        innodb_buffer_pool_dump_at_shutdown=OFF
+        innodb_buffer_pool_load_at_startup=OFF
+        innodb_buffer_pool_size=64M
+        innodb_doublewrite=OFF
+        innodb_flush_log_at_trx_commit=0
+        innodb_flush_method=O_DIRECT
+        innodb_numa_interleave=ON
+        innodb_adaptive_hash_index=OFF
+        sync_binlog=0
+        sync_relay_log=0
+        performance_schema=OFF
+        slow-query-log=OFF
+        EOF
+        
         # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 14 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
+        eatmydata -- go run test.go -docker=false -follow -shard shardedrecovery_stress_verticalsplit_heavy | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
       run: |

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -1,9 +1,9 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
-name: Cluster (11)
+name: Cluster (vtctlbackup_sharded_clustertest_heavy)
 on: [push, pull_request]
 concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (11)')
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtctlbackup_sharded_clustertest_heavy)')
   cancel-in-progress: true
 
 env:
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    name: Run endtoend tests on Cluster (11)
+    name: Run endtoend tests on Cluster (vtctlbackup_sharded_clustertest_heavy)
     runs-on: ubuntu-18.04
 
     steps:
@@ -72,8 +72,27 @@ jobs:
 
         set -x
 
+        # Increase our local ephemeral port range as we could exhaust this
+        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+        # Increase our open file descriptor limit as we could hit this
+        ulimit -n 65536
+        cat <<-EOF>>./config/mycnf/mysql57.cnf
+        innodb_buffer_pool_dump_at_shutdown=OFF
+        innodb_buffer_pool_load_at_startup=OFF
+        innodb_buffer_pool_size=64M
+        innodb_doublewrite=OFF
+        innodb_flush_log_at_trx_commit=0
+        innodb_flush_method=O_DIRECT
+        innodb_numa_interleave=ON
+        innodb_adaptive_hash_index=OFF
+        sync_binlog=0
+        sync_relay_log=0
+        performance_schema=OFF
+        slow-query-log=OFF
+        EOF
+        
         # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 11 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
+        eatmydata -- go run test.go -docker=false -follow -shard vtctlbackup_sharded_clustertest_heavy | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
       run: |

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -1,9 +1,9 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
-name: Cluster (23)
+name: Cluster (worker_vault_heavy)
 on: [push, pull_request]
 concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (23)')
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (worker_vault_heavy)')
   cancel-in-progress: true
 
 env:
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    name: Run endtoend tests on Cluster (23)
+    name: Run endtoend tests on Cluster (worker_vault_heavy)
     runs-on: ubuntu-18.04
 
     steps:
@@ -72,8 +72,27 @@ jobs:
 
         set -x
 
+        # Increase our local ephemeral port range as we could exhaust this
+        sudo sysctl -w net.ipv4.ip_local_port_range="22768 61999"
+        # Increase our open file descriptor limit as we could hit this
+        ulimit -n 65536
+        cat <<-EOF>>./config/mycnf/mysql57.cnf
+        innodb_buffer_pool_dump_at_shutdown=OFF
+        innodb_buffer_pool_load_at_startup=OFF
+        innodb_buffer_pool_size=64M
+        innodb_doublewrite=OFF
+        innodb_flush_log_at_trx_commit=0
+        innodb_flush_method=O_DIRECT
+        innodb_numa_interleave=ON
+        innodb_adaptive_hash_index=OFF
+        sync_binlog=0
+        sync_relay_log=0
+        performance_schema=OFF
+        slow-query-log=OFF
+        EOF
+        
         # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 23 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
+        eatmydata -- go run test.go -docker=false -follow -shard worker_vault_heavy | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
       run: |

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -59,7 +59,7 @@ var (
 		"20",
 		"21",
 		"22",
-		"23",
+		"worker_vault_heavy",
 		"24",
 		"26",
 		"vstream_failover",
@@ -304,7 +304,7 @@ func generateClusterWorkflows(list []string, tpl string) {
 				break
 			}
 		}
-		if strings.HasPrefix(cluster, "vreplication") {
+		if strings.HasPrefix(cluster, "vreplication") || strings.HasSuffix(cluster, "heavy") {
 			test.LimitResourceUsage = true
 		}
 

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -47,12 +47,12 @@ var (
 	// Clusters 10, 25 are executed on docker, using the docker_test_cluster 10, 25 workflows.
 	// Hence, they are not listed in the list below.
 	clusterList = []string{
-		"11",
+		"vtctlbackup_sharded_clustertest_heavy",
 		"12",
 		"13",
-		"14",
+		"ers_prs_newfeatures_heavy",
 		"15",
-		"16",
+		"shardedrecovery_stress_verticalsplit_heavy",
 		"17",
 		"18",
 		"19",

--- a/test/config.json
+++ b/test/config.json
@@ -107,7 +107,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/backup/vtctlbackup"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "11",
+			"Shard": "vtctlbackup_sharded_clustertest_heavy",
 			"RetryMax": 1,
 			"Tags": []
 		},
@@ -206,7 +206,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/clustertest"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "11",
+			"Shard": "vtctlbackup_sharded_clustertest_heavy",
 			"RetryMax": 1,
 			"Tags": []
 		},
@@ -436,7 +436,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/recovery/unshardedrecovery"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "11",
+			"Shard": "vtctlbackup_sharded_clustertest_heavy",
 			"RetryMax": 1,
 			"Tags": []
 		},
@@ -445,7 +445,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/reparent/emergencyreparent"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "14",
+			"Shard": "ers_prs_newfeatures_heavy",
 			"RetryMax": 1,
 			"Tags": ["upgrade_downgrade_reparent"]
 		},
@@ -454,7 +454,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/reparent/plannedreparent"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "14",
+			"Shard": "ers_prs_newfeatures_heavy",
 			"RetryMax": 1,
 			"Tags": ["upgrade_downgrade_reparent"]
 		},
@@ -463,7 +463,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/reparent/newfeaturetest"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "14",
+			"Shard": "ers_prs_newfeatures_heavy",
 			"RetryMax": 1,
 			"Tags": [""]
 		},
@@ -494,7 +494,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/sharded"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "11",
+			"Shard": "vtctlbackup_sharded_clustertest_heavy",
 			"RetryMax": 1,
 			"Tags": []
 		},
@@ -503,7 +503,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/recovery/shardedrecovery"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "16",
+			"Shard": "shardedrecovery_stress_verticalsplit_heavy",
 			"RetryMax": 2,
 			"Tags": []
 		},
@@ -512,7 +512,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/stress"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "16",
+			"Shard": "shardedrecovery_stress_verticalsplit_heavy",
 			"RetryMax": 1,
 			"Tags": []
 		},
@@ -624,7 +624,7 @@
 		},
 		"upgrade": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/versionupgrade", "-keep-data", "-force-vtdataroot", "/tmp/vtdataroot/vtroot_10901", "-force-port-start", "11900", "-force-base-tablet-uid", "1190"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/versionupgrade", "-keep-data", "-force-vtdataroot", "/tmp/vtdataroot/vtroot_10901", "-force-port-start", "vtctlbackup_sharded_clustertest_heavy900", "-force-base-tablet-uid", "vtctlbackup_sharded_clustertest_heavy90"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "28",
@@ -636,7 +636,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/sharding/verticalsplit"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "16",
+			"Shard": "shardedrecovery_stress_verticalsplit_heavy",
 			"RetryMax": 1,
 			"Tags": [
 				"worker_test"

--- a/test/config.json
+++ b/test/config.json
@@ -1025,7 +1025,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/worker"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "23",
+			"Shard": "worker_vault_heavy",
 			"RetryMax": 3,
 			"Tags": [
 				"worker_test"
@@ -1135,7 +1135,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/vault"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "23",
+			"Shard": "worker_vault_heavy",
 			"RetryMax": 1,
 			"Tags": []
 		},


### PR DESCRIPTION
## Description
In https://github.com/vitessio/vitess/pull/9935 we added support for marking a test as requiring additional configuration in order to limit resource usage. This was done to make our heaviest (vreplication) tests more reliable as they would often fail when there was any resource contention on the runners. In this PR we're leveraging that work to modify some of the generic Cluster e2e tests that also often failed when resource contention seemed high.

In the process we also rename those tests to be something more meaningful and append `_heavy` to the name as a generic marker that they should be configured to limit resource usage. So going forward we can append that string to any other test name if we feel that resource contention is the common cause of failures.

## Related Issue(s)
 - Related to: https://github.com/vitessio/vitess/pull/9935


## Checklist
- [x] Should this PR be backported? No
- [x] Tests are not required
- [x] Documentation is not required