### PR TITLE
Fix: Sequence query to ignore reserved and transaction

### DIFF
--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -54,6 +54,11 @@ type noopVCursor struct {
 	ctx context.Context
 }
 
+// SetContextWithValue implements VCursor interface.
+func (t *noopVCursor) SetContextWithValue(key, value interface{}) func() {
+	return func() {}
+}
+
 // ConnCollation implements VCursor
 func (t *noopVCursor) ConnCollation() collations.ID {
 	return collations.CollationUtf8mb4ID

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -67,6 +67,10 @@ type (
 		// ErrorGroupCancellableContext updates context that can be cancelled.
 		ErrorGroupCancellableContext() (*errgroup.Group, func())
 
+		// SetContextWithValue updates context with key and value and
+		// provides back function to move back to original context.
+		SetContextWithValue(key, value interface{}) func()
+
 		// V3 functions.
 		Execute(method string, query string, bindvars map[string]*querypb.BindVariable, rollbackOnError bool, co vtgatepb.CommitOrder) (*sqltypes.Result, error)
 		AutocommitApproval() bool

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -220,6 +220,15 @@ func (vc *vcursorImpl) ErrorGroupCancellableContext() (*errgroup.Group, func()) 
 	}
 }
 
+// SetContextWithValue implements the VCursor interface.
+func (vc *vcursorImpl) SetContextWithValue(k, v interface{}) func() {
+	origCtx := vc.ctx
+	vc.ctx = context.WithValue(vc.ctx, k, v)
+	return func() {
+		vc.ctx = origCtx
+	}
+}
+
 // RecordWarning stores the given warning in the current session
 func (vc *vcursorImpl) RecordWarning(warning *querypb.QueryWarning) {
 	vc.safeSession.RecordWarning(warning)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR ignore the session setting related to transaction and reserved connection and always go through the `EXECUTE` call on the tabletserver.

sequence does not require a connection most of the time and even if a new set of sequence cache is required it is executed using its little own transaction in tabletserver ([ignoring conn passed](https://github.com/vitessio/vitess/blob/2b5f72c5dd0411c3ff9da4517c4a8d32c4f57fc5/go/vt/vttablet/tabletserver/query_executor.go#L133,L146) and [own transaction](https://github.com/vitessio/vitess/blob/2b5f72c5dd0411c3ff9da4517c4a8d32c4f57fc5/go/vt/vttablet/tabletserver/query_executor.go#L563)) ignoring the connection id provided by the vtgate or a new one started with `Begin` or `Reserve` calls.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Fixes #9851 

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->