### PR TITLE
Track full git sha1 string instead of the short version

### DIFF
--- a/go/vt/servenv/buildinfo_test.go
+++ b/go/vt/servenv/buildinfo_test.go
@@ -31,7 +31,7 @@ func TestVersionString(t *testing.T) {
 		buildUser:       "user",
 		buildTime:       now.Unix(),
 		buildTimePretty: "time is now",
-		buildGitRev:     "d54b87c",
+		buildGitRev:     "d54b87ca0be09b678bb4490060e8f23f890ddb92",
 		buildGitBranch:  "gitBranch",
 		goVersion:       "1.18",
 		goOS:            "amiga",
@@ -39,11 +39,11 @@ func TestVersionString(t *testing.T) {
 		version:         "v1.2.3-SNAPSHOT",
 	}
 
-	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Git revision d54b87c branch 'gitBranch') built on time is now by user@host using 1.18 amiga/amd64", v.String())
+	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.18 amiga/amd64", v.String())
 
 	v.jenkinsBuildNumber = 422
 
-	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Jenkins build 422) (Git revision d54b87c branch 'gitBranch') built on time is now by user@host using 1.18 amiga/amd64", v.String())
+	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Jenkins build 422) (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.18 amiga/amd64", v.String())
 
 	assert.Equal(t, "5.7.9-vitess-v1.2.3-SNAPSHOT", v.MySQLVersion())
 }

--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -21,7 +21,7 @@ source $DIR/shell_functions.inc
 # a tar ball might be used, which will prevent the git metadata from being available.
 # Should this be the case then allow environment variables to be used to source
 # this information instead.
-DEFAULT_BUILD_GIT_REV=$(git rev-parse --short HEAD)
+DEFAULT_BUILD_GIT_REV=$(git rev-parse HEAD)
 DEFAULT_BUILD_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 echo "\


### PR DESCRIPTION
Signed-off-by: Ankit Malpani <malpani@stripe.com>

## Description
Track full git sha1 string instead of the short version
This is needed for our deployment monitoring systems to identify and remediate any stale running vttablets

```
Before Change:
"BuildGitRev": "c7481c8249"
"BuildInformation": {"<redacted>.1644873069.c7481c8249.<branch>.4": 1}

After Change:
"BuildGitRev": "1d878d8a0be09b678bb4490060e8f23f890ddb92"
"BuildInformation": {"<redacted>.1648062731.1d878d8a0be09b678bb4490060e8f23f890ddb92.<branch>.48": 1},
```
An alternate is to not change the existing `BuildGitRev` but introduce a new variable `BuildGitFullRev`. I thought that would be redundant and hence updating the existing value to be complete

## Related Issue(s)
Fixes https://github.com/vitessio/vitess/issues/9952

## Checklist
- [no] Should this PR be backported?
- [updated] Tests were added or are not required
- [ no] Documentation was added or is not required

## Deployment Notes
na