### PR TITLE
Move VTOrc tests to run against MySQL 8.0

### DIFF
--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Set up Go
@@ -37,8 +37,17 @@ jobs:
 
     - name: Get dependencies
       run: |
+        # Get key to latest MySQL repo
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+
+        # Setup MySQL 8.0
+        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+
+        # Install everything else we need, and configure
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata xz-utils
         sudo service mysql stop
         sudo service etcd stop
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -1,9 +1,9 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
-name: Cluster (vtorc)
+name: Cluster (vtorc_8.0)
 on: [push, pull_request]
 concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtorc)')
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtorc_8.0)')
   cancel-in-progress: true
 
 env:
@@ -13,8 +13,8 @@ env:
 
 jobs:
   build:
-    name: Run endtoend tests on Cluster (vtorc)
-    runs-on: ubuntu-18.04
+    name: Run endtoend tests on Cluster (vtorc_8.0)
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Set up Go
@@ -37,8 +37,17 @@ jobs:
 
     - name: Get dependencies
       run: |
+        # Get key to latest MySQL repo
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+
+        # Setup MySQL 8.0
+        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+
+        # Install everything else we need, and configure
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata xz-utils
         sudo service mysql stop
         sudo service etcd stop
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
@@ -73,7 +82,7 @@ jobs:
         set -x
 
         # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtorc | tee -a output.txt | go-junit-report -set-exit-code > report.xml
+        eatmydata -- go run test.go -docker=false -follow -shard vtorc_8.0 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
       run: |

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -124,6 +124,7 @@ var (
 	}
 	clustersRequiringMySQL80 = []string{
 		"mysql80",
+		"vtorc",
 		"vreplication_across_db_versions",
 	}
 )

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -108,6 +108,7 @@ var (
 		"vreplication_basic",
 		"vreplication_v2",
 		"vtorc",
+		"vtorc_8.0",
 		"schemadiff_vrepl",
 	}
 
@@ -124,7 +125,7 @@ var (
 	}
 	clustersRequiringMySQL80 = []string{
 		"mysql80",
-		"vtorc",
+		"vtorc_8.0",
 		"vreplication_across_db_versions",
 	}
 )

--- a/test/config.json
+++ b/test/config.json
@@ -1130,6 +1130,33 @@
 			"RetryMax": 3,
 			"Tags": []
 		},
+		"vtorc_primary_failure_8.0": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtorc/primaryfailure"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtorc_8.0",
+			"RetryMax": 3,
+			"Tags": []
+		},
+		"vtorc_graceful_takeover_8.0": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtorc/gracefultakeover"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtorc_8.0",
+			"RetryMax": 3,
+			"Tags": []
+		},
+		"vtorc_general_8.0": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtorc/general"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtorc_8.0",
+			"RetryMax": 3,
+			"Tags": []
+		},
 		"vault": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vault"],


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR moves the VTOrc tests to run against MySQL 8.0 instead of MySQL 5.7

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? No
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->