### PR TITLE
Skip end-to-end test if binary is below a certain major version

### DIFF
--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -364,7 +364,7 @@ func (cluster *LocalProcessCluster) StartKeyspace(keyspace Keyspace, shardNames 
 		}
 	}
 
-	//Apply VSchema
+	// Apply VSchema
 	if keyspace.VSchema != "" {
 		if err = cluster.VtctlclientProcess.ApplyVSchema(keyspace.Name, keyspace.VSchema); err != nil {
 			log.Errorf("error applying vschema: %v, %v", keyspace.VSchema, err)
@@ -512,7 +512,7 @@ func (cluster *LocalProcessCluster) StartKeyspaceLegacy(keyspace Keyspace, shard
 		}
 	}
 
-	//Apply VSchema
+	// Apply VSchema
 	if keyspace.VSchema != "" {
 		if err = cluster.VtctlclientProcess.ApplyVSchema(keyspace.Name, keyspace.VSchema); err != nil {
 			log.Errorf("error applying vschema: %v, %v", keyspace.VSchema, err)
@@ -644,15 +644,15 @@ func NewCluster(cell string, hostname string) *LocalProcessCluster {
 // populateVersionInfo is used to populate the version information for the binaries used to setup the cluster.
 func (cluster *LocalProcessCluster) populateVersionInfo() error {
 	var err error
-	cluster.VtTabletMajorVersion, err = getMajorVersion("vttablet")
+	cluster.VtTabletMajorVersion, err = GetMajorVersion("vttablet")
 	if err != nil {
 		return err
 	}
-	cluster.VtctlMajorVersion, err = getMajorVersion("vtctl")
+	cluster.VtctlMajorVersion, err = GetMajorVersion("vtctl")
 	return err
 }
 
-func getMajorVersion(binaryName string) (int, error) {
+func GetMajorVersion(binaryName string) (int, error) {
 	version, err := exec.Command(binaryName, "--version").Output()
 	if err != nil {
 		return 0, err

--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -127,7 +127,7 @@ func VtctlProcessInstance(topoPort int, hostname string) *VtctlProcess {
 		topoRootPath = ""
 	}
 
-	version, err := getMajorVersion("vtctl")
+	version, err := GetMajorVersion("vtctl")
 	if err != nil {
 		log.Warningf("failed to get major vtctl version; interop with CLI changes for VEP-4 may not work: %s", err)
 	}

--- a/go/test/endtoend/cluster/vtctlclient_process.go
+++ b/go/test/endtoend/cluster/vtctlclient_process.go
@@ -207,7 +207,7 @@ func (vtctlclient *VtctlClientProcess) ExecuteCommandWithOutput(args ...string) 
 // VtctlClientProcessInstance returns a VtctlProcess handle for vtctlclient process
 // configured with the given Config.
 func VtctlClientProcessInstance(hostname string, grpcPort int, tmpDirectory string) *VtctlClientProcess {
-	version, err := getMajorVersion("vtctl") // `vtctlclient` does not have a --version flag, so we assume both vtctl/vtctlclient have the same version
+	version, err := GetMajorVersion("vtctl") // `vtctlclient` does not have a --version flag, so we assume both vtctl/vtctlclient have the same version
 	if err != nil {
 		log.Warningf("failed to get major vtctlclient version; interop with CLI changes for VEP-4 may not work: %s", err)
 	}

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -58,7 +58,7 @@ type VtgateProcess struct {
 	VSchemaURL            string
 	SysVarSetEnabled      bool
 	PlannerVersion        plancontext.PlannerVersion
-	//Extra Args to be set before starting the vtgate process
+	// Extra Args to be set before starting the vtgate process
 	ExtraArgs []string
 
 	proc *exec.Cmd
@@ -83,7 +83,6 @@ func (vtgate *VtgateProcess) Setup() (err error) {
 		"--cell", vtgate.Cell,
 		"--cells_to_watch", vtgate.CellsToWatch,
 		"--tablet_types_to_wait", vtgate.TabletTypesToWait,
-		"--gateway_implementation", vtgate.GatewayImplementation,
 		"--service_map", vtgate.ServiceMap,
 		"--mysql_auth_server_impl", vtgate.MySQLAuthServerImpl,
 	}

--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"vitess.io/vitess/go/test/endtoend/cluster"
+
 	"vitess.io/vitess/go/test/utils"
 
 	"github.com/google/go-cmp/cmp"
@@ -95,4 +97,15 @@ func Exec(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {
 func ExecAllowError(t *testing.T, conn *mysql.Conn, query string) (*sqltypes.Result, error) {
 	t.Helper()
 	return conn.ExecuteFetch(query, 1000, true)
+}
+
+// SkipIfBinaryIsBelowVersion skips the given test if the binary's major version is below majorVersion.
+func SkipIfBinaryIsBelowVersion(t *testing.T, majorVersion int, binary string) {
+	version, err := cluster.GetMajorVersion(binary)
+	if err != nil {
+		return
+	}
+	if version < majorVersion {
+		t.Skip("Current version of ", binary, ": v", version, ", expected version >= v", majorVersion)
+	}
 }

--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 
@@ -107,5 +108,25 @@ func SkipIfBinaryIsBelowVersion(t *testing.T, majorVersion int, binary string) {
 	}
 	if version < majorVersion {
 		t.Skip("Current version of ", binary, ": v", version, ", expected version >= v", majorVersion)
+	}
+}
+
+// AssertMatchesWithTimeout asserts that the given query produces the expected result.
+// The query will be executed every 'r' duration until it matches the expected result.
+// If after 'd' duration we still did not find the expected result, the test will be marked as failed.
+func AssertMatchesWithTimeout(t *testing.T, conn *mysql.Conn, query, expected string, r time.Duration, d time.Duration, failureMsg string) {
+	t.Helper()
+	timeout := time.After(d)
+	diff := "actual and expectation does not match"
+	for len(diff) > 0 {
+		select {
+		case <-timeout:
+			require.Fail(t, failureMsg, diff)
+		case <-time.After(r):
+			qr := Exec(t, conn, query)
+			diff = cmp.Diff(expected,
+				fmt.Sprintf("%v", qr.Rows))
+		}
+
 	}
 }

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -42,8 +42,10 @@ func TestSubqueriesHasValues(t *testing.T) {
 	utils.AssertMatches(t, conn, `SELECT id2 FROM t1 WHERE id1 NOT IN (SELECT id1 FROM t1 WHERE id1 > 10) ORDER BY id2`, `[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)] [INT64(5)] [INT64(6)]]`)
 }
 
+// Test only supported in >= v14.0.0
 func TestSubqueriesExists(t *testing.T) {
 	defer cluster.PanicHandler(t)
+	utils.SkipIfBinaryIsBelowVersion(t, 14, "vtgate")
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -19,14 +19,11 @@ package sharded
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"vitess.io/vitess/go/test/endtoend/utils"
-
-	"github.com/google/go-cmp/cmp"
 
 	"github.com/stretchr/testify/require"
 
@@ -212,11 +209,16 @@ func TestInitAndUpdate(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	utils.AssertMatches(t, conn, "SHOW VSCHEMA TABLES", `[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`)
+	utils.AssertMatchesWithTimeout(t, conn,
+		"SHOW VSCHEMA TABLES",
+		`[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`,
+		100*time.Millisecond,
+		3*time.Second,
+		"initial table list not complete")
 
 	// Init
 	_ = utils.Exec(t, conn, "create table test_sc (id bigint primary key)")
-	assertMatchesWithTimeout(t, conn,
+	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
 		`[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")]]`,
 		100*time.Millisecond,
@@ -225,7 +227,7 @@ func TestInitAndUpdate(t *testing.T) {
 
 	// Tables Update via health check.
 	_ = utils.Exec(t, conn, "create table test_sc1 (id bigint primary key)")
-	assertMatchesWithTimeout(t, conn,
+	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
 		`[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")] [VARCHAR("test_sc1")]]`,
 		100*time.Millisecond,
@@ -233,7 +235,7 @@ func TestInitAndUpdate(t *testing.T) {
 		"test_sc1 not in vschema tables")
 
 	_ = utils.Exec(t, conn, "drop table test_sc, test_sc1")
-	assertMatchesWithTimeout(t, conn,
+	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
 		`[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`,
 		100*time.Millisecond,
@@ -252,7 +254,7 @@ func TestDMLOnNewTable(t *testing.T) {
 	utils.Exec(t, conn, `create table new_table_tracked(id bigint, name varchar(100), primary key(id)) Engine=InnoDB`)
 
 	// wait for vttablet's schema reload interval to pass
-	assertMatchesWithTimeout(t, conn,
+	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
 		`[[VARCHAR("dual")] [VARCHAR("new_table_tracked")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`,
 		100*time.Millisecond,
@@ -277,21 +279,4 @@ func TestDMLOnNewTable(t *testing.T) {
 	utils.Exec(t, conn, `insert into t8(id8) values(2)`)
 	defer utils.Exec(t, conn, `delete from t8`)
 	utils.AssertMatchesNoOrder(t, conn, `select id from new_table_tracked join t8`, `[[INT64(0)] [INT64(1)]]`)
-}
-
-func assertMatchesWithTimeout(t *testing.T, conn *mysql.Conn, query, expected string, r time.Duration, d time.Duration, failureMsg string) {
-	t.Helper()
-	timeout := time.After(d)
-	diff := "actual and expectation does not match"
-	for len(diff) > 0 {
-		select {
-		case <-timeout:
-			require.Fail(t, failureMsg, diff)
-		case <-time.After(r):
-			qr := utils.Exec(t, conn, query)
-			diff = cmp.Diff(expected,
-				fmt.Sprintf("%v", qr.Rows))
-		}
-
-	}
 }

--- a/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
@@ -19,14 +19,12 @@ package unsharded
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"vitess.io/vitess/go/test/endtoend/utils"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
@@ -98,16 +96,18 @@ func TestNewUnshardedTable(t *testing.T) {
 	defer conn.Close()
 
 	// ensuring our initial table "main" is in the schema
-	qr := utils.Exec(t, conn, "SHOW VSCHEMA TABLES")
-	got := fmt.Sprintf("%v", qr.Rows)
-	want := `[[VARCHAR("dual")] [VARCHAR("main")]]`
-	require.Equal(t, want, got)
+	utils.AssertMatchesWithTimeout(t, conn,
+		"SHOW VSCHEMA TABLES",
+		`[[VARCHAR("dual")] [VARCHAR("main")]]`,
+		100*time.Millisecond,
+		3*time.Second,
+		"initial table list not complete")
 
 	// create a new table which is not part of the VSchema
 	utils.Exec(t, conn, `create table new_table_tracked(id bigint, name varchar(100), primary key(id)) Engine=InnoDB`)
 
 	// waiting for the vttablet's schema_reload interval to kick in
-	assertMatchesWithTimeout(t, conn,
+	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
 		`[[VARCHAR("dual")] [VARCHAR("main")] [VARCHAR("new_table_tracked")]]`,
 		100*time.Millisecond,
@@ -126,27 +126,10 @@ func TestNewUnshardedTable(t *testing.T) {
 	utils.Exec(t, conn, `drop table new_table_tracked`)
 
 	// waiting for the vttablet's schema_reload interval to kick in
-	assertMatchesWithTimeout(t, conn,
+	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
 		`[[VARCHAR("dual")] [VARCHAR("main")]]`,
 		100*time.Millisecond,
 		3*time.Second,
 		"new_table_tracked not in vschema tables")
-}
-
-func assertMatchesWithTimeout(t *testing.T, conn *mysql.Conn, query, expected string, r time.Duration, d time.Duration, failureMsg string) {
-	t.Helper()
-	timeout := time.After(d)
-	diff := "actual and expectation does not match"
-	for len(diff) > 0 {
-		select {
-		case <-timeout:
-			require.Fail(t, failureMsg, diff)
-		case <-time.After(r):
-			qr := utils.Exec(t, conn, query)
-			diff = cmp.Diff(expected,
-				fmt.Sprintf("%v", qr.Rows))
-		}
-
-	}
 }


### PR DESCRIPTION
## Description

This pull request adds a new helper function to the `endtoend/utils` package that skips a test if the major version of a binary is below a certain increment.

Some new functionalities can only be tested from a certain version of `vtgate`, `vttablet`, etc. However, the upgrade-downgrade tests execute all the end-to-end tests of a package regardless of which binary version supports them. This new helper function alleviates this issue.

Recently, the `TestSubqueriesExists` test started failing in the upgrade-downgrade test suite. This test uses a vtgate feature that only exists in `>= 14`, thus the new helper function is called at the beginning of the test to skip it if vtgate is below `v14`.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
