### PR TITLE
[vtadmin] custom discovery resolver

### DIFF
--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -2653,8 +2653,9 @@ func TestGetTablets(t *testing.T) {
 			Id:   "c1",
 			Name: "one",
 		},
-		Discovery:       disco,
-		ResolverOptions: &resolver.Options{},
+		ResolverOptions: &resolver.Options{
+			Discovery: disco,
+		},
 	})
 	db.DialFunc = func(cfg vitessdriver.Configuration) (*sql.DB, error) {
 		return nil, assert.AnError

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -36,6 +36,7 @@ import (
 	"vitess.io/vitess/go/vt/vitessdriver"
 	"vitess.io/vitess/go/vt/vtadmin/cluster"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery/fakediscovery"
+	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 	vtadminerrors "vitess.io/vitess/go/vt/vtadmin/errors"
 	"vitess.io/vitess/go/vt/vtadmin/testutil"
 	"vitess.io/vitess/go/vt/vtadmin/vtctldclient/fakevtctldclient"
@@ -2652,7 +2653,8 @@ func TestGetTablets(t *testing.T) {
 			Id:   "c1",
 			Name: "one",
 		},
-		Discovery: disco,
+		Discovery:       disco,
+		ResolverOptions: &resolver.Options{},
 	})
 	db.DialFunc = func(cfg vitessdriver.Configuration) (*sql.DB, error) {
 		return nil, assert.AnError

--- a/go/vt/vtadmin/cluster/discovery/discovery.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery.go
@@ -53,6 +53,10 @@ type Discovery interface {
 	// return an address is not specified by the interface, and can be
 	// implementation-specific.
 	DiscoverVTGateAddr(ctx context.Context, tags []string) (string, error)
+	// DiscoverVTGateAddrs returns a list of addresses of vtgates found in the
+	// discovery service. This is semantically equivalent to the result of
+	// DiscoverVTGateAddr for each gate returned by a call to DiscoverVTGates.
+	DiscoverVTGateAddrs(ctx context.Context, tags []string) ([]string, error)
 	// DiscoverVTGates returns a list of vtgates found in the discovery service.
 	// Tags can optionally be used to filter gates. Order of the gates is not
 	// specified by the interface, and can be implementation-specific.
@@ -68,6 +72,10 @@ type Discovery interface {
 	// return an address is not specified by the interface, and can be
 	// implementation-specific.
 	DiscoverVtctldAddr(ctx context.Context, tags []string) (string, error)
+	// DiscoverVtctldAddrs returns a list of addresses of vtctlds found in the
+	// discovery service. This is semantically equivalent to the result of
+	// DiscoverVtctldAddr for each gate returned by a call to DiscoverVtctlds.
+	DiscoverVtctldAddrs(ctx context.Context, tags []string) ([]string, error)
 	// DiscoverVtctlds returns a list of vtctlds found in the discovery service.
 	// Tags can optionally be used to filter vtctlds. Order of the vtctlds is
 	// not specified by the interface, and can be implementation-specific.

--- a/go/vt/vtadmin/cluster/discovery/discovery_consul.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_consul.go
@@ -228,6 +228,31 @@ func (c *ConsulDiscovery) DiscoverVTGateAddr(ctx context.Context, tags []string)
 	return addr, nil
 }
 
+// DiscoverVTGateAddrs is part of the Discovery interface.
+func (c *ConsulDiscovery) DiscoverVTGateAddrs(ctx context.Context, tags []string) ([]string, error) {
+	span, ctx := trace.NewSpan(ctx, "ConsulDiscovery.DiscoverVTGateAddrs")
+	defer span.Finish()
+
+	executeFQDNTemplate := false
+
+	vtgates, err := c.discoverVTGates(ctx, tags, executeFQDNTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs := make([]string, len(vtgates))
+	for i, vtgate := range vtgates {
+		addr, err := textutil.ExecuteTemplate(c.vtgateAddrTmpl, vtgate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute vtgate address template for %v: %w", vtgate, err)
+		}
+
+		addrs[i] = addr
+	}
+
+	return addrs, nil
+}
+
 // DiscoverVTGates is part of the Discovery interface.
 func (c *ConsulDiscovery) DiscoverVTGates(ctx context.Context, tags []string) ([]*vtadminpb.VTGate, error) {
 	span, ctx := trace.NewSpan(ctx, "ConsulDiscovery.DiscoverVTGates")
@@ -346,6 +371,31 @@ func (c *ConsulDiscovery) DiscoverVtctldAddr(ctx context.Context, tags []string)
 	}
 
 	return addr, nil
+}
+
+// DiscoverVtctldAddrs is part of the Discovery interface.
+func (c *ConsulDiscovery) DiscoverVtctldAddrs(ctx context.Context, tags []string) ([]string, error) {
+	span, ctx := trace.NewSpan(ctx, "ConsulDiscovery.DiscoverVtctldAddrs")
+	defer span.Finish()
+
+	executeFQDNTemplate := false
+
+	vtctlds, err := c.discoverVtctlds(ctx, tags, executeFQDNTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs := make([]string, len(vtctlds))
+	for i, vtctld := range vtctlds {
+		addr, err := textutil.ExecuteTemplate(c.vtctldAddrTmpl, vtctld)
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute vtctld address template for %v: %w", vtctld, err)
+		}
+
+		addrs[i] = addr
+	}
+
+	return addrs, nil
 }
 
 // DiscoverVtctlds is part of the Discovery interface.

--- a/go/vt/vtadmin/cluster/discovery/discovery_json.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_json.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 
 	"vitess.io/vitess/go/trace"
+
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
 
@@ -146,6 +147,24 @@ func (d *JSONDiscovery) DiscoverVTGateAddr(ctx context.Context, tags []string) (
 	return gate.Hostname, nil
 }
 
+// DiscoverVTGateAddrs is part of the Discovery interface.
+func (d *JSONDiscovery) DiscoverVTGateAddrs(ctx context.Context, tags []string) ([]string, error) {
+	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVTGateAddrs")
+	defer span.Finish()
+
+	gates, err := d.discoverVTGates(ctx, tags)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs := make([]string, len(gates))
+	for i, gate := range gates {
+		addrs[i] = gate.Hostname
+	}
+
+	return addrs, nil
+}
+
 // DiscoverVTGates is part of the Discovery interface.
 func (d *JSONDiscovery) DiscoverVTGates(ctx context.Context, tags []string) ([]*vtadminpb.VTGate, error) {
 	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVTGates")
@@ -226,6 +245,24 @@ func (d *JSONDiscovery) DiscoverVtctldAddr(ctx context.Context, tags []string) (
 	}
 
 	return vtctld.Hostname, nil
+}
+
+// DiscoverVtctldAddrs is part of the Discovery interface.
+func (d *JSONDiscovery) DiscoverVtctldAddrs(ctx context.Context, tags []string) ([]string, error) {
+	span, ctx := trace.NewSpan(ctx, "JSONDiscovery.DiscoverVtctldAddrs")
+	defer span.Finish()
+
+	vtctlds, err := d.discoverVtctlds(ctx, tags)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs := make([]string, len(vtctlds))
+	for i, vtctld := range vtctlds {
+		addrs[i] = vtctld.Hostname
+	}
+
+	return addrs, nil
 }
 
 // DiscoverVtctlds is part of the Discovery interface.

--- a/go/vt/vtadmin/cluster/discovery/fakediscovery/discovery.go
+++ b/go/vt/vtadmin/cluster/discovery/fakediscovery/discovery.go
@@ -181,6 +181,21 @@ func (d *Fake) DiscoverVTGateAddr(ctx context.Context, tags []string) (string, e
 	return gate.Hostname, nil
 }
 
+// DiscoverVTGateAddrs is part of the discovery.Discovery interface.
+func (d *Fake) DiscoverVTGateAddrs(ctx context.Context, tags []string) ([]string, error) {
+	gates, err := d.DiscoverVTGates(ctx, tags)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs := make([]string, len(gates))
+	for i, gate := range gates {
+		addrs[i] = gate.Hostname
+	}
+
+	return addrs, nil
+}
+
 // DiscoverVtctlds is part of the discover.Discovery interface.
 func (d *Fake) DiscoverVtctlds(ctx context.Context, tags []string) ([]*vtadminpb.Vtctld, error) {
 	if d.vtctlds.shouldErr {
@@ -232,6 +247,21 @@ func (d *Fake) DiscoverVtctldAddr(ctx context.Context, tags []string) (string, e
 	}
 
 	return vtctld.Hostname, nil
+}
+
+// DiscoverVtctldAddrs is part of the discovery.Discovery interface.
+func (d *Fake) DiscoverVtctldAddrs(ctx context.Context, tags []string) ([]string, error) {
+	vtctlds, err := d.DiscoverVtctlds(ctx, tags)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs := make([]string, len(vtctlds))
+	for i, vtctld := range vtctlds {
+		addrs[i] = vtctld.Hostname
+	}
+
+	return addrs, nil
 }
 
 // DiscoverVtctld is part of the discover.Discovery interface.

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -1,0 +1,78 @@
+package resolver
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/resolver"
+
+	"vitess.io/vitess/go/trace"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery"
+)
+
+type Builder struct {
+	scheme string
+	disco  discovery.Discovery
+}
+
+// TODO: inject options from the cluster config here (to be called by vtctldclient.Proxy and vtsql.VTGateProxy)
+func NewBuilder(scheme string, disco discovery.Discovery) *Builder {
+	return &Builder{scheme: scheme, disco: disco}
+}
+
+func (b *Builder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	r := &Resolver{
+		disco: b.disco,
+		cc:    cc,
+	}
+
+	r.resolve()
+	return r, nil
+}
+
+func (b *Builder) Scheme() string {
+	return b.scheme
+}
+
+type Resolver struct {
+	disco discovery.Discovery
+	cc    resolver.ClientConn
+}
+
+func (r *Resolver) resolve() {
+	span, ctx := trace.NewSpan(context.Background(), "vtadmin.cluster.Resolver.resolve")
+	defer span.Finish()
+
+	log.Infof("(vtadmin.cluster.Resolver).resolve called")
+
+	// TODO: apply timeout (via config)
+	// TODO: support tags from cluster configs
+	// TODO: use target.Authority field (in Builder.Build) to switch between
+	//		 vtctld/vtgate and use in package vtsql as well.
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	vtctlds, err := r.disco.DiscoverVtctlds(ctx, nil)
+	if err != nil {
+		log.Errorf("error discovering vtctlds: %s", err)
+		return
+	}
+
+	log.Infof("found %d vtctlds", len(vtctlds))
+	addrs := make([]resolver.Address, len(vtctlds))
+	for i, vtctld := range vtctlds {
+		addrs[i] = resolver.Address{Addr: vtctld.Hostname}
+	}
+
+	// TODO: check error and log
+	_ = r.cc.UpdateState(resolver.State{
+		Addresses: addrs,
+	})
+}
+
+func (r *Resolver) ResolveNow(o resolver.ResolveNowOptions) {
+	r.resolve()
+}
+
+func (r *Resolver) Close() {}

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package resolver provides a discovery-based resolver for VTAdmin clusters.
 //
 // It uses a discovery.Discovery implementation to dynamically update the set of

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -34,6 +34,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -198,6 +199,8 @@ func (r *resolver) resolve() (*grpcresolver.State, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover %ss (cluster %s): %w", r.component, r.cluster, err)
 	}
+
+	span.Annotate("addrs", strings.Join(addrs, ","))
 
 	state := &grpcresolver.State{
 		Addresses: make([]grpcresolver.Address, len(addrs)),

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -339,7 +339,7 @@ func (r *resolver) Debug() map[string]any {
 	}
 
 	if r.lastResolveError != nil {
-		m["error"] = r.lastResolvedAt.String()
+		m["error"] = r.lastResolveError.Error()
 	}
 
 	return m

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -11,37 +11,59 @@ import (
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery"
 )
 
-type Builder struct {
+type builder struct {
 	scheme string
 	disco  discovery.Discovery
+	opts   Options
 }
 
-// TODO: inject options from the cluster config here (to be called by vtctldclient.Proxy and vtsql.VTGateProxy)
-func NewBuilder(scheme string, disco discovery.Discovery) *Builder {
-	return &Builder{scheme: scheme, disco: disco}
+type Options struct {
+	ResolveTimeout time.Duration
+	DiscoveryTags  []string
 }
 
-func (b *Builder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+// NewBuilder returns a gRPC resolver.Builder for the given scheme. For vtadmin,
+// the scheme should be a cluster ID.
+//
+// The target provided to Builder.Build will be used to switch on vtctld or
+// vtgate, based on the Authority field of the target. This means that the addr
+// passed to Dial should have the form "{clusterID}://{vtctld|vtgate}/". Other
+// target Authorities will cause an error.
+func NewBuilder(scheme string, disco discovery.Discovery, opts Options) resolver.Builder {
+	return &builder{
+		scheme: scheme,
+		disco:  disco,
+		opts:   opts,
+	}
+}
+
+// Build is part of the resolver.Builder interface. See the commentary on
+// NewBuilder in this package for more details on this particular
+// implementation.
+func (b *builder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	r := &Resolver{
 		disco: b.disco,
 		cc:    cc,
+		opts:  b.opts,
 	}
 
 	r.resolve()
 	return r, nil
 }
 
-func (b *Builder) Scheme() string {
+// Scheme is part of the resolver.Builder interface.
+func (b *builder) Scheme() string {
 	return b.scheme
 }
 
 type Resolver struct {
 	disco discovery.Discovery
 	cc    resolver.ClientConn
+	opts  Options
 }
 
 func (r *Resolver) resolve() {
-	span, ctx := trace.NewSpan(context.Background(), "vtadmin.cluster.Resolver.resolve")
+	span, ctx := trace.NewSpan(context.Background(), "(vtadmin/cluster/resolver).resolve")
 	defer span.Finish()
 
 	log.Infof("(vtadmin.cluster.Resolver).resolve called")
@@ -50,7 +72,7 @@ func (r *Resolver) resolve() {
 	// TODO: support tags from cluster configs
 	// TODO: use target.Authority field (in Builder.Build) to switch between
 	//		 vtctld/vtgate and use in package vtsql as well.
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	ctx, cancel := context.WithTimeout(ctx, r.opts.ResolveTimeout)
 	defer cancel()
 
 	vtctlds, err := r.disco.DiscoverVtctlds(ctx, nil)

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -149,10 +149,10 @@ func (b *builder) Debug() map[string]any {
 
 	resolvers := make([]map[string]any, len(b.resolvers))
 	m := map[string]any{
-		"scheme":          b.scheme,
-		"resolve_timeout": b.opts.DiscoveryTimeout,
-		"discovery_tags":  b.opts.DiscoveryTags,
-		"resolvers":       resolvers,
+		"scheme":            b.scheme,
+		"discovery_tags":    b.opts.DiscoveryTags,
+		"discovery_timeout": b.opts.DiscoveryTimeout,
+		"resolvers":         resolvers,
 	}
 
 	for i, r := range b.resolvers {

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -1,3 +1,9 @@
+// Package resolver provides a discovery-based resolver for VTAdmin clusters.
+//
+// It uses a discovery.Discovery implementation to dynamically update the set of
+// vtctlds and vtgates in a cluster being used by a grpc.ClientConn, allowing
+// VTAdmin to transparently reconnect to different vtctlds and vtgates both
+// periodically and when hosts are recycled.
 package resolver
 
 import (

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -165,6 +165,7 @@ func (b *builder) build(target grpcresolver.Target, cc grpcresolver.ClientConn, 
 
 	var sc serviceconfig.Config
 	if b.opts.BalancerPolicy != "" {
+		// c.f. https://github.com/grpc/grpc/blob/master/doc/service_config.md#example
 		scpr := cc.ParseServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{ "%s": {} }] }`, b.opts.BalancerPolicy))
 		if scpr.Err != nil {
 			return nil, fmt.Errorf("failed to initialize service config with load balancer policy %s: %s", b.opts.BalancerPolicy, scpr.Err)

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -20,6 +20,24 @@ limitations under the License.
 // vtctlds and vtgates in a cluster being used by a grpc.ClientConn, allowing
 // VTAdmin to transparently reconnect to different vtctlds and vtgates both
 // periodically and when hosts are recycled.
+//
+// Some potential improvements we can add, if desired:
+//
+// 1. Background refresh. We would take a config flag that governs the refresh
+//	  interval and backoff (for when background refresh happens around the same
+//	  time as grpc-core calls to ResolveNow) and spin up a goroutine. We would
+//	  then have to spin this down when Close is called.
+//
+// 2. Stats!
+//
+// 3. Have *builder track the *resolvers it builds. The reason we want this is
+// 	  because VtctldClientProxy and VTGateProxy can only hold a reference to the
+//	  a Builder, not the Resolvers that Builder builds. If we then implement
+//	  debug.Debuggable for our builder and resolver implementations, we can then
+//	  wire all this allllll the way back up to /debug/ route for a cluster to
+//	  inspect the state of our resolvers. In particular we would be interested
+//	  in the last resolution time, last resolution error (if last resolution
+//	  failed), and the current address set.
 package resolver
 
 import (

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -58,6 +58,14 @@ type builder struct {
 	resolvers []*resolver
 }
 
+// DialAddr returns the dial address for a resolver scheme and component.
+//
+// VtctldClientProxy and VTGateProxy should use this to ensure their Dial calls
+// use their respective discovery resolvers.
+func DialAddr(resolver grpcresolver.Builder, component string) string {
+	return fmt.Sprintf("%s://%s/", resolver.Scheme(), component)
+}
+
 type Options struct {
 	Discovery        discovery.Discovery
 	DiscoveryTags    []string

--- a/go/vt/vtadmin/cluster/resolver/resolver_test.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resolver
 
 import (
+	"net/url"
 	"testing"
 	"time"
 
@@ -69,7 +70,7 @@ func TestResolveNow(t *testing.T) {
 
 	cc := mockClientConn{}
 	r := mustBuild(t, &builder{opts: testopts}, grpcresolver.Target{
-		Authority: "vtctld",
+		URL: url.URL{Host: "vtctld"},
 	}, &cc, grpcresolver.BuildOptions{})
 
 	r.ResolveNow(grpcresolver.ResolveNowOptions{})
@@ -114,7 +115,7 @@ func TestResolveWithTags(t *testing.T) {
 
 	cc := mockClientConn{}
 	r := mustBuild(t, &builder{opts: testopts}, grpcresolver.Target{
-		Authority: "vtgate",
+		URL: url.URL{Host: "vtgate"},
 	}, &cc, grpcresolver.BuildOptions{})
 	r.opts.DiscoveryTags = []string{"tag2"}
 
@@ -140,7 +141,7 @@ func TestResolveEmptyList(t *testing.T) {
 	cc := mockClientConn{}
 	r := mustBuild(t,
 		&builder{opts: testopts}, grpcresolver.Target{
-			Authority: "vtgate", // we only have vtctlds
+			URL: url.URL{Host: "vtgate"}, // we only have vtctlds
 		}, &cc, grpcresolver.BuildOptions{},
 	)
 
@@ -182,7 +183,7 @@ func TestBuild(t *testing.T) {
 		{
 			name: "vtctld",
 			target: grpcresolver.Target{
-				Authority: "vtctld",
+				URL: url.URL{Host: "vtctld"},
 			},
 			assertion: func(t *testing.T, cc *mockClientConn) {
 				assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
@@ -195,7 +196,7 @@ func TestBuild(t *testing.T) {
 		{
 			name: "vtgate",
 			target: grpcresolver.Target{
-				Authority: "vtgate",
+				URL: url.URL{Host: "vtgate"},
 			},
 			assertion: func(t *testing.T, cc *mockClientConn) {
 				assert.Empty(t, cc.Addrs, "resolver should not add addresses to clientconn (no vtgates in discovery)")
@@ -205,7 +206,7 @@ func TestBuild(t *testing.T) {
 		{
 			name: "bad authority",
 			target: grpcresolver.Target{
-				Authority: "unsupported",
+				URL: url.URL{Host: "unsupported"},
 			},
 			shouldErr: true,
 		},

--- a/go/vt/vtadmin/cluster/resolver/resolver_test.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver_test.go
@@ -45,7 +45,7 @@ func (cc *mockClientConn) UpdateState(state grpcresolver.State) error {
 func (cc *mockClientConn) ReportError(err error) { cc.ReportedError = err }
 
 var testopts = Options{
-	ResolveTimeout: time.Millisecond * 50,
+	DiscoveryTimeout: time.Millisecond * 50,
 }
 
 func mustBuild(t *testing.T, b *builder, target grpcresolver.Target, cc grpcresolver.ClientConn, opts grpcresolver.BuildOptions) *resolver {

--- a/go/vt/vtadmin/cluster/resolver/resolver_test.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	grpcresolver "google.golang.org/grpc/resolver"
+
+	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery/fakediscovery"
+
+	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
+)
+
+type mockClientConn struct {
+	grpcresolver.ClientConn
+	Addrs             []grpcresolver.Address
+	UpdateStateCalled bool
+}
+
+func (cc *mockClientConn) UpdateState(state grpcresolver.State) error {
+	cc.UpdateStateCalled = true
+	cc.Addrs = state.Addresses
+	return nil
+}
+
+var opts = Options{
+	ResolveTimeout: time.Millisecond * 50,
+}
+
+func TestResolveNow(t *testing.T) {
+	t.Parallel()
+
+	disco := fakediscovery.New()
+	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
+		Hostname: "one",
+	})
+
+	cc := mockClientConn{}
+	r := &resolver{
+		target: grpcresolver.Target{
+			Authority: "vtctld",
+		},
+		cc:    &cc,
+		disco: disco,
+		opts:  opts,
+	}
+
+	r.ResolveNow(grpcresolver.ResolveNowOptions{})
+
+	assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
+		{
+			Addr: "one",
+		},
+	})
+
+	disco.Clear()
+	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
+		Hostname: "two",
+	}, &vtadminpb.Vtctld{
+		Hostname: "three",
+	})
+
+	r.ResolveNow(grpcresolver.ResolveNowOptions{})
+
+	assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
+		{
+			Addr: "two",
+		},
+		{
+			Addr: "three",
+		},
+	})
+}
+
+func TestResolveWithTags(t *testing.T) {
+	t.Parallel()
+
+	disco := fakediscovery.New()
+	disco.AddTaggedGates([]string{"tag1"}, &vtadminpb.VTGate{
+		Hostname: "one",
+	})
+	disco.AddTaggedGates([]string{"tag2"}, &vtadminpb.VTGate{
+		Hostname: "two",
+	})
+
+	cc := mockClientConn{}
+	r := &resolver{
+		target: grpcresolver.Target{
+			Authority: "vtgate",
+		},
+		cc:    &cc,
+		disco: disco,
+		opts:  opts,
+	}
+	r.opts.DiscoveryTags = []string{"tag2"}
+
+	r.ResolveNow(grpcresolver.ResolveNowOptions{})
+
+	assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
+		{
+			Addr: "two",
+		},
+	})
+}
+
+func TestResolveEmptyList(t *testing.T) {
+	t.Parallel()
+
+	disco := fakediscovery.New()
+	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
+		Hostname: "one",
+	})
+
+	cc := mockClientConn{}
+	r := &resolver{
+		target: grpcresolver.Target{
+			Authority: "vtgate", // we only have vtctlds
+		},
+		cc:    &cc,
+		disco: disco,
+		opts:  opts,
+	}
+
+	r.ResolveNow(grpcresolver.ResolveNowOptions{})
+
+	assert.Empty(t, cc.Addrs, "ClientConn should have no addresses")
+	assert.False(t, cc.UpdateStateCalled, "resolver should not call cc.UpdateState with empty host list")
+
+	disco.AddTaggedGates(nil, &vtadminpb.VTGate{
+		Hostname: "gate:one",
+	})
+
+	r.ResolveNow(grpcresolver.ResolveNowOptions{})
+	assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
+		{
+			Addr: "gate:one",
+		},
+	})
+	assert.True(t, cc.UpdateStateCalled, "resolver should call cc.UpdateState after discovering new hosts")
+}
+
+func TestBuild(t *testing.T) {
+	t.Parallel()
+
+	disco := fakediscovery.New()
+	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
+		Hostname: "vtctld:one",
+	})
+
+	b := &builder{disco: disco, opts: opts}
+
+	tests := []struct {
+		name      string
+		target    grpcresolver.Target
+		shouldErr bool
+		assertion func(t *testing.T, cc *mockClientConn)
+	}{
+		{
+			name: "vtctld",
+			target: grpcresolver.Target{
+				Authority: "vtctld",
+			},
+			assertion: func(t *testing.T, cc *mockClientConn) {
+				assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
+					{
+						Addr: "vtctld:one",
+					},
+				})
+			},
+		},
+		{
+			name: "vtgate",
+			target: grpcresolver.Target{
+				Authority: "vtgate",
+			},
+			assertion: func(t *testing.T, cc *mockClientConn) {
+				assert.Empty(t, cc.Addrs, "resolver should not UpdateState on clientconn (no vtgates in discovery)")
+				assert.False(t, cc.UpdateStateCalled, "resolver should not call UpdateState on clientconn (no vtgates in discovery)")
+			},
+		},
+		{
+			name: "bad authority",
+			target: grpcresolver.Target{
+				Authority: "unsupported",
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cc := &mockClientConn{}
+			_, err := b.Build(tt.target, cc, grpcresolver.BuildOptions{})
+			if tt.shouldErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			func() {
+				t.Helper()
+				tt.assertion(t, cc)
+			}()
+		})
+	}
+}

--- a/go/vt/vtadmin/cluster/resolver/resolver_test.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver_test.go
@@ -64,9 +64,11 @@ func TestResolveNow(t *testing.T) {
 	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
 		Hostname: "one",
 	})
+	testopts := testopts
+	testopts.Discovery = disco
 
 	cc := mockClientConn{}
-	r := mustBuild(t, &builder{disco: disco, opts: testopts}, grpcresolver.Target{
+	r := mustBuild(t, &builder{opts: testopts}, grpcresolver.Target{
 		Authority: "vtctld",
 	}, &cc, grpcresolver.BuildOptions{})
 
@@ -107,9 +109,11 @@ func TestResolveWithTags(t *testing.T) {
 	disco.AddTaggedGates([]string{"tag2"}, &vtadminpb.VTGate{
 		Hostname: "two",
 	})
+	testopts := testopts
+	testopts.Discovery = disco
 
 	cc := mockClientConn{}
-	r := mustBuild(t, &builder{disco: disco, opts: testopts}, grpcresolver.Target{
+	r := mustBuild(t, &builder{opts: testopts}, grpcresolver.Target{
 		Authority: "vtgate",
 	}, &cc, grpcresolver.BuildOptions{})
 	r.opts.DiscoveryTags = []string{"tag2"}
@@ -130,10 +134,12 @@ func TestResolveEmptyList(t *testing.T) {
 	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
 		Hostname: "one",
 	})
+	testopts := testopts
+	testopts.Discovery = disco
 
 	cc := mockClientConn{}
 	r := mustBuild(t,
-		&builder{disco: disco, opts: testopts}, grpcresolver.Target{
+		&builder{opts: testopts}, grpcresolver.Target{
 			Authority: "vtgate", // we only have vtctlds
 		}, &cc, grpcresolver.BuildOptions{},
 	)
@@ -162,8 +168,10 @@ func TestBuild(t *testing.T) {
 	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
 		Hostname: "vtctld:one",
 	})
+	testopts := testopts
+	testopts.Discovery = disco
 
-	b := &builder{disco: disco, opts: testopts}
+	b := &builder{opts: testopts}
 
 	tests := []struct {
 		name      string

--- a/go/vt/vtadmin/vtctldclient/config.go
+++ b/go/vt/vtadmin/vtctldclient/config.go
@@ -31,9 +31,7 @@ import (
 
 // Config represents the options that modify the behavior of a Proxy.
 type Config struct {
-	Discovery   discovery.Discovery
-	Credentials *grpcclient.StaticAuthClientCreds
-
+	Credentials     *grpcclient.StaticAuthClientCreds
 	CredentialsPath string
 
 	Cluster *vtadminpb.Cluster
@@ -46,9 +44,10 @@ type Config struct {
 // (*Config).Parse() for more details.
 func Parse(cluster *vtadminpb.Cluster, disco discovery.Discovery, args []string) (*Config, error) {
 	cfg := &Config{
-		Cluster:         cluster,
-		Discovery:       disco,
-		ResolverOptions: &resolver.Options{},
+		Cluster: cluster,
+		ResolverOptions: &resolver.Options{
+			Discovery: disco,
+		},
 	}
 
 	err := cfg.Parse(args)

--- a/go/vt/vtadmin/vtctldclient/config.go
+++ b/go/vt/vtadmin/vtctldclient/config.go
@@ -24,6 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery"
+	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 	"vitess.io/vitess/go/vt/vtadmin/credentials"
 
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
@@ -39,6 +40,8 @@ type Config struct {
 	Cluster *vtadminpb.Cluster
 
 	ConnectivityTimeout time.Duration
+
+	resolver *resolver.Builder
 }
 
 const defaultConnectivityTimeout = 2 * time.Second
@@ -50,6 +53,7 @@ func Parse(cluster *vtadminpb.Cluster, disco discovery.Discovery, args []string)
 	cfg := &Config{
 		Cluster:   cluster,
 		Discovery: disco,
+		resolver:  resolver.NewBuilder(cluster.Id, disco),
 	}
 
 	err := cfg.Parse(args)

--- a/go/vt/vtadmin/vtctldclient/config.go
+++ b/go/vt/vtadmin/vtctldclient/config.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-
 	grpcresolver "google.golang.org/grpc/resolver"
 
 	"vitess.io/vitess/go/vt/grpcclient"

--- a/go/vt/vtadmin/vtctldclient/config.go
+++ b/go/vt/vtadmin/vtctldclient/config.go
@@ -40,12 +40,8 @@ type Config struct {
 
 	Cluster *vtadminpb.Cluster
 
-	ConnectivityTimeout time.Duration
-
 	resolver grpcresolver.Builder
 }
-
-const defaultConnectivityTimeout = 2 * time.Second
 
 // Parse returns a new config with the given cluster and discovery, after
 // attempting to parse the command-line pflags into that Config. See
@@ -73,8 +69,6 @@ func Parse(cluster *vtadminpb.Cluster, disco discovery.Discovery, args []string)
 // (*cluster.Cluster).New().
 func (c *Config) Parse(args []string) error {
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	fs.DurationVar(&c.ConnectivityTimeout, "grpc-connectivity-timeout", defaultConnectivityTimeout, "The maximum duration to wait for a gRPC connection to be established to the vtctld.")
 
 	credentialsTmplStr := fs.String("credentials-path-tmpl", "",
 		"Go template used to specify a path to a credentials file, which is a json file containing "+

--- a/go/vt/vtadmin/vtctldclient/config.go
+++ b/go/vt/vtadmin/vtctldclient/config.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/spf13/pflag"
 
+	grpcresolver "google.golang.org/grpc/resolver"
+
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
@@ -41,7 +43,7 @@ type Config struct {
 
 	ConnectivityTimeout time.Duration
 
-	resolver *resolver.Builder
+	resolver grpcresolver.Builder
 }
 
 const defaultConnectivityTimeout = 2 * time.Second
@@ -53,13 +55,16 @@ func Parse(cluster *vtadminpb.Cluster, disco discovery.Discovery, args []string)
 	cfg := &Config{
 		Cluster:   cluster,
 		Discovery: disco,
-		resolver:  resolver.NewBuilder(cluster.Id, disco),
 	}
 
 	err := cfg.Parse(args)
 	if err != nil {
 		return nil, err
 	}
+
+	cfg.resolver = resolver.NewBuilder(cluster.Id, disco, resolver.Options{
+		ResolveTimeout: time.Second, // TODO: add flag
+	})
 
 	return cfg, nil
 }

--- a/go/vt/vtadmin/vtctldclient/config_test.go
+++ b/go/vt/vtadmin/vtctldclient/config_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,7 +57,7 @@ func TestParse(t *testing.T) {
 			Credentials:         nil,
 			CredentialsPath:     "",
 			ConnectivityTimeout: defaultConnectivityTimeout,
-			resolver:            resolver.NewBuilder("", nil, resolver.Options{}),
+			resolver:            resolver.NewBuilder("", nil, resolver.Options{ResolveTimeout: time.Second}),
 		}
 		assert.Equal(t, expected, cfg)
 	})
@@ -95,7 +96,7 @@ func TestParse(t *testing.T) {
 				Credentials:         creds,
 				CredentialsPath:     credsfile.Name(),
 				ConnectivityTimeout: defaultConnectivityTimeout,
-				resolver:            resolver.NewBuilder("", nil, resolver.Options{}),
+				resolver:            resolver.NewBuilder("", nil, resolver.Options{ResolveTimeout: time.Second}),
 			}
 
 			assert.Equal(t, expected, cfg)

--- a/go/vt/vtadmin/vtctldclient/config_test.go
+++ b/go/vt/vtadmin/vtctldclient/config_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/grpcclient"
+	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
@@ -46,15 +47,16 @@ func TestParse(t *testing.T) {
 	t.Run("no credentials provided", func(t *testing.T) {
 		t.Parallel()
 
-		cfg, err := Parse(nil, nil, []string{})
+		cfg, err := Parse(&vtadminpb.Cluster{}, nil, []string{})
 		require.NoError(t, err)
 
 		expected := &Config{
-			Cluster:             nil,
+			Cluster:             &vtadminpb.Cluster{},
 			Discovery:           nil,
 			Credentials:         nil,
 			CredentialsPath:     "",
 			ConnectivityTimeout: defaultConnectivityTimeout,
+			resolver:            resolver.NewBuilder("", nil),
 		}
 		assert.Equal(t, expected, cfg)
 	})
@@ -93,6 +95,7 @@ func TestParse(t *testing.T) {
 				Credentials:         creds,
 				CredentialsPath:     credsfile.Name(),
 				ConnectivityTimeout: defaultConnectivityTimeout,
+				resolver:            resolver.NewBuilder("", nil),
 			}
 
 			assert.Equal(t, expected, cfg)

--- a/go/vt/vtadmin/vtctldclient/config_test.go
+++ b/go/vt/vtadmin/vtctldclient/config_test.go
@@ -56,7 +56,9 @@ func TestParse(t *testing.T) {
 			Discovery:       nil,
 			Credentials:     nil,
 			CredentialsPath: "",
-			resolver:        resolver.NewBuilder("", nil, resolver.Options{ResolveTimeout: time.Second}),
+			ResolverOptions: &resolver.Options{
+				DiscoveryTimeout: 100 * time.Millisecond,
+			},
 		}
 		assert.Equal(t, expected, cfg)
 	})
@@ -94,7 +96,9 @@ func TestParse(t *testing.T) {
 				Discovery:       nil,
 				Credentials:     creds,
 				CredentialsPath: credsfile.Name(),
-				resolver:        resolver.NewBuilder("", nil, resolver.Options{ResolveTimeout: time.Second}),
+				ResolverOptions: &resolver.Options{
+					DiscoveryTimeout: 100 * time.Millisecond,
+				},
 			}
 
 			assert.Equal(t, expected, cfg)

--- a/go/vt/vtadmin/vtctldclient/config_test.go
+++ b/go/vt/vtadmin/vtctldclient/config_test.go
@@ -52,12 +52,11 @@ func TestParse(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := &Config{
-			Cluster:             &vtadminpb.Cluster{},
-			Discovery:           nil,
-			Credentials:         nil,
-			CredentialsPath:     "",
-			ConnectivityTimeout: defaultConnectivityTimeout,
-			resolver:            resolver.NewBuilder("", nil, resolver.Options{ResolveTimeout: time.Second}),
+			Cluster:         &vtadminpb.Cluster{},
+			Discovery:       nil,
+			Credentials:     nil,
+			CredentialsPath: "",
+			resolver:        resolver.NewBuilder("", nil, resolver.Options{ResolveTimeout: time.Second}),
 		}
 		assert.Equal(t, expected, cfg)
 	})
@@ -92,11 +91,10 @@ func TestParse(t *testing.T) {
 				Cluster: &vtadminpb.Cluster{
 					Name: "testcluster",
 				},
-				Discovery:           nil,
-				Credentials:         creds,
-				CredentialsPath:     credsfile.Name(),
-				ConnectivityTimeout: defaultConnectivityTimeout,
-				resolver:            resolver.NewBuilder("", nil, resolver.Options{ResolveTimeout: time.Second}),
+				Discovery:       nil,
+				Credentials:     creds,
+				CredentialsPath: credsfile.Name(),
+				resolver:        resolver.NewBuilder("", nil, resolver.Options{ResolveTimeout: time.Second}),
 			}
 
 			assert.Equal(t, expected, cfg)

--- a/go/vt/vtadmin/vtctldclient/config_test.go
+++ b/go/vt/vtadmin/vtctldclient/config_test.go
@@ -53,7 +53,6 @@ func TestParse(t *testing.T) {
 
 		expected := &Config{
 			Cluster:         &vtadminpb.Cluster{},
-			Discovery:       nil,
 			Credentials:     nil,
 			CredentialsPath: "",
 			ResolverOptions: &resolver.Options{
@@ -93,7 +92,6 @@ func TestParse(t *testing.T) {
 				Cluster: &vtadminpb.Cluster{
 					Name: "testcluster",
 				},
-				Discovery:       nil,
 				Credentials:     creds,
 				CredentialsPath: credsfile.Name(),
 				ResolverOptions: &resolver.Options{

--- a/go/vt/vtadmin/vtctldclient/config_test.go
+++ b/go/vt/vtadmin/vtctldclient/config_test.go
@@ -56,7 +56,7 @@ func TestParse(t *testing.T) {
 			Credentials:         nil,
 			CredentialsPath:     "",
 			ConnectivityTimeout: defaultConnectivityTimeout,
-			resolver:            resolver.NewBuilder("", nil),
+			resolver:            resolver.NewBuilder("", nil, resolver.Options{}),
 		}
 		assert.Equal(t, expected, cfg)
 	})
@@ -95,7 +95,7 @@ func TestParse(t *testing.T) {
 				Credentials:         creds,
 				CredentialsPath:     credsfile.Name(),
 				ConnectivityTimeout: defaultConnectivityTimeout,
-				resolver:            resolver.NewBuilder("", nil),
+				resolver:            resolver.NewBuilder("", nil, resolver.Options{}),
 			}
 
 			assert.Equal(t, expected, cfg)

--- a/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
+++ b/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
@@ -71,8 +71,6 @@ type VtctldClient struct {
 // incorrectly.
 var _ vtctldclient.VtctldClient = (*VtctldClient)(nil)
 
-func (fake *VtctldClient) WaitForReady(ctx context.Context) error { return nil }
-
 // CreateKeyspace is part of the vtctldclient.VtctldClient interface.
 func (fake *VtctldClient) CreateKeyspace(ctx context.Context, req *vtctldatapb.CreateKeyspaceRequest, opts ...grpc.CallOption) (*vtctldatapb.CreateKeyspaceResponse, error) {
 	if fake.CreateKeyspaceShouldErr {

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -88,7 +88,7 @@ func New(cfg *Config) *ClientProxy {
 		creds:     cfg.Credentials,
 		discovery: cfg.Discovery,
 		DialFunc:  grpcvtctldclient.NewWithDialOpts,
-		resolver:  cfg.resolver,
+		resolver:  cfg.ResolverOptions.NewBuilder(cfg.Cluster.Id, cfg.Discovery),
 		closed:    true,
 	}
 }

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -135,7 +135,7 @@ func (vtctld *ClientProxy) Dial(ctx context.Context) error {
 	opts = append(opts, grpc.WithResolvers(vtctld.resolver))
 
 	// TODO: update DialFunc to take ctx as first arg.
-	client, err := vtctld.DialFunc(vtctld.resolver.Scheme()+"://vtctld/", grpcclient.FailFast(false), append(opts, grpc.WithBlock())...)
+	client, err := vtctld.DialFunc(vtctld.resolver.Scheme()+"://vtctld/", grpcclient.FailFast(false), opts...)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -198,5 +198,9 @@ func (vtctld *ClientProxy) Debug() map[string]any {
 		m["dialed_at"] = debug.TimeToString(vtctld.dialedAt)
 	}
 
+	if dr, ok := vtctld.resolver.(debug.Debuggable); ok {
+		m["resolver"] = dr.Debug()
+	}
+
 	return m
 }

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -71,8 +71,6 @@ type ClientProxy struct {
 
 	m        sync.Mutex
 	closed   bool
-	host     string
-	lastPing time.Time
 	dialedAt time.Time
 }
 
@@ -104,41 +102,14 @@ func (vtctld *ClientProxy) Dial(ctx context.Context) error {
 
 	vtctld.m.Lock()
 	defer vtctld.m.Unlock()
-	//
-	// 	if vtctld.VtctldClient != nil {
-	// 		if !vtctld.closed {
-	// 			waitCtx, waitCancel := context.WithTimeout(ctx, vtctld.cfg.ConnectivityTimeout)
-	// 			defer waitCancel()
-	//
-	// 			if err := vtctld.VtctldClient.WaitForReady(waitCtx); err == nil {
-	// 				// Our cached connection is still open and ready, so we're good to go.
-	// 				span.Annotate("is_noop", true)
-	// 				span.Annotate("vtctld_host", vtctld.host)
-	//
-	// 				vtctld.lastPing = time.Now()
-	//
-	// 				return nil
-	// 			}
-	// 			// If WaitForReady returns an error, that indicates our cached connection
-	// 			// is no longer valid. We fall through to close the cached connection,
-	// 			// discover a new vtctld, and establish a new connection.
-	// 		}
-	//
-	// 		span.Annotate("is_stale", true)
-	//
-	// 		// close before reopen. this is safe to call on an already-closed client.
-	// 		if err := vtctld.Close(); err != nil {
-	// 			// Even if the client connection does not shut down cleanly, we don't want to block
-	// 			// Dial from discovering a new vtctld. This makes VTAdmin's dialer more resilient,
-	// 			// but, as a caveat, it _can_ potentially leak improperly-closed gRPC connections.
-	// 			log.Errorf("error closing possibly-stale connection before re-dialing: %w", err)
-	// 		}
-	// 	}
 
 	if vtctld.VtctldClient != nil {
 		if !vtctld.closed {
+			span.Annotate("is_noop", true)
 			return nil
 		}
+
+		span.Annotate("is_stale", true)
 
 		if err := vtctld.closeLocked(); err != nil {
 			// Even if the client connection does not shut down cleanly, we don't want to block
@@ -148,12 +119,6 @@ func (vtctld *ClientProxy) Dial(ctx context.Context) error {
 		}
 	}
 
-	// 	addr, err := vtctld.discovery.DiscoverVtctldAddr(ctx, nil)
-	// 	if err != nil {
-	// 		return fmt.Errorf("error discovering vtctld to dial: %w", err)
-	// 	}
-	//
-	// 	span.Annotate("vtctld_host", addr)
 	span.Annotate("is_using_credentials", vtctld.creds != nil)
 
 	opts := []grpc.DialOption{
@@ -174,22 +139,9 @@ func (vtctld *ClientProxy) Dial(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	//
-	// 	waitCtx, waitCancel := context.WithTimeout(ctx, vtctld.cfg.ConnectivityTimeout)
-	// 	defer waitCancel()
-	//
-	// 	if err := client.WaitForReady(waitCtx); err != nil {
-	// 		// If the gRPC connection does not transition to a READY state within the context timeout,
-	// 		// then return an error. The onus to redial (or not) is on the caller of the Dial function.
-	// 		// As an enhancement, we could update this Dial function to try redialing the discovered vtctld
-	// 		// a few times with a backoff before giving up.
-	// 		log.Infof("Could not transition to READY state for gRPC connection to %s: %s\n", addr, err.Error())
-	// 		return err
-	// 	}
 
 	log.Infof("Established gRPC connection to vtctld\n")
 	vtctld.dialedAt = time.Now()
-	// vtctld.host = addr
 	vtctld.VtctldClient = client
 	vtctld.closed = false
 
@@ -231,7 +183,6 @@ func (vtctld *ClientProxy) Debug() map[string]any {
 	defer vtctld.m.Unlock()
 
 	m := map[string]any{
-		"host":         vtctld.host,
 		"is_connected": !vtctld.closed,
 	}
 
@@ -244,7 +195,6 @@ func (vtctld *ClientProxy) Debug() map[string]any {
 	}
 
 	if !vtctld.closed {
-		m["last_ping"] = debug.TimeToString(vtctld.lastPing)
 		m["dialed_at"] = debug.TimeToString(vtctld.dialedAt)
 	}
 

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -22,11 +22,12 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/resolver"
+	grpcresolver "google.golang.org/grpc/resolver"
 
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 	"vitess.io/vitess/go/vt/vtadmin/debug"
 	"vitess.io/vitess/go/vt/vtadmin/vtadminproto"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldclient"
@@ -65,7 +66,7 @@ type ClientProxy struct {
 	// this should always be grpcvtctldclient.NewWithDialOpts, but it is
 	// exported for testing purposes.
 	DialFunc func(addr string, ff grpcclient.FailFast, opts ...grpc.DialOption) (vtctldclient.VtctldClient, error)
-	resolver resolver.Builder
+	resolver grpcresolver.Builder
 
 	m        sync.Mutex
 	closed   bool
@@ -132,7 +133,7 @@ func (vtctld *ClientProxy) Dial(ctx context.Context) error {
 	opts = append(opts, grpc.WithResolvers(vtctld.resolver))
 
 	// TODO: update DialFunc to take ctx as first arg.
-	client, err := vtctld.DialFunc(vtctld.resolver.Scheme()+"://vtctld/", grpcclient.FailFast(false), opts...)
+	client, err := vtctld.DialFunc(resolver.DialAddr(vtctld.resolver, "vtctld"), grpcclient.FailFast(false), opts...)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -27,7 +27,6 @@ import (
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery"
 	"vitess.io/vitess/go/vt/vtadmin/debug"
 	"vitess.io/vitess/go/vt/vtadmin/vtadminproto"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldclient"
@@ -58,10 +57,9 @@ type Proxy interface {
 type ClientProxy struct {
 	vtctldclient.VtctldClient // embedded to provide easy implementation of the vtctlservicepb.VtctldClient interface
 
-	cluster   *vtadminpb.Cluster
-	creds     *grpcclient.StaticAuthClientCreds
-	discovery discovery.Discovery
-	cfg       *Config
+	cluster *vtadminpb.Cluster
+	creds   *grpcclient.StaticAuthClientCreds
+	cfg     *Config
 
 	// DialFunc is called to open a new vtctdclient connection. In production,
 	// this should always be grpcvtctldclient.NewWithDialOpts, but it is
@@ -83,13 +81,12 @@ type ClientProxy struct {
 // use.
 func New(cfg *Config) *ClientProxy {
 	return &ClientProxy{
-		cfg:       cfg,
-		cluster:   cfg.Cluster,
-		creds:     cfg.Credentials,
-		discovery: cfg.Discovery,
-		DialFunc:  grpcvtctldclient.NewWithDialOpts,
-		resolver:  cfg.ResolverOptions.NewBuilder(cfg.Cluster.Id, cfg.Discovery),
-		closed:    true,
+		cfg:      cfg,
+		cluster:  cfg.Cluster,
+		creds:    cfg.Credentials,
+		DialFunc: grpcvtctldclient.NewWithDialOpts,
+		resolver: cfg.ResolverOptions.NewBuilder(cfg.Cluster.Id),
+		closed:   true,
 	}
 }
 

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/resolver"
 
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery"
-	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 	"vitess.io/vitess/go/vt/vtadmin/debug"
 	"vitess.io/vitess/go/vt/vtadmin/vtadminproto"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldclient"
@@ -67,7 +67,7 @@ type ClientProxy struct {
 	// this should always be grpcvtctldclient.NewWithDialOpts, but it is
 	// exported for testing purposes.
 	DialFunc func(addr string, ff grpcclient.FailFast, opts ...grpc.DialOption) (vtctldclient.VtctldClient, error)
-	resolver *resolver.Builder
+	resolver resolver.Builder
 
 	m        sync.Mutex
 	closed   bool

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -90,9 +90,6 @@ func TestDial(t *testing.T) {
 	})
 	defer proxy.Close() // prevents grpc-core from logging a bunch of "connection errors" after deferred listener.Close() above.
 
-	// We don't have a vtctld host until we call Dial
-	// require.Empty(t, proxy.host)
-
 	err = proxy.Dial(context.Background())
 	assert.NoError(t, err)
 
@@ -140,9 +137,6 @@ func TestRedial(t *testing.T) {
 		resolver:            resolver.NewBuilder("test", disco, resolver.Options{}),
 	})
 
-	// We don't have a vtctld host until we call Dial
-	// require.Empty(t, proxy.host)
-
 	// Check for a successful connection to whichever vtctld we discover first.
 	err = proxy.Dial(context.Background())
 	assert.NoError(t, err)
@@ -183,18 +177,6 @@ func TestRedial(t *testing.T) {
 	// 10ms seems to work consistently on my machine, but we'll work on this before
 	// shipping.
 	time.Sleep(time.Millisecond * 10)
-
-	// Wait for the client connection to shut down. (If we redial too quickly,
-	// we get into a race condition with gRPC's internal retry logic.
-	// (Using WaitForReady here _does_ expose more function internals than is ideal for a unit test,
-	// but it's far less flaky than using time.Sleep.)
-	// for {
-	// 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	// 	defer cancel()
-	// 	if err = proxy.VtctldClient.WaitForReady(ctx); err != nil {
-	// 		break
-	// 	}
-	// }
 
 	// Finally, check that we discover, dial + establish a new connection to the remaining vtctld.
 	err = proxy.Dial(context.Background())

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -85,9 +85,8 @@ func TestDial(t *testing.T) {
 			Id:   "test",
 			Name: "testcluster",
 		},
-		Discovery:           disco,
-		ConnectivityTimeout: defaultConnectivityTimeout,
-		resolver:            resolver.NewBuilder("test", disco, resolver.Options{}),
+		Discovery: disco,
+		resolver:  resolver.NewBuilder("test", disco, resolver.Options{}),
 	})
 	defer proxy.Close() // prevents grpc-core from logging a bunch of "connection errors" after deferred listener.Close() above.
 
@@ -162,9 +161,8 @@ func TestRedial(t *testing.T) {
 			Id:   "test",
 			Name: "testcluster",
 		},
-		Discovery:           disco,
-		ConnectivityTimeout: defaultConnectivityTimeout,
-		resolver:            &testResolverBuilder{resolver.NewBuilder("test", disco, resolver.Options{}), reResolveFired},
+		Discovery: disco,
+		resolver:  &testResolverBuilder{resolver.NewBuilder("test", disco, resolver.Options{}), reResolveFired},
 	})
 
 	// Check for a successful connection to whichever vtctld we discover first.

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -85,8 +85,8 @@ func TestDial(t *testing.T) {
 			Id:   "test",
 			Name: "testcluster",
 		},
-		Discovery: disco,
 		ResolverOptions: &resolver.Options{
+			Discovery:        disco,
 			DiscoveryTimeout: 50 * time.Millisecond,
 		},
 	})
@@ -163,8 +163,8 @@ func TestRedial(t *testing.T) {
 			Id:   "test",
 			Name: "testcluster",
 		},
-		Discovery: disco,
 		ResolverOptions: &resolver.Options{
+			Discovery:        disco,
 			DiscoveryTimeout: 50 * time.Millisecond,
 		},
 	})

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -86,7 +86,7 @@ func TestDial(t *testing.T) {
 		},
 		Discovery:           disco,
 		ConnectivityTimeout: defaultConnectivityTimeout,
-		resolver:            resolver.NewBuilder("test", disco),
+		resolver:            resolver.NewBuilder("test", disco, resolver.Options{}),
 	})
 	defer proxy.Close() // prevents grpc-core from logging a bunch of "connection errors" after deferred listener.Close() above.
 
@@ -137,7 +137,7 @@ func TestRedial(t *testing.T) {
 		},
 		Discovery:           disco,
 		ConnectivityTimeout: defaultConnectivityTimeout,
-		resolver:            resolver.NewBuilder("test", disco),
+		resolver:            resolver.NewBuilder("test", disco, resolver.Options{}),
 	})
 
 	// We don't have a vtctld host until we call Dial

--- a/go/vt/vtadmin/vtsql/config.go
+++ b/go/vt/vtadmin/vtsql/config.go
@@ -32,16 +32,13 @@ import (
 
 // Config represents the options that modify the behavior of a vtqsl.VTGateProxy.
 type Config struct {
-	Discovery     discovery.Discovery
-	DiscoveryTags []string
-	Credentials   Credentials
-
-	DialPingTimeout time.Duration
-
+	Credentials Credentials
 	// CredentialsPath is used only to power vtadmin debug endpoints; there may
 	// be a better way where we don't need to put this in the config, because
 	// it's not really an "option" in normal use.
 	CredentialsPath string
+
+	DialPingTimeout time.Duration
 
 	Cluster         *vtadminpb.Cluster
 	ResolverOptions *resolver.Options
@@ -52,9 +49,10 @@ type Config struct {
 // (*Config).Parse() for more details.
 func Parse(cluster *vtadminpb.Cluster, disco discovery.Discovery, args []string) (*Config, error) {
 	cfg := &Config{
-		Cluster:         cluster,
-		Discovery:       disco,
-		ResolverOptions: &resolver.Options{},
+		Cluster: cluster,
+		ResolverOptions: &resolver.Options{
+			Discovery: disco,
+		},
 	}
 
 	err := cfg.Parse(args)

--- a/go/vt/vtadmin/vtsql/config_test.go
+++ b/go/vt/vtadmin/vtsql/config_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/grpcclient"
+	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
@@ -92,7 +93,7 @@ func TestConfigParse(t *testing.T) {
 
 		err = cfg.Parse(args)
 		assert.NoError(t, err)
-		assert.Equal(t, expectedTags, cfg.DiscoveryTags)
+		assert.Equal(t, expectedTags, cfg.ResolverOptions.DiscoveryTags)
 		assert.Equal(t, expectedCreds, cfg.Credentials)
 	})
 
@@ -144,7 +145,10 @@ func TestConfigParse(t *testing.T) {
 				Name: "testcluster",
 			},
 			DialPingTimeout: time.Millisecond * 500,
-			DiscoveryTags:   expectedTags,
+			ResolverOptions: &resolver.Options{
+				DiscoveryTags:    expectedTags,
+				DiscoveryTimeout: 100 * time.Millisecond,
+			},
 			Credentials:     expectedCreds,
 			CredentialsPath: path,
 		}

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vitessdriver"
+	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 	"vitess.io/vitess/go/vt/vtadmin/debug"
 	"vitess.io/vitess/go/vt/vtadmin/vtadminproto"
 
@@ -102,10 +103,6 @@ func New(cfg *Config) *VTGateProxy {
 		DialFunc:        vitessdriver.OpenWithConfiguration,
 		dialPingTimeout: cfg.DialPingTimeout,
 		resolver:        cfg.ResolverOptions.NewBuilder(cfg.Cluster.Id),
-		// resolver: resolver.NewBuilder(cfg.Cluster.Id, cfg.Discovery, resolver.Options{
-		// 	ResolveTimeout: time.Second, // TODO: add flag
-		// 	DiscoveryTags:  discoveryTags,
-		// }),
 	}
 }
 
@@ -165,7 +162,7 @@ func (vtgate *VTGateProxy) Dial(ctx context.Context, target string, opts ...grpc
 
 	conf := vitessdriver.Configuration{
 		Protocol:        fmt.Sprintf("grpc_%s", vtgate.cluster.Id),
-		Address:         fmt.Sprintf("%s://vtgate/", vtgate.resolver.Scheme()),
+		Address:         resolver.DialAddr(vtgate.resolver, "vtgate"),
 		Target:          target,
 		GRPCDialOptions: append(opts, grpc.WithInsecure(), grpc.WithResolvers(vtgate.resolver)),
 	}

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -269,9 +269,6 @@ func (vtgate *VTGateProxy) closeLocked() error {
 }
 
 // Debug implements debug.Debuggable for VTGateProxy.
-//
-// TODO (@ajm188): this is not safe to call concurrently with Dial. Add a mutex
-// to guard.
 func (vtgate *VTGateProxy) Debug() map[string]any {
 	vtgate.m.Lock()
 	defer vtgate.m.Unlock()

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -173,19 +173,6 @@ func (vtgate *VTGateProxy) Dial(ctx context.Context, target string, opts ...grpc
 
 	span.Annotate("is_noop", false)
 
-	if vtgate.host == "" {
-		gate, err := vtgate.discovery.DiscoverVTGateAddr(ctx, vtgate.discoveryTags)
-		if err != nil {
-			return fmt.Errorf("error discovering vtgate to dial: %w", err)
-		}
-
-		vtgate.host = gate
-		// re-annotate the hostname
-		span.Annotate("vtgate_host", gate)
-	}
-
-	log.Infof("Dialing %s ...", vtgate.host)
-
 	conf := vitessdriver.Configuration{
 		Protocol:        fmt.Sprintf("grpc_%s", vtgate.cluster.Id),
 		Address:         fmt.Sprintf("%s://vtgate/", vtgate.resolver.Scheme()),

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -130,7 +130,7 @@ func (vtgate *VTGateProxy) Dial(ctx context.Context, target string, opts ...grpc
 	span, _ := trace.NewSpan(ctx, "VTGateProxy.Dial")
 	defer span.Finish()
 
-	vtgate.annotateSpan(span)
+	vtadminproto.AnnotateClusterSpan(vtgate.cluster, span)
 
 	vtgate.m.Lock()
 	defer vtgate.m.Unlock()
@@ -188,7 +188,7 @@ func (vtgate *VTGateProxy) ShowTablets(ctx context.Context) (*sql.Rows, error) {
 	span, ctx := trace.NewSpan(ctx, "VTGateProxy.ShowTablets")
 	defer span.Finish()
 
-	vtgate.annotateSpan(span)
+	vtadminproto.AnnotateClusterSpan(vtgate.cluster, span)
 
 	if vtgate.conn == nil {
 		return nil, ErrConnClosed
@@ -207,7 +207,7 @@ func (vtgate *VTGateProxy) PingContext(ctx context.Context) error {
 	span, ctx := trace.NewSpan(ctx, "VTGateProxy.PingContext")
 	defer span.Finish()
 
-	vtgate.annotateSpan(span)
+	vtadminproto.AnnotateClusterSpan(vtgate.cluster, span)
 
 	return vtgate.pingContext(ctx)
 }
@@ -272,8 +272,4 @@ func (vtgate *VTGateProxy) Debug() map[string]any {
 	}
 
 	return m
-}
-
-func (vtgate *VTGateProxy) annotateSpan(span trace.Span) {
-	vtadminproto.AnnotateClusterSpan(vtgate.cluster, span)
 }

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -32,7 +32,6 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vitessdriver"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery"
-	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 	"vitess.io/vitess/go/vt/vtadmin/debug"
 	"vitess.io/vitess/go/vt/vtadmin/vtadminproto"
 
@@ -112,10 +111,11 @@ func New(cfg *Config) *VTGateProxy {
 		cfg:             cfg,
 		DialFunc:        vitessdriver.OpenWithConfiguration,
 		dialPingTimeout: cfg.DialPingTimeout,
-		resolver: resolver.NewBuilder(cfg.Cluster.Id, cfg.Discovery, resolver.Options{
-			ResolveTimeout: time.Second, // TODO: add flag
-			DiscoveryTags:  discoveryTags,
-		}),
+		resolver:        cfg.ResolverOptions.NewBuilder(cfg.Cluster.Id, cfg.Discovery),
+		// resolver: resolver.NewBuilder(cfg.Cluster.Id, cfg.Discovery, resolver.Options{
+		// 	ResolveTimeout: time.Second, // TODO: add flag
+		// 	DiscoveryTags:  discoveryTags,
+		// }),
 	}
 }
 

--- a/go/vt/vtadmin/vtsql/vtsql_test.go
+++ b/go/vt/vtadmin/vtsql/vtsql_test.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/vitessdriver"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery/fakediscovery"
+	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 	"vitess.io/vitess/go/vt/vtadmin/vtsql/fakevtsql"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -169,6 +170,8 @@ func TestDial(t *testing.T) {
 
 				tt.proxy.discovery = tt.disco
 			}
+
+			tt.proxy.resolver = resolver.NewBuilder(tt.proxy.cluster.Id, tt.disco, resolver.Options{})
 
 			err := tt.proxy.Dial(ctx, "")
 			if tt.shouldErr {

--- a/go/vt/vtadmin/vtsql/vtsql_test.go
+++ b/go/vt/vtadmin/vtsql/vtsql_test.go
@@ -159,13 +159,12 @@ func TestDial(t *testing.T) {
 				if len(tt.gates) > 0 {
 					tt.disco.AddTaggedGates(nil, tt.gates...)
 				}
-
-				tt.proxy.discovery = tt.disco
 			}
 
 			tt.proxy.resolver = (&resolver.Options{
+				Discovery:        tt.disco,
 				DiscoveryTimeout: 50 * time.Millisecond,
-			}).NewBuilder(tt.proxy.cluster.Id, tt.disco)
+			}).NewBuilder(tt.proxy.cluster.Id)
 
 			err := tt.proxy.Dial(ctx, "")
 			if tt.shouldErr {

--- a/go/vt/vtctl/grpcvtctldclient/client_test.go
+++ b/go/vt/vtctl/grpcvtctldclient/client_test.go
@@ -35,34 +35,6 @@ import (
 	vtctlservicepb "vitess.io/vitess/go/vt/proto/vtctlservice"
 )
 
-func TestWaitForReady(t *testing.T) {
-	ts := memorytopo.NewServer("cell1")
-	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return grpcvtctldserver.NewVtctldServer(ts)
-	})
-
-	testutil.WithTestServer(t, vtctld, func(t *testing.T, client vtctldclient.VtctldClient) {
-		ctx := context.Background()
-		err := client.WaitForReady(ctx)
-		assert.NoError(t, err)
-	})
-}
-
-func TestWaitForReadyShutdown(t *testing.T) {
-	ts := memorytopo.NewServer("cell1")
-	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
-		return grpcvtctldserver.NewVtctldServer(ts)
-	})
-
-	testutil.WithTestServer(t, vtctld, func(t *testing.T, client vtctldclient.VtctldClient) {
-		client.Close()
-		ctx := context.Background()
-		err := client.WaitForReady(ctx)
-
-		assert.Error(t, ErrConnectionShutdown, err)
-	})
-}
-
 func TestFindAllShardsInKeyspace(t *testing.T) {
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1")

--- a/go/vt/vtctl/localvtctldclient/client.go
+++ b/go/vt/vtctl/localvtctldclient/client.go
@@ -17,7 +17,6 @@ limitations under the License.
 package localvtctldclient
 
 import (
-	"context"
 	"errors"
 	"sync"
 
@@ -37,9 +36,6 @@ type localVtctldClient struct {
 
 // Close is part of the vtctldclient.VtctldClient interface.
 func (client *localVtctldClient) Close() error { return nil }
-
-// WaitForReady is part of the vtctldclient.VtctldClient interface.
-func (client *localVtctldClient) WaitForReady(ctx context.Context) error { return nil }
 
 //go:generate -command localvtctldclient go run ../vtctldclient/codegen
 //go:generate localvtctldclient -targetpkg localvtctldclient -impl localVtctldClient -out client_gen.go -local

--- a/go/vt/vtctl/vtctldclient/client.go
+++ b/go/vt/vtctl/vtctldclient/client.go
@@ -3,7 +3,6 @@
 package vtctldclient
 
 import (
-	"context"
 	"fmt"
 	"log"
 
@@ -15,10 +14,6 @@ type VtctldClient interface {
 
 	// Close augments the vtctlservicepb.VtctlClient interface with io.Closer.
 	Close() error
-
-	// WaitForReady waits until the connection to the vtctld is in a ready state,
-	// or until the context times out.
-	WaitForReady(ctx context.Context) error
 }
 
 // Factory is a function that creates new VtctldClients.


### PR DESCRIPTION
## Description

This PR introduces a custom grpc resolver based on our `discovery.Discovery` interface for use in both vtctld and vtgate grpc communication in vtadmin.

### Motivation and Rationale

There are two* main drawbacks to the current discovery/dialing approach in both vtctldclient and vtsql for vtadmin:
1. If there are N potential hosts to connect to, a given vtadmin process will pick exactly one and send all traffic for all requests to that host for its lifetime. This both unevenly distributes load and could in theory overwhelm the one host connected.
2. This one's only sort of a drawback, as we've taken steps in both #7709 and #9915 to detect and mitigate, but grpc's "design" "philosophy" is that it'll "handle" transient failures and try in the background (_forever ..._) to reestablish. This means if a vtctld/vtgate goes away permanently, we'll just spin and spin and surface errors back to the user rather than actually do anything useful.

This solves both of these problems by using the [`resolver` API](https://pkg.go.dev/google.golang.org/grpc@v1.37.0/resolver#Resolver) to use our discovery to (1) provide multiple hosts for grpc to multiplex the ClientConn over and (2) let grpc request a re-resolve (re-discovery, in our case) to update the address list if it's getting connection failures.

### Preparatory changes

1. Discovery now has `Discover{Vtctld,VTGate}Addrs` with the semantics of `Discover*Addr` (in that we run the addr template) but with N addresses returned instead.
2. maybe others i'll remember, or none!

### Overview

When you call `grpc.Dial(addr, opts...)`, grpc will parse `addr` as follows:

```
(<scheme>://)?(<authority>/)?<endpoint>
```

So, for example, the addr `dns://some_authority/foo.bar` will be parsed into `&Target{Scheme: "dns", Authority: "some_authority", Endpoint: "foo.bar"}`.

If there is a resolver registered for the given scheme (there is both a global and local registry; more on this in a bit), then grpc will use that resolver to resolve the target into one or more addresses to connect to. Otherwise (or if the target has no scheme, in the case of "/some_authority/foo.bar" or just "//foo.bar"), the default scheme (dns) is used. The `Dial` call then returns a single ClientConn, which has a SubConn for each address returned by the resolver, which grpc can choose (or not, depending on the balancer configuration, connection errors, etc) to multiplex the RPCs over. After enough transient failures, or periodically (opaquely, "when grpc damn well feels like it") it will request the resolver to `ResolveNow` again, and the resolver should call `UpdateState` with the new set of addresses that grpc should use for that `ClientConn`.

### `grpc.WithResolvers(...)`

As mentioned above, when `Dial`-ing, grpc has two resolver registries to check -- the global one (via [`resolver.Register`](https://pkg.go.dev/google.golang.org/grpc@v1.39.0/resolver#Register), and a ClientConn-local one. The latter takes precedence over the former, and is the one we're interested in. To add a resolver to the local registry, grpc provides a DialOption called [`WithResolvers`](https://pkg.go.dev/google.golang.org/grpc@v1.39.0#WithResolvers), which works exactly the same as `resolver.Register`, except that it's local to the ClientConn being dialed.

This allows us to have resolvers for each cluster, with their own configuration options, without risking – or having to reason about – them stepping over each other.

### Within VTAdmin

With all that prologue out of the way, let's talk about how this ties together within the context of vtadmin. Each cluster gets two resolvers, one for vtctldclient proxies, and one for vtgate proxies. Each of these uses the `cluster.Id` as the "scheme" (N.B. because we only ever dial with `WithResolvers`, things are local to the cluster so we could _probably_ get away with using the same scheme (e.g. "vtadmin://") across all clusters, but there's no harm (as far as I can tell) in doing things the way I currently have them either), and then either "vtctld" or "vtgate" as the "authority". In order to instruct grpc to use our resolvers, then, we do not dial an actual address, but instead either the "address" "{clusterId}://vtctld/" or "{clusterId}://vtgate/".

So, when creating a `VtctldClientProxy` or `VTGateProxy` from the cluster CLI options (via the Parse methods), we new up a `resolver.Options` (our type), which takes a Discovery implementation, and then parses any `DiscoveryTags`, `DiscoveryTimeout`, and `BalancerPolicy` (more on this one below) from the cluster flags. We then use the options to instantiate a resolver.Builder, which will get passed into `WithResolvers` when either the vtctld or vtgate client makes its call to Dial.

Within the resolver itself, whenever grpc asks us to ResolveNow, we use the `discoverFunc` (which is either `DiscoverVtctldAddrs` or `DiscoverVTGateAddrs`, depending on the "authority" (component)) to look up the appropriate set of addresses, which we send back to the ClientConn via UpdateState. We also log information about the resolution, and update the resolver to remember what address list it most recently sent to the ClientConn for debug purposes. Information about the resolver state is bubbled up from resolver instance => resolver builder => vtgate or vtctld proxy => cluster debug endpoint(s). For example, running locally the other day, I can show (I've changed some of the field names since then, but you get the idea):

```
➜  vitess git:(andrew/vtadmin-vtctldclient-resolver) ✗ curl -s localhost:14200/debug/clusters | jq '.[][].resolver | select(. != null)'  
{
  "discovery_tags": null,
  "resolve_timeout": 1000000000,
  "resolvers": [
    {
      "addr_list": [
        {
          "Addr": "localhost:15999",
          "ServerName": "",
          "Attributes": null,
          "Type": 0,
          "Metadata": null
        }
      ],
      "cluster": "local",
      "component": "vtctld",
      "created_at": "2022-03-28T13:17:06Z",
      "last_resolved_at": "2022-03-28T13:17:36Z"
    }
  ],
  "scheme": "local"
}
{
  "discovery_tags": [],
  "resolve_timeout": 1000000000,
  "resolvers": [
    {
      "addr_list": [
        {
          "Addr": "localhost:15991",
          "ServerName": "",
          "Attributes": null,
          "Type": 0,
          "Metadata": null
        }
      ],
      "cluster": "local",
      "component": "vtgate",
      "created_at": "2022-03-28T13:17:06Z",
      "last_resolved_at": "2022-03-28T13:17:36Z"
    }
  ],
  "scheme": "local"
}
```

### BalancerPolicy

The default balancer policy when none is specified is called `pick_first`. This is effectively grpc doing `net.Dial(state.Addresses[0])`, which still gives us the problem of "all the load goes to one host". To get around this, without making the resolver have to be aware of shuffling the host list, we expose new flag(s) (`--{vtctld,vtgate}-grpc-balancer-policy`) to allow users to specify the empty string (default policy), `pick_first` explicitly, or `round_robin`.

To simulate RR balancing, I added a non-existent vtctld to my static discovery file and enabled RR:

```
W0330 09:40:30.874143   57707 component.go:41] [core] grpc: addrConn.createTransport failed to connect to {localhost:20991  <nil> 0 <nil>}. Err: connection error: desc = "transport: Error while dialing dial tcp: lookup localhost: operation was canceled". Reconnecting...
W0330 09:40:30.874757   57707 component.go:41] [core] grpc: addrConn.createTransport failed to connect to {localhost:20991  <nil> 0 <nil>}. Err: connection error: desc = "transport: Error while dialing dial tcp [::1]:20991: connect: connection refused". Reconnecting...
```

```
diff --git a/examples/local/vtadmin/discovery.json b/examples/local/vtadmin/discovery.json
index def7dd50f8..a3e3f8c282 100644
--- a/examples/local/vtadmin/discovery.json
+++ b/examples/local/vtadmin/discovery.json
@@ -5,6 +5,12 @@
                 "fqdn": "localhost:15000",
                 "hostname": "localhost:15999"
             }
+        },
+        {
+            "host":{
+                "fqdn": "localhost:20000",
+                "hostname": "localhost:20991"
+            }
         }
     ],
     "vtgates": [
```

```
diff --git a/examples/local/scripts/vtadmin-up.sh b/examples/local/scripts/vtadmin-up.sh
index fae840847b..3b0fe53dcf 100755
--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -14,8 +14,9 @@ vtadmin \
   --http-tracing \
   --logtostderr \
   --alsologtostderr \
   --rbac-config="./vtadmin/rbac.yaml" \
-  --cluster "id=local,name=local,discovery=staticfile,discovery-staticfile-path=./vtadmin/discovery.json,tablet-fqdn-tmpl={{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
+  --cluster "id=local,name=local,discovery=staticfile,discovery-staticfile-path=./vtadmin/discovery.json,vtctld-grpc-balancer-policy=round_robin,tablet-fqdn-tmpl={{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
   > "${log_dir}/vtadmin-api.out" 2>&1 &
 vtadmin_pid=$!
 ```

After removing the RR policy flag (sending us back to `pick_first`, meaning we would pick the legit vtctld), things went back to normal:

```
I0330 09:42:00.050492   58484 resolver.go:243] [vtadmin.cluster.resolver]: resolving vtctlds (cluster local)
I0330 09:42:00.050554   58484 resolver.go:306] [vtadmin.cluster.resolver]: found 2 vtctlds (cluster local)
I0330 09:42:00.051179   58484 resolver.go:243] [vtadmin.cluster.resolver]: resolving vtgates (cluster local)
I0330 09:42:00.051216   58484 resolver.go:306] [vtadmin.cluster.resolver]: found 1 vtgates (cluster local)
I0330 09:42:00.051183   58484 resolver.go:243] [vtadmin.cluster.resolver]: resolving vtgates (cluster local)
I0330 09:42:00.053309   58484 resolver.go:306] [vtadmin.cluster.resolver]: found 1 vtgates (cluster local)
I0330 09:42:00.051487   58484 proxy.go:141] Established gRPC connection to vtctld
I0330 09:42:00.058540   58484 vtsql.go:145] Have valid connection to vtgate, reusing it.
```

### Appendix

Some notable changes:

1. vtctld and vtgate configs no longer take a Discovery directly. This was only used in order to discover a host to Dial, which is now handled by the resolver transparently, so they don't need it, and push the Discovery down to the resolver builder.
2. We can't annotate dial spans with the "host" we've dialed, because we don't know (it's all background in grpc/resolver code). As a compromise, we have a reference to the builder, which we implement `debug.Debuggable` for, so the address list and balancer policy show up in the /debug endpoint(s) for vtadmin and for a given cluster.

### Testing

In addition to the unit tests I updated and added, which all pass, this has been tested both against the local example and against development vtadmin deployments.

## Related Issue(s)

- #9915 
- #9422 
- #7709 (which is still useful / applicable, as it gives us additional healthchecking of the connections)

## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->