### PR TITLE
VStreamer: recompute table plan if a new table is encountered for the same id

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -601,14 +601,23 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 		// will generate a new plan and FIELD event.
 		id := ev.TableID(vs.format)
 
-		if _, ok := vs.plans[id]; ok {
-			return nil, nil
-		}
-
 		tm, err := ev.TableMap(vs.format)
 		if err != nil {
 			return nil, err
 		}
+
+		if plan, ok := vs.plans[id]; ok {
+			// When the underlying mysql server restarts the table map can change.
+			// Usually the vstreamer will also error out when this happens, and vstreamer re-initializes its table map.
+			// But if the vstreamer is not aware of the restart, we could get an id that matches one in the cache, but
+			// is for a different table. We then invalidate and recompute the plan for this id.
+			if plan == nil || plan.Table.Name == tm.Name {
+				return nil, nil
+			}
+			vs.plans[id] = nil
+			log.Infof("table map changed: id %d for %s has changed to %s", id, plan.Table.Name, tm.Name)
+		}
+
 		if tm.Database == "_vt" && tm.Name == "resharding_journal" {
 			// A journal is a special case that generates a JOURNAL event.
 			return nil, vs.buildJournalPlan(id, tm)


### PR DESCRIPTION
## Description

VStreamer caches a "table plan" for each new table it encounters via the binlog TABLE_MAP_EVENT.  

MySQL internally generates a unique (incrementing) id for a table as it inserts them into the binlog. The first time we see an id, we compute the table plan (essentially the list of columns with name and type information). If we get the same id again, we currently assume it is the same table and use the cached plan. 

However when the mysql server restarts it starts a new numbering for table ids and depending on the DMLs encountered the table id map can be different from the earlier one. 

Thus the binlog will contain the same id for different tables. While streaming from an older GTID, it can happen that we have cached a plan for table1 for id 100, say. And later we get the same id 100 for table2. Usually this will result in an error because the fields for the table will not match the row image. If a vstreamer encounters an error it just restarts after 5 seconds, when it recreates the plans and heals itself.

But in rare situations where the schemas are almost identical we can generate unrelated FieldEvents and consequently a DML for the wrong table.

This PR adds a check before using a cached plan. If the table name for the cached plan doesn't match that for the table map event, it nullifies that cache entry and recomputes the plan for this id.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)

#9976 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
