### PR TITLE
fix: make concatenate and limit concurrent safe

### DIFF
--- a/go/vt/vtgate/engine/limit.go
+++ b/go/vt/vtgate/engine/limit.go
@@ -88,6 +88,8 @@ func (l *Limit) TryStreamExecute(vcursor VCursor, bindVars map[string]*querypb.B
 		return err
 	}
 
+	bindVars = copyBindVars(bindVars)
+
 	// When offset is present, we hijack the limit value so we can calculate
 	// the offset in memory from the result of the scatter query with count + offset.
 	bindVars["__upper_limit"] = sqltypes.Int64BindVariable(int64(count + offset))


### PR DESCRIPTION
## Description
Some of our end-to-end tests for UNION were flaky and failing intermittently. These changes make the concatenate and the limit operator more resilient to running concurrent queries.

## Related Issue(s)
Fixes #9945
