### PR TITLE
Flaky TestReparentDuringWorkerCopy fix

### DIFF
--- a/go/test/endtoend/worker/worker_test.go
+++ b/go/test/endtoend/worker/worker_test.go
@@ -307,6 +307,11 @@ func verifySuccessfulWorkerCopyWithReparent(t *testing.T, isMysqlDown bool) {
 	localCluster.VtctlclientProcess.ExecuteCommand("PlannedReparentShard", "--", "--keyspace_shard",
 		"test_keyspace/-80", "--new_primary", shard0Replica.Alias)
 
+	// Sleep here for one second. (as long as executefetch_retry_time)
+	// We want the next PRS call to run after the first one has passed and the retry time for the
+	// failing query has expired. More info on why this is needed https://github.com/vitessio/vitess/issues/9985#issuecomment-1079666698
+	time.Sleep(1 * time.Second)
+
 	localCluster.VtctlclientProcess.ExecuteCommand("PlannedReparentShard", "--", "--keyspace_shard",
 		"test_keyspace/80-", "--new_primary", shard1Replica.Alias)
 


### PR DESCRIPTION


<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

As seen in the comment https://github.com/vitessio/vitess/issues/9985#issuecomment-1079666698, the test `TestReparentDuringWorkerCopy` is flaky.
This PR fixes by adding a 1 second wait between the two PRS calls. This makes it so that the retry loop of the failing query due to the first PRS would have run successfully by then.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #9985 

## Checklist
- [x] Should this PR be backported? No
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->