### PR TITLE
More testing for vreplication unique key violation protection

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-duplicate-entry2/alter
+++ b/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-duplicate-entry2/alter
@@ -1,0 +1,1 @@
+add column empty_text varchar(5) not null default '', add unique key uk_empty_text(empty_text)

--- a/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-duplicate-entry2/create.sql
+++ b/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-duplicate-entry2/create.sql
@@ -1,0 +1,10 @@
+drop table if exists onlineddl_test;
+create table onlineddl_test (
+  id int auto_increment,
+  val int not null,
+  ts timestamp,
+  primary key(id)
+) auto_increment=1;
+
+insert into onlineddl_test values (null, 2, now());
+insert into onlineddl_test values (null, 3, now());

--- a/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-duplicate-entry2/expect_failure
+++ b/go/test/endtoend/onlineddl/vrepl_suite/testdata/fail-duplicate-entry2/expect_failure
@@ -1,0 +1,1 @@
+Duplicate entry


### PR DESCRIPTION

## Description

This PR adds a endtoend test for the `vreplication` suite to validate a unique key violation scenario. The expecteation is for `vreplication` to fail the migration due to a unique key.

## Related Issue(s)

- #6926 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->