### PR TITLE
Compatibility Fixes for 1.18

### DIFF
--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install golangci-lint
-      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 
     - name: Clean Env
       run: $(go env GOPATH)/bin/golangci-lint cache clean

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,8 @@ linters:
     - structcheck
     - typecheck
     - varcheck
+    - staticcheck
+    - gosimple
 
     # Extras
     - gofmt
@@ -33,10 +35,6 @@ linters:
     # revive is a replacement for golint, but we do not run it in CI for now.
     # This is only enabled as a post-commit hook
     # - revive
-
-    # these linters have known issues with Go 1.18 but will be fixed soon
-    # - staticcheck
-    # - gosimple
 
 issues:
   exclude-rules:

--- a/go/vt/tlstest/tlstest.go
+++ b/go/vt/tlstest/tlstest.go
@@ -135,7 +135,13 @@ func CreateCA(root string) {
 
 	openssl("genrsa", "-out", key)
 
-	openssl("req", "-new", "-x509", "-nodes", "-days", "3600", "-batch",
+	openssl("req",
+		"-new",
+		"-x509",
+		"-days", "3600",
+		"-nodes",
+		"-batch",
+		"-sha256",
 		"-config", config,
 		"-key", key,
 		"-out", cert)
@@ -156,10 +162,15 @@ func CreateSignedCert(root, parent, serial, name, commonName string) {
 	if err := os.WriteFile(config, []byte(fmt.Sprintf(certConfig, commonName, commonName)), os.ModePerm); err != nil {
 		log.Fatalf("cannot write file %v: %v", config, err)
 	}
-	openssl("req", "-newkey", "rsa:2048", "-days", "3600", "-nodes",
+	openssl("req",
+		"-newkey", "rsa:2048",
+		"-days", "3600",
+		"-nodes",
 		"-batch",
+		"-sha256",
 		"-config", config,
-		"-keyout", key, "-out", req)
+		"-keyout", key,
+		"-out", req)
 	openssl("rsa", "-in", key, "-out", key)
 	openssl("x509", "-req",
 		"-in", req,

--- a/go/vt/tlstest/tlstest.go
+++ b/go/vt/tlstest/tlstest.go
@@ -37,7 +37,7 @@ default_ca = default_ca
 
 [ default_ca ]
 database = %s
-default_md = default
+default_md = sha256
 default_crl_days = 30
 
 [ req ]
@@ -174,6 +174,7 @@ func CreateSignedCert(root, parent, serial, name, commonName string) {
 	openssl("rsa", "-in", key, "-out", key)
 	openssl("x509", "-req",
 		"-in", req,
+		"-sha256",
 		"-days", "3600",
 		"-CA", caCert,
 		"-CAkey", caKey,

--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -16,7 +16,7 @@
 GOLANGCI_LINT=$(command -v golangci-lint >/dev/null 2>&1)
 if [ $? -eq 1 ]; then
   echo "Downloading golangci-lint..."
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
+  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 fi
 
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')

--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -16,7 +16,7 @@
 GOLANGCI_LINT=$(command -v golangci-lint >/dev/null 2>&1)
 if [ $? -eq 1 ]; then
   echo "Downloading golangci-lint..."
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
+  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
 fi
 
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')


### PR DESCRIPTION
## Description

Here's a couple things that were broken after the 1.18 upgrade:

- the `tlstest` package was signing our certs with SHA1, which has been deprecated in 1.18. Change it to use sha256 to fix the tests.
- `golangci-lint` was properly installed in CI, but not locally, so some people were seeing local errors.

cc @systay @ajm188

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->