### PR TITLE
VTTablet Init: fix race which can result in  schemacopy table not getting created

### DIFF
--- a/go/vt/vttablet/tabletserver/health_streamer.go
+++ b/go/vt/vttablet/tabletserver/health_streamer.go
@@ -396,7 +396,9 @@ func (hs *healthStreamer) InitSchemaLocked(conn *connpool.DBConn) (bool, error) 
 	for _, query := range mysql.VTDatabaseInit {
 		_, err := conn.Exec(hs.ctx, query, 1, false)
 		if err != nil {
-			return false, err
+			// it is possible that the _vt schema was already created by online ddl or vreplication as part of its init
+			// so ignore any errors and continue running future ddls
+			log.Infof("InitSchemaLocked: unable to run query %s: %s, ddl was probably already executed", query, err)
 		}
 	}
 


### PR DESCRIPTION
## Description
During the first tick of the health streamer the `schemacopy` table is attempted to be created. However we first try to create the `_vt` database. If it fails the following ddls are not run and hence the table doesn't get created. There are other code paths (in online ddl, vexec and vreplication) that can also create `_vt`. This race can result in the `schemacopy` table not getting created at all.
```
func (hs *healthStreamer) InitSchemaLocked(conn *connpool.DBConn) (bool, error) {
	for _, query := range mysql.VTDatabaseInit {
		_, err := conn.Exec(hs.ctx, query, 1, false)
		if err != nil {
			return false, err
		}
	}

	return true, nil
}
```
This PR ignores the errors from previous ddls to ensure that this race is handled.

### Note
The current method of ensuring that the `_vt` schema is up-to-date is not ideal: it is being done in multiple places in the code and we have several bugs surface where the correct code path was not followed resulting in the desired schema not being available.

There is a plan to consolidate the schema initialization and there should be a PR to achieve this soon. 

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->