### PR TITLE
ApplySchema: allow-zero-in-date embedded as query comment in call to ExecuteFetchAsDba

### DIFF
--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -437,10 +437,10 @@ func (exec *TabletExecutor) executeOneTablet(
 				return
 			}
 			if ddlStmt, ok := stmt.(sqlparser.DDLStatement); ok {
+				// Add comments directive to allow zero in date
 				comments := sqlparser.Comments{`/*vt+ allowZeroInDate=true */`}
-				if ddlStmt.GetComments() != nil {
-					comments = append(comments, ddlStmt.GetComments()...)
-				}
+				// Preserve potentially existing comments
+				comments = append(comments, ddlStmt.GetComments()...)
 				ddlStmt.SetComments(comments)
 				sql = sqlparser.String(ddlStmt)
 			}

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -438,6 +438,9 @@ func (exec *TabletExecutor) executeOneTablet(
 			}
 			if ddlStmt, ok := stmt.(sqlparser.DDLStatement); ok {
 				comments := sqlparser.Comments{`/*vt+ allowZeroInDate=true */`}
+				if ddlStmt.GetComments() != nil {
+					comments = append(comments, ddlStmt.GetComments()...)
+				}
 				ddlStmt.SetComments(comments)
 				sql = sqlparser.String(ddlStmt)
 			}

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -430,7 +430,17 @@ func (exec *TabletExecutor) executeOneTablet(
 		result, err = exec.tmc.ExecuteQuery(ctx, tablet, []byte(sql), 10)
 	} else {
 		if exec.ddlStrategySetting != nil && exec.ddlStrategySetting.IsAllowZeroInDateFlag() {
-			sql = fmt.Sprintf("set @@session.sql_mode=REPLACE(REPLACE(@@session.sql_mode, 'NO_ZERO_DATE', ''), 'NO_ZERO_IN_DATE', ''); %s", sql)
+			// --allow-zero-in-date Applies to DDLs
+			stmt, err := sqlparser.Parse(string(sql))
+			if err != nil {
+				errChan <- ShardWithError{Shard: tablet.Shard, Err: err.Error()}
+				return
+			}
+			if ddlStmt, ok := stmt.(sqlparser.DDLStatement); ok {
+				comments := sqlparser.Comments{`/*vt+ allowZeroInDate=true */`}
+				ddlStmt.SetComments(comments)
+				sql = sqlparser.String(ddlStmt)
+			}
 		}
 		result, err = exec.tmc.ExecuteFetchAsDba(ctx, tablet, false, []byte(sql), 10, false, true)
 	}


### PR DESCRIPTION


## Description

Fixes https://github.com/vitessio/vitess/issues/9996

Previously, `vtctlclient ApplySchema -skip_preflight -strategy "direct -allow-zero-in-date"` would prepend a given SQL with a `set @@session.sql_mode=` before sending to `ExecuteFetchAsDba`. This caused errors in the SQL to be silently dropped.

Now, instead, we embed a `/*vt+ allowZeroInDate=true */` hint in the SQL (only applicable to DDLs, which is fine, this is all we need).

Then, on `tabletmaneger`'s side, we parse the query, and if we're able to find such `/*vt+ allowZeroInDate=true */`, we run `set @@session.sql_mode=` before actually executing the SQL.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/9996
- caused by #9273 

Added validation test

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

