### PR TITLE
Fix: reserved connection retry logic when vttablet or mysql is down

### DIFF
--- a/go/test/endtoend/vtgate/reservedconn/reconnect3/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/reconnect3/main_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedconn
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"vitess.io/vitess/go/test/endtoend/utils"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	keyspaceName    = "ks"
+	cell            = "zone1"
+	hostname        = "localhost"
+	sqlSchema       = `create table test(id bigint primary key)Engine=InnoDB;`
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1
+		}
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      keyspaceName,
+			SchemaSQL: sqlSchema,
+		}
+		if err := clusterInstance.StartUnshardedKeyspace(*keyspace, 2, false); err != nil {
+			return 1
+		}
+
+		// Start vtgate
+		clusterInstance.VtGateExtraArgs = []string{"--enable_system_settings=true"}
+		if err := clusterInstance.StartVtgate(); err != nil {
+			return 1
+		}
+
+		vtParams = mysql.ConnParams{
+			Host: clusterInstance.Hostname,
+			Port: clusterInstance.VtgateMySQLPort,
+		}
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func TestMysqlDownServingChange(t *testing.T) {
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	utils.Exec(t, conn, "set default_week_format = 1")
+	_ = utils.Exec(t, conn, "select /*vt+ PLANNER=gen4 */ * from test")
+
+	primaryTablet := clusterInstance.Keyspaces[0].Shards[0].PrimaryTablet()
+	require.NoError(t,
+		primaryTablet.MysqlctlProcess.Stop())
+	require.NoError(t,
+		clusterInstance.VtctlclientProcess.ExecuteCommand("EmergencyReparentShard", "-keyspace_shard", "ks/0"))
+
+	// This should work without any error.
+	_ = utils.Exec(t, conn, "select /*vt+ PLANNER=gen4 */ * from test")
+}

--- a/go/test/endtoend/vtgate/reservedconn/reconnect4/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/reconnect4/main_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedconn
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"vitess.io/vitess/go/test/endtoend/utils"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	keyspaceName    = "ks"
+	cell            = "zone1"
+	hostname        = "localhost"
+	sqlSchema       = `create table test(id bigint primary key)Engine=InnoDB;`
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1
+		}
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      keyspaceName,
+			SchemaSQL: sqlSchema,
+		}
+		if err := clusterInstance.StartUnshardedKeyspace(*keyspace, 2, false); err != nil {
+			return 1
+		}
+
+		// Start vtgate
+		clusterInstance.VtGateExtraArgs = []string{"--enable_system_settings=true"}
+		if err := clusterInstance.StartVtgate(); err != nil {
+			return 1
+		}
+
+		vtParams = mysql.ConnParams{
+			Host: clusterInstance.Hostname,
+			Port: clusterInstance.VtgateMySQLPort,
+		}
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func TestVttabletDownServingChange(t *testing.T) {
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	utils.Exec(t, conn, "set default_week_format = 1")
+	_ = utils.Exec(t, conn, "select /*vt+ PLANNER=gen4 */ * from test")
+
+	primaryTablet := clusterInstance.Keyspaces[0].Shards[0].PrimaryTablet()
+	require.NoError(t,
+		primaryTablet.MysqlctlProcess.Stop())
+	// kill vttablet process
+	_ = primaryTablet.VttabletProcess.TearDown()
+	require.NoError(t,
+		clusterInstance.VtctlclientProcess.ExecuteCommand("EmergencyReparentShard", "-keyspace_shard", "ks/0"))
+
+	// This should work without any error.
+	_ = utils.Exec(t, conn, "select /*vt+ PLANNER=gen4 */ * from test")
+}

--- a/go/vt/vterrors/constants.go
+++ b/go/vt/vterrors/constants.go
@@ -27,6 +27,12 @@ const (
 // RxOp regex for operation not allowed error
 var RxOp = regexp.MustCompile("operation not allowed in state (NOT_SERVING|SHUTTING_DOWN)")
 
+// TxEngineClosed for transaction engine closed error
+const TxEngineClosed = "tx engine can't accept new connections in state %v"
+
+// RxTxEngineClosed regex for operation not allowed error
+var RxTxEngineClosed = regexp.MustCompile("tx engine can't accept new connections in state (NotServing|Transitioning)")
+
 // WrongTablet for invalid tablet type error
 const WrongTablet = "wrong tablet type"
 

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -183,7 +183,14 @@ func (stc *ScatterConn) ExecuteMultiShard(
 
 			qs, err = getQueryService(rs, info)
 			if err != nil {
-				return nil, err
+				if info.reservedID == 0 || info.transactionID != 0 {
+					return nil, err
+				}
+				err = session.ResetShard(info.alias)
+				if err != nil {
+					return nil, err
+				}
+				qs = rs.Gateway
 			}
 
 			retryRequest := func(exec func()) {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1464,7 +1464,7 @@ func convertErrorCode(err error) vtrpcpb.Code {
 		errCode = vtrpcpb.Code_RESOURCE_EXHAUSTED
 	case mysql.ERLockWaitTimeout:
 		errCode = vtrpcpb.Code_DEADLINE_EXCEEDED
-	case mysql.CRServerGone, mysql.ERServerShutdown, mysql.ERServerIsntAvailable:
+	case mysql.CRServerGone, mysql.ERServerShutdown, mysql.ERServerIsntAvailable, mysql.CRConnectionError, mysql.CRConnHostError:
 		errCode = vtrpcpb.Code_UNAVAILABLE
 	case mysql.ERFormNotFound, mysql.ERKeyNotFound, mysql.ERBadFieldError, mysql.ERNoSuchThread, mysql.ERUnknownTable, mysql.ERCantFindUDF, mysql.ERNonExistingGrant,
 		mysql.ERNoSuchTable, mysql.ERNonExistingTableGrant, mysql.ERKeyDoesNotExist:

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -214,7 +214,7 @@ func (te *TxEngine) isTxPoolAvailable(addToWaitGroup func(int)) error {
 
 	canOpenTransactions := te.state == AcceptingReadOnly || te.state == AcceptingReadAndWrite
 	if !canOpenTransactions {
-		return vterrors.Errorf(vtrpc.Code_UNAVAILABLE, "tx engine can't accept new connections in state %v", te.state)
+		return vterrors.Errorf(vtrpc.Code_UNAVAILABLE, vterrors.TxEngineClosed, te.state)
 	}
 	addToWaitGroup(1)
 	return nil

--- a/test/config.json
+++ b/test/config.json
@@ -840,6 +840,24 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
+		"vtgate_reserved_conn3": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/reservedconn/reconnect3"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_reservedconn",
+			"RetryMax": 1,
+			"Tags": []
+		},
+		"vtgate_reserved_conn4": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/reservedconn/reconnect4"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_reservedconn",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"vtgate_tablet_healthcheck_cache": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/tablet_healthcheck_cache", "-timeout", "45m"],


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes issues with reserved connection when the vttablet or the underlying MySQL process is down.
The VTGate needs to understand the error codes/messages to redirect it to the new available tablet.

```
Issue 1: 
MySQL error: code 2002/2003 when the underlying MySQL is not available for connection.

Issue 2: 
Vttablet is down: ERROR 1105 (HY000): tablet: cell:"zone1" uid:100 is either down or nonexistent

Issue 3:
Vttablet tx engine is closed: tx engine can't accept new connections in state NotServing
```

In all the above scenarios the current reserved connection held should be dropped and a new one should be created by calling the ReserveExecute API to the tablet.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [X] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->