### PR TITLE
[vtadmin-web] Fix default redirect on Tablet view

### DIFF
--- a/web/vtadmin/src/components/ReadOnlyGate.tsx
+++ b/web/vtadmin/src/components/ReadOnlyGate.tsx
@@ -23,12 +23,26 @@ import { isReadOnlyMode } from '../util/env';
  *      <ReadOnlyGate>
  *          <SomeSpicyWriteAction />
  *      </ReadOnlyGate>
+ *
+ * Do not use ReadOnly gate in a react-router Switch statement as it will break
+ * redirects. The following will NOT work:
+ *
+ *      <Switch>
+ *          <ReadOnlyGate>
+ *              <Route path="/private">readonly content</Route>
+ *          <ReadOnlyGate>
+ *      </Switch>
+ *
+ * In this case, you'll want to do the following:
+ *
+ *      <Switch>
+ *          {isReadOnlyMode &&
+ *              <Route path="/private">readonly content</Route>
+ *          }
+ *      </Switch>
  */
 export const ReadOnlyGate: React.FunctionComponent = ({ children }) => {
     if (isReadOnlyMode()) {
-        // Returning `null` here prevents ReadOnlyGate from being used around
-        // <Route> components within a switch statement; returning a fragment
-        // doesn't seem to have this issue.
         return <></>;
     }
 

--- a/web/vtadmin/src/components/routes/tablet/Tablet.test.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Tablet.test.tsx
@@ -89,9 +89,9 @@ describe('Tablet view', () => {
             (process as any).env.REACT_APP_READONLY_MODE = 'true';
         });
 
-        it('hides the "Advanced" tab', async () => {
+        it('hides the "Advanced" tab', () => {
             renderHelper();
-            const tab = await screen.queryByRole('tab', { name: 'Advanced' });
+            const tab = screen.queryByRole('tab', { name: 'Advanced' });
             expect(tab).toBe(null);
         });
 

--- a/web/vtadmin/src/components/routes/tablet/Tablet.test.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Tablet.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory, MemoryHistory } from 'history';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Route, Router, Switch } from 'react-router-dom';
+
+import { Tablet } from './Tablet';
+
+// Preserve process.env to restore its original values after each test run
+const ORIGINAL_PROCESS_ENV = { ...process.env };
+
+const INITIAL_HISTORY = ['/tablet/someCluster/someAlias/qps'];
+
+const renderHelper = (history?: MemoryHistory) => {
+    const queryClient = new QueryClient();
+
+    // Note that when testing redirects, history.location will have the expected value
+    // but window.location will not.
+    const _history = history || createMemoryHistory({ initialEntries: INITIAL_HISTORY });
+
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <Router history={_history}>
+                <Switch>
+                    <Route path="/tablet/:clusterID/:alias">
+                        <Tablet />
+                    </Route>
+
+                    {/* <Route path="/tablet/:clusterID/:alias">
+                        <Tablet />
+                    </Route> */}
+
+                    <Route>
+                        <div>no match</div>
+                    </Route>
+                </Switch>
+            </Router>
+        </QueryClientProvider>
+    );
+};
+
+describe('Tablet view', () => {
+    afterEach(() => {
+        process.env = ORIGINAL_PROCESS_ENV;
+        jest.clearAllMocks();
+    });
+
+    it('renders', async () => {
+        const history = createMemoryHistory({ initialEntries: INITIAL_HISTORY });
+        renderHelper(history);
+        const title = screen.getByRole('heading', { level: 1 });
+        expect(title).toHaveTextContent('someAlias');
+    });
+
+    it('displays the advanced tab', async () => {
+        expect(process.env.REACT_APP_READONLY_MODE).toBeFalsy();
+        renderHelper();
+
+        const tab = screen.getByRole('tab', { name: 'Advanced' });
+        expect(tab).toHaveTextContent('Advanced');
+    });
+
+    // Weird thing worth mentioning -- when testing redirects, the page contents doesn't render
+    // as expected, so any assertions against `screen` will (probably) not work. This might be an async thing;
+    // either way, this kind of redirect is deprecated in the next version of react-router.
+    it('redirects from "/" to a default route', () => {
+        const history = createMemoryHistory({ initialEntries: INITIAL_HISTORY });
+        renderHelper(history);
+        expect(history.location.pathname).toEqual('/tablet/someCluster/someAlias/qps');
+    });
+
+    describe('read-only mode', () => {
+        beforeEach(() => {
+            (process as any).env.REACT_APP_READONLY_MODE = 'true';
+        });
+
+        it('hides the "Advanced" tab', async () => {
+            renderHelper();
+            const tab = await screen.queryByRole('tab', { name: 'Advanced' });
+            expect(tab).toBe(null);
+        });
+
+        it('redirects from /advanced', () => {
+            const history = createMemoryHistory({ initialEntries: ['/tablet/someCluster/someAlias/advanced'] });
+            renderHelper(history);
+            expect(history.location.pathname).toEqual('/tablet/someCluster/someAlias/qps');
+        });
+    });
+});

--- a/web/vtadmin/src/components/routes/tablet/Tablet.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Tablet.tsx
@@ -17,6 +17,7 @@
 import { Link, Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom';
 import { useExperimentalTabletDebugVars, useTablet } from '../../../hooks/api';
 import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
+import { isReadOnlyMode } from '../../../util/env';
 import { formatDisplayType, formatState } from '../../../util/tablets';
 import { Code } from '../../Code';
 import { ContentContainer } from '../../layout/ContentContainer';
@@ -124,11 +125,11 @@ export const Tablet = () => {
                         </div>
                     </Route>
 
-                    <ReadOnlyGate>
+                    {!isReadOnlyMode() && (
                         <Route path={`${path}/advanced`}>
                             <Advanced tablet={tablet} />
                         </Route>
-                    </ReadOnlyGate>
+                    )}
 
                     <Redirect to={`${path}/qps`} />
                 </Switch>

--- a/web/vtadmin/src/components/tabs/Tab.tsx
+++ b/web/vtadmin/src/components/tabs/Tab.tsx
@@ -30,7 +30,12 @@ interface Props {
 
 export const Tab = ({ activeClassName, className, count, status, text, to }: Props) => {
     return (
-        <NavLink activeClassName={cx(style.active, activeClassName)} className={cx(style.tab, className)} to={to}>
+        <NavLink
+            activeClassName={cx(style.active, activeClassName)}
+            className={cx(style.tab, className)}
+            role="tab"
+            to={to}
+        >
             {!!status && <Pip className={style.pip} state={status} />}
             {text}
             {typeof count === 'number' && <span className={style.count}>{count}</span>}

--- a/web/vtadmin/src/components/tabs/TabContainer.tsx
+++ b/web/vtadmin/src/components/tabs/TabContainer.tsx
@@ -24,5 +24,9 @@ interface Props {
 }
 
 export const TabContainer: FunctionComponent<Props> = ({ children, className, size = 'medium' }) => {
-    return <div className={cx(style.tabContainer, style[size], className)}>{children}</div>;
+    return (
+        <div className={cx(style.tabContainer, style[size], className)} role="tablist">
+            {children}
+        </div>
+    );
 };


### PR DESCRIPTION
## Description

This fixes a bug where the ReadOnlyGate component was breaking redirects when used within a `<Switch>`:

<img width="1392" alt="Screen Shot 2022-03-30 at 11 25 08 AM" src="https://user-images.githubusercontent.com/855595/160874453-88999271-5de3-406f-8c0c-0c9648c3e442.png">

Turns out my comment was wholly incorrect! Writing these tests took way more time than it was worth! And, best of all, this will likely need to be [rewritten](https://reactrouter.com/docs/en/v6/upgrading/v5#remove-redirects-inside-switch) when we upgrade to the next version of react-router anyway! 🤡 Oh well.

## Related Issue(s)

N/A

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A 