### PR TITLE
sqlparser: cache comment parsing

### DIFF
--- a/go/tools/asthelpergen/clone_gen.go
+++ b/go/tools/asthelpergen/clone_gen.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"go/types"
 	"log"
+	"strings"
 
 	"github.com/dave/jennifer/jen"
 )
@@ -231,7 +232,7 @@ func (c *cloneGen) ptrToStructMethod(t types.Type, strct *types.Struct, spi gene
 	var fields []jen.Code
 	for i := 0; i < strct.NumFields(); i++ {
 		field := strct.Field(i)
-		if isBasic(field.Type()) || field.Name() == "_" {
+		if isBasic(field.Type()) || strings.HasPrefix(field.Name(), "_") {
 			continue
 		}
 		// out.Field = CloneType(n.Field)

--- a/go/tools/asthelpergen/equals_gen.go
+++ b/go/tools/asthelpergen/equals_gen.go
@@ -19,6 +19,7 @@ package asthelpergen
 import (
 	"fmt"
 	"go/types"
+	"strings"
 
 	"github.com/dave/jennifer/jen"
 )
@@ -147,7 +148,7 @@ func compareAllStructFields(strct *types.Struct, spi generatorSPI) jen.Code {
 	var others []*jen.Statement
 	for i := 0; i < strct.NumFields(); i++ {
 		field := strct.Field(i)
-		if field.Type().Underlying().String() == "any" || field.Name() == "_" {
+		if field.Type().Underlying().String() == "any" || strings.HasPrefix(field.Name(), "_") {
 			// we can safely ignore this, we do not want ast to contain `any` types.
 			continue
 		}

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -438,10 +438,8 @@ func (exec *TabletExecutor) executeOneTablet(
 			}
 			if ddlStmt, ok := stmt.(sqlparser.DDLStatement); ok {
 				// Add comments directive to allow zero in date
-				comments := sqlparser.Comments{`/*vt+ allowZeroInDate=true */`}
-				// Preserve potentially existing comments
-				comments = append(comments, ddlStmt.GetComments()...)
-				ddlStmt.SetComments(comments)
+				const directive = `/*vt+ allowZeroInDate=true */`
+				ddlStmt.SetComments(ddlStmt.GetParsedComments().Prepend(directive))
 				sql = sqlparser.String(ddlStmt)
 			}
 		}

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -127,22 +127,22 @@ func CanNormalize(stmt Statement) bool {
 
 // CachePlan takes Statement and returns true if the query plan should be cached
 func CachePlan(stmt Statement) bool {
-	var directives CommentDirectives
+	var comments *ParsedComments
 	switch stmt := stmt.(type) {
 	case *Select:
-		directives = ExtractCommentDirectives(stmt.Comments)
+		comments = stmt.Comments
 	case *Insert:
-		directives = ExtractCommentDirectives(stmt.Comments)
+		comments = stmt.Comments
 	case *Update:
-		directives = ExtractCommentDirectives(stmt.Comments)
+		comments = stmt.Comments
 	case *Delete:
-		directives = ExtractCommentDirectives(stmt.Comments)
+		comments = stmt.Comments
 	case *Union, *Stream:
 		return true
 	default:
 		return false
 	}
-	return !directives.IsSet(DirectiveSkipQueryPlanCache)
+	return !comments.Directives().IsSet(DirectiveSkipQueryPlanCache)
 }
 
 // MustRewriteAST takes Statement and returns true if RewriteAST must run on it for correct execution irrespective of user flags.

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -37,11 +37,15 @@ type (
 		SQLNode
 	}
 
+	Commented interface {
+		SetComments(comments Comments)
+		GetParsedComments() *ParsedComments
+	}
+
 	// SupportOptimizerHint represents a statement that accepts optimizer hints.
 	SupportOptimizerHint interface {
 		iSupportOptimizerHint()
-		SetComments(comments Comments)
-		GetComments() Comments
+		Commented
 	}
 
 	// SelectStatement any SELECT statement.
@@ -58,8 +62,7 @@ type (
 		SetWith(with *With)
 		MakeDistinct()
 		GetColumnCount() int
-		SetComments(comments Comments)
-		GetComments() Comments
+		Commented
 	}
 
 	// DDLStatement represents any DDL Statement
@@ -79,9 +82,8 @@ type (
 		AffectedTables() TableNames
 		SetTable(qualifier string, name string)
 		SetFromTables(tables TableNames)
-		SetComments(comments Comments)
-		GetComments() Comments
 		SetFullyParsed(fullyParsed bool)
+		Commented
 		Statement
 	}
 
@@ -230,7 +232,7 @@ type (
 		SQLCalcFoundRows bool
 		// The From field must be the first AST element of this struct so the rewriter sees it first
 		From        []TableExpr
-		Comments    Comments
+		Comments    *ParsedComments
 		SelectExprs SelectExprs
 		Where       *Where
 		With        *With
@@ -273,7 +275,7 @@ type (
 
 	// VStream represents a VSTREAM statement.
 	VStream struct {
-		Comments   Comments
+		Comments   *ParsedComments
 		SelectExpr SelectExpr
 		Table      TableName
 		Where      *Where
@@ -282,7 +284,7 @@ type (
 
 	// Stream represents a SELECT statement.
 	Stream struct {
-		Comments   Comments
+		Comments   *ParsedComments
 		SelectExpr SelectExpr
 		Table      TableName
 	}
@@ -297,7 +299,7 @@ type (
 	// If you add fields here, consider adding them to calls to validateUnshardedRoute.
 	Insert struct {
 		Action     InsertAction
-		Comments   Comments
+		Comments   *ParsedComments
 		Ignore     Ignore
 		Table      TableName
 		Partitions Partitions
@@ -316,7 +318,7 @@ type (
 	// If you add fields here, consider adding them to calls to validateUnshardedRoute.
 	Update struct {
 		With       *With
-		Comments   Comments
+		Comments   *ParsedComments
 		Ignore     Ignore
 		TableExprs TableExprs
 		Exprs      UpdateExprs
@@ -330,7 +332,7 @@ type (
 	Delete struct {
 		With       *With
 		Ignore     Ignore
-		Comments   Comments
+		Comments   *ParsedComments
 		Targets    TableNames
 		TableExprs TableExprs
 		Partitions Partitions
@@ -341,14 +343,14 @@ type (
 
 	// Set represents a SET statement.
 	Set struct {
-		Comments Comments
+		Comments *ParsedComments
 		Exprs    SetExprs
 	}
 
 	// SetTransaction represents a SET TRANSACTION statement.
 	SetTransaction struct {
 		SQLNode
-		Comments        Comments
+		Comments        *ParsedComments
 		Scope           Scope
 		Characteristics []Characteristic
 	}
@@ -370,7 +372,7 @@ type (
 
 	// DropDatabase represents a DROP database statement.
 	DropDatabase struct {
-		Comments Comments
+		Comments *ParsedComments
 		DBName   TableIdent
 		IfExists bool
 	}
@@ -387,7 +389,7 @@ type (
 
 	// CreateDatabase represents a CREATE database statement.
 	CreateDatabase struct {
-		Comments      Comments
+		Comments      *ParsedComments
 		DBName        TableIdent
 		IfNotExists   bool
 		CreateOptions []CollateAndCharset
@@ -445,13 +447,13 @@ type (
 	// ShowMigrationLogs represents a SHOW VITESS_MIGRATION '<uuid>' LOGS statement
 	ShowMigrationLogs struct {
 		UUID     string
-		Comments Comments
+		Comments *ParsedComments
 	}
 
 	// RevertMigration represents a REVERT VITESS_MIGRATION statement
 	RevertMigration struct {
 		UUID     string
-		Comments Comments
+		Comments *ParsedComments
 	}
 
 	// AlterMigrationType represents the type of operation in an ALTER VITESS_MIGRATION statement
@@ -469,7 +471,7 @@ type (
 		AlterOptions    []AlterOption
 		PartitionSpec   *PartitionSpec
 		PartitionOption *PartitionOption
-		Comments        Comments
+		Comments        *ParsedComments
 		FullyParsed     bool
 	}
 
@@ -479,14 +481,14 @@ type (
 		FromTables TableNames
 		// The following fields are set if a DDL was fully analyzed.
 		IfExists bool
-		Comments Comments
+		Comments *ParsedComments
 	}
 
 	// DropView represents a DROP VIEW statement.
 	DropView struct {
 		FromTables TableNames
 		IfExists   bool
-		Comments   Comments
+		Comments   *ParsedComments
 	}
 
 	// CreateTable represents a CREATE TABLE statement.
@@ -496,7 +498,7 @@ type (
 		IfNotExists bool
 		TableSpec   *TableSpec
 		OptLike     *OptLike
-		Comments    Comments
+		Comments    *ParsedComments
 		FullyParsed bool
 	}
 
@@ -510,7 +512,7 @@ type (
 		Select      SelectStatement
 		CheckOption string
 		IsReplace   bool
-		Comments    Comments
+		Comments    *ParsedComments
 	}
 
 	// AlterView represents a ALTER VIEW query
@@ -522,7 +524,7 @@ type (
 		Columns     Columns
 		Select      SelectStatement
 		CheckOption string
-		Comments    Comments
+		Comments    *ParsedComments
 	}
 
 	// Definer stores the user for AlterView and CreateView definers
@@ -618,7 +620,7 @@ type (
 	PrepareStmt struct {
 		Name                ColIdent
 		Statement           string
-		Comments            Comments
+		Comments            *ParsedComments
 		StatementIdentifier ColIdent
 	}
 
@@ -626,7 +628,7 @@ type (
 	// More info available on https://dev.mysql.com/doc/refman/8.0/en/execute.html
 	ExecuteStmt struct {
 		Name      ColIdent
-		Comments  Comments
+		Comments  *ParsedComments
 		Arguments Columns
 	}
 
@@ -634,7 +636,7 @@ type (
 	// More info available on https://dev.mysql.com/doc/refman/8.0/en/deallocate-prepare.html
 	DeallocateStmt struct {
 		Type     DeallocateStmtType
-		Comments Comments
+		Comments *ParsedComments
 		Name     ColIdent
 	}
 
@@ -1232,128 +1234,128 @@ func (node *TruncateTable) SetComments(comments Comments) {
 
 // SetComments implements DDLStatement.
 func (node *AlterTable) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments implements DDLStatement.
 func (node *CreateTable) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments implements DDLStatement.
 func (node *CreateView) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments implements DDLStatement.
 func (node *DropTable) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments implements DDLStatement.
 func (node *DropView) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments implements DDLStatement.
 func (node *AlterView) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments for RevertMigration, does not implement DDLStatement
 func (node *RevertMigration) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments for Delete
 func (node *Delete) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments for Insert
 func (node *Insert) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments for Stream
 func (node *Stream) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments for Update
 func (node *Update) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // SetComments for VStream
 func (node *VStream) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
-// GetComments implements DDLStatement.
-func (node *RenameTable) GetComments() Comments {
+// GetParsedComments implements DDLStatement.
+func (node *RenameTable) GetParsedComments() *ParsedComments {
 	// irrelevant
 	return nil
 }
 
-// GetComments implements DDLStatement.
-func (node *TruncateTable) GetComments() Comments {
+// GetParsedComments implements DDLStatement.
+func (node *TruncateTable) GetParsedComments() *ParsedComments {
 	// irrelevant
 	return nil
 }
 
-// GetComments implements DDLStatement.
-func (node *AlterTable) GetComments() Comments {
+// GetParsedComments implements DDLStatement.
+func (node *AlterTable) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
-// GetComments implements DDLStatement.
-func (node *CreateTable) GetComments() Comments {
+// GetParsedComments implements DDLStatement.
+func (node *CreateTable) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
-// GetComments implements DDLStatement.
-func (node *CreateView) GetComments() Comments {
+// GetParsedComments implements DDLStatement.
+func (node *CreateView) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
-// GetComments implements DDLStatement.
-func (node *DropTable) GetComments() Comments {
+// GetParsedComments implements DDLStatement.
+func (node *DropTable) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
-// GetComments implements DDLStatement.
-func (node *DropView) GetComments() Comments {
+// GetParsedComments implements DDLStatement.
+func (node *DropView) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
-// GetComments implements DDLStatement.
-func (node *AlterView) GetComments() Comments {
+// GetParsedComments implements DDLStatement.
+func (node *AlterView) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
-// GetComments implements SupportOptimizerHint.
-func (node *Delete) GetComments() Comments {
+// GetParsedComments implements SupportOptimizerHint.
+func (node *Delete) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
-// GetComments implements Insert.
-func (node *Insert) GetComments() Comments {
+// GetParsedComments implements Insert.
+func (node *Insert) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
-// GetComments implements Stream.
-func (node *Stream) GetComments() Comments {
+// GetParsedComments implements Stream.
+func (node *Stream) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
-// GetComments implements Update.
-func (node *Update) GetComments() Comments {
+// GetParsedComments implements Update.
+func (node *Update) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
-// GetComments implements VStream.
-func (node *VStream) GetComments() Comments {
+// GetParsedComments implements VStream.
+func (node *VStream) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
@@ -1804,6 +1806,18 @@ type ShowFilter struct {
 
 // Comments represents a list of comments.
 type Comments []string
+
+func (c Comments) Parsed() *ParsedComments {
+	if len(c) == 0 {
+		return nil
+	}
+	return &ParsedComments{comments: c}
+}
+
+type ParsedComments struct {
+	comments    Comments
+	_directives CommentDirectives
+}
 
 // SelectExprs represents SELECT expressions.
 type SelectExprs []SelectExpr

--- a/go/vt/sqlparser/ast_clone.go
+++ b/go/vt/sqlparser/ast_clone.go
@@ -85,8 +85,6 @@ func CloneSQLNode(in SQLNode) SQLNode {
 		return CloneRefOfColumnType(in)
 	case Columns:
 		return CloneColumns(in)
-	case Comments:
-		return CloneComments(in)
 	case *Commit:
 		return CloneRefOfCommit(in)
 	case *CommonTableExpr:
@@ -241,6 +239,8 @@ func CloneSQLNode(in SQLNode) SQLNode {
 		return CloneRefOfOtherRead(in)
 	case *ParenTableExpr:
 		return CloneRefOfParenTableExpr(in)
+	case *ParsedComments:
+		return CloneRefOfParsedComments(in)
 	case *PartitionDefinition:
 		return CloneRefOfPartitionDefinition(in)
 	case *PartitionOption:
@@ -481,7 +481,7 @@ func CloneRefOfAlterTable(n *AlterTable) *AlterTable {
 	out.AlterOptions = CloneSliceOfAlterOption(n.AlterOptions)
 	out.PartitionSpec = CloneRefOfPartitionSpec(n.PartitionSpec)
 	out.PartitionOption = CloneRefOfPartitionOption(n.PartitionOption)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	return &out
 }
 
@@ -495,7 +495,7 @@ func CloneRefOfAlterView(n *AlterView) *AlterView {
 	out.Definer = CloneRefOfDefiner(n.Definer)
 	out.Columns = CloneColumns(n.Columns)
 	out.Select = CloneSelectStatement(n.Select)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	return &out
 }
 
@@ -667,18 +667,6 @@ func CloneColumns(n Columns) Columns {
 	return res
 }
 
-// CloneComments creates a deep clone of the input.
-func CloneComments(n Comments) Comments {
-	if n == nil {
-		return nil
-	}
-	res := make(Comments, 0, len(n))
-	for _, x := range n {
-		res = append(res, x)
-	}
-	return res
-}
-
 // CloneRefOfCommit creates a deep clone of the input.
 func CloneRefOfCommit(n *Commit) *Commit {
 	if n == nil {
@@ -761,7 +749,7 @@ func CloneRefOfCreateDatabase(n *CreateDatabase) *CreateDatabase {
 		return nil
 	}
 	out := *n
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.DBName = CloneTableIdent(n.DBName)
 	out.CreateOptions = CloneSliceOfCollateAndCharset(n.CreateOptions)
 	return &out
@@ -776,7 +764,7 @@ func CloneRefOfCreateTable(n *CreateTable) *CreateTable {
 	out.Table = CloneTableName(n.Table)
 	out.TableSpec = CloneRefOfTableSpec(n.TableSpec)
 	out.OptLike = CloneRefOfOptLike(n.OptLike)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	return &out
 }
 
@@ -790,7 +778,7 @@ func CloneRefOfCreateView(n *CreateView) *CreateView {
 	out.Definer = CloneRefOfDefiner(n.Definer)
 	out.Columns = CloneColumns(n.Columns)
 	out.Select = CloneSelectStatement(n.Select)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	return &out
 }
 
@@ -811,7 +799,7 @@ func CloneRefOfDeallocateStmt(n *DeallocateStmt) *DeallocateStmt {
 		return nil
 	}
 	out := *n
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.Name = CloneColIdent(n.Name)
 	return &out
 }
@@ -841,7 +829,7 @@ func CloneRefOfDelete(n *Delete) *Delete {
 	}
 	out := *n
 	out.With = CloneRefOfWith(n.With)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.Targets = CloneTableNames(n.Targets)
 	out.TableExprs = CloneTableExprs(n.TableExprs)
 	out.Partitions = ClonePartitions(n.Partitions)
@@ -877,7 +865,7 @@ func CloneRefOfDropDatabase(n *DropDatabase) *DropDatabase {
 		return nil
 	}
 	out := *n
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.DBName = CloneTableIdent(n.DBName)
 	return &out
 }
@@ -899,7 +887,7 @@ func CloneRefOfDropTable(n *DropTable) *DropTable {
 	}
 	out := *n
 	out.FromTables = CloneTableNames(n.FromTables)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	return &out
 }
 
@@ -910,7 +898,7 @@ func CloneRefOfDropView(n *DropView) *DropView {
 	}
 	out := *n
 	out.FromTables = CloneTableNames(n.FromTables)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	return &out
 }
 
@@ -921,7 +909,7 @@ func CloneRefOfExecuteStmt(n *ExecuteStmt) *ExecuteStmt {
 	}
 	out := *n
 	out.Name = CloneColIdent(n.Name)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.Arguments = CloneColumns(n.Arguments)
 	return &out
 }
@@ -1110,7 +1098,7 @@ func CloneRefOfInsert(n *Insert) *Insert {
 		return nil
 	}
 	out := *n
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.Table = CloneTableName(n.Table)
 	out.Partitions = ClonePartitions(n.Partitions)
 	out.Columns = CloneColumns(n.Columns)
@@ -1473,6 +1461,16 @@ func CloneRefOfParenTableExpr(n *ParenTableExpr) *ParenTableExpr {
 	return &out
 }
 
+// CloneRefOfParsedComments creates a deep clone of the input.
+func CloneRefOfParsedComments(n *ParsedComments) *ParsedComments {
+	if n == nil {
+		return nil
+	}
+	out := *n
+	out.comments = CloneComments(n.comments)
+	return &out
+}
+
 // CloneRefOfPartitionDefinition creates a deep clone of the input.
 func CloneRefOfPartitionDefinition(n *PartitionDefinition) *PartitionDefinition {
 	if n == nil {
@@ -1539,7 +1537,7 @@ func CloneRefOfPrepareStmt(n *PrepareStmt) *PrepareStmt {
 	}
 	out := *n
 	out.Name = CloneColIdent(n.Name)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.StatementIdentifier = CloneColIdent(n.StatementIdentifier)
 	return &out
 }
@@ -1602,7 +1600,7 @@ func CloneRefOfRevertMigration(n *RevertMigration) *RevertMigration {
 		return nil
 	}
 	out := *n
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	return &out
 }
 
@@ -1648,7 +1646,7 @@ func CloneRefOfSelect(n *Select) *Select {
 	out := *n
 	out.Cache = CloneRefOfBool(n.Cache)
 	out.From = CloneSliceOfTableExpr(n.From)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.SelectExprs = CloneSelectExprs(n.SelectExprs)
 	out.Where = CloneRefOfWhere(n.Where)
 	out.With = CloneRefOfWith(n.With)
@@ -1687,7 +1685,7 @@ func CloneRefOfSet(n *Set) *Set {
 		return nil
 	}
 	out := *n
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.Exprs = CloneSetExprs(n.Exprs)
 	return &out
 }
@@ -1722,7 +1720,7 @@ func CloneRefOfSetTransaction(n *SetTransaction) *SetTransaction {
 	}
 	out := *n
 	out.SQLNode = CloneSQLNode(n.SQLNode)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.Characteristics = CloneSliceOfCharacteristic(n.Characteristics)
 	return &out
 }
@@ -1788,7 +1786,7 @@ func CloneRefOfShowMigrationLogs(n *ShowMigrationLogs) *ShowMigrationLogs {
 		return nil
 	}
 	out := *n
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	return &out
 }
 
@@ -1808,7 +1806,7 @@ func CloneRefOfStream(n *Stream) *Stream {
 		return nil
 	}
 	out := *n
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.SelectExpr = CloneSelectExpr(n.SelectExpr)
 	out.Table = CloneTableName(n.Table)
 	return &out
@@ -1989,7 +1987,7 @@ func CloneRefOfUpdate(n *Update) *Update {
 	}
 	out := *n
 	out.With = CloneRefOfWith(n.With)
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.TableExprs = CloneTableExprs(n.TableExprs)
 	out.Exprs = CloneUpdateExprs(n.Exprs)
 	out.Where = CloneRefOfWhere(n.Where)
@@ -2037,7 +2035,7 @@ func CloneRefOfVStream(n *VStream) *VStream {
 		return nil
 	}
 	out := *n
-	out.Comments = CloneComments(n.Comments)
+	out.Comments = CloneRefOfParsedComments(n.Comments)
 	out.SelectExpr = CloneSelectExpr(n.SelectExpr)
 	out.Table = CloneTableName(n.Table)
 	out.Where = CloneRefOfWhere(n.Where)
@@ -2873,6 +2871,18 @@ func CloneTableAndLockTypes(n TableAndLockTypes) TableAndLockTypes {
 	res := make(TableAndLockTypes, 0, len(n))
 	for _, x := range n {
 		res = append(res, CloneRefOfTableAndLockType(x))
+	}
+	return res
+}
+
+// CloneComments creates a deep clone of the input.
+func CloneComments(n Comments) Comments {
+	if n == nil {
+		return nil
+	}
+	res := make(Comments, 0, len(n))
+	for _, x := range n {
+		res = append(res, x)
 	}
 	return res
 }

--- a/go/vt/sqlparser/ast_equals.go
+++ b/go/vt/sqlparser/ast_equals.go
@@ -212,12 +212,6 @@ func EqualsSQLNode(inA, inB SQLNode) bool {
 			return false
 		}
 		return EqualsColumns(a, b)
-	case Comments:
-		b, ok := inB.(Comments)
-		if !ok {
-			return false
-		}
-		return EqualsComments(a, b)
 	case *Commit:
 		b, ok := inB.(*Commit)
 		if !ok {
@@ -680,6 +674,12 @@ func EqualsSQLNode(inA, inB SQLNode) bool {
 			return false
 		}
 		return EqualsRefOfParenTableExpr(a, b)
+	case *ParsedComments:
+		b, ok := inB.(*ParsedComments)
+		if !ok {
+			return false
+		}
+		return EqualsRefOfParsedComments(a, b)
 	case *PartitionDefinition:
 		b, ok := inB.(*PartitionDefinition)
 		if !ok {
@@ -1196,7 +1196,7 @@ func EqualsRefOfAlterTable(a, b *AlterTable) bool {
 		EqualsSliceOfAlterOption(a.AlterOptions, b.AlterOptions) &&
 		EqualsRefOfPartitionSpec(a.PartitionSpec, b.PartitionSpec) &&
 		EqualsRefOfPartitionOption(a.PartitionOption, b.PartitionOption) &&
-		EqualsComments(a.Comments, b.Comments)
+		EqualsRefOfParsedComments(a.Comments, b.Comments)
 }
 
 // EqualsRefOfAlterView does deep equals between the two objects.
@@ -1214,7 +1214,7 @@ func EqualsRefOfAlterView(a, b *AlterView) bool {
 		EqualsRefOfDefiner(a.Definer, b.Definer) &&
 		EqualsColumns(a.Columns, b.Columns) &&
 		EqualsSelectStatement(a.Select, b.Select) &&
-		EqualsComments(a.Comments, b.Comments)
+		EqualsRefOfParsedComments(a.Comments, b.Comments)
 }
 
 // EqualsRefOfAlterVschema does deep equals between the two objects.
@@ -1419,19 +1419,6 @@ func EqualsColumns(a, b Columns) bool {
 	return true
 }
 
-// EqualsComments does deep equals between the two objects.
-func EqualsComments(a, b Comments) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := 0; i < len(a); i++ {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
 // EqualsRefOfCommit does deep equals between the two objects.
 func EqualsRefOfCommit(a, b *Commit) bool {
 	if a == b {
@@ -1530,7 +1517,7 @@ func EqualsRefOfCreateDatabase(a, b *CreateDatabase) bool {
 	}
 	return a.IfNotExists == b.IfNotExists &&
 		a.FullyParsed == b.FullyParsed &&
-		EqualsComments(a.Comments, b.Comments) &&
+		EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		EqualsTableIdent(a.DBName, b.DBName) &&
 		EqualsSliceOfCollateAndCharset(a.CreateOptions, b.CreateOptions)
 }
@@ -1549,7 +1536,7 @@ func EqualsRefOfCreateTable(a, b *CreateTable) bool {
 		EqualsTableName(a.Table, b.Table) &&
 		EqualsRefOfTableSpec(a.TableSpec, b.TableSpec) &&
 		EqualsRefOfOptLike(a.OptLike, b.OptLike) &&
-		EqualsComments(a.Comments, b.Comments)
+		EqualsRefOfParsedComments(a.Comments, b.Comments)
 }
 
 // EqualsRefOfCreateView does deep equals between the two objects.
@@ -1568,7 +1555,7 @@ func EqualsRefOfCreateView(a, b *CreateView) bool {
 		EqualsRefOfDefiner(a.Definer, b.Definer) &&
 		EqualsColumns(a.Columns, b.Columns) &&
 		EqualsSelectStatement(a.Select, b.Select) &&
-		EqualsComments(a.Comments, b.Comments)
+		EqualsRefOfParsedComments(a.Comments, b.Comments)
 }
 
 // EqualsRefOfCurTimeFuncExpr does deep equals between the two objects.
@@ -1592,7 +1579,7 @@ func EqualsRefOfDeallocateStmt(a, b *DeallocateStmt) bool {
 		return false
 	}
 	return a.Type == b.Type &&
-		EqualsComments(a.Comments, b.Comments) &&
+		EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		EqualsColIdent(a.Name, b.Name)
 }
 
@@ -1629,7 +1616,7 @@ func EqualsRefOfDelete(a, b *Delete) bool {
 	}
 	return EqualsRefOfWith(a.With, b.With) &&
 		a.Ignore == b.Ignore &&
-		EqualsComments(a.Comments, b.Comments) &&
+		EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		EqualsTableNames(a.Targets, b.Targets) &&
 		EqualsTableExprs(a.TableExprs, b.TableExprs) &&
 		EqualsPartitions(a.Partitions, b.Partitions) &&
@@ -1670,7 +1657,7 @@ func EqualsRefOfDropDatabase(a, b *DropDatabase) bool {
 		return false
 	}
 	return a.IfExists == b.IfExists &&
-		EqualsComments(a.Comments, b.Comments) &&
+		EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		EqualsTableIdent(a.DBName, b.DBName)
 }
 
@@ -1697,7 +1684,7 @@ func EqualsRefOfDropTable(a, b *DropTable) bool {
 	return a.Temp == b.Temp &&
 		a.IfExists == b.IfExists &&
 		EqualsTableNames(a.FromTables, b.FromTables) &&
-		EqualsComments(a.Comments, b.Comments)
+		EqualsRefOfParsedComments(a.Comments, b.Comments)
 }
 
 // EqualsRefOfDropView does deep equals between the two objects.
@@ -1710,7 +1697,7 @@ func EqualsRefOfDropView(a, b *DropView) bool {
 	}
 	return a.IfExists == b.IfExists &&
 		EqualsTableNames(a.FromTables, b.FromTables) &&
-		EqualsComments(a.Comments, b.Comments)
+		EqualsRefOfParsedComments(a.Comments, b.Comments)
 }
 
 // EqualsRefOfExecuteStmt does deep equals between the two objects.
@@ -1722,7 +1709,7 @@ func EqualsRefOfExecuteStmt(a, b *ExecuteStmt) bool {
 		return false
 	}
 	return EqualsColIdent(a.Name, b.Name) &&
-		EqualsComments(a.Comments, b.Comments) &&
+		EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		EqualsColumns(a.Arguments, b.Arguments)
 }
 
@@ -1950,7 +1937,7 @@ func EqualsRefOfInsert(a, b *Insert) bool {
 		return false
 	}
 	return a.Action == b.Action &&
-		EqualsComments(a.Comments, b.Comments) &&
+		EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		a.Ignore == b.Ignore &&
 		EqualsTableName(a.Table, b.Table) &&
 		EqualsPartitions(a.Partitions, b.Partitions) &&
@@ -2364,6 +2351,17 @@ func EqualsRefOfParenTableExpr(a, b *ParenTableExpr) bool {
 	return EqualsTableExprs(a.Exprs, b.Exprs)
 }
 
+// EqualsRefOfParsedComments does deep equals between the two objects.
+func EqualsRefOfParsedComments(a, b *ParsedComments) bool {
+	if a == b {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return EqualsComments(a.comments, b.comments)
+}
+
 // EqualsRefOfPartitionDefinition does deep equals between the two objects.
 func EqualsRefOfPartitionDefinition(a, b *PartitionDefinition) bool {
 	if a == b {
@@ -2447,7 +2445,7 @@ func EqualsRefOfPrepareStmt(a, b *PrepareStmt) bool {
 	}
 	return a.Statement == b.Statement &&
 		EqualsColIdent(a.Name, b.Name) &&
-		EqualsComments(a.Comments, b.Comments) &&
+		EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		EqualsColIdent(a.StatementIdentifier, b.StatementIdentifier)
 }
 
@@ -2519,7 +2517,7 @@ func EqualsRefOfRevertMigration(a, b *RevertMigration) bool {
 		return false
 	}
 	return a.UUID == b.UUID &&
-		EqualsComments(a.Comments, b.Comments)
+		EqualsRefOfParsedComments(a.Comments, b.Comments)
 }
 
 // EqualsRefOfRollback does deep equals between the two objects.
@@ -2573,7 +2571,7 @@ func EqualsRefOfSelect(a, b *Select) bool {
 		a.SQLCalcFoundRows == b.SQLCalcFoundRows &&
 		EqualsRefOfBool(a.Cache, b.Cache) &&
 		EqualsSliceOfTableExpr(a.From, b.From) &&
-		EqualsComments(a.Comments, b.Comments) &&
+		EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		EqualsSelectExprs(a.SelectExprs, b.SelectExprs) &&
 		EqualsRefOfWhere(a.Where, b.Where) &&
 		EqualsRefOfWith(a.With, b.With) &&
@@ -2623,7 +2621,7 @@ func EqualsRefOfSet(a, b *Set) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return EqualsComments(a.Comments, b.Comments) &&
+	return EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		EqualsSetExprs(a.Exprs, b.Exprs)
 }
 
@@ -2662,7 +2660,7 @@ func EqualsRefOfSetTransaction(a, b *SetTransaction) bool {
 		return false
 	}
 	return EqualsSQLNode(a.SQLNode, b.SQLNode) &&
-		EqualsComments(a.Comments, b.Comments) &&
+		EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		a.Scope == b.Scope &&
 		EqualsSliceOfCharacteristic(a.Characteristics, b.Characteristics)
 }
@@ -2743,7 +2741,7 @@ func EqualsRefOfShowMigrationLogs(a, b *ShowMigrationLogs) bool {
 		return false
 	}
 	return a.UUID == b.UUID &&
-		EqualsComments(a.Comments, b.Comments)
+		EqualsRefOfParsedComments(a.Comments, b.Comments)
 }
 
 // EqualsRefOfStarExpr does deep equals between the two objects.
@@ -2765,7 +2763,7 @@ func EqualsRefOfStream(a, b *Stream) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return EqualsComments(a.Comments, b.Comments) &&
+	return EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		EqualsSelectExpr(a.SelectExpr, b.SelectExpr) &&
 		EqualsTableName(a.Table, b.Table)
 }
@@ -2975,7 +2973,7 @@ func EqualsRefOfUpdate(a, b *Update) bool {
 		return false
 	}
 	return EqualsRefOfWith(a.With, b.With) &&
-		EqualsComments(a.Comments, b.Comments) &&
+		EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		a.Ignore == b.Ignore &&
 		EqualsTableExprs(a.TableExprs, b.TableExprs) &&
 		EqualsUpdateExprs(a.Exprs, b.Exprs) &&
@@ -3028,7 +3026,7 @@ func EqualsRefOfVStream(a, b *VStream) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return EqualsComments(a.Comments, b.Comments) &&
+	return EqualsRefOfParsedComments(a.Comments, b.Comments) &&
 		EqualsSelectExpr(a.SelectExpr, b.SelectExpr) &&
 		EqualsTableName(a.Table, b.Table) &&
 		EqualsRefOfWhere(a.Where, b.Where) &&
@@ -4601,6 +4599,19 @@ func EqualsTableAndLockTypes(a, b TableAndLockTypes) bool {
 	}
 	for i := 0; i < len(a); i++ {
 		if !EqualsRefOfTableAndLockType(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// EqualsComments does deep equals between the two objects.
+func EqualsComments(a, b Comments) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
 			return false
 		}
 	}

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -929,8 +929,11 @@ func (node *OtherAdmin) Format(buf *TrackedBuffer) {
 }
 
 // Format formats the node.
-func (node Comments) Format(buf *TrackedBuffer) {
-	for _, c := range node {
+func (node *ParsedComments) Format(buf *TrackedBuffer) {
+	if node == nil {
+		return
+	}
+	for _, c := range node.comments {
 		buf.astPrintf(node, "%s ", c)
 	}
 }

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1249,8 +1249,11 @@ func (node *OtherAdmin) formatFast(buf *TrackedBuffer) {
 }
 
 // formatFast formats the node.
-func (node Comments) formatFast(buf *TrackedBuffer) {
-	for _, c := range node {
+func (node *ParsedComments) formatFast(buf *TrackedBuffer) {
+	if node == nil {
+		return
+	}
+	for _, c := range node.comments {
 		buf.WriteString(c)
 		buf.WriteByte(' ')
 	}

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -291,37 +291,41 @@ func (ct *ColumnType) SQLType() querypb.Type {
 // If the list is empty, one will be created containing the query hint.
 // If the list already contains a query hint, the given string will be merged with the existing one.
 // This is done because only one query hint is allowed per query.
-func (node Comments) AddQueryHint(queryHint string) (Comments, error) {
+func (node *ParsedComments) AddQueryHint(queryHint string) (Comments, error) {
 	if queryHint == "" {
-		return node, nil
+		if node == nil {
+			return nil, nil
+		}
+		return node.comments, nil
 	}
-	queryHintCommentStr := fmt.Sprintf("%s %s */", queryOptimizerPrefix, queryHint)
-	if len(node) == 0 {
-		return Comments{queryHintCommentStr}, nil
-	}
+
 	var newComments Comments
 	var hasQueryHint bool
-	for _, comment := range node {
-		if strings.HasPrefix(comment, queryOptimizerPrefix) {
-			if hasQueryHint {
-				return nil, vterrors.New(vtrpcpb.Code_INTERNAL, "Must have only one query hint")
-			}
-			hasQueryHint = true
-			idx := strings.Index(comment, "*/")
-			if idx == -1 {
-				return nil, vterrors.New(vtrpcpb.Code_INTERNAL, "Query hint comment is malformed")
-			}
-			if strings.Contains(comment, queryHint) {
-				newComments = append(Comments{comment}, newComments...)
+
+	if node != nil {
+		for _, comment := range node.comments {
+			if strings.HasPrefix(comment, queryOptimizerPrefix) {
+				if hasQueryHint {
+					return nil, vterrors.New(vtrpcpb.Code_INTERNAL, "Must have only one query hint")
+				}
+				hasQueryHint = true
+				idx := strings.Index(comment, "*/")
+				if idx == -1 {
+					return nil, vterrors.New(vtrpcpb.Code_INTERNAL, "Query hint comment is malformed")
+				}
+				if strings.Contains(comment, queryHint) {
+					newComments = append(Comments{comment}, newComments...)
+					continue
+				}
+				newComment := fmt.Sprintf("%s %s */", strings.TrimSpace(comment[:idx]), queryHint)
+				newComments = append(Comments{newComment}, newComments...)
 				continue
 			}
-			newComment := fmt.Sprintf("%s %s */", strings.TrimSpace(comment[:idx]), queryHint)
-			newComments = append(Comments{newComment}, newComments...)
-			continue
+			newComments = append(newComments, comment)
 		}
-		newComments = append(newComments, comment)
 	}
 	if !hasQueryHint {
+		queryHintCommentStr := fmt.Sprintf("%s %s */", queryOptimizerPrefix, queryHint)
 		newComments = append(Comments{queryHintCommentStr}, newComments...)
 	}
 	return newComments, nil
@@ -640,7 +644,7 @@ func NewSelect(comments Comments, exprs SelectExprs, selectOptions []string, int
 	}
 	return &Select{
 		Cache:            cache,
-		Comments:         comments,
+		Comments:         comments.Parsed(),
 		Distinct:         distinct,
 		StraightJoinHint: straightJoinHint,
 		SQLCalcFoundRows: sqlFoundRows,
@@ -865,11 +869,11 @@ func (node *Select) GetColumnCount() int {
 
 // SetComments implements the SelectStatement interface
 func (node *Select) SetComments(comments Comments) {
-	node.Comments = comments
+	node.Comments = comments.Parsed()
 }
 
 // GetComments implements the SelectStatement interface
-func (node *Select) GetComments() Comments {
+func (node *Select) GetParsedComments() *ParsedComments {
 	return node.Comments
 }
 
@@ -981,8 +985,8 @@ func (node *Union) SetComments(comments Comments) {
 }
 
 // GetComments implements the SelectStatement interface
-func (node *Union) GetComments() Comments {
-	return node.Left.GetComments()
+func (node *Union) GetParsedComments() *ParsedComments {
+	return node.Left.GetParsedComments()
 }
 
 func requiresParen(stmt SelectStatement) bool {

--- a/go/vt/sqlparser/ast_funcs_test.go
+++ b/go/vt/sqlparser/ast_funcs_test.go
@@ -26,51 +26,52 @@ import (
 
 func TestAddQueryHint(t *testing.T) {
 	tcs := []struct {
-		node      Comments
+		comments  Comments
 		queryHint string
 		expected  Comments
 		err       string
 	}{
 		{
-			node:      Comments{},
+			comments:  Comments{},
 			queryHint: "",
-			expected:  Comments{},
+			expected:  nil,
 		},
 		{
-			node:      Comments{},
+			comments:  Comments{},
 			queryHint: "SET_VAR(aa)",
 			expected:  Comments{"/*+ SET_VAR(aa) */"},
 		},
 		{
-			node:      Comments{"/* toto */"},
+			comments:  Comments{"/* toto */"},
 			queryHint: "SET_VAR(aa)",
 			expected:  Comments{"/*+ SET_VAR(aa) */", "/* toto */"},
 		},
 		{
-			node:      Comments{"/* toto */", "/*+ SET_VAR(bb) */"},
+			comments:  Comments{"/* toto */", "/*+ SET_VAR(bb) */"},
 			queryHint: "SET_VAR(aa)",
 			expected:  Comments{"/*+ SET_VAR(bb) SET_VAR(aa) */", "/* toto */"},
 		},
 		{
-			node:      Comments{"/* toto */", "/*+ SET_VAR(bb) "},
+			comments:  Comments{"/* toto */", "/*+ SET_VAR(bb) "},
 			queryHint: "SET_VAR(aa)",
 			err:       "Query hint comment is malformed",
 		},
 		{
-			node:      Comments{"/* toto */", "/*+ SET_VAR(bb) */", "/*+ SET_VAR(cc) */"},
+			comments:  Comments{"/* toto */", "/*+ SET_VAR(bb) */", "/*+ SET_VAR(cc) */"},
 			queryHint: "SET_VAR(aa)",
 			err:       "Must have only one query hint",
 		},
 		{
-			node:      Comments{"/*+ SET_VAR(bb) */"},
+			comments:  Comments{"/*+ SET_VAR(bb) */"},
 			queryHint: "SET_VAR(bb)",
 			expected:  Comments{"/*+ SET_VAR(bb) */"},
 		},
 	}
 
 	for i, tc := range tcs {
-		t.Run(fmt.Sprintf("%d %s", i, String(tc.expected)), func(t *testing.T) {
-			got, err := tc.node.AddQueryHint(tc.queryHint)
+		comments := tc.comments.Parsed()
+		t.Run(fmt.Sprintf("%d %s", i, String(comments)), func(t *testing.T) {
+			got, err := comments.AddQueryHint(tc.queryHint)
 			if tc.err != "" {
 				require.EqualError(t, err, tc.err)
 			} else {

--- a/go/vt/sqlparser/ast_rewrite.go
+++ b/go/vt/sqlparser/ast_rewrite.go
@@ -84,8 +84,6 @@ func (a *application) rewriteSQLNode(parent SQLNode, node SQLNode, replacer repl
 		return a.rewriteRefOfColumnType(parent, node, replacer)
 	case Columns:
 		return a.rewriteColumns(parent, node, replacer)
-	case Comments:
-		return a.rewriteComments(parent, node, replacer)
 	case *Commit:
 		return a.rewriteRefOfCommit(parent, node, replacer)
 	case *CommonTableExpr:
@@ -240,6 +238,8 @@ func (a *application) rewriteSQLNode(parent SQLNode, node SQLNode, replacer repl
 		return a.rewriteRefOfOtherRead(parent, node, replacer)
 	case *ParenTableExpr:
 		return a.rewriteRefOfParenTableExpr(parent, node, replacer)
+	case *ParsedComments:
+		return a.rewriteRefOfParsedComments(parent, node, replacer)
 	case *PartitionDefinition:
 		return a.rewriteRefOfPartitionDefinition(parent, node, replacer)
 	case *PartitionOption:
@@ -685,8 +685,8 @@ func (a *application) rewriteRefOfAlterTable(parent SQLNode, node *AlterTable, r
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*AlterTable).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*AlterTable).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -732,8 +732,8 @@ func (a *application) rewriteRefOfAlterView(parent SQLNode, node *AlterView, rep
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*AlterView).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*AlterView).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -1263,36 +1263,6 @@ func (a *application) rewriteColumns(parent SQLNode, node Columns, replacer repl
 	}
 	return true
 }
-func (a *application) rewriteComments(parent SQLNode, node Comments, replacer replacerFunc) bool {
-	if node == nil {
-		return true
-	}
-	if a.pre != nil {
-		a.cur.replacer = replacer
-		a.cur.parent = parent
-		a.cur.node = node
-		kontinue := !a.pre(&a.cur)
-		if a.cur.revisit {
-			node = a.cur.node.(Comments)
-			a.cur.revisit = false
-			return a.rewriteComments(parent, node, replacer)
-		}
-		if kontinue {
-			return true
-		}
-	}
-	if a.post != nil {
-		if a.pre == nil {
-			a.cur.replacer = replacer
-			a.cur.parent = parent
-			a.cur.node = node
-		}
-		if !a.post(&a.cur) {
-			return false
-		}
-	}
-	return true
-}
 func (a *application) rewriteRefOfCommit(parent SQLNode, node *Commit, replacer replacerFunc) bool {
 	if node == nil {
 		return true
@@ -1526,8 +1496,8 @@ func (a *application) rewriteRefOfCreateDatabase(parent SQLNode, node *CreateDat
 			return true
 		}
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*CreateDatabase).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*CreateDatabase).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -1573,8 +1543,8 @@ func (a *application) rewriteRefOfCreateTable(parent SQLNode, node *CreateTable,
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*CreateTable).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*CreateTable).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -1620,8 +1590,8 @@ func (a *application) rewriteRefOfCreateView(parent SQLNode, node *CreateView, r
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*CreateView).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*CreateView).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -1679,8 +1649,8 @@ func (a *application) rewriteRefOfDeallocateStmt(parent SQLNode, node *Deallocat
 			return true
 		}
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*DeallocateStmt).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*DeallocateStmt).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -1764,8 +1734,8 @@ func (a *application) rewriteRefOfDelete(parent SQLNode, node *Delete, replacer 
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*Delete).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*Delete).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -1875,8 +1845,8 @@ func (a *application) rewriteRefOfDropDatabase(parent SQLNode, node *DropDatabas
 			return true
 		}
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*DropDatabase).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*DropDatabase).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -1939,8 +1909,8 @@ func (a *application) rewriteRefOfDropTable(parent SQLNode, node *DropTable, rep
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*DropTable).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*DropTable).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -1971,8 +1941,8 @@ func (a *application) rewriteRefOfDropView(parent SQLNode, node *DropView, repla
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*DropView).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*DropView).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -2003,8 +1973,8 @@ func (a *application) rewriteRefOfExecuteStmt(parent SQLNode, node *ExecuteStmt,
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*ExecuteStmt).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*ExecuteStmt).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -2548,8 +2518,8 @@ func (a *application) rewriteRefOfInsert(parent SQLNode, node *Insert, replacer 
 			return true
 		}
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*Insert).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*Insert).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -3586,6 +3556,30 @@ func (a *application) rewriteRefOfParenTableExpr(parent SQLNode, node *ParenTabl
 	}
 	return true
 }
+func (a *application) rewriteRefOfParsedComments(parent SQLNode, node *ParsedComments, replacer replacerFunc) bool {
+	if node == nil {
+		return true
+	}
+	if a.pre != nil {
+		a.cur.replacer = replacer
+		a.cur.parent = parent
+		a.cur.node = node
+		if !a.pre(&a.cur) {
+			return true
+		}
+	}
+	if a.post != nil {
+		if a.pre == nil {
+			a.cur.replacer = replacer
+			a.cur.parent = parent
+			a.cur.node = node
+		}
+		if !a.post(&a.cur) {
+			return false
+		}
+	}
+	return true
+}
 func (a *application) rewriteRefOfPartitionDefinition(parent SQLNode, node *PartitionDefinition, replacer replacerFunc) bool {
 	if node == nil {
 		return true
@@ -3791,8 +3785,8 @@ func (a *application) rewriteRefOfPrepareStmt(parent SQLNode, node *PrepareStmt,
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*PrepareStmt).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*PrepareStmt).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -3975,8 +3969,8 @@ func (a *application) rewriteRefOfRevertMigration(parent SQLNode, node *RevertMi
 			return true
 		}
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*RevertMigration).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*RevertMigration).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -4113,8 +4107,8 @@ func (a *application) rewriteRefOfSelect(parent SQLNode, node *Select, replacer 
 			return false
 		}
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*Select).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*Select).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -4241,8 +4235,8 @@ func (a *application) rewriteRefOfSet(parent SQLNode, node *Set, replacer replac
 			return true
 		}
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*Set).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*Set).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -4347,8 +4341,8 @@ func (a *application) rewriteRefOfSetTransaction(parent SQLNode, node *SetTransa
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*SetTransaction).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*SetTransaction).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -4538,8 +4532,8 @@ func (a *application) rewriteRefOfShowMigrationLogs(parent SQLNode, node *ShowMi
 			return true
 		}
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*ShowMigrationLogs).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*ShowMigrationLogs).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -4592,8 +4586,8 @@ func (a *application) rewriteRefOfStream(parent SQLNode, node *Stream, replacer 
 			return true
 		}
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*Stream).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*Stream).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -5161,8 +5155,8 @@ func (a *application) rewriteRefOfUpdate(parent SQLNode, node *Update, replacer 
 	}) {
 		return false
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*Update).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*Update).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}
@@ -5309,8 +5303,8 @@ func (a *application) rewriteRefOfVStream(parent SQLNode, node *VStream, replace
 			return true
 		}
 	}
-	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
-		parent.(*VStream).Comments = newNode.(Comments)
+	if !a.rewriteRefOfParsedComments(node, node.Comments, func(newNode, parent SQLNode) {
+		parent.(*VStream).Comments = newNode.(*ParsedComments)
 	}) {
 		return false
 	}

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -311,7 +311,7 @@ func (er *astRewriter) rewriteAliasedExpr(node *AliasedExpr) (*BindVarNeeds, err
 func (er *astRewriter) rewrite(cursor *Cursor) bool {
 	// Add SET_VAR comment to this node if it supports it and is needed
 	if supportOptimizerHint, supportsOptimizerHint := cursor.Node().(SupportOptimizerHint); supportsOptimizerHint && er.setVarComment != "" {
-		newComments, err := supportOptimizerHint.GetComments().AddQueryHint(er.setVarComment)
+		newComments, err := supportOptimizerHint.GetParsedComments().AddQueryHint(er.setVarComment)
 		if err != nil {
 			er.err = err
 			return false

--- a/go/vt/sqlparser/ast_visit.go
+++ b/go/vt/sqlparser/ast_visit.go
@@ -84,8 +84,6 @@ func VisitSQLNode(in SQLNode, f Visit) error {
 		return VisitRefOfColumnType(in, f)
 	case Columns:
 		return VisitColumns(in, f)
-	case Comments:
-		return VisitComments(in, f)
 	case *Commit:
 		return VisitRefOfCommit(in, f)
 	case *CommonTableExpr:
@@ -240,6 +238,8 @@ func VisitSQLNode(in SQLNode, f Visit) error {
 		return VisitRefOfOtherRead(in, f)
 	case *ParenTableExpr:
 		return VisitRefOfParenTableExpr(in, f)
+	case *ParsedComments:
+		return VisitRefOfParsedComments(in, f)
 	case *PartitionDefinition:
 		return VisitRefOfPartitionDefinition(in, f)
 	case *PartitionOption:
@@ -519,7 +519,7 @@ func VisitRefOfAlterTable(in *AlterTable, f Visit) error {
 	if err := VisitRefOfPartitionOption(in.PartitionOption, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	return nil
@@ -543,7 +543,7 @@ func VisitRefOfAlterView(in *AlterView, f Visit) error {
 	if err := VisitSelectStatement(in.Select, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	return nil
@@ -782,10 +782,6 @@ func VisitColumns(in Columns, f Visit) error {
 	}
 	return nil
 }
-func VisitComments(in Comments, f Visit) error {
-	_, err := f(in)
-	return err
-}
 func VisitRefOfCommit(in *Commit, f Visit) error {
 	if in == nil {
 		return nil
@@ -895,7 +891,7 @@ func VisitRefOfCreateDatabase(in *CreateDatabase, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitTableIdent(in.DBName, f); err != nil {
@@ -919,7 +915,7 @@ func VisitRefOfCreateTable(in *CreateTable, f Visit) error {
 	if err := VisitRefOfOptLike(in.OptLike, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	return nil
@@ -943,7 +939,7 @@ func VisitRefOfCreateView(in *CreateView, f Visit) error {
 	if err := VisitSelectStatement(in.Select, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	return nil
@@ -970,7 +966,7 @@ func VisitRefOfDeallocateStmt(in *DeallocateStmt, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitColIdent(in.Name, f); err != nil {
@@ -1006,7 +1002,7 @@ func VisitRefOfDelete(in *Delete, f Visit) error {
 	if err := VisitRefOfWith(in.With, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitTableNames(in.Targets, f); err != nil {
@@ -1060,7 +1056,7 @@ func VisitRefOfDropDatabase(in *DropDatabase, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitTableIdent(in.DBName, f); err != nil {
@@ -1090,7 +1086,7 @@ func VisitRefOfDropTable(in *DropTable, f Visit) error {
 	if err := VisitTableNames(in.FromTables, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	return nil
@@ -1105,7 +1101,7 @@ func VisitRefOfDropView(in *DropView, f Visit) error {
 	if err := VisitTableNames(in.FromTables, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	return nil
@@ -1120,7 +1116,7 @@ func VisitRefOfExecuteStmt(in *ExecuteStmt, f Visit) error {
 	if err := VisitColIdent(in.Name, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitColumns(in.Arguments, f); err != nil {
@@ -1362,7 +1358,7 @@ func VisitRefOfInsert(in *Insert, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitTableName(in.Table, f); err != nil {
@@ -1813,6 +1809,15 @@ func VisitRefOfParenTableExpr(in *ParenTableExpr, f Visit) error {
 	}
 	return nil
 }
+func VisitRefOfParsedComments(in *ParsedComments, f Visit) error {
+	if in == nil {
+		return nil
+	}
+	if cont, err := f(in); err != nil || !cont {
+		return err
+	}
+	return nil
+}
 func VisitRefOfPartitionDefinition(in *PartitionDefinition, f Visit) error {
 	if in == nil {
 		return nil
@@ -1910,7 +1915,7 @@ func VisitRefOfPrepareStmt(in *PrepareStmt, f Visit) error {
 	if err := VisitColIdent(in.Name, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitColIdent(in.StatementIdentifier, f); err != nil {
@@ -1994,7 +1999,7 @@ func VisitRefOfRevertMigration(in *RevertMigration, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	return nil
@@ -2053,7 +2058,7 @@ func VisitRefOfSelect(in *Select, f Visit) error {
 			return err
 		}
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitSelectExprs(in.SelectExprs, f); err != nil {
@@ -2112,7 +2117,7 @@ func VisitRefOfSet(in *Set, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitSetExprs(in.Exprs, f); err != nil {
@@ -2159,7 +2164,7 @@ func VisitRefOfSetTransaction(in *SetTransaction, f Visit) error {
 	if err := VisitSQLNode(in.SQLNode, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	for _, el := range in.Characteristics {
@@ -2248,7 +2253,7 @@ func VisitRefOfShowMigrationLogs(in *ShowMigrationLogs, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	return nil
@@ -2272,7 +2277,7 @@ func VisitRefOfStream(in *Stream, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitSelectExpr(in.SelectExpr, f); err != nil {
@@ -2517,7 +2522,7 @@ func VisitRefOfUpdate(in *Update, f Visit) error {
 	if err := VisitRefOfWith(in.With, f); err != nil {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitTableExprs(in.TableExprs, f); err != nil {
@@ -2585,7 +2590,7 @@ func VisitRefOfVStream(in *VStream, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitComments(in.Comments, f); err != nil {
+	if err := VisitRefOfParsedComments(in.Comments, f); err != nil {
 		return err
 	}
 	if err := VisitSelectExpr(in.SelectExpr, f); err != nil {

--- a/go/vt/sqlparser/cached_size.go
+++ b/go/vt/sqlparser/cached_size.go
@@ -17,7 +17,13 @@ limitations under the License.
 
 package sqlparser
 
-import hack "vitess.io/vitess/go/hack"
+import (
+	"math"
+	"reflect"
+	"unsafe"
+
+	hack "vitess.io/vitess/go/hack"
+)
 
 type cachedObject interface {
 	CachedSize(alloc bool) int64
@@ -186,7 +192,7 @@ func (cached *AlterTable) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(112)
+		size += int64(96)
 	}
 	// field Table vitess.io/vitess/go/vt/sqlparser.TableName
 	size += cached.Table.CachedSize(false)
@@ -203,13 +209,8 @@ func (cached *AlterTable) CachedSize(alloc bool) int64 {
 	size += cached.PartitionSpec.CachedSize(true)
 	// field PartitionOption *vitess.io/vitess/go/vt/sqlparser.PartitionOption
 	size += cached.PartitionOption.CachedSize(true)
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	return size
 }
 func (cached *AlterView) CachedSize(alloc bool) int64 {
@@ -218,7 +219,7 @@ func (cached *AlterView) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(160)
+		size += int64(144)
 	}
 	// field ViewName vitess.io/vitess/go/vt/sqlparser.TableName
 	size += cached.ViewName.CachedSize(false)
@@ -241,13 +242,8 @@ func (cached *AlterView) CachedSize(alloc bool) int64 {
 	}
 	// field CheckOption string
 	size += hack.RuntimeAllocSize(int64(len(cached.CheckOption)))
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	return size
 }
 func (cached *AlterVschema) CachedSize(alloc bool) int64 {
@@ -694,15 +690,10 @@ func (cached *CreateDatabase) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(80)
+		size += int64(64)
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field DBName vitess.io/vitess/go/vt/sqlparser.TableIdent
 	size += cached.DBName.CachedSize(false)
 	// field CreateOptions []vitess.io/vitess/go/vt/sqlparser.CollateAndCharset
@@ -720,7 +711,7 @@ func (cached *CreateTable) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(96)
+		size += int64(80)
 	}
 	// field Table vitess.io/vitess/go/vt/sqlparser.TableName
 	size += cached.Table.CachedSize(false)
@@ -728,13 +719,8 @@ func (cached *CreateTable) CachedSize(alloc bool) int64 {
 	size += cached.TableSpec.CachedSize(true)
 	// field OptLike *vitess.io/vitess/go/vt/sqlparser.OptLike
 	size += cached.OptLike.CachedSize(true)
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	return size
 }
 func (cached *CreateView) CachedSize(alloc bool) int64 {
@@ -743,7 +729,7 @@ func (cached *CreateView) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(160)
+		size += int64(144)
 	}
 	// field ViewName vitess.io/vitess/go/vt/sqlparser.TableName
 	size += cached.ViewName.CachedSize(false)
@@ -766,13 +752,8 @@ func (cached *CreateView) CachedSize(alloc bool) int64 {
 	}
 	// field CheckOption string
 	size += hack.RuntimeAllocSize(int64(len(cached.CheckOption)))
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	return size
 }
 func (cached *CurTimeFuncExpr) CachedSize(alloc bool) int64 {
@@ -795,15 +776,10 @@ func (cached *DeallocateStmt) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(80)
+		size += int64(64)
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field Name vitess.io/vitess/go/vt/sqlparser.ColIdent
 	size += cached.Name.CachedSize(false)
 	return size
@@ -840,17 +816,12 @@ func (cached *Delete) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(160)
+		size += int64(144)
 	}
 	// field With *vitess.io/vitess/go/vt/sqlparser.With
 	size += cached.With.CachedSize(true)
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field Targets vitess.io/vitess/go/vt/sqlparser.TableNames
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Targets)) * int64(32))
@@ -919,15 +890,10 @@ func (cached *DropDatabase) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(48)
+		size += int64(32)
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field DBName vitess.io/vitess/go/vt/sqlparser.TableIdent
 	size += cached.DBName.CachedSize(false)
 	return size
@@ -950,7 +916,7 @@ func (cached *DropTable) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(64)
+		size += int64(48)
 	}
 	// field FromTables vitess.io/vitess/go/vt/sqlparser.TableNames
 	{
@@ -959,13 +925,8 @@ func (cached *DropTable) CachedSize(alloc bool) int64 {
 			size += elem.CachedSize(false)
 		}
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	return size
 }
 func (cached *DropView) CachedSize(alloc bool) int64 {
@@ -974,7 +935,7 @@ func (cached *DropView) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(64)
+		size += int64(48)
 	}
 	// field FromTables vitess.io/vitess/go/vt/sqlparser.TableNames
 	{
@@ -983,13 +944,8 @@ func (cached *DropView) CachedSize(alloc bool) int64 {
 			size += elem.CachedSize(false)
 		}
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	return size
 }
 func (cached *ExecuteStmt) CachedSize(alloc bool) int64 {
@@ -998,17 +954,12 @@ func (cached *ExecuteStmt) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(96)
+		size += int64(80)
 	}
 	// field Name vitess.io/vitess/go/vt/sqlparser.ColIdent
 	size += cached.Name.CachedSize(false)
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field Arguments vitess.io/vitess/go/vt/sqlparser.Columns
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Arguments)) * int64(40))
@@ -1293,15 +1244,10 @@ func (cached *Insert) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(160)
+		size += int64(144)
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field Table vitess.io/vitess/go/vt/sqlparser.TableName
 	size += cached.Table.CachedSize(false)
 	// field Partitions vitess.io/vitess/go/vt/sqlparser.Partitions
@@ -1852,6 +1798,40 @@ func (cached *ParenTableExpr) CachedSize(alloc bool) int64 {
 	}
 	return size
 }
+
+//go:nocheckptr
+func (cached *ParsedComments) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(32)
+	}
+	// field comments vitess.io/vitess/go/vt/sqlparser.Comments
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.comments)) * int64(16))
+		for _, elem := range cached.comments {
+			size += hack.RuntimeAllocSize(int64(len(elem)))
+		}
+	}
+	// field _directives vitess.io/vitess/go/vt/sqlparser.CommentDirectives
+	if cached._directives != nil {
+		size += int64(48)
+		hmap := reflect.ValueOf(cached._directives)
+		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
+		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
+		size += hack.RuntimeAllocSize(int64(numOldBuckets * 272))
+		if len(cached._directives) > 0 || numBuckets > 1 {
+			size += hack.RuntimeAllocSize(int64(numBuckets * 272))
+		}
+		for k, v := range cached._directives {
+			size += hack.RuntimeAllocSize(int64(len(k)))
+			size += hack.RuntimeAllocSize(int64(len(v)))
+		}
+	}
+	return size
+}
 func (cached *ParsedQuery) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -1965,19 +1945,14 @@ func (cached *PrepareStmt) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(128)
+		size += int64(112)
 	}
 	// field Name vitess.io/vitess/go/vt/sqlparser.ColIdent
 	size += cached.Name.CachedSize(false)
 	// field Statement string
 	size += hack.RuntimeAllocSize(int64(len(cached.Statement)))
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field StatementIdentifier vitess.io/vitess/go/vt/sqlparser.ColIdent
 	size += cached.StatementIdentifier.CachedSize(false)
 	return size
@@ -2076,17 +2051,12 @@ func (cached *RevertMigration) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(48)
+		size += int64(24)
 	}
 	// field UUID string
 	size += hack.RuntimeAllocSize(int64(len(cached.UUID)))
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	return size
 }
 func (cached *RootNode) CachedSize(alloc bool) int64 {
@@ -2133,7 +2103,7 @@ func (cached *Select) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(192)
+		size += int64(176)
 	}
 	// field Cache *bool
 	size += hack.RuntimeAllocSize(int64(1))
@@ -2146,13 +2116,8 @@ func (cached *Select) CachedSize(alloc bool) int64 {
 			}
 		}
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field SelectExprs vitess.io/vitess/go/vt/sqlparser.SelectExprs
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.SelectExprs)) * int64(16))
@@ -2218,15 +2183,10 @@ func (cached *Set) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(48)
+		size += int64(32)
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field Exprs vitess.io/vitess/go/vt/sqlparser.SetExprs
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Exprs)) * int64(8))
@@ -2258,19 +2218,14 @@ func (cached *SetTransaction) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(80)
+		size += int64(64)
 	}
 	// field SQLNode vitess.io/vitess/go/vt/sqlparser.SQLNode
 	if cc, ok := cached.SQLNode.(cachedObject); ok {
 		size += cc.CachedSize(true)
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field Characteristics []vitess.io/vitess/go/vt/sqlparser.Characteristic
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.Characteristics)) * int64(16))
@@ -2370,17 +2325,12 @@ func (cached *ShowMigrationLogs) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(48)
+		size += int64(24)
 	}
 	// field UUID string
 	size += hack.RuntimeAllocSize(int64(len(cached.UUID)))
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	return size
 }
 func (cached *ShowTablesOpt) CachedSize(alloc bool) int64 {
@@ -2417,15 +2367,10 @@ func (cached *Stream) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(80)
+		size += int64(64)
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field SelectExpr vitess.io/vitess/go/vt/sqlparser.SelectExpr
 	if cc, ok := cached.SelectExpr.(cachedObject); ok {
 		size += cc.CachedSize(true)
@@ -2707,17 +2652,12 @@ func (cached *Update) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(128)
+		size += int64(112)
 	}
 	// field With *vitess.io/vitess/go/vt/sqlparser.With
 	size += cached.With.CachedSize(true)
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field TableExprs vitess.io/vitess/go/vt/sqlparser.TableExprs
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.TableExprs)) * int64(16))
@@ -2781,15 +2721,10 @@ func (cached *VStream) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(96)
+		size += int64(80)
 	}
-	// field Comments vitess.io/vitess/go/vt/sqlparser.Comments
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.Comments)) * int64(16))
-		for _, elem := range cached.Comments {
-			size += hack.RuntimeAllocSize(int64(len(elem)))
-		}
-	}
+	// field Comments *vitess.io/vitess/go/vt/sqlparser.ParsedComments
+	size += cached.Comments.CachedSize(true)
 	// field SelectExpr vitess.io/vitess/go/vt/sqlparser.SelectExpr
 	if cc, ok := cached.SelectExpr.(cachedObject); ok {
 		size += cc.CachedSize(true)

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sqlparser
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"unicode"
@@ -201,86 +200,68 @@ const commentDirectivePreamble = "/*vt+"
 
 // CommentDirectives is the parsed representation for execution directives
 // conveyed in query comments
-type CommentDirectives map[string]any
+type CommentDirectives map[string]string
 
-// ExtractCommentDirectives parses the comment list for any execution directives
+// Directives parses the comment list for any execution directives
 // of the form:
 //
 //     /*vt+ OPTION_ONE=1 OPTION_TWO OPTION_THREE=abcd */
 //
 // It returns the map of the directive values or nil if there aren't any.
-func ExtractCommentDirectives(comments Comments) CommentDirectives {
-	if comments == nil {
+func (c *ParsedComments) Directives() CommentDirectives {
+	if c == nil {
 		return nil
 	}
+	if c._directives == nil {
+		c._directives = make(CommentDirectives)
 
-	var vals map[string]any
-
-	for _, commentStr := range comments {
-		if commentStr[0:5] != commentDirectivePreamble {
-			continue
-		}
-
-		if vals == nil {
-			vals = make(map[string]any)
-		}
-
-		// Split on whitespace and ignore the first and last directive
-		// since they contain the comment start/end
-		directives := strings.Fields(commentStr)
-		for i := 1; i < len(directives)-1; i++ {
-			directive := directives[i]
-			sep := strings.IndexByte(directive, '=')
-
-			// No value is equivalent to a true boolean
-			if sep == -1 {
-				vals[directive] = true
+		for _, commentStr := range c.comments {
+			if commentStr[0:5] != commentDirectivePreamble {
 				continue
 			}
 
-			strVal := directive[sep+1:]
-			directive = directive[:sep]
-
-			intVal, err := strconv.Atoi(strVal)
-			if err == nil {
-				vals[directive] = intVal
-				continue
+			// Split on whitespace and ignore the first and last directive
+			// since they contain the comment start/end
+			directives := strings.Fields(commentStr)
+			for i := 1; i < len(directives)-1; i++ {
+				directive, val, ok := strings.Cut(directives[i], "=")
+				if !ok {
+					val = "true"
+				}
+				c._directives[directive] = val
 			}
-
-			boolVal, err := strconv.ParseBool(strVal)
-			if err == nil {
-				vals[directive] = boolVal
-				continue
-			}
-
-			vals[directive] = strVal
 		}
 	}
-	return vals
+	return c._directives
+}
+
+func (c *ParsedComments) Length() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.comments)
+}
+
+func (c *ParsedComments) Prepend(comment string) Comments {
+	if c == nil {
+		return Comments{comment}
+	}
+	comments := make(Comments, 0, len(c.comments)+1)
+	comments = append(comments, comment)
+	comments = append(comments, c.comments...)
+	return comments
 }
 
 // IsSet checks the directive map for the named directive and returns
 // true if the directive is set and has a true/false or 0/1 value
 func (d CommentDirectives) IsSet(key string) bool {
-	if d == nil {
-		return false
-	}
-
 	val, ok := d[key]
 	if !ok {
 		return false
 	}
-
-	boolVal, ok := val.(bool)
-	if ok {
-		return boolVal
-	}
-
-	intVal, ok := val.(int)
-	if ok {
-		return intVal == 1
-	}
-	return false
+	// ParseBool handles "0", "1", "true", "false" and all similars
+	set, _ := strconv.ParseBool(val)
+	return set
 }
 
 // GetString gets a directive value as string, with default value if not found
@@ -289,126 +270,99 @@ func (d CommentDirectives) GetString(key string, defaultVal string) string {
 	if !ok {
 		return defaultVal
 	}
-	stringVal := fmt.Sprintf("%v", val)
-	if unquoted, err := strconv.Unquote(stringVal); err == nil {
-		stringVal = unquoted
+	if unquoted, err := strconv.Unquote(val); err == nil {
+		return unquoted
 	}
-	return stringVal
+	return val
 }
 
 // MultiShardAutocommitDirective returns true if multishard autocommit directive is set to true in query.
 func MultiShardAutocommitDirective(stmt Statement) bool {
+	var comments *ParsedComments
 	switch stmt := stmt.(type) {
 	case *Insert:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		if directives.IsSet(DirectiveMultiShardAutocommit) {
-			return true
-		}
+		comments = stmt.Comments
 	case *Update:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		if directives.IsSet(DirectiveMultiShardAutocommit) {
-			return true
-		}
+		comments = stmt.Comments
 	case *Delete:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		if directives.IsSet(DirectiveMultiShardAutocommit) {
-			return true
-		}
-	default:
-		return false
+		comments = stmt.Comments
 	}
-	return false
+	return comments != nil && comments.Directives().IsSet(DirectiveMultiShardAutocommit)
 }
 
 // SkipQueryPlanCacheDirective returns true if skip query plan cache directive is set to true in query.
 func SkipQueryPlanCacheDirective(stmt Statement) bool {
+	var comments *ParsedComments
 	switch stmt := stmt.(type) {
 	case *Select:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		if directives.IsSet(DirectiveSkipQueryPlanCache) {
-			return true
-		}
+		comments = stmt.Comments
 	case *Insert:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		if directives.IsSet(DirectiveSkipQueryPlanCache) {
-			return true
-		}
+		comments = stmt.Comments
 	case *Update:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		if directives.IsSet(DirectiveSkipQueryPlanCache) {
-			return true
-		}
+		comments = stmt.Comments
 	case *Delete:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		if directives.IsSet(DirectiveSkipQueryPlanCache) {
-			return true
-		}
-	default:
-		return false
+		comments = stmt.Comments
 	}
-	return false
+	return comments != nil && comments.Directives().IsSet(DirectiveSkipQueryPlanCache)
 }
 
 // IgnoreMaxPayloadSizeDirective returns true if the max payload size override
 // directive is set to true.
 func IgnoreMaxPayloadSizeDirective(stmt Statement) bool {
+	var comments *ParsedComments
 	switch stmt := stmt.(type) {
 	// For transactional statements, they should always be passed down and
 	// should not come into max payload size requirement.
 	case *Begin, *Commit, *Rollback, *Savepoint, *SRollback, *Release:
 		return true
 	case *Select:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		return directives.IsSet(DirectiveIgnoreMaxPayloadSize)
+		comments = stmt.Comments
 	case *Insert:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		return directives.IsSet(DirectiveIgnoreMaxPayloadSize)
+		comments = stmt.Comments
 	case *Update:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		return directives.IsSet(DirectiveIgnoreMaxPayloadSize)
+		comments = stmt.Comments
 	case *Delete:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		return directives.IsSet(DirectiveIgnoreMaxPayloadSize)
-	default:
-		return false
+		comments = stmt.Comments
 	}
+	return comments != nil && comments.Directives().IsSet(DirectiveIgnoreMaxPayloadSize)
 }
 
 // IgnoreMaxMaxMemoryRowsDirective returns true if the max memory rows override
 // directive is set to true.
 func IgnoreMaxMaxMemoryRowsDirective(stmt Statement) bool {
+	var comments *ParsedComments
 	switch stmt := stmt.(type) {
 	case *Select:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		return directives.IsSet(DirectiveIgnoreMaxMemoryRows)
+		comments = stmt.Comments
 	case *Insert:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		return directives.IsSet(DirectiveIgnoreMaxMemoryRows)
+		comments = stmt.Comments
 	case *Update:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		return directives.IsSet(DirectiveIgnoreMaxMemoryRows)
+		comments = stmt.Comments
 	case *Delete:
-		directives := ExtractCommentDirectives(stmt.Comments)
-		return directives.IsSet(DirectiveIgnoreMaxMemoryRows)
-	default:
-		return false
+		comments = stmt.Comments
 	}
+	return comments != nil && comments.Directives().IsSet(DirectiveIgnoreMaxMemoryRows)
 }
 
 // AllowScatterDirective returns true if the allow scatter override is set to true
 func AllowScatterDirective(stmt Statement) bool {
-	var directives CommentDirectives
+	var comments *ParsedComments
 	switch stmt := stmt.(type) {
 	case *Select:
-		directives = ExtractCommentDirectives(stmt.Comments)
+		comments = stmt.Comments
 	case *Insert:
-		directives = ExtractCommentDirectives(stmt.Comments)
+		comments = stmt.Comments
 	case *Update:
-		directives = ExtractCommentDirectives(stmt.Comments)
+		comments = stmt.Comments
 	case *Delete:
-		directives = ExtractCommentDirectives(stmt.Comments)
-	default:
-		return false
+		comments = stmt.Comments
 	}
-	return directives.IsSet(DirectiveAllowScatter)
+	return comments != nil && comments.Directives().IsSet(DirectiveAllowScatter)
+}
+
+func CommentsForStatement(stmt Statement) Comments {
+	if commented, ok := stmt.(Commented); ok {
+		return commented.GetParsedComments().comments
+	}
+	return nil
 }

--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -268,26 +268,26 @@ func TestExtractCommentDirectives(t *testing.T) {
 		vals:  nil,
 	}, {
 		input: "/* not a vt comment */",
-		vals:  nil,
+		vals:  CommentDirectives{},
 	}, {
 		input: "/*vt+ */",
 		vals:  CommentDirectives{},
 	}, {
 		input: "/*vt+ SINGLE_OPTION */",
 		vals: CommentDirectives{
-			"SINGLE_OPTION": true,
+			"SINGLE_OPTION": "true",
 		},
 	}, {
 		input: "/*vt+ ONE_OPT TWO_OPT */",
 		vals: CommentDirectives{
-			"ONE_OPT": true,
-			"TWO_OPT": true,
+			"ONE_OPT": "true",
+			"TWO_OPT": "true",
 		},
 	}, {
 		input: "/*vt+ ONE_OPT */ /* other comment */ /*vt+ TWO_OPT */",
 		vals: CommentDirectives{
-			"ONE_OPT": true,
-			"TWO_OPT": true,
+			"ONE_OPT": "true",
+			"TWO_OPT": "true",
 		},
 	}, {
 		input: "/*vt+ ONE_OPT=abc TWO_OPT=def */",
@@ -298,20 +298,20 @@ func TestExtractCommentDirectives(t *testing.T) {
 	}, {
 		input: "/*vt+ ONE_OPT=true TWO_OPT=false */",
 		vals: CommentDirectives{
-			"ONE_OPT": true,
-			"TWO_OPT": false,
+			"ONE_OPT": "true",
+			"TWO_OPT": "false",
 		},
 	}, {
 		input: "/*vt+ ONE_OPT=true TWO_OPT=\"false\" */",
 		vals: CommentDirectives{
-			"ONE_OPT": true,
+			"ONE_OPT": "true",
 			"TWO_OPT": "\"false\"",
 		},
 	}, {
 		input: "/*vt+ RANGE_OPT=[a:b] ANOTHER ANOTHER_WITH_VALEQ=val= AND_ONE_WITH_EQ== */",
 		vals: CommentDirectives{
 			"RANGE_OPT":          "[a:b]",
-			"ANOTHER":            true,
+			"ANOTHER":            "true",
 			"ANOTHER_WITH_VALEQ": "val=",
 			"AND_ONE_WITH_EQ":    "=",
 		},
@@ -333,7 +333,7 @@ func TestExtractCommentDirectives(t *testing.T) {
 			}
 			for _, sql := range sqls {
 				t.Run(sql, func(t *testing.T) {
-					var comments Comments
+					var comments *ParsedComments
 					stmt, _ := Parse(sql)
 					switch s := stmt.(type) {
 					case *Select:
@@ -357,10 +357,10 @@ func TestExtractCommentDirectives(t *testing.T) {
 					default:
 						t.Errorf("Unexpected statement type %+v", s)
 					}
-					vals := ExtractCommentDirectives(comments)
 
+					vals := comments.Directives()
 					if !reflect.DeepEqual(vals, testCase.vals) {
-						t.Errorf("test input: '%v', got vals:\n%+v, want\n%+v", testCase.input, vals, testCase.vals)
+						t.Errorf("test input: '%v', got vals %T:\n%+v, want %T\n%+v", testCase.input, vals, vals, testCase.vals, testCase.vals)
 					}
 				})
 			}
@@ -368,11 +368,11 @@ func TestExtractCommentDirectives(t *testing.T) {
 	}
 
 	d := CommentDirectives{
-		"ONE_OPT": true,
-		"TWO_OPT": false,
-		"three":   1,
-		"four":    2,
-		"five":    0,
+		"ONE_OPT": "true",
+		"TWO_OPT": "false",
+		"three":   "1",
+		"four":    "2",
+		"five":    "0",
 		"six":     "true",
 	}
 
@@ -396,7 +396,7 @@ func TestExtractCommentDirectives(t *testing.T) {
 		t.Errorf("d.IsSet(five) should be false")
 	}
 
-	if d.IsSet("six") {
+	if !d.IsSet("six") {
 		t.Errorf("d.IsSet(six) should be false")
 	}
 }

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -5458,7 +5458,7 @@ var yyPgo = [...]int{
 	1894, 1893, 3437, 2944, 126, 1874, 177,
 }
 
-//line sql.y:6428
+//line sql.y:6429
 type yySymType struct {
 	union             any
 	empty             struct{}
@@ -7686,7 +7686,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:762
 		{
-			yyLOCAL = &Stream{Comments: Comments(yyDollar[2].strs), SelectExpr: yyDollar[3].selectExprUnion(), Table: yyDollar[5].tableName}
+			yyLOCAL = &Stream{Comments: Comments(yyDollar[2].strs).Parsed(), SelectExpr: yyDollar[3].selectExprUnion(), Table: yyDollar[5].tableName}
 		}
 		yyVAL.union = yyLOCAL
 	case 78:
@@ -7694,7 +7694,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:768
 		{
-			yyLOCAL = &VStream{Comments: Comments(yyDollar[2].strs), SelectExpr: yyDollar[3].selectExprUnion(), Table: yyDollar[5].tableName, Where: NewWhere(WhereClause, yyDollar[6].exprUnion()), Limit: yyDollar[7].limitUnion()}
+			yyLOCAL = &VStream{Comments: Comments(yyDollar[2].strs).Parsed(), SelectExpr: yyDollar[3].selectExprUnion(), Table: yyDollar[5].tableName, Where: NewWhere(WhereClause, yyDollar[6].exprUnion()), Limit: yyDollar[7].limitUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 79:
@@ -7721,7 +7721,7 @@ yydefault:
 			// insert_data returns a *Insert pre-filled with Columns & Values
 			ins := yyDollar[6].insUnion()
 			ins.Action = yyDollar[1].insertActionUnion()
-			ins.Comments = yyDollar[2].strs
+			ins.Comments = Comments(yyDollar[2].strs).Parsed()
 			ins.Ignore = yyDollar[3].ignoreUnion()
 			ins.Table = yyDollar[4].tableName
 			ins.Partitions = yyDollar[5].partitionsUnion()
@@ -7740,7 +7740,7 @@ yydefault:
 				cols = append(cols, updateList.Name.Name)
 				vals = append(vals, updateList.Expr)
 			}
-			yyLOCAL = &Insert{Action: yyDollar[1].insertActionUnion(), Comments: Comments(yyDollar[2].strs), Ignore: yyDollar[3].ignoreUnion(), Table: yyDollar[4].tableName, Partitions: yyDollar[5].partitionsUnion(), Columns: cols, Rows: Values{vals}, OnDup: OnDup(yyDollar[8].updateExprsUnion())}
+			yyLOCAL = &Insert{Action: yyDollar[1].insertActionUnion(), Comments: Comments(yyDollar[2].strs).Parsed(), Ignore: yyDollar[3].ignoreUnion(), Table: yyDollar[4].tableName, Partitions: yyDollar[5].partitionsUnion(), Columns: cols, Rows: Values{vals}, OnDup: OnDup(yyDollar[8].updateExprsUnion())}
 		}
 		yyVAL.union = yyLOCAL
 	case 83:
@@ -7764,7 +7764,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:822
 		{
-			yyLOCAL = &Update{With: yyDollar[1].withUnion(), Comments: Comments(yyDollar[3].strs), Ignore: yyDollar[4].ignoreUnion(), TableExprs: yyDollar[5].tableExprsUnion(), Exprs: yyDollar[7].updateExprsUnion(), Where: NewWhere(WhereClause, yyDollar[8].exprUnion()), OrderBy: yyDollar[9].orderByUnion(), Limit: yyDollar[10].limitUnion()}
+			yyLOCAL = &Update{With: yyDollar[1].withUnion(), Comments: Comments(yyDollar[3].strs).Parsed(), Ignore: yyDollar[4].ignoreUnion(), TableExprs: yyDollar[5].tableExprsUnion(), Exprs: yyDollar[7].updateExprsUnion(), Where: NewWhere(WhereClause, yyDollar[8].exprUnion()), OrderBy: yyDollar[9].orderByUnion(), Limit: yyDollar[10].limitUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 86:
@@ -7772,7 +7772,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:828
 		{
-			yyLOCAL = &Delete{With: yyDollar[1].withUnion(), Comments: Comments(yyDollar[3].strs), Ignore: yyDollar[4].ignoreUnion(), TableExprs: TableExprs{&AliasedTableExpr{Expr: yyDollar[6].tableName, As: yyDollar[7].tableIdent}}, Partitions: yyDollar[8].partitionsUnion(), Where: NewWhere(WhereClause, yyDollar[9].exprUnion()), OrderBy: yyDollar[10].orderByUnion(), Limit: yyDollar[11].limitUnion()}
+			yyLOCAL = &Delete{With: yyDollar[1].withUnion(), Comments: Comments(yyDollar[3].strs).Parsed(), Ignore: yyDollar[4].ignoreUnion(), TableExprs: TableExprs{&AliasedTableExpr{Expr: yyDollar[6].tableName, As: yyDollar[7].tableIdent}}, Partitions: yyDollar[8].partitionsUnion(), Where: NewWhere(WhereClause, yyDollar[9].exprUnion()), OrderBy: yyDollar[10].orderByUnion(), Limit: yyDollar[11].limitUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 87:
@@ -7780,7 +7780,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:832
 		{
-			yyLOCAL = &Delete{With: yyDollar[1].withUnion(), Comments: Comments(yyDollar[3].strs), Ignore: yyDollar[4].ignoreUnion(), Targets: yyDollar[6].tableNamesUnion(), TableExprs: yyDollar[8].tableExprsUnion(), Where: NewWhere(WhereClause, yyDollar[9].exprUnion())}
+			yyLOCAL = &Delete{With: yyDollar[1].withUnion(), Comments: Comments(yyDollar[3].strs).Parsed(), Ignore: yyDollar[4].ignoreUnion(), Targets: yyDollar[6].tableNamesUnion(), TableExprs: yyDollar[8].tableExprsUnion(), Where: NewWhere(WhereClause, yyDollar[9].exprUnion())}
 		}
 		yyVAL.union = yyLOCAL
 	case 88:
@@ -7788,7 +7788,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:836
 		{
-			yyLOCAL = &Delete{With: yyDollar[1].withUnion(), Comments: Comments(yyDollar[3].strs), Ignore: yyDollar[4].ignoreUnion(), Targets: yyDollar[5].tableNamesUnion(), TableExprs: yyDollar[7].tableExprsUnion(), Where: NewWhere(WhereClause, yyDollar[8].exprUnion())}
+			yyLOCAL = &Delete{With: yyDollar[1].withUnion(), Comments: Comments(yyDollar[3].strs).Parsed(), Ignore: yyDollar[4].ignoreUnion(), Targets: yyDollar[5].tableNamesUnion(), TableExprs: yyDollar[7].tableExprsUnion(), Where: NewWhere(WhereClause, yyDollar[8].exprUnion())}
 		}
 		yyVAL.union = yyLOCAL
 	case 89:
@@ -7796,7 +7796,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:840
 		{
-			yyLOCAL = &Delete{With: yyDollar[1].withUnion(), Comments: Comments(yyDollar[3].strs), Ignore: yyDollar[4].ignoreUnion(), Targets: yyDollar[5].tableNamesUnion(), TableExprs: yyDollar[7].tableExprsUnion(), Where: NewWhere(WhereClause, yyDollar[8].exprUnion())}
+			yyLOCAL = &Delete{With: yyDollar[1].withUnion(), Comments: Comments(yyDollar[3].strs).Parsed(), Ignore: yyDollar[4].ignoreUnion(), Targets: yyDollar[5].tableNamesUnion(), TableExprs: yyDollar[7].tableExprsUnion(), Where: NewWhere(WhereClause, yyDollar[8].exprUnion())}
 		}
 		yyVAL.union = yyLOCAL
 	case 90:
@@ -7875,7 +7875,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:889
 		{
-			yyLOCAL = &Set{Comments: Comments(yyDollar[2].strs), Exprs: yyDollar[3].setExprsUnion()}
+			yyLOCAL = &Set{Comments: Comments(yyDollar[2].strs).Parsed(), Exprs: yyDollar[3].setExprsUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 101:
@@ -7883,7 +7883,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:895
 		{
-			yyLOCAL = &SetTransaction{Comments: Comments(yyDollar[2].strs), Scope: yyDollar[3].scopeUnion(), Characteristics: yyDollar[5].characteristicsUnion()}
+			yyLOCAL = &SetTransaction{Comments: Comments(yyDollar[2].strs).Parsed(), Scope: yyDollar[3].scopeUnion(), Characteristics: yyDollar[5].characteristicsUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 102:
@@ -7891,7 +7891,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:899
 		{
-			yyLOCAL = &SetTransaction{Comments: Comments(yyDollar[2].strs), Characteristics: yyDollar[4].characteristicsUnion(), Scope: ImplicitScope}
+			yyLOCAL = &SetTransaction{Comments: Comments(yyDollar[2].strs).Parsed(), Characteristics: yyDollar[4].characteristicsUnion(), Scope: ImplicitScope}
 		}
 		yyVAL.union = yyLOCAL
 	case 103:
@@ -8020,7 +8020,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:979
 		{
-			yyLOCAL = &CreateView{ViewName: yyDollar[8].tableName.ToViewName(), Comments: Comments(yyDollar[2].strs), IsReplace: yyDollar[3].booleanUnion(), Algorithm: yyDollar[4].str, Definer: yyDollar[5].definerUnion(), Security: yyDollar[6].str, Columns: yyDollar[9].columnsUnion(), Select: yyDollar[11].selStmtUnion(), CheckOption: yyDollar[12].str}
+			yyLOCAL = &CreateView{ViewName: yyDollar[8].tableName.ToViewName(), Comments: Comments(yyDollar[2].strs).Parsed(), IsReplace: yyDollar[3].booleanUnion(), Algorithm: yyDollar[4].str, Definer: yyDollar[5].definerUnion(), Security: yyDollar[6].str, Columns: yyDollar[9].columnsUnion(), Select: yyDollar[11].selStmtUnion(), CheckOption: yyDollar[12].str}
 		}
 		yyVAL.union = yyLOCAL
 	case 118:
@@ -8148,7 +8148,7 @@ yydefault:
 		var yyLOCAL *CreateTable
 //line sql.y:1067
 		{
-			yyLOCAL = &CreateTable{Comments: Comments(yyDollar[2].strs), Table: yyDollar[6].tableName, IfNotExists: yyDollar[5].booleanUnion(), Temp: yyDollar[3].booleanUnion()}
+			yyLOCAL = &CreateTable{Comments: Comments(yyDollar[2].strs).Parsed(), Table: yyDollar[6].tableName, IfNotExists: yyDollar[5].booleanUnion(), Temp: yyDollar[3].booleanUnion()}
 			setDDL(yylex, yyLOCAL)
 		}
 		yyVAL.union = yyLOCAL
@@ -8157,7 +8157,7 @@ yydefault:
 		var yyLOCAL *AlterTable
 //line sql.y:1074
 		{
-			yyLOCAL = &AlterTable{Comments: Comments(yyDollar[2].strs), Table: yyDollar[4].tableName}
+			yyLOCAL = &AlterTable{Comments: Comments(yyDollar[2].strs).Parsed(), Table: yyDollar[4].tableName}
 			setDDL(yylex, yyLOCAL)
 		}
 		yyVAL.union = yyLOCAL
@@ -8202,7 +8202,7 @@ yydefault:
 		var yyLOCAL *CreateDatabase
 //line sql.y:1103
 		{
-			yyLOCAL = &CreateDatabase{Comments: Comments(yyDollar[4].strs), DBName: yyDollar[6].tableIdent, IfNotExists: yyDollar[5].booleanUnion()}
+			yyLOCAL = &CreateDatabase{Comments: Comments(yyDollar[4].strs).Parsed(), DBName: yyDollar[6].tableIdent, IfNotExists: yyDollar[5].booleanUnion()}
 			setDDL(yylex, yyLOCAL)
 		}
 		yyVAL.union = yyLOCAL
@@ -10687,7 +10687,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:2707
 		{
-			yyLOCAL = &AlterView{ViewName: yyDollar[7].tableName.ToViewName(), Comments: Comments(yyDollar[2].strs), Algorithm: yyDollar[3].str, Definer: yyDollar[4].definerUnion(), Security: yyDollar[5].str, Columns: yyDollar[8].columnsUnion(), Select: yyDollar[10].selStmtUnion(), CheckOption: yyDollar[11].str}
+			yyLOCAL = &AlterView{ViewName: yyDollar[7].tableName.ToViewName(), Comments: Comments(yyDollar[2].strs).Parsed(), Algorithm: yyDollar[3].str, Definer: yyDollar[4].definerUnion(), Security: yyDollar[5].str, Columns: yyDollar[8].columnsUnion(), Select: yyDollar[10].selStmtUnion(), CheckOption: yyDollar[11].str}
 		}
 		yyVAL.union = yyLOCAL
 	case 500:
@@ -11533,7 +11533,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:3231
 		{
-			yyLOCAL = &DropTable{FromTables: yyDollar[6].tableNamesUnion(), IfExists: yyDollar[5].booleanUnion(), Comments: Comments(yyDollar[2].strs), Temp: yyDollar[3].booleanUnion()}
+			yyLOCAL = &DropTable{FromTables: yyDollar[6].tableNamesUnion(), IfExists: yyDollar[5].booleanUnion(), Comments: Comments(yyDollar[2].strs).Parsed(), Temp: yyDollar[3].booleanUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 594:
@@ -11554,7 +11554,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:3244
 		{
-			yyLOCAL = &DropView{FromTables: yyDollar[5].tableNamesUnion(), Comments: Comments(yyDollar[2].strs), IfExists: yyDollar[4].booleanUnion()}
+			yyLOCAL = &DropView{FromTables: yyDollar[5].tableNamesUnion(), Comments: Comments(yyDollar[2].strs).Parsed(), IfExists: yyDollar[4].booleanUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 596:
@@ -11562,7 +11562,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:3248
 		{
-			yyLOCAL = &DropDatabase{Comments: Comments(yyDollar[2].strs), DBName: yyDollar[5].tableIdent, IfExists: yyDollar[4].booleanUnion()}
+			yyLOCAL = &DropDatabase{Comments: Comments(yyDollar[2].strs).Parsed(), DBName: yyDollar[5].tableIdent, IfExists: yyDollar[4].booleanUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 597:
@@ -12434,7 +12434,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:3767
 		{
-			yyLOCAL = &RevertMigration{Comments: Comments(yyDollar[2].strs), UUID: string(yyDollar[4].str)}
+			yyLOCAL = &RevertMigration{Comments: Comments(yyDollar[2].strs).Parsed(), UUID: string(yyDollar[4].str)}
 		}
 		yyVAL.union = yyLOCAL
 	case 711:
@@ -12701,7 +12701,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:3940
 		{
-			yyLOCAL = &PrepareStmt{Name: yyDollar[3].colIdent, Comments: yyDollar[2].strs, Statement: yyDollar[5].str}
+			yyLOCAL = &PrepareStmt{Name: yyDollar[3].colIdent, Comments: Comments(yyDollar[2].strs).Parsed(), Statement: yyDollar[5].str}
 		}
 		yyVAL.union = yyLOCAL
 	case 750:
@@ -12709,7 +12709,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:3944
 		{
-			yyLOCAL = &PrepareStmt{Name: yyDollar[3].colIdent, Comments: yyDollar[2].strs, StatementIdentifier: NewColIdentWithAt(string(yyDollar[5].str), SingleAt)}
+			yyLOCAL = &PrepareStmt{Name: yyDollar[3].colIdent, Comments: Comments(yyDollar[2].strs).Parsed(), StatementIdentifier: NewColIdentWithAt(string(yyDollar[5].str), SingleAt)}
 		}
 		yyVAL.union = yyLOCAL
 	case 751:
@@ -12717,7 +12717,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:3950
 		{
-			yyLOCAL = &ExecuteStmt{Name: yyDollar[3].colIdent, Comments: yyDollar[2].strs, Arguments: yyDollar[4].columnsUnion()}
+			yyLOCAL = &ExecuteStmt{Name: yyDollar[3].colIdent, Comments: Comments(yyDollar[2].strs).Parsed(), Arguments: yyDollar[4].columnsUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 752:
@@ -12741,7 +12741,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:3965
 		{
-			yyLOCAL = &DeallocateStmt{Type: DeallocateType, Comments: yyDollar[2].strs, Name: yyDollar[4].colIdent}
+			yyLOCAL = &DeallocateStmt{Type: DeallocateType, Comments: Comments(yyDollar[2].strs).Parsed(), Name: yyDollar[4].colIdent}
 		}
 		yyVAL.union = yyLOCAL
 	case 755:
@@ -12749,7 +12749,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:3969
 		{
-			yyLOCAL = &DeallocateStmt{Type: DropType, Comments: yyDollar[2].strs, Name: yyDollar[4].colIdent}
+			yyLOCAL = &DeallocateStmt{Type: DropType, Comments: Comments(yyDollar[2].strs).Parsed(), Name: yyDollar[4].colIdent}
 		}
 		yyVAL.union = yyLOCAL
 	case 756:

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -277,7 +277,7 @@ func costForDML(foundVindex *vindexes.ColumnVindex, opcode engine.Opcode) costDM
 	}
 }
 
-func buildDMLPlan(vschema plancontext.VSchema, dmlType string, stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, tableExprs sqlparser.TableExprs, where *sqlparser.Where, orderBy sqlparser.OrderBy, limit *sqlparser.Limit, comments sqlparser.Comments, nodes ...sqlparser.SQLNode) (*engine.DML, *vindexes.ColumnVindex, error) {
+func buildDMLPlan(vschema plancontext.VSchema, dmlType string, stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, tableExprs sqlparser.TableExprs, where *sqlparser.Where, orderBy sqlparser.OrderBy, limit *sqlparser.Limit, comments *sqlparser.ParsedComments, nodes ...sqlparser.SQLNode) (*engine.DML, *vindexes.ColumnVindex, error) {
 	edml := engine.NewDML()
 	pb := newPrimitiveBuilder(vschema, newJointab(reservedVars))
 	rb, err := pb.processDMLTable(tableExprs, reservedVars, nil)
@@ -310,7 +310,7 @@ func buildDMLPlan(vschema plancontext.VSchema, dmlType string, stmt sqlparser.St
 	// routed tables won't happen.
 	edml.Query = generateQuery(stmt)
 
-	directives := sqlparser.ExtractCommentDirectives(comments)
+	directives := comments.Directives()
 	if directives.IsSet(sqlparser.DirectiveMultiShardAutocommit) {
 		edml.MultiShardAutocommit = true
 	}

--- a/go/vt/vtgate/planbuilder/gen4_planner.go
+++ b/go/vt/vtgate/planbuilder/gen4_planner.go
@@ -284,12 +284,10 @@ func planOrderByOnUnion(ctx *plancontext.PlanningContext, plan logicalPlan, unio
 }
 
 func pushCommentDirectivesOnPlan(plan logicalPlan, stmt sqlparser.SelectStatement) (logicalPlan, error) {
-	directives := sqlparser.ExtractCommentDirectives(sqlparser.GetFirstSelect(stmt).Comments)
-	scatterAsWarns := false
-	if directives.IsSet(sqlparser.DirectiveScatterErrorsAsWarnings) {
-		scatterAsWarns = true
-	}
+	directives := sqlparser.GetFirstSelect(stmt).Comments.Directives()
+	scatterAsWarns := directives.IsSet(sqlparser.DirectiveScatterErrorsAsWarnings)
 	queryTimeout := queryTimeout(directives)
+
 	if scatterAsWarns || queryTimeout > 0 {
 		_, _ = visit(plan, func(logicalPlan logicalPlan) (bool, logicalPlan, error) {
 			switch plan := logicalPlan.(type) {

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -286,7 +286,7 @@ func checkColumnCounts(ins *sqlparser.Insert, selectStmt sqlparser.SelectStateme
 }
 
 func applyCommentDirectives(ins *sqlparser.Insert, eins *engine.Insert) {
-	directives := sqlparser.ExtractCommentDirectives(ins.Comments)
+	directives := ins.Comments.Directives()
 	if directives.IsSet(sqlparser.DirectiveMultiShardAutocommit) {
 		eins.MultiShardAutocommit = true
 	}

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -17,6 +17,8 @@ limitations under the License.
 package planbuilder
 
 import (
+	"strconv"
+
 	"vitess.io/vitess/go/mysql/collations"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -842,18 +844,10 @@ func (rb *route) exprIsValue(expr sqlparser.Expr) bool {
 
 // queryTimeout returns DirectiveQueryTimeout value if set, otherwise returns 0.
 func queryTimeout(d sqlparser.CommentDirectives) int {
-	if d == nil {
-		return 0
-	}
-
-	val, ok := d[sqlparser.DirectiveQueryTimeout]
-	if !ok {
-		return 0
-	}
-
-	intVal, ok := val.(int)
-	if ok {
-		return intVal
+	if val, ok := d[sqlparser.DirectiveQueryTimeout]; ok {
+		if intVal, err := strconv.Atoi(val); err == nil {
+			return intVal
+		}
 	}
 	return 0
 }

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -190,12 +190,11 @@ func (pb *primitiveBuilder) processSelect(sel *sqlparser.Select, reservedVars *s
 
 	if rb, ok := pb.plan.(*route); ok {
 		// TODO(sougou): this can probably be improved.
-		directives := sqlparser.ExtractCommentDirectives(sel.Comments)
+		directives := sel.Comments.Directives()
 		rb.eroute.QueryTimeout = queryTimeout(directives)
 		if rb.eroute.TargetDestination != nil {
 			return errors.New("unsupported: SELECT with a target destination")
 		}
-
 		if directives.IsSet(sqlparser.DirectiveScatterErrorsAsWarnings) {
 			rb.eroute.ScatterErrorsAsWarnings = true
 		}

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -85,7 +85,7 @@ func (a analyzer) newSemTable(statement sqlparser.SelectStatement, coll collatio
 		NotSingleRouteErr: a.projErr,
 		NotUnshardedErr:   a.unshardedErr,
 		Warning:           a.warning,
-		Comments:          statement.GetComments(),
+		Comments:          statement.GetParsedComments(),
 		SubqueryMap:       a.binder.subqueryMap,
 		SubqueryRef:       a.binder.subqueryRef,
 		ColumnEqualities:  map[columnName][]sqlparser.Expr{},

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -88,7 +88,7 @@ type (
 
 		ExprTypes   map[sqlparser.Expr]Type
 		selectScope map[*sqlparser.Select]*scope
-		Comments    sqlparser.Comments
+		Comments    *sqlparser.ParsedComments
 		SubqueryMap map[*sqlparser.Select][]*sqlparser.ExtractedSubquery
 		SubqueryRef map[*sqlparser.Subquery]*sqlparser.ExtractedSubquery
 

--- a/go/vt/vttablet/tabletmanager/rpc_query.go
+++ b/go/vt/vttablet/tabletmanager/rpc_query.go
@@ -60,11 +60,7 @@ func (tm *TabletManager) ExecuteFetchAsDba(ctx context.Context, query []byte, db
 		if !ok {
 			return nil
 		}
-		comments := ddlStmt.GetComments()
-		if comments == nil {
-			return nil
-		}
-		return sqlparser.ExtractCommentDirectives(comments)
+		return ddlStmt.GetParsedComments().Directives()
 	}
 	directives := getDirectives()
 	directiveIsSet := func(name string) bool {

--- a/go/vt/vttablet/tabletmanager/rpc_query.go
+++ b/go/vt/vttablet/tabletmanager/rpc_query.go
@@ -51,26 +51,13 @@ func (tm *TabletManager) ExecuteFetchAsDba(ctx context.Context, query []byte, db
 	}
 
 	// Handle special possible directives
-	getDirectives := func() sqlparser.CommentDirectives {
-		stmt, err := sqlparser.Parse(string(query))
-		if err != nil {
-			return nil
+	var directives sqlparser.CommentDirectives
+	if stmt, err := sqlparser.Parse(string(query)); err == nil {
+		if cmnt, ok := stmt.(sqlparser.Commented); ok {
+			directives = cmnt.GetParsedComments().Directives()
 		}
-		ddlStmt, ok := stmt.(sqlparser.DDLStatement)
-		if !ok {
-			return nil
-		}
-		return ddlStmt.GetParsedComments().Directives()
 	}
-	directives := getDirectives()
-	directiveIsSet := func(name string) bool {
-		if directives == nil {
-			return false
-		}
-		_, ok := directives[name]
-		return ok
-	}
-	if directiveIsSet("allowZeroInDate") {
+	if directives.IsSet("allowZeroInDate") {
 		if _, err := conn.ExecuteFetch("set @@session.sql_mode=REPLACE(REPLACE(@@session.sql_mode, 'NO_ZERO_DATE', ''), 'NO_ZERO_IN_DATE', '')", 1, false); err != nil {
 			return nil, err
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -302,7 +302,7 @@ func buildTablePlan(tableName string, rule *binlogdatapb.Rule, colInfos []*Colum
 		comments := sqlparser.Comments{
 			fmt.Sprintf(`/*vt+ %s */`, strings.Join(commentsList, " ")),
 		}
-		tpb.sendSelect.Comments = comments
+		tpb.sendSelect.Comments = comments.Parsed()
 	}
 	sendRule.Filter = sqlparser.String(tpb.sendSelect)
 

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -156,7 +156,7 @@ func (rs *rowStreamer) buildPlan() error {
 		return err
 	}
 
-	directives := sqlparser.ExtractCommentDirectives(sel.Comments)
+	directives := sel.Comments.Directives()
 	if s := directives.GetString("ukColumns", ""); s != "" {
 		rs.ukColumnNames, err = textutil.SplitUnescape(s, ",")
 		if err != nil {


### PR DESCRIPTION
## Description

This is from an internal issue by @aquarapid. Our `sqlparser` code is not very efficient at parsing directives inside of SQL comments. Very often during planning, we parse comment sets over and over again. We can do better!

This branch refactors the `sqlparser` so that the AST structure that represents a group of comments only needs to parse directives in the comments once, because it now caches the parsing internally. While I was in the area, I tweaked the behavior of how we store parsed directives. The old `map[string]any` wasn't great: it was eagerly parsing the types of the directives when it needn't need to. This design is simpler and uses way less memory. :ok_hand: 

cc @systay 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->