### PR TITLE
[VTAdmin] Update dynamic clusters to accept no clusters

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -97,7 +97,7 @@ func run(cmd *cobra.Command, args []string) {
 	configs := clusterFileConfig.Combine(defaultClusterConfig, clusterConfigs)
 	clusters := make([]*cluster.Cluster, len(configs))
 
-	if len(configs) == 0 {
+	if len(configs) == 0 && !httpOpts.EnableDynamicClusters {
 		bootSpan.Finish()
 		fatal("must specify at least one cluster")
 	}


### PR DESCRIPTION
Signed-off-by: notfelineit <notfelineit@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This fix allows users to not pass in clusters at boot up time, when the flag --http-enable-dynamic-clusters is passed.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
N/A

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
N/A