### PR TITLE
[vtadmin-web] Add /vschema route to Keyspace detail view + QueryErrorPlaceholder and QueryLoadingPlaceholder components

### DIFF
--- a/web/vtadmin/src/components/Spinner.module.scss
+++ b/web/vtadmin/src/components/Spinner.module.scss
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.spinner {
+    border: 0.25em solid;
+    border-color: theme('colors.vtblue.50');
+    border-right-color: transparent;
+    vertical-align: -0.125em;
+
+    @apply animate-spin;
+    @apply border-2;
+    @apply h-8;
+    @apply inline-block;
+    @apply rounded-full;
+    @apply w-8;
+}

--- a/web/vtadmin/src/components/Spinner.tsx
+++ b/web/vtadmin/src/components/Spinner.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import cx from 'classnames';
+
+import style from './Spinner.module.scss';
+
+export const Spinner = () => {
+    return <div className={style.spinner} />;
+};

--- a/web/vtadmin/src/components/Spinner.tsx
+++ b/web/vtadmin/src/components/Spinner.tsx
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import cx from 'classnames';
-
 import style from './Spinner.module.scss';
 
 export const Spinner = () => {

--- a/web/vtadmin/src/components/placeholders/QueryErrorPlaceholder.test.tsx
+++ b/web/vtadmin/src/components/placeholders/QueryErrorPlaceholder.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { QueryErrorPlaceholder } from './QueryErrorPlaceholder';
+import * as httpAPI from '../../api/http';
+import { useClusters } from '../../hooks/api';
+
+jest.mock('../../api/http');
+
+const queryHelper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+
+    const wrapper: React.FC = ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    return renderHook(() => useClusters(), { wrapper });
+};
+
+describe('QueryErrorPlaceholder', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders an error message', async () => {
+        const errorMessage = 'nope';
+        (httpAPI.fetchClusters as any).mockRejectedValueOnce(new Error(errorMessage));
+
+        const { result, waitFor } = queryHelper();
+        await waitFor(() => result.current.isError);
+
+        render(<QueryErrorPlaceholder query={result.current} />);
+
+        const placeholder = await screen.findByRole('status');
+        expect(placeholder).not.toBeNull();
+
+        const button = within(placeholder).getByRole('button');
+        expect(button).not.toBeNull();
+
+        const message = within(placeholder).getByTestId('error-message');
+        expect(message.textContent).toEqual(errorMessage);
+    });
+
+    it('refetches', async () => {
+        (httpAPI.fetchClusters as any).mockRejectedValueOnce(new Error()).mockRejectedValueOnce(new Error());
+
+        expect((httpAPI.fetchClusters as any).mock.calls.length).toEqual(0);
+
+        const { result, waitFor } = queryHelper();
+        await waitFor(() => result.current.isError);
+
+        render(<QueryErrorPlaceholder query={result.current} />);
+
+        expect((httpAPI.fetchClusters as any).mock.calls.length).toEqual(1);
+
+        let placeholder = await screen.findByRole('status');
+        let button = within(placeholder).getByRole('button');
+        expect(button).not.toBeNull();
+        expect(button.textContent).toEqual('Try again');
+
+        fireEvent.click(button);
+
+        await waitFor(() => result.current.isFetching);
+        expect((httpAPI.fetchClusters as any).mock.calls.length).toEqual(2);
+    });
+
+    it('does not render when no error', async () => {
+        (httpAPI.fetchClusters as any).mockResolvedValueOnce({ clusters: [] });
+        const { result, waitFor } = queryHelper();
+
+        render(<QueryErrorPlaceholder query={result.current} />);
+
+        await waitFor(() => result.current.isSuccess);
+
+        const placeholder = screen.queryByRole('status');
+        expect(placeholder).toBeNull();
+    });
+
+    it('does not render when loading', async () => {
+        (httpAPI.fetchClusters as any).mockRejectedValueOnce(new Error());
+        const { result, waitFor } = queryHelper();
+
+        const { rerender } = render(<QueryErrorPlaceholder query={result.current} />);
+        await waitFor(() => result.current.isLoading);
+
+        let placeholder = screen.queryByRole('status');
+        expect(placeholder).toBeNull();
+
+        await waitFor(() => !result.current.isLoading);
+
+        rerender(<QueryErrorPlaceholder query={result.current} />);
+        placeholder = screen.queryByRole('status');
+        expect(placeholder).not.toBeNull();
+    });
+});

--- a/web/vtadmin/src/components/placeholders/QueryErrorPlaceholder.tsx
+++ b/web/vtadmin/src/components/placeholders/QueryErrorPlaceholder.tsx
@@ -41,10 +41,10 @@ export const QueryErrorPlaceholder: React.FC<Props> = ({ query, title = 'An erro
     const message = (query.error as any).response?.error?.message || (query.error as any).message;
 
     return (
-        <div className="my-12 text-center">
+        <div aria-live="polite" className="my-12 text-center" role="status">
             <span className="text-[6rem]">😰</span>
             <div className="text-xl font-bold my-4">{title}</div>
-            <code>{message}</code>
+            <code data-testid="error-message">{message}</code>
 
             <div className="my-12">
                 <button className="btn btn-secondary" onClick={() => query.refetch()} type="button">

--- a/web/vtadmin/src/components/placeholders/QueryErrorPlaceholder.tsx
+++ b/web/vtadmin/src/components/placeholders/QueryErrorPlaceholder.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UseQueryResult } from 'react-query';
+
+interface Props {
+    query: UseQueryResult;
+    title?: React.ReactNode;
+}
+
+/**
+ * QueryErrorPlaceholder is a straightforward component that displays
+ * errors returned from a useQuery hook. To simplify its use, this component
+ * takes care of hiding itself when `props.query` is in any state other than an error.
+ * It's perfectly fine to render it this:
+ *
+ *      <QueryErrorPlaceholder query={query} ... />
+ *
+ * ...conversely, it is NOT necessary (although also fine!) to do a check like this:
+ *
+ *      {query.isError && <QueryErrorPlaceholder query={query} .../>}
+ */
+export const QueryErrorPlaceholder: React.FC<Props> = ({ query, title = 'An error occurred' }) => {
+    if (!query.isError || query.isLoading) {
+        return null;
+    }
+
+    const message = (query.error as any).response?.error?.message || (query.error as any).message;
+
+    return (
+        <div className="my-12 text-center">
+            <span className="text-[6rem]">😰</span>
+            <div className="text-xl font-bold my-4">{title}</div>
+            <code>{message}</code>
+
+            <div className="my-12">
+                <button className="btn btn-secondary" onClick={() => query.refetch()} type="button">
+                    Try again
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/web/vtadmin/src/components/placeholders/QueryLoadingPlaceholder.test.tsx
+++ b/web/vtadmin/src/components/placeholders/QueryLoadingPlaceholder.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import * as httpAPI from '../../api/http';
+
+import { useClusters } from '../../hooks/api';
+import { QueryLoadingPlaceholder } from './QueryLoadingPlaceholder';
+
+jest.mock('../../api/http');
+
+const queryHelper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+
+    const wrapper: React.FC = ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    return renderHook(() => useClusters(), { wrapper });
+};
+
+describe('QueryLoadingPlaceholder', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders only when loading', async () => {
+        (httpAPI.fetchClusters as any).mockResolvedValueOnce({ clusters: [] });
+        const { result, waitFor } = queryHelper();
+
+        const { rerender } = render(<QueryLoadingPlaceholder query={result.current} />);
+
+        await waitFor(() => result.current.isLoading);
+
+        let placeholder = screen.queryByRole('status');
+        expect(placeholder).not.toBeNull();
+        expect(placeholder?.textContent).toEqual('Loading...');
+
+        await waitFor(() => result.current.isSuccess);
+
+        rerender(<QueryLoadingPlaceholder query={result.current} />);
+        placeholder = screen.queryByRole('status');
+        expect(placeholder).toBeNull();
+    });
+});

--- a/web/vtadmin/src/components/placeholders/QueryLoadingPlaceholder.tsx
+++ b/web/vtadmin/src/components/placeholders/QueryLoadingPlaceholder.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UseQueryResult } from 'react-query';
+import { Spinner } from '../Spinner';
+
+interface Props {
+    query: UseQueryResult;
+}
+
+/**
+ * QueryLoadingPlaceholder is a straightforward component that displays a loading
+ * message when given a query from a useQueryHook. To simplify its use, this component
+ * takes care of hiding itself when `props.query` is in any state other than "loading".
+ * It's perfectly fine to render it this:
+ *
+ *      <QueryLoadingPlaceholder query={query} ... />
+ *
+ * ...conversely, it is NOT necessary (although also fine!) to do a check like this:
+ *
+ *      {query.isLoading && <QueryLoadingPlaceholder query={query} ... />}
+ */
+export const QueryLoadingPlaceholder: React.FC<Props> = (props) => {
+    if (!props.query.isLoading) {
+        return null;
+    }
+
+    return (
+        <div aria-busy="true" aria-live="polite" className="text-center my-12" role="status">
+            <Spinner />
+            <div className="my-4 text-secondary">
+                {props.query.failureCount > 2 ? 'Still loading...' : 'Loading...'}
+            </div>
+        </div>
+    );
+};

--- a/web/vtadmin/src/components/placeholders/QueryLoadingPlaceholder.tsx
+++ b/web/vtadmin/src/components/placeholders/QueryLoadingPlaceholder.tsx
@@ -39,7 +39,7 @@ export const QueryLoadingPlaceholder: React.FC<Props> = (props) => {
     }
 
     return (
-        <div aria-busy="true" aria-live="polite" className="text-center my-12" role="status">
+        <div aria-busy="true" className="text-center my-12" role="status">
             <Spinner />
             <div className="my-4 text-secondary">
                 {props.query.failureCount > 2 ? 'Still loading...' : 'Loading...'}

--- a/web/vtadmin/src/components/routes/keyspace/Keyspace.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Keyspace.tsx
@@ -23,10 +23,12 @@ import { ContentContainer } from '../../layout/ContentContainer';
 import { NavCrumbs } from '../../layout/NavCrumbs';
 import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
 import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
+import { QueryLoadingPlaceholder } from '../../placeholders/QueryLoadingPlaceholder';
 import { Tab } from '../../tabs/Tab';
 import { TabContainer } from '../../tabs/TabContainer';
 import style from './Keyspace.module.scss';
 import { KeyspaceShards } from './KeyspaceShards';
+import { KeyspaceVSchema } from './KeyspaceVSchema';
 
 interface RouteParams {
     clusterID: string;
@@ -40,7 +42,8 @@ export const Keyspace = () => {
 
     useDocumentTitle(`${name} (${clusterID})`);
 
-    const { data: keyspace, ...kq } = useKeyspace({ clusterID, name });
+    const kq = useKeyspace({ clusterID, name });
+    const { data: keyspace } = kq;
 
     if (kq.error) {
         return (
@@ -86,6 +89,7 @@ export const Keyspace = () => {
             <ContentContainer>
                 <TabContainer>
                     <Tab text="Shards" to={`${url}/shards`} />
+                    <Tab text="VSchema" to={`${url}/vschema`} />
                     <Tab text="JSON" to={`${url}/json`} />
                 </TabContainer>
 
@@ -94,15 +98,17 @@ export const Keyspace = () => {
                         <KeyspaceShards keyspace={keyspace} />
                     </Route>
 
+                    <Route path={`${path}/vschema`}>
+                        <KeyspaceVSchema clusterID={clusterID} name={name} />
+                    </Route>
+
                     <Route path={`${path}/json`}>
+                        <QueryLoadingPlaceholder query={kq} />
                         <Code code={JSON.stringify(keyspace, null, 2)} />
                     </Route>
 
                     <Redirect exact from={path} to={{ pathname: `${path}/shards`, search }} />
                 </Switch>
-
-                {/* TODO skeleton placeholder */}
-                {!!kq.isLoading && <div className={style.placeholder}>Loading</div>}
             </ContentContainer>
         </div>
     );

--- a/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
@@ -32,6 +32,7 @@ import { ShardLink } from '../../links/ShardLink';
 import { getShardSortRange } from '../../../util/keyspaces';
 import { Pip } from '../../pips/Pip';
 import { Tooltip } from '../../tooltip/Tooltip';
+import { QueryLoadingPlaceholder } from '../../placeholders/QueryLoadingPlaceholder';
 
 interface Props {
     keyspace: pb.Keyspace | null | undefined;
@@ -40,7 +41,9 @@ interface Props {
 const TABLE_COLUMNS = ['Shard', 'Primary Serving?', 'Tablets', 'Primary Tablet'];
 
 export const KeyspaceShards = ({ keyspace }: Props) => {
-    const { data: tablets = [], ...tq } = useTablets();
+    const tq = useTablets();
+    const { data: tablets = [] } = tq;
+
     const { value: filter, updateValue: updateFilter } = useSyncedURLParam('shardFilter');
 
     const data = useMemo(() => {
@@ -150,6 +153,7 @@ export const KeyspaceShards = ({ keyspace }: Props) => {
 
     return (
         <div className={style.container}>
+            <QueryLoadingPlaceholder query={tq} />
             <DataFilter
                 autoFocus
                 onChange={(e) => updateFilter(e.target.value)}

--- a/web/vtadmin/src/components/routes/keyspace/KeyspaceVSchema.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/KeyspaceVSchema.tsx
@@ -29,7 +29,7 @@ export const KeyspaceVSchema = ({ clusterID, name }: Props) => {
     return (
         <div>
             <QueryLoadingPlaceholder query={query} />
-            <QueryErrorPlaceholder query={query} title="Couldn't load vschema" />
+            <QueryErrorPlaceholder query={query} title="Couldn't load VSchema" />
             {query.isSuccess && <Code code={JSON.stringify(query.data, null, 2)} />}
         </div>
     );

--- a/web/vtadmin/src/components/routes/keyspace/KeyspaceVSchema.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/KeyspaceVSchema.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useVSchema } from '../../../hooks/api';
+import { Code } from '../../Code';
+import { QueryErrorPlaceholder } from '../../placeholders/QueryErrorPlaceholder';
+import { QueryLoadingPlaceholder } from '../../placeholders/QueryLoadingPlaceholder';
+
+interface Props {
+    clusterID: string;
+    name: string;
+}
+
+export const KeyspaceVSchema = ({ clusterID, name }: Props) => {
+    const query = useVSchema({ clusterID, keyspace: name });
+    return (
+        <div>
+            <QueryLoadingPlaceholder query={query} />
+            <QueryErrorPlaceholder query={query} title="Couldn't load vschema" />
+            {query.isSuccess && <Code code={JSON.stringify(query.data, null, 2)} />}
+        </div>
+    );
+};

--- a/web/vtadmin/src/setupTests.ts
+++ b/web/vtadmin/src/setupTests.ts
@@ -1,5 +1,11 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { setLogger } from 'react-query';
+
+// Suppress network (and "network", i.e., localhost) errors
+// from being logged to the console during testing.
+// See https://react-query.tanstack.com/guides/testing
+setLogger({
+    log: console.log,
+    warn: console.warn,
+    error: () => {},
+});


### PR DESCRIPTION
## Description

This adds a /vschema route to view the (JSON) vschema for a keyspace. 

We can certainly experiment with less... JSON-y ways of presenting this data, but JSON is a good place to start.

Here's a couple of examples:

<img width="1904" alt="Screen Shot 2022-04-01 at 11 33 24 AM" src="https://user-images.githubusercontent.com/855595/161295918-ba9e73f3-9e9a-4382-84cc-091eb32b32c2.png">

<img width="1904" alt="Screen Shot 2022-04-01 at 11 33 20 AM" src="https://user-images.githubusercontent.com/855595/161295924-4523790b-b426-43a4-b03e-2a7523bb1e73.png">

As part of this, I wanted to take a little time for loading and error handling state. To that end, I've added three new components: `Spinner`, `QueryLoadingPlaceholder`, and `QueryErrorPlaceholder`. In order to keep this PR small, I've only used them in this one view. I'll update everywhere else in a separate PR. 

I wanted to keep the loading and error placeholders in separate components for flexibility; components that define a more involved loading UX, like a skeleton table, can then just use the error placeholder on its own. Also... `Spinner` is dead simple and could probably use a revisit in the near future to permit different sizes, etc. :') 

Here's what the whole flow looks like when vtadmin-api returns (in this case, fake) 500s from the `/vschema/{cluster_id}/{keyspace}` route:

https://user-images.githubusercontent.com/855595/161296619-b53d1cf0-c0fa-4cdf-af65-0508eb079a30.mov

## Related Issue(s)

N/A


## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A