### PR TITLE
Move Shard 12 and 18 CI tests to self hosted runners

### DIFF
--- a/.github/docker/cluster_test_12/Dockerfile
+++ b/.github/docker/cluster_test_12/Dockerfile
@@ -1,0 +1,42 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
+
+ARG bootstrap_version=5
+ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
+
+FROM "${image}"
+
+USER root
+
+# Re-copy sources from working tree
+RUN rm -rf /vt/src/vitess.io/vitess/*
+COPY . /vt/src/vitess.io/vitess
+
+# install XtraBackup
+RUN wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+RUN apt-get update
+RUN apt-get install -y gnupg2
+RUN dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+RUN apt-get update
+RUN apt-get install -y percona-xtrabackup-24
+
+# Set the working directory
+WORKDIR /vt/src/vitess.io/vitess
+
+# Fix permissions
+RUN chown -R vitess:vitess /vt
+
+USER vitess
+
+# Set environment variables
+ENV VTROOT /vt/src/vitess.io/vitess
+# Set the vtdataroot such that it uses the volume mount
+ENV VTDATAROOT /vt/vtdataroot
+
+# create the vtdataroot directory
+RUN mkdir -p $VTDATAROOT
+
+# install goimports
+RUN go install golang.org/x/tools/cmd/goimports@latest
+
+# sleep for 50 minutes
+CMD sleep 3000

--- a/.github/docker/cluster_test_18/Dockerfile
+++ b/.github/docker/cluster_test_18/Dockerfile
@@ -1,0 +1,45 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
+
+ARG bootstrap_version=5
+ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
+
+FROM "${image}"
+
+USER root
+
+# Re-copy sources from working tree
+RUN rm -rf /vt/src/vitess.io/vitess/*
+COPY . /vt/src/vitess.io/vitess
+
+# install XtraBackup
+RUN wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+RUN apt-get update
+RUN apt-get install -y gnupg2
+RUN dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+RUN apt-get update
+RUN apt-get install -y percona-xtrabackup-24
+
+# Set the working directory
+WORKDIR /vt/src/vitess.io/vitess
+
+# Fix permissions
+RUN chown -R vitess:vitess /vt
+
+USER vitess
+
+# Set environment variables
+ENV VTROOT /vt/src/vitess.io/vitess
+# Set the vtdataroot such that it uses the volume mount
+ENV VTDATAROOT /vt/vtdataroot
+
+# create the vtdataroot directory
+RUN mkdir -p $VTDATAROOT
+
+# install goimports
+RUN go install golang.org/x/tools/cmd/goimports@latest
+
+# make tools
+RUN make tools
+
+# sleep for 50 minutes
+CMD sleep 3000

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -6,83 +6,36 @@ concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (12)')
   cancel-in-progress: true
 
-env:
-  LAUNCHABLE_ORGANIZATION: "vitess"
-  LAUNCHABLE_WORKSPACE: "vitess-app"
-  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-
 jobs:
   build:
     name: Run endtoend tests on Cluster (12)
-    runs-on: ubuntu-18.04
+    runs-on: self-hosted
 
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Set up python
-      uses: actions/setup-python@v2
+      - name: Build Docker Image
+        run: docker build -f ./.github/docker/cluster_test_12/Dockerfile -t cluster_test_12:$GITHUB_SHA  .
 
-    - name: Tune the OS
-      run: |
-        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
-        # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
-        echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
-        sudo sysctl -p /etc/sysctl.conf
+      - name: Run test
+        timeout-minutes: 30
+        run: docker run --name "cluster_test_12_$GITHUB_SHA" cluster_test_12:$GITHUB_SHA /bin/bash -c 'source build.env && go run test.go -keep-data=true -docker=false -print-log -follow -shard 12 -- -- --keep-data=true'
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Print Volume Used
+        if: ${{ always() }}
+        run: |
+          docker inspect -f '{{ (index .Mounts 0).Name }}' cluster_test_12_$GITHUB_SHA
 
-    - name: Get dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-        go mod download
+      - name: Cleanup Docker Volume
+        run: |
+          docker rm -v cluster_test_12_$GITHUB_SHA
 
-        # install JUnit report formatter
-        go install github.com/jstemmer/go-junit-report@latest
+      - name: Cleanup Docker Container
+        if: ${{ always() }}
+        run: |
+          docker rm -f cluster_test_12_$GITHUB_SHA
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
-
-    - name: Setup launchable dependencies
-      run: |
-        # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
-        pip3 install --user launchable~=1.0 > /dev/null
-
-        # verify that launchable setup is all correct.
-        launchable verify || true
-
-        # Tell Launchable about the build you are producing and testing
-        launchable record build --name "$GITHUB_RUN_ID" --source .
-
-    - name: Run cluster endtoend test
-      timeout-minutes: 30
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
-
-        set -x
-
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 12 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
-
-    - name: Print test output and Record test result in launchable
-      run: |
-        # send recorded tests to launchable
-        launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
-
-        # print test output
-        cat output.txt
-      if: always()
+      - name: Cleanup Docker Image
+        run: |
+          docker image rm cluster_test_12:$GITHUB_SHA

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -6,87 +6,36 @@ concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (18)')
   cancel-in-progress: true
 
-env:
-  LAUNCHABLE_ORGANIZATION: "vitess"
-  LAUNCHABLE_WORKSPACE: "vitess-app"
-  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-
 jobs:
   build:
     name: Run endtoend tests on Cluster (18)
-    runs-on: ubuntu-18.04
+    runs-on: self-hosted
 
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Set up python
-      uses: actions/setup-python@v2
+      - name: Build Docker Image
+        run: docker build -f ./.github/docker/cluster_test_18/Dockerfile -t cluster_test_18:$GITHUB_SHA  .
 
-    - name: Tune the OS
-      run: |
-        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
-        # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
-        echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
-        sudo sysctl -p /etc/sysctl.conf
+      - name: Run test
+        timeout-minutes: 30
+        run: docker run --name "cluster_test_18_$GITHUB_SHA" cluster_test_18:$GITHUB_SHA /bin/bash -c 'source build.env && go run test.go -keep-data=true -docker=false -print-log -follow -shard 18 -- -- --keep-data=true'
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Print Volume Used
+        if: ${{ always() }}
+        run: |
+          docker inspect -f '{{ (index .Mounts 0).Name }}' cluster_test_18_$GITHUB_SHA
 
-    - name: Get dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-        go mod download
+      - name: Cleanup Docker Volume
+        run: |
+          docker rm -v cluster_test_18_$GITHUB_SHA
 
-        # install JUnit report formatter
-        go install github.com/jstemmer/go-junit-report@latest
+      - name: Cleanup Docker Container
+        if: ${{ always() }}
+        run: |
+          docker rm -f cluster_test_18_$GITHUB_SHA
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
-
-    - name: Installing zookeeper and consul
-      run: |
-          make tools
-
-    - name: Setup launchable dependencies
-      run: |
-        # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
-        pip3 install --user launchable~=1.0 > /dev/null
-
-        # verify that launchable setup is all correct.
-        launchable verify || true
-
-        # Tell Launchable about the build you are producing and testing
-        launchable record build --name "$GITHUB_RUN_ID" --source .
-
-    - name: Run cluster endtoend test
-      timeout-minutes: 30
-      run: |
-        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
-        # which musn't be more than 107 characters long.
-        export VTDATAROOT="/tmp/"
-        source build.env
-
-        set -x
-
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 18 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
-
-    - name: Print test output and Record test result in launchable
-      run: |
-        # send recorded tests to launchable
-        launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
-
-        # print test output
-        cat output.txt
-      if: always()
+      - name: Cleanup Docker Image
+        run: |
+          docker image rm cluster_test_18:$GITHUB_SHA

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -77,6 +77,9 @@ jobs:
     - name: Run cluster endtoend test
       timeout-minutes: 30
       run: |
+        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+        # which musn't be more than 107 characters long.
+        export VTDATAROOT="/tmp/"
         source build.env
 
         set -x

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -48,7 +48,6 @@ var (
 	// Hence, they are not listed in the list below.
 	clusterList = []string{
 		"vtctlbackup_sharded_clustertest_heavy",
-		"12",
 		"13",
 		"ers_prs_newfeatures_heavy",
 		"15",
@@ -112,8 +111,10 @@ var (
 		"schemadiff_vrepl",
 	}
 
-	clusterSelfHostedList []string
-	clusterDockerList     = []string{}
+	clusterSelfHostedList = []string{
+		"12",
+	}
+	clusterDockerList = []string{}
 	// TODO: currently some percona tools including xtrabackup are installed on all clusters, we can possibly optimize
 	// this by only installing them in the required clusters
 	clustersRequiringXtraBackup = append(clusterList, clusterSelfHostedList...)

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -53,7 +53,6 @@ var (
 		"15",
 		"shardedrecovery_stress_verticalsplit_heavy",
 		"17",
-		"18",
 		"19",
 		"20",
 		"21",
@@ -113,6 +112,7 @@ var (
 
 	clusterSelfHostedList = []string{
 		"12",
+		"18",
 	}
 	clusterDockerList = []string{}
 	// TODO: currently some percona tools including xtrabackup are installed on all clusters, we can possibly optimize

--- a/test/config.json
+++ b/test/config.json
@@ -170,7 +170,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/cellalias"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "12",
+			"Shard": "13",
 			"RetryMax": 3,
 			"Tags": []
 		},


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
It is getting very hard to reproduce some of the flaky tests like `TestFallbackSecurityPolicy` (https://github.com/vitessio/vitess/issues/9946) and `TestReparenting` (https://github.com/vitessio/vitess/issues/9949). 

Shard 12 and 18 are being moved to the self-hosted runners so that the next time this failure occurs, we have the associated logs.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/9946
- https://github.com/vitessio/vitess/issues/9949

## Checklist
- [x] Should this PR be backported? No
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->