### PR TITLE
Route explain tab plan to the proper Keyspace

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -806,3 +806,13 @@ func TestFilterAfterLeftJoin(t *testing.T) {
 	query := "select /*vt+ PLANNER=gen4 */ A.id1, A.id2 from t1 as A left join t1 as B on A.id1 = B.id2 WHERE B.id1 IS NULL"
 	utils.AssertMatches(t, conn, query, `[[INT64(1) INT64(10)]]`)
 }
+
+func TestDescribeVindex(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	utils.AssertContainsError(t, conn, "describe hash", "'vt_ks.hash' doesn't exist")
+}

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -2476,6 +2476,15 @@ func TestExecutorShowVitessMigrations(t *testing.T) {
 	assert.Contains(t, sbc2.StringQueries(), "SELECT * FROM _vt.schema_migrations")
 }
 
+func TestExecutorDescHash(t *testing.T) {
+	executor, _, _, _ := createExecutorEnv()
+	showQuery := "desc hash_index"
+	session := NewSafeSession(&vtgatepb.Session{TargetString: "TestExecutor"})
+	ctx := context.Background()
+	_, err := executor.Execute(ctx, "", session, showQuery, nil)
+	require.NoError(t, err)
+}
+
 func exec(executor *Executor, session *SafeSession, sql string) (*sqltypes.Result, error) {
 	return executor.Execute(context.Background(), "TestExecute", session, sql, nil)
 }

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -497,6 +497,17 @@ func (vw *vschemaWrapper) AllKeyspace() ([]*vindexes.Keyspace, error) {
 	return []*vindexes.Keyspace{vw.keyspace}, nil
 }
 
+// FindKeyspace implements the VSchema interface
+func (vw *vschemaWrapper) FindKeyspace(keyspace string) (*vindexes.Keyspace, error) {
+	if vw.keyspace == nil {
+		return nil, errors.New("keyspace not available")
+	}
+	if vw.keyspace.Name == keyspace {
+		return vw.keyspace, nil
+	}
+	return nil, nil
+}
+
 func (vw *vschemaWrapper) Planner() plancontext.PlannerVersion {
 	return vw.version
 }

--- a/go/vt/vtgate/planbuilder/plancontext/vschema.go
+++ b/go/vt/vtgate/planbuilder/plancontext/vschema.go
@@ -30,6 +30,7 @@ type VSchema interface {
 	SysVarSetEnabled() bool
 	KeyspaceExists(keyspace string) bool
 	AllKeyspace() ([]*vindexes.Keyspace, error)
+	FindKeyspace(keyspace string) (*vindexes.Keyspace, error)
 	GetSemTable() *semantics.SemTable
 	Planner() PlannerVersion
 	SetPlannerVersion(pv PlannerVersion)

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -77,7 +77,7 @@ type iExecute interface {
 	VSchema() *vindexes.VSchema
 }
 
-//VSchemaOperator is an interface to Vschema Operations
+// VSchemaOperator is an interface to Vschema Operations
 type VSchemaOperator interface {
 	GetCurrentSrvVschema() *vschemapb.SrvVSchema
 	UpdateVSchema(ctx context.Context, ksName string, vschema *vschemapb.SrvVSchema) error
@@ -378,6 +378,19 @@ func (vc *vcursorImpl) AllKeyspace() ([]*vindexes.Keyspace, error) {
 	return kss, nil
 }
 
+// FindKeyspace implements the VSchema interface
+func (vc *vcursorImpl) FindKeyspace(keyspace string) (*vindexes.Keyspace, error) {
+	if len(vc.vschema.Keyspaces) == 0 {
+		return nil, errNoDbAvailable
+	}
+	for _, ks := range vc.vschema.Keyspaces {
+		if ks.Keyspace.Name == keyspace {
+			return ks.Keyspace, nil
+		}
+	}
+	return nil, nil
+}
+
 // Planner implements the ContextVSchema interface
 func (vc *vcursorImpl) Planner() plancontext.PlannerVersion {
 	if vc.safeSession.Options != nil &&
@@ -608,7 +621,7 @@ func (vc *vcursorImpl) SetSysVar(name string, expr string) {
 	vc.safeSession.SetSystemVariable(name, expr)
 }
 
-//NeedsReservedConn implements the SessionActions interface
+// NeedsReservedConn implements the SessionActions interface
 func (vc *vcursorImpl) NeedsReservedConn() {
 	vc.safeSession.SetReservedConn(true)
 }


### PR DESCRIPTION
## Description

This pull request introduces `FindKeyspace` to the `VSchema` interface, allowing us to route explain queries to the proper keyspace regardless if the target is a MySQL table or a Vindex table.

Based on the issue reported in #10019, running a query that describes a Vindex led to a `panic` in VTGate. When running the local example to have a sharded cluster, the queries that follow used to crash:

```
mysql> use customer;
mysql> desc hash;
ERROR 2013 (HY000): Lost connection to MySQL server during query
No connection. Trying to reconnect...
Connection id:    8
Current database: customer

ERROR 2013 (HY000): Lost connection to MySQL server during query
No connection. Trying to reconnect...
Connection id:    9
Current database: customer

ERROR 2013 (HY000): Lost connection to MySQL server during query
mysql> 
```

With the patch proposed in this pull request, the same queries produce the output that follows.

```
mysql> use customer;
mysql> desc hash;
ERROR 1146 (42S02): target: customer.80-.primary: vttablet: rpc error: code = NotFound desc = Table 'vt_customer.hash' doesn't exist (errno 1146) (sqlstate 42S02) (CallerID: userData1): Sql: "explain `hash`", BindVars: {}
```

The MySQL error is expected as there is no `hash` table in this keyspace. Describe/explain are used to obtain information about table structure or query execution plans, not indexes.

## Related Issue(s)

- Fixes #10019

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
