### PR TITLE
Skip CI workflows based on the list of modified files

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -1,30 +1,43 @@
 name: check_formatting
 on: [pull_request,push]
 jobs:
-
   build:
     name: Check Formatting
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      if: needs.check_relevant_files.outputs.go_files == 'true'
+      uses: actions/checkout@v2
+
+    - name: Check for changes in Go files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          go_files:
+            - '**/*.go'
+            - '*.go'
+            - 'go.[sumod]'
 
     - name: Set up Go
+      if: steps.changes.outputs.go_files == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.go_files == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      if: steps.changes.outputs.go_files == 'true'
       run: |
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Run go fmt
+      if: steps.changes.outputs.go_files == 'true'
       run: |
         gofmt -l . | grep -vF vendor/ && exit 1 || echo "All files formatted correctly"

--- a/.github/workflows/check_imports.yml
+++ b/.github/workflows/check_imports.yml
@@ -1,25 +1,36 @@
 name: check_imports
 on: [pull_request,push]
 jobs:
-
   build:
     name: Check Imports
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in Go files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          go_files:
+            - '**/*.go'
+            - '*.go'
+            - 'go.[sumod]'
 
     - name: Set up Go
+      if: steps.changes.outputs.go_files == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Install goimports
+      if: steps.changes.outputs.go_files == 'true'
       run: |
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run goimports
+      if: steps.changes.outputs.go_files == 'true'
       run: |
         out=$(goimports -local vitess.io/vitess -l -w $(find . -name "*.go" | grep -v ".pb.go"))
         echo $out | grep go > /dev/null && echo -e "The following files are malformatted:\n$out" && exit 1 || echo "All the files are formatted correctly"

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -16,8 +16,10 @@ jobs:
         filters: |
           parser_changes:
             - 'go/vt/sqlparser/**'
-            - 'tools/check_make_parser.sh'
             - 'go.[sumod]'
+            - 'build.env'
+            - 'bootstrap.sh'
+            - 'tools/**'
 
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -6,20 +6,32 @@ jobs:
     name: Check Make Parser
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          parser_changes:
+            - 'go/vt/sqlparser/**'
+            - 'tools/check_make_parser.sh'
+            - 'go.[sumod]'
 
     - name: Set up Go
       uses: actions/setup-go@v2
+      if: steps.changes.outputs.parser_changes == 'true'
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.parser_changes == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.parser_changes == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y make unzip g++ etcd curl git wget
@@ -27,9 +39,11 @@ jobs:
         go mod download
 
     - name: Run make minimaltools
+      if: steps.changes.outputs.parser_changes == 'true'
       run: |
         make minimaltools
 
     - name: check_make_parser
+      if: steps.changes.outputs.parser_changes == 'true'
       run: |
         tools/check_make_parser.sh

--- a/.github/workflows/check_make_proto.yml
+++ b/.github/workflows/check_make_proto.yml
@@ -6,20 +6,37 @@ jobs:
     name: Check Make Proto
     runs-on: ubuntu-latest
     steps:
-    
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          proto_changes:
+            - 'bootstrap.sh'
+            - 'tools/**'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'Makefile'
+            - 'go/vt/proto/**'
+            - 'proto/*.proto'
+
     - name: Set up Go
       uses: actions/setup-go@v2
+      if: steps.changes.outputs.proto_changes == 'true'
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.proto_changes == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out code
-      uses: actions/checkout@v2
 
     - name: Get dependencies
+      if: steps.changes.outputs.proto_changes == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y make unzip g++ etcd curl git wget
@@ -28,6 +45,7 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make minimaltools
+      if: steps.changes.outputs.proto_changes == 'true'
       run: |
         make minimaltools
 

--- a/.github/workflows/check_make_proto.yml
+++ b/.github/workflows/check_make_proto.yml
@@ -50,5 +50,6 @@ jobs:
         make minimaltools
 
     - name: check_make_proto
+      if: steps.changes.outputs.proto_changes == 'true'
       run: |
         tools/check_make_proto.sh

--- a/.github/workflows/check_make_sizegen.yml
+++ b/.github/workflows/check_make_sizegen.yml
@@ -6,20 +6,37 @@ jobs:
     name: Check Make Sizegen
     runs-on: ubuntu-latest
     steps:
-    
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          sizegen:
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'tools/**'
+            - 'bootstrap.sh'
+
     - name: Set up Go
+      if: steps.changes.outputs.sizegen == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.sizegen == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     - name: Check out code
+      if: steps.changes.outputs.sizegen == 'true'
       uses: actions/checkout@v2
 
     - name: Get dependencies
+      if: steps.changes.outputs.sizegen == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y make unzip g++ etcd curl git wget
@@ -28,9 +45,11 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make minimaltools
+      if: steps.changes.outputs.sizegen == 'true'
       run: |
         make minimaltools
 
     - name: check_make_sizegen
+      if: steps.changes.outputs.sizegen == 'true'
       run: |
         tools/check_make_sizegen.sh

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -6,20 +6,37 @@ jobs:
     name: Check Make Visitor
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          visitor:
+            - 'go/tools/asthelpergen/**'
+            - 'go/vt/sqlparser/**'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'tools/**'
+            - 'bootstrap.sh'
+            - 'misc/git/hooks/asthelpers'
 
     - name: Set up Go
+      if: steps.changes.outputs.visitor == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.visitor == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.visitor == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y make unzip g++ etcd curl git wget
@@ -28,9 +45,11 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make minimaltools
+      if: steps.changes.outputs.visitor == 'true'
       run: |
         make minimaltools
 
     - name: check_make_visitor
+      if: steps.changes.outputs.visitor == 'true'
       run: |
         misc/git/hooks/asthelpers

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -21,7 +21,15 @@ jobs:
         with:
           filters: |
             end_to_end:
-              - 'go/**'
+              - 'go/**/*.go'
+              - 'test.go'
+              - 'Makefile'
+              - 'build.env'
+              - 'go.[sumod]'
+              - 'proto/*.proto'
+              - 'tools/**'
+              - 'config/**'
+              - '.github/docker/**'
 
       - name: Build Docker Image
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -30,6 +30,7 @@ jobs:
               - 'tools/**'
               - 'config/**'
               - '.github/docker/**'
+              - 'bootstrap.sh'
 
       - name: Build Docker Image
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -15,27 +15,39 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Check for changes in relevant files
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            end_to_end:
+              - 'go/**'
+
       - name: Build Docker Image
+        if: steps.changes.outputs.end_to_end == 'true'
         run: docker build -f ./.github/docker/cluster_test_12/Dockerfile -t cluster_test_12:$GITHUB_SHA  .
 
       - name: Run test
+        if: steps.changes.outputs.end_to_end == 'true'
         timeout-minutes: 30
         run: docker run --name "cluster_test_12_$GITHUB_SHA" cluster_test_12:$GITHUB_SHA /bin/bash -c 'source build.env && go run test.go -keep-data=true -docker=false -print-log -follow -shard 12 -- -- --keep-data=true'
 
       - name: Print Volume Used
-        if: ${{ always() }}
+        if: always() && steps.changes.outputs.end_to_end == 'true'
         run: |
           docker inspect -f '{{ (index .Mounts 0).Name }}' cluster_test_12_$GITHUB_SHA
 
       - name: Cleanup Docker Volume
+        if: steps.changes.outputs.end_to_end == 'true'
         run: |
           docker rm -v cluster_test_12_$GITHUB_SHA
 
       - name: Cleanup Docker Container
-        if: ${{ always() }}
+        if: always() && steps.changes.outputs.end_to_end == 'true'
         run: |
           docker rm -f cluster_test_12_$GITHUB_SHA
 
       - name: Cleanup Docker Image
+        if: steps.changes.outputs.end_to_end == 'true'
         run: |
           docker image rm cluster_test_12:$GITHUB_SHA

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard 13 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard 15 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard 17 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -15,27 +15,39 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Check for changes in relevant files
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            end_to_end:
+              - 'go/**'
+
       - name: Build Docker Image
+        if: steps.changes.outputs.end_to_end == 'true'
         run: docker build -f ./.github/docker/cluster_test_18/Dockerfile -t cluster_test_18:$GITHUB_SHA  .
 
       - name: Run test
+        if: steps.changes.outputs.end_to_end == 'true'
         timeout-minutes: 30
         run: docker run --name "cluster_test_18_$GITHUB_SHA" cluster_test_18:$GITHUB_SHA /bin/bash -c 'source build.env && go run test.go -keep-data=true -docker=false -print-log -follow -shard 18 -- -- --keep-data=true'
 
       - name: Print Volume Used
-        if: ${{ always() }}
+        if: always() && steps.changes.outputs.end_to_end == 'true'
         run: |
           docker inspect -f '{{ (index .Mounts 0).Name }}' cluster_test_18_$GITHUB_SHA
 
       - name: Cleanup Docker Volume
+        if: steps.changes.outputs.end_to_end == 'true'
         run: |
           docker rm -v cluster_test_18_$GITHUB_SHA
 
       - name: Cleanup Docker Container
-        if: ${{ always() }}
+        if: always() && steps.changes.outputs.end_to_end == 'true'
         run: |
           docker rm -f cluster_test_18_$GITHUB_SHA
 
       - name: Cleanup Docker Image
+        if: steps.changes.outputs.end_to_end == 'true'
         run: |
           docker image rm cluster_test_18:$GITHUB_SHA

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -21,7 +21,15 @@ jobs:
         with:
           filters: |
             end_to_end:
-              - 'go/**'
+              - 'go/**/*.go'
+              - 'test.go'
+              - 'Makefile'
+              - 'build.env'
+              - 'go.[sumod]'
+              - 'proto/*.proto'
+              - 'tools/**'
+              - 'config/**'
+              - '.github/docker/**'
 
       - name: Build Docker Image
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -30,6 +30,7 @@ jobs:
               - 'tools/**'
               - 'config/**'
               - '.github/docker/**'
+              - 'bootstrap.sh'
 
       - name: Build Docker Image
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard 19 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard 20 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard 21 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard 22 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,10 +66,12 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Installing zookeeper and consul
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
           make tools
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -70,6 +83,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -83,6 +97,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard 24 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -105,4 +105,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard 26 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -98,6 +111,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard ers_prs_newfeatures_heavy | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -119,4 +119,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -26,7 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -17,25 +17,37 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get key to latest MySQL repo
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
@@ -64,6 +76,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -75,6 +88,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -88,10 +102,10 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard mysql80 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard onlineddl_declarative | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard onlineddl_ghost | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard onlineddl_revert | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard onlineddl_revertible | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard onlineddl_scheduler | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard onlineddl_singleton | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl_stress | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl_stress_suite | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard onlineddl_vrepl_suite | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard resharding | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard resharding_bytes | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard schemadiff_vrepl | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |
@@ -118,4 +119,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -98,6 +111,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard shardedrecovery_stress_verticalsplit_heavy | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,10 +66,12 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Installing zookeeper and consul
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
           make tools
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -70,6 +83,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -83,6 +97,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_consul | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -105,4 +105,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_tablegc | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_throttler | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard tabletmanager_throttler_custom_config | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -17,25 +17,37 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get key to latest MySQL repo
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
@@ -64,6 +76,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -75,6 +88,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -108,10 +122,10 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vreplication_across_db_versions | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -26,7 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |
@@ -118,4 +119,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -98,6 +111,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vreplication_basic | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -98,6 +111,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vreplication_cellalias | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -119,4 +119,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -119,4 +119,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -98,6 +111,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vreplication_migrate | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -98,6 +111,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vreplication_multicell | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -119,4 +119,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |
@@ -118,4 +119,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -98,6 +111,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vreplication_v2 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vstream_failover | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vstream_stoponreshard_false | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vstream_stoponreshard_true | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vstream_with_keyspaces_to_watch | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |
@@ -118,4 +119,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -98,6 +111,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtctlbackup_sharded_clustertest_heavy | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_buffer | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_concurrentdml | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_gen4 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_godriver | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_queries | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_readafterwrite | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_reservedconn | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_schema | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_schema_tracker | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_tablet_healthcheck_cache | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |
@@ -99,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_topo | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -105,4 +105,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,10 +66,12 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Installing zookeeper and consul
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
           make tools
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -70,6 +83,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -83,6 +97,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_topo_consul | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_topo_etcd | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_transaction | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_unsharded | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_vindex | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtgate_vschema | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtorc | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -17,25 +17,37 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get key to latest MySQL repo
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
@@ -64,6 +76,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -75,6 +88,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -88,10 +102,10 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard vtorc_8.0 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -26,7 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -98,6 +111,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard worker_vault_heavy | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -119,4 +119,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -17,25 +17,36 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -55,6 +66,7 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -66,6 +78,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -79,6 +92,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard xb_recovery | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -100,4 +100,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -26,8 +26,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -34,6 +34,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -6,25 +6,44 @@ jobs:
     name: cluster initial sharding multi
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Run initial sharding multi
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go run test.go -print-log initial_sharding_multi

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -7,25 +7,45 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+            - 'docker/**'
 
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Run tests which require docker - 1
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go run test.go -docker=true --follow -shard 10

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -7,25 +7,45 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+            - 'docker/**'
 
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Run tests which require docker - 2
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go run test.go -docker=true --follow -shard 25

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -6,20 +6,38 @@ jobs:
     name: End-to-End Test (Race)
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Setup MySQL 8.0
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
@@ -37,10 +55,12 @@ jobs:
         go mod download
 
     - name: Run make minimaltools
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         make minimaltools
 
     - name: e2e_race
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         make e2e_test_race

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -6,26 +6,45 @@ jobs:
     name: End-to-End Test
     runs-on: ubuntu-18.04
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
@@ -36,14 +55,17 @@ jobs:
         go mod download
 
     - name: Run make minimaltools
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         make minimaltools
 
     - name: Build
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         make build
 
     - name: endtoend
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- tools/e2e_test_runner.sh

--- a/.github/workflows/ensure_bootstrap_updated.yml
+++ b/.github/workflows/ensure_bootstrap_updated.yml
@@ -6,26 +6,39 @@ jobs:
     name: Check Bootstrap Updated
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'docker/**'
+            - 'test.go'
+            - 'Makefile'
 
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.13
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: run ensure_bootstrap_version
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         make ensure_bootstrap_version
         git status

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -5,33 +5,50 @@ jobs:
     name: Lint using golangci-lint
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Check for changes in Go files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          go_files:
+            - '**/*.go'
+            - '*.go'
+            - 'go.[sumod]'
+
     - name: Set up Go
+      if: steps.changes.outputs.go_files == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
       id: go
 
     - name: Tune the OS
+      if: steps.changes.outputs.go_files == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      if: steps.changes.outputs.go_files == 'true'
       run: |
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
     - name: Install golangci-lint
+      if: steps.changes.outputs.go_files == 'true'
       run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 
     - name: Clean Env
+      if: steps.changes.outputs.go_files == 'true'
       run: $(go env GOPATH)/bin/golangci-lint cache clean
 
     - name: Print linter version
+      if: steps.changes.outputs.go_files == 'true'
       run: $(go env GOPATH)/bin/golangci-lint --version
 
     - name: Run golangci-lint
+      if: steps.changes.outputs.go_files == 'true'
       run: $(go env GOPATH)/bin/golangci-lint run go/...

--- a/.github/workflows/gomod-tidy.yml
+++ b/.github/workflows/gomod-tidy.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Check for changes in relevant files
+    - name: Check for changes in Go files
       uses: dorny/paths-filter@v2
       id: changes
       with:
@@ -16,6 +16,7 @@ jobs:
           go_files:
             - '**/*.go'
             - '*.go'
+            - 'go.[sumod]'
 
     - name: Set up Go
       if: steps.changes.outputs.go_files == 'true'

--- a/.github/workflows/gomod-tidy.yml
+++ b/.github/workflows/gomod-tidy.yml
@@ -5,26 +5,39 @@ jobs:
     name: Check go mod tidy
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          go_files:
+            - '**/*.go'
+            - '*.go'
+
     - name: Set up Go
+      if: steps.changes.outputs.go_files == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
       id: go
 
     - name: Tune the OS
+      if: steps.changes.outputs.go_files == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      if: steps.changes.outputs.go_files == 'true'
       run: |
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
     - name: Run go mod tidy
+      if: steps.changes.outputs.go_files == 'true'
       run: |
         set -e
         go mod tidy

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -11,20 +11,39 @@ jobs:
         topo: [etcd,k8s]
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          example:
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+            - 'examples/**'
 
     - name: Set up Go
+      if: steps.changes.outputs.examples == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.examples == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.examples == 'true'
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
           # Setup MySQL 8.0
@@ -46,14 +65,17 @@ jobs:
         go mod download
 
     - name: Run make minimaltools
+      if: steps.changes.outputs.examples == 'true'
       run: |
         make minimaltools
 
     - name: Build
+      if: steps.changes.outputs.examples == 'true'
       run: |
         make build
 
     - name: local_example
+      if: steps.changes.outputs.examples == 'true'
       timeout-minutes: 30
       run: |
         export TOPO=${{matrix.topo}}

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -11,20 +11,39 @@ jobs:
         topo: [consul,etcd,k8s]
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          example:
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+            - 'examples/**'
 
     - name: Set up Go
+      if: steps.changes.outputs.examples == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.examples == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.examples == 'true'
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
           # Setup MySQL 8.0
@@ -46,14 +65,17 @@ jobs:
         go mod download
 
     - name: Run make minimaltools
+      if: steps.changes.outputs.examples == 'true'
       run: |
         make minimaltools
 
     - name: Build
+      if: steps.changes.outputs.examples == 'true'
       run: |
         make build
 
     - name: local_example
+      if: steps.changes.outputs.examples == 'true'
       timeout-minutes: 30
       run: |
         export TOPO=${{matrix.topo}}

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -11,20 +11,39 @@ jobs:
         topo: [etcd]
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          example:
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+            - 'examples/**'
 
     - name: Set up Go
+      if: steps.changes.outputs.example == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.example == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.example == 'true'
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
           # Setup MySQL 8.0
@@ -46,14 +65,17 @@ jobs:
         go mod download
 
     - name: Run make minimaltools
+      if: steps.changes.outputs.example == 'true'
       run: |
         make minimaltools
 
     - name: Build
+      if: steps.changes.outputs.example == 'true'
       run: |
         make build
 
     - name: region_example
+      if: steps.changes.outputs.example == 'true'
       timeout-minutes: 30
       run: |
         export TOPO=${{matrix.topo}}

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -27,6 +27,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -10,20 +10,37 @@ jobs:
     name: Unit Test (Race)
     runs-on: ubuntu-18.04
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          unit_tests:
+            - 'go/**'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
+      if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -45,9 +62,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         make tools
+
     - name: unit_race
+      if: steps.changes.outputs.unit_tests == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test_race

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -28,6 +28,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -19,17 +19,24 @@ jobs:
       id: changes
       with:
         filters: |
-          end_to_end:
+          unit_tests:
             - 'go/**'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
@@ -37,7 +44,7 @@ jobs:
         sudo sysctl -p /etc/sysctl.conf
 
     - name: Get dependencies
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -74,12 +81,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         make tools
 
     - name: Run test
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -11,22 +11,33 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -63,10 +74,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         make tools
 
     - name: Run test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -28,6 +28,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -19,17 +19,24 @@ jobs:
       id: changes
       with:
         filters: |
-          end_to_end:
+          unit_tests:
             - 'go/**'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
@@ -37,7 +44,7 @@ jobs:
         sudo sysctl -p /etc/sysctl.conf
 
     - name: Get dependencies
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -74,12 +81,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         make tools
 
     - name: Run test
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -11,22 +11,33 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -63,10 +74,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         make tools
 
     - name: Run test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -28,6 +28,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -19,17 +19,24 @@ jobs:
       id: changes
       with:
         filters: |
-          end_to_end:
+          unit_tests:
             - 'go/**'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
@@ -37,7 +44,7 @@ jobs:
         sudo sysctl -p /etc/sysctl.conf
 
     - name: Get dependencies
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -59,12 +66,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         make tools
 
     - name: Run test
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -11,22 +11,33 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -48,10 +59,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         make tools
 
     - name: Run test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -28,6 +28,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -11,22 +11,33 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -66,10 +77,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         make tools
 
     - name: Run test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -19,17 +19,24 @@ jobs:
       id: changes
       with:
         filters: |
-          end_to_end:
+          unit_tests:
             - 'go/**'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
@@ -37,7 +44,7 @@ jobs:
         sudo sysctl -p /etc/sysctl.conf
 
     - name: Get dependencies
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -77,12 +84,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         make tools
 
     - name: Run test
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -56,22 +56,43 @@ jobs:
       - get_latest_release
 
     steps:
+    - name: Check out commit's code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out commit's code
-      uses: actions/checkout@v2
-
     - name: Get base dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -92,15 +113,18 @@ jobs:
 
     # Checkout to the last release of Vitess
     - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
       with:
         ref: ${{ needs.get_latest_release.outputs.latest_release }}
 
     - name: Get dependencies for the last release
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
     - name: Building last release's binaries
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 10
       run: |
         source build.env
@@ -111,13 +135,16 @@ jobs:
 
     # Checkout to this build's commit
     - name: Check out commit's code
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
 
     - name: Get dependencies for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
     - name: Building the binaries for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 10
       run: |
         source build.env
@@ -127,6 +154,7 @@ jobs:
 
     # Swap binaries, use last release's VTTablet
     - name: Use last release's VTTablet
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
 
@@ -136,6 +164,7 @@ jobs:
 
     # Run test with VTTablet at version N-1 and VTBackup at version N
     - name: Run backups tests (vttablet=N-1, vtbackup=N)
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
@@ -145,6 +174,7 @@ jobs:
 
     # Swap binaries again, use current version's VTTablet, and last release's VTBackup
     - name: Use current version VTTablet, and other version VTBackup
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
 
@@ -156,6 +186,7 @@ jobs:
 
     # Run test again with VTTablet at version N, and VTBackup at version N-1
     - name: Run backups tests (vttablet=N, vtbackup=N-1)
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -57,25 +57,51 @@ jobs:
       - get_latest_release
 
     steps:
+    # Checkout to this build's commit
+    - name: Checkout to commit's code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
     - name: Get base dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo DEBIAN_FRONTEND="noninteractive" apt-get update
         # Uninstall any previously installed MySQL first
@@ -112,15 +138,18 @@ jobs:
 
     # Checkout to the last release of Vitess
     - name: Checkout to the other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
       with:
         ref: ${{ needs.get_latest_release.outputs.latest_release }}
 
     - name: Get dependencies for the last release
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
     - name: Building last release's binaries
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 5
       run: |
         source build.env
@@ -131,17 +160,21 @@ jobs:
 
     # Checkout to this build's commit
     - name: Checkout to commit's code
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
 
     - name: Get dependencies for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
     - name: Run make minimaltools
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         make minimaltools
 
     - name: Building the binaries for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 5
       run: |
         source build.env
@@ -152,6 +185,7 @@ jobs:
     # We create a sharded Vitess cluster following the local example.
     # We also insert a few rows in our three tables.
     - name: Create the example Vitess cluster with all components using version N
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 5
       run: |
         source build.env ; cd examples/local
@@ -159,6 +193,7 @@ jobs:
 
     # Taking a backup
     - name: Take a backup of all the shards
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 2
       run: |
         source build.env ; cd examples/local
@@ -172,6 +207,7 @@ jobs:
     #     - corder:   5
     # We shall see the same number of rows after restoring the backup.
     - name: Insert more data after the backup
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env ; cd examples/local ; source ./env.sh
 
@@ -181,6 +217,7 @@ jobs:
 
     # Stop all the tablets and remove their data
     - name: Stop tablets
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 5
       run: |
         source build.env ; cd examples/local
@@ -188,6 +225,7 @@ jobs:
 
     # We downgrade: we use the version N-1 of vttablet
     - name: Downgrade - Swap binaries, use VTTablet N-1
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
 
@@ -197,6 +235,7 @@ jobs:
 
     # Starting the tablets again, they will automatically start restoring the last backup.
     - name: Start new tablets and restore
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 5
       run: |
         source build.env ; cd examples/local
@@ -206,6 +245,7 @@ jobs:
 
     # Count the number of rows in each table to make sure the restoration is successful.
     - name: Assert the number of rows in every table
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env ; cd examples/local ; source ./env.sh
 
@@ -215,6 +255,7 @@ jobs:
 
     # We insert one more row in every table.
     - name: Insert more rows in the tables
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env ; cd examples/local ; source ./env.sh
 
@@ -224,6 +265,7 @@ jobs:
 
     # Taking a second backup of the cluster.
     - name: Take a second backup of all the shards
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 2
       run: |
         source build.env ; cd examples/local
@@ -231,6 +273,7 @@ jobs:
 
     # Stopping the tablets so we can perform the upgrade.
     - name: Stop tablets
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 5
       run: |
         source build.env ; cd examples/local
@@ -238,6 +281,7 @@ jobs:
 
     # We upgrade: we swap binaries and use the version N of the tablet.
     - name: Upgrade - Swap binaries, use VTTablet N
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
 
@@ -247,6 +291,7 @@ jobs:
 
     # Starting the tablets again and restoring the previous backup.
     - name: Start new tablets and restore
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 5
       run: |
         source build.env ; cd examples/local
@@ -256,6 +301,7 @@ jobs:
 
     # We count the number of rows in every table to check that the restore step was successful.
     - name: Assert the number of rows in every table
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env ; cd examples/local ; source ./env.sh
 
@@ -264,6 +310,7 @@ jobs:
         echo "select count(sku) from corder;" | mysql 2>&1| grep 6
 
     - name: Stop the Vitess cluster
+      if: steps.changes.outputs.end_to_end == 'true'
       if: always()
       run: |
         source build.env ; cd examples/local

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -57,19 +57,43 @@ jobs:
       - get_latest_release
 
     steps:
+    - name: Check out commit's code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     - name: Get base dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo DEBIAN_FRONTEND="noninteractive" apt-get update
         # Uninstall any previously installed MySQL first
@@ -106,15 +130,18 @@ jobs:
 
     # Checkout to the last release of Vitess
     - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
       with:
         ref: ${{ needs.get_latest_release.outputs.latest_release }}
 
     - name: Get dependencies for the last release
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
     - name: Building last release's binaries
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 10
       run: |
         source build.env
@@ -125,13 +152,16 @@ jobs:
 
     # Checkout to this build's commit
     - name: Check out commit's code
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
 
     - name: Get dependencies for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
     - name: Building the binaries for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 10
       run: |
         source build.env
@@ -141,6 +171,7 @@ jobs:
 
     # Running a test with vtgate and vttablet using version n
     - name: Run query serving tests (vtgate=N, vttablet=N)
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
@@ -150,6 +181,7 @@ jobs:
 
     # Swap the binaries in the bin. Use vtgate version n-1 and keep vttablet at version n
     - name: Use last release's VTGate
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
 
@@ -159,6 +191,7 @@ jobs:
 
     # Running a test with vtgate at version n-1 and vttablet at version n
     - name: Run query serving tests (vtgate=N-1, vttablet=N)
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
@@ -168,6 +201,7 @@ jobs:
 
     # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n-1
     - name: Use current version VTGate, and other version VTTablet
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
 
@@ -179,6 +213,7 @@ jobs:
 
     # Running a test with vtgate at version n and vttablet at version n-1
     - name: Run query serving tests (vtgate=N, vttablet=N-1)
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -57,19 +57,43 @@ jobs:
       - get_latest_release
 
     steps:
+    - name: Check out commit's code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     - name: Get base dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo DEBIAN_FRONTEND="noninteractive" apt-get update
         # Uninstall any previously installed MySQL first
@@ -106,15 +130,18 @@ jobs:
 
     # Checkout to the last release of Vitess
     - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
       with:
         ref: ${{ needs.get_latest_release.outputs.latest_release }}
 
     - name: Get dependencies for the last release
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
     - name: Building last release's binaries
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 10
       run: |
         source build.env
@@ -125,13 +152,16 @@ jobs:
 
     # Checkout to this build's commit
     - name: Check out commit's code
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
 
     - name: Get dependencies for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
     - name: Building the binaries for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 10
       run: |
         source build.env
@@ -141,6 +171,7 @@ jobs:
 
     # Swap the binaries in the bin. Use vtctl version n-1 and keep vttablet at version n
     - name: Use last release's Vtctl
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
 
@@ -154,6 +185,7 @@ jobs:
 
     # Running a test with vtctl at version n-1 and vttablet at version n
     - name: Run reparent tests (vtctl=N-1, vttablet=N)
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -57,19 +57,43 @@ jobs:
       - get_latest_release
 
     steps:
+    - name: Check out commit's code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     - name: Get base dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo DEBIAN_FRONTEND="noninteractive" apt-get update
         # Uninstall any previously installed MySQL first
@@ -106,15 +130,18 @@ jobs:
 
     # Checkout to the last release of Vitess
     - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
       with:
         ref: ${{ needs.get_latest_release.outputs.latest_release }}
 
     - name: Get dependencies for the last release
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
     - name: Building last release's binaries
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 10
       run: |
         source build.env
@@ -125,13 +152,16 @@ jobs:
 
     # Checkout to this build's commit
     - name: Check out commit's code
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
 
     - name: Get dependencies for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
     - name: Building the binaries for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 10
       run: |
         source build.env
@@ -141,6 +171,7 @@ jobs:
 
     # Swap the binaries. Use vtctl version n and keep vttablet at version n-1
     - name: Use current version Vtctl, and other version VTTablet
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
 
@@ -151,6 +182,7 @@ jobs:
 
     # Running a test with vtctl at version n and vttablet at version n-1
     - name: Run reparent tests (vtctl=N, vttablet=N-1)
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -36,8 +36,6 @@ func TestSelectNull(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	// test modifying a file
-
 	utils.Exec(t, conn, "begin")
 	utils.Exec(t, conn, "insert into t5_null_vindex(id, idx) values(1, 'a'), (2, 'b'), (3, null)")
 	utils.Exec(t, conn, "commit")

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -36,6 +36,8 @@ func TestSelectNull(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
+	// test modifying a file
+
 	utils.Exec(t, conn, "begin")
 	utils.Exec(t, conn, "insert into t5_null_vindex(id, idx) values(1, 'a'), (2, 'b'), (3, null)")
 	utils.Exec(t, conn, "commit")

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -24,7 +24,7 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - '**/endtoend/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -24,8 +24,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/*.go'
-            - '**/endtoend/**/**.go'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -32,6 +32,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -24,7 +24,8 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - '**/endtoend/**.go'
+            - '**/endtoend/*.go'
+            - '**/endtoend/**/**.go'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -132,4 +132,3 @@ jobs:
 
         # print test output
         cat output.txt
-      if: always()

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -15,25 +15,36 @@ jobs:
     {{if .Ubuntu20}}runs-on: ubuntu-20.04{{else}}runs-on: ubuntu-18.04{{end}}
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
@@ -59,12 +70,14 @@ jobs:
     {{if .MakeTools}}
 
     - name: Installing zookeeper and consul
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
           make tools
 
     {{end}}
 
     - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
         pip3 install --user launchable~=1.0 > /dev/null
@@ -76,6 +89,7 @@ jobs:
         launchable record build --name "$GITHUB_RUN_ID" --source .
 
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -110,6 +124,7 @@ jobs:
         eatmydata -- go run test.go -docker=false -follow -shard {{.Shard}} | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
     - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
         # send recorded tests to launchable
         launchable record tests --build "$GITHUB_RUN_ID" go-test . || true

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
       id: changes
       with:
         filters: |

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -7,19 +7,30 @@ jobs:
     {{if .Ubuntu20}}runs-on: ubuntu-20.04{{else}}runs-on: ubuntu-latest{{end}}
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         go run test.go -docker=true --follow -shard {{.Shard}}

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -16,7 +16,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -24,6 +24,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_mysql80.tpl
+++ b/test/templates/cluster_endtoend_test_mysql80.tpl
@@ -32,6 +32,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_mysql80.tpl
+++ b/test/templates/cluster_endtoend_test_mysql80.tpl
@@ -24,7 +24,14 @@ jobs:
       with:
         filters: |
           end_to_end:
-            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -19,7 +19,15 @@ jobs:
         with:
           filters: |
             end_to_end:
-              - 'go/**'
+              - 'go/**/*.go'
+              - 'test.go'
+              - 'Makefile'
+              - 'build.env'
+              - 'go.[sumod]'
+              - 'proto/*.proto'
+              - 'tools/**'
+              - 'config/**'
+              - '.github/docker/**'
 
       - name: Build Docker Image
         if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -31,8 +31,7 @@ jobs:
         run: docker run --name "{{.ImageName}}_$GITHUB_SHA" {{.ImageName}}:$GITHUB_SHA /bin/bash -c 'source build.env && go run test.go -keep-data=true -docker=false -print-log -follow -shard {{.Shard}} -- -- --keep-data=true'
 
       - name: Print Volume Used
-        if: steps.changes.outputs.end_to_end == 'true'
-        if: ${{"{{ always() }}"}}
+        if: always() && steps.changes.outputs.end_to_end == 'true'
         run: |
           docker inspect -f '{{"{{ (index .Mounts 0).Name }}"}}' {{.ImageName}}_$GITHUB_SHA
 
@@ -42,8 +41,7 @@ jobs:
           docker rm -v {{.ImageName}}_$GITHUB_SHA
 
       - name: Cleanup Docker Container
-        if: steps.changes.outputs.end_to_end == 'true'
-        if: ${{"{{ always() }}"}}
+        if: always() && steps.changes.outputs.end_to_end == 'true'
         run: |
           docker rm -f {{.ImageName}}_$GITHUB_SHA
 

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -13,27 +13,41 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Check for changes in relevant files
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            end_to_end:
+              - 'go/**'
+
       - name: Build Docker Image
+        if: steps.changes.outputs.end_to_end == 'true'
         run: docker build -f {{.Dockerfile}} -t {{.ImageName}}:$GITHUB_SHA  .
 
       - name: Run test
+        if: steps.changes.outputs.end_to_end == 'true'
         timeout-minutes: 30
         run: docker run --name "{{.ImageName}}_$GITHUB_SHA" {{.ImageName}}:$GITHUB_SHA /bin/bash -c 'source build.env && go run test.go -keep-data=true -docker=false -print-log -follow -shard {{.Shard}} -- -- --keep-data=true'
 
       - name: Print Volume Used
+        if: steps.changes.outputs.end_to_end == 'true'
         if: ${{"{{ always() }}"}}
         run: |
           docker inspect -f '{{"{{ (index .Mounts 0).Name }}"}}' {{.ImageName}}_$GITHUB_SHA
 
       - name: Cleanup Docker Volume
+        if: steps.changes.outputs.end_to_end == 'true'
         run: |
           docker rm -v {{.ImageName}}_$GITHUB_SHA
 
       - name: Cleanup Docker Container
+        if: steps.changes.outputs.end_to_end == 'true'
         if: ${{"{{ always() }}"}}
         run: |
           docker rm -f {{.ImageName}}_$GITHUB_SHA
 
       - name: Cleanup Docker Image
+        if: steps.changes.outputs.end_to_end == 'true'
         run: |
           docker image rm {{.ImageName}}:$GITHUB_SHA

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -28,6 +28,7 @@ jobs:
               - 'tools/**'
               - 'config/**'
               - '.github/docker/**'
+              - 'bootstrap.sh'
 
       - name: Build Docker Image
         if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -26,6 +26,7 @@ jobs:
             - 'proto/*.proto'
             - 'tools/**'
             - 'config/**'
+            - 'bootstrap.sh'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -17,17 +17,24 @@ jobs:
       id: changes
       with:
         filters: |
-          end_to_end:
+          unit_tests:
             - 'go/**'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
 
     - name: Set up Go
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
@@ -35,7 +42,7 @@ jobs:
         sudo sysctl -p /etc/sysctl.conf
 
     - name: Get dependencies
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -120,12 +127,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       run: |
         make tools
 
     - name: Run test
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.changes.outputs.unit_tests == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -9,22 +9,33 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          end_to_end:
+            - 'go/**'
+
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -109,10 +120,12 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make tools
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         make tools
 
     - name: Run test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         eatmydata -- make unit_test

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -26,6 +26,7 @@ jobs:
               - 'proto/*.proto'
               - 'tools/**'
               - 'config/**'
+              - 'bootstrap.sh'
 
       - name: Build Docker Image
         if: steps.changes.outputs.unit_tests == 'true'

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -17,36 +17,43 @@ jobs:
         id: changes
         with:
           filters: |
-            end_to_end:
+            unit_tests:
               - 'go/**'
+              - 'test.go'
+              - 'Makefile'
+              - 'build.env'
+              - 'go.[sumod]'
+              - 'proto/*.proto'
+              - 'tools/**'
+              - 'config/**'
 
       - name: Build Docker Image
-        if: steps.changes.outputs.end_to_end == 'true'
+        if: steps.changes.outputs.unit_tests == 'true'
         run: docker build -f {{.Dockerfile}} -t {{.ImageName}}:$GITHUB_SHA  .
 
       - name: Run test
-        if: steps.changes.outputs.end_to_end == 'true'
+        if: steps.changes.outputs.unit_tests == 'true'
         timeout-minutes: 30
         run: docker run --name "{{.ImageName}}_$GITHUB_SHA" {{.ImageName}}:$GITHUB_SHA /bin/bash -c 'make unit_test'
 
       - name: Print Volume Used
-        if: steps.changes.outputs.end_to_end == 'true'
+        if: steps.changes.outputs.unit_tests == 'true'
         if: ${{"{{ always() }}"}}
         run: |
           docker inspect -f '{{"{{ (index .Mounts 0).Name }}"}}' {{.ImageName}}_$GITHUB_SHA
 
       - name: Cleanup Docker Volume
-        if: steps.changes.outputs.end_to_end == 'true'
+        if: steps.changes.outputs.unit_tests == 'true'
         run: |
           docker rm -v {{.ImageName}}_$GITHUB_SHA
 
       - name: Cleanup Docker Container
-        if: steps.changes.outputs.end_to_end == 'true'
+        if: steps.changes.outputs.unit_tests == 'true'
         if: ${{"{{ always() }}"}}
         run: |
           docker rm -f {{.ImageName}}_$GITHUB_SHA
 
       - name: Cleanup Docker Image
-        if: steps.changes.outputs.end_to_end == 'true'
+        if: steps.changes.outputs.unit_tests == 'true'
         run: |
           docker image rm {{.ImageName}}:$GITHUB_SHA

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -12,27 +12,41 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Check for changes in relevant files
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            end_to_end:
+              - 'go/**'
+
       - name: Build Docker Image
+        if: steps.changes.outputs.end_to_end == 'true'
         run: docker build -f {{.Dockerfile}} -t {{.ImageName}}:$GITHUB_SHA  .
 
       - name: Run test
+        if: steps.changes.outputs.end_to_end == 'true'
         timeout-minutes: 30
         run: docker run --name "{{.ImageName}}_$GITHUB_SHA" {{.ImageName}}:$GITHUB_SHA /bin/bash -c 'make unit_test'
 
       - name: Print Volume Used
+        if: steps.changes.outputs.end_to_end == 'true'
         if: ${{"{{ always() }}"}}
         run: |
           docker inspect -f '{{"{{ (index .Mounts 0).Name }}"}}' {{.ImageName}}_$GITHUB_SHA
 
       - name: Cleanup Docker Volume
+        if: steps.changes.outputs.end_to_end == 'true'
         run: |
           docker rm -v {{.ImageName}}_$GITHUB_SHA
 
       - name: Cleanup Docker Container
+        if: steps.changes.outputs.end_to_end == 'true'
         if: ${{"{{ always() }}"}}
         run: |
           docker rm -f {{.ImageName}}_$GITHUB_SHA
 
       - name: Cleanup Docker Image
+        if: steps.changes.outputs.end_to_end == 'true'
         run: |
           docker image rm {{.ImageName}}:$GITHUB_SHA


### PR DESCRIPTION
## Description

During the last few months, we've observed congestion in the GitHub Actions workflow queue. When there are several concurrent commits, the number of queued workflows increases a lot. We have recently introduced the `concurrency` feature of GitHub Actions. It enables us to cancel duplicated workflows in the same Pull Request, however, it does not help reduce the size of the queue when new commits are pushed to different Pull Request. The hypothesis is that we can reduce the number of queued workflows when new commits are pushed, without impeding our testing strategy.

The changes proposed in this Pull Request aim to reduce the size of that queue. Based on the list of files that have changed (added, modified, or deleted), we want to run certain workflows. For instance, modifying a README does not require running the entire set of workflows. The solution proposed was initially designed by @doeg.

GitHub Actions has two instructions: `on.paths` and `on.paths-ignore`, they allow us to skip or run workflow depending on a list of changed files. This solution works well, but not when the underlying job is marked as `required` in the repository's settings. Which is the case for most of our tests. Some issues regarding the same problem have been raised [here](https://github.community/t/unable-to-merge-pull-request-due-to-branch-protection-rules-since-github-actions-check-doesnt-trigger/126250) and [here](https://stackoverflow.com/questions/66751567/return-passing-status-on-github-workflow-when-using-paths-ignore). GitHub provides a [workaround](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks) which isn't the most elegant solution.

We started using [paths-filter](https://github.com/dorny/paths-filter). Instead of skipping the entire job, this alternative allows us to skip individual steps. It means that the required job will still run from start to finish, and only some of the steps will be skipped, resulting in a successful required job. For each workflow, we've added a new step that uses `paths-filter` and determines if relevant files have changed. The list of relevant files varies with the type of workflow we're running. A boolean is then outputted from this step. We then check this boolean in the `if` condition of all subsequent steps.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
