### PR TITLE
VReplication: maintain original column case for pkCols

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl_suite/testdata/update-pk-col-uppercase/alter
+++ b/go/test/endtoend/onlineddl/vrepl_suite/testdata/update-pk-col-uppercase/alter
@@ -1,0 +1,1 @@
+engine=innodb

--- a/go/test/endtoend/onlineddl/vrepl_suite/testdata/update-pk-col-uppercase/create.sql
+++ b/go/test/endtoend/onlineddl/vrepl_suite/testdata/update-pk-col-uppercase/create.sql
@@ -1,0 +1,29 @@
+drop table if exists onlineddl_test;
+create table onlineddl_test (
+  Id varchar(64) NOT NULL,
+  val varchar(64) DEFAULT NULL,
+  dt datetime DEFAULT NULL,
+  primary key (Id)
+) auto_increment=1;
+
+insert ignore into onlineddl_test values (md5(rand()), md5(rand()), now());
+insert ignore into onlineddl_test values (md5(rand()), md5(rand()), now());
+insert ignore into onlineddl_test values (md5(rand()), md5(rand()), now());
+insert ignore into onlineddl_test values (md5(rand()), md5(rand()), now());
+insert ignore into onlineddl_test values (md5(rand()), md5(rand()), now());
+insert ignore into onlineddl_test values (md5(rand()), md5(rand()), now());
+insert ignore into onlineddl_test values (md5(rand()), md5(rand()), now());
+insert ignore into onlineddl_test values (md5(rand()), md5(rand()), now());
+
+drop event if exists onlineddl_test;
+delimiter ;;
+create event onlineddl_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  update onlineddl_test set Id=md5(rand()) order by rand() limit 1;
+end ;;

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -419,7 +419,7 @@ func (tpb *tablePlanBuilder) analyzeExpr(selExpr sqlparser.SelectExpr) (*colExpr
 		cexpr.expr = expr
 		cexpr.operation = opExpr
 		tpb.sendSelect.SelectExprs = append(tpb.sendSelect.SelectExprs, &sqlparser.AliasedExpr{Expr: selExpr, As: as})
-		cexpr.references[as.Lowered()] = true
+		cexpr.references[as.String()] = true
 		return cexpr, nil
 	}
 	if expr, ok := aliased.Expr.(*sqlparser.FuncExpr); ok {
@@ -451,7 +451,7 @@ func (tpb *tablePlanBuilder) analyzeExpr(selExpr sqlparser.SelectExpr) (*colExpr
 			cexpr.operation = opSum
 			cexpr.expr = innerCol
 			tpb.addCol(innerCol.Name)
-			cexpr.references[innerCol.Name.Lowered()] = true
+			cexpr.references[innerCol.Name.String()] = true
 			return cexpr, nil
 		case "keyspace_id":
 			if len(expr.Exprs) != 0 {
@@ -470,7 +470,7 @@ func (tpb *tablePlanBuilder) analyzeExpr(selExpr sqlparser.SelectExpr) (*colExpr
 				return false, fmt.Errorf("unsupported qualifier for column: %v", sqlparser.String(node))
 			}
 			tpb.addCol(node.Name)
-			cexpr.references[node.Name.Lowered()] = true
+			cexpr.references[node.Name.String()] = true
 		case *sqlparser.Subquery:
 			return false, fmt.Errorf("unsupported subquery: %v", sqlparser.String(node))
 		case *sqlparser.FuncExpr:


### PR DESCRIPTION

## Description

Currently, vreplication maps `pkCol` (primary key column list) based on lower case column names. This is incorrect, and went under the radar because it only shows in a specific scenario: a PK column that is non-lower case is updated during vreplication workflow.

The fix is an extract from @rohit-nayak-ps 's #9742, where he just recently identified the same.

Added a `onlineddl/vrepl-suite` test to validate new behavior (the test fails without the fix in this PR).


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
