### PR TITLE
Backport #9842: TabletManager: Check for context cancellation in loop within ChangeTabletType()

### DIFF
--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -186,6 +186,9 @@ func (ts *tmState) ChangeTabletType(ctx context.Context, tabletType topodatapb.T
 			// We must read the data again and verify whether the previous write succeeded or not.
 			// The only way to guarantee safety is to keep retrying read until we succeed
 			for {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				ti, errInReading := ts.tm.TopoServer.GetTablet(ctx, ts.tm.tabletAlias)
 				if errInReading != nil {
 					<-time.After(100 * time.Millisecond)

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -187,7 +187,7 @@ func (ts *tmState) ChangeTabletType(ctx context.Context, tabletType topodatapb.T
 			// The only way to guarantee safety is to keep retrying read until we succeed
 			for {
 				if ctx.Err() != nil {
-					return ctx.Err()
+					return fmt.Errorf("context canceled updating tablet_type for %s in the topo, please retry", ts.tm.tabletAlias)
 				}
 				ti, errInReading := ts.tm.TopoServer.GetTablet(ctx, ts.tm.tabletAlias)
 				if errInReading != nil {


### PR DESCRIPTION
## Description
There is currently the possibility of an infinite loop inside `ChangeTabletType()` because we don't check for context cancellation inside an active polling loop. This PR adds the check.

## Related Issue(s)
Original PR: #9842 
#9838

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
