### PR TITLE
Backport #9833: Check if context is cancelled in applyEvents() loop to avoid deadlocks

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -477,6 +477,7 @@ func shouldIgnoreQuery(query string) bool {
 		"_vt.vreplication_log", // ignore all selects, updates and inserts into this table
 		"@@session.sql_mode",   // ignore all selects, and sets of this variable
 		", time_heartbeat=",    // update of last heartbeat time, can happen out-of-band, so can't test for it
+		"context cancel",
 	}
 	for _, q := range queriesToIgnore {
 		if strings.Contains(query, q) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -335,6 +335,9 @@ func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
 	defer vp.vr.stats.VReplicationLags.Add(strconv.Itoa(int(vp.vr.id)), math.MaxInt64)
 	var sbm int64 = -1
 	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		// check throttler.
 		if !vp.vr.vre.throttlerClient.ThrottleCheckOKOrWait(ctx) {
 			continue


### PR DESCRIPTION
## Description

There is a code-path in `applyEvents()` in `vplayer.go` where it waits on a throttler check and sleeps if it is determined that a wait is needed. If the context is cancelled here then it can loop infinitely. The vreplication controller tries to shutdown due to the context failure, but it waits for all streams to end. This results in a deadlock.

This PR checks for a context cancellation in between throttle checks.

## Related Issue(s)
Original PR: #9833 
#9827 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
