### PR TITLE
[vtsql] Remove vtsql.PingContext check from dial calls

### DIFF
--- a/go/vt/vtadmin/vtsql/config.go
+++ b/go/vt/vtadmin/vtsql/config.go
@@ -18,7 +18,6 @@ package vtsql
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/spf13/pflag"
 
@@ -37,8 +36,6 @@ type Config struct {
 	// be a better way where we don't need to put this in the config, because
 	// it's not really an "option" in normal use.
 	CredentialsPath string
-
-	DialPingTimeout time.Duration
 
 	Cluster         *vtadminpb.Cluster
 	ResolverOptions *resolver.Options
@@ -74,9 +71,6 @@ func (c *Config) Parse(args []string) error {
 	}
 
 	c.ResolverOptions.InstallFlags(fs)
-
-	fs.DurationVar(&c.DialPingTimeout, "dial-ping-timeout", time.Millisecond*500,
-		"Timeout to use when pinging an existing connection during calls to Dial.")
 
 	credentialsTmplStr := fs.String("credentials-path-tmpl", "",
 		"Go template used to specify a path to a credentials file, which is a json file containing "+

--- a/go/vt/vtadmin/vtsql/config_test.go
+++ b/go/vt/vtadmin/vtsql/config_test.go
@@ -144,7 +144,6 @@ func TestConfigParse(t *testing.T) {
 				Id:   "cid",
 				Name: "testcluster",
 			},
-			DialPingTimeout: time.Millisecond * 500,
 			ResolverOptions: &resolver.Options{
 				DiscoveryTags:    expectedTags,
 				DiscoveryTimeout: 100 * time.Millisecond,

--- a/go/vt/vtadmin/vtsql/vtsql_test.go
+++ b/go/vt/vtadmin/vtsql/vtsql_test.go
@@ -102,9 +102,8 @@ func TestDial(t *testing.T) {
 		{
 			name: "existing conn",
 			proxy: &VTGateProxy{
-				cluster:         &vtadminpb.Cluster{},
-				conn:            sql.OpenDB(&fakevtsql.Connector{}),
-				dialPingTimeout: time.Millisecond * 10,
+				cluster: &vtadminpb.Cluster{},
+				conn:    sql.OpenDB(&fakevtsql.Connector{}),
 			},
 			shouldErr: false,
 		},


### PR DESCRIPTION
## Description

Now that custom resolvers exist, we can rely on the underlying grpc
balancer/resolver/clientconn state management to ensure we have
healthy connections (e.g., our resolver will return N hosts from
discovery, which grpc will transition to/among).

### Testing

Spun up 2 gates in a static discovery configuration:

```
    "vtgates": [
        {
            "host": {
                "hostname": "localhost:15992"
            }
        },
        {
            "host": {
                "hostname": "localhost:15991"
            }
        }
    ]
```

(NB: the default gRPC balancer is `pick_first`, so all dials will end up on `:15992`)

Next, I started vtadmin, ensured we were connected, and then killed the gate running on `:15922`. Here are the logs (_note because this is static discovery, the first gate is still in the list, hence the fail/success/fail/success pattern in the logs as gRPC tries the first host, then the next_):

```
I0404 14:38:57.849995   40798 resolver.go:269] [vtadmin.cluster.resolver]: resolving vtgates (cluster local)
I0404 14:38:57.850079   40798 resolver.go:332] [vtadmin.cluster.resolver]: found 2 vtgates (cluster local)
W0404 14:38:57.851532   40798 component.go:41] [core] grpc: addrConn.createTransport failed to connect to {localhost:15992  <nil> <nil> 0 <nil>}. Err: connection error: desc = "transport: Error while dialing dial tcp [::1]:15992: connect: connection refused"
I0404 14:39:25.311038   40798 vtsql.go:139] Have valid connection to vtgate, reusing it.
```

vtadmin worked the entire time

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

**Please note that when you deploy this, you'll need to remove any `--vtsql-dial-ping-timeout` occurrences in your cluster configs** (does not apply to dynamic clusters, which don't use that flag at all). VTAdmin is pre-stable, so I don't feel too bad about doing that :) 