### PR TITLE
[vtadmin] grpc healthserver + channelz

### DIFF
--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -14,6 +14,7 @@ vtadmin \
   --http-tracing \
   --logtostderr \
   --alsologtostderr \
+  --rbac \
   --rbac-config="./vtadmin/rbac.yaml" \
   --cluster "id=local,name=local,discovery=staticfile,discovery-staticfile-path=./vtadmin/discovery.json,tablet-fqdn-tmpl={{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
   > "${log_dir}/vtadmin-api.out" 2>&1 &

--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -141,13 +141,17 @@ func run(cmd *cobra.Command, args []string) {
 }
 
 func main() {
+	// Common flags
 	rootCmd.Flags().StringVar(&opts.Addr, "addr", ":15000", "address to serve on")
 	rootCmd.Flags().DurationVar(&opts.CMuxReadTimeout, "lmux-read-timeout", time.Second, "how long to spend connection muxing")
 	rootCmd.Flags().DurationVar(&opts.LameDuckDuration, "lame-duck-duration", time.Second*5, "length of lame duck period at shutdown")
+
+	// Cluster config flags
 	rootCmd.Flags().Var(&clusterConfigs, "cluster", "per-cluster configuration. any values here take precedence over those in -cluster-defaults or -cluster-config")
 	rootCmd.Flags().Var(&clusterFileConfig, "cluster-config", "path to a yaml cluster configuration. see clusters.example.yaml") // (TODO:@amason) provide example config.
 	rootCmd.Flags().Var(&defaultClusterConfig, "cluster-defaults", "default options for all clusters")
 
+	// Tracing flags
 	rootCmd.Flags().AddGoFlag(flag.Lookup("tracer"))                 // defined in go/vt/trace
 	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-enable-logging")) // defined in go/vt/trace
 	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-sampling-type"))  // defined in go/vt/trace
@@ -155,8 +159,10 @@ func main() {
 	rootCmd.Flags().BoolVar(&opts.EnableTracing, "grpc-tracing", false, "whether to enable tracing on the gRPC server")
 	rootCmd.Flags().BoolVar(&httpOpts.EnableTracing, "http-tracing", false, "whether to enable tracing on the HTTP server")
 
+	// gRPC server flags
 	rootCmd.Flags().BoolVar(&opts.EnableChannelz, "grpc-enable-channelz", false, "whether to enable the channelz service on the gRPC server")
 
+	// HTTP server flags
 	rootCmd.Flags().BoolVar(&httpOpts.DisableCompression, "http-no-compress", false, "whether to disable compression of HTTP API responses")
 	rootCmd.Flags().BoolVar(&httpOpts.DisableDebug, "http-no-debug", false, "whether to disable /debug/pprof/* and /debug/env HTTP endpoints")
 	rootCmd.Flags().Var(&debug.OmitEnv, "http-debug-omit-env", "name of an environment variable to omit from /debug/env, if http debug endpoints are enabled. specify multiple times to omit multiple env vars")
@@ -171,7 +177,7 @@ func main() {
 	)
 	rootCmd.Flags().BoolVar(&httpOpts.EnableDynamicClusters, "http-enable-dynamic-clusters", false, "whether to enable dynamic clusters that are set by request header cookies")
 
-	// rbac flags
+	// RBAC flags
 	rootCmd.Flags().StringVar(&rbacConfigPath, "rbac-config", "", "path to an RBAC config file. must be set if passing --rbac")
 	rootCmd.Flags().BoolVar(&enableRBAC, "rbac", false, "whether to enable RBAC. must be set if not passing --rbac")
 	rootCmd.Flags().BoolVar(&disableRBAC, "no-rbac", false, "whether to disable RBAC. must be set if not passing --no-rbac")

--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -155,6 +155,8 @@ func main() {
 	rootCmd.Flags().BoolVar(&opts.EnableTracing, "grpc-tracing", false, "whether to enable tracing on the gRPC server")
 	rootCmd.Flags().BoolVar(&httpOpts.EnableTracing, "http-tracing", false, "whether to enable tracing on the HTTP server")
 
+	rootCmd.Flags().BoolVar(&opts.EnableChannelz, "grpc-enable-channelz", false, "whether to enable the channelz service on the gRPC server")
+
 	rootCmd.Flags().BoolVar(&httpOpts.DisableCompression, "http-no-compress", false, "whether to disable compression of HTTP API responses")
 	rootCmd.Flags().BoolVar(&httpOpts.DisableDebug, "http-no-debug", false, "whether to disable /debug/pprof/* and /debug/env HTTP endpoints")
 	rootCmd.Flags().Var(&debug.OmitEnv, "http-debug-omit-env", "name of an environment variable to omit from /debug/env, if http debug endpoints are enabled. specify multiple times to omit multiple env vars")

--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -160,6 +160,7 @@ func main() {
 	rootCmd.Flags().BoolVar(&httpOpts.EnableTracing, "http-tracing", false, "whether to enable tracing on the HTTP server")
 
 	// gRPC server flags
+	rootCmd.Flags().BoolVar(&opts.AllowReflection, "grpc-allow-reflection", false, "whether to register the gRPC server for reflection; this is required to use tools like `grpc_cli`")
 	rootCmd.Flags().BoolVar(&opts.EnableChannelz, "grpc-enable-channelz", false, "whether to enable the channelz service on the gRPC server")
 
 	// HTTP server flags

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -106,10 +106,6 @@ func NewAPI(clusters []*cluster.Cluster, opts Options) *API {
 		return c1.ID < c2.ID
 	}).Sort(clusters)
 
-	if opts.GRPCOpts.Services == nil {
-		opts.GRPCOpts.Services = []string{"vtadmin.VTAdminServer"}
-	}
-
 	var (
 		authn rbac.Authenticator
 		authz *rbac.Authorizer

--- a/go/vt/vtadmin/grpcserver/server.go
+++ b/go/vt/vtadmin/grpcserver/server.go
@@ -63,25 +63,10 @@ type Options struct {
 	// EnableTracing specifies whether to install opentracing interceptors on
 	// the gRPC server.
 	EnableTracing bool
-	// Services is a list of service names to declare as SERVING in health
-	// checks. Names should be fully-qualified (package_name.service_name, e.g.
-	// vtadmin.VTAdminServer, not VTAdminServer), and must be unique for a
-	// single Server instance. Users of this package are responsible for
-	// ensuring they do not pass a list with duplicate service names.
-	//
-	// The service name "grpc.health.v1.Health" is reserved by this package in
-	// order to power the healthcheck service. Attempting to pass this in the
-	// Services list to a grpcserver will be ignored.
-	//
-	// See https://github.com/grpc/grpc/blob/7324556353e831c57d30973db33df489c3ed3576/doc/health-checking.md
-	// for more details on healthchecking.
-	Services []string
 
 	StreamInterceptors []grpc.StreamServerInterceptor
 	UnaryInterceptors  []grpc.UnaryServerInterceptor
 }
-
-const healthServiceName = "grpc.health.v1.Health" // reserved health service name
 
 // Server provides a multiplexed gRPC/HTTP server.
 type Server struct {
@@ -225,15 +210,8 @@ func (s *Server) ListenAndServe() error { // nolint:funlen
 		shutdown <- err
 	}()
 
-	s.healthServer.SetServingStatus(healthServiceName, healthpb.HealthCheckResponse_SERVING)
-
-	for _, name := range s.opts.Services {
-		if name == healthServiceName {
-			log.Warningf("Attempted to register a service under the reserved healthcheck service name %s; ignoring", healthServiceName)
-			continue
-		}
-
-		s.healthServer.SetServingStatus(name, healthpb.HealthCheckResponse_SERVING)
+	for service := range s.gRPCServer.GetServiceInfo() {
+		s.healthServer.SetServingStatus(service, healthpb.HealthCheckResponse_SERVING)
 	}
 
 	s.setServing(true)

--- a/go/vt/vtadmin/grpcserver/server.go
+++ b/go/vt/vtadmin/grpcserver/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/soheilhy/cmux"
 	"google.golang.org/grpc"
+	channelz "google.golang.org/grpc/channelz/service"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/reflection"
 
@@ -63,6 +64,9 @@ type Options struct {
 	// EnableTracing specifies whether to install opentracing interceptors on
 	// the gRPC server.
 	EnableTracing bool
+	// EnableChannelz specifies whether to register the channelz service on the
+	// gRPC server.
+	EnableChannelz bool
 
 	StreamInterceptors []grpc.StreamServerInterceptor
 	UnaryInterceptors  []grpc.UnaryServerInterceptor
@@ -121,6 +125,10 @@ func New(name string, opts Options) *Server {
 
 	healthServer := health.NewServer()
 	healthpb.RegisterHealthServer(gserv, healthServer)
+
+	if opts.EnableChannelz {
+		channelz.RegisterChannelzServiceToServer(gserv)
+	}
 
 	return &Server{
 		name:         name,


### PR DESCRIPTION
## Description

This started off as a branch to more properly use the health server, but then ended up doing some misc cleanup and adding in channelz, which I wanted to do as well.

Main changes:
1. Add `--rbac` to the vtadmin-up example script.
2. Remove  `Services` from `grpcserver.Options`, since (a) we're gonna inspect the server for what services are registered and (b) there was no flag to ever let users set custom services anyway!! 🙈 
3. Add an option to enable [channelz](https://grpc.io/blog/a-short-introduction-to-channelz/), which is useful for debugging (I was playing around with this when working on the custom resolver stuff)

### channelz demo

First, I started vtadmin without `--grpc-enable-channelz` and tried to run a client against it. As expected, it failed with:

```
F0405 09:07:41.291721   63470 main.go:22] rpc error: code = Unimplemented desc = unknown service grpc.channelz.v1.Channelz
```

Then, I restarted vtadmin-api with `--grpc-enable-channelz`, and ran the following (linking to gist because it will probably exceed GitHub's PR body size limit). It starts one goroutine that polls the GetClusters endpoint, and then runs `GetTopChannels` from channelz in a loop until we get something non-empty (to avoid races between this and the goroutine).

[Gist](https://gist.github.com/ajm188/03b19d5205ebffa15a51d62ee5f1fc91)

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->