### PR TITLE
[Dynamic Clusters] No Duplicates

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -246,22 +246,24 @@ func (api *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				err = json.Unmarshal(decoded, &clusterJSON)
 				if err == nil {
 					clusterID := clusterJSON.ClusterName
-					c, err := cluster.Config{
-						ID:            clusterID,
-						Name:          clusterID,
-						DiscoveryImpl: "dynamic",
-						DiscoveryFlagsByImpl: cluster.FlagsByImpl{
-							"dynamic": map[string]string{
-								"discovery": string(decoded),
+					if _, exists := api.clusterMap[clusterID]; !exists {
+						c, err := cluster.Config{
+							ID:            clusterID,
+							Name:          clusterID,
+							DiscoveryImpl: "dynamic",
+							DiscoveryFlagsByImpl: cluster.FlagsByImpl{
+								"dynamic": map[string]string{
+									"discovery": string(decoded),
+								},
 							},
-						},
-					}.Cluster()
-					if err == nil {
-						api.clusterMap[clusterID] = c
-						api.clusters = append(api.clusters, c)
-						err = api.clusterCache.Add(clusterID, c, 24*time.Hour)
-						if err != nil {
-							log.Infof("could not add dynamic cluster %s to cluster cache: %+v", clusterID, err)
+						}.Cluster()
+						if err == nil {
+							api.clusterMap[clusterID] = c
+							api.clusters = append(api.clusters, c)
+							err = api.clusterCache.Add(clusterID, c, 24*time.Hour)
+							if err != nil {
+								log.Infof("could not add dynamic cluster %s to cluster cache: %+v", clusterID, err)
+							}
 						}
 					}
 					selectedCluster := api.clusterMap[clusterID]


### PR DESCRIPTION
Signed-off-by: notfelineit <notfelineit@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes dynamic cluster behavior by only creating adding a cluster to `clusterMap`, `clusters`, and `clusterCache` if it does not already exist in `clusterMap`. 

In this case, `clusterMap` is the source of truth for what exists across the 3 stores.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
N/A

## Checklist
- [ ] Should this PR be backported? **No**
- [ ] Tests were added or are not required **Tests are added**
- [ ] Documentation was added or is not required **No**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
N/A