### PR TITLE
[vtadmin] threadsafe dynamic clusters

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -253,11 +253,17 @@ func (api *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						if err == nil {
 							api.clusterMap[clusterID] = c
 							api.clusters = append(api.clusters, c)
+							sort.ClustersBy(func(c1, c2 *cluster.Cluster) bool {
+								return c1.ID < c2.ID
+							}).Sort(api.clusters)
+
 							err = api.clusterCache.Add(clusterID, c, cache.DefaultExpiration)
 							if err != nil {
 								log.Infof("could not add dynamic cluster %s to cluster cache: %+v", clusterID, err)
 							}
 						}
+					} else {
+						log.Infof("API already has cluster with id %s, using that instead", clusterID)
 					}
 
 					selectedCluster := api.clusterMap[clusterID]

--- a/go/vt/vtadmin/debug.go
+++ b/go/vt/vtadmin/debug.go
@@ -26,9 +26,17 @@ type debugAPI struct {
 
 // Cluster is part of the debug.API interface.
 func (dapi *debugAPI) Cluster(id string) (*cluster.Cluster, bool) {
+	dapi.api.clusterMu.Lock()
+	defer dapi.api.clusterMu.Unlock()
+
 	c, ok := dapi.api.clusterMap[id]
 	return c, ok
 }
 
 // Clusters is part of the debug.API interface.
-func (dapi *debugAPI) Clusters() []*cluster.Cluster { return dapi.api.clusters }
+func (dapi *debugAPI) Clusters() []*cluster.Cluster {
+	dapi.api.clusterMu.Lock()
+	defer dapi.api.clusterMu.Unlock()
+
+	return dapi.api.clusters
+}


### PR DESCRIPTION


## Description

Dynamic clusters currently make any api endpoint accessing `.clusters` or `.clusterMap` not thread safe, as the dynamic handler _could_ be mutating those structures as another endpoint attempts to access them. This fixes that by adding a mutex (abstracted away under the `getCluster(s)ForRequest`) and all other callsites updated to use that.

There's a second piece around duplicate clusters which @notfelineit is working on.

## Related Issue(s)

- #9544
- #10043 


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required — tested manually, still able to add the dynamic cluster, and serve static clusters
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->