### PR TITLE
tablet lag throttler: small API improvements

### DIFF
--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -78,6 +78,16 @@ Table lifecycle now supports views. It ensures to not purge rows from views, and
 
 On Mysql `8.0.23` or later, the states `PURGE` and `EVAC` are automatically skipped, thanks to `8.0.23` improvement to `DROP TABLE` speed of operation.
 
+### Tablet throttler
+
+Added `/throttler/throttled-apps` endpoint, which reports back all current throttling instructions. Note, this only reports explicit throttling requests (sych as ones submitted by `/throtler/throttle-app?app=...`). It does not list incidental rejections based on throttle thresholds.
+
+API endpoint `/throttler/throttle-app` now accepts a `ratio` query argument, a floating point in the range `[0..1]`, where:
+
+- `0` means "do not throttle at all"
+- `1` means "always throttle"
+- any numbr in between is allowd. For example, `0.3` means "throttle in 0.3 probability", ie on a per request and based on a dice roll, there's a `30%` change a request is denied. Overall we can expect about `30%` of requests to be denied. Example: `/throttler/throttle-app?app=vreplication&ratio=0.25`
+
 ### Compatibility
 
 #### Join with `USING`

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1723,7 +1723,7 @@ func (tsv *TabletServer) registerThrottlerThrottleAppHandler() {
 		json.NewEncoder(w).Encode(appThrottle)
 	})
 	tsv.exporter.HandleFunc("/throttler/throttled-apps", func(w http.ResponseWriter, r *http.Request) {
-		throttledApps := tsv.lagThrottler.ThrottledAppsSnapshot()
+		throttledApps := tsv.lagThrottler.ThrottledApps()
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(throttledApps)

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -327,9 +327,18 @@ func (throttler *Throttler) readSelfMySQLThrottleMetric() *mysql.MySQLThrottleMe
 	return metric
 }
 
-// ThrottledAppsSnapshot returns a snapshot (a copy) of current throttled apps
-func (throttler *Throttler) ThrottledAppsSnapshot() map[string]cache.Item {
+// throttledAppsSnapshot returns a snapshot (a copy) of current throttled apps
+func (throttler *Throttler) throttledAppsSnapshot() map[string]cache.Item {
 	return throttler.throttledApps.Items()
+}
+
+// ThrottledAppsSnapshot returns a snapshot (a copy) of current throttled apps
+func (throttler *Throttler) ThrottledApps() (result []base.AppThrottle) {
+	for _, item := range throttler.throttledAppsSnapshot() {
+		appThrottle, _ := item.Object.(*base.AppThrottle)
+		result = append(result, *appThrottle)
+	}
+	return result
 }
 
 // isDormant returns true when the last check was more than dormantPeriod ago


### PR DESCRIPTION

## Description
- `/throttler/throttle` now accepts `ratio` query param, `float64` in the range `[0..1]`

Example usage:
```sh
curl -s 'http://127.0.0.1:15100/throttler/throttle-app?app=vreplication&duration=1h&ratio=0.2' | jq .
```
```json
{
  "AppName": "vreplication",
  "ExpireAt": "2022-04-06T10:19:52.897780736Z",
  "Ratio": 0.2
}
```

- support `/throttler/throttled-apps` to get information about apps currently throttled.

Example output:
```sh
curl -s http://127.0.0.1:15100/throttler/throttled-apps | jq .
```
```json
{
  "abusing-app": {
    "Object": {
      "AppName": "abusing-app",
      "ExpireAt": "2032-04-03T09:18:30.331164282Z",
      "Ratio": 1
    },
    "Expiration": 0
  },
  "vreplication": {
    "Object": {
      "AppName": "vreplication",
      "ExpireAt": "2022-04-06T10:19:52.897780736Z",
      "Ratio": 0.2
    },
    "Expiration": 0
  }
}
```

- Tests to follow
- Release notes to follow

## Related Issue(s)


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
