### PR TITLE
schemadiff: load, normalize, validate and compare schemas

### DIFF
--- a/go/vt/schemadiff/diff.go
+++ b/go/vt/schemadiff/diff.go
@@ -59,9 +59,9 @@ func DiffTables(create1 *sqlparser.CreateTable, create2 *sqlparser.CreateTable, 
 	case create1 == nil && create2 == nil:
 		return nil, nil
 	case create1 == nil:
-		return NewCreateTableEntity(create2).Create()
+		return NewCreateTableEntity(create2).Create(), nil
 	case create2 == nil:
-		return NewCreateTableEntity(create1).Drop()
+		return NewCreateTableEntity(create1).Drop(), nil
 	default:
 		c1 := NewCreateTableEntity(create1)
 		c2 := NewCreateTableEntity(create2)
@@ -113,9 +113,9 @@ func DiffViews(create1 *sqlparser.CreateView, create2 *sqlparser.CreateView, hin
 	case create1 == nil && create2 == nil:
 		return nil, nil
 	case create1 == nil:
-		return NewCreateViewEntity(create2).Create()
+		return NewCreateViewEntity(create2).Create(), nil
 	case create2 == nil:
-		return NewCreateViewEntity(create1).Drop()
+		return NewCreateViewEntity(create1).Drop(), nil
 	default:
 		c1 := NewCreateViewEntity(create1)
 		c2 := NewCreateViewEntity(create2)

--- a/go/vt/schemadiff/diff.go
+++ b/go/vt/schemadiff/diff.go
@@ -143,13 +143,13 @@ func DiffSchemasSQL(sql1 string, sql2 string, hints *DiffHints) ([]EntityDiff, e
 func DiffSchemas(schema1 *Schema, schema2 *Schema, hints *DiffHints) ([]EntityDiff, error) {
 	var err error
 	if schema1 == nil {
-		schema1, err = NewSchemaFromSQL("")
+		schema1, err = NewSchemaFromStatements(nil)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if schema2 == nil {
-		schema2, err = NewSchemaFromSQL("")
+		schema2, err = NewSchemaFromStatements(nil)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/schemadiff/diff.go
+++ b/go/vt/schemadiff/diff.go
@@ -141,18 +141,11 @@ func DiffSchemasSQL(sql1 string, sql2 string, hints *DiffHints) ([]EntityDiff, e
 // DiffSchemasSQL compares two schemas and returns the list of diffs that turn
 // 1st schema into 2nd. Any of the schemas may be nil.
 func DiffSchemas(schema1 *Schema, schema2 *Schema, hints *DiffHints) ([]EntityDiff, error) {
-	var err error
 	if schema1 == nil {
-		schema1, err = NewSchemaFromStatements(nil)
-		if err != nil {
-			return nil, err
-		}
+		schema1 = newEmptySchema()
 	}
 	if schema2 == nil {
-		schema2, err = NewSchemaFromStatements(nil)
-		if err != nil {
-			return nil, err
-		}
+		schema2 = newEmptySchema()
 	}
 	return schema1.Diff(schema2, hints)
 }

--- a/go/vt/schemadiff/diff.go
+++ b/go/vt/schemadiff/diff.go
@@ -59,12 +59,9 @@ func DiffTables(create1 *sqlparser.CreateTable, create2 *sqlparser.CreateTable, 
 	case create1 == nil && create2 == nil:
 		return nil, nil
 	case create1 == nil:
-		return &CreateTableEntityDiff{createTable: create2}, nil
+		return NewCreateTableEntity(create2).Create()
 	case create2 == nil:
-		dropTable := &sqlparser.DropTable{
-			FromTables: []sqlparser.TableName{create1.Table},
-		}
-		return &DropTableEntityDiff{dropTable: dropTable}, nil
+		return NewCreateTableEntity(create1).Drop()
 	default:
 		c1 := NewCreateTableEntity(create1)
 		c2 := NewCreateTableEntity(create2)
@@ -116,15 +113,46 @@ func DiffViews(create1 *sqlparser.CreateView, create2 *sqlparser.CreateView, hin
 	case create1 == nil && create2 == nil:
 		return nil, nil
 	case create1 == nil:
-		return &CreateViewEntityDiff{createView: create2}, nil
+		return NewCreateViewEntity(create2).Create()
 	case create2 == nil:
-		dropView := &sqlparser.DropView{
-			FromTables: []sqlparser.TableName{create1.ViewName},
-		}
-		return &DropViewEntityDiff{dropView: dropView}, nil
+		return NewCreateViewEntity(create1).Drop()
 	default:
 		c1 := NewCreateViewEntity(create1)
 		c2 := NewCreateViewEntity(create2)
 		return c1.Diff(c2, hints)
 	}
+}
+
+// DiffSchemasSQL compares two schemas and returns the list of diffs that turn
+// 1st schema into 2nd. Schemas are build from SQL, each of which can contain an arbitrary number of
+// CREATE TABLE and CREATE VIEW statements.
+func DiffSchemasSQL(sql1 string, sql2 string, hints *DiffHints) ([]EntityDiff, error) {
+	schema1, err := NewSchemaFromSQL(sql1)
+	if err != nil {
+		return nil, err
+	}
+	schema2, err := NewSchemaFromSQL(sql2)
+	if err != nil {
+		return nil, err
+	}
+	return schema1.Diff(schema2, hints)
+}
+
+// DiffSchemasSQL compares two schemas and returns the list of diffs that turn
+// 1st schema into 2nd. Any of the schemas may be nil.
+func DiffSchemas(schema1 *Schema, schema2 *Schema, hints *DiffHints) ([]EntityDiff, error) {
+	var err error
+	if schema1 == nil {
+		schema1, err = NewSchemaFromSQL("")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if schema2 == nil {
+		schema2, err = NewSchemaFromSQL("")
+		if err != nil {
+			return nil, err
+		}
+	}
+	return schema1.Diff(schema2, hints)
 }

--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -64,7 +64,7 @@ func TestDiffTables(t *testing.T) {
 	}
 	hints := &DiffHints{}
 	for _, ts := range tt {
-		t.Run(ts.name, func(*testing.T) {
+		t.Run(ts.name, func(t *testing.T) {
 			var fromCreateTable *sqlparser.CreateTable
 			if ts.from != "" {
 				fromStmt, err := sqlparser.Parse(ts.from)
@@ -158,7 +158,7 @@ func TestDiffViews(t *testing.T) {
 	}
 	hints := &DiffHints{}
 	for _, ts := range tt {
-		t.Run(ts.name, func(*testing.T) {
+		t.Run(ts.name, func(t *testing.T) {
 			var fromCreateView *sqlparser.CreateView
 			if ts.from != "" {
 				fromStmt, err := sqlparser.Parse(ts.from)
@@ -208,6 +208,135 @@ func TestDiffViews(t *testing.T) {
 				require.False(t, dq.IsEmpty())
 				diff = dq.StatementString()
 				assert.Equal(t, ts.diff, diff)
+			}
+		})
+	}
+}
+
+func TestDiffSchemas(t *testing.T) {
+	tt := []struct {
+		name        string
+		from        string
+		to          string
+		diffs       []string
+		expectError string
+	}{
+		{
+			name: "identical tables",
+			from: "create table t(id int primary key)",
+			to:   "create table t(id int primary key)",
+		},
+		{
+			name: "change of table columns",
+			from: "create table t(id int primary key)",
+			to:   "create table t(id int primary key, i int)",
+			diffs: []string{
+				"alter table t add column i int",
+			},
+		},
+		{
+			name: "create table",
+			to:   "create table t(id int primary key)",
+			diffs: []string{
+				"create table t (\n\tid int primary key\n)",
+			},
+		},
+		{
+			name: "drop table",
+			from: "create table t(id int primary key)",
+			diffs: []string{
+				"drop table t",
+			},
+		},
+		{
+			name: "create, alter, drop tables",
+			from: "create table t1(id int primary key); create table t2(id int primary key); create table t3(id int primary key)",
+			to:   "create table t4(id int primary key); create table t2(id bigint primary key); create table t3(id int primary key)",
+			diffs: []string{
+				"drop table t1",
+				"alter table t2 modify column id bigint primary key",
+				"create table t4 (\n\tid int primary key\n)",
+			},
+		},
+		{
+			name: "identical views",
+			from: "create table t(id int); create view v1 as select * from t",
+			to:   "create table t(id int); create view v1 as select * from t",
+		},
+		{
+			name: "modified view",
+			from: "create table t(id int); create view v1 as select * from t",
+			to:   "create table t(id int); create view v1 as select id from t",
+			diffs: []string{
+				"alter view v1 as select id from t",
+			},
+		},
+		{
+			name: "drop view",
+			from: "create table t(id int); create view v1 as select * from t",
+			to:   "create table t(id int);",
+			diffs: []string{
+				"drop view v1",
+			},
+		},
+		{
+			name: "create view",
+			from: "create table t(id int)",
+			to:   "create table t(id int); create view v1 as select id from t",
+			diffs: []string{
+				"create view v1 as select id from t",
+			},
+		},
+		{
+			name:        "create view: unresolved dependencies",
+			from:        "create table t(id int)",
+			to:          "create table t(id int); create view v1 as select id from t2",
+			expectError: ErrViewDependencyUnresolved.Error(),
+		},
+		{
+			name:        "fail convert table to view",
+			from:        "create table t(id int); create table v1 (id int))",
+			to:          "create table t(id int); create view v1 as select * from t",
+			expectError: ErrEntityTypeMismatch.Error(),
+		},
+		{
+			name:        "fail convert view to table",
+			from:        "create table t(id int); create view v1 as select * from t",
+			to:          "create table t(id int); create table v1 (id int))",
+			expectError: ErrEntityTypeMismatch.Error(),
+		},
+		{
+			name: "create, alter, drop tables and views",
+			from: "create view v1 as select * from t1; create table t1(id int primary key); create table t2(id int primary key); create view v2 as select * from t2; create table t3(id int primary key);",
+			to:   "create view v0 as select * from v2, t2; create table t4(id int primary key); create view v2 as select id from t2; create table t2(id bigint primary key); create table t3(id int primary key)",
+			diffs: []string{
+				"drop table t1",
+				"drop view v1",
+				"alter table t2 modify column id bigint primary key",
+				"create table t4 (\n\tid int primary key\n)",
+				"alter view v2 as select id from t2",
+				"create view v0 as select * from v2, t2",
+			},
+		},
+	}
+	hints := &DiffHints{}
+	for _, ts := range tt {
+		t.Run(ts.name, func(t *testing.T) {
+			diffs, err := DiffSchemasSQL(ts.from, ts.to, hints)
+			if ts.expectError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, ts.expectError, err.Error())
+			} else {
+				assert.NoError(t, err)
+				statements := []string{}
+				for _, d := range diffs {
+					statement := sqlparser.String(d.Statement())
+					statements = append(statements, statement)
+				}
+				if ts.diffs == nil {
+					ts.diffs = []string{}
+				}
+				assert.Equal(t, ts.diffs, statements)
 			}
 		})
 	}

--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -242,6 +242,14 @@ func TestDiffSchemas(t *testing.T) {
 			},
 		},
 		{
+			name: "create table (2)",
+			from: ";;; ; ;    ;;;",
+			to:   "create table t(id int primary key)",
+			diffs: []string{
+				"create table t (\n\tid int primary key\n)",
+			},
+		},
+		{
 			name: "drop table",
 			from: "create table t(id int primary key)",
 			diffs: []string{
@@ -306,6 +314,12 @@ func TestDiffSchemas(t *testing.T) {
 			expectError: ErrEntityTypeMismatch.Error(),
 		},
 		{
+			name:        "unsupported statement",
+			from:        "create table t(id int)",
+			to:          "drop table t",
+			expectError: ErrUnsupportedStatement.Error(),
+		},
+		{
 			name: "create, alter, drop tables and views",
 			from: "create view v1 as select * from t1; create table t1(id int primary key); create table t2(id int primary key); create view v2 as select * from t2; create table t3(id int primary key);",
 			to:   "create view v0 as select * from v2, t2; create table t4(id int primary key); create view v2 as select id from t2; create table t2(id bigint primary key); create table t3(id int primary key)",
@@ -325,7 +339,7 @@ func TestDiffSchemas(t *testing.T) {
 			diffs, err := DiffSchemasSQL(ts.from, ts.to, hints)
 			if ts.expectError != "" {
 				assert.Error(t, err)
-				assert.Contains(t, ts.expectError, err.Error())
+				assert.Contains(t, err.Error(), ts.expectError)
 			} else {
 				assert.NoError(t, err)
 				statements := []string{}

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -114,13 +114,9 @@ func getViewDependentTableNames(createView *sqlparser.CreateView) (names []strin
 		case *sqlparser.AliasedTableExpr:
 			if tableName, ok := node.Expr.(sqlparser.TableName); ok {
 				names = append(names, tableName.Name.String())
-			} else {
-				name, err := node.TableName()
-				if err != nil {
-					return true, err
-				}
-				names = append(names, name.Name.String())
 			}
+			// or, this could be a more complex expression, like a derived table `(select * from v1) as derived`,
+			// in which case further Walk-ing will eventually find the "real" table name
 		}
 		return true, nil
 	}, createView)

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -256,23 +256,23 @@ func (s *Schema) Diff(other *Schema, hints *DiffHints) (diffs []EntityDiff, err 
 			diff, err := fromEntity.Diff(e, hints)
 
 			switch {
-			case err == nil:
-				// No error, let's check the diff:
-				if diff != nil && !diff.IsEmpty() {
-					diffs = append(diffs, diff)
-				}
 			case err != nil && errors.Is(err, ErrEntityTypeMismatch):
 				// e.g. comparing a table with a view
 				// there's no single "diff", ie no single ALTER statement to convert from one to another,
 				// hence the error.
-				// But in our context, we know better. We know we should DROP the one, CREATE the other.
+				// But in our schema context, we know better. We know we should DROP the one, CREATE the other.
 				// We proceed to do that, and implicitly ignore the error
 				diffs = append(diffs, fromEntity.Drop())
 				diffs = append(diffs, e.Create())
 				// And we're good. We can move on to comparing next entity.
-			default:
+			case err != nil:
 				// Any other kind of error
 				return nil, err
+			default:
+				// No error, let's check the diff:
+				if diff != nil && !diff.IsEmpty() {
+					diffs = append(diffs, diff)
+				}
 			}
 		} else { // !ok
 			// Added entity

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schemadiff
+
+import (
+	"io"
+	"sort"
+
+	"github.com/pkg/errors"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+//
+type Schema struct {
+	tables []*CreateTableEntity
+	views  []*CreateViewEntity
+
+	named  map[string]Entity
+	sorted []Entity
+}
+
+func NewSchema() *Schema {
+	schema := &Schema{
+		tables: []*CreateTableEntity{},
+		views:  []*CreateViewEntity{},
+		named:  map[string]Entity{},
+		sorted: []Entity{},
+	}
+	return schema
+}
+
+func NewSchemaFromEntities(entities []Entity) (*Schema, error) {
+	schema := NewSchema()
+	for _, e := range entities {
+		switch c := e.(type) {
+		case *CreateTableEntity:
+			schema.tables = append(schema.tables, c)
+		case *CreateViewEntity:
+			schema.views = append(schema.views, c)
+		default:
+			return nil, ErrUnsupportedEntity
+		}
+	}
+	if err := schema.normalize(); err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
+
+func NewSchemaFromStatements(statements []sqlparser.Statement) (*Schema, error) {
+	entities := []Entity{}
+	for _, s := range statements {
+		switch stmt := s.(type) {
+		case *sqlparser.CreateTable:
+			entities = append(entities, NewCreateTableEntity(stmt))
+		case *sqlparser.CreateView:
+			entities = append(entities, NewCreateViewEntity(stmt))
+		default:
+			return nil, errors.Wrap(ErrUnsupportedStatement, sqlparser.String(s))
+		}
+	}
+	return NewSchemaFromEntities(entities)
+}
+
+func NewSchemaFromQueries(queries []string) (*Schema, error) {
+	statements := []sqlparser.Statement{}
+	for _, q := range queries {
+		stmt, err := sqlparser.Parse(q)
+		if err != nil {
+			return nil, err
+		}
+		statements = append(statements, stmt)
+	}
+	return NewSchemaFromStatements(statements)
+}
+
+func NewSchemaFromSQL(sql string) (*Schema, error) {
+	statements := []sqlparser.Statement{}
+	tokenizer := sqlparser.NewStringTokenizer(sql)
+	for {
+		stmt, err := sqlparser.ParseNext(tokenizer)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, errors.Wrapf(err, "could not parse statement in schema snapshot")
+		}
+		statements = append(statements, stmt)
+	}
+	return NewSchemaFromStatements(statements)
+}
+
+func (s *Schema) normalize() error {
+	// Verify no two entities share same name
+	for _, t := range s.tables {
+		name := t.Name()
+		if _, ok := s.named[name]; ok {
+			return errors.Wrap(ErrDuplicateName, name)
+		}
+		s.named[name] = t
+	}
+	for _, v := range s.views {
+		name := v.Name()
+		if _, ok := s.named[name]; ok {
+			return errors.Wrap(ErrDuplicateName, name)
+		}
+		s.named[name] = v
+	}
+
+	// Generally speaking, we want tables and views to be sorted alphabetically
+	sort.SliceStable(s.tables, func(i, j int) bool {
+		return s.tables[i].Name() < s.tables[j].Name()
+	})
+	sort.SliceStable(s.views, func(i, j int) bool {
+		return s.views[i].Name() < s.views[j].Name()
+	})
+
+	// More importantly, we want tables and views to be sorted in applicable order.
+	// For example, if a view v reads from table t, then t must be defined before v.
+	// We actually prioritise all tables first, then views.
+	// If a view v1 depends on v2, then v2 must come before v1, even though v1
+	// precedes v2 alphabetically
+	handledNames := map[string]bool{}
+	for _, t := range s.tables {
+		s.sorted = append(s.sorted, t)
+		handledNames[t.Name()] = true
+	}
+
+	handledViewsInItration := -1
+	for handledViewsInItration != 0 {
+		for _, v := range s.views {
+			name := v.Name()
+			if handledNames[name] {
+				// already handled; skip
+				continue
+			}
+			// Not handled. Is this view dependant on already handled objects?
+			allDependenciesHandled := true
+			for _, fromTable := range v.GetFromTables() {
+				if !handledNames[fromTable.Name.String()] {
+					// "from" table is not yet handled. This means this view cannot be defined yet.
+					allDependenciesHandled = false
+					break
+				}
+			}
+			if allDependenciesHandled {
+				s.sorted = append(s.sorted, v)
+				handledNames[v.Name()] = true
+				handledViewsInItration++
+			}
+		}
+	}
+	if len(s.sorted) != len(s.tables)+len(s.views) {
+		return ErrViewDependencyLoop
+	}
+	return nil
+}
+
+func (s *Schema) Entities() []Entity {
+	return s.sorted
+}
+
+func (s *Schema) EntityNames() []string {
+	names := []string{}
+	for _, e := range s.Entities() {
+		names = append(names, e.Name())
+	}
+	return names
+}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schemadiff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var createQueries = []string{
+	"create view v5 as select * from t1, v3",
+	"create table t3(id int)",
+	"create table t1(id int)",
+	"create view v6 as select * from v4",
+	"create view v4 as select * from t2 as something_else, v3",
+	"create table t2(id int)",
+	"create table t5(id int)",
+	"create view v2 as select * from v3, t2",
+	"create view v1 as select * from v3",
+	"create view v3 as select * from t3 as t3",
+	"create view v0 as select 1 from DUAL",
+}
+
+var expectSortedNames = []string{
+	"t1",
+	"t2",
+	"t3",
+	"t5",
+	"v0", // level 1 ("dual" is an implicit table)
+	"v3", // level 1
+	"v1", // level 2
+	"v2", // level 2
+	"v4", // level 2
+	"v5", // level 2
+	"v6", // level 3
+}
+
+func TestNewSchemaFromQueries(t *testing.T) {
+	schema, err := NewSchemaFromQueries(createQueries)
+	assert.NoError(t, err)
+	assert.NotNil(t, schema)
+
+	assert.Equal(t, expectSortedNames, schema.EntityNames())
+}
+
+func TestNewSchemaFromSQL(t *testing.T) {
+	schema, err := NewSchemaFromSQL(strings.Join(createQueries, ";"))
+	assert.NoError(t, err)
+	assert.NotNil(t, schema)
+
+	assert.Equal(t, expectSortedNames, schema.EntityNames())
+}
+
+func TestNewSchemaFromQueriesWithDuplicate(t *testing.T) {
+	// v2 already exists
+	queries := append(createQueries,
+		"create view v2 as select * from v1, t2",
+	)
+	_, err := NewSchemaFromQueries(queries)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrDuplicateName)
+}
+
+func TestNewSchemaFromQueriesUnresolved(t *testing.T) {
+	// v8 does not exist
+	queries := append(createQueries,
+		"create view v7 as select * from v8, t2",
+	)
+	_, err := NewSchemaFromQueries(queries)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrViewDependencyUnresolved)
+}
+
+func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {
+	// v8 does not exist
+	queries := append(createQueries,
+		"create view v7 as select * from something_else as t1, t2",
+	)
+	_, err := NewSchemaFromQueries(queries)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrViewDependencyUnresolved)
+}
+
+func TestNewSchemaFromQueriesLoop(t *testing.T) {
+	// v7 and v8 depend on each other
+	queries := append(createQueries,
+		"create view v7 as select * from v8, t2",
+		"create view v8 as select * from t1, v7",
+	)
+	_, err := NewSchemaFromQueries(queries)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrViewDependencyUnresolved)
+}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var createQueries = []string{
-	"create view v5 as select * from t1, v3",
+	"create view v5 as select * from t1, (select * from v3) as some_alias",
 	"create table t3(id int)",
 	"create table t1(id int)",
 	"create view v6 as select * from v4",
@@ -35,6 +35,7 @@ var createQueries = []string{
 	"create view v1 as select * from v3",
 	"create view v3 as select * from t3 as t3",
 	"create view v0 as select 1 from DUAL",
+	"create view v9 as select 1",
 }
 
 var expectSortedNames = []string{
@@ -44,6 +45,7 @@ var expectSortedNames = []string{
 	"t5",
 	"v0", // level 1 ("dual" is an implicit table)
 	"v3", // level 1
+	"v9", // level 1 (no source table)
 	"v1", // level 2
 	"v2", // level 2
 	"v4", // level 2

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -679,14 +679,14 @@ func (c *CreateTableEntity) diffColumns(alterTable *sqlparser.AlterTable,
 }
 
 // Create implements Entity interface
-func (c *CreateTableEntity) Create() (diff EntityDiff, err error) {
-	return &CreateTableEntityDiff{createTable: &c.CreateTable}, nil
+func (c *CreateTableEntity) Create() EntityDiff {
+	return &CreateTableEntityDiff{createTable: &c.CreateTable}
 }
 
 // Drop implements Entity interface
-func (c *CreateTableEntity) Drop() (diff EntityDiff, err error) {
+func (c *CreateTableEntity) Drop() EntityDiff {
 	dropTable := &sqlparser.DropTable{
 		FromTables: []sqlparser.TableName{c.Table},
 	}
-	return &DropTableEntityDiff{dropTable: dropTable}, nil
+	return &DropTableEntityDiff{dropTable: dropTable}
 }

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -676,3 +676,14 @@ func (c *CreateTableEntity) diffColumns(alterTable *sqlparser.AlterTable,
 		}
 	}
 }
+
+func (c *CreateTableEntity) Create() (diff EntityDiff, err error) {
+	return &CreateTableEntityDiff{createTable: &c.CreateTable}, nil
+}
+
+func (c *CreateTableEntity) Drop() (diff EntityDiff, err error) {
+	dropTable := &sqlparser.DropTable{
+		FromTables: []sqlparser.TableName{c.Table},
+	}
+	return &DropTableEntityDiff{dropTable: dropTable}, nil
+}

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -110,6 +110,10 @@ func NewCreateTableEntity(c *sqlparser.CreateTable) *CreateTableEntity {
 	return &CreateTableEntity{CreateTable: *c}
 }
 
+func (c *CreateTableEntity) Name() string {
+	return c.CreateTable.GetTable().Name.String()
+}
+
 // Diff implements Entity interface function
 func (c *CreateTableEntity) Diff(other Entity, hints *DiffHints) (EntityDiff, error) {
 	otherCreateTable, ok := other.(*CreateTableEntity)

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -101,7 +101,7 @@ func (d *DropTableEntityDiff) StatementString() (s string) {
 	return s
 }
 
-//
+// CreateTableEntity stands for a TABLE construct. It contains the table's CREATE statement.
 type CreateTableEntity struct {
 	sqlparser.CreateTable
 }
@@ -110,6 +110,7 @@ func NewCreateTableEntity(c *sqlparser.CreateTable) *CreateTableEntity {
 	return &CreateTableEntity{CreateTable: *c}
 }
 
+// Name implements Entity interface
 func (c *CreateTableEntity) Name() string {
 	return c.CreateTable.GetTable().Name.String()
 }
@@ -677,10 +678,12 @@ func (c *CreateTableEntity) diffColumns(alterTable *sqlparser.AlterTable,
 	}
 }
 
+// Create implements Entity interface
 func (c *CreateTableEntity) Create() (diff EntityDiff, err error) {
 	return &CreateTableEntityDiff{createTable: &c.CreateTable}, nil
 }
 
+// Drop implements Entity interface
 func (c *CreateTableEntity) Drop() (diff EntityDiff, err error) {
 	dropTable := &sqlparser.DropTable{
 		FromTables: []sqlparser.TableName{c.Table},

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -38,16 +38,28 @@ var (
 	ErrViewDependencyUnresolved       = errors.New("Views have unresolved/loop dependencies")
 )
 
+// Entity stands for a database object we can diff:
+// - A table
+// - A view
 type Entity interface {
+	// Name of entity, ie table name, view name, etc.
 	Name() string
+	// Diff returns an entitty diff given another entity. The diff direction is from this entity and to the other entity.
 	Diff(other Entity, hints *DiffHints) (diff EntityDiff, err error)
+	// Create returns an entity diff that describes how to create this entity
 	Create() (diff EntityDiff, err error)
+	// Create returns an entity diff that describes how to drop this entity
 	Drop() (diff EntityDiff, err error)
 }
 
+// EntityDiff represents the diff between two entities
 type EntityDiff interface {
+	// IsEmpty returns true when the two entities are considered identical
 	IsEmpty() bool
+	// Statement returns a valid SQL statement that applies the diff, e.g. an ALTER TABLE ...
+	// It returns nil if the diff is empty
 	Statement() sqlparser.Statement
+	// StatementString "stringifies" the this diff's Statement(). It returns an empty string if the diff is empty
 	StatementString() string
 }
 
@@ -57,6 +69,7 @@ const (
 	AutoIncrementApplyAlways
 )
 
+// DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
 	StrictIndexOrdering   bool
 	AutoIncrementStrategy int

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -35,7 +35,7 @@ var (
 	ErrUnsupportedEntity              = errors.New("Unsupported entity type")
 	ErrUnsupportedStatement           = errors.New("Unsupported statement")
 	ErrDuplicateName                  = errors.New("Duplicate name")
-	ErrViewDependencyLoop             = errors.New("Views have dependency loop")
+	ErrViewDependencyUnresolved       = errors.New("Views have unresolved/loop dependencies")
 )
 
 type Entity interface {

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -32,9 +32,14 @@ var (
 	ErrNotFullyParsed                 = errors.New("unable to fully parse statement")
 	ErrExpectedCreateTable            = errors.New("expected a CREATE TABLE statement")
 	ErrExpectedCreateView             = errors.New("expected a CREATE VIEW statement")
+	ErrUnsupportedEntity              = errors.New("Unsupported entity type")
+	ErrUnsupportedStatement           = errors.New("Unsupported statement")
+	ErrDuplicateName                  = errors.New("Duplicate name")
+	ErrViewDependencyLoop             = errors.New("Views have dependency loop")
 )
 
 type Entity interface {
+	Name() string
 	Diff(other Entity, hints *DiffHints) (diff EntityDiff, err error)
 }
 

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -47,9 +47,9 @@ type Entity interface {
 	// Diff returns an entitty diff given another entity. The diff direction is from this entity and to the other entity.
 	Diff(other Entity, hints *DiffHints) (diff EntityDiff, err error)
 	// Create returns an entity diff that describes how to create this entity
-	Create() (diff EntityDiff, err error)
+	Create() EntityDiff
 	// Create returns an entity diff that describes how to drop this entity
-	Drop() (diff EntityDiff, err error)
+	Drop() EntityDiff
 }
 
 // EntityDiff represents the diff between two entities

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -41,6 +41,8 @@ var (
 type Entity interface {
 	Name() string
 	Diff(other Entity, hints *DiffHints) (diff EntityDiff, err error)
+	Create() (diff EntityDiff, err error)
+	Drop() (diff EntityDiff, err error)
 }
 
 type EntityDiff interface {

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -150,3 +150,14 @@ func (c *CreateViewEntity) ViewDiff(other *CreateViewEntity, hints *DiffHints) (
 	}
 	return &AlterViewEntityDiff{alterView: alterView}, nil
 }
+
+func (c *CreateViewEntity) Create() (diff EntityDiff, err error) {
+	return &CreateViewEntityDiff{createView: &c.CreateView}, nil
+}
+
+func (c *CreateViewEntity) Drop() (diff EntityDiff, err error) {
+	dropView := &sqlparser.DropView{
+		FromTables: []sqlparser.TableName{c.ViewName},
+	}
+	return &DropViewEntityDiff{dropView: dropView}, nil
+}

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -105,6 +105,10 @@ func NewCreateViewEntity(c *sqlparser.CreateView) *CreateViewEntity {
 	return &CreateViewEntity{CreateView: *c}
 }
 
+func (c *CreateViewEntity) Name() string {
+	return c.CreateView.GetTable().Name.String()
+}
+
 // Diff implements Entity interface function
 func (c *CreateViewEntity) Diff(other Entity, hints *DiffHints) (EntityDiff, error) {
 	otherCreateView, ok := other.(*CreateViewEntity)

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -96,7 +96,7 @@ func (d *DropViewEntityDiff) StatementString() (s string) {
 	return s
 }
 
-//
+// CreateViewEntity stands for a VIEW construct. It contains the view's CREATE statement.
 type CreateViewEntity struct {
 	sqlparser.CreateView
 }
@@ -105,6 +105,7 @@ func NewCreateViewEntity(c *sqlparser.CreateView) *CreateViewEntity {
 	return &CreateViewEntity{CreateView: *c}
 }
 
+// Name implements Entity interface
 func (c *CreateViewEntity) Name() string {
 	return c.CreateView.GetTable().Name.String()
 }
@@ -151,10 +152,12 @@ func (c *CreateViewEntity) ViewDiff(other *CreateViewEntity, hints *DiffHints) (
 	return &AlterViewEntityDiff{alterView: alterView}, nil
 }
 
+// Create implements Entity interface
 func (c *CreateViewEntity) Create() (diff EntityDiff, err error) {
 	return &CreateViewEntityDiff{createView: &c.CreateView}, nil
 }
 
+// Drop implements Entity interface
 func (c *CreateViewEntity) Drop() (diff EntityDiff, err error) {
 	dropView := &sqlparser.DropView{
 		FromTables: []sqlparser.TableName{c.ViewName},

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -153,14 +153,14 @@ func (c *CreateViewEntity) ViewDiff(other *CreateViewEntity, hints *DiffHints) (
 }
 
 // Create implements Entity interface
-func (c *CreateViewEntity) Create() (diff EntityDiff, err error) {
-	return &CreateViewEntityDiff{createView: &c.CreateView}, nil
+func (c *CreateViewEntity) Create() EntityDiff {
+	return &CreateViewEntityDiff{createView: &c.CreateView}
 }
 
 // Drop implements Entity interface
-func (c *CreateViewEntity) Drop() (diff EntityDiff, err error) {
+func (c *CreateViewEntity) Drop() EntityDiff {
 	dropView := &sqlparser.DropView{
 		FromTables: []sqlparser.TableName{c.ViewName},
 	}
-	return &DropViewEntityDiff{dropView: dropView}, nil
+	return &DropViewEntityDiff{dropView: dropView}
 }

--- a/go/vt/schemadiff/view_test.go
+++ b/go/vt/schemadiff/view_test.go
@@ -130,7 +130,7 @@ func TestCreateViewDiff(t *testing.T) {
 	}
 	hints := &DiffHints{}
 	for _, ts := range tt {
-		t.Run(ts.name, func(*testing.T) {
+		t.Run(ts.name, func(t *testing.T) {
 			fromStmt, err := sqlparser.Parse(ts.from)
 			assert.NoError(t, err)
 			fromCreateView, ok := fromStmt.(*sqlparser.CreateView)


### PR DESCRIPTION

## Description

Up till now [schemadiff](https://github.com/vitessio/vitess/pull/9719) allowed us to compare a table with another table, or a view with another view. This is [now in use](https://github.com/vitessio/vitess/pull/9772) in declarative schema changes.

This PR introduces schema comparisons.

A `Schema` is a collection of database objects -- right now this means tables and views. You may load a schema by:

- a list of well formed entities, or
- a list of well formed `Statement`s, or
- a list of `CREATE ...` queries, or
- a SQL blob that contains multiple `CREATE` queries

A schema is validated upon loading:

- can't have two objects with same name
- all view dependencies are resolved

As for the latter: `schemadiff` parses each view and analyze its dependencies. It validates that all dependencies are met. e.g. you can't create a view that reads from a nonexistent table. Also, you can't create two views that have circular dependency.

Lastly, the schema is normalized: we reorder the objects by order of valid creation: first, the tables; then, views that only depend on tables; then, 2nd level views, etc.

### Diff

`schemadiff` can now do, well, a schema-diff. Compare two `Schema` objects. This returns a (possibly empty) list of diffs, which create/alter/drop tables and views so as to mutate one schema to another. This is all done declaratively.

See the added tests for more insights.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required
