### PR TITLE
[vtadmin] grpc dynamic clusters

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -245,9 +245,9 @@ func (api *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 
 				dynamicAPI = api.WithCluster(c, id)
+			} else {
+				log.Warningf("failed to unmarshal dynamic cluster spec from cookie; falling back to static API; error: %s", err)
 			}
-
-			log.Warningf("failed to unmarshal dynamic cluster spec from cookie; falling back to static API; error: %s", err)
 		}
 	}
 

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -89,10 +89,6 @@ type Options struct {
 	EnableDynamicClusters bool
 }
 
-type DynamicClusterJSON struct {
-	ClusterName string `json:"name,omitempty"`
-}
-
 // NewAPI returns a new API, configured to service the given set of clusters,
 // and configured with the given options.
 //

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -145,6 +145,8 @@ func NewAPI(clusters []*cluster.Cluster, opts Options) *API {
 		authz:      authz,
 	}
 
+	// TODO: this is no longer an http opt. Should rename the flag and move up
+	// to the struct top-level.
 	if opts.HTTPOpts.EnableDynamicClusters {
 		api.clusterCache = cache.New(24*time.Hour, 24*time.Hour)
 		api.clusterCache.OnEvicted(api.EjectDynamicCluster)

--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -37,7 +37,6 @@ import (
 	"vitess.io/vitess/go/vt/vtadmin/cluster"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery/fakediscovery"
 	vtadminerrors "vitess.io/vitess/go/vt/vtadmin/errors"
-	vtadminhttp "vitess.io/vitess/go/vt/vtadmin/http"
 	vtadmintestutil "vitess.io/vitess/go/vt/vtadmin/testutil"
 	"vitess.io/vitess/go/vt/vtadmin/vtctldclient/fakevtctldclient"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver"
@@ -4957,7 +4956,7 @@ func TestServeHTTP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			api := NewAPI(tt.clusters, Options{HTTPOpts: vtadminhttp.Options{EnableDynamicClusters: tt.enableDynamicClusters}})
+			api := NewAPI(tt.clusters, Options{EnableDynamicClusters: tt.enableDynamicClusters})
 
 			// Copy the Cookie over to a new Request
 			req := httptest.NewRequest(http.MethodGet, "/api/clusters", nil)

--- a/go/vt/vtadmin/cluster/dynamic/api.go
+++ b/go/vt/vtadmin/cluster/dynamic/api.go
@@ -1,0 +1,17 @@
+package dynamic
+
+import (
+	"net/http"
+
+	"vitess.io/vitess/go/vt/vtadmin/cluster"
+
+	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
+)
+
+// API is the interface dynamic APIs must implement.
+// It is implemented by vtadmin.API.
+type API interface {
+	vtadminpb.VTAdminServer
+	WithCluster(c *cluster.Cluster, id string) API
+	Handler() http.Handler
+}

--- a/go/vt/vtadmin/cluster/dynamic/cluster.go
+++ b/go/vt/vtadmin/cluster/dynamic/cluster.go
@@ -1,0 +1,67 @@
+package dynamic
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"vitess.io/vitess/go/vt/vtadmin/cluster"
+)
+
+// DiscoveryImpl is the name of the discovery implementation used by clusters
+// unpacked from ClusterFromString.
+const DiscoveryImpl = "dynamic"
+
+// ClusterJSON is a struct to unmarshal json strings into dynamic cluster
+// configurations.
+type ClusterJSON struct {
+	Name string `json:"name,omitempty"`
+}
+
+// ClusterFromString returns a cluster ID and possibly fully-usable Cluster
+// from a base64-encoded JSON spec.
+//
+// If an error occurs decoding or unmarshalling the string, this function
+// returns, respectively, the empty string, a nil Cluster, and a non-nil error.
+//
+// If the string can be decoded and unmarshalled, then the id will be non-empty,
+// but errors may still be returned from instantiating the cluster, for example
+// if the configuration in the JSON spec is invalid.
+//
+// Therefore, callers should handle the return values as follows:
+//
+//		c, id, err := dynamic.ClusterFromString(s)
+//		if id == "" {
+//			// handle err, do not use `c`.
+//		}
+//		if err != nil {
+//			// log error. if desired, lookup the existing cluster with ID: `id`
+//		}
+//		// Use `c` (or existing cluster with ID == `id`) based on the dynamic cluster
+//		api.WithCluster(c, id).DoAThing()
+//
+func ClusterFromString(s string) (c *cluster.Cluster, id string, err error) {
+	dec, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var spec ClusterJSON
+	if err := json.Unmarshal(dec, &spec); err != nil {
+		return nil, "", err
+	}
+
+	id = spec.Name
+	cfg := &cluster.Config{
+		ID:            id,
+		Name:          id,
+		DiscoveryImpl: DiscoveryImpl,
+		DiscoveryFlagsByImpl: cluster.FlagsByImpl{
+			DiscoveryImpl: map[string]string{
+				"discovery": string(dec),
+			},
+		},
+	}
+	c, err = cfg.Cluster()
+
+	return c, id, err
+}

--- a/go/vt/vtadmin/cluster/dynamic/cluster.go
+++ b/go/vt/vtadmin/cluster/dynamic/cluster.go
@@ -3,6 +3,7 @@ package dynamic
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 
 	"vitess.io/vitess/go/vt/vtadmin/cluster"
 )
@@ -10,6 +11,10 @@ import (
 // DiscoveryImpl is the name of the discovery implementation used by clusters
 // unpacked from ClusterFromString.
 const DiscoveryImpl = "dynamic"
+
+// ErrNoID is returned from ClusterFromString when a cluster spec has a missing
+// or empty id.
+var ErrNoID = errors.New("cannot have cluster without an id")
 
 // ClusterJSON is a struct to unmarshal json strings into dynamic cluster
 // configurations.
@@ -51,6 +56,9 @@ func ClusterFromString(s string) (c *cluster.Cluster, id string, err error) {
 	}
 
 	id = spec.Name
+	if id == "" {
+		return nil, "", ErrNoID
+	}
 	cfg := &cluster.Config{
 		ID:            id,
 		Name:          id,

--- a/go/vt/vtadmin/cluster/dynamic/cluster_test.go
+++ b/go/vt/vtadmin/cluster/dynamic/cluster_test.go
@@ -1,0 +1,75 @@
+package dynamic
+
+import (
+	"encoding/base32"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterFromString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		s          string
+		encoder    func(b []byte) string
+		expectedID string
+		shouldErr  bool
+	}{
+		{
+			name:       "ok",
+			s:          `{"name": "dynamic_cluster"}`,
+			expectedID: "dynamic_cluster",
+		},
+		{
+			name:      "empty id",
+			s:         `{"name": ""}`,
+			shouldErr: true,
+		},
+		{
+			name:      "no id",
+			s:         `{"vtctlds": []}`,
+			shouldErr: true,
+		},
+		{
+			name:      "bad encoding",
+			s:         "…∆ø†h¬®çå®øç", // this junk (when base32 hex'd) breaks base64 std decoding
+			encoder:   base32.HexEncoding.EncodeToString,
+			shouldErr: true,
+		},
+		{
+			name:      "invalid json",
+			s:         `{`,
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.encoder == nil {
+				tt.encoder = base64.StdEncoding.EncodeToString
+			}
+
+			enc := tt.encoder([]byte(tt.s))
+
+			c, id, err := ClusterFromString(enc)
+			if tt.shouldErr {
+				assert.Error(t, err)
+				assert.Nil(t, c, "when err != nil, cluster must be nil")
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotEmpty(t, id, "when err == nil, id must be non-empty")
+
+			assert.Equal(t, tt.expectedID, id)
+			assert.NotNil(t, c, "when err == nil, cluster should not be nil")
+		})
+	}
+}

--- a/go/vt/vtadmin/cluster/dynamic/interceptors.go
+++ b/go/vt/vtadmin/cluster/dynamic/interceptors.go
@@ -1,0 +1,134 @@
+package dynamic
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/vtadmin/cluster"
+
+	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
+)
+
+// StreamServerInterceptor returns a StreamServerInterceptor that redirects a
+// streaming RPC to a dynamic API if the incoming context has a cluster spec in
+// its metadata. Otherwise, the interceptor is a no-op, and the original stream
+// handler is invoked.
+func StreamServerInterceptor(api API) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		c, id, ok, err := clusterFromIncomingContextMetadata(ss.Context())
+		switch { // TODO: see if it's possible to de-duplicate this somehow. Unfortunately the callbacks have different signatures which might make it impossible.
+		case !ok:
+			// No dynamic cluster metadata, proceed directly to handler.
+			return handler(srv, ss)
+		case id == "":
+			// There was a cluster spec in the metadata, but we couldn't even
+			// get an id out of it. Warn and fallback to static API.
+			log.Warningf("failed to unmarshal dynamic cluster spec from incoming context metadata; falling back to static API; error: %v", err)
+			return handler(srv, ss)
+		}
+
+		if err != nil {
+			log.Warningf("failed to extract valid cluster from incoming metadata; attempting to use existing cluster with id=%s; error: %v", id, err)
+		}
+
+		dynamicAPI := api.WithCluster(c, id)
+		streamHandler := streamHandlersByName[nameFromFullMethod(info.FullMethod)]
+		return streamHandler(dynamicAPI, ss)
+	}
+}
+
+// UnaryServerInterceptor returns a UnaryServerInterceptor that redirects a
+// unary RPC to a dynamic API if the incoming context has a cluster spec in its
+// metadata. Otherwise, the interceptor is a no-op, and the original method
+// handler is invoked.
+func UnaryServerInterceptor(api API) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		c, id, ok, err := clusterFromIncomingContextMetadata(ctx)
+		switch {
+		case !ok:
+			// No dynamic cluster metadata, proceed directly to handler.
+			return handler(ctx, req)
+		case id == "":
+			// There was a cluster spec in the metadata, but we couldn't even
+			// get an id out of it. Warn and fallback to static API.
+			log.Warningf("failed to unmarshal dynamic cluster spec from incoming context metadata; falling back to static API; error: %v", err)
+			return handler(ctx, req)
+		}
+
+		if err != nil {
+			log.Warningf("failed to extract valid cluster from incoming metadata; attempting to use existing cluster with id=%s; error: %v", id, err)
+		}
+
+		dynamicAPI := api.WithCluster(c, id)
+		method := methodHandlersByName[nameFromFullMethod(info.FullMethod)]
+
+		// NOTE: because we don't have access to the interceptor
+		// chain (but we _could_ if we wanted to add a method to the
+		// DynamicAPI interface), this MUST be the last interceptor
+		// in the chain.
+		return method(dynamicAPI, ctx, dec(req), nil)
+	}
+}
+
+func clusterFromIncomingContextMetadata(ctx context.Context) (*cluster.Cluster, string, bool, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, "", false, nil
+	}
+
+	clusterMetadata := md.Get("cluster")
+	if len(clusterMetadata) != 1 {
+		return nil, "", false, nil
+	}
+
+	c, id, err := ClusterFromString(clusterMetadata[0])
+	return c, id, true, err
+}
+
+// dec returns a function that merges the src proto.Message into dst.
+func dec(src interface{}) func(dst interface{}) error {
+	return func(dst interface{}) error {
+		// gRPC handlers expect a function called `dec` which
+		// decodes an arbitrary req into a req of the correct type
+		// for the particular handler.
+		//
+		// Because we are doing a lookup that matches on method
+		// name, we know that the `req` passed to the interceptor
+		// and the `req2` passed to `dec` are the same type, we're
+		// just going to proto.Merge blindly and return nil.
+		proto.Merge(dst.(proto.Message), src.(proto.Message))
+		return nil
+	}
+}
+
+func nameFromFullMethod(fullMethod string) string {
+	parts := strings.Split(fullMethod, "/")
+	return parts[len(parts)-1]
+}
+
+var (
+	methodHandlersByName = map[string]methodHandler{}
+	streamHandlersByName = map[string]grpc.StreamHandler{}
+)
+
+// for whatever reason, grpc exports the StreamHandler type but _not_ the
+// methodHandler type, but this is an identical type. Furthermore, the cast in
+// the init() below will fail to compile if our types ever stop aligning.
+//
+// c.f. https://github.com/grpc/grpc-go/blob/v1.39.0/server.go#L81
+type methodHandler func(srv interface{}, ctx context.Context, dec func(in interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error)
+
+func init() {
+	for _, m := range vtadminpb.VTAdmin_ServiceDesc.Methods {
+		methodHandlersByName[m.MethodName] = methodHandler(m.Handler)
+	}
+
+	for _, s := range vtadminpb.VTAdmin_ServiceDesc.Streams {
+		streamHandlersByName[s.StreamName] = s.Handler
+	}
+}

--- a/go/vt/vtadmin/http/api.go
+++ b/go/vt/vtadmin/http/api.go
@@ -31,9 +31,6 @@ type Options struct {
 	// CORSOrigins is the list of origins to allow via CORS. An empty or nil
 	// slice disables CORS entirely.
 	CORSOrigins []string
-	// EnableDynamicClusters makes it so that clients can pass clusters dynamically
-	// in a session-like way
-	EnableDynamicClusters bool
 	// EnableTracing specifies whether to install a tracing middleware on the
 	// API subrouter.
 	EnableTracing bool

--- a/misc/errcheck_excludes.txt
+++ b/misc/errcheck_excludes.txt
@@ -29,6 +29,8 @@ os.Rename
 (*github.com/spf13/cobra.Command).MarkFlagRequired
 (*github.com/spf13/cobra.Command).MarkPersistentFlagFilename
 
+(*github.com/spf13/pflag.FlagSet).MarkDeprecated
+
 (*google.golang.org/grpc.ClientConn).Close
 (*google.golang.org/grpc.Server).Serve
 


### PR DESCRIPTION
## Description

This refactor enables the specifying of a dynamic cluster via [grpc metadata](https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md) in addition to an http cookie.

**NOTE** this deprecates the `--http-enable-dynamic-clusters` flag in favor of the `--enable-dynamic-clusters`. After we've deployed this, I'll circle back around to clean up the flag.

### Testing

- `curl`-ing with a cookie still works, as before
- grpc demo: https://gist.github.com/ajm188/5b5c8ba0cc5660298697e0f762081d45

## Overview

### Preparatory refactor

The first thing we do is extract as much of the non-"related to serving an http request" code out of `ServeHTTP(w, r)` as possible, moving it to `package dynamic` (in `vitess.io/vitess/go/vt/vtadmin/cluster/dynamic`). Now, the ServeHTTP handler "simply":
1. says "hey, here's a cookie, can you get me a cluster out of it?" (this is `dynamic.ClusterFromString`)
2. then, depending on the answer to that question:
    a. if we can extract a cluster, says "hey, give me a dynamic API with this cluster or with this cluster id" (this is the `WithCluster` method of the `dynamic.API` interface, which `vtadmin.API` implements), and we invoke that API's `Handler()` to serve the request
    b. if we can't extract a cluster, then the original API is used

### gRPC metadata

Again, the [docs on metadata](https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md) are actually quite thorough and good, so if you want to dig deeper I would recommend reading those, but the tl;dr is:

* when you're sending metadata to someone, you put it into an "outgoing" context
* when you're checking if you were sent metadata from someone else, you extract it from an "incoming" context
* metadata is just a map of `map[string][]string` (that is, specifying the same key multiple times will append to a list instead of overwriting existing values)

### The Interceptors

For this write-up, I'm only going to discuss the unary interceptor because:
1. vtadmin has no streaming rpcs (............... yet?)
2. the streaming interceptor is basically the same "shape" of code as the unary, just with slightly different types

So! The first thing we do, on package `init` is cache a mapping of `fullMethodName => methodHandler`, so we can lookup later (the Service Descriptor provides a list of method handlers, so you would have to scan the entire list if we didn't do this).

A `methodHandler` is a function with the type:

```go
type methodHandler func(srv interface{}, ctx context.Context, dec func(in interface{}) error) interceptor grpc.UnaryServerInterceptor) (resp interface{}, err error)
```

If we look at how one of these method handlers is used in the generated vtadmin_grpc.pb.go code, we'll get a better sense of what these arguments actually are in practice:

```go

func _VTAdmin_GetGates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
	in := new(GetGatesRequest)
	if err := dec(in); err != nil {
		return nil, err
	}
	if interceptor == nil {
		return srv.(VTAdminServer).GetGates(ctx, in)
	}
	info := &grpc.UnaryServerInfo{
		Server:     srv,
		FullMethod: "/vtadmin.VTAdmin/GetGates",
	}
	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
		return srv.(VTAdminServer).GetGates(ctx, req.(*GetGatesRequest))
	}
	return interceptor(ctx, in, info, handler)
}
```

Here we see that:
- `srv` is _some_ implementation of `VTAdminServer` (in practice, the thing you pass to `vtadminpb.RegisterVTAdminServer(api.serv.GRPCServer(), api)`)
- `ctx` is the context that gets passed as the first argument on the concrete `GetGates` method that we wrote in `api.go`.
- `dec` is a function that takes an input which comes from ....... somewhere (off the wire, decoded by grpc), and decoded into an instance of `GetGatesRequest` (this will become the `req` argument to our concrete `GetGates` method in `api.go`). if we can't decode the input ("if `dec` returns an error") we fail immediately.
- `interceptor` is the next function in the interceptor chain. if we're at the end of the chain (`interceptor == nil`), then we invoke the concrete `GetGates` method on `srv` (i.e. we go directly to our method in `api.go`). if we have more interceptors to call, we keep walking down the chain until either an interceptor fails, or we invoke the `handler`.

Soooooo, there's nothing stopping us from accessing this function and providing it a _different_ `srv` argument than what we registered via `vtadminpb.RegisterVTAdminServer(api.serv.GRPCServer(), api)`, which _also_ implements the `VTAdminServer` interface. Let's take another look at the type of `dynamic.API`:

```go
// vtadmin/cluster/dynamic/api.go

type API interface {
    vtadminpb.VTAdminServer
    WithCluster(*cluster.Cluster, string) API
    Handler() http.Handler
}
```

Oh, how convenient! The thing we get back from `WithCluster` is also of type `dynamic.API`, which implements `VTAdminServer`, which means we can safely use it as the `srv` argument to the `methodHandler`! Neat!

So, taking a look at our interceptor:

```go
func UnaryServerInterceptor(api API) grpc.UnaryServerInterceptor {
	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
		c, id, ok, err := clusterFromIncomingContextMetadata(ctx)
		switch {
		case !ok:
			// No dynamic cluster metadata, proceed directly to handler.
			return handler(ctx, req)
		case id == "":
			// There was a cluster spec in the metadata, but we couldn't even
			// get an id out of it. Warn and fallback to static API.
			log.Warningf("failed to unmarshal dynamic cluster spec from incoming context metadata; falling back to static API; error: %v", err)
			return handler(ctx, req)
		}

		if err != nil {
			log.Warningf("failed to extract valid cluster from incoming metadata; attempting to use existing cluster with id=%s; error: %v", id, err)
		}

		dynamicAPI := api.WithCluster(c, id)
		method := methodHandlersByName[nameFromFullMethod(info.FullMethod)]
		return method(dynamicAPI, ctx, dec(req), nil)
	}
}
```

This mirrors the structure of the `ServeHTTP` version, with some grpc/interceptor specifics sprinkled on top. Namely:
1. try to get a cluster out of the metadata (`ok == false` if there was no metadata, or no "cluster" key)
2. if we failed to get a cluster, invoke `handler`, which continues us down the interceptor to chain to eventually invoke the method on the original, static API (this is the existing behavior)
3. if we did get a cluster, call `WithCluster` on the static API to get a dynamic API back, and lookup `methodHandler` for this method that we cached at `init`-time; pass in the dynamic API as `srv`, and a dummy `dec` function that just proto-clones the request.
    a. we know it's safe to do this request cloning/casting, because grpc has actually already decoded the original request into a object of the correct request type
    b. we currently don't support further interceptors after this one (we pass `nil` as the interceptor argument). we can change that by adding a method to `dynamic.API` to access an interceptor chain if we ever need to do that. for now, we just have to be sure these interceptors are the final ones we pass in `grpcserver.NewServer` (which we do)

## Related Issue(s)

- #9544 
- #10044 

## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->