### PR TITLE
Address flakiness of vreplication v2 workflow test

### DIFF
--- a/go/test/endtoend/cluster/vtctlclient_process.go
+++ b/go/test/endtoend/cluster/vtctlclient_process.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -189,19 +190,31 @@ func (vtctlclient *VtctlClientProcess) ExecuteCommand(args ...string) (err error
 }
 
 // ExecuteCommandWithOutput executes any vtctlclient command and returns output
-func (vtctlclient *VtctlClientProcess) ExecuteCommandWithOutput(args ...string) (result string, err error) {
+func (vtctlclient *VtctlClientProcess) ExecuteCommandWithOutput(args ...string) (string, error) {
+	var resultByte []byte
+	var resultStr string
+	var err error
+	retries := 10
+	retryDelay := 1 * time.Second
 	pArgs := []string{"--server", vtctlclient.Server}
 	if *isCoverage {
 		pArgs = append(pArgs, "--test.coverprofile="+getCoveragePath("vtctlclient-"+args[0]+".out"), "--test.v")
 	}
 	pArgs = append(pArgs, args...)
-	tmpProcess := exec.Command(
-		vtctlclient.Binary,
-		filterDoubleDashArgs(pArgs, vtctlclient.VtctlClientMajorVersion)...,
-	)
-	log.Infof("Executing vtctlclient with command: %v", strings.Join(tmpProcess.Args, " "))
-	resultByte, err := tmpProcess.CombinedOutput()
-	return filterResultWhenRunsForCoverage(string(resultByte)), err
+	for i := 1; i <= retries; i++ {
+		tmpProcess := exec.Command(
+			vtctlclient.Binary,
+			filterDoubleDashArgs(pArgs, vtctlclient.VtctlClientMajorVersion)...,
+		)
+		log.Infof("Executing vtctlclient with command: %v (attempt %d of %d)", strings.Join(tmpProcess.Args, " "), i, retries)
+		resultByte, err = tmpProcess.CombinedOutput()
+		resultStr = string(resultByte)
+		if err == nil || !shouldRetry(resultStr) {
+			break
+		}
+		time.Sleep(retryDelay)
+	}
+	return filterResultWhenRunsForCoverage(resultStr), err
 }
 
 // VtctlClientProcessInstance returns a VtctlProcess handle for vtctlclient process
@@ -240,4 +253,13 @@ func (vtctlclient *VtctlClientProcess) InitTablet(tablet *Vttablet, cell string,
 	}
 	args = append(args, fmt.Sprintf("%s-%010d", cell, tablet.TabletUID), tabletType)
 	return vtctlclient.ExecuteCommand(args...)
+}
+
+// shouldRetry tells us if the command should be retried based on the results/output -- meaning that it
+// is likely an ephemeral or recoverable issue that is likely to succeed when retried.
+func shouldRetry(cmdResults string) bool {
+	if strings.Contains(cmdResults, "Deadlock found when trying to get lock; try restarting transaction") {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
## Description
For whatever reasons, we've been seeing more InnoDB Deadlock errors when getting the workflow status for VDiff lately (e.g. [here](https://github.com/vitessio/vitess/runs/5996959498?check_suite_focus=true) and virtually all failures for [the workflow](https://github.com/vitessio/vitess/actions/workflows/cluster_endtoend_vreplication_across_db_versions.yml)). This work adds retry support (up to 10 times) when this occurs, with a sleep of 1 second in between tries to give the database state time to clear up.

> I suspect that some recent changes have made these deadlocks more likely — at least in our VReplication e2e tests where we only have `PRIMARY` tablets and we do a lot of VReplication workflows in quick succession — especially with MySQL 8.0 as the usage of MySQL 8 on the target tablets is the only significant difference between the [across_db_versions test](https://github.com/vitessio/vitess/blob/main/go/test/endtoend/vreplication/vreplication_test.go#L203-L207) and the [basic test](https://github.com/vitessio/vitess/blob/67f656651786035ceb87d5a19caf41e3ab739c24/go/test/endtoend/vreplication/vreplication_test.go#L145-L149).

For example, this command where the MySQL `deadlock detected` was most often hit before and we now see it succeed after retrying (from [this run](https://github.com/vitessio/vitess/runs/5999037974?check_suite_focus=true)):
```
2022-04-12T23:33:52.9832227Z === RUN   TestV2WorkflowsAcrossDBVersions/reshardCustomer3to2SplitMerge/reshard/vdiff
2022-04-12T23:33:52.9832944Z I0412 23:33:11.553832   19813 vtctlclient_process.go:209] Executing vtctlclient with command: vtctlclient --server 127.0.0.1:15999 VDiff -- --tablet_types=primary --source_cell= --format json customer.c4c3 (attempt 1 of 10)
2022-04-12T23:33:52.9833651Z I0412 23:33:13.755188   19813 vtctlclient_process.go:209] Executing vtctlclient with command: vtctlclient --server 127.0.0.1:15999 VDiff -- --tablet_types=primary --source_cell= --format json customer.c4c3 (attempt 2 of 10)
2022-04-12T23:33:52.9834340Z I0412 23:33:18.240967   19813 vtctlclient_process.go:209] Executing vtctlclient with command: vtctlclient --server 127.0.0.1:15999 VDiff -- --tablet_types=primary --source_cell= --format json customer.c4c3 (attempt 3 of 10)
2022-04-12T23:33:52.9834552Z I0412 23:33:21.726784   19813 vreplication_test.go:787] vdiff err: <nil>, output: {
2022-04-12T23:33:52.9834643Z "customer": {
2022-04-12T23:33:52.9834768Z "ProcessedRows": 16,
2022-04-12T23:33:52.9834883Z "MatchingRows": 16,
2022-04-12T23:33:52.9835011Z "MismatchedRows": 0,
2022-04-12T23:33:52.9835133Z "ExtraRowsSource": 0,
2022-04-12T23:33:52.9835276Z "ExtraRowsSourceDiffs": null,
2022-04-12T23:33:52.9835397Z "ExtraRowsTarget": 0,
2022-04-12T23:33:52.9835525Z "ExtraRowsTargetDiffs": null,
2022-04-12T23:33:52.9835666Z "MismatchedRowsSample": null,
2022-04-12T23:33:52.9835786Z "TableName": "customer"
2022-04-12T23:33:52.9835871Z },
...
```

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? NO
- [x] Tests were updated
- [X] Documentation is not required