### PR TITLE
[13.0] Fix: Sequence query to ignore reserved and transaction

### DIFF
--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -55,6 +55,11 @@ type noopVCursor struct {
 	ctx context.Context
 }
 
+// SetContextWithValue implements VCursor interface.
+func (t *noopVCursor) SetContextWithValue(key, value interface{}) func() {
+	return func() {}
+}
+
 // ConnCollation implements VCursor
 func (t *noopVCursor) ConnCollation() collations.ID {
 	return collations.CollationUtf8mb4ID

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -68,6 +68,10 @@ type (
 		// ErrorGroupCancellableContext updates context that can be cancelled.
 		ErrorGroupCancellableContext() (*errgroup.Group, func())
 
+		// SetContextWithValue updates context with key and value and
+		// provides back function to move back to original context.
+		SetContextWithValue(key, value interface{}) func()
+
 		// V3 functions.
 		Execute(method string, query string, bindvars map[string]*querypb.BindVariable, rollbackOnError bool, co vtgatepb.CommitOrder) (*sqltypes.Result, error)
 		AutocommitApproval() bool

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -49,14 +49,53 @@ func TestSelectNext(t *testing.T) {
 
 	query := "select next :n values from user_seq"
 	bv := map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)}
-	_, err := executorExec(executor, query, bv)
-	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           query,
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
 	}}
 
+	// Autocommit
+	session := NewAutocommitSession(&vtgatepb.Session{})
+	_, err := executor.Execute(context.Background(), "TestSelectNext", session, query, bv)
+	require.NoError(t, err)
+
 	utils.MustMatch(t, wantQueries, sbclookup.Queries)
+	assert.Zero(t, sbclookup.BeginCount.Get())
+	assert.Zero(t, sbclookup.ReserveCount.Get())
+	sbclookup.Queries = nil
+
+	// Txn
+	session = NewAutocommitSession(&vtgatepb.Session{})
+	session.Session.InTransaction = true
+	_, err = executor.Execute(context.Background(), "TestSelectNext", session, query, bv)
+	require.NoError(t, err)
+
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
+	assert.Zero(t, sbclookup.BeginCount.Get())
+	assert.Zero(t, sbclookup.ReserveCount.Get())
+	sbclookup.Queries = nil
+
+	// Reserve
+	session = NewAutocommitSession(&vtgatepb.Session{})
+	session.Session.InReservedConn = true
+	_, err = executor.Execute(context.Background(), "TestSelectNext", session, query, bv)
+	require.NoError(t, err)
+
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
+	assert.Zero(t, sbclookup.BeginCount.Get())
+	assert.Zero(t, sbclookup.ReserveCount.Get())
+	sbclookup.Queries = nil
+
+	// Reserve and Txn
+	session = NewAutocommitSession(&vtgatepb.Session{})
+	session.Session.InReservedConn = true
+	session.Session.InTransaction = true
+	_, err = executor.Execute(context.Background(), "TestSelectNext", session, query, bv)
+	require.NoError(t, err)
+
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
+	assert.Zero(t, sbclookup.BeginCount.Get())
+	assert.Zero(t, sbclookup.ReserveCount.Get())
 }
 
 func TestSelectDBA(t *testing.T) {

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -35,6 +35,7 @@ import (
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -629,7 +630,7 @@ func (stc *ScatterConn) multiGoTransaction(
 		startTime, statsKey := stc.startAction(name, rs.Target)
 		defer stc.endAction(startTime, allErrors, statsKey, &err, session)
 
-		shardActionInfo := actionInfo(rs.Target, session, autocommit)
+		shardActionInfo := actionInfo(ctx, rs.Target, session, autocommit)
 		updated, err := action(rs, i, shardActionInfo)
 		if updated == nil {
 			return
@@ -785,8 +786,12 @@ func requireNewQS(err error, target *querypb.Target) bool {
 }
 
 // actionInfo looks at the current session, and returns information about what needs to be done for this tablet
-func actionInfo(target *querypb.Target, session *SafeSession, autocommit bool) *shardActionInfo {
+func actionInfo(ctx context.Context, target *querypb.Target, session *SafeSession, autocommit bool) *shardActionInfo {
 	if !(session.InTransaction() || session.InReservedConn()) {
+		return &shardActionInfo{}
+	}
+	ignoreSession := ctx.Value(engine.IgnoreReserveTxn)
+	if ignoreSession != nil {
 		return &shardActionInfo{}
 	}
 	// No need to protect ourselves from the race condition between

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -215,6 +215,15 @@ func (vc *vcursorImpl) ErrorGroupCancellableContext() (*errgroup.Group, func()) 
 	}
 }
 
+// SetContextWithValue implements the VCursor interface.
+func (vc *vcursorImpl) SetContextWithValue(k, v interface{}) func() {
+	origCtx := vc.ctx
+	vc.ctx = context.WithValue(vc.ctx, k, v)
+	return func() {
+		vc.ctx = origCtx
+	}
+}
+
 // RecordWarning stores the given warning in the current session
 func (vc *vcursorImpl) RecordWarning(warning *querypb.QueryWarning) {
 	vc.safeSession.RecordWarning(warning)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This is backport of #9968 

This PR ignore the session setting related to transaction and reserved connection and always go through the `EXECUTE` call on the tabletserver.

sequence does not require a connection most of the time and even if a new set of sequence cache is required it is executed using its little own transaction in tabletserver ([ignoring conn passed](https://github.com/vitessio/vitess/blob/2b5f72c5dd0411c3ff9da4517c4a8d32c4f57fc5/go/vt/vttablet/tabletserver/query_executor.go#L133,L146) and [own transaction](https://github.com/vitessio/vitess/blob/2b5f72c5dd0411c3ff9da4517c4a8d32c4f57fc5/go/vt/vttablet/tabletserver/query_executor.go#L563)) ignoring the connection id provided by the vtgate or a new one started with `Begin` or `Reserve` calls.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Fixes #9851 

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->