### PR TITLE
mysql protocol: support ComBinlogDump, ComRegisterReplica

### DIFF
--- a/go/mysql/binlog_dump.go
+++ b/go/mysql/binlog_dump.go
@@ -27,6 +27,21 @@ var (
 	readPacketErr      = vterrors.Errorf(vtrpcpb.Code_INTERNAL, "error reading BinlogDumpGTID packet")
 )
 
+func (c *Conn) parseComBinlogDump(data []byte) (logFile string, binlogPos uint32, err error) {
+	pos := 1
+
+	binlogPos, pos, ok := readUint32(data, pos)
+	if !ok {
+		return logFile, binlogPos, readPacketErr
+	}
+
+	pos += 2 // flags
+	pos += 4 // server-id
+
+	logFile = string(data[pos:])
+	return logFile, binlogPos, nil
+}
+
 func (c *Conn) parseComBinlogDumpGTID(data []byte) (logFile string, logPos uint64, position Position, err error) {
 	pos := 1
 	pos += 2 // flags

--- a/go/mysql/conn_flaky_test.go
+++ b/go/mysql/conn_flaky_test.go
@@ -817,6 +817,14 @@ func (t testRun) ComStmtExecute(c *Conn, prepare *PrepareData, callback func(*sq
 	panic("implement me")
 }
 
+func (t testRun) ComRegisterReplica(c *Conn, replicaHost string, replicaPort uint16, replicaUser string, replicaPassword string) error {
+	panic("implement me")
+}
+
+func (t testRun) ComBinlogDump(c *Conn, logFile string, binlogPos uint32) error {
+	panic("implement me")
+}
+
 func (t testRun) ComBinlogDumpGTID(c *Conn, gtidSet GTIDSet) error {
 	panic("implement me")
 }

--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -243,6 +243,10 @@ const (
 	// ComBinlogDumpGTID is COM_BINLOG_DUMP_GTID.
 	ComBinlogDumpGTID = 0x1e
 
+	// ComRegisterReplica is COM_REGISTER_SLAVE
+	// https://dev.mysql.com/doc/internals/en/com-register-slave.html
+	ComRegisterReplica = 0x15
+
 	// OKPacket is the header of the OK packet.
 	OKPacket = 0x00
 

--- a/go/mysql/encoding.go
+++ b/go/mysql/encoding.go
@@ -188,6 +188,11 @@ func readEOFString(data []byte, pos int) (string, int, bool) {
 	return string(data[pos:]), len(data) - pos, true
 }
 
+func readUint8(data []byte, pos int) (uint8, int, bool) {
+	b, pos, ok := readByte(data, pos)
+	return uint8(b), pos, ok
+}
+
 func readUint16(data []byte, pos int) (uint16, int, bool) {
 	if pos+1 >= len(data) {
 		return 0, 0, false

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -475,6 +475,16 @@ func (db *DB) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, callback
 	return nil
 }
 
+// ComRegisterReplica is part of the mysql.Handler interface.
+func (db *DB) ComRegisterReplica(c *mysql.Conn, replicaHost string, replicaPort uint16, replicaUser string, replicaPassword string) error {
+	return nil
+}
+
+// ComBinlogDump is part of the mysql.Handler interface.
+func (db *DB) ComBinlogDump(c *mysql.Conn, logFile string, binlogPos uint32) error {
+	return nil
+}
+
 // ComBinlogDumpGTID is part of the mysql.Handler interface.
 func (db *DB) ComBinlogDumpGTID(c *mysql.Conn, gtidSet mysql.GTIDSet) error {
 	return nil

--- a/go/mysql/register_replica.go
+++ b/go/mysql/register_replica.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mysql
+
+import (
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+var (
+	comRegisterReplicaPacketErr = vterrors.Errorf(vtrpcpb.Code_INTERNAL, "error reading BinlogDumpGTID packet")
+)
+
+func (c *Conn) parseComRegisterReplica(data []byte) (
+	replicaHost string,
+	replicaPort uint16,
+	replicaUser string,
+	replicaPassword string,
+	err error,
+) {
+	pos := 1
+	pos += 4 // server-id
+
+	// hostname
+	hostnameLen, pos, ok := readUint8(data, pos)
+	if !ok {
+		return replicaHost, replicaPort, replicaUser, replicaPassword, comRegisterReplicaPacketErr
+	}
+	replicaHost = string(data[pos : pos+int(hostnameLen)])
+	pos += int(hostnameLen)
+
+	// username
+	usernameLen, pos, ok := readUint8(data, pos)
+	if !ok {
+		return replicaHost, replicaPort, replicaUser, replicaPassword, comRegisterReplicaPacketErr
+	}
+	replicaUser = string(data[pos : pos+int(usernameLen)])
+	pos += int(usernameLen)
+
+	// password
+	passwordLen, pos, ok := readUint8(data, pos)
+	if !ok {
+		return replicaHost, replicaPort, replicaUser, replicaPassword, comRegisterReplicaPacketErr
+	}
+	replicaPassword = string(data[pos : pos+int(passwordLen)])
+	pos += int(passwordLen)
+
+	// port
+	replicaPort, _, ok = readUint16(data, pos)
+	if !ok {
+		return replicaHost, replicaPort, replicaUser, replicaPassword, comRegisterReplicaPacketErr
+	}
+	// remaining: (commented because of ineffectual assignment)
+	// pos += 4 // replication rank
+	// pos += 4 // master-id
+
+	return replicaHost, replicaPort, replicaUser, replicaPassword, nil
+}

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -116,8 +116,17 @@ type Handler interface {
 	// execute query.
 	ComStmtExecute(c *Conn, prepare *PrepareData, callback func(*sqltypes.Result) error) error
 
+	// ComRegisterReplica is called when a connection receives a ComRegisterReplica request
+	ComRegisterReplica(c *Conn, replicaHost string, replicaPort uint16, replicaUser string, replicaPassword string) error
+
+	// ComBinlogDump is called when a connection receives a ComBinlogDump request
+	ComBinlogDump(c *Conn, logFile string, binlogPos uint32) error
+
 	// ComBinlogDumpGTID is called when a connection receives a ComBinlogDumpGTID request
 	ComBinlogDumpGTID(c *Conn, gtidSet GTIDSet) error
+
+	// // ComBinlogRegisterReplkica is called when a connection receives a ComRegisterReplica (COM_REGISTER_SLAVE) request
+	// ComRegisterReplica(c *Conn, gtidSet GTIDSet) error
 
 	// WarningCount is called at the end of each query to obtain
 	// the value to be returned to the client in the EOF packet.

--- a/go/mysql/server_flaky_test.go
+++ b/go/mysql/server_flaky_test.go
@@ -225,6 +225,12 @@ func (th *testHandler) ComPrepare(c *Conn, query string, bindVars map[string]*qu
 func (th *testHandler) ComStmtExecute(c *Conn, prepare *PrepareData, callback func(*sqltypes.Result) error) error {
 	return nil
 }
+func (th *testHandler) ComRegisterReplica(c *Conn, replicaHost string, replicaPort uint16, replicaUser string, replicaPassword string) error {
+	return nil
+}
+func (th *testHandler) ComBinlogDump(c *Conn, logFile string, binlogPos uint32) error {
+	return nil
+}
 func (th *testHandler) ComBinlogDumpGTID(c *Conn, gtidSet GTIDSet) error {
 	return nil
 }

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -338,6 +338,16 @@ func (vh *vtgateHandler) WarningCount(c *mysql.Conn) uint16 {
 	return uint16(len(vh.session(c).GetWarnings()))
 }
 
+// ComRegisterReplica is part of the mysql.Handler interface.
+func (vh *vtgateHandler) ComRegisterReplica(c *mysql.Conn, replicaHost string, replicaPort uint16, replicaUser string, replicaPassword string) error {
+	return vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "ComRegisterReplica")
+}
+
+// ComBinlogDump is part of the mysql.Handler interface.
+func (vh *vtgateHandler) ComBinlogDump(c *mysql.Conn, logFile string, binlogPos uint32) error {
+	return vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "ComBinlogDump")
+}
+
 // ComBinlogDumpGTID is part of the mysql.Handler interface.
 func (vh *vtgateHandler) ComBinlogDumpGTID(c *mysql.Conn, gtidSet mysql.GTIDSet) error {
 	return vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "ComBinlogDumpGTID")

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -64,6 +64,14 @@ func (th *testHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData,
 	return nil
 }
 
+func (th *testHandler) ComRegisterReplica(c *mysql.Conn, replicaHost string, replicaPort uint16, replicaUser string, replicaPassword string) error {
+	return nil
+}
+
+func (th *testHandler) ComBinlogDump(c *mysql.Conn, logFile string, binlogPos uint32) error {
+	return nil
+}
+
 func (th *testHandler) ComBinlogDumpGTID(c *mysql.Conn, gtidSet mysql.GTIDSet) error {
 	return nil
 }


### PR DESCRIPTION

## Description
`mysql.Conn` now supports:

- `COM_BINLOG_DUMP`, https://dev.mysql.com/doc/internals/en/com-binlog-dump.html, implemented as `ComBinlogDump`
- `COM_REGISTER_SLAVE`, https://dev.mysql.com/doc/internals/en/com-register-slave.html, implemented as `ComRegisterReplica`

Conn recognizes these two COMmands, and delegates to handlers.


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
