### PR TITLE
Always reset reserved shard session on CODE_UNAVAILABLE

### DIFF
--- a/go/vt/vterrors/constants.go
+++ b/go/vt/vterrors/constants.go
@@ -30,9 +30,6 @@ var RxOp = regexp.MustCompile("operation not allowed in state (NOT_SERVING|SHUTT
 // TxEngineClosed for transaction engine closed error
 const TxEngineClosed = "tx engine can't accept new connections in state %v"
 
-// RxTxEngineClosed regex for operation not allowed error
-var RxTxEngineClosed = regexp.MustCompile("tx engine can't accept new connections in state (NotServing|Transitioning)")
-
 // WrongTablet for invalid tablet type error
 const WrongTablet = "wrong tablet type"
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Case: when a connection to VTGate has reserved connection and no transaction open on it.
This PR removed the specific error message check when vtgate receives `code_unavailable` grpc message from API call to vttablet. This will ensure that the query is routed through gateway and will reach the healthy tablet to serve the query.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [X] Should this PR be backported? Maybe
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->