### PR TITLE
[vtadmin] Remove deprecated dynamic cluster flag

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -153,9 +153,6 @@ func main() {
 	rootCmd.Flags().Var(&clusterFileConfig, "cluster-config", "path to a yaml cluster configuration. see clusters.example.yaml") // (TODO:@amason) provide example config.
 	rootCmd.Flags().Var(&defaultClusterConfig, "cluster-defaults", "default options for all clusters")
 	rootCmd.Flags().BoolVar(&enableDynamicClusters, "enable-dynamic-clusters", false, "whether to enable dynamic clusters that are set by request header cookies or gRPC metadata")
-	// TODO: (ajm188) delete in next PR
-	rootCmd.Flags().BoolVar(&enableDynamicClusters, "http-enable-dynamic-clusters", false, "whether to enable dynamic clusters that are set by request header cookies")
-	rootCmd.Flags().MarkDeprecated("http-enable-dynamic-clusters", "Replaced by `--enable-dynamic-clusters`")
 
 	// Tracing flags
 	rootCmd.Flags().AddGoFlag(flag.Lookup("tracer"))                 // defined in go/vt/trace


### PR DESCRIPTION
## Description

After #10050, dynamic clusters are no longer http-only, and as a result you should use the less now–confusingly-named `--enable-dynamic-clusters` flag.

## Related Issue(s)

#10050 


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **no**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->