### PR TITLE
[vtadmin] full dynamic cluster config

### DIFF
--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -4871,7 +4871,7 @@ func TestServeHTTP(t *testing.T) {
 		{
 			name:                  "multiple clusters with dynamic clusters",
 			enableDynamicClusters: true,
-			cookie:                `{"name": "dynamiccluster1", "vtctlds": [{"host":{"fqdn": "localhost:15000", "hostname": "localhost:15999"}}], "vtgates": [{"host": {"hostname": "localhost:15991"}}]}`,
+			cookie:                `{"id": "dynamiccluster1", "name": "dynamiccluster1", "discovery": "dynamic", "discovery-dynamic-discovery": "{\"vtctlds\": [{\"host\":{\"fqdn\": \"localhost:15000\", \"hostname\": \"localhost:15999\"}}], \"vtgates\": [{\"host\": {\"hostname\": \"localhost:15991\"}}]}"}`,
 			clusters: []*cluster.Cluster{
 				{
 					ID:        "c1",
@@ -4894,7 +4894,7 @@ func TestServeHTTP(t *testing.T) {
 		{
 			name:                  "multiple clusters with dynamic clusters - no duplicates",
 			enableDynamicClusters: true,
-			cookie:                `{"name": "dynamiccluster1", "vtctlds": [{"host":{"fqdn": "localhost:15000", "hostname": "localhost:15999"}}], "vtgates": [{"host": {"hostname": "localhost:15991"}}]}`,
+			cookie:                `{"id": "dynamiccluster1", "name": "dynamiccluster1", "discovery": "dynamic", "discovery-dynamic-discovery": "{\"vtctlds\": [{\"host\":{\"fqdn\": \"localhost:15000\", \"hostname\": \"localhost:15999\"}}], \"vtgates\": [{\"host\": {\"hostname\": \"localhost:15991\"}}]}"}`,
 			clusters: []*cluster.Cluster{
 				{
 					ID:        "c1",
@@ -4918,7 +4918,7 @@ func TestServeHTTP(t *testing.T) {
 		{
 			name:                  "multiple clusters with invalid json cookie and dynamic clusters",
 			enableDynamicClusters: true,
-			cookie:                `{"name "dynamiccluster1", "vtctlds": [{"host":{"fqdn": "localhost:15000", "hostname": "localhost:15999"}}], "vtgates": [{"host": {"hostname": "localhost:15991"}}]}`,
+			cookie:                `{"id "dynamiccluster1", "name": "dynamiccluster1", "discovery": "dynamic", "discovery-dynamic-discovery": "{\"vtctlds\": [{\"host\":{\"fqdn\": \"localhost:15000\", \"hostname\": \"localhost:15999\"}}], \"vtgates\": [{\"host\": {\"hostname\": \"localhost:15991\"}}]}"}`,
 			clusters: []*cluster.Cluster{
 				{
 					ID:        "c1",

--- a/go/vt/vtadmin/cluster/dynamic/cluster_test.go
+++ b/go/vt/vtadmin/cluster/dynamic/cluster_test.go
@@ -20,13 +20,17 @@ func TestClusterFromString(t *testing.T) {
 		shouldErr  bool
 	}{
 		{
-			name:       "ok",
-			s:          `{"name": "dynamic_cluster"}`,
+			name: "ok",
+			s: `{
+				"id": "dynamic_cluster",
+				"discovery": "dynamic",
+				"discovery-dynamic-discovery": "{\"vtctlds\": [ { \"host\": { \"fqdn\": \"localhost:15000\", \"hostname\": \"localhost:15999\" } } ], \"vtgates\": [ { \"host\": {\"hostname\": \"localhost:15991\" } } ] }"
+			}`,
 			expectedID: "dynamic_cluster",
 		},
 		{
 			name:      "empty id",
-			s:         `{"name": ""}`,
+			s:         `{"id": ""}`,
 			shouldErr: true,
 		},
 		{


### PR DESCRIPTION
## Description

This PR changes the unmarshalling technique used for dynamic cluster configs, to support a fully-configured dynamic cluster with parity to what you can do on the CLI.

The most notable changes for end users are:
- you must specify an `id` key rather than a `name` key. you _should_ also specify a `name` key, but it's not strictly required.
- you must specify your discovery implementation name. this means you can use dynamic clusters with _other_ discovery implementations (like consul!) "for free" 
- when using dynamic discovery with a dynamic cluster (boy that's a lotta "dynamic"), you are technically going through a double layer (mmmm, burritosssss) of json unmarshalling, which means your `discovery-dynamic-discovery` option must be properly quoted and escaped (see the tests).

Below are some screenshots where I uploaded first the original dynamic cluster, and then a dynamic cluster with some configuration options. Here are the configs used:

### minimal dynamic cluster
```json
{
    "id": "dynamic",
    "name": "my-dynamic-cluster",
    "discovery": "dynamic",
    "discovery-dynamic-discovery": "{\"vtctlds\": [ { \"host\": { \"fqdn\": \"localhost:15000\", \"hostname\": \"localhost:15999\" } } ], \"vtgates\": [ { \"host\": {\"hostname\": \"localhost:15991\" } } ] }"
}
```

### configured

```json
{
    "id": "dynamic2",
    "name": "my-configured-dynamic-cluster",
    "discovery": "dynamic",
    "discovery-dynamic-discovery": "{\"vtctlds\": [ { \"host\": { \"fqdn\": \"localhost:15000\", \"hostname\": \"localhost:15999\" } } ], \"vtgates\": [ { \"host\": {\"hostname\": \"localhost:15991\" } } ] }",
    "vtsql-discovery-timeout": "1h"
}
```

Pulling up the debug page for the configured cluster, we can see that the `vtsql` discovery timeout did indeed get set to 1h, rather than the default 100ms:

```
 curl -s localhost:14200/debug/cluster/dynamic2 | jq '.' | grep timeout      
      "discovery-timeout": "1h"
      "discovery_timeout": 100000000,
      "discovery_timeout": 3600000000000,
```

<img width="780" alt="Screen Shot 2022-04-11 at 1 54 26 PM" src="https://user-images.githubusercontent.com/4276638/162804367-4cbcbb28-b74d-4511-b733-ded56e59f586.png">
<img width="799" alt="Screen Shot 2022-04-11 at 1 56 46 PM" src="https://user-images.githubusercontent.com/4276638/162804375-86231655-3e8c-4f1d-bb2b-b483e974c61a.png">


## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->