### PR TITLE
Tweak backport checklist item wording in pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,17 +8,20 @@
 <!-- if this PR is Work in Progress please create it as a Draft Pull Request -->
 
 ## Description
+
 <!-- A few sentences describing the overall goals of the pull request's commits. -->
 <!-- If this is a bug fix and you think the fix should be backported, please write so. -->
 
 ## Related Issue(s)
+
 <!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
 
-
 ## Checklist
-- [ ] Should this PR be backported?
-- [ ] Tests were added or are not required
-- [ ] Documentation was added or is not required
+
+-   [ ] "Backport me!" label has been added if this change should be backported
+-   [ ] Tests were added or are not required
+-   [ ] Documentation was added or is not required
 
 ## Deployment Notes
+
 <!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->


### PR DESCRIPTION
## Description
 
I've long found it unsatisfying that the "Should this PR be backported?" item in the PR template is not easily check-off-able. (I always check it off but add a "no" comment, lol.) So I tweaked the wording to be a bit less ambiguous + to satisfy such completionist tendencies. 


## Related Issue(s)

N/A

## Checklist
- [x] Should this PR be backported? No 😈 
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A