### PR TITLE
Case-insensitive planner-version flag in VTExplain

### DIFF
--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
@@ -145,7 +147,7 @@ func parseAndRun() error {
 		return err
 	}
 
-	plannerVersion := querypb.ExecuteOptions_PlannerVersion(querypb.ExecuteOptions_PlannerVersion_value[*plannerVersionStr])
+	plannerVersion, _ := plancontext.PlannerNameToVersion(*plannerVersionStr)
 	if plannerVersion != querypb.ExecuteOptions_V3 && plannerVersion != querypb.ExecuteOptions_Gen4 {
 		return fmt.Errorf("invalid value specified for planner-version of '%s' -- valid values are V3 and Gen4", *plannerVersionStr)
 	}


### PR DESCRIPTION
## Description

This Pull Request makes the `--planner-version` flag of VTExplain case-insensitive. Previously, when running a VTExplain command with the default planner-version value, the following error would show up:

```
ERROR: invalid value specified for planner-version of 'gen4' -- valid values are V3 and Gen4
```

This was happening because the default value is set to `gen4` instead of `Gen4`. The behavior used in VTGate regarding case insensitivity was copied to VTExplain.


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required