### PR TITLE
Gen4 feature: optimize OR queries to IN

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -3927,3 +3927,114 @@ Gen4 plan same as above
   }
 }
 Gen4 plan same as above
+
+# optimize ORs to IN route op codes #1
+"select col from user where id = 1 or id = 2"
+{
+  "QueryType": "SELECT",
+  "Original": "select col from user where id = 1 or id = 2",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select col from `user` where 1 != 1",
+    "Query": "select col from `user` where id = 1 or id = 2",
+    "Table": "`user`"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select col from user where id = 1 or id = 2",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select col from `user` where 1 != 1",
+    "Query": "select col from `user` where id = 1 or id = 2",
+    "Table": "`user`",
+    "Values": [
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "user_index"
+  }
+}
+
+# optimize ORs to IN route op codes #2
+"select col from user where id = 1 or id = 2 or id = 3"
+{
+  "QueryType": "SELECT",
+  "Original": "select col from user where id = 1 or id = 2 or id = 3",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select col from `user` where 1 != 1",
+    "Query": "select col from `user` where id = 1 or id = 2 or id = 3",
+    "Table": "`user`"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select col from user where id = 1 or id = 2 or id = 3",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select col from `user` where 1 != 1",
+    "Query": "select col from `user` where id = 1 or id = 2 or id = 3",
+    "Table": "`user`",
+    "Values": [
+      "(INT64(1), INT64(2), INT64(3))"
+    ],
+    "Vindex": "user_index"
+  }
+}
+
+# optimize ORs to IN route op codes #3
+"select col from user where (id = 1 or id = 2) or (id = 3 or id = 4)"
+{
+  "QueryType": "SELECT",
+  "Original": "select col from user where (id = 1 or id = 2) or (id = 3 or id = 4)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select col from `user` where 1 != 1",
+    "Query": "select col from `user` where id = 1 or id = 2 or (id = 3 or id = 4)",
+    "Table": "`user`"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select col from user where (id = 1 or id = 2) or (id = 3 or id = 4)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select col from `user` where 1 != 1",
+    "Query": "select col from `user` where id = 1 or id = 2 or (id = 3 or id = 4)",
+    "Table": "`user`",
+    "Values": [
+      "(INT64(1), INT64(2), INT64(3), INT64(4))"
+    ],
+    "Vindex": "user_index"
+  }
+}


### PR DESCRIPTION
## Description
When using a vindex is difficult because the necessary predicates are hidden behind `OR`, we can try and see if the `OR`s can be merged into an `IN` instead, which is easier to plan efficiently. 

## Checklist
- [x] Should this PR be backported? `nope`
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
