### PR TITLE
Upgrade main to `go1.18.1`

### DIFF
--- a/.github/docker/cluster_test_12/Dockerfile
+++ b/.github/docker/cluster_test_12/Dockerfile
@@ -1,6 +1,6 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}"

--- a/.github/docker/cluster_test_18/Dockerfile
+++ b/.github/docker/cluster_test_18/Dockerfile
@@ -1,6 +1,6 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}"

--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -22,7 +22,7 @@ jobs:
       if: steps.changes.outputs.go_files == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.go_files == 'true'

--- a/.github/workflows/check_imports.yml
+++ b/.github/workflows/check_imports.yml
@@ -22,7 +22,7 @@ jobs:
       if: steps.changes.outputs.go_files == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Install goimports
       if: steps.changes.outputs.go_files == 'true'

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-go@v2
       if: steps.changes.outputs.parser_changes == 'true'
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.parser_changes == 'true'

--- a/.github/workflows/check_make_proto.yml
+++ b/.github/workflows/check_make_proto.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/setup-go@v2
       if: steps.changes.outputs.proto_changes == 'true'
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.proto_changes == 'true'

--- a/.github/workflows/check_make_sizegen.yml
+++ b/.github/workflows/check_make_sizegen.yml
@@ -27,7 +27,7 @@ jobs:
       if: steps.changes.outputs.sizegen == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.sizegen == 'true'

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -28,7 +28,7 @@ jobs:
       if: steps.changes.outputs.visitor == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.visitor == 'true'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -40,7 +40,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -29,7 +29,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       run: |

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -29,7 +29,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -29,7 +29,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -22,7 +22,7 @@ jobs:
       if: steps.changes.outputs.go_files == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
       id: go
 
     - name: Tune the OS

--- a/.github/workflows/gomod-tidy.yml
+++ b/.github/workflows/gomod-tidy.yml
@@ -22,7 +22,7 @@ jobs:
       if: steps.changes.outputs.go_files == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
       id: go
 
     - name: Tune the OS

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -35,7 +35,7 @@ jobs:
       if: steps.changes.outputs.examples == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -35,7 +35,7 @@ jobs:
       if: steps.changes.outputs.examples == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -35,7 +35,7 @@ jobs:
       if: steps.changes.outputs.examples == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -33,7 +33,7 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -34,7 +34,7 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -34,7 +34,7 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -34,7 +34,7 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -34,7 +34,7 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -80,7 +80,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -82,7 +82,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -81,7 +81,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -81,7 +81,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -81,7 +81,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ $(PROTO_GO_OUTS): minimaltools install_protoc-gen-go proto/*.proto
 # This rule builds the bootstrap images for all flavors.
 DOCKER_IMAGES_FOR_TEST = mariadb mariadb103 mysql56 mysql57 mysql80 percona percona57 percona80
 DOCKER_IMAGES = common $(DOCKER_IMAGES_FOR_TEST)
-BOOTSTRAP_VERSION=5
+BOOTSTRAP_VERSION=6
 ensure_bootstrap_version:
 	find docker/ -type f -exec sed -i "s/^\(ARG bootstrap_version\)=.*/\1=${BOOTSTRAP_VERSION}/" {} \;
 	sed -i 's/\(^.*flag.String(\"bootstrap-version\",\) *\"[^\"]\+\"/\1 \"${BOOTSTRAP_VERSION}\"/' test.go

--- a/build.env
+++ b/build.env
@@ -17,7 +17,7 @@
 source ./tools/shell_functions.inc
 
 go version >/dev/null 2>&1 || fail "Go is not installed or is not in \$PATH. See https://vitess.io/contributing/build-from-source for install instructions."
-goversion_min 1.18 || fail "Go version reported: `go version`. Version 1.18+ required. See https://vitess.io/contributing/build-from-source for install instructions."
+goversion_min 1.18.1 || fail "Go version reported: `go version`. Version 1.18.1+ required. See https://vitess.io/contributing/build-from-source for install instructions."
 
 mkdir -p dist
 mkdir -p bin

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -21,7 +21,7 @@
 # TODO(mberlin): Remove the symlink and this note once
 # https://github.com/docker/hub-feedback/issues/292 is fixed.
 
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mariadb
+++ b/docker/base/Dockerfile.mariadb
@@ -1,4 +1,4 @@
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mariadb103
+++ b/docker/base/Dockerfile.mariadb103
@@ -1,4 +1,4 @@
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb103"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mysql56
+++ b/docker/base/Dockerfile.mysql56
@@ -1,4 +1,4 @@
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql56"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mysql80
+++ b/docker/base/Dockerfile.mysql80
@@ -1,4 +1,4 @@
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.percona
+++ b/docker/base/Dockerfile.percona
@@ -1,4 +1,4 @@
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-percona"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.percona57
+++ b/docker/base/Dockerfile.percona57
@@ -1,4 +1,4 @@
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-percona57"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.percona80
+++ b/docker/base/Dockerfile.percona80
@@ -1,4 +1,4 @@
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-percona80"
 
 FROM "${image}"

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM golang:1.18-buster
+FROM golang:1.18.1-buster
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/docker/lite/Dockerfile.alpine
+++ b/docker/lite/Dockerfile.alpine
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb103"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mariadb
+++ b/docker/lite/Dockerfile.mariadb
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mariadb103
+++ b/docker/lite/Dockerfile.mariadb103
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb103"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mysql56
+++ b/docker/lite/Dockerfile.mysql56
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql56"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mysql57
+++ b/docker/lite/Dockerfile.mysql57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mysql80
+++ b/docker/lite/Dockerfile.mysql80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.percona
+++ b/docker/lite/Dockerfile.percona
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-percona"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.percona57
+++ b/docker/lite/Dockerfile.percona57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-percona57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-percona80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.testing
+++ b/docker/lite/Dockerfile.testing
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.mysql57
+++ b/docker/lite/Dockerfile.ubi7.mysql57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.mysql80
+++ b/docker/lite/Dockerfile.ubi7.mysql80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.percona57
+++ b/docker/lite/Dockerfile.ubi7.percona57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-percona57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.percona80
+++ b/docker/lite/Dockerfile.ubi7.percona80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-percona80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi8.arm64.mysql80
+++ b/docker/lite/Dockerfile.ubi8.arm64.mysql80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi8.mysql80
+++ b/docker/lite/Dockerfile.ubi8.mysql80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,4 +1,4 @@
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM "${image}"

--- a/docker/vttestserver/Dockerfile.mysql57
+++ b/docker/vttestserver/Dockerfile.mysql57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -96,6 +96,7 @@ func TestSubqueryInINClause(t *testing.T) {
 }
 
 func TestSubqueryInUpdate(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 14, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 

--- a/go/vt/servenv/buildinfo_test.go
+++ b/go/vt/servenv/buildinfo_test.go
@@ -33,17 +33,17 @@ func TestVersionString(t *testing.T) {
 		buildTimePretty: "time is now",
 		buildGitRev:     "d54b87ca0be09b678bb4490060e8f23f890ddb92",
 		buildGitBranch:  "gitBranch",
-		goVersion:       "1.18",
+		goVersion:       "1.18.1",
 		goOS:            "amiga",
 		goArch:          "amd64",
 		version:         "v1.2.3-SNAPSHOT",
 	}
 
-	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.18 amiga/amd64", v.String())
+	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.18.1 amiga/amd64", v.String())
 
 	v.jenkinsBuildNumber = 422
 
-	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Jenkins build 422) (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.18 amiga/amd64", v.String())
+	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Jenkins build 422) (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.18.1 amiga/amd64", v.String())
 
 	assert.Equal(t, "5.7.9-vitess-v1.2.3-SNAPSHOT", v.MySQLVersion())
 }

--- a/test.go
+++ b/test.go
@@ -1,4 +1,4 @@
-///bin/true; exec /usr/bin/env go run "$0" "$@"
+// /bin/true; exec /usr/bin/env go run "$0" "$@"
 
 /*
  * Copyright 2019 The Vitess Authors.
@@ -74,7 +74,7 @@ For example:
 // Flags
 var (
 	flavor           = flag.String("flavor", "mysql57", "comma-separated bootstrap flavor(s) to run against (when using Docker mode). Available flavors: all,"+flavors)
-	bootstrapVersion = flag.String("bootstrap-version", "5", "the version identifier to use for the docker images")
+	bootstrapVersion = flag.String("bootstrap-version", "6", "the version identifier to use for the docker images")
 	runCount         = flag.Int("runs", 1, "run each test this many times")
 	retryMax         = flag.Int("retry", 3, "max number of retries, to detect flaky tests")
 	logPass          = flag.Bool("log-pass", false, "log test output even if it passes")

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -38,7 +38,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -30,7 +30,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_mysql80.tpl
+++ b/test/templates/cluster_endtoend_test_mysql80.tpl
@@ -38,7 +38,7 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/dockerfile.tpl
+++ b/test/templates/dockerfile.tpl
@@ -1,4 +1,4 @@
-ARG bootstrap_version=5
+ARG bootstrap_version=6
 ARG image="vitess/bootstrap:${bootstrap_version}-{{.Platform}}"
 
 FROM "${image}"

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -32,7 +32,7 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.1
 
     - name: Tune the OS
       if: steps.changes.outputs.unit_tests == 'true'

--- a/tools/shell_functions.inc
+++ b/tools/shell_functions.inc
@@ -18,15 +18,19 @@
 
 # goversion_min returns true if major.minor go version is at least some value.
 function goversion_min() {
-  [[ "$(go version)" =~ go([0-9]+)\.([0-9]+) ]]
+  [[ "$(go version)" =~ go([0-9]+)\.([0-9]+)\.([0-9]+) ]]
   gotmajor=${BASH_REMATCH[1]}
   gotminor=${BASH_REMATCH[2]}
-  [[ "$1" =~ ([0-9]+)\.([0-9]+) ]]
+  gotpatch=${BASH_REMATCH[3]}
+  [[ "$1" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]
   wantmajor=${BASH_REMATCH[1]}
   wantminor=${BASH_REMATCH[2]}
+  wantpatch=${BASH_REMATCH[3]}
   [ "$gotmajor" -lt "$wantmajor" ] && return 1
   [ "$gotmajor" -gt "$wantmajor" ] && return 0
   [ "$gotminor" -lt "$wantminor" ] && return 1
+  [ "$gotminor" -gt "$wantminor" ] && return 0
+  [ "$gotpatch" -lt "$wantpatch" ] && return 1
   return 0
 }
 


### PR DESCRIPTION
## Description
This Pull Request upgrades the golang version used on `main` to `go1.18.1`. The Go team has recently released a new patch release for `go1.18` that contains vulnerability fixes, that impact Vitess.

Snippet from the [Go release history website](https://go.dev/doc/devel/release#go1.18.minor):
> go1.18.1 (released 2022-04-12) includes security fixes to the crypto/elliptic, crypto/x509, and encoding/pem packages, as well as bug fixes to the compiler, linker, runtime, the go command, vet, and the bytes, crypto/x509, and go/types packages. See the [Go 1.18.1 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.18.1+label%3ACherryPickApproved) on our issue tracker for details.

Note that the minimum required Go version is `1.18.1`, if this requirement is not met, the following error will appear when building Vitess:
```
Version 1.18.1+ required. See https://vitess.io/contributing/build-from-source for install instructions.
```

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
