### PR TITLE
Only start SQL thread temporarily to WaitForPosition if needed

### DIFF
--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -255,7 +255,8 @@ func (c *Conn) StartReplicationUntilAfterCommand(pos Position) string {
 	return c.flavor.startReplicationUntilAfter(pos)
 }
 
-// StartReplicationSQLUntilAfterCommand returns the command to start the replication's SQL thread.
+// StartReplicationSQLUntilAfterCommand returns the command to start the replication's SQL
+// thread and have it run until it has reached the given position, at which point it will stop.
 func (c *Conn) StartReplicationSQLUntilAfterCommand(pos Position) string {
 	return c.flavor.startReplicationSQLUntilAfter(pos)
 }

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -70,6 +70,10 @@ type flavor interface {
 	// to run until `pos` is reached. After reaching pos, replication will be stopped again
 	startReplicationUntilAfter(pos Position) string
 
+	// startReplicationSQLUntilAfter will restart replication's SQL_thread, but only allow it
+	// to run until `pos` is reached. After reaching pos, it will be stopped again
+	startReplicationSQLUntilAfter(pos Position) string
+
 	// stopReplicationCommand returns the command to stop the replication.
 	stopReplicationCommand() string
 
@@ -249,6 +253,11 @@ func (c *Conn) RestartReplicationCommands() []string {
 // StartReplicationUntilAfterCommand returns the command to start the replication.
 func (c *Conn) StartReplicationUntilAfterCommand(pos Position) string {
 	return c.flavor.startReplicationUntilAfter(pos)
+}
+
+// StartReplicationSQLUntilAfterCommand returns the command to start the replication's SQL thread.
+func (c *Conn) StartReplicationSQLUntilAfterCommand(pos Position) string {
+	return c.flavor.startReplicationSQLUntilAfter(pos)
 }
 
 // StopReplicationCommand returns the command to stop the replication.

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -66,21 +66,24 @@ type flavor interface {
 	// restartReplicationCommands returns the commands to stop, reset and start the replication.
 	restartReplicationCommands() []string
 
-	// startReplicationUntilAfter will restart replication, but only allow it
+	// startReplicationUntilAfter will start replication, but only allow it
 	// to run until `pos` is reached. After reaching pos, replication will be stopped again
 	startReplicationUntilAfter(pos Position) string
 
-	// startReplicationSQLUntilAfter will restart replication's SQL_thread, but only allow it
+	// startSQLThreadUntilAfter will start replication's sql thread(s), but only allow it
 	// to run until `pos` is reached. After reaching pos, it will be stopped again
-	startReplicationSQLUntilAfter(pos Position) string
+	startSQLThreadUntilAfter(pos Position) string
 
 	// stopReplicationCommand returns the command to stop the replication.
 	stopReplicationCommand() string
 
-	// stopIOThreadCommand returns the command to stop the replica's io thread only.
+	// stopIOThreadCommand returns the command to stop the replica's IO thread only.
 	stopIOThreadCommand() string
 
-	// startSQLThreadCommand returns the command to start the replica's sql thread only.
+	// stopSQLThreadCommand returns the command to stop the replica's SQL thread(s) only.
+	stopSQLThreadCommand() string
+
+	// startSQLThreadCommand returns the command to start the replica's SQL thread only.
 	startSQLThreadCommand() string
 
 	// sendBinlogDumpCommand sends the packet required to start
@@ -240,25 +243,26 @@ func (c *Conn) PrimaryFilePosition() (Position, error) {
 	}, nil
 }
 
-// StartReplicationCommand returns the command to start the replication.
+// StartReplicationCommand returns the command to start replication.
 func (c *Conn) StartReplicationCommand() string {
 	return c.flavor.startReplicationCommand()
 }
 
-// RestartReplicationCommands returns the commands to stop, reset and start the replication.
+// RestartReplicationCommands returns the commands to stop, reset and start replication.
 func (c *Conn) RestartReplicationCommands() []string {
 	return c.flavor.restartReplicationCommands()
 }
 
-// StartReplicationUntilAfterCommand returns the command to start the replication.
+// StartReplicationUntilAfterCommand returns the command to start replication.
 func (c *Conn) StartReplicationUntilAfterCommand(pos Position) string {
 	return c.flavor.startReplicationUntilAfter(pos)
 }
 
-// StartReplicationSQLUntilAfterCommand returns the command to start the replication's SQL
-// thread and have it run until it has reached the given position, at which point it will stop.
-func (c *Conn) StartReplicationSQLUntilAfterCommand(pos Position) string {
-	return c.flavor.startReplicationSQLUntilAfter(pos)
+// StartSQLThreadUntilAfterCommand returns the command to start the replica's SQL
+// thread(s) and have it run until it has reached the given position, at which point
+// it will stop.
+func (c *Conn) StartSQLThreadUntilAfterCommand(pos Position) string {
+	return c.flavor.startSQLThreadUntilAfter(pos)
 }
 
 // StopReplicationCommand returns the command to stop the replication.
@@ -269,6 +273,11 @@ func (c *Conn) StopReplicationCommand() string {
 // StopIOThreadCommand returns the command to stop the replica's io thread.
 func (c *Conn) StopIOThreadCommand() string {
 	return c.flavor.stopIOThreadCommand()
+}
+
+// StopSQLThreadCommand returns the command to stop the replica's SQL thread(s).
+func (c *Conn) StopSQLThreadCommand() string {
+	return c.flavor.stopSQLThreadCommand()
 }
 
 // StartSQLThreadCommand returns the command to start the replica's SQL thread.

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -78,6 +78,10 @@ func (flv *filePosFlavor) stopIOThreadCommand() string {
 	return "unsupported"
 }
 
+func (flv *filePosFlavor) stopSQLThreadCommand() string {
+	return "unsupported"
+}
+
 func (flv *filePosFlavor) startSQLThreadCommand() string {
 	return "unsupported"
 }
@@ -269,7 +273,7 @@ func (*filePosFlavor) startReplicationUntilAfter(pos Position) string {
 	return "unsupported"
 }
 
-func (*filePosFlavor) startReplicationSQLUntilAfter(pos Position) string {
+func (*filePosFlavor) startSQLThreadUntilAfter(pos Position) string {
 	return "unsupported"
 }
 

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -269,6 +269,10 @@ func (*filePosFlavor) startReplicationUntilAfter(pos Position) string {
 	return "unsupported"
 }
 
+func (*filePosFlavor) startReplicationSQLUntilAfter(pos Position) string {
+	return "unsupported"
+}
+
 // enableBinlogPlaybackCommand is part of the Flavor interface.
 func (*filePosFlavor) enableBinlogPlaybackCommand() string {
 	return ""

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -57,7 +57,7 @@ func (mariadbFlavor) startReplicationUntilAfter(pos Position) string {
 	return fmt.Sprintf("START SLAVE UNTIL master_gtid_pos = \"%s\"", pos)
 }
 
-func (mariadbFlavor) startReplicationSQLUntilAfter(pos Position) string {
+func (mariadbFlavor) startSQLThreadUntilAfter(pos Position) string {
 	return fmt.Sprintf("START SLAVE SQL_THREAD UNTIL master_gtid_pos = \"%s\"", pos)
 }
 
@@ -79,6 +79,10 @@ func (mariadbFlavor) stopReplicationCommand() string {
 
 func (mariadbFlavor) stopIOThreadCommand() string {
 	return "STOP SLAVE IO_THREAD"
+}
+
+func (mariadbFlavor) stopSQLThreadCommand() string {
+	return "STOP SLAVE SQL_THREAD"
 }
 
 func (mariadbFlavor) startSQLThreadCommand() string {

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -57,6 +57,10 @@ func (mariadbFlavor) startReplicationUntilAfter(pos Position) string {
 	return fmt.Sprintf("START SLAVE UNTIL master_gtid_pos = \"%s\"", pos)
 }
 
+func (mariadbFlavor) startReplicationSQLUntilAfter(pos Position) string {
+	return fmt.Sprintf("START SLAVE SQL_THREAD UNTIL master_gtid_pos = \"%s\"", pos)
+}
+
 func (mariadbFlavor) startReplicationCommand() string {
 	return "START SLAVE"
 }

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -72,6 +72,10 @@ func (mysqlFlavor) startReplicationUntilAfter(pos Position) string {
 	return fmt.Sprintf("START SLAVE UNTIL SQL_AFTER_GTIDS = '%s'", pos)
 }
 
+func (mysqlFlavor) startReplicationSQLUntilAfter(pos Position) string {
+	return fmt.Sprintf("START SLAVE SQL_THREAD UNTIL SQL_AFTER_GTIDS = '%s'", pos)
+}
+
 func (mysqlFlavor) stopReplicationCommand() string {
 	return "STOP SLAVE"
 }

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -72,7 +72,7 @@ func (mysqlFlavor) startReplicationUntilAfter(pos Position) string {
 	return fmt.Sprintf("START SLAVE UNTIL SQL_AFTER_GTIDS = '%s'", pos)
 }
 
-func (mysqlFlavor) startReplicationSQLUntilAfter(pos Position) string {
+func (mysqlFlavor) startSQLThreadUntilAfter(pos Position) string {
 	return fmt.Sprintf("START SLAVE SQL_THREAD UNTIL SQL_AFTER_GTIDS = '%s'", pos)
 }
 
@@ -82,6 +82,10 @@ func (mysqlFlavor) stopReplicationCommand() string {
 
 func (mysqlFlavor) stopIOThreadCommand() string {
 	return "STOP SLAVE IO_THREAD"
+}
+
+func (mysqlFlavor) stopSQLThreadCommand() string {
+	return "STOP SLAVE SQL_THREAD"
 }
 
 func (mysqlFlavor) startSQLThreadCommand() string {

--- a/go/mysql/flavor_mysqlgr.go
+++ b/go/mysql/flavor_mysqlgr.go
@@ -61,8 +61,8 @@ func (mysqlGRFlavor) startReplicationUntilAfter(pos Position) string {
 	return ""
 }
 
-// startReplicationSQLUntilAfter is disabled in mysqlGRFlavor
-func (mysqlGRFlavor) startReplicationSQLUntilAfter(pos Position) string {
+// startSQLThreadUntilAfter is disabled in mysqlGRFlavor
+func (mysqlGRFlavor) startSQLThreadUntilAfter(pos Position) string {
 	return ""
 }
 
@@ -75,6 +75,11 @@ func (mysqlGRFlavor) stopReplicationCommand() string {
 
 // stopIOThreadCommand is disabled in mysqlGRFlavor
 func (mysqlGRFlavor) stopIOThreadCommand() string {
+	return ""
+}
+
+// stopSQLThreadCommand is disabled in mysqlGRFlavor
+func (mysqlGRFlavor) stopSQLThreadCommand() string {
 	return ""
 }
 

--- a/go/mysql/flavor_mysqlgr.go
+++ b/go/mysql/flavor_mysqlgr.go
@@ -61,6 +61,11 @@ func (mysqlGRFlavor) startReplicationUntilAfter(pos Position) string {
 	return ""
 }
 
+// startReplicationSQLUntilAfter is disabled in mysqlGRFlavor
+func (mysqlGRFlavor) startReplicationSQLUntilAfter(pos Position) string {
+	return ""
+}
+
 // stopReplicationCommand returns the command to stop the replication.
 // we return empty here since `STOP GROUP_REPLICATION` should be called by
 // the external orchestrator

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -294,7 +294,7 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos mysql.Positio
 			// Let's ensure the replication state is put back to what it was when we started.
 			// Doing this in a deferred function ensures that we do so even if we timeout while waiting.
 			resetStmts = append(resetStmts, conn.StopSQLThreadCommand())
-			if err = mysqld.StartSQLThreadUntilAfter(ctx, targetPos); err != nil {
+			if err = mysqld.executeSuperQueryListConn(ctx, conn, []string{conn.StartSQLThreadCommand()}); err != nil {
 				return vterrors.Wrap(err,
 					fmt.Sprintf("the replication SQL thread(s) was stopped and we could not temporarily start it in order to wait for the target position of %v",
 						targetPos))


### PR DESCRIPTION
## Description

After https://github.com/vitessio/vitess/pull/9512 we always attempted to start the replication `SQL_Thread`(s) when waiting for a given position. The problem with this, however, is that [if the `SQL_Thread` is running but the `IO_Thread` is not then the tablet repair does not try and start replication on a replica tablet](https://github.com/planetscale/vitess/blob/ef7363e918e5c7093d72f15471f4c0d408ac0d10/go/vt/vttablet/tabletmanager/replmanager.go#L106-L117). So in certain states such as when initializing a shard, replication may end up in a non-healthy state and never be repaired.

This changes the behavior so that:
1. We only attempt to start the `SQL_Thread`(s) if it's not already running
2. If we explicitly start the `SQL_Thread(s)` then we also explicitly reset it to what it was (stopped) as we exit the call

Because the caller should be/have a TabletManager which has a mutex, this should ensure that the replication manager calls are serialized and because we are resetting the replication state after mutating it, everything should work as it did before https://github.com/vitessio/vitess/pull/9512 with the exception being that when waiting we ensure that the replica at least has the possibility of catching up.

## Related Issue(s)
  - Follow-up to: https://github.com/vitessio/vitess/pull/9512

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests are not required
-   [x] Documentation is not required