### PR TITLE
Use git command instead of GitHub API to list modified files

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -12,7 +12,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           go_files:
             - '**/*.go'

--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in Go files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -12,6 +12,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           go_files:
             - '**/*.go'

--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in Go files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_imports.yml
+++ b/.github/workflows/check_imports.yml
@@ -12,7 +12,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           go_files:
             - '**/*.go'

--- a/.github/workflows/check_imports.yml
+++ b/.github/workflows/check_imports.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in Go files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_imports.yml
+++ b/.github/workflows/check_imports.yml
@@ -12,6 +12,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           go_files:
             - '**/*.go'

--- a/.github/workflows/check_imports.yml
+++ b/.github/workflows/check_imports.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in Go files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -13,6 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           parser_changes:
             - 'go/vt/sqlparser/**'

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -13,7 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           parser_changes:
             - 'go/vt/sqlparser/**'

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_make_proto.yml
+++ b/.github/workflows/check_make_proto.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_make_proto.yml
+++ b/.github/workflows/check_make_proto.yml
@@ -13,6 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           proto_changes:
             - 'bootstrap.sh'

--- a/.github/workflows/check_make_proto.yml
+++ b/.github/workflows/check_make_proto.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_make_proto.yml
+++ b/.github/workflows/check_make_proto.yml
@@ -13,7 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           proto_changes:
             - 'bootstrap.sh'

--- a/.github/workflows/check_make_sizegen.yml
+++ b/.github/workflows/check_make_sizegen.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_make_sizegen.yml
+++ b/.github/workflows/check_make_sizegen.yml
@@ -13,6 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           sizegen:
             - 'go/**/*.go'

--- a/.github/workflows/check_make_sizegen.yml
+++ b/.github/workflows/check_make_sizegen.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_make_sizegen.yml
+++ b/.github/workflows/check_make_sizegen.yml
@@ -13,7 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           sizegen:
             - 'go/**/*.go'

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -13,6 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           visitor:
             - 'go/tools/asthelpergen/**'

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -13,7 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           visitor:
             - 'go/tools/asthelpergen/**'

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check for changes in relevant files
-        uses: frouioui/paths-filter@master
+        uses: frouioui/paths-filter@main
         id: changes
         with:
           token: ''

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -19,6 +19,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          token: "${{ github.token}}"
           filters: |
             end_to_end:
               - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check for changes in relevant files
-        uses: dorny/paths-filter@v2
+        uses: frouioui/paths-filter@master
         id: changes
         with:
           token: ''

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -19,7 +19,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
-          token: "${{ github.token}}"
+          token: ''
           filters: |
             end_to_end:
               - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check for changes in relevant files
-        uses: frouioui/paths-filter@master
+        uses: frouioui/paths-filter@main
         id: changes
         with:
           token: ''

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -19,6 +19,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          token: "${{ github.token}}"
           filters: |
             end_to_end:
               - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check for changes in relevant files
-        uses: dorny/paths-filter@v2
+        uses: frouioui/paths-filter@master
         id: changes
         with:
           token: ''

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -19,7 +19,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
-          token: "${{ github.token}}"
+          token: ''
           filters: |
             end_to_end:
               - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -24,6 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -24,7 +24,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -13,7 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -13,6 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -14,7 +14,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -14,6 +14,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -14,7 +14,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -14,6 +14,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -13,7 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -13,6 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -13,7 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -13,6 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/ensure_bootstrap_updated.yml
+++ b/.github/workflows/ensure_bootstrap_updated.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/ensure_bootstrap_updated.yml
+++ b/.github/workflows/ensure_bootstrap_updated.yml
@@ -13,7 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'docker/**'

--- a/.github/workflows/ensure_bootstrap_updated.yml
+++ b/.github/workflows/ensure_bootstrap_updated.yml
@@ -13,6 +13,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'docker/**'

--- a/.github/workflows/ensure_bootstrap_updated.yml
+++ b/.github/workflows/ensure_bootstrap_updated.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -12,7 +12,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           go_files:
             - '**/*.go'

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in Go files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -12,6 +12,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           go_files:
             - '**/*.go'

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in Go files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/gomod-tidy.yml
+++ b/.github/workflows/gomod-tidy.yml
@@ -12,7 +12,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           go_files:
             - '**/*.go'

--- a/.github/workflows/gomod-tidy.yml
+++ b/.github/workflows/gomod-tidy.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in Go files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/gomod-tidy.yml
+++ b/.github/workflows/gomod-tidy.yml
@@ -12,6 +12,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           go_files:
             - '**/*.go'

--- a/.github/workflows/gomod-tidy.yml
+++ b/.github/workflows/gomod-tidy.yml
@@ -9,7 +9,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in Go files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -18,7 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           examples:
             - 'go/**/*.go'

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -18,6 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           examples:
             - 'go/**/*.go'

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -18,7 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           examples:
             - 'go/**/*.go'

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -18,6 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           examples:
             - 'go/**/*.go'

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -18,7 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           examples:
             - 'go/**/*.go'

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -18,6 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           examples:
             - 'go/**/*.go'

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -17,7 +17,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           unit_tests:
             - 'go/**'

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -17,6 +17,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           unit_tests:
             - 'go/**'

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -18,6 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           unit_tests:
             - 'go/**'

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -18,7 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           unit_tests:
             - 'go/**'

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -18,6 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           unit_tests:
             - 'go/**'

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -18,7 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           unit_tests:
             - 'go/**'

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -18,6 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           unit_tests:
             - 'go/**'

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -18,7 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           unit_tests:
             - 'go/**'

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -18,6 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{ github.token}}"
         filters: |
           unit_tests:
             - 'go/**'

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -18,7 +18,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{ github.token}}"
+        token: ''
         filters: |
           unit_tests:
             - 'go/**'

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -63,7 +63,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'go/**'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -63,6 +63,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'go/**'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -62,7 +62,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -65,6 +65,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'go/**'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -62,7 +62,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -65,7 +65,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'go/**'

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -64,6 +64,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'go/**'

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -64,7 +64,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'go/**'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -64,6 +64,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'go/**'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -64,7 +64,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'go/**'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -64,6 +64,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: ${{ github.token }}
         filters: |
           end_to_end:
             - 'go/**'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -64,7 +64,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: ${{ github.token }}
+        token: ''
         filters: |
           end_to_end:
             - 'go/**'

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -22,7 +22,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{`{{ github.token}}`}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -22,6 +22,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{`{{ github.token}}`}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -14,7 +14,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{`{{ github.token}}`}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -14,6 +14,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{`{{ github.token}}`}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/test/templates/cluster_endtoend_test_mysql80.tpl
+++ b/test/templates/cluster_endtoend_test_mysql80.tpl
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/test/templates/cluster_endtoend_test_mysql80.tpl
+++ b/test/templates/cluster_endtoend_test_mysql80.tpl
@@ -22,7 +22,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{`{{ github.token}}`}}"
+        token: ''
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/test/templates/cluster_endtoend_test_mysql80.tpl
+++ b/test/templates/cluster_endtoend_test_mysql80.tpl
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/test/templates/cluster_endtoend_test_mysql80.tpl
+++ b/test/templates/cluster_endtoend_test_mysql80.tpl
@@ -22,6 +22,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{`{{ github.token}}`}}"
         filters: |
           end_to_end:
             - 'go/**/*.go'

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -17,7 +17,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
-          token: "${{`{{ github.token}}`}}"
+          token: ''
           filters: |
             end_to_end:
               - 'go/**/*.go'

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check for changes in relevant files
-        uses: frouioui/paths-filter@master
+        uses: frouioui/paths-filter@main
         id: changes
         with:
           token: ''

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check for changes in relevant files
-        uses: dorny/paths-filter@v2
+        uses: frouioui/paths-filter@master
         id: changes
         with:
           token: ''

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -17,6 +17,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          token: "${{`{{ github.token}}`}}"
           filters: |
             end_to_end:
               - 'go/**/*.go'

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -16,7 +16,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
-        token: "${{`{{ github.token}}`}}"
+        token: ''
         filters: |
           unit_tests:
             - 'go/**'

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -16,6 +16,7 @@ jobs:
       uses: dorny/paths-filter@v2
       id: changes
       with:
+        token: "${{`{{ github.token}}`}}"
         filters: |
           unit_tests:
             - 'go/**'

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: dorny/paths-filter@v2
+      uses: frouioui/paths-filter@master
       id: changes
       with:
         token: ''

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
-      uses: frouioui/paths-filter@master
+      uses: frouioui/paths-filter@main
       id: changes
       with:
         token: ''

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check for changes in relevant files
-        uses: frouioui/paths-filter@master
+        uses: frouioui/paths-filter@main
         id: changes
         with:
           token: ''

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -16,6 +16,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          token: "${{`{{ github.token}}`}}"
           filters: |
             unit_tests:
               - 'go/**'

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -16,7 +16,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
-          token: "${{`{{ github.token}}`}}"
+          token: ''
           filters: |
             unit_tests:
               - 'go/**'

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check for changes in relevant files
-        uses: dorny/paths-filter@v2
+        uses: frouioui/paths-filter@master
         id: changes
         with:
           token: ''


### PR DESCRIPTION
## Description

This Pull Request aims to fix the API Rate error we were observing with the new `dorny/paths-filter` integration. We recently implemented a feature that skips workflows based on the list of modified files, using `dorny/paths-filter`, however, when several commits were pushed at the same time we observed the following error:

```
Error: API rate limit exceeded for installation ID 5040149.
```

We think this can be alleviated by simply not using the GitHub API. In fact, even if `dorny/paths-filter` was making only API call per workflow, we would easily reach the [1000 requests/hour limit](https://docs.github.com/en/developers/apps/building-github-apps/rate-limits-for-github-apps#user-to-server-rate-limits-for-github-enterprise-cloud) with over 80 workflows. Simply push 13 commits in the Vitess organization within the same hour and the limit would be reached.

> When using GITHUB_TOKEN, the rate limit is 1,000 requests per hour per repository. For requests to resources that belong to an enterprise account on GitHub.com, GitHub Enterprise Cloud's rate limit applies, and the limit is 15,000 requests per hour per repository.

In `dorny/paths-filter`'s README, the [usage of the tool](https://github.com/dorny/paths-filter#usage) is documented as follows:

```yaml
- uses: dorny/paths-filter@v2
  with:
    
    ...
    
    # Personal access token used to fetch a list of changed files
    # from GitHub REST API.
    # It's only used if action is triggered by a pull request event.
    # GitHub token from workflow context is used as default value.
    # If an empty string is provided, the action falls back to detect
    # changes using git commands.
    # Default: ${{ github.token }}
    token: ''
```

Setting `token` to an empty string should therefore force the use of the `git` command instead of the GitHub API. After trying to set the `token` to an empty string, there was a weird behavior where running the following `git` command would return a large list of modified files (even though they are not modified by the PR).

```
git log --format= --no-renames --name-status -z -n 1 
```

In [this](https://github.com/vitessio/vitess/runs/6075107859?check_suite_focus=true) workflow, we can see that `paths-filter` is attempting to calculate the diff using the `git` command. However, as we can see in the screenshot below, they find over 4000 modified files, which does not correspond to the changes made by this commit or the other commits on the PR's branch.

![image](https://user-images.githubusercontent.com/35779988/164007159-68ffcbc0-c9d9-4f6b-addc-b143c9073705.png)


The `git log --format ...` command is used by default in `dorny/paths-filter` when `token` is set to an empty string. To fix this issue, I forked `dorny/paths-filter` ([here](https://github.com/frouioui/paths-filter)) and pushed a [commit](https://github.com/frouioui/paths-filter/commit/5266f0ac598cc28b01df67af503dfdaae5e4be85) that fixes the issue. I changed all the workflows to use this new fork.

The fix consists of doing a `diff` using the following command:

```
git diff --no-renames --name-status -z {BASE_SHA}..{HEAD_SHA}
```

That way we only capture the difference that happened between the PR's base and the current commit.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

