### PR TITLE
OnlineDDL: skip GetSchema where possible

### DIFF
--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -217,6 +217,17 @@ func (exec *TabletExecutor) isOnlineSchemaDDL(stmt sqlparser.Statement) (isOnlin
 //   1. Alter more than 100,000 rows.
 //   2. Change a table with more than 2,000,000 rows (Drops are fine).
 func (exec *TabletExecutor) detectBigSchemaChanges(ctx context.Context, parsedDDLs []sqlparser.DDLStatement) (bool, error) {
+	// We want to avoid any overhead if possible. If all DDLs are online schema changes, then we want to
+	// skip GetSchema altogether.
+	foundAnyNonOnlineDDL := false
+	for _, ddl := range parsedDDLs {
+		if !exec.isOnlineSchemaDDL(ddl) {
+			foundAnyNonOnlineDDL = true
+		}
+	}
+	if !foundAnyNonOnlineDDL {
+		return false, nil
+	}
 	// exec.tablets is guaranteed to have at least one element;
 	// Otherwise, Open should fail and executor should fail.
 	primaryTabletInfo := exec.tablets[0]


### PR DESCRIPTION

## Description

In `ApplySchema`, there is a check for big schema changes. This is a legacy check from a time when we did not support online DDL. Big-schema-changes is _mostly_ skipped when there are online DDLs. However, one step is not skipped, which is `GetSchema`. 

Currently, we first `GetSchema`, then iterate all DDLs, and for each DDL check if it is online or not, and if not  - whether it is a "big change".

When all DDLs are online, the `GetSchema` step is wasteful. It reads all tables with some metadata.

In this PR, we first do a preliminary check to see whether there is at all any non-online DDL. If there is at least one non-online DDL, we proceed with `GetSchema`. But if all DDLs are online - we skip `GetSchema` altogether.

## Related Issue(s)

- #6926 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

