### PR TITLE
[vtadmin] Refactor api.getSchemas => cluster.GetSchemas

### DIFF
--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -144,6 +144,16 @@ func TestFindSchema(t *testing.T) {
 					DBConfig: vtadmintestutil.Dbcfg{
 						ShouldErr: true,
 					},
+					VtctldClient: &fakevtctldclient.VtctldClient{
+						GetKeyspacesResults: struct {
+							Keyspaces []*vtctldatapb.Keyspace
+							Error     error
+						}{
+							Keyspaces: []*vtctldatapb.Keyspace{
+								{Name: "testkeyspace"},
+							},
+						},
+					},
 				},
 			},
 			req: &vtadminpb.FindSchemaRequest{


### PR DESCRIPTION
## Description

This is part 1 of a preparatory refactor to get caching in front of /schema related endpoints (which I'm writing up an issue for and will post here when I have it). The main effort is to get all of the fetching logic happening at the cluster-level instead of the api-level, so that we can have per-cluster caches.

## Related Issue(s)

- TK

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
    - (my first pass at this refactor actually broke several schema-related tests, which makes me pretty confident i've got it right this time -- also I tested locally)
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
