### PR TITLE
Make go version check reliable by using double brackets

### DIFF
--- a/tools/shell_functions.inc
+++ b/tools/shell_functions.inc
@@ -26,11 +26,11 @@ function goversion_min() {
   wantmajor=${BASH_REMATCH[1]}
   wantminor=${BASH_REMATCH[2]}
   wantpatch=${BASH_REMATCH[3]}
-  [ "$gotmajor" -lt "$wantmajor" ] && return 1
-  [ "$gotmajor" -gt "$wantmajor" ] && return 0
-  [ "$gotminor" -lt "$wantminor" ] && return 1
-  [ "$gotminor" -gt "$wantminor" ] && return 0
-  [ "$gotpatch" -lt "$wantpatch" ] && return 1
+  [[ $gotmajor -lt $wantmajor ]] && return 1
+  [[ $gotmajor -gt $wantmajor ]] && return 0
+  [[ $gotminor -lt $wantminor ]] && return 1
+  [[ $gotminor -gt $wantminor ]] && return 0
+  [[ $gotpatch -lt $wantpatch ]] && return 1
   return 0
 }
 


### PR DESCRIPTION
## Description

For more complex integer operations in most modern shells you should use double parens (shell uses `let` builtin) or double brackets (shell uses `test` builtin) to ensure proper variable expansion and expression evaluation (we explicitly use [`bash`](https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html) today in the build scripts).

In this case the lack of determinism and potential errors in [the go version check](https://github.com/planetscale/vitess/blob/b5ca7a6326d54d52842f1571f8a100b4497f7d1b/tools/shell_functions.inc#L20-L35) comes from expansion of variables w/o a declared type (`declare -i number` or `typeset -in`) or implicit type via e.g. `let foo=${bar}+0`. So if we did not get a valid integer from any of the regexp capture groups (in my case I had go 1.18 installed so no patch version) then the variable expansion can result in strings getting compared to integers. With the single brackets [the go version check](https://github.com/planetscale/vitess/blob/b5ca7a6326d54d52842f1571f8a100b4497f7d1b/tools/shell_functions.inc#L20-L35) does not work in this scenario and we see this output from `make build`:
```
$ make build
Thu Apr 21 11:42:02 EDT 2022: Building source tree
./tools/shell_functions.inc: line 29: [: -lt: unary operator expected
./tools/shell_functions.inc: line 30: [: -gt: unary operator expected
./tools/shell_functions.inc: line 31: [: -lt: unary operator expected
./tools/shell_functions.inc: line 32: [: -gt: unary operator expected
./tools/shell_functions.inc: line 33: [: -lt: unary operator expected
```

The build will still complete but we do not enforce the go version as intended. With this change we do (for example, in my case):
```
$ make build
Thu Apr 21 14:18:40 EDT 2022: Building source tree
ERROR: Go version reported: go version go1.18 darwin/arm64. Version 1.18.1+ required. See https://vitess.io/contributing/build-from-source for install instructions.
make: *** [build] Error 1
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required