### PR TITLE
schemadiff: support for RangeRotationStrategy diff hint

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -370,6 +370,59 @@ func (c *CreateTableEntity) diffOptions(alterTable *sqlparser.AlterTable,
 	return nil
 }
 
+// rangePartitionsAddedRemoved returns true when:
+// - both table partitions are RANGE type
+// - there is exactly one consequitive non-empty shared sequence of partitions (same names, same range values, in same order)
+// - table1 may have non-empty list of partitions _preceding_ this sequence, and table2 may not
+// - table2 may have non-empty list of partitions _following_ this sequence, and table1 may not
+func (c *CreateTableEntity) isRangePartitionsRotation(
+	t1Partitions *sqlparser.PartitionOption,
+	t2Partitions *sqlparser.PartitionOption,
+) bool {
+	// Validate that both tables have range partitioning
+	if t1Partitions.Type != t2Partitions.Type {
+		return false
+	}
+	if t1Partitions.Type != sqlparser.RangeType {
+		return false
+	}
+	definitions1 := t1Partitions.Definitions
+	definitions2 := t2Partitions.Definitions
+	// there has to be a non-empty shared list, therefore both definitions must be non-empty:
+	if len(definitions1) == 0 {
+		return false
+	}
+	if len(definitions2) == 0 {
+		return false
+	}
+	// It's OK for prefix of t1 partitions to be nonexistent in t2 (as they may have been rotated away in t2)
+	for len(definitions1) > 0 && sqlparser.String(definitions1[0]) != sqlparser.String(definitions2[0]) {
+		definitions1 = definitions1[1:]
+	}
+	if len(definitions1) == 0 {
+		// We've exhaused definition1 trying to find a shared partition with definitions2. Nothing found.
+		// so there is no shared sequence between the two tables.
+		return false
+	}
+	if len(definitions1) > len(definitions2) {
+		return false
+	}
+	// To save computation, and ecause we've already shown that sqlparser.String(definitions1[0]) == sqlparser.String(definitions2[0]),
+	// we can skip one element
+	definitions1 = definitions1[1:]
+	definitions2 = definitions2[1:]
+	// Now let's ensure that whatever is remaining in definitions1 is an exact match for a prefix of definitions2
+	// It's ok if we end up with leftover elements in definition2
+	for len(definitions1) > 0 {
+		if sqlparser.String(definitions1[0]) != sqlparser.String(definitions2[0]) {
+			return false
+		}
+		definitions1 = definitions1[1:]
+		definitions2 = definitions2[1:]
+	}
+	return true
+}
+
 func (c *CreateTableEntity) diffPartitions(alterTable *sqlparser.AlterTable,
 	t1Partitions *sqlparser.PartitionOption,
 	t2Partitions *sqlparser.PartitionOption,
@@ -393,12 +446,19 @@ func (c *CreateTableEntity) diffPartitions(alterTable *sqlparser.AlterTable,
 		return nil
 	default:
 		// partitioning was changed
-		// we produce a complete re-partitioing schema. What we don't do is try and figure out the minimal
+		// For most cases, we produce a complete re-partitioing schema: we don't try and figure out the minimal
 		// needed change. For example, maybe the minimal change is to REORGANIZE a specific partition and split
 		// into two, thus unaffecting the rest of the partitions. But we don't evaluate that, we just set a
 		// complete new ALTER TABLE ... PARTITION BY statement.
 		// The idea is that it doesn't matter: we're not looking to do optimal in-place ALTERs, we run
 		// Online DDL alters, where we create a new table anyway. Thus, the optimization is meaningless.
+
+		// Having said that, we _do_ analyze the scenario of a RANGE partitioning rotation of partitions:
+		// where zero or more partitions may have been dropped from the earlier range, and zero or more
+		// partitions have been added with a later range:
+		if c.isRangePartitionsRotation(t1Partitions, t2Partitions) && hints.IgnoreRangePartitionsRotation {
+			return nil
+		}
 		alterTable.PartitionOption = t2Partitions
 	}
 	return nil

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -462,7 +462,7 @@ func (c *CreateTableEntity) diffPartitions(alterTable *sqlparser.AlterTable,
 				return nil
 			case RangeRotationStatements:
 				return ErrRangeRotattionStatementsStrategyUnsupported
-			case RangeRotationAlways:
+			case RangeRotationFullSpec:
 				// proceed to return a full rebuild
 			}
 		}

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -27,14 +27,14 @@ import (
 
 func TestCreateTableDiff(t *testing.T) {
 	tt := []struct {
-		name                          string
-		from                          string
-		to                            string
-		diff                          string
-		isError                       bool
-		errorMsg                      string
-		autoinc                       int
-		ignoreRangePartitionsRotation bool
+		name     string
+		from     string
+		to       string
+		diff     string
+		isError  bool
+		errorMsg string
+		autoinc  int
+		rotation int
 	}{
 		{
 			name: "identical",
@@ -338,52 +338,52 @@ func TestCreateTableDiff(t *testing.T) {
 			diff: "alter table t1 partition by range (id) (partition p2 values less than (20), partition p3 values less than (30), partition p4 values less than (40))",
 		},
 		{
-			name:                          "change partitioning range: ignore rotate",
-			from:                          "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
-			to:                            "create table t1 (id int primary key) partition by range (id) (partition p2 values less than (20), partition p3 values less than (30), partition p4 values less than (40))",
-			ignoreRangePartitionsRotation: true,
+			name:     "change partitioning range: ignore rotate",
+			from:     "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
+			to:       "create table t1 (id int primary key) partition by range (id) (partition p2 values less than (20), partition p3 values less than (30), partition p4 values less than (40))",
+			rotation: RangeRotationIgnore,
 		},
 		{
-			name:                          "change partitioning range: ignore rotate, not a rotation",
-			from:                          "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
-			to:                            "create table t1 (id int primary key) partition by range (id) (partition p2 values less than (25), partition p3 values less than (30), partition p4 values less than (40))",
-			ignoreRangePartitionsRotation: true,
-			diff:                          "alter table t1 partition by range (id) (partition p2 values less than (25), partition p3 values less than (30), partition p4 values less than (40))",
+			name:     "change partitioning range: ignore rotate, not a rotation",
+			from:     "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
+			to:       "create table t1 (id int primary key) partition by range (id) (partition p2 values less than (25), partition p3 values less than (30), partition p4 values less than (40))",
+			rotation: RangeRotationIgnore,
+			diff:     "alter table t1 partition by range (id) (partition p2 values less than (25), partition p3 values less than (30), partition p4 values less than (40))",
 		},
 		{
-			name:                          "change partitioning range: ignore rotate, not a rotation 2",
-			from:                          "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
-			to:                            "create table t1 (id int primary key) partition by range (id) (partition p2 values less than (20), partition p3 values less than (35), partition p4 values less than (40))",
-			ignoreRangePartitionsRotation: true,
-			diff:                          "alter table t1 partition by range (id) (partition p2 values less than (20), partition p3 values less than (35), partition p4 values less than (40))",
+			name:     "change partitioning range: ignore rotate, not a rotation 2",
+			from:     "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
+			to:       "create table t1 (id int primary key) partition by range (id) (partition p2 values less than (20), partition p3 values less than (35), partition p4 values less than (40))",
+			rotation: RangeRotationIgnore,
+			diff:     "alter table t1 partition by range (id) (partition p2 values less than (20), partition p3 values less than (35), partition p4 values less than (40))",
 		},
 		{
-			name:                          "change partitioning range: ignore rotate, not a rotation 3",
-			from:                          "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
-			to:                            "create table t1 (id int primary key) partition by range (id) (partition p2 values less than (20), partition pX values less than (30), partition p4 values less than (40))",
-			ignoreRangePartitionsRotation: true,
-			diff:                          "alter table t1 partition by range (id) (partition p2 values less than (20), partition pX values less than (30), partition p4 values less than (40))",
+			name:     "change partitioning range: ignore rotate, not a rotation 3",
+			from:     "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
+			to:       "create table t1 (id int primary key) partition by range (id) (partition p2 values less than (20), partition pX values less than (30), partition p4 values less than (40))",
+			rotation: RangeRotationIgnore,
+			diff:     "alter table t1 partition by range (id) (partition p2 values less than (20), partition pX values less than (30), partition p4 values less than (40))",
 		},
 		{
-			name:                          "change partitioning range: ignore rotate, not a rotation 4",
-			from:                          "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
-			to:                            "create table t1 (id int primary key) partition by range (id) (partition pX values less than (20), partition p3 values less than (30), partition p4 values less than (40))",
-			ignoreRangePartitionsRotation: true,
-			diff:                          "alter table t1 partition by range (id) (partition pX values less than (20), partition p3 values less than (30), partition p4 values less than (40))",
+			name:     "change partitioning range: ignore rotate, not a rotation 4",
+			from:     "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
+			to:       "create table t1 (id int primary key) partition by range (id) (partition pX values less than (20), partition p3 values less than (30), partition p4 values less than (40))",
+			rotation: RangeRotationIgnore,
+			diff:     "alter table t1 partition by range (id) (partition pX values less than (20), partition p3 values less than (30), partition p4 values less than (40))",
 		},
 		{
-			name:                          "change partitioning range: ignore rotate, nothing shared",
-			from:                          "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
-			to:                            "create table t1 (id int primary key) partition by range (id) (partition p4 values less than (40), partition p5 values less than (50), partition p6 values less than (60))",
-			ignoreRangePartitionsRotation: true,
-			diff:                          "alter table t1 partition by range (id) (partition p4 values less than (40), partition p5 values less than (50), partition p6 values less than (60))",
+			name:     "change partitioning range: ignore rotate, nothing shared",
+			from:     "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
+			to:       "create table t1 (id int primary key) partition by range (id) (partition p4 values less than (40), partition p5 values less than (50), partition p6 values less than (60))",
+			rotation: RangeRotationIgnore,
+			diff:     "alter table t1 partition by range (id) (partition p4 values less than (40), partition p5 values less than (50), partition p6 values less than (60))",
 		},
 		{
-			name:                          "change partitioning range: ignore rotate, no names shared, definitions shared",
-			from:                          "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
-			to:                            "create table t1 (id int primary key) partition by range (id) (partition pA values less than (20), partition pB values less than (30), partition pC values less than (40))",
-			ignoreRangePartitionsRotation: true,
-			diff:                          "alter table t1 partition by range (id) (partition pA values less than (20), partition pB values less than (30), partition pC values less than (40))",
+			name:     "change partitioning range: ignore rotate, no names shared, definitions shared",
+			from:     "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p3 values less than (30))",
+			to:       "create table t1 (id int primary key) partition by range (id) (partition pA values less than (20), partition pB values less than (30), partition pC values less than (40))",
+			rotation: RangeRotationIgnore,
+			diff:     "alter table t1 partition by range (id) (partition pA values less than (20), partition pB values less than (30), partition pC values less than (40))",
 		},
 
 		//
@@ -558,7 +558,7 @@ func TestCreateTableDiff(t *testing.T) {
 			other := NewCreateTableEntity(toCreateTable)
 			hints := standardHints
 			hints.AutoIncrementStrategy = ts.autoinc
-			hints.IgnoreRangePartitionsRotation = ts.ignoreRangePartitionsRotation
+			hints.RangeRotationStrategy = ts.rotation
 			alter, err := c.Diff(other, &hints)
 			switch {
 			case ts.isError:

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -70,7 +70,7 @@ const (
 )
 
 const (
-	RangeRotationAlways = iota
+	RangeRotationFullSpec = iota
 	RangeRotationStatements
 	RangeRotationIgnore
 )

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -71,6 +71,7 @@ const (
 
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
-	StrictIndexOrdering   bool
-	AutoIncrementStrategy int
+	StrictIndexOrdering           bool
+	AutoIncrementStrategy         int
+	IgnoreRangePartitionsRotation bool
 }

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -23,19 +23,19 @@ import (
 )
 
 var (
-	ErrEntityTypeMismatch             = errors.New("mismatched entity type")
-	ErrStrictIndexOrderingUnsupported = errors.New("strict index ordering is unsupported")
-	ErrPartitioningUnsupported        = errors.New("partitions are unsupported")
-	ErrUnsupportedTableOption         = errors.New("unsupported table option")
-	ErrUnexpectedDiffAction           = errors.New("unexpected diff action")
-	ErrUnexpectedTableSpec            = errors.New("unexpected table spec")
-	ErrNotFullyParsed                 = errors.New("unable to fully parse statement")
-	ErrExpectedCreateTable            = errors.New("expected a CREATE TABLE statement")
-	ErrExpectedCreateView             = errors.New("expected a CREATE VIEW statement")
-	ErrUnsupportedEntity              = errors.New("Unsupported entity type")
-	ErrUnsupportedStatement           = errors.New("Unsupported statement")
-	ErrDuplicateName                  = errors.New("Duplicate name")
-	ErrViewDependencyUnresolved       = errors.New("Views have unresolved/loop dependencies")
+	ErrEntityTypeMismatch                          = errors.New("mismatched entity type")
+	ErrStrictIndexOrderingUnsupported              = errors.New("strict index ordering is unsupported")
+	ErrRangeRotattionStatementsStrategyUnsupported = errors.New("range rotation statement strategy unsupported")
+	ErrUnsupportedTableOption                      = errors.New("unsupported table option")
+	ErrUnexpectedDiffAction                        = errors.New("unexpected diff action")
+	ErrUnexpectedTableSpec                         = errors.New("unexpected table spec")
+	ErrNotFullyParsed                              = errors.New("unable to fully parse statement")
+	ErrExpectedCreateTable                         = errors.New("expected a CREATE TABLE statement")
+	ErrExpectedCreateView                          = errors.New("expected a CREATE VIEW statement")
+	ErrUnsupportedEntity                           = errors.New("Unsupported entity type")
+	ErrUnsupportedStatement                        = errors.New("Unsupported statement")
+	ErrDuplicateName                               = errors.New("Duplicate name")
+	ErrViewDependencyUnresolved                    = errors.New("Views have unresolved/loop dependencies")
 )
 
 // Entity stands for a database object we can diff:
@@ -69,9 +69,15 @@ const (
 	AutoIncrementApplyAlways
 )
 
+const (
+	RangeRotationAlways = iota
+	RangeRotationStatements
+	RangeRotationIgnore
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
-	StrictIndexOrdering           bool
-	AutoIncrementStrategy         int
-	IgnoreRangePartitionsRotation bool
+	StrictIndexOrdering   bool
+	AutoIncrementStrategy int
+	RangeRotationStrategy int
 }


### PR DESCRIPTION
## Description

Diffing partitions is a complex topic. There can be scenarios where a change of partitioning scheme required an entire rebuild of the table (e.g. change of number of `HASH` partitions), and cases where optimally one could get by with only modifying some of the partitions (e.g. `COALESCE` two partitions into one).

Normally, when we see a diff of partitions, we just invoke an `ALTER TABLE... PARTITION BY...` with the entire new partitioning scheme. The idea? Even a `COALESCE` for two partitions out of `200` is a blocking schema change. As we push forward Online DDL, we are opinionated that it's better to rebuild the entire table, online, than just `2` partitions out of `200`, in a blocking operation.

However, there are exceptions to this.

A common partitioning scheme that does not require blocking: rotation of [range partitioning](https://dev.mysql.com/doc/refman/8.0/en/partitioning-range.html). The classic example is, say, partitioning by day, such that every day we add a new partition; and possibly every day we also purge an old partition.
We could be adding a bunch of partitions at a time, or drop a bunch of partitions at a time.
Adding new partitions is super cheap, and dropping old partitions can be cheap or expensive, depending on the size of dropped partition and version of MySQL.

In this PR `schemadiff` identifies a rotating range partitioning scheme: two tables that are partitioned by `RANGE`, share exactly one consecutive non-empty sequence of partitions (i.e., the two tables have _some partitions in common_), and possibly:
- 1st table (aka "old" table) does not have some newer partitions (these have just been rotated in), and
- 2nd table (aka "new" table) does not have some older partitions (they have been rotated away)

As of this PR `schemadiff` supports a `RangeRotationStrategy`, of the following values:

- `RangeRotationFullSpec`: generate a full partitioning spec, meaning do not optimize for partition rotation; this behavior is the same as before this PR
- `RangeRotationIgnore`: consider this as a non-diff. This is similar in concept to ignoring an `AUTO_INCREMENT` increase.
- `RangeRotationStatements` **NOT YET IMPLEMENTED**. Will throw an error. Once implemented, will return the proper `DROP PARTITION ...` and `ADD PARTITION ...` statements that perform the rotation.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
