### PR TITLE
Avoid deadlocks related to 0 receiver behavior

### DIFF
--- a/go/test/endtoend/messaging/main_test.go
+++ b/go/test/endtoend/messaging/main_test.go
@@ -38,25 +38,43 @@ var (
 	userKeyspace         = "user"
 	lookupKeyspace       = "lookup"
 	createShardedMessage = `create table sharded_message(
-		id bigint,
-		priority bigint default 0,
-		time_next bigint default 0,
-		epoch bigint,
-		time_acked bigint,
-		message varchar(128),
+		# required columns
+		id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
+		priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
+		epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+		time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
+		time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
+
+		# add as many custom fields here as required
+		# optional - these are suggestions
+		tenant_id bigint,
+		message json,
+
+		# required indexes
 		primary key(id),
-		index poller_idx (time_acked, priority, time_next desc),
-		) comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
+		index poller_idx(time_acked, priority, time_next desc)
+
+		# add any secondary indexes or foreign keys - no restrictions
+	) comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 	createUnshardedMessage = `create table unsharded_message(
-		id bigint,
-		priority bigint default 0,
-		time_next bigint default 0,
-		epoch bigint,
-		time_acked bigint,
-		message varchar(128),
+		# required columns
+		id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
+		priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
+		epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+		time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
+		time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
+
+		# add as many custom fields here as required
+		# optional - these are suggestions
+		tenant_id bigint,
+		message json,
+
+		# required indexes
 		primary key(id),
-		index poller_idx (time_acked, priority, time_next desc),
-		) comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
+		index poller_idx(time_acked, priority, time_next desc)
+
+		# add any secondary indexes or foreign keys - no restrictions
+	) comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 	userVschema = `{
 	  "sharded": true,
 	  "vindexes": {

--- a/go/test/endtoend/messaging/main_test.go
+++ b/go/test/endtoend/messaging/main_test.go
@@ -45,8 +45,7 @@ var (
 		time_acked bigint,
 		message varchar(128),
 		primary key(id),
-		index next_idx(priority, time_next desc),
-		index ack_idx(time_acked)
+		index poller_idx (time_acked, priority, time_next desc),
 		) comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 	createUnshardedMessage = `create table unsharded_message(
 		id bigint,
@@ -56,8 +55,7 @@ var (
 		time_acked bigint,
 		message varchar(128),
 		primary key(id),
-		index next_idx(priority, time_next desc),
-		index ack_idx(time_acked)
+		index poller_idx (time_acked, priority, time_next desc),
 		) comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 	userVschema = `{
 	  "sharded": true,

--- a/go/test/endtoend/messaging/message_test.go
+++ b/go/test/endtoend/messaging/message_test.go
@@ -45,7 +45,7 @@ import (
 )
 
 var createMessage = `
-create table my_message(
+create table vitess_message(
 	# required columns
 	id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
 	priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
@@ -174,7 +174,7 @@ func TestMessage(t *testing.T) {
 }
 
 var createThreeColMessage = `
-create table my_message(
+create table vitess_message3(
 	# required columns
 	id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
 	priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',

--- a/go/test/endtoend/vtgate/godriver/main_test.go
+++ b/go/test/endtoend/vtgate/godriver/main_test.go
@@ -18,6 +18,7 @@ package godriver
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strconv"
 	"testing"
@@ -80,6 +81,8 @@ create table my_message(
   }
 }
 `
+
+	testMessage = "{\"message\":\"hello world\"}"
 )
 
 func TestMain(m *testing.M) {
@@ -141,7 +144,7 @@ func TestStreamMessaging(t *testing.T) {
 	defer db.Close()
 
 	// Exec not allowed in streaming
-	_, err = db.Exec("insert into my_message(id, message) values(1, 'hello world')")
+	_, err = db.Exec(fmt.Sprintf("insert into my_message(id, message) values(1, '%s')", testMessage))
 	require.NoError(t, err)
 
 	// for streaming messages

--- a/go/test/endtoend/vtgate/godriver/main_test.go
+++ b/go/test/endtoend/vtgate/godriver/main_test.go
@@ -44,15 +44,15 @@ var (
 create table my_message(
   time_scheduled bigint,
   id bigint,
-  time_next bigint,
+  time_next bigint DEFAULT 0,
   epoch bigint,
   time_created bigint,
   time_acked bigint,
   message varchar(128),
-  priority tinyint NOT NULL DEFAULT '0',
+  priority tinyint NOT NULL DEFAULT 0,
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(priority, time_next)
+  index poller_idx(time_acked, priority, time_next)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30';
 `
 	VSchema = `

--- a/go/test/endtoend/vtgate/godriver/main_test.go
+++ b/go/test/endtoend/vtgate/godriver/main_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package godriver
 
 import (
-	"database/sql"
 	"flag"
 	"os"
 	"strconv"
@@ -142,8 +141,7 @@ func TestStreamMessaging(t *testing.T) {
 	defer db.Close()
 
 	// Exec not allowed in streaming
-	timenow := time.Now().Add(time.Second * 60).UnixNano()
-	_, err = db.Exec("insert into my_message(id, message, time_scheduled) values(1, 'hello world', :curr_time)", sql.Named("curr_time", timenow))
+	_, err = db.Exec("insert into my_message(id, message) values(1, 'hello world')")
 	require.NoError(t, err)
 
 	// for streaming messages

--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -469,9 +469,7 @@ func (mm *messageManager) rescanReceivers(start int) {
 // if successful. If the message is already present,
 // it still returns true.
 func (mm *messageManager) Add(mr *MessageRow) bool {
-	mm.mu.Lock()
-	defer mm.mu.Unlock()
-	if len(mm.receivers) == 0 {
+	if mm.receiverCount() == 0 {
 		return false
 	}
 	// If cache is empty, we have to broadcast that we're not empty
@@ -879,7 +877,7 @@ func (mm *messageManager) GeneratePurgeQuery(timeCutoff int64) (string, map[stri
 	}
 }
 
-// BuildMessageRow builds a MessageRow for a db row.
+// BuildMessageRow builds a MessageRow from a db row.
 func BuildMessageRow(row []sqltypes.Value) (*MessageRow, error) {
 	mr := &MessageRow{Row: row[4:]}
 	if !row[0].IsNull() {

--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -479,7 +479,9 @@ func (mm *messageManager) rescanReceivers(start int) {
 // if successful. If the message is already present,
 // it still returns true.
 func (mm *messageManager) Add(mr *MessageRow) bool {
-	if mm.getReceiverCount() == 0 {
+	mm.mu.Lock()
+	defer mm.mu.Unlock()
+	if len(mm.receivers) == 0 {
 		return false
 	}
 	// If cache is empty, we have to broadcast that we're not empty

--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -209,7 +209,7 @@ type messageManager struct {
 	// older than lastPollPosition must be ignored by the vstream. It
 	// consequently also blocks vstream from updating the cache while the
 	// poller is active.
-	// TODO(mattalord): since this is primarily a flow control mechanism, we
+	// TODO(mattlord): since this is primarily a flow control mechanism, we
 	// should do it in a more idiomatic go way using channels or cond vars.
 	cacheManagementMu sync.Mutex
 	// The lastPollPosition variable is the main point of coordination

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -148,12 +148,12 @@ func TestReceiverCancel(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		runtime.Gosched()
 		time.Sleep(10 * time.Millisecond)
-		if mm.receiverCount() != 0 {
+		if mm.receiverCount.Get() != 0 {
 			continue
 		}
 		return
 	}
-	t.Errorf("receivers were not cleared: %d", len(mm.receivers))
+	t.Errorf("receivers were not cleared: %d", mm.receiverCount.Get())
 }
 
 func TestMessageManagerState(t *testing.T) {
@@ -281,7 +281,7 @@ func TestMessageManagerSend(t *testing.T) {
 		runtime.Gosched()
 		time.Sleep(10 * time.Millisecond)
 		mm.mu.Lock()
-		if len(mm.receivers) != 1 {
+		if mm.receiverCount.Get() != 1 {
 			mm.mu.Unlock()
 			continue
 		}

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -148,12 +148,12 @@ func TestReceiverCancel(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		runtime.Gosched()
 		time.Sleep(10 * time.Millisecond)
-		if mm.receiverCount.Get() != 0 {
+		if len(mm.receivers) != 0 {
 			continue
 		}
 		return
 	}
-	t.Errorf("receivers were not cleared: %d", mm.receiverCount.Get())
+	t.Errorf("receivers were not cleared: %d", len(mm.receivers))
 }
 
 func TestMessageManagerState(t *testing.T) {
@@ -281,7 +281,7 @@ func TestMessageManagerSend(t *testing.T) {
 		runtime.Gosched()
 		time.Sleep(10 * time.Millisecond)
 		mm.mu.Lock()
-		if mm.receiverCount.Get() != 1 {
+		if len(mm.receivers) != 1 {
 			mm.mu.Unlock()
 			continue
 		}
@@ -503,9 +503,7 @@ func TestMessageManagerStreamerAndPoller(t *testing.T) {
 	for {
 		runtime.Gosched()
 		time.Sleep(10 * time.Millisecond)
-		mm.streamMu.Lock()
-		pos := mm.lastPollPosition
-		mm.streamMu.Unlock()
+		pos := mm.getLastPollPosition()
 		if pos != nil {
 			break
 		}

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/schema_test.json
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/schema_test.json
@@ -336,7 +336,6 @@
         "Name": "PRIMARY",
         "Unique": true,
         "Columns": [
-          "time_scheduled",
           "id"
         ],
         "Cardinality": [
@@ -347,10 +346,9 @@
       }
     ],
     "PKColumns": [
-      0,
-      1
+      0
     ],
-    "Type": 2
+    "Type": 0
   },
   {
     "Name": "dual",

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/schema_test.json
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/schema_test.json
@@ -319,13 +319,16 @@
         "Name": "priority"
       },
       {
-        "Name": "time_next"
-      },
-      {
         "Name": "epoch"
       },
       {
+        "Name": "time_next"
+      },
+      {
         "Name": "time_acked"
+      },
+      {
+        "Name": "tenant_id"
       },
       {
         "Name": "message"
@@ -348,7 +351,7 @@
     "PKColumns": [
       0
     ],
-    "Type": 0
+    "Type": 2
   },
   {
     "Name": "dual",


### PR DESCRIPTION
## Description

There's conditional behavior and code paths in the message manager when the number of receivers is 0. The main mutex and the stream mutex locks are used to ensure overall consistency. But:
1. The order that those locks are taken in was not enforced or consistent
2. There was a gap in the poller between when the 0 receiver code path was checked — specifically that it was NOT 0 — and the main mutex lock was taken to ensure that this invariant holds during the polling run here: https://github.com/vitessio/vitess/blob/c9853797bda8752202583695133c41a25d390930/go/vt/vttablet/tabletserver/messager/message_manager.go#L752-L787

### These two factors can lead to deadlocks when the receiver count goes to/from 0 while the the poller runs:

In [`unsubscribe()` we have the main mutex](https://github.com/vitessio/vitess/blob/c9853797bda8752202583695133c41a25d390930/go/vt/vttablet/tabletserver/messager/message_manager.go#L421-L423), and while holding it we then [call `stopVStream()` if the subscriber/receiver count is at 0](https://github.com/vitessio/vitess/blob/c9853797bda8752202583695133c41a25d390930/go/vt/vttablet/tabletserver/messager/message_manager.go#L437-L439). Then `stopVStream()` [tries to get the stream mutex](https://github.com/vitessio/vitess/blob/c9853797bda8752202583695133c41a25d390930/go/vt/vttablet/tabletserver/messager/message_manager.go#L629-L631).

Concurrently, `runPoller()` — which by default, or more accurately when using [the documented message table structure here](https://vitess.io/docs/13.0/reference/features/messaging/#creating-a-message-table) via the `vt_poller_interval` comment directive, runs on a 30 second ticker — [gets the stream mutex first](https://github.com/vitessio/vitess/blob/c9853797bda8752202583695133c41a25d390930/go/vt/vttablet/tabletserver/messager/message_manager.go#L751-L758), then it [later tries to get the main mutex](https://github.com/vitessio/vitess/blob/c9853797bda8752202583695133c41a25d390930/go/vt/vttablet/tabletserver/messager/message_manager.go#L776-L778).

Now we are deadlocked. They're both waiting on each other.

This then in turn causes things like `PlannedReparentShard` to hang because [during the transition from primary serving we stop/close the message service](https://github.com/vitessio/vitess/blob/c9853797bda8752202583695133c41a25d390930/go/vt/vttablet/tabletserver/state_manager.go#L450), which in turn [will wait trying to get the main mutex](https://github.com/vitessio/vitess/blob/c9853797bda8752202583695133c41a25d390930/go/vt/vttablet/tabletserver/messager/message_manager.go#L346-L354).

### Changes

1. **We clean up the mutex usage**.  In order to ensure that the cache stays in sync with the database and we are moving forward linearly though the logical GTID stream — updated by the poller and its results streamer, and the binlog streamer — we now use the `cacheManagementMu` lock. The explicit usage of this new mutex allows us to avoid the deadlocks seen before because it's taken immediately when the poller or binlog streamer process data coming from the database (which is used to update the cache), and we no longer need to take this lock when starting or stopping the binlog streamer itself.
    - After the initial changes made in the PR I could see that we were still prone to deadlocks in various places due to checking the receiver count all the time (I could see this in the race test stack traces, see Notes below), which required the main mutex, while holding the stream mutex. Anywhere we were holding the stream mutex, and checking receiver count — which we did A LOT, for example when processing every row event from the binlog stream via [`processRowEvent()`](https://github.com/vitessio/vitess/blob/341d80a5f96b65ce9a16211ebd4d2034f859ab78/go/vt/vttablet/tabletserver/messager/message_manager.go#L707)->[`Add()`](https://github.com/vitessio/vitess/blob/341d80a5f96b65ce9a16211ebd4d2034f859ab78/go/vt/vttablet/tabletserver/messager/message_manager.go#L469-L474) — we were at risk of a deadlock. The main mutex became VERY hot because we were checking the receiver count all the time to ensure the fast path (do nothing when there's no receivers).
2. **We add an important predicate to the poller query** — `time_acked is null` — to try and limit the size of scans done on the underlying message table to try and ensure that the poller runs quickly. This aspect is important because the binlog event processing is blocked during this time. It also prevents us from doing unnecessary work as InnoDB does most of the work — all query (WHERE) predicates become index condition pushdowns and the new `poller_idx` index can be used for the ordering to apply the `LIMIT` as well — and passes the minimum amount of potentially useful data up the stack InnoDB->MySQL->MessageManager->Cache.
3. **We update the tests so that we're using the new recommended/documented (see docs ticket below) message table structure and thus we're testing behavior with the structure we tell users to use.**

## Notes

This is able to complete on `vitessio/main`:
```
$ make build; failed=0; for i in {1..100}; do if ! go test -race -v -failfast -timeout 1m vitess.io/vitess/go/vt/vttablet/tabletserver/messager; then echo -e '\nUh oh! We have a problem...\n'; failed=1; break; fi; go clean -testcache; done; if [[ ${failed} -eq 0 ]]; then echo -e '\nWe made it! All good...\n'; fi
```

Whatever changes are made here we should continue to pass that test (it does). It's even more reliable now — you can run it 1,000 times and no flakiness.

## Related Issue(s)
  - Fixes: https://github.com/vitessio/vitess/issues/9936

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests are not required (the existing unit and e2e tests cover the behavior)
-   [x] Documentation: https://github.com/vitessio/website/pull/1015