### PR TITLE
Remove vtadmin-down.sh from teardown.sh

### DIFF
--- a/examples/local/401_teardown.sh
+++ b/examples/local/401_teardown.sh
@@ -46,8 +46,6 @@ else
 	CELL=zone1 ./scripts/etcd-down.sh
 fi
 
-./scripts/vtadmin-down.sh
-
 # pedantic check: grep for any remaining processes
 
 if [ ! -z "$VTDATAROOT" ]; then


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

This removes `vtadmin-down.sh` from `teardown.sh` in order to avoid errors like the following:

```
cat: ~/go/src/vitess.io/vitess/examples/local/vtdataroot/tmp/vtadmin-web.pid: No such file or directory
./scripts/vtadmin-down.sh: line 6: kill: `': not a pid or valid job spec
Stopping vtadmin-api...
cat: ~/go/src/vitess.io/vitess/examples/local/vtdataroot/tmp/vtadmin-api.pid: No such file or directory
./scripts/vtadmin-down.sh: line 9: kill: `': not a pid or valid job spec
```

I plan to add vtadmin-up to the local example scripts at the same time as (a) #10118 and (b) vitess.io documentation. 

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A
