### PR TITLE
Avoid enabling reserved connection on show query

### DIFF
--- a/go/vt/sysvars/sysvars.go
+++ b/go/vt/sysvars/sysvars.go
@@ -260,5 +260,11 @@ func GetInterestingVariables() []string {
 	res = append(res, Version.Name)
 	res = append(res, VersionComment.Name)
 	res = append(res, Socket.Name)
+
+	for _, variable := range UseReservedConn {
+		if variable.SupportSetVar {
+			res = append(res, variable.Name)
+		}
+	}
 	return res
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1036,7 +1036,7 @@ func prepareSetVarComment(vcursor *vcursorImpl, stmt sqlparser.Statement) (strin
 	switch stmt.(type) {
 	// If the statement is a transaction statement or a set no reserved connection / SET_VAR is needed
 	case *sqlparser.Begin, *sqlparser.Commit, *sqlparser.Rollback, *sqlparser.Savepoint,
-		*sqlparser.SRollback, *sqlparser.Release, *sqlparser.Set:
+		*sqlparser.SRollback, *sqlparser.Release, *sqlparser.Set, *sqlparser.Show:
 		return "", nil
 	case sqlparser.SupportOptimizerHint:
 		break

--- a/go/vt/vtgate/executor_set_test.go
+++ b/go/vt/vtgate/executor_set_test.go
@@ -515,15 +515,48 @@ func TestSetVar(t *testing.T) {
 		{sql: "delete from user"},
 		{sql: "insert into user (id) values (1)"},
 		{sql: "replace into user(id, col) values (1, 'new')"},
-		{sql: "show create table user"},
+		{sql: "set autocommit = 0"},
+		{sql: "show create table user"}, // reserved connection should not be set.
 		{sql: "create table foo(bar bigint)", rc: true},
 	}
 
 	for _, tc := range tcases {
 		t.Run(tc.sql, func(t *testing.T) {
+			// reset reserved conn need.
+			session.SetReservedConn(false)
+
 			_, err = executor.Execute(context.Background(), "TestSetVar", session, tc.sql, map[string]*querypb.BindVariable{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.rc, session.InReservedConn())
 		})
 	}
+}
+
+func TestSetVarShowVariables(t *testing.T) {
+	executor, _, _, sbc := createExecutorEnv()
+	executor.normalize = true
+
+	oldVersion := sqlparser.MySQLVersion
+	sqlparser.MySQLVersion = "80000"
+	defer func() {
+		sqlparser.MySQLVersion = oldVersion
+	}()
+	session := NewAutocommitSession(&vtgatepb.Session{EnableSystemSettings: true, TargetString: KsTestUnsharded})
+
+	sbc.SetResults([]*sqltypes.Result{
+		// select query result for checking any change in system settings
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("orig|new", "varchar|varchar"),
+			"|only_full_group_by"),
+		// show query result
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("Variable_name|Value", "varchar|varchar"),
+			"sql_mode|ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE")})
+
+	_, err := executor.Execute(context.Background(), "TestSetVar", session, "set @@sql_mode = only_full_group_by", map[string]*querypb.BindVariable{})
+	require.NoError(t, err)
+
+	// this should return the updated value of sql_mode.
+	qr, err := executor.Execute(context.Background(), "TestSetVar", session, "show variables like 'sql_mode'", map[string]*querypb.BindVariable{})
+	require.NoError(t, err)
+	assert.False(t, session.InReservedConn(), "reserved connection should not be used")
+	assert.Equal(t, `[[VARCHAR("sql_mode") VARCHAR("only_full_group_by")]]`, fmt.Sprintf("%v", qr.Rows))
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR avoids using the reserved connection for Show query and handles `show variables` by doing variable replace at vtgate level.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
