### PR TITLE
Do not mutate replication state in WaitSourcePos

### DIFF
--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"context"
@@ -267,32 +266,6 @@ func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos mysql.Positio
 		}
 		if mpos.AtLeast(targetPos) {
 			return nil
-		}
-
-		replicationStatus, err := conn.ShowReplicationStatus()
-		if err != nil && !errors.Is(err, mysql.ErrNotReplica) {
-			return err
-		}
-
-		// If the SQL thread(s) is not already running -- e.g. in the case of EmergencyReparentShard where the
-		// instance is transitioning to PRIMARY (elect) and we can no longer talk to the old PRIMARY, we need
-		// it to catch up as much as possible by executing all of the locally queued binary log events (in
-		// the existing relay logs) before it starts serving traffic for the shard to minimize potential data
-		// loss -- then we try to start the SQL Thread(s) before waiting for the position to be reached at
-		// which point the SQL thread(s) will be stopped again, since the replicas can only make forward
-		// progress if the SQL thread is started and we have already verified that the replica is not already
-		// as advanced as we want it to be
-		if !replicationStatus.SQLHealthy() {
-			// Let's ensure the replication state is put back to what it was when we started.
-			// Doing this in a deferred function ensures that we do so even if we timeout while waiting.
-			defer func() {
-				mysqld.executeSuperQueryListConn(ctx, conn, []string{conn.StopSQLThreadCommand()})
-			}()
-			if err = mysqld.executeSuperQueryListConn(ctx, conn, []string{conn.StartSQLThreadCommand()}); err != nil {
-				return vterrors.Wrap(err,
-					fmt.Sprintf("the replication SQL thread(s) was stopped and we could not temporarily start it in order to wait for the target position of %v",
-						targetPos))
-			}
 		}
 
 		// Find the query to run, run it.


### PR DESCRIPTION
## Description

Mutating the state there results in race conditions with tablet repairs that can leave
replication broken and requiring manual repair using using `START SLAVE`.

This reverts the state mutating parts from https://github.com/vitessio/vitess/pull/9512 and the follow-up https://github.com/vitessio/vitess/pull/10104.

It leaves the other helper functions in place as they could be useful for other purposes at some point. They are effectively unused though so we could remove them as well since it's currently dead code.

## Related Issue(s)
 - https://github.com/vitessio/vitess/pull/9512 — this issue needs to be re-opened and addressed differently
 - https://github.com/vitessio/vitess/pull/10104 — this is effectively reverted (the state mutating parts anyway, the other functions could be useful at some point)

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported (this should be backported to release-13.0)
-   [ ] Tests were added or are not required
-   [x] Documentation is not required
