### PR TITLE
Fix for empty results when no shards can be found to route to

### DIFF
--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -109,3 +109,17 @@ func TestSubqueryInUpdate(t *testing.T) {
 	utils.AssertMatches(t, conn, `SELECT id2 FROM t1 WHERE id1 = 1`, `[[INT64(2)]]`)
 	utils.AssertMatches(t, conn, `SELECT id2, keyspace_id FROM t1_id2_idx WHERE id2 IN (2,10)`, `[[INT64(2) VARBINARY("\x16k@\xb4J\xbaK\xd6")]]`)
 }
+
+func TestSubqueryInReference(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 14, "vtgate")
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec(`insert into t1(id1, id2) values (1,10), (2, 20), (3, 30), (4, 40), (5, 50)`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ exists(select * from t1 where id1 = 3)`, `[[INT64(1)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ exists(select * from t1 where id1 = 9)`, `[[INT64(0)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ exists(select * from t1)`, `[[INT64(1)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ exists(select * from t1 where id2 = 30)`, `[[INT64(1)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ exists(select * from t1 where id2 = 9)`, `[[INT64(0)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ count(*) from t1 where id2 = 9`, `[[INT64(0)]]`)
+}

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -122,4 +122,21 @@ func TestSubqueryInReference(t *testing.T) {
 	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ exists(select * from t1 where id2 = 30)`, `[[INT64(1)]]`)
 	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ exists(select * from t1 where id2 = 9)`, `[[INT64(0)]]`)
 	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ count(*) from t1 where id2 = 9`, `[[INT64(0)]]`)
+
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ 1 in (select 1 from t1 where id1 = 3)`, `[[INT64(1)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ 1 in (select 1 from t1 where id1 = 9)`, `[[INT64(0)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ 1 in (select id1 from t1)`, `[[INT64(1)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ 1 in (select 1 from t1 where id2 = 30)`, `[[INT64(1)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ 1 in (select 1 from t1 where id2 = 9)`, `[[INT64(0)]]`)
+
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ 1 not in (select 1 from t1 where id1 = 3)`, `[[INT64(0)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ 1 not in (select 1 from t1 where id1 = 9)`, `[[INT64(1)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ 1 not in (select id1 from t1)`, `[[INT64(0)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ 1 not in (select 1 from t1 where id2 = 30)`, `[[INT64(0)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ 1 not in (select 1 from t1 where id2 = 9)`, `[[INT64(1)]]`)
+
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ (select id2 from t1 where id1 = 3)`, `[[INT64(30)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ (select id2 from t1 where id1 = 9)`, `[[NULL]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ (select id1 from t1 where id2 = 30)`, `[[INT64(3)]]`)
+	mcmp.AssertMatches(`select /*vt+ PLANNER=gen4 */ (select id1 from t1 where id2 = 9)`, `[[NULL]]`)
 }

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -254,14 +254,18 @@ func (route *Route) TryStreamExecute(vcursor VCursor, bindVars map[string]*query
 
 	// No route.
 	if len(rss) == 0 {
-		if wantfields {
-			r, err := route.GetFields(vcursor, bindVars)
-			if err != nil {
-				return err
-			}
-			return callback(r)
+		// Here we were earlier returning no rows back.
+		// But this was incorrect for queries like select count(*) from user where name='x'
+		// If the lookup_vindex for name, returns no shards, we still want a result from here
+		// with a single row with 0 as the output.
+		// However, at this level it is hard to distinguish between the cases that need a result
+		// and the ones that don't. So, we are sending the query to any shard! This is safe because
+		// the query contains a predicate that make it not match any rows on that shard. (If they did,
+		// we should have gotten that shard back already from findRoute)
+		rss, bvs, err = route.anyShard(vcursor, bindVars)
+		if err != nil {
+			return err
 		}
-		return nil
 	}
 
 	if len(route.OrderBy) == 0 {

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -284,7 +284,10 @@ func TestSelectNone(t *testing.T) {
 	}
 	result, err := sel.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
 	require.NoError(t, err)
-	require.Empty(t, vc.log)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
+		`ExecuteMultiShard ks.-20: dummy_select {} false false`,
+	})
 	expectResult(t, "sel.Execute", result, &sqltypes.Result{})
 
 	vc.Rewind()
@@ -416,6 +419,8 @@ func TestSelectEqualNoRoute(t *testing.T) {
 	vc.ExpectLog(t, []string{
 		`Execute select from, toc from lkp where from in ::from from: type:TUPLE values:{type:INT64 value:"1"} false`,
 		`ResolveDestinations ks [type:INT64 value:"1"] Destinations:DestinationNone()`,
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
+		`ExecuteMultiShard ks.-20: dummy_select {} false false`,
 	})
 	expectResult(t, "sel.Execute", result, &sqltypes.Result{})
 
@@ -787,7 +792,7 @@ func TestRouteGetFields(t *testing.T) {
 		`Execute select from, toc from lkp where from in ::from from: type:TUPLE values:{type:INT64 value:"1"} false`,
 		`ResolveDestinations ks [type:INT64 value:"1"] Destinations:DestinationNone()`,
 		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
-		`ExecuteMultiShard ks.-20: dummy_select_field {} false false`,
+		`ExecuteMultiShard ks.-20: dummy_select {} false false`,
 	})
 	expectResult(t, "sel.Execute", result, &sqltypes.Result{})
 

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -293,8 +293,11 @@ func TestSelectNone(t *testing.T) {
 	vc.Rewind()
 	result, err = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
 	require.NoError(t, err)
-	require.Empty(t, vc.log)
-	expectResult(t, "sel.StreamExecute", result, nil)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
+		`StreamExecuteMulti dummy_select ks.-20: {} `,
+	})
+	expectResult(t, "sel.StreamExecute", result, &sqltypes.Result{})
 }
 
 func TestSelectEqualUniqueScatter(t *testing.T) {
@@ -430,8 +433,10 @@ func TestSelectEqualNoRoute(t *testing.T) {
 	vc.ExpectLog(t, []string{
 		`Execute select from, toc from lkp where from in ::from from: type:TUPLE values:{type:INT64 value:"1"} false`,
 		`ResolveDestinations ks [type:INT64 value:"1"] Destinations:DestinationNone()`,
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
+		`StreamExecuteMulti dummy_select ks.-20: {} `,
 	})
-	expectResult(t, "sel.StreamExecute", result, nil)
+	expectResult(t, "sel.StreamExecute", result, &sqltypes.Result{})
 }
 
 func TestINUnique(t *testing.T) {
@@ -803,7 +808,7 @@ func TestRouteGetFields(t *testing.T) {
 		`Execute select from, toc from lkp where from in ::from from: type:TUPLE values:{type:INT64 value:"1"} false`,
 		`ResolveDestinations ks [type:INT64 value:"1"] Destinations:DestinationNone()`,
 		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
-		`ExecuteMultiShard ks.-20: dummy_select_field {} false false`,
+		`StreamExecuteMulti dummy_select ks.-20: {} `,
 	})
 	expectResult(t, "sel.StreamExecute", result, &sqltypes.Result{})
 }

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -119,6 +119,14 @@ type RoutingParameters struct {
 	Values []evalengine.Expr
 }
 
+func (code Opcode) IsSingleShard() bool {
+	switch code {
+	case Unsharded, DBA, Next, EqualUnique, Reference:
+		return true
+	}
+	return false
+}
+
 func (rp *RoutingParameters) findRoute(vcursor VCursor, bindVars map[string]*querypb.BindVariable) ([]*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, error) {
 	switch rp.Opcode {
 	case None:

--- a/go/vt/vtgate/planbuilder/gen4_planner.go
+++ b/go/vt/vtgate/planbuilder/gen4_planner.go
@@ -96,6 +96,10 @@ func gen4SelectStmtPlanner(
 
 	primitive := plan.Primitive()
 	if rb, ok := primitive.(*engine.Route); ok {
+		// this is done because engine.Route doesn't handle the empty result well
+		// if it doesn't find a shard to send the query to.
+		// All other engine primitives can handle this, so we only need it when
+		// Route is the last (and only) instruction before the user sees a result
 		rb.NoRoutesSpecialHandling = true
 	}
 

--- a/go/vt/vtgate/planbuilder/gen4_planner.go
+++ b/go/vt/vtgate/planbuilder/gen4_planner.go
@@ -93,7 +93,13 @@ func gen4SelectStmtPlanner(
 			return primitive, nil
 		}
 	}
-	return plan.Primitive(), nil
+
+	primitive := plan.Primitive()
+	if rb, ok := primitive.(*engine.Route); ok {
+		rb.NoRoutesSpecialHandling = true
+	}
+
+	return primitive, nil
 }
 
 func gen4planSQLCalcFoundRows(vschema plancontext.VSchema, sel *sqlparser.Select, query string, reservedVars *sqlparser.ReservedVars) (engine.Primitive, error) {

--- a/go/vt/vtgate/planbuilder/routeGen4.go
+++ b/go/vt/vtgate/planbuilder/routeGen4.go
@@ -158,11 +158,7 @@ func (rb *routeGen4) Inputs() []logicalPlan {
 }
 
 func (rb *routeGen4) isSingleShard() bool {
-	switch rb.eroute.Opcode {
-	case engine.Unsharded, engine.DBA, engine.Next, engine.EqualUnique, engine.Reference:
-		return true
-	}
-	return false
+	return rb.eroute.Opcode.IsSingleShard()
 }
 
 func (rb *routeGen4) unionCanMerge(other *routeGen4, distinct bool) bool {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -3324,3 +3324,139 @@ Gen4 plan same as above
   }
 }
 Gen4 plan same as above
+
+# Reference with a subquery which can be merged
+"select exists(select id from user where id = 4)"
+{
+  "QueryType": "SELECT",
+  "Original": "select exists(select id from user where id = 4)",
+  "Instructions": {
+    "OperatorType": "Subquery",
+    "Variant": "PulloutExists",
+    "PulloutVars": [
+      "__sq_has_values1",
+      "__sq1"
+    ],
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1",
+        "Query": "select id from `user` where id = 4",
+        "Table": "`user`",
+        "Values": [
+          "INT64(4)"
+        ],
+        "Vindex": "user_index"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select :__sq_has_values1 from dual where 1 != 1",
+        "Query": "select :__sq_has_values1 from dual",
+        "Table": "dual"
+      }
+    ]
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select exists(select id from user where id = 4)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select exists (select id from `user` where 1 != 1) from dual where 1 != 1",
+    "Query": "select exists (select id from `user` where id = 4) from dual",
+    "Table": "dual",
+    "Values": [
+      "INT64(4)"
+    ],
+    "Vindex": "user_index"
+  }
+}
+
+# Reference with a subquery which cannot be merged
+"select exists(select * from user)"
+{
+  "QueryType": "SELECT",
+  "Original": "select exists(select * from user)",
+  "Instructions": {
+    "OperatorType": "Subquery",
+    "Variant": "PulloutExists",
+    "PulloutVars": [
+      "__sq_has_values1",
+      "__sq1"
+    ],
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select * from `user` where 1 != 1",
+        "Query": "select * from `user`",
+        "Table": "`user`"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select :__sq_has_values1 from dual where 1 != 1",
+        "Query": "select :__sq_has_values1 from dual",
+        "Table": "dual"
+      }
+    ]
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select exists(select * from user)",
+  "Instructions": {
+    "OperatorType": "Subquery",
+    "Variant": "PulloutExists",
+    "PulloutVars": [
+      "__sq_has_values1"
+    ],
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select * from `user` where 1 != 1",
+        "Query": "select * from `user`",
+        "Table": "`user`"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select :__sq_has_values1 from dual where 1 != 1",
+        "Query": "select :__sq_has_values1 from dual",
+        "Table": "dual"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
Queries that follow the following pattern - 
```mysql
select exists(select * from foo where some_field=some_value)
```

The table `foo` would has a lookup vindex on `some_field` and there are no matching rows for `some_value`. What Vitess would do when no shards could be found to route to is to return an empty result. This is correct for most cases, but not always. The query above would return an empty result instead of a `0`.

## Related Issue(s)
- Fixes #10144 

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported YES
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
