### PR TITLE
fix: handle reserved connection reset when tx killer has locked the connection

### DIFF
--- a/go/vt/vterrors/constants.go
+++ b/go/vt/vterrors/constants.go
@@ -41,3 +41,9 @@ const (
 	// PrimaryVindexNotSet is the error message to be used when there is no primary vindex found on a table
 	PrimaryVindexNotSet = "table '%s' does not have a primary vindex"
 )
+
+// TxKillerRollback purpose when acquire lock on connection for rolling back transaction.
+const TxKillerRollback = "in use: for tx killer rollback"
+
+// TxClosed regex for connection closed
+var TxClosed = regexp.MustCompile("transaction ([a-z0-9:]+) (?:ended|not found|in use: for tx killer rollback)")

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"regexp"
 	"sync"
 	"time"
 
@@ -709,8 +708,6 @@ func (stc *ScatterConn) ExecuteLock(
 	return qr, err
 }
 
-var txClosed = regexp.MustCompile("transaction ([a-z0-9:]+) (?:ended|not found)")
-
 func wasConnectionClosed(err error) bool {
 	sqlErr := mysql.NewSQLErrorFromError(err).(*mysql.SQLError)
 	message := sqlErr.Error()
@@ -719,7 +716,7 @@ func wasConnectionClosed(err error) bool {
 	case mysql.CRServerGone, mysql.CRServerLost:
 		return true
 	case mysql.ERQueryInterrupted:
-		return txClosed.MatchString(message)
+		return vterrors.TxClosed.MatchString(message)
 	default:
 		return false
 	}

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -122,7 +122,7 @@ func (tp *TxPool) Shutdown(ctx context.Context) {
 
 func (tp *TxPool) transactionKiller() {
 	defer tp.env.LogError()
-	for _, conn := range tp.scp.GetOutdated(tp.Timeout(), "for tx killer rollback") {
+	for _, conn := range tp.scp.GetOutdated(tp.Timeout(), vterrors.TxKillerRollback) {
 		log.Warningf("killing transaction (exceeded timeout: %v): %s", tp.Timeout(), conn.String(tp.env.Config().SanitizeLogMessages))
 		switch {
 		case conn.IsTainted():


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes an issue with reserved connection session reset when the reserved connection is blocked by connection_killer for being idle for 'X' allocated time. As the connection is now getting closed, the query received on that session should be able to ask for a new reserved connection to execute the query on the vttablet.

## Checklist

-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
