### PR TITLE
schemadiff: EntityDiff has a 'Entities() (from Entity, to Entity)' function

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -27,13 +27,15 @@ import (
 
 func TestDiffTables(t *testing.T) {
 	tt := []struct {
-		name    string
-		from    string
-		to      string
-		diff    string
-		cdiff   string
-		action  string
-		isError bool
+		name     string
+		from     string
+		to       string
+		diff     string
+		cdiff    string
+		fromName string
+		toName   string
+		action   string
+		isError  bool
 	}{
 		{
 			name: "identical",
@@ -41,12 +43,14 @@ func TestDiffTables(t *testing.T) {
 			to:   "create table t(id int primary key)",
 		},
 		{
-			name:   "change of columns",
-			from:   "create table t(id int primary key)",
-			to:     "create table t(id int primary key, i int)",
-			diff:   "alter table t add column i int",
-			cdiff:  "ALTER TABLE `t` ADD COLUMN `i` int",
-			action: "alter",
+			name:     "change of columns",
+			from:     "create table t(id int primary key)",
+			to:       "create table t(id int primary key, i int)",
+			diff:     "alter table t add column i int",
+			cdiff:    "ALTER TABLE `t` ADD COLUMN `i` int",
+			action:   "alter",
+			fromName: "t",
+			toName:   "t",
 		},
 		{
 			name:   "create",
@@ -54,13 +58,15 @@ func TestDiffTables(t *testing.T) {
 			diff:   "create table t (\n\tid int primary key\n)",
 			cdiff:  "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY\n)",
 			action: "create",
+			toName: "t",
 		},
 		{
-			name:   "drop",
-			from:   "create table t(id int primary key)",
-			diff:   "drop table t",
-			cdiff:  "DROP TABLE `t`",
-			action: "drop",
+			name:     "drop",
+			from:     "create table t(id int primary key)",
+			diff:     "drop table t",
+			cdiff:    "DROP TABLE `t`",
+			action:   "drop",
+			fromName: "t",
 		},
 		{
 			name: "none",
@@ -116,6 +122,14 @@ func TestDiffTables(t *testing.T) {
 					// validate we can parse back the statement
 					_, err = sqlparser.Parse(diff)
 					assert.NoError(t, err)
+
+					eFrom, eTo := d.Entities()
+					if ts.fromName != "" {
+						assert.Equal(t, ts.fromName, eFrom.Name())
+					}
+					if ts.toName != "" {
+						assert.Equal(t, ts.toName, eTo.Name())
+					}
 				}
 				{
 					canonicalDiff := d.CanonicalStatementString()
@@ -141,13 +155,15 @@ func TestDiffTables(t *testing.T) {
 
 func TestDiffViews(t *testing.T) {
 	tt := []struct {
-		name    string
-		from    string
-		to      string
-		diff    string
-		cdiff   string
-		action  string
-		isError bool
+		name     string
+		from     string
+		to       string
+		diff     string
+		cdiff    string
+		fromName string
+		toName   string
+		action   string
+		isError  bool
 	}{
 		{
 			name: "identical",
@@ -155,12 +171,14 @@ func TestDiffViews(t *testing.T) {
 			to:   "create view v1 as select a, b, c from t",
 		},
 		{
-			name:   "change of column list, qualifiers",
-			from:   "create view v1 (col1, `col2`, `col3`) as select `a`, `b`, c from t",
-			to:     "create view v1 (`col1`, col2, colother) as select a, b, `c` from t",
-			diff:   "alter view v1(col1, col2, colother) as select a, b, c from t",
-			cdiff:  "ALTER VIEW `v1`(`col1`, `col2`, `colother`) AS SELECT `a`, `b`, `c` FROM `t`",
-			action: "alter",
+			name:     "change of column list, qualifiers",
+			from:     "create view v1 (col1, `col2`, `col3`) as select `a`, `b`, c from t",
+			to:       "create view v1 (`col1`, col2, colother) as select a, b, `c` from t",
+			diff:     "alter view v1(col1, col2, colother) as select a, b, c from t",
+			cdiff:    "ALTER VIEW `v1`(`col1`, `col2`, `colother`) AS SELECT `a`, `b`, `c` FROM `t`",
+			action:   "alter",
+			fromName: "v1",
+			toName:   "v1",
 		},
 		{
 			name:   "create",
@@ -168,13 +186,15 @@ func TestDiffViews(t *testing.T) {
 			diff:   "create view v1 as select a, b, c from t",
 			cdiff:  "CREATE VIEW `v1` AS SELECT `a`, `b`, `c` FROM `t`",
 			action: "create",
+			toName: "v1",
 		},
 		{
-			name:   "drop",
-			from:   "create view v1 as select a, b, c from t",
-			diff:   "drop view v1",
-			cdiff:  "DROP VIEW `v1`",
-			action: "drop",
+			name:     "drop",
+			from:     "create view v1 as select a, b, c from t",
+			diff:     "drop view v1",
+			cdiff:    "DROP VIEW `v1`",
+			action:   "drop",
+			fromName: "v1",
 		},
 		{
 			name: "none",
@@ -231,6 +251,13 @@ func TestDiffViews(t *testing.T) {
 					_, err = sqlparser.Parse(diff)
 					assert.NoError(t, err)
 
+					eFrom, eTo := d.Entities()
+					if ts.fromName != "" {
+						assert.Equal(t, ts.fromName, eFrom.Name())
+					}
+					if ts.toName != "" {
+						assert.Equal(t, ts.toName, eTo.Name())
+					}
 				}
 				{
 					canonicalDiff := d.CanonicalStatementString()

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -30,6 +30,8 @@ func TestCreateTableDiff(t *testing.T) {
 		name     string
 		from     string
 		to       string
+		fromName string
+		toName   string
 		diff     string
 		cdiff    string
 		isError  bool
@@ -87,11 +89,13 @@ func TestCreateTableDiff(t *testing.T) {
 			cdiff: "ALTER TABLE `t1` ADD COLUMN `i` int NOT NULL DEFAULT 0",
 		},
 		{
-			name:  "dropped column",
-			from:  "create table t1 (id int primary key, `i` int not null default 0)",
-			to:    "create table t2 (`id` int primary key)",
-			diff:  "alter table t1 drop column i",
-			cdiff: "ALTER TABLE `t1` DROP COLUMN `i`",
+			name:     "dropped column",
+			from:     "create table t1 (id int primary key, `i` int not null default 0)",
+			to:       "create table t2 (`id` int primary key)",
+			diff:     "alter table t1 drop column i",
+			cdiff:    "ALTER TABLE `t1` DROP COLUMN `i`",
+			fromName: "t1",
+			toName:   "t2",
 		},
 		{
 			name:  "modified column",
@@ -645,6 +649,14 @@ func TestCreateTableDiff(t *testing.T) {
 					// validate we can parse back the statement
 					_, err := sqlparser.Parse(diff)
 					assert.NoError(t, err)
+
+					eFrom, eTo := alter.Entities()
+					if ts.fromName != "" {
+						assert.Equal(t, ts.fromName, eFrom.Name())
+					}
+					if ts.toName != "" {
+						assert.Equal(t, ts.toName, eTo.Name())
+					}
 				}
 				{
 					cdiff := alter.CanonicalStatementString()
@@ -652,6 +664,7 @@ func TestCreateTableDiff(t *testing.T) {
 					_, err := sqlparser.Parse(cdiff)
 					assert.NoError(t, err)
 				}
+
 			}
 		})
 	}

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -56,6 +56,8 @@ type Entity interface {
 type EntityDiff interface {
 	// IsEmpty returns true when the two entities are considered identical
 	IsEmpty() bool
+	// Entities returns the two diffed entitied, aka "from" and "to"
+	Entities() (from Entity, to Entity)
 	// Statement returns a valid SQL statement that applies the diff, e.g. an ALTER TABLE ...
 	// It returns nil if the diff is empty
 	Statement() sqlparser.Statement


### PR DESCRIPTION

## Description

`Entities() (from Entity, to Entity)` return from "from" and "to" entities for the diff.
- When the diff is e.g. a `AlterTableEntityDiff`, this returns both the "from"'s CreateTable and the "to"s CreateTable.
- if the diff is a `CreateTableEntityDiff` then there's only a "to" ; "from" is `nil`.
- if the diff is a `DropTableEntityDiff` then there's only a "from" ; "to" is `nil`.

this is symmetrical in View diffs.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

cc @dbussink 