### PR TITLE
[vtadmin-web] Add `PORT=14201` to 'npm run local' to avoid CORS errors in dev mode

### DIFF
--- a/web/vtadmin/package.json
+++ b/web/vtadmin/package.json
@@ -40,7 +40,7 @@
     "web-vitals": "^0.2.4"
   },
   "scripts": {
-    "local": "REACT_APP_VTADMIN_API_ADDRESS=\"http://localhost:14200\" REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS=\"true\" react-scripts start",
+    "local": "REACT_APP_VTADMIN_API_ADDRESS=\"http://localhost:14200\" REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS=\"true\" PORT=14201 react-scripts start",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

In https://github.com/vitessio/vitess/pull/10081 I changed the vtadmin-web port in `./vtadmin-up.sh` from `3000` to `14201`, and updated vtadmin-api's `--http-origin` flag accordingly. 

I did not, however, remember to update the port in this `npm run local` script, which means it was still running on `3000` and then getting CORS errors when configured to request a vtadmin-api started by way of `./vtadmin-up.sh`. 

## Related Issue(s)

This fixes a regression after https://github.com/vitessio/vitess/pull/10081

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A 
