### PR TITLE
Delay sysvars init;  it pulls in collations, which depends on

### DIFF
--- a/go/vt/vtgate/planbuilder/system_variables.go
+++ b/go/vt/vtgate/planbuilder/system_variables.go
@@ -19,20 +19,21 @@ package planbuilder
 import (
 	"fmt"
 
-	"vitess.io/vitess/go/vt/sysvars"
-
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
-
+	"vitess.io/vitess/go/vt/sysvars"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
 func init() {
-	forSettings(sysvars.ReadOnly, buildSetOpReadOnly)
-	forSettings(sysvars.IgnoreThese, buildSetOpIgnore)
-	forSettings(sysvars.UseReservedConn, buildSetOpReservedConn)
-	forSettings(sysvars.CheckAndIgnore, buildSetOpCheckAndIgnore)
-	forSettings(sysvars.NotSupported, buildNotSupported)
-	forSettings(sysvars.VitessAware, buildSetOpVitessAware)
+	servenv.OnInit(func() {
+		forSettings(sysvars.ReadOnly, buildSetOpReadOnly)
+		forSettings(sysvars.IgnoreThese, buildSetOpIgnore)
+		forSettings(sysvars.UseReservedConn, buildSetOpReservedConn)
+		forSettings(sysvars.CheckAndIgnore, buildSetOpCheckAndIgnore)
+		forSettings(sysvars.NotSupported, buildNotSupported)
+		forSettings(sysvars.VitessAware, buildSetOpVitessAware)
+	})
 }
 
 func forSettings(systemVariables []sysvars.SystemVariable, f func(setting) planFunc) {


### PR DESCRIPTION
mysql_server_version flag in servenv already being initialized

This showed up as `vtcombo` ignoring the `-mysql_server_version` flag and always thinking that it was running against 8.0.  This would manifest itself in vtcombo always using `utf8` against MySQL 5.7, even if it was running with `-db_charset utf8mb4`

Signed-off-by: Jacques Grove <aquarapid@gmail.com>

