### PR TITLE
Propagate error from 'updateLocked' to client

### DIFF
--- a/go/test/endtoend/tabletmanager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_test.go
@@ -44,6 +44,7 @@ func TestEnsureDB(t *testing.T) {
 
 	// Make it the primary.
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("TabletExternallyReparented", tablet.Alias)
+	//log.Info(fmt.Sprintf("error: %s", err))
 	require.NoError(t, err)
 
 	// It is still NOT_SERVING because the db is read-only.

--- a/go/test/endtoend/tabletmanager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_test.go
@@ -44,8 +44,7 @@ func TestEnsureDB(t *testing.T) {
 
 	// Make it the primary.
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("TabletExternallyReparented", tablet.Alias)
-	//log.Info(fmt.Sprintf("error: %s", err))
-	require.NoError(t, err)
+	require.EqualError(t, err, "exit status 1")
 
 	// It is still NOT_SERVING because the db is read-only.
 	assert.Equal(t, "NOT_SERVING", tablet.VttabletProcess.GetTabletStatus())

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -223,7 +223,7 @@ func (ts *tmState) ChangeTabletType(ctx context.Context, tabletType topodatapb.T
 	statsTabletTypeCount.Add(s, 1)
 
 	err := ts.updateLocked(ctx)
-	// no need to short circuit. apply all steps and return error in the end.
+	// No need to short circuit. Apply all steps and return error in the end.
 	ts.publishStateLocked(ctx)
 	ts.tm.notifyShardSync()
 	return err
@@ -270,7 +270,7 @@ func (ts *tmState) updateLocked(ctx context.Context) error {
 		if err := ts.tm.QueryServiceControl.SetServingType(ts.tablet.Type, terTime, false, reason); err != nil {
 			errStr := fmt.Sprintf("SetServingType(serving=false) failed: %v", err)
 			log.Errorf(errStr)
-			// no need to short circuit. apply all steps and return error in the end.
+			// No need to short circuit. Apply all steps and return error in the end.
 			returnErr = vterrors.Wrapf(err, errStr)
 		}
 	}
@@ -278,7 +278,7 @@ func (ts *tmState) updateLocked(ctx context.Context) error {
 	if err := ts.applyDenyList(ctx); err != nil {
 		errStr := fmt.Sprintf("Cannot update denied tables rule: %v", err)
 		log.Errorf(errStr)
-		// no need to short circuit. apply all steps and return error in the end.
+		// No need to short circuit. Apply all steps and return error in the end.
 		returnErr = vterrors.Wrapf(err, errStr)
 	}
 

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/vterrors"
 
 	"context"
 
@@ -98,7 +99,7 @@ func (ts *tmState) Open() {
 
 	ts.isOpen = true
 	ts.isOpening = true
-	ts.updateLocked(ts.ctx)
+	_ = ts.updateLocked(ts.ctx)
 	ts.isOpening = false
 	ts.publishStateLocked(ts.ctx)
 }
@@ -167,7 +168,7 @@ func (ts *tmState) RefreshFromTopoInfo(ctx context.Context, shardInfo *topo.Shar
 		}
 	}
 
-	ts.updateLocked(ctx)
+	_ = ts.updateLocked(ctx)
 }
 
 func (ts *tmState) ChangeTabletType(ctx context.Context, tabletType topodatapb.TabletType, action DBAction) error {
@@ -221,10 +222,11 @@ func (ts *tmState) ChangeTabletType(ctx context.Context, tabletType topodatapb.T
 	statsTabletType.Set(s)
 	statsTabletTypeCount.Add(s, 1)
 
-	ts.updateLocked(ctx)
+	err := ts.updateLocked(ctx)
+	// no need to short circuit. apply all steps and return error in the end.
 	ts.publishStateLocked(ctx)
 	ts.tm.notifyShardSync()
-	return nil
+	return err
 }
 
 func (ts *tmState) SetMysqlPort(mport int32) {
@@ -243,13 +245,19 @@ func (ts *tmState) UpdateTablet(update func(tablet *topodatapb.Tablet)) {
 	ts.publishForDisplay()
 }
 
-func (ts *tmState) updateLocked(ctx context.Context) {
+func (ts *tmState) updateLocked(ctx context.Context) error {
 	span, ctx := trace.NewSpan(ctx, "tmState.update")
 	defer span.Finish()
 	ts.publishForDisplay()
-
+	// SetServingType can result in error. Although we have forever retries to fix these transient errors
+	// but, under certain condition these errors are non-transient (see https://github.com/vitessio/vitess/issues/10145).
+	// There is no way to distinguish between retry (transient) and non-retryable errors, therefore we will
+	// always return error from 'SetServingType' and 'applyDenyList' to our client. It is up to them to handle it accordingly.
+	// UpdateLock is called from 'ChangeTableType', 'Open' and 'RefreshFromTopoInfo'. For 'Open' and 'RefreshTopoInfo' we don't need
+	// to propagate error to client hence no changes there but we will propagate error from 'ChangeTableType' to client.
+	var returnErr error
 	if !ts.isOpen {
-		return
+		return fmt.Errorf("TabletManager state is not open")
 	}
 
 	terTime := logutil.ProtoToTime(ts.tablet.PrimaryTermStartTime)
@@ -260,12 +268,18 @@ func (ts *tmState) updateLocked(ctx context.Context) {
 	if reason != "" {
 		log.Infof("Disabling query service: %v", reason)
 		if err := ts.tm.QueryServiceControl.SetServingType(ts.tablet.Type, terTime, false, reason); err != nil {
-			log.Errorf("SetServingType(serving=false) failed: %v", err)
+			errStr := fmt.Sprintf("SetServingType(serving=false) failed: %v", err)
+			log.Errorf(errStr)
+			// no need to short circuit. apply all steps and return error in the end.
+			returnErr = vterrors.Wrapf(err, errStr)
 		}
 	}
 
 	if err := ts.applyDenyList(ctx); err != nil {
-		log.Errorf("Cannot update denied tables rule: %v", err)
+		errStr := fmt.Sprintf("Cannot update denied tables rule: %v", err)
+		log.Errorf(errStr)
+		// no need to short circuit. apply all steps and return error in the end.
+		returnErr = vterrors.Wrapf(err, errStr)
 	}
 
 	ts.tm.replManager.SetTabletType(ts.tablet.Type)
@@ -297,9 +311,13 @@ func (ts *tmState) updateLocked(ctx context.Context) {
 	// Open TabletServer last so that it advertises serving after all other services are up.
 	if reason == "" {
 		if err := ts.tm.QueryServiceControl.SetServingType(ts.tablet.Type, terTime, true, ""); err != nil {
-			log.Errorf("Cannot start query service: %v", err)
+			errStr := fmt.Sprintf("Cannot start query service: %v", err)
+			log.Errorf(errStr)
+			returnErr = vterrors.Wrapf(err, errStr)
 		}
 	}
+
+	return returnErr
 }
 
 func (ts *tmState) populateLocalMetadataLocked() {


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>

## Description

SetServingType can result in error. Although we have forever retries to fix these transient errors but, under certain conditions these errors are non-transient (see https://github.com/vitessio/vitess/issues/10145).
There is no way to distinguish between retry (transient) and non-retryable errors, therefore we will always return error from 'SetServingType' and 'applyDenyList' to our client. It is up to them to handle it accordingly.
UpdateLock is called from 'ChangeTableType', 'Open' and 'RefreshFromTopoInfo'. For 'Open' and 'RefreshTopoInfo' we don't need to propagate error to client hence no changes there but we will propagate error from 'ChangeTableType' to client.
	
This is a bug. I will discuss with team if it needs a back porting or not. I believe No.

## Related Issue(s)

Fixes #10145

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

