### PR TITLE
Add failing diff case for index reordering

### DIFF
--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -283,6 +283,11 @@ func TestCreateTableDiff(t *testing.T) {
 			to:   "create table t2 (`id` int, i int, key i2_idx (`i`, id), key i_idx ( i ), primary key(id) )",
 		},
 		{
+			name: "reordered key, no diff 3",
+			from: "CREATE TABLE `pets` (`id` int, `name` VARCHAR(255), `login` VARCHAR(255), PRIMARY KEY (`id`), KEY (`login`), KEY (`name`) )",
+			to:   "CREATE TABLE `pets` (`id` int, `name` VARCHAR(255), `login` VARCHAR(255), PRIMARY KEY (`id`), KEY (`name`), KEY (`login`) )",
+		},
+		{
 			name:  "reordered key, add key",
 			from:  "create table t1 (`id` int primary key, i int, key i_idx(i), key i2_idx(i, `id`))",
 			to:    "create table t2 (`id` int primary key, i int, key i2_idx (`i`, id), key i_idx3(id), key i_idx ( i ) )",


### PR DESCRIPTION
Add a new test case for index reordering that is currently failing.

This shouldn't generate a diff, but it does but the `ALTER` statement itself is also invalid:

```
alter table pets drop key, add KEY (login)
```

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required