### PR TITLE
Fix for empty results when no shards can be found to route to

### DIFF
--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -94,6 +94,7 @@ func TestSubqueryInINClause(t *testing.T) {
 
 func TestSubqueryInReference(t *testing.T) {
 	defer cluster.PanicHandler(t)
+	utils.SkipIfBinaryIsBelowVersion(t, 14, "vtgate")
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -94,7 +94,7 @@ func TestSubqueryInINClause(t *testing.T) {
 
 func TestSubqueryInReference(t *testing.T) {
 	defer cluster.PanicHandler(t)
-	utils.SkipIfBinaryIsBelowVersion(t, 14, "vtgate")
+	utils.SkipIfBinaryIsBelowVersion(t, 13, "vtgate")
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -119,6 +119,14 @@ type RoutingParameters struct {
 	Values []evalengine.Expr
 }
 
+func (code Opcode) IsSingleShard() bool {
+	switch code {
+	case Unsharded, DBA, Next, EqualUnique, Reference:
+		return true
+	}
+	return false
+}
+
 func (rp *RoutingParameters) findRoute(vcursor VCursor, bindVars map[string]*querypb.BindVariable) ([]*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, error) {
 	switch rp.Opcode {
 	case None:

--- a/go/vt/vtgate/planbuilder/gen4_planner.go
+++ b/go/vt/vtgate/planbuilder/gen4_planner.go
@@ -78,7 +78,17 @@ func gen4Planner(query string, plannerVersion querypb.ExecuteOptions_PlannerVers
 				return primitive, nil
 			}
 		}
-		return plan.Primitive(), nil
+
+		primitive := plan.Primitive()
+		if rb, ok := primitive.(*engine.Route); ok {
+			// this is done because engine.Route doesn't handle the empty result well
+			// if it doesn't find a shard to send the query to.
+			// All other engine primitives can handle this, so we only need it when
+			// Route is the last (and only) instruction before the user sees a result
+			rb.NoRoutesSpecialHandling = true
+		}
+
+		return primitive, nil
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/routeGen4.go
+++ b/go/vt/vtgate/planbuilder/routeGen4.go
@@ -158,11 +158,7 @@ func (rb *routeGen4) Inputs() []logicalPlan {
 }
 
 func (rb *routeGen4) isSingleShard() bool {
-	switch rb.eroute.Opcode {
-	case engine.Unsharded, engine.DBA, engine.Next, engine.EqualUnique, engine.Reference:
-		return true
-	}
-	return false
+	return rb.eroute.Opcode.IsSingleShard()
 }
 
 func (rb *routeGen4) unionCanMerge(other *routeGen4, distinct bool) bool {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -3058,3 +3058,139 @@ Gen4 plan same as above
   }
 }
 Gen4 plan same as above
+
+# Reference with a subquery which can be merged
+"select exists(select id from user where id = 4)"
+{
+  "QueryType": "SELECT",
+  "Original": "select exists(select id from user where id = 4)",
+  "Instructions": {
+    "OperatorType": "Subquery",
+    "Variant": "PulloutExists",
+    "PulloutVars": [
+      "__sq_has_values1",
+      "__sq1"
+    ],
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1",
+        "Query": "select id from `user` where id = 4",
+        "Table": "`user`",
+        "Values": [
+          "INT64(4)"
+        ],
+        "Vindex": "user_index"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select :__sq_has_values1 from dual where 1 != 1",
+        "Query": "select :__sq_has_values1 from dual",
+        "Table": "dual"
+      }
+    ]
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select exists(select id from user where id = 4)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select exists (select id from `user` where 1 != 1) from dual where 1 != 1",
+    "Query": "select exists (select id from `user` where id = 4) from dual",
+    "Table": "dual",
+    "Values": [
+      "INT64(4)"
+    ],
+    "Vindex": "user_index"
+  }
+}
+
+# Reference with a subquery which cannot be merged
+"select exists(select * from user)"
+{
+  "QueryType": "SELECT",
+  "Original": "select exists(select * from user)",
+  "Instructions": {
+    "OperatorType": "Subquery",
+    "Variant": "PulloutExists",
+    "PulloutVars": [
+      "__sq_has_values1",
+      "__sq1"
+    ],
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select * from `user` where 1 != 1",
+        "Query": "select * from `user`",
+        "Table": "`user`"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select :__sq_has_values1 from dual where 1 != 1",
+        "Query": "select :__sq_has_values1 from dual",
+        "Table": "dual"
+      }
+    ]
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select exists(select * from user)",
+  "Instructions": {
+    "OperatorType": "Subquery",
+    "Variant": "PulloutExists",
+    "PulloutVars": [
+      "__sq_has_values1"
+    ],
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select * from `user` where 1 != 1",
+        "Query": "select * from `user`",
+        "Table": "`user`"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select :__sq_has_values1 from dual where 1 != 1",
+        "Query": "select :__sq_has_values1 from dual",
+        "Table": "dual"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
_This is a backport_

Queries that follow the following pattern - 
```mysql
select exists(select * from foo where some_field=some_value)
```

The table `foo` would has a lookup vindex on `some_field` and there are no matching rows for `some_value`. What Vitess would do when no shards could be found to route to is to return an empty result. This is correct for most cases, but not always. The query above would return an empty result instead of a `0`.

## Related Issue(s)
Backport of #10152
Fixes #10144
