### PR TITLE
schemadiff: normalize() table. Set names to all keys

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -17,6 +17,7 @@ limitations under the License.
 package schemadiff
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -76,7 +77,7 @@ func (d *CreateTableEntityDiff) IsEmpty() bool {
 
 // IsEmpty implements EntityDiff
 func (d *CreateTableEntityDiff) Entities() (from Entity, to Entity) {
-	return nil, &CreateTableEntity{CreateTable: *d.createTable}
+	return nil, NewCreateTableEntity(d.createTable)
 }
 
 // Statement implements EntityDiff
@@ -149,7 +150,38 @@ type CreateTableEntity struct {
 }
 
 func NewCreateTableEntity(c *sqlparser.CreateTable) *CreateTableEntity {
-	return &CreateTableEntity{CreateTable: *c}
+	entity := &CreateTableEntity{CreateTable: *c}
+	entity.normalize()
+	return entity
+}
+
+// normalize normalizes table definition:
+// - setting names to all keys
+func (c *CreateTableEntity) normalize() {
+	// let's verify all keys have names
+	keyNameExists := map[string]bool{}
+	// first, we iterate and take note for all keys that do aleady have names
+	for _, key := range c.CreateTable.TableSpec.Indexes {
+		if name := key.Info.Name.String(); name != "" {
+			keyNameExists[name] = true
+		}
+	}
+	// now, let's look at keys that do not have names, and assign them new names
+	for _, key := range c.CreateTable.TableSpec.Indexes {
+		if name := key.Info.Name.String(); name == "" {
+			// we know there must be at least one column covered by this key
+			colName := key.Columns[0].Column.String()
+			// like MySQL, we first try to call our index by the name of the first column:
+			suggestedKeyName := colName
+			// now let's see if that name is taken; if it is, enumerate new news until we find a free name
+			for enumerate := 2; keyNameExists[suggestedKeyName] == true; enumerate++ {
+				suggestedKeyName = fmt.Sprintf("%s_%d", colName, enumerate)
+			}
+			// OK we found a free slot!
+			key.Info.Name = sqlparser.NewColIdent(suggestedKeyName)
+			keyNameExists[suggestedKeyName] = true
+		}
+	}
 }
 
 // Name implements Entity interface

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -174,7 +174,7 @@ func (c *CreateTableEntity) normalize() {
 			// like MySQL, we first try to call our index by the name of the first column:
 			suggestedKeyName := colName
 			// now let's see if that name is taken; if it is, enumerate new news until we find a free name
-			for enumerate := 2; keyNameExists[suggestedKeyName] == true; enumerate++ {
+			for enumerate := 2; keyNameExists[suggestedKeyName]; enumerate++ {
 				suggestedKeyName = fmt.Sprintf("%s_%d", colName, enumerate)
 			}
 			// OK we found a free slot!

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -224,6 +224,27 @@ func TestCreateTableDiff(t *testing.T) {
 			cdiff: "ALTER TABLE `t1` ADD KEY `i_idx` (`i`)",
 		},
 		{
+			name:  "added key without name",
+			from:  "create table t1 (`id` int primary key, i int)",
+			to:    "create table t2 (id int primary key, `i` int, key (i))",
+			diff:  "alter table t1 add key i (i)",
+			cdiff: "ALTER TABLE `t1` ADD KEY `i` (`i`)",
+		},
+		{
+			name:  "added key without name, conflicting name",
+			from:  "create table t1 (`id` int primary key, i int, key i(i))",
+			to:    "create table t2 (id int primary key, `i` int, key i(i), key (i))",
+			diff:  "alter table t1 add key i_2 (i)",
+			cdiff: "ALTER TABLE `t1` ADD KEY `i_2` (`i`)",
+		},
+		{
+			name:  "added key without name, conflicting name 2",
+			from:  "create table t1 (`id` int primary key, i int, key i(i), key i_2(i))",
+			to:    "create table t2 (id int primary key, `i` int, key i(i), key i_2(i), key (i))",
+			diff:  "alter table t1 add key i_3 (i)",
+			cdiff: "ALTER TABLE `t1` ADD KEY `i_3` (`i`)",
+		},
+		{
 			name:  "added column and key",
 			from:  "create table t1 (`id` int primary key)",
 			to:    "create table t2 (id int primary key, `i` int, key `i_idx` (i))",
@@ -286,6 +307,11 @@ func TestCreateTableDiff(t *testing.T) {
 			name: "reordered key, no diff 3",
 			from: "CREATE TABLE `pets` (`id` int, `name` VARCHAR(255), `login` VARCHAR(255), PRIMARY KEY (`id`), KEY (`login`), KEY (`name`) )",
 			to:   "CREATE TABLE `pets` (`id` int, `name` VARCHAR(255), `login` VARCHAR(255), PRIMARY KEY (`id`), KEY (`name`), KEY (`login`) )",
+		},
+		{
+			name: "reordered key, no diff 4",
+			from: "CREATE TABLE `pets` (`id` int, `name` VARCHAR(255), `login` VARCHAR(255), PRIMARY KEY (`id`), KEY login (login, name), KEY (`login`), KEY (`name`) )",
+			to:   "CREATE TABLE `pets` (`id` int, `name` VARCHAR(255), `login` VARCHAR(255), PRIMARY KEY (`id`), KEY (`name`), KEY (`login`), KEY login (login, name) )",
 		},
 		{
 			name:  "reordered key, add key",

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -283,6 +283,11 @@ func TestCreateTableDiff(t *testing.T) {
 			to:   "create table t2 (`id` int, i int, key i2_idx (`i`, id), key i_idx ( i ), primary key(id) )",
 		},
 		{
+			name: "reordered key, no diff 3",
+			from: "CREATE TABLE `pets` (`id` int, `name` VARCHAR(255), `login` VARCHAR(255), PRIMARY KEY (`id`), KEY (`login`), KEY (`name`) )",
+			to:   "CREATE TABLE `pets` (`id` int, `name` VARCHAR(255), `login` VARCHAR(255), PRIMARY KEY (`id`), KEY (`name`), KEY (`login`) )",
+		},
+		{
 			name:  "reordered key, add key",
 			from:  "create table t1 (`id` int primary key, i int, key i_idx(i), key i2_idx(i, `id`))",
 			to:    "create table t2 (`id` int primary key, i int, key i2_idx (`i`, id), key i_idx3(id), key i_idx ( i ) )",


### PR DESCRIPTION
`NewCreateTableEntity` now normalizes a table upon creation, modifying its `CreateStatement` into a canonical form.

This PR is a first in several iterations. This PR ensures all keys are named. For example, in the following statement:

```sql
create table t2 (id int primary key, i int, key (i))
```
the key over `i` is not named.
`normalize()` will set a name to the key. The name is chosen in similar way to MySQL's algorithm:

- Try the name of first column covered by the key, `i` in our example
- If that name is taken, try `i_2`
- If that name is taken, try `i_3`
- etc.

unit tests added to both validate and explain the logic.

Note that normalization edits the `CreateTable` statement in-place.