### PR TITLE
Temp: Pin XtraBackup version used at 2.4.24 for 5.7 tests

### DIFF
--- a/.github/docker/cluster_test_12/Dockerfile
+++ b/.github/docker/cluster_test_12/Dockerfile
@@ -11,14 +11,6 @@ USER root
 RUN rm -rf /vt/src/vitess.io/vitess/*
 COPY . /vt/src/vitess.io/vitess
 
-# install XtraBackup
-RUN wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-RUN apt-get update
-RUN apt-get install -y gnupg2
-RUN dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-RUN apt-get update
-RUN apt-get install -y percona-xtrabackup-24
-
 # Set the working directory
 WORKDIR /vt/src/vitess.io/vitess
 

--- a/.github/docker/cluster_test_18/Dockerfile
+++ b/.github/docker/cluster_test_18/Dockerfile
@@ -11,14 +11,6 @@ USER root
 RUN rm -rf /vt/src/vitess.io/vitess/*
 COPY . /vt/src/vitess.io/vitess
 
-# install XtraBackup
-RUN wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-RUN apt-get update
-RUN apt-get install -y gnupg2
-RUN dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-RUN apt-get update
-RUN apt-get install -y percona-xtrabackup-24
-
 # Set the working directory
 WORKDIR /vt/src/vitess.io/vitess
 

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -32,6 +32,7 @@ jobs:
               - 'config/**'
               - '.github/docker/**'
               - 'bootstrap.sh'
+              - '.github/workflows/**'
 
       - name: Build Docker Image
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -32,6 +32,7 @@ jobs:
               - 'config/**'
               - '.github/docker/**'
               - 'bootstrap.sh'
+              - '.github/workflows/**'
 
       - name: Build Docker Image
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -80,10 +80,10 @@ jobs:
         sudo apt-get install -y gnupg2
         sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          sudo apt install -y "./${debfile}"
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
         else
           sudo apt-get install -y percona-xtrabackup-24
         fi

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -8,14 +8,14 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  LAUNCHABLE_WORKSPACE: "vitess-app"
+  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
+
   # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
+  # If this is NOT set then the latest version available will be used.
   XTRABACKUP_VERSION: "2.4.24-1"
-  LAUNCHABLE_WORKSPACE: "vitess-app"
-  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
 jobs:
   build:

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -82,10 +82,9 @@ jobs:
         if [[ -n ${XTRABACKUP_VERSION} ]]; then
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
           wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          sudo dpkg -i "${debfile}"
-          sudo apt --fix-broken install
+          sudo apt install -y "./${debfile}"
         else
-          sudo apt-get install percona-xtrabackup-24
+          sudo apt-get install -y percona-xtrabackup-24
         fi
 
     - name: Setup launchable dependencies

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -77,7 +77,7 @@ jobs:
 
         wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
         if [[ -n ${XTRABACKUP_VERSION} ]]; then
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -83,6 +83,7 @@ jobs:
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
           wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
           sudo dpkg -i "${debfile}"
+          sudo apt --fix-broken install
         else
           sudo apt-get install percona-xtrabackup-24
         fi

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -82,7 +82,7 @@ jobs:
         if [[ -n ${XTRABACKUP_VERSION} ]]; then
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
           wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
+          sudo dpkg -i "${debfile}"
         else
           sudo apt-get install percona-xtrabackup-24
         fi

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Installing zookeeper and consul
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Installing zookeeper and consul
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -36,6 +36,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -78,12 +78,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
+++ b/.github/workflows/cluster_endtoend_shardedrecovery_stress_verticalsplit_heavy.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Installing zookeeper and consul
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Installing zookeeper and consul
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -36,6 +36,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -78,12 +78,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
@@ -73,18 +74,6 @@ jobs:
 
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
-
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Installing zookeeper and consul
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Installing zookeeper and consul
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -36,6 +36,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc_8.0.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_8.0.yml
@@ -78,12 +78,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -8,12 +8,6 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
-  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -74,18 +74,6 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
-        sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
-        else
-          sudo apt-get install percona-xtrabackup-24
-        fi
-
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
+++ b/.github/workflows/cluster_endtoend_worker_vault_heavy.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -80,10 +80,10 @@ jobs:
         sudo apt-get install -y gnupg2
         sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          sudo apt install -y "./${debfile}"
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
         else
           sudo apt-get install -y percona-xtrabackup-24
         fi

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -8,14 +8,14 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  LAUNCHABLE_WORKSPACE: "vitess-app"
+  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
+
   # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
+  # If this is NOT set then the latest version available will be used.
   XTRABACKUP_VERSION: "2.4.24-1"
-  LAUNCHABLE_WORKSPACE: "vitess-app"
-  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
 jobs:
   build:

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -8,10 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -82,10 +82,9 @@ jobs:
         if [[ -n ${XTRABACKUP_VERSION} ]]; then
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
           wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          sudo dpkg -i "${debfile}"
-          sudo apt --fix-broken install
+          sudo apt install -y "./${debfile}"
         else
-          sudo apt-get install percona-xtrabackup-24
+          sudo apt-get install -y percona-xtrabackup-24
         fi
 
     - name: Setup launchable dependencies

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -77,7 +77,7 @@ jobs:
 
         wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
         if [[ -n ${XTRABACKUP_VERSION} ]]; then
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -41,6 +41,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -83,6 +83,7 @@ jobs:
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
           wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
           sudo dpkg -i "${debfile}"
+          sudo apt --fix-broken install
         else
           sudo apt-get install percona-xtrabackup-24
         fi

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -8,6 +8,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
@@ -69,11 +74,17 @@ jobs:
         # install JUnit report formatter
         go install github.com/jstemmer/go-junit-report@latest
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
     - name: Setup launchable dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -82,7 +82,7 @@ jobs:
         if [[ -n ${XTRABACKUP_VERSION} ]]; then
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
           wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
+          sudo dpkg -i "${debfile}"
         else
           sudo apt-get install percona-xtrabackup-24
         fi

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -30,6 +30,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -30,6 +30,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -30,6 +30,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -30,6 +30,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -114,11 +114,13 @@ var (
 		"12",
 		"18",
 	}
-	clusterDockerList = []string{}
-	// TODO: currently some percona tools including xtrabackup are installed on all clusters, we can possibly optimize
-	// this by only installing them in the required clusters
-	clustersRequiringXtraBackup = append(clusterList, clusterSelfHostedList...)
-	clustersRequiringMakeTools  = []string{
+	clusterDockerList           = []string{}
+	clustersRequiringXtraBackup = []string{
+		"20",
+		"xb_recovery",
+		"vtctlbackup_sharded_clustertest_heavy",
+	}
+	clustersRequiringMakeTools = []string{
 		"18",
 		"24",
 		"vtgate_topo_consul",

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -118,7 +118,6 @@ var (
 	clustersRequiringXtraBackup = []string{
 		"20",
 		"xb_recovery",
-		"vtctlbackup_sharded_clustertest_heavy",
 	}
 	clustersRequiringMakeTools = []string{
 		"18",

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -39,6 +39,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -80,10 +80,10 @@ jobs:
         sudo apt-get install -y gnupg2
         sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        if [[ -n ${XTRABACKUP_VERSION} ]]; then
-          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
-          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          sudo apt install -y "./${debfile}"
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
         else
           sudo apt-get install -y percona-xtrabackup-24
         fi

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -6,10 +6,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
-  # This is used if we need to pin the xtrabackup version used in the tests.
+  # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used.
+  # If this is NOT set then the latest version available will be used IF
+  # needed (see the InstallXtraBackup templating variable).
   XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{`{{ github.event.pull_request.head.sha }}`}}"

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -6,6 +6,11 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  # This is used if we need to pin the xtrabackup version used in the tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
   LAUNCHABLE_WORKSPACE: "vitess-app"
   GITHUB_PR_HEAD_SHA: "${{`{{ github.event.pull_request.head.sha }}`}}"
 
@@ -69,11 +74,17 @@ jobs:
 
         {{if .InstallXtraBackup}}
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n ${XTRABACKUP_VERSION} ]]; then
+          debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
+          dpkg -i "${debfile}"
+        else
+          sudo apt-get install percona-xtrabackup-24
+        fi
 
         {{end}}
 

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -77,7 +77,7 @@ jobs:
 
         wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo "dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb"
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
         if [[ -n ${XTRABACKUP_VERSION} ]]; then
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -6,14 +6,15 @@ concurrency:
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"
+  LAUNCHABLE_WORKSPACE: "vitess-app"
+  GITHUB_PR_HEAD_SHA: "${{`{{ github.event.pull_request.head.sha }}`}}"
+{{if .InstallXtraBackup}}
   # This is used if we need to pin the xtrabackup version used in tests.
   # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
   #   https://jira.percona.com/browse/PXB-2756
-  # If this is NOT set then the latest version available will be used IF
-  # needed (see the InstallXtraBackup templating variable).
+  # If this is NOT set then the latest version available will be used.
   XTRABACKUP_VERSION: "2.4.24-1"
-  LAUNCHABLE_WORKSPACE: "vitess-app"
-  GITHUB_PR_HEAD_SHA: "${{`{{ github.event.pull_request.head.sha }}`}}"
+{{end}}
 
 jobs:
   build:

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -83,6 +83,7 @@ jobs:
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
           wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
           sudo dpkg -i "${debfile}"
+          sudo apt --fix-broken install
         else
           sudo apt-get install percona-xtrabackup-24
         fi

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -82,10 +82,9 @@ jobs:
         if [[ -n ${XTRABACKUP_VERSION} ]]; then
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
           wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          sudo dpkg -i "${debfile}"
-          sudo apt --fix-broken install
+          sudo apt install -y "./${debfile}"
         else
-          sudo apt-get install percona-xtrabackup-24
+          sudo apt-get install -y percona-xtrabackup-24
         fi
 
         {{end}}

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -82,7 +82,7 @@ jobs:
         if [[ -n ${XTRABACKUP_VERSION} ]]; then
           debfile="percona-xtrabackup-24_${XTRABACKUP_VERSION}.$(lsb_release -sc)_amd64.deb"
           wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/${debfile}"
-          dpkg -i "${debfile}"
+          sudo dpkg -i "${debfile}"
         else
           sudo apt-get install percona-xtrabackup-24
         fi

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -26,6 +26,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_mysql80.tpl
+++ b/test/templates/cluster_endtoend_test_mysql80.tpl
@@ -34,6 +34,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -30,6 +30,7 @@ jobs:
               - 'config/**'
               - '.github/docker/**'
               - 'bootstrap.sh'
+              - '.github/workflows/**'
 
       - name: Build Docker Image
         if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -28,6 +28,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
       if: steps.changes.outputs.unit_tests == 'true'

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -28,6 +28,7 @@ jobs:
               - 'tools/**'
               - 'config/**'
               - 'bootstrap.sh'
+              - '.github/workflows/**'
 
       - name: Build Docker Image
         if: steps.changes.outputs.unit_tests == 'true'


### PR DESCRIPTION
## Description

⚠️ **Note:** pinning the version is *_temporary_* until XtraBackup 2.5.26 is released, at which time we will switch back to using the latest ⚠️ 

This pins the XtraBackup version used in our non-8.0 CI jobs to 2.4.24 as [2.4.25 crashes with the `--xtrabackup_stream_mode=tar` flag used with 5.7](https://jira.percona.com/browse/PXB-2756) (with 8.0 we use `--xtrabackup_stream_mode=xbstream`).

## Open Questions
1. Should we also pin the version for the 8.0 CI jobs for consistency? 
   * Decision: NO
2. Should we pin this permanently, even after 2.4.26 comes out with the fix in the coming weeks?
    * Decision: NO

## Related Issue(s)
  - Fixes: https://github.com/vitessio/vitess/issues/10146

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required