### PR TITLE
refactor: move the Subshard opcode

### DIFF
--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -53,6 +53,8 @@ const (
 	// MultiEqual is used for routing queries with IN with tuple clause
 	// Requires: A Vindex, and a multi Tuple Values.
 	MultiEqual
+	// SubShard is for when we are missing one or more columns from a composite vindex
+	SubShard
 	// Scatter is for routing a scattered statement.
 	Scatter
 	// Next is for fetching from a sequence.
@@ -68,8 +70,6 @@ const (
 	// Is used when the query explicitly sets a target destination:
 	// in the clause e.g: UPDATE `keyspace[-]`.x1 SET foo=1
 	ByDestination
-	// SubShard is for when we are missing one or more columns from a composite vindex
-	SubShard
 )
 
 var opName = map[Opcode]string{

--- a/go/vt/vtgate/planbuilder/route_test.go
+++ b/go/vt/vtgate/planbuilder/route_test.go
@@ -42,23 +42,24 @@ For easy reference, opcodes are:
 	DBA         	 7
 	Reference   	 8
 	None        	 9
-	Subshard         10 <- not covered
-	NumRouteOpcodes  11
 */
 
 func TestJoinCanMerge(t *testing.T) {
 	testcases := [][]bool{
-		{true, false, false, false, false, false, false, false, true, false, false},
-		{false, true, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, true, true, false, false},
-		{true, true, true, true, true, true, true, true, true, true, true},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
+		{true, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, true, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+
+		{false, false, false, false, false, false, false, false, false, false, false, false}, // this whole line is not tested
+
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, true, true, false, false},
+		{true, true, true, true, true /*not tested*/, false, true, true, true, true, true, true},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
 	}
 
 	ks := &vindexes.Keyspace{}
@@ -66,6 +67,10 @@ func TestJoinCanMerge(t *testing.T) {
 		for right, val := range vals {
 			name := fmt.Sprintf("%s:%s", engine.Opcode(left).String(), engine.Opcode(right).String())
 			t.Run(name, func(t *testing.T) {
+				if left == int(engine.SubShard) || right == int(engine.SubShard) {
+					t.Skip("not used by v3")
+				}
+
 				lRoute := &route{
 					// Setting condition will make SelectEqualUnique match itself.
 					condition: &sqlparser.ColName{},
@@ -86,17 +91,20 @@ func TestJoinCanMerge(t *testing.T) {
 
 func TestSubqueryCanMerge(t *testing.T) {
 	testcases := [][]bool{
-		{true, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, true, true, false, false},
-		{true, true, true, true, true, true, true, true, true, true, true},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
+		{true, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+
+		{false, false, false, false, false, false, false, false, false, false, false, false, false}, // this whole line is not tested
+
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, true, true, false, false},
+		{true, true, true, true, true /*not tested*/, false, true, true, true, true, true, true},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
 	}
 
 	ks := &vindexes.Keyspace{}
@@ -108,25 +116,35 @@ func TestSubqueryCanMerge(t *testing.T) {
 	for left, vals := range testcases {
 		lRoute.eroute = engine.NewSimpleRoute(engine.Opcode(left), ks)
 		for right, val := range vals {
-			rRoute.eroute = engine.NewSimpleRoute(engine.Opcode(right), ks)
-			assert.Equal(t, val, lRoute.SubqueryCanMerge(pb, rRoute), fmt.Sprintf("%v:%v", lRoute.eroute.RouteType(), rRoute.eroute.RouteType()))
+			name := fmt.Sprintf("%s:%s", engine.Opcode(left).String(), engine.Opcode(right).String())
+			t.Run(name, func(t *testing.T) {
+				if left == int(engine.SubShard) || right == int(engine.SubShard) {
+					t.Skip("not used by v3")
+				}
+
+				rRoute.eroute = engine.NewSimpleRoute(engine.Opcode(right), ks)
+				assert.Equal(t, val, lRoute.SubqueryCanMerge(pb, rRoute), fmt.Sprintf("%v:%v", lRoute.eroute.RouteType(), rRoute.eroute.RouteType()))
+			})
 		}
 	}
 }
 
 func TestUnionCanMerge(t *testing.T) {
 	testcases := [][]bool{
-		{true, false, false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, true, false, false, false, false, false},
-		{false, false, false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, false, true, false, false, false},
-		{false, false, false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, false, false, false, false, false},
+		{true, false, false, false, false /*not tested*/, false, false, false, false, false, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, false, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, false, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, false, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, false, false, false},
+
+		{false, false, false, false, false, false, false, false, false, false, false, false, false}, // this whole line is not tested
+
+		{false, false, false, false, false /*not tested*/, false, true, false, false, false, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, false, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, true, false, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, true, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, false, false, false},
+		{false, false, false, false, false /*not tested*/, false, false, false, false, false, false, false},
 	}
 
 	ks := &vindexes.Keyspace{}
@@ -135,8 +153,15 @@ func TestUnionCanMerge(t *testing.T) {
 	for left, vals := range testcases {
 		lRoute.eroute = engine.NewSimpleRoute(engine.Opcode(left), ks)
 		for right, val := range vals {
-			rRoute.eroute = engine.NewSimpleRoute(engine.Opcode(right), ks)
-			assert.Equal(t, val, lRoute.unionCanMerge(rRoute, false), fmt.Sprintf("can't create a single route from these two inputs %v:%v", lRoute.eroute.RouteType(), rRoute.eroute.RouteType()))
+			name := fmt.Sprintf("%s:%s", engine.Opcode(left).String(), engine.Opcode(right).String())
+			t.Run(name, func(t *testing.T) {
+				if left == int(engine.SubShard) || right == int(engine.SubShard) {
+					t.Skip("not used by v3")
+				}
+
+				rRoute.eroute = engine.NewSimpleRoute(engine.Opcode(right), ks)
+				assert.Equal(t, val, lRoute.unionCanMerge(rRoute, false), fmt.Sprintf("can't create a single route from these two inputs %v:%v", lRoute.eroute.RouteType(), rRoute.eroute.RouteType()))
+			})
 		}
 	}
 }


### PR DESCRIPTION
## Description
This changes the engine opcode list to be according to most preferable first.

## Related Issue(s)
Based on feedback from #10151

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
