### PR TITLE
Emit the ENGINE field for table options as case sensitive

### DIFF
--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -473,11 +473,10 @@ func (node *PartitionValueRange) Format(buf *TrackedBuffer) {
 // Format formats the node
 func (node *PartitionEngine) Format(buf *TrackedBuffer) {
 	if node.Storage {
-		buf.WriteString("storage ")
+		buf.astPrintf(node, "%s", "storage ")
 	}
-	buf.WriteString("engine ")
-
-	buf.astPrintf(node, "%s", node.Name)
+	buf.astPrintf(node, "%s", "engine ")
+	buf.astPrintf(node, "%#s", node.Name)
 }
 
 // Format formats the node.

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -651,7 +651,6 @@ func (node *PartitionEngine) formatFast(buf *TrackedBuffer) {
 		buf.WriteString("storage ")
 	}
 	buf.WriteString("engine ")
-
 	buf.WriteString(node.Name)
 }
 

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -10546,7 +10546,7 @@ yydefault:
 		var yyLOCAL *TableOption
 //line sql.y:2407
 		{
-			yyLOCAL = &TableOption{Name: string(yyDollar[1].str), String: yyDollar[3].tableIdent.String()}
+			yyLOCAL = &TableOption{Name: string(yyDollar[1].str), String: yyDollar[3].tableIdent.String(), CaseSensitive: true}
 		}
 		yyVAL.union = yyLOCAL
 	case 419:

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -2405,7 +2405,7 @@ table_option:
   }
 | ENGINE equal_opt table_alias
   {
-    $$ = &TableOption{Name:string($1), String:$3.String()}
+    $$ = &TableOption{Name:string($1), String:$3.String(), CaseSensitive: true}
   }
 | INSERT_METHOD equal_opt insert_method_options
   {

--- a/go/vt/sqlparser/tracked_buffer_test.go
+++ b/go/vt/sqlparser/tracked_buffer_test.go
@@ -97,6 +97,10 @@ func TestCanonicalOutput(t *testing.T) {
 			"CREATE TABLE `a` (\n\t`v` varchar(32)\n) ENGINE InnoDB",
 		},
 		{
+			"create table a (id int not null primary key) engine InnoDB, charset utf8mb4, collate utf8mb4_0900_ai_ci partition by range (`id`) (partition `p10` values less than(10) engine InnoDB)",
+			"CREATE TABLE `a` (\n\t`id` int NOT NULL PRIMARY KEY\n) ENGINE InnoDB,\n  CHARSET utf8mb4,\n  COLLATE utf8mb4_0900_ai_ci PARTITION BY RANGE (`id`) (PARTITION `p10` VALUES LESS THAN (10) ENGINE InnoDB)",
+		},
+		{
 			"alter table a comment='a b c'",
 			"ALTER TABLE `a` COMMENT 'a b c'",
 		},

--- a/go/vt/sqlparser/tracked_buffer_test.go
+++ b/go/vt/sqlparser/tracked_buffer_test.go
@@ -89,8 +89,12 @@ func TestCanonicalOutput(t *testing.T) {
 			"CREATE TABLE `insert` (\n\t`update` int,\n\tPRIMARY KEY (`delete`)\n)",
 		},
 		{
-			"alter table a engine=innodb",
-			"ALTER TABLE `a` ENGINE INNODB",
+			"alter table a engine=InnoDB",
+			"ALTER TABLE `a` ENGINE InnoDB",
+		},
+		{
+			"create table a (v varchar(32)) engine=InnoDB",
+			"CREATE TABLE `a` (\n\t`v` varchar(32)\n) ENGINE InnoDB",
 		},
 		{
 			"alter table a comment='a b c'",

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -722,7 +722,7 @@ func (cached *Route) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(112)
+		size += int64(128)
 	}
 	// field Query string
 	size += hack.RuntimeAllocSize(int64(len(cached.Query)))


### PR DESCRIPTION
This value has different casing in the canonical format from MySQL, so the parser here should not always uppercase the value assigned for the engine.

## Related Issue(s)

Part of extension work after https://github.com/vitessio/vitess/pull/9719

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required