### PR TITLE
Revert semi_sync change to reintroduce enable_semi_sync and remove durability_policy

### DIFF
--- a/examples/legacy_local/scripts/vtctld-up.sh
+++ b/examples/legacy_local/scripts/vtctld-up.sh
@@ -33,7 +33,6 @@ vtctld \
  --file_backup_storage_root $VTDATAROOT/backups \
  --log_dir $VTDATAROOT/tmp \
  --port $vtctld_web_port \
- --durability_policy 'semi_sync' \
  --grpc_port $grpc_port \
  --pid_file $VTDATAROOT/tmp/vtctld.pid \
   > $VTDATAROOT/tmp/vtctld.out 2>&1 &

--- a/examples/local/scripts/vtctld-up.sh
+++ b/examples/local/scripts/vtctld-up.sh
@@ -33,7 +33,6 @@ vtctld \
  --file_backup_storage_root $VTDATAROOT/backups \
  --log_dir $VTDATAROOT/tmp \
  --port $vtctld_web_port \
- --durability_policy 'semi_sync' \
  --grpc_port $grpc_port \
  --pid_file $VTDATAROOT/tmp/vtctld.pid \
   > $VTDATAROOT/tmp/vtctld.out 2>&1 &

--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -49,9 +49,9 @@ import (
 )
 
 var (
-	waitTime         = flag.Duration("wait-time", 24*time.Hour, "time to wait on an action")
-	detachedMode     = flag.Bool("detach", false, "detached mode - run vtcl detached from the terminal")
-	durabilityPolicy = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
+	waitTime     = flag.Duration("wait-time", 24*time.Hour, "time to wait on an action")
+	detachedMode = flag.Bool("detach", false, "detached mode - run vtcl detached from the terminal")
+	_            = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
 )
 
 func init() {
@@ -100,7 +100,7 @@ func main() {
 		log.Warningf("cannot connect to syslog: %v", err)
 	}
 
-	if err := reparentutil.SetDurabilityPolicy(*durabilityPolicy); err != nil {
+	if err := reparentutil.SetDurabilityPolicy("none"); err != nil {
 		log.Errorf("error in setting durability policy: %v", err)
 		exit.Return(1)
 	}

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -48,7 +48,7 @@ var (
 	cell                   = flag.String("cell", "", "cell to pick servers from")
 	commandDisplayInterval = flag.Duration("command_display_interval", time.Second, "Interval between each status update when vtworker is executing a single command from the command line")
 	username               = flag.String("username", "", "If set, value is set as immediate caller id in the request and used by vttablet for TableACL check")
-	durabilityPolicy       = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
+	_                      = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
 )
 
 func init() {
@@ -86,7 +86,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	if err := reparentutil.SetDurabilityPolicy(*durabilityPolicy); err != nil {
+	if err := reparentutil.SetDurabilityPolicy("none"); err != nil {
 		log.Errorf("error in setting durability policy: %v", err)
 		exit.Return(1)
 	}

--- a/go/flags/endtoend/flags_test.go
+++ b/go/flags/endtoend/flags_test.go
@@ -830,7 +830,7 @@ var (
   --enable_replication_reporter
 	Use polling to track replication lag.
   --enable_semi_sync
-	(DEPRECATED - Set the correct durability_policy instead) Enable semi-sync when configuring replication, on primary and replica tablets only (rdonly tablets will not ack).
+	Enable semi-sync when configuring replication, on primary and replica tablets only (rdonly tablets will not ack).
   --enable_transaction_limit
 	If true, limit on number of transactions open at the same time will be enforced for all users. User trying to open a new transaction after exhausting their limit will receive an error immediately, regardless of whether there are available slots or not.
   --enable_transaction_limit_dry_run

--- a/go/test/endtoend/backup/transform/backup_transform_utils.go
+++ b/go/test/endtoend/backup/transform/backup_transform_utils.go
@@ -68,7 +68,6 @@ func TestMainSetup(m *testing.M, useMysqlctld bool) {
 		localCluster = cluster.NewCluster(cell, hostname)
 		defer localCluster.Teardown()
 
-		localCluster.VtctldExtraArgs = append(localCluster.VtctldExtraArgs, "--durability_policy=semi_sync")
 		// Start topo server
 		err := localCluster.StartTopo()
 		if err != nil {

--- a/go/test/endtoend/backup/vtbackup/main_test.go
+++ b/go/test/endtoend/backup/vtbackup/main_test.go
@@ -61,7 +61,6 @@ func TestMain(m *testing.M) {
 		localCluster = cluster.NewCluster(cell, hostname)
 		defer localCluster.Teardown()
 
-		localCluster.VtctldExtraArgs = append(localCluster.VtctldExtraArgs, "--durability_policy=semi_sync")
 		// Start topo server
 		err := localCluster.StartTopo()
 		if err != nil {

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -83,7 +83,6 @@ var (
 // LaunchCluster : starts the cluster as per given params.
 func LaunchCluster(setupType int, streamMode string, stripes int) (int, error) {
 	localCluster = cluster.NewCluster(cell, hostname)
-	localCluster.VtctldExtraArgs = append(localCluster.VtctldExtraArgs, "--durability_policy=semi_sync")
 
 	// Start topo server
 	err := localCluster.StartTopo()

--- a/go/test/endtoend/recovery/pitr/shardedpitr_test.go
+++ b/go/test/endtoend/recovery/pitr/shardedpitr_test.go
@@ -371,7 +371,6 @@ func removeTablets(t *testing.T, tablets []*cluster.Vttablet) {
 
 func initializeCluster(t *testing.T) {
 	clusterInstance = cluster.NewCluster(cell, hostname)
-	clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 
 	// Start topo server
 	err := clusterInstance.StartTopo()

--- a/go/test/endtoend/recovery/pitrtls/shardedpitr_tls_test.go
+++ b/go/test/endtoend/recovery/pitrtls/shardedpitr_tls_test.go
@@ -108,7 +108,6 @@ func removeTablets(t *testing.T, tablets []*cluster.Vttablet) {
 
 func initializeCluster(t *testing.T) {
 	clusterInstance = cluster.NewCluster(cell, hostname)
-	clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 
 	// Start topo server
 	err := clusterInstance.StartTopo()

--- a/go/test/endtoend/recovery/shardedrecovery/sharded_recovery_test.go
+++ b/go/test/endtoend/recovery/shardedrecovery/sharded_recovery_test.go
@@ -465,7 +465,6 @@ func removeTablets(t *testing.T, tablets []*cluster.Vttablet) {
 func initializeCluster(t *testing.T) (int, error) {
 
 	localCluster = cluster.NewCluster(cell, hostname)
-	localCluster.VtctldExtraArgs = append(localCluster.VtctldExtraArgs, "--durability_policy=semi_sync")
 
 	// Start topo server
 	err := localCluster.StartTopo()

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -80,7 +80,6 @@ func TestMainImpl(m *testing.M) {
 		localCluster = cluster.NewCluster(cell, hostname)
 		defer localCluster.Teardown()
 
-		localCluster.VtctldExtraArgs = append(localCluster.VtctldExtraArgs, "--durability_policy=semi_sync")
 		// Start topo server
 		err := localCluster.StartTopo()
 		if err != nil {

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -374,7 +374,6 @@ func TestERSForInitialization(t *testing.T) {
 	clusterInstance := cluster.NewCluster("zone1", "localhost")
 	defer clusterInstance.Teardown()
 	keyspace := &cluster.Keyspace{Name: utils.KeyspaceName}
-	clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 	// Start topo server
 	err := clusterInstance.StartTopo()
 	require.NoError(t, err)

--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -30,6 +30,11 @@ import (
 // ERS TESTS
 
 func TestRecoverWithMultipleFailures(t *testing.T) {
+	// This test is skipped until we have a way to specify the durability_policies again
+	// Since we removed the usage of durability_policies
+	// ERS will not have the information required to figure out that these multiple failures
+	// can be tolerated
+	t.Skip()
 	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, true)
 	defer utils.TeardownCluster(clusterInstance)
@@ -58,6 +63,11 @@ func TestRecoverWithMultipleFailures(t *testing.T) {
 // TestERSFailFast tests that ERS will fail fast if it cannot find any tablet which can be safely promoted instead of promoting
 // a tablet and hanging while inserting a row in the reparent journal on getting semi-sync ACKs
 func TestERSFailFast(t *testing.T) {
+	// This test is skipped until we have a way to specify the durability_policies again
+	// Since we removed the usage of durability_policies
+	// ERS will not have the information required to figure out that the promoted primary
+	// wont be able to make progress
+	t.Skip()
 	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, true)
 	defer utils.TeardownCluster(clusterInstance)

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -91,7 +91,6 @@ func setupCluster(ctx context.Context, t *testing.T, shardName string, cells []s
 
 	if enableSemiSync {
 		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--enable_semi_sync")
-		clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 	}
 
 	// Start topo server
@@ -203,7 +202,6 @@ func setupClusterLegacy(ctx context.Context, t *testing.T, shardName string, cel
 
 	if enableSemiSync {
 		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--enable_semi_sync")
-		clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 	}
 
 	// Start topo server
@@ -412,7 +410,7 @@ func ErsIgnoreTablet(clusterInstance *cluster.LocalProcessCluster, tab *cluster.
 
 // ErsWithVtctl runs ERS via vtctl binary
 func ErsWithVtctl(clusterInstance *cluster.LocalProcessCluster) (string, error) {
-	args := []string{"--durability_policy=semi_sync", "EmergencyReparentShard", "--", "--keyspace_shard", fmt.Sprintf("%s/%s", KeyspaceName, ShardName)}
+	args := []string{"EmergencyReparentShard", "--", "--keyspace_shard", fmt.Sprintf("%s/%s", KeyspaceName, ShardName)}
 	return clusterInstance.VtctlProcess.ExecuteCommandWithOutput(args...)
 }
 

--- a/go/test/endtoend/sharding/initialsharding/sharding_util.go
+++ b/go/test/endtoend/sharding/initialsharding/sharding_util.go
@@ -97,7 +97,6 @@ func ClusterWrapper(isMulti bool) (int, error) {
 	ClusterInstance = nil
 	ClusterInstance = cluster.NewCluster(cell, hostname)
 
-	ClusterInstance.VtctldExtraArgs = append(ClusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 	// Start topo server
 	if err := ClusterInstance.StartTopo(); err != nil {
 		return 1, err

--- a/go/test/endtoend/sharding/mergesharding/mergesharding_base.go
+++ b/go/test/endtoend/sharding/mergesharding/mergesharding_base.go
@@ -108,7 +108,6 @@ func TestMergesharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 
 	// Launch keyspace
 	keyspace := &cluster.Keyspace{Name: keyspaceName}
-	clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 
 	// Start topo server
 	err := clusterInstance.StartTopo()

--- a/go/test/endtoend/sharding/resharding/resharding_base.go
+++ b/go/test/endtoend/sharding/resharding/resharding_base.go
@@ -189,7 +189,6 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 
 	// Launch keyspace
 	keyspace := &cluster.Keyspace{Name: keyspaceName}
-	clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 
 	// Start topo server
 	err := clusterInstance.StartTopo()

--- a/go/test/endtoend/vault/vault_test.go
+++ b/go/test/endtoend/vault/vault_test.go
@@ -218,7 +218,6 @@ func setupVaultServer(t *testing.T, vs *VaultServer) (string, string) {
 func initializeClusterEarly(t *testing.T) {
 	clusterInstance = cluster.NewCluster(cell, hostname)
 
-	clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 	// Start topo server
 	err := clusterInstance.StartTopo()
 	require.NoError(t, err)

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -750,7 +750,6 @@ func SetupNewClusterSemiSync(t *testing.T) *VtOrcClusterInfo {
 	var tablets []*cluster.Vttablet
 	clusterInstance := cluster.NewCluster(Cell1, Hostname)
 	keyspace := &cluster.Keyspace{Name: keyspaceName}
-	clusterInstance.VtctldExtraArgs = append(clusterInstance.VtctldExtraArgs, "--durability_policy=semi_sync")
 	// Start topo server
 	err := clusterInstance.StartTopo()
 	require.NoError(t, err, "Error starting topo: %v", err)

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -41,7 +41,7 @@ import (
 var (
 	enableRealtimeStats = flag.Bool("enable_realtime_stats", false, "Required for the Realtime Stats view. If set, vtctld will maintain a streaming RPC to each tablet (in all cells) to gather the realtime health stats.")
 	enableUI            = flag.Bool("enable_vtctld_ui", true, "If true, the vtctld web interface will be enabled. Default is true.")
-	durabilityPolicy    = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
+	_                   = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
 	sanitizeLogMessages = flag.Bool("vtctld_sanitize_log_messages", false, "When true, vtctld sanitizes logging.")
 
 	_ = flag.String("web_dir", "", "NOT USED, here for backward compatibility")
@@ -54,7 +54,7 @@ const (
 
 // InitVtctld initializes all the vtctld functionality.
 func InitVtctld(ts *topo.Server) error {
-	err := reparentutil.SetDurabilityPolicy(*durabilityPolicy)
+	err := reparentutil.SetDurabilityPolicy("none")
 	if err != nil {
 		log.Errorf("error in setting durability policy: %v", err)
 		return err

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	enableSemiSync   = flag.Bool("enable_semi_sync", false, "(DEPRECATED - Set the correct durability_policy instead) Enable semi-sync when configuring replication, on primary and replica tablets only (rdonly tablets will not ack).")
+	enableSemiSync   = flag.Bool("enable_semi_sync", false, "Enable semi-sync when configuring replication, on primary and replica tablets only (rdonly tablets will not ack).")
 	setSuperReadOnly = flag.Bool("use_super_read_only", true, "Set super_read_only flag when performing planned failover.")
 )
 

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	_                = flag.Bool("enable_semi_sync", false, "(DEPRECATED - Set the correct durability_policy instead) Enable semi-sync when configuring replication, on primary and replica tablets only (rdonly tablets will not ack).")
+	enableSemiSync   = flag.Bool("enable_semi_sync", false, "(DEPRECATED - Set the correct durability_policy instead) Enable semi-sync when configuring replication, on primary and replica tablets only (rdonly tablets will not ack).")
 	setSuperReadOnly = flag.Bool("use_super_read_only", true, "Set super_read_only flag when performing planned failover.")
 )
 
@@ -872,18 +872,45 @@ func isPrimaryEligible(tabletType topodatapb.TabletType) bool {
 }
 
 func (tm *TabletManager) fixSemiSync(tabletType topodatapb.TabletType, semiSync SemiSyncAction) error {
-	switch semiSync {
-	case SemiSyncActionNone:
+	if !*enableSemiSync {
+		// Semi-sync handling is not enabled.
+		if semiSync == SemiSyncActionSet {
+			log.Error("invalid configuration - semi-sync should be setup according to durability policies, but enable_semi_sync is not set")
+		}
 		return nil
-	case SemiSyncActionSet:
-		// Always enable replica-side since it doesn't hurt to keep it on for a primary.
-		// The primary-side needs to be off for a replica, or else it will get stuck.
-		return tm.MysqlDaemon.SetSemiSyncEnabled(tabletType == topodatapb.TabletType_PRIMARY, true)
-	case SemiSyncActionUnset:
-		return tm.MysqlDaemon.SetSemiSyncEnabled(false, false)
-	default:
-		return vterrors.Errorf(vtrpc.Code_INTERNAL, "Unknown SemiSyncAction - %v", semiSync)
 	}
+
+	// Only enable if we're eligible for becoming primary (REPLICA type).
+	// Ineligible tablets (RDONLY) shouldn't ACK because we'll never promote them.
+	if !isPrimaryEligible(tabletType) {
+		if semiSync == SemiSyncActionSet {
+			log.Error("invalid configuration - semi-sync should be setup according to durability policies, but the tablet is not primaryEligible")
+		}
+		return tm.MysqlDaemon.SetSemiSyncEnabled(false, false)
+	}
+
+	if semiSync == SemiSyncActionUnset {
+		log.Error("invalid configuration - enabling semi sync even though not specified by durability policies. Possibly in the process of upgrading.")
+	}
+	// Always enable replica-side since it doesn't hurt to keep it on for a primary.
+	// The primary-side needs to be off for a replica, or else it will get stuck.
+	return tm.MysqlDaemon.SetSemiSyncEnabled(tabletType == topodatapb.TabletType_PRIMARY, true)
+
+	// This following code will be uncommented and the above deleted when we are ready to use the
+	// durability policies for setting the semi_sync information
+
+	//switch semiSync {
+	//case SemiSyncActionNone:
+	//	return nil
+	//case SemiSyncActionSet:
+	//	// Always enable replica-side since it doesn't hurt to keep it on for a primary.
+	//	// The primary-side needs to be off for a replica, or else it will get stuck.
+	//	return tm.MysqlDaemon.SetSemiSyncEnabled(tabletType == topodatapb.TabletType_PRIMARY, true)
+	//case SemiSyncActionUnset:
+	//	return tm.MysqlDaemon.SetSemiSyncEnabled(false, false)
+	//default:
+	//	return vterrors.Errorf(vtrpc.Code_INTERNAL, "Unknown SemiSyncAction - %v", semiSync)
+	//}
 }
 
 func (tm *TabletManager) isPrimarySideSemiSyncEnabled() bool {

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -919,10 +919,14 @@ func (tm *TabletManager) isPrimarySideSemiSyncEnabled() bool {
 }
 
 func (tm *TabletManager) fixSemiSyncAndReplication(tabletType topodatapb.TabletType, semiSync SemiSyncAction) error {
-	if semiSync == SemiSyncActionNone {
-		// Semi-sync handling is not required.
+	if !*enableSemiSync {
+		// Semi-sync handling is not enabled.
 		return nil
 	}
+	//if semiSync == SemiSyncActionNone {
+	//	// Semi-sync handling is not required.
+	//	return nil
+	//}
 
 	if tabletType == topodatapb.TabletType_PRIMARY {
 		// Primary is special. It is always handled at the
@@ -948,7 +952,8 @@ func (tm *TabletManager) fixSemiSyncAndReplication(tabletType topodatapb.TabletT
 		return nil
 	}
 
-	shouldAck := semiSync == SemiSyncActionSet
+	//shouldAck := semiSync == SemiSyncActionSet
+	shouldAck := isPrimaryEligible(tabletType)
 	acking, err := tm.MysqlDaemon.SemiSyncReplicationStatus()
 	if err != nil {
 		return vterrors.Wrap(err, "failed to get SemiSyncReplicationStatus")

--- a/go/vt/vttablet/tabletmanager/rpc_replication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication_test.go
@@ -17,10 +17,15 @@ limitations under the License.
 package tabletmanager
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"testing"
 	"time"
+
+	"vitess.io/vitess/go/vt/proto/topodata"
 
 	"github.com/stretchr/testify/require"
 
@@ -73,4 +78,118 @@ func TestPromoteReplicaReplicationManagerFailure(t *testing.T) {
 	require.Error(t, err)
 	// At the end we expect the replication manager to be stopped.
 	require.True(t, tm.replManager.ticks.Running())
+}
+
+func captureStderr(f func()) (string, error) {
+	old := os.Stderr // keep backup of the real stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	os.Stderr = w
+
+	outC := make(chan string)
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// calling function which stderr we are going to capture:
+	f()
+
+	// back to normal state
+	w.Close()
+	os.Stderr = old // restoring the real stderr
+	return <-outC, nil
+}
+
+func TestTabletManager_fixSemiSync(t *testing.T) {
+	tests := []struct {
+		name                 string
+		tabletType           topodata.TabletType
+		semiSync             SemiSyncAction
+		logOutput            string
+		shouldEnableSemiSync bool
+	}{
+		{
+			name:                 "enableSemiSync=true(primary eligible),durabilitySemiSync=true",
+			tabletType:           topodata.TabletType_REPLICA,
+			semiSync:             SemiSyncActionSet,
+			logOutput:            "",
+			shouldEnableSemiSync: true,
+		}, {
+			name:                 "enableSemiSync=true(primary eligible),durabilitySemiSync=false",
+			tabletType:           topodata.TabletType_REPLICA,
+			semiSync:             SemiSyncActionUnset,
+			logOutput:            "invalid configuration - enabling semi sync even though not specified by durability policies.",
+			shouldEnableSemiSync: true,
+		}, {
+			name:                 "enableSemiSync=true(primary eligible),durabilitySemiSync=none",
+			tabletType:           topodata.TabletType_REPLICA,
+			semiSync:             SemiSyncActionNone,
+			logOutput:            "",
+			shouldEnableSemiSync: true,
+		}, {
+			name:                 "enableSemiSync=true(primary not-eligible),durabilitySemiSync=true",
+			tabletType:           topodata.TabletType_DRAINED,
+			semiSync:             SemiSyncActionSet,
+			logOutput:            "invalid configuration - semi-sync should be setup according to durability policies, but the tablet is not primaryEligible",
+			shouldEnableSemiSync: true,
+		}, {
+			name:                 "enableSemiSync=true(primary not-eligible),durabilitySemiSync=false",
+			tabletType:           topodata.TabletType_DRAINED,
+			semiSync:             SemiSyncActionUnset,
+			logOutput:            "",
+			shouldEnableSemiSync: true,
+		}, {
+			name:                 "enableSemiSync=true(primary not-eligible),durabilitySemiSync=none",
+			tabletType:           topodata.TabletType_DRAINED,
+			semiSync:             SemiSyncActionNone,
+			logOutput:            "",
+			shouldEnableSemiSync: true,
+		}, {
+			name:                 "enableSemiSync=false,durabilitySemiSync=true",
+			tabletType:           topodata.TabletType_REPLICA,
+			semiSync:             SemiSyncActionSet,
+			logOutput:            "invalid configuration - semi-sync should be setup according to durability policies, but enable_semi_sync is not set",
+			shouldEnableSemiSync: false,
+		}, {
+			name:                 "enableSemiSync=false,durabilitySemiSync=false",
+			tabletType:           topodata.TabletType_REPLICA,
+			semiSync:             SemiSyncActionUnset,
+			logOutput:            "",
+			shouldEnableSemiSync: false,
+		}, {
+			name:                 "enableSemiSync=false,durabilitySemiSync=none",
+			tabletType:           topodata.TabletType_REPLICA,
+			semiSync:             SemiSyncActionNone,
+			logOutput:            "",
+			shouldEnableSemiSync: false,
+		},
+	}
+	oldEnableSemiSync := *enableSemiSync
+	defer func() {
+		*enableSemiSync = oldEnableSemiSync
+	}()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			*enableSemiSync = tt.shouldEnableSemiSync
+			fakeMysql := fakemysqldaemon.NewFakeMysqlDaemon(nil)
+			tm := &TabletManager{
+				MysqlDaemon: fakeMysql,
+			}
+			logOutput, err := captureStderr(func() {
+				err := tm.fixSemiSync(tt.tabletType, tt.semiSync)
+				require.NoError(t, err)
+			})
+			require.NoError(t, err)
+			if tt.logOutput != "" {
+				require.Contains(t, logOutput, tt.logOutput)
+			} else {
+				require.Equal(t, "", logOutput)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

We found a problem with the current implementation of the durability_policy flag. This flag only takes one value for the vtctld binary. This is incorrect, because people can be running multiple keyspaces each having its own different durability_policy. Since vtctld is a global component, we cannot require the user to create a vtctld for each keyspace having different durability_policies.

The proposed solution is to store the durability_policy in the topo server instead of having it as a flag. This change however will also require a two release upgrade process. In release-13 we are using the flag `enable_semi_sync` flag, and we want to continue doing that in release-14. We also want to deprecate the durability_policy flag. 

This PR reintroduces the enable_semi_sync flag and its usage. It removes the usages of durability_policy flag in the tests and binaries. Two tests in the ERS package which rely on the durability_policy information have been skipped for now.

This PR will be followed up by another PR which will add the RPCs to store and update the durability_policies in the keyspace information.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #8975 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required - Release notes documentation and online docs will be updated after the next PR is also ready.

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
