### PR TITLE
[vtadmin] non-blocking resolver

### DIFF
--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -23,12 +23,7 @@ limitations under the License.
 //
 // Some potential improvements we can add, if desired:
 //
-// 1. Background refresh. We would take a config flag that governs the refresh
-//	  interval and backoff (for when background refresh happens around the same
-//	  time as grpc-core calls to ResolveNow) and spin up a goroutine. We would
-//	  then have to spin this down when Close is called.
-//
-// 2. Stats!
+// 1. Stats!
 package resolver
 
 import (

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	grpcbackoff "google.golang.org/grpc/backoff"
 	grpcresolver "google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 
@@ -46,6 +47,7 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery"
 	"vitess.io/vitess/go/vt/vtadmin/debug"
+	"vitess.io/vitess/go/vt/vtadmin/internal/backoff"
 )
 
 const logPrefix = "[vtadmin.cluster.resolver]"
@@ -113,6 +115,23 @@ type Options struct {
 	DiscoveryTags    []string
 	DiscoveryTimeout time.Duration
 
+	// MinDiscoveryInterval is the minimum amount of time to wait before re-
+	// discovering after a successful discovery resolution. This is useful to
+	// avoid spamming the backing discovery service if multiple ResolveNow calls
+	// are made in rapid succession.
+	//
+	// Note that the interval for failed discovery resolutions are governed by
+	// the backoff strategy and configuration, not this field.
+	MinDiscoveryInterval time.Duration
+
+	// BackoffStrategy specfies the strategy to use when backing off of failed
+	// discovery resolution. Permitted values are "exponential", "linear", and
+	// "none"; the empty string defaults to "exponential".
+	BackoffStrategy string
+	// BackoffConfig is the configuration used by the given backoff strategy.
+	// For a "none" strategy, this is ignored.
+	BackoffConfig grpcbackoff.Config
+
 	// BalancerPolicy, if set, will cause a resolver to provide a ServiceConfig
 	// to the resolver's ClientConn with a corresponding loadBalancingConfig.
 	// Omitting this option will cause grpc to use its default load balacing
@@ -138,6 +157,8 @@ func (opts *Options) NewBuilder(scheme string) grpcresolver.Builder {
 	}
 }
 
+var defaultBackoffConfig = grpcbackoff.DefaultConfig
+
 // InstallFlags installs the resolver.Options flags on the given flagset. It is
 // used by both vtsql and vtctldclient proxies.
 func (opts *Options) InstallFlags(fs *pflag.FlagSet) {
@@ -149,6 +170,20 @@ func (opts *Options) InstallFlags(fs *pflag.FlagSet) {
 	fs.Var(&opts.BalancerPolicy, "grpc-balancer-policy",
 		fmt.Sprintf("Specify a load balancer policy to use for resolvers built by these options (the default grpc behavior is pick_first). Valid choices are %s",
 			strings.Join(allBalancerPolicies, ",")))
+
+	fs.DurationVar(&opts.MinDiscoveryInterval, "min-rediscovery-interval", time.Second*30,
+		"") // TODO: help text
+
+	fs.StringVar(&opts.BackoffStrategy, "backoff-strategy", "",
+		"") // TODO: help text
+	fs.DurationVar(&opts.BackoffConfig.BaseDelay, "backoff-base-delay", defaultBackoffConfig.BaseDelay,
+		"") // TODO: help text
+	fs.DurationVar(&opts.BackoffConfig.MaxDelay, "backoff-max-delay", defaultBackoffConfig.MaxDelay,
+		"") // TODO: help text
+	fs.Float64Var(&opts.BackoffConfig.Multiplier, "backoff-multiplier", defaultBackoffConfig.Multiplier,
+		"") // TODO: help text
+	fs.Float64Var(&opts.BackoffConfig.Jitter, "backoff-jitter", defaultBackoffConfig.Jitter,
+		"") // TODO: help text
 }
 
 // Build is part of the resolver.Builder interface. See the commentary on
@@ -169,8 +204,6 @@ func (b *builder) Build(target grpcresolver.Target, cc grpcresolver.ClientConn, 
 	b.m.Lock()
 	b.resolvers = append(b.resolvers, r)
 	b.m.Unlock()
-
-	r.ResolveNow(grpcresolver.ResolveNowOptions{})
 
 	return r, nil
 }
@@ -199,17 +232,24 @@ func (b *builder) build(target grpcresolver.Target, cc grpcresolver.ClientConn, 
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return &resolver{
-		component:     target.URL.Host,
-		cluster:       target.URL.Scheme,
-		discoverAddrs: fn,
-		opts:          b.opts,
-		cc:            cc,
-		sc:            sc,
-		ctx:           ctx,
-		cancel:        cancel,
-		createdAt:     time.Now().UTC(),
-	}, nil
+	r := &resolver{
+		component:       target.URL.Host,
+		cluster:         target.URL.Scheme,
+		discoverAddrs:   fn,
+		backoffStrategy: backoff.Get(b.opts.BackoffStrategy, b.opts.BackoffConfig),
+		opts:            b.opts,
+		cc:              cc,
+		sc:              sc,
+		rn:              make(chan struct{}, 1),
+		ctx:             ctx,
+		cancel:          cancel,
+		createdAt:       time.Now().UTC(),
+	}
+
+	r.wg.Add(1)
+	go r.watch()
+
+	return r, nil
 }
 
 // Scheme is part of the resolver.Builder interface.
@@ -238,16 +278,19 @@ func (b *builder) Debug() map[string]any {
 }
 
 type resolver struct {
-	component     string
-	cluster       string
-	discoverAddrs func(ctx context.Context, tags []string) ([]string, error)
-	opts          Options
+	component       string
+	cluster         string
+	discoverAddrs   func(ctx context.Context, tags []string) ([]string, error)
+	backoffStrategy backoff.Strategy
+	opts            Options
 
 	cc grpcresolver.ClientConn
 	sc serviceconfig.Config // optionally used to enforce a balancer policy
 
+	rn     chan struct{} // used to signal that ResolveNow has been called
 	ctx    context.Context
 	cancel context.CancelFunc
+	wg     sync.WaitGroup
 
 	// for debug.Debuggable
 	// TODO: consider proper exported stats - histograms for timings, error rates, etc.
@@ -257,6 +300,83 @@ type resolver struct {
 	lastResolvedAt   time.Time
 	lastResolveError error
 	lastAddrs        []grpcresolver.Address
+}
+
+func (r *resolver) watch() {
+	defer r.wg.Done()
+
+	// Handles calling r.resolve and recording debug metrics appropriately,
+	// called in the for loop below.
+	resolveOnce := func() (state *grpcresolver.State, err error) {
+		lastResolvedAt := time.Now().UTC()
+		defer func() {
+			r.m.Lock()
+			defer r.m.Unlock()
+
+			r.lastResolvedAt = lastResolvedAt
+			r.lastResolveError = err
+			if state != nil {
+				r.lastAddrs = state.Addresses
+			}
+		}()
+
+		state, err = r.resolve()
+		return state, err
+	}
+
+	backoffIndex := 1
+	for {
+		state, err := resolveOnce()
+		switch err {
+		case nil:
+			switch len(state.Addresses) {
+			case 0:
+				log.Warningf("%s: found no %ss (cluster %s); updating grpc clientconn state anyway", logPrefix, r.component, r.cluster)
+			default:
+				log.Infof("%s: found %d %ss (cluster %s)", logPrefix, len(state.Addresses), r.component, r.cluster)
+			}
+
+			if updateErr := r.cc.UpdateState(*state); updateErr != nil {
+				log.Errorf("%s: failed to update %ss addresses for %s (cluster %s): %s", logPrefix, r.component, r.cluster, updateErr)
+				err = updateErr
+			}
+		default:
+			log.Errorf("%s: failed to resolve new addresses for %s (cluster %s): %s", logPrefix, r.component, r.cluster, err)
+			r.cc.ReportError(err)
+		}
+
+		var timer *time.Timer
+		if err == nil {
+			// Success. Wait for next call to ResolveNow (via r.rn chan), but
+			// also at least a minimum time to avoid spamming the backing
+			// discovery.
+			backoffIndex = 1
+			timer = time.NewTimer(r.opts.MinDiscoveryInterval)
+			select {
+			case <-r.ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+
+				return
+			case <-r.rn:
+			}
+		} else {
+			timer = time.NewTimer(r.backoffStrategy.Backoff(backoffIndex))
+			backoffIndex++
+		}
+
+		select {
+		case <-r.ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+
+			return
+		case <-timer.C:
+			timer.Stop()
+		}
+	}
 }
 
 func (r *resolver) resolve() (*grpcresolver.State, error) {
@@ -302,53 +422,26 @@ func (r *resolver) resolve() (*grpcresolver.State, error) {
 // ClientConn's when errors occur, as well as periodically to refresh the set of
 // addresses a ClientConn can use for SubConns.
 func (r *resolver) ResolveNow(o grpcresolver.ResolveNowOptions) {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	var (
-		state *grpcresolver.State
-		err   error
-	)
-
-	r.lastResolvedAt = time.Now().UTC()
-	defer func() {
-		r.lastResolveError = err
-		if state != nil {
-			r.lastAddrs = state.Addresses
-		}
-	}()
-
-	state, err = r.resolve()
-	if err != nil {
-		log.Errorf("%s: failed to resolve new addresses for %s (cluster %s): %s", logPrefix, r.component, r.cluster, err)
-		r.cc.ReportError(err)
-		return
-	}
-
-	switch len(state.Addresses) {
-	case 0:
-		log.Warningf("%s: found no %ss (cluster %s); updating grpc clientconn state anyway", logPrefix, r.component, r.cluster)
+	select {
+	case r.rn <- struct{}{}:
 	default:
-		log.Infof("%s: found %d %ss (cluster %s)", logPrefix, len(state.Addresses), r.component, r.cluster)
-	}
-
-	err = r.cc.UpdateState(*state)
-	if err != nil {
-		log.Errorf("%s: failed to update %ss addresses for %s (cluster %s): %s", logPrefix, r.component, r.cluster, err)
-		r.cc.ReportError(err)
-		return
 	}
 }
 
 // Close is part of the resolver.Resolver interface.
 func (r *resolver) Close() {
-	r.cancel() // cancel any ongoing call to ResolveNow, and therefore any resultant discovery lookup.
+	// First, cancel any ongoing discovery calls and terminate the watcher loop.
+	r.cancel()
+	// Then, wait for the watch goroutine to gracefully exit.
+	r.wg.Wait()
 }
 
 // Debug implements debug.Debuggable for resolver.
 func (r *resolver) Debug() map[string]any {
 	r.m.Lock()
 	defer r.m.Unlock()
+
+	// TODO: add a field for "closed"
 
 	m := map[string]any{
 		"cluster":    r.cluster,

--- a/go/vt/vtadmin/cluster/resolver/resolver.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver.go
@@ -172,18 +172,22 @@ func (opts *Options) InstallFlags(fs *pflag.FlagSet) {
 			strings.Join(allBalancerPolicies, ",")))
 
 	fs.DurationVar(&opts.MinDiscoveryInterval, "min-rediscovery-interval", time.Second*30,
-		"") // TODO: help text
+		"Minimum amount of time to wait between successful discovery resolution calls. "+
+			"Useful to avoid spamming the backing discovery service if multiple ResolveNow calls are made in rapid succession "+
+			"(Note that the interval for failed discovery resolutions are governed by the backoff strategy and configuration, not this flag).")
 
 	fs.StringVar(&opts.BackoffStrategy, "backoff-strategy", "",
-		"") // TODO: help text
+		"Backoff strategy to use when backing off of failed discovery resolutions. "+
+			`Permitted values are "exponential", "linear", and "none", and the empty string defaults to "exponential".`)
 	fs.DurationVar(&opts.BackoffConfig.BaseDelay, "backoff-base-delay", defaultBackoffConfig.BaseDelay,
-		"") // TODO: help text
+		"The amount of time to backoff after the first failure.")
 	fs.DurationVar(&opts.BackoffConfig.MaxDelay, "backoff-max-delay", defaultBackoffConfig.MaxDelay,
-		"") // TODO: help text
+		"The upper bound of time to wait, including backoffs offset by jitter.")
 	fs.Float64Var(&opts.BackoffConfig.Multiplier, "backoff-multiplier", defaultBackoffConfig.Multiplier,
-		"") // TODO: help text
+		"The factor to multiply (or add, in the case of \"linear\" backoff after a failed retry. "+
+			"Ideally should be greater than 1.")
 	fs.Float64Var(&opts.BackoffConfig.Jitter, "backoff-jitter", defaultBackoffConfig.Jitter,
-		"") // TODO: help text
+		"The factor to which backoffs are randomized.")
 }
 
 // Build is part of the resolver.Builder interface. See the commentary on

--- a/go/vt/vtadmin/cluster/resolver/resolver_test.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package resolver
 
 import (
+	"context"
+	"fmt"
 	"net/url"
+	"sort"
 	"testing"
 	"time"
 
@@ -32,24 +35,88 @@ import (
 
 type mockClientConn struct {
 	grpcresolver.ClientConn
-	Addrs             []grpcresolver.Address
-	UpdateStateCalled bool
-	ReportedError     error
+
+	updates chan grpcresolver.State
+	errors  chan error
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func newMockClientConn(minExpectedCalls int) *mockClientConn {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &mockClientConn{
+		updates: make(chan grpcresolver.State, minExpectedCalls),
+		errors:  make(chan error, minExpectedCalls),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+}
+
+func (cc *mockClientConn) close() {
+	cc.cancel()
+}
+
+func (cc *mockClientConn) assertUpdateWithin(t testing.TB, timeout time.Duration, expected grpcresolver.State, msgAndArgs ...any) bool {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		return assert.Fail(t, "failed to receive update", "did not receive update %v within %v: %s", expected, timeout, ctx.Err())
+	case actual := <-cc.updates:
+		sort.Slice(expected.Addresses, func(i, j int) bool {
+			return expected.Addresses[i].Addr < expected.Addresses[j].Addr
+		})
+		sort.Slice(actual.Addresses, func(i, j int) bool {
+			return actual.Addresses[i].Addr < actual.Addresses[j].Addr
+		})
+
+		return assert.Equal(t, expected, actual, msgAndArgs...)
+	}
+}
+
+func (cc *mockClientConn) assertErrorReportedWithin(t testing.TB, timeout time.Duration, msgAndArgs ...any) bool {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		return assert.Fail(t, "failed to receive reported error", "did not receive reported error within %v: %s", timeout, ctx.Err())
+	case actual := <-cc.errors:
+		return assert.Error(t, actual, msgAndArgs...)
+	}
 }
 
 func (cc *mockClientConn) UpdateState(state grpcresolver.State) error {
-	cc.UpdateStateCalled = true
-	cc.Addrs = state.Addresses
-	return nil
+	select {
+	case <-cc.ctx.Done():
+		return fmt.Errorf("failed to update state; clientconn closed: %w", cc.ctx.Err())
+	case cc.updates <- state:
+		return nil
+	default:
+		return fmt.Errorf("%w: failed to update; buffer full", assert.AnError)
+	}
 }
 
-func (cc *mockClientConn) ReportError(err error) { cc.ReportedError = err }
+func (cc *mockClientConn) ReportError(err error) {
+	select {
+	case <-cc.ctx.Done():
+	case cc.errors <- err:
+	default:
+	}
+}
 
 var testopts = Options{
-	DiscoveryTimeout: time.Millisecond * 50,
+	DiscoveryTimeout:     time.Millisecond * 50,
+	MinDiscoveryInterval: 0,
 }
 
-func mustBuild(t *testing.T, b *builder, target grpcresolver.Target, cc grpcresolver.ClientConn, opts grpcresolver.BuildOptions) *resolver {
+func mustBuild(t testing.TB, b *builder, target grpcresolver.Target, cc grpcresolver.ClientConn, opts grpcresolver.BuildOptions) *resolver {
 	t.Helper()
 
 	r, err := b.build(target, cc, opts)
@@ -68,18 +135,21 @@ func TestResolveNow(t *testing.T) {
 	testopts := testopts
 	testopts.Discovery = disco
 
-	cc := mockClientConn{}
+	cc := newMockClientConn(1)
 	r := mustBuild(t, &builder{opts: testopts}, grpcresolver.Target{
 		URL: url.URL{Host: "vtctld"},
-	}, &cc, grpcresolver.BuildOptions{})
+	}, cc, grpcresolver.BuildOptions{})
 
 	r.ResolveNow(grpcresolver.ResolveNowOptions{})
 
-	assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
-		{
+	expectedUpdate := grpcresolver.State{
+		Addresses: []grpcresolver.Address{{
 			Addr: "one",
-		},
-	})
+		}},
+	}
+	cc.assertUpdateWithin(t, time.Millisecond*100, expectedUpdate)
+	cc.close()
+	r.Close()
 
 	disco.Clear()
 	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
@@ -88,16 +158,23 @@ func TestResolveNow(t *testing.T) {
 		Hostname: "three",
 	})
 
+	cc = newMockClientConn(1)
+	r = mustBuild(t, &builder{opts: testopts}, grpcresolver.Target{
+		URL: url.URL{Host: "vtctld"},
+	}, cc, grpcresolver.BuildOptions{})
 	r.ResolveNow(grpcresolver.ResolveNowOptions{})
 
-	assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
+	expectedUpdate.Addresses = []grpcresolver.Address{
 		{
 			Addr: "two",
 		},
 		{
 			Addr: "three",
 		},
-	})
+	}
+	cc.assertUpdateWithin(t, time.Millisecond*100, expectedUpdate)
+	cc.close()
+	r.Close()
 }
 
 func TestResolveWithTags(t *testing.T) {
@@ -113,19 +190,22 @@ func TestResolveWithTags(t *testing.T) {
 	testopts := testopts
 	testopts.Discovery = disco
 
-	cc := mockClientConn{}
+	cc := newMockClientConn(1)
 	r := mustBuild(t, &builder{opts: testopts}, grpcresolver.Target{
 		URL: url.URL{Host: "vtgate"},
-	}, &cc, grpcresolver.BuildOptions{})
+	}, cc, grpcresolver.BuildOptions{})
 	r.opts.DiscoveryTags = []string{"tag2"}
 
-	r.ResolveNow(grpcresolver.ResolveNowOptions{})
-
-	assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
-		{
+	expectedUpdate := grpcresolver.State{
+		Addresses: []grpcresolver.Address{{
 			Addr: "two",
-		},
-	})
+		}},
+	}
+
+	r.ResolveNow(grpcresolver.ResolveNowOptions{})
+	cc.assertUpdateWithin(t, time.Millisecond*100, expectedUpdate)
+	cc.close()
+	r.Close()
 }
 
 func TestResolveEmptyList(t *testing.T) {
@@ -138,28 +218,41 @@ func TestResolveEmptyList(t *testing.T) {
 	testopts := testopts
 	testopts.Discovery = disco
 
-	cc := mockClientConn{}
+	cc := newMockClientConn(1)
 	r := mustBuild(t,
 		&builder{opts: testopts}, grpcresolver.Target{
 			URL: url.URL{Host: "vtgate"}, // we only have vtctlds
-		}, &cc, grpcresolver.BuildOptions{},
+		}, cc, grpcresolver.BuildOptions{},
 	)
 
-	r.ResolveNow(grpcresolver.ResolveNowOptions{})
+	expectedUpdate := grpcresolver.State{
+		Addresses: []grpcresolver.Address{},
+	}
 
-	assert.Empty(t, cc.Addrs, "ClientConn should have no addresses")
-	assert.True(t, cc.UpdateStateCalled, "resolver should still call cc.UpdateState with empty host list")
+	r.ResolveNow(grpcresolver.ResolveNowOptions{})
+	cc.assertUpdateWithin(t, time.Millisecond*50, expectedUpdate, "resolver should still call cc.UpdateState with empty host list")
+	cc.close()
+	r.Close()
 
 	disco.AddTaggedGates(nil, &vtadminpb.VTGate{
 		Hostname: "gate:one",
 	})
 
+	cc = newMockClientConn(1)
+	r = mustBuild(t,
+		&builder{opts: testopts}, grpcresolver.Target{
+			URL: url.URL{Host: "vtgate"},
+		}, cc, grpcresolver.BuildOptions{},
+	)
+
+	expectedUpdate.Addresses = []grpcresolver.Address{{
+		Addr: "gate:one",
+	}}
+
 	r.ResolveNow(grpcresolver.ResolveNowOptions{})
-	assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
-		{
-			Addr: "gate:one",
-		},
-	})
+	cc.assertUpdateWithin(t, time.Millisecond*50, expectedUpdate)
+	cc.close()
+	r.Close()
 }
 
 func TestBuild(t *testing.T) {
@@ -175,22 +268,22 @@ func TestBuild(t *testing.T) {
 	b := &builder{opts: testopts}
 
 	tests := []struct {
-		name      string
-		target    grpcresolver.Target
-		shouldErr bool
-		assertion func(t *testing.T, cc *mockClientConn)
+		name               string
+		target             grpcresolver.Target
+		shouldErr          bool
+		expectUpdateWithin time.Duration
+		expectedUpdate     grpcresolver.State
+		msgAndArgs         []any
 	}{
 		{
 			name: "vtctld",
 			target: grpcresolver.Target{
 				URL: url.URL{Host: "vtctld"},
 			},
-			assertion: func(t *testing.T, cc *mockClientConn) {
-				assert.ElementsMatch(t, cc.Addrs, []grpcresolver.Address{
-					{
-						Addr: "vtctld:one",
-					},
-				})
+			expectedUpdate: grpcresolver.State{
+				Addresses: []grpcresolver.Address{{
+					Addr: "vtctld:one",
+				}},
 			},
 		},
 		{
@@ -198,10 +291,8 @@ func TestBuild(t *testing.T) {
 			target: grpcresolver.Target{
 				URL: url.URL{Host: "vtgate"},
 			},
-			assertion: func(t *testing.T, cc *mockClientConn) {
-				assert.Empty(t, cc.Addrs, "resolver should not add addresses to clientconn (no vtgates in discovery)")
-				assert.True(t, cc.UpdateStateCalled, "resolver should still call UpdateState on clientconn (no vtgates in discovery)")
-			},
+			expectedUpdate: grpcresolver.State{Addresses: []grpcresolver.Address{}},
+			msgAndArgs:     []any{"resolver should still call UpdateState on clientconn (no vtgates in discovery)"},
 		},
 		{
 			name: "bad authority",
@@ -217,8 +308,8 @@ func TestBuild(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cc := &mockClientConn{}
-			_, err := b.Build(tt.target, cc, grpcresolver.BuildOptions{})
+			cc := newMockClientConn(1)
+			r, err := b.Build(tt.target, cc, grpcresolver.BuildOptions{})
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return
@@ -226,10 +317,15 @@ func TestBuild(t *testing.T) {
 
 			require.NoError(t, err)
 
-			func() {
-				t.Helper()
-				tt.assertion(t, cc)
-			}()
+			timeout := tt.expectUpdateWithin
+			if timeout == 0 {
+				timeout = time.Millisecond * 50
+			}
+
+			cc.assertUpdateWithin(t, timeout, tt.expectedUpdate, tt.msgAndArgs...)
+
+			cc.close()
+			r.Close()
 		})
 	}
 }

--- a/go/vt/vtadmin/cluster/resolver/resolver_test.go
+++ b/go/vt/vtadmin/cluster/resolver/resolver_test.go
@@ -191,10 +191,11 @@ func TestResolveWithTags(t *testing.T) {
 	testopts.Discovery = disco
 
 	cc := newMockClientConn(1)
-	r := mustBuild(t, &builder{opts: testopts}, grpcresolver.Target{
+	opts := testopts
+	opts.DiscoveryTags = []string{"tag2"}
+	r := mustBuild(t, &builder{opts: opts}, grpcresolver.Target{
 		URL: url.URL{Host: "vtgate"},
 	}, cc, grpcresolver.BuildOptions{})
-	r.opts.DiscoveryTags = []string{"tag2"}
 
 	expectedUpdate := grpcresolver.State{
 		Addresses: []grpcresolver.Address{{

--- a/go/vt/vtadmin/internal/backoff/backoff.go
+++ b/go/vt/vtadmin/internal/backoff/backoff.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package backoff implements different backoff strategies for retrying failed
+// operations in VTAdmin.
+//
+// It is first a reimplementation of grpc-go's internal exponential backoff
+// strategy, with one modification to prevent a jittered backoff from exceeding
+// the MaxDelay specified in a config.
+//
+// Then, for other use-cases, it implements a linear backoff strategy, as well
+// as a "none" strategy which is primarly intended for use in tests.
+package backoff
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	grpcbackoff "google.golang.org/grpc/backoff"
+
+	"vitess.io/vitess/go/vt/log"
+	vtrand "vitess.io/vitess/go/vt/vtadmin/internal/rand"
+)
+
+// Strategy defines the interface for different backoff strategies.
+type Strategy interface {
+	// Backoff returns the amount of time to backoff for the given retry count.
+	Backoff(retries int) time.Duration
+}
+
+var (
+	DefaultExponential = Exponential{grpcbackoff.DefaultConfig}
+	DefaultLinear      = Linear{grpcbackoff.DefaultConfig}
+	DefaultNone        = None{}
+)
+
+// Exponential implements an exponential backoff strategy with optional jitter.
+type Exponential struct {
+	Config grpcbackoff.Config
+}
+
+// Backoff is part of the Strategy interface.
+func (e Exponential) Backoff(retries int) time.Duration {
+	return backoffCommon(retries, e.Config, func(cur float64) float64 { return cur * e.Config.Multiplier })
+}
+
+// Linear implements a linear backoff strategy with optional jitter.
+type Linear struct {
+	Config grpcbackoff.Config
+}
+
+// Backoff is part of the Strategy interface.
+func (l Linear) Backoff(retries int) time.Duration {
+	return backoffCommon(retries, l.Config, func(cur float64) float64 { return cur + l.Config.Multiplier })
+}
+
+func backoffCommon(retries int, cfg grpcbackoff.Config, adjust func(cur float64) float64) time.Duration {
+	if retries == 0 {
+		return cfg.BaseDelay
+	}
+
+	backoff, max := float64(cfg.BaseDelay), float64(cfg.MaxDelay)
+	for backoff < max && retries > 0 {
+		backoff = adjust(backoff)
+		retries--
+	}
+	if backoff > max {
+		backoff = max
+	}
+	// Randomize backoff delays so that if a cluster of requests start at
+	// the same time, they won't operate in lockstep.
+	backoff *= 1 + cfg.Jitter*(vtrand.Float64()*2-1)
+	if backoff < 0 {
+		return 0
+	}
+
+	// NOTE: We differ from grpc's exponential backoff here, which actually can
+	// jitter to a backoff that exceeds the config's MaxDelay, which in my (ajm188)
+	// opinion is a bug.
+	if backoff > max {
+		backoff = max
+	}
+
+	return time.Duration(backoff)
+}
+
+// None implements a "backoff" strategy that can be summarized as "don't".
+type None struct{}
+
+// Backoff is part of the Strategy interface.
+func (None) Backoff(int) time.Duration { return 0 }
+
+// Get returns a backoff Strategy for the specified strategy name, with the
+// given config. Strategy lookup is case-insensitive, and the empty string
+// defaults to an exponential strategy. It panics if an unsupported strategy
+// name is specified.
+//
+// Currently-supported strategies are "exponential", "linear", and "none".
+func Get(strategy string, cfg grpcbackoff.Config) Strategy {
+	switch strings.ToLower(strategy) {
+	case "":
+		log.Warningf("no backoff strategy specified; defaulting to exponential")
+		fallthrough
+	case "exponential":
+		return Exponential{cfg}
+	case "linear":
+		return Linear{cfg}
+	case "none":
+		return None{}
+	default:
+		panic(fmt.Sprintf("unknown backoff strategy: %s", strategy))
+	}
+}

--- a/go/vt/vtadmin/internal/backoff/backoff_test.go
+++ b/go/vt/vtadmin/internal/backoff/backoff_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backoff
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	grpcbackoff "google.golang.org/grpc/backoff"
+)
+
+func TestExponentialBackoff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		cfg    grpcbackoff.Config
+		delays []time.Duration
+	}{
+		{
+			name: "",
+			cfg: grpcbackoff.Config{
+				BaseDelay:  time.Second,
+				Multiplier: 2,
+				Jitter:     0,
+				MaxDelay:   time.Second * 5,
+			},
+			delays: []time.Duration{
+				time.Second,
+				time.Second * 2,
+				time.Second * 4,
+				time.Second * 5, // multiplying exceeds max
+
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			exp := Get("exponential", tt.cfg)
+			for retry, expectedDelay := range tt.delays {
+				actualDelay := exp.Backoff(retry)
+				assert.Equal(t, expectedDelay, actualDelay, "incorrect backoff delay for retry count %v", retry)
+			}
+		})
+	}
+
+	t.Run("jitter never exceeds max delay", func(t *testing.T) {
+		t.Parallel()
+
+		exp := Get("exponential", grpcbackoff.Config{
+			BaseDelay:  time.Second,
+			Multiplier: 1,
+			Jitter:     2,
+			MaxDelay:   time.Second,
+		})
+		delays := []time.Duration{
+			time.Second,
+			time.Second,
+			time.Second,
+			time.Second,
+			time.Second,
+			time.Second,
+			time.Second,
+			time.Second, // you get the idea ...
+		}
+
+		for retry, expectedDelay := range delays {
+			actualDelay := exp.Backoff(retry)
+			assert.GreaterOrEqual(t, expectedDelay, actualDelay, "incorrect backoff delay for retry count %v", retry)
+		}
+	})
+}

--- a/go/vt/vtadmin/internal/rand/rand.go
+++ b/go/vt/vtadmin/internal/rand/rand.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides functions mirroring math/rand that are safe for
+// concurrent use, seeded independently of math/rand's global source.
+package rand
+
+/*
+- TODO: (ajm188) implement the rest of the global functions vtadmin uses.
+- TODO: (ajm188) consider moving to go/internal at the top-level for use in
+		more places.
+*/
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var (
+	r = rand.New(rand.NewSource(time.Now().UnixNano()))
+	m sync.Mutex
+)
+
+// Float64 implements rand.Float64 on the vtrand global source.
+func Float64() float64 {
+	m.Lock()
+	defer m.Unlock()
+
+	return r.Float64()
+}

--- a/go/vt/vtadmin/vtctldclient/config_test.go
+++ b/go/vt/vtadmin/vtctldclient/config_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/backoff"
 
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
@@ -56,7 +57,9 @@ func TestParse(t *testing.T) {
 			Credentials:     nil,
 			CredentialsPath: "",
 			ResolverOptions: &resolver.Options{
-				DiscoveryTimeout: 100 * time.Millisecond,
+				DiscoveryTimeout:     100 * time.Millisecond,
+				MinDiscoveryInterval: time.Second * 30,
+				BackoffConfig:        backoff.DefaultConfig,
 			},
 		}
 		assert.Equal(t, expected, cfg)
@@ -95,7 +98,9 @@ func TestParse(t *testing.T) {
 				Credentials:     creds,
 				CredentialsPath: credsfile.Name(),
 				ResolverOptions: &resolver.Options{
-					DiscoveryTimeout: 100 * time.Millisecond,
+					DiscoveryTimeout:     100 * time.Millisecond,
+					MinDiscoveryInterval: time.Second * 30,
+					BackoffConfig:        backoff.DefaultConfig,
 				},
 			}
 

--- a/go/vt/vtadmin/vtsql/config_test.go
+++ b/go/vt/vtadmin/vtsql/config_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/backoff"
 
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
@@ -145,8 +146,10 @@ func TestConfigParse(t *testing.T) {
 				Name: "testcluster",
 			},
 			ResolverOptions: &resolver.Options{
-				DiscoveryTags:    expectedTags,
-				DiscoveryTimeout: 100 * time.Millisecond,
+				DiscoveryTags:        expectedTags,
+				DiscoveryTimeout:     100 * time.Millisecond,
+				MinDiscoveryInterval: time.Second * 30,
+				BackoffConfig:        backoff.DefaultConfig,
 			},
 			Credentials:     expectedCreds,
 			CredentialsPath: path,


### PR DESCRIPTION
## Description

This PR updates the cluster discovery resolver to make `ResolveNow` a non-blocking call, by signaling on a channel to watcher goroutine which is continually updating the address list for a cluster component with backoff on failure. It's largely a port of grpc-go's dns-resolver with the "do a dns lookup" replaced with "make a discovery call". (See [dns_resolver](https://github.com/grpc/grpc-go/blob/3bf6719fc8ab5dac43b8494fcdc7e892efde6ea1/internal/resolver/dns/dns_resolver.go#L209) for reference).

The only notable changes are:
* I added extra backoff strategies, namely "linear" (which does `cur + multiplier` instead of exponential's `cur * multiplier`) and "none" (which never backs-off).
* I fixed the backoff for exponential and linear, to prevent jittering from exceeding the configured MaxDelay. This is an oversight in grpc-go's implementation as far as I can tell.
* I added a configuration option to govern the minimum wait time between successful iterations of the watcher loop. In grpc-go this is hard-coded to 30s.
* I corrected some usages of the timer. The DNS resolver leaks open timer channels in certain conditions.

## Related Issue(s)

#9977 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
