### PR TITLE
Implement fallback behavior for cross-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,13 +86,11 @@ endif
 	export GOBIN=""
 	# For the specified GOOS + GOARCH, build all the binaries by default with CGO disabled
 	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
+	
 	# unset GOOS and embed local resources in the vttablet executable
-	if [ -d /go/bin ]; then
-		# Probably in the bootstrap container
-		(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice --verbose append --exec=/go/bin/${GOOS}_${GOARCH}/vttablet)
-	else
-		(cd go/cmd/vttablet && unset GOOS && unset GOARCH && go run github.com/GeertJohan/go.rice/rice --verbose append --exec=$${HOME}/go/bin/${GOOS}_${GOARCH}/vttablet)
-	fi
+	# if these settings fail revert to previous behavior
+	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice --verbose append --exec=/go/bin/${GOOS}_${GOARCH}/vttablet) || \
+	(cd go/cmd/vttablet && unset GOOS && unset GOARCH && go run github.com/GeertJohan/go.rice/rice --verbose append --exec=$${HOME}/go/bin/${GOOS}_${GOARCH}/vttablet)
 	# Cross-compiling w/ cgo isn't trivial and we don't need vtorc, so we can skip building it
 
 debug:


### PR DESCRIPTION
Signed-off-by: FancyFane <fane@planetscale.com>

## Description

Changes were recently made to the cross-compile section of the Makefile. These changes use an if statement, which never falls back to the old behavior. This causes our weekly Vitess releases to fail when compiling Apple ARM binaries. This change allows the fallback behavior for this scenario. 


## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ n/a ] Tests were added or are not required
-   [ n/a ] Documentation was added or is not required

## Deployment Notes
None.