### PR TITLE
check for connectionID before adding to querylist

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -301,7 +301,7 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 						return err
 					}
 					defer dbConn.Recycle()
-					return qre.execStreamSQL(dbConn, sql, func(result *sqltypes.Result) error {
+					return qre.execStreamSQL(dbConn, qre.connID == 0, sql, func(result *sqltypes.Result) error {
 						// this stream result is potentially used by more than one client, so
 						// the consolidator will return it to the pool once it knows it's no longer
 						// being shared
@@ -333,7 +333,7 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		conn = dbConn
 	}
 
-	return qre.execStreamSQL(conn, sql, func(result *sqltypes.Result) error {
+	return qre.execStreamSQL(conn, qre.connID == 0, sql, func(result *sqltypes.Result) error {
 		// this stream result is only used by the calling client, so it can be
 		// returned to the pool once the callback has fully returned
 		defer returnStreamResult(result)
@@ -948,7 +948,7 @@ func (qre *QueryExecutor) execStatefulConn(conn *StatefulConnection, sql string,
 	return conn.Exec(ctx, sql, int(qre.tsv.qe.maxResultSize.Get()), wantfields)
 }
 
-func (qre *QueryExecutor) execStreamSQL(conn *connpool.DBConn, sql string, callback func(*sqltypes.Result) error) error {
+func (qre *QueryExecutor) execStreamSQL(conn *connpool.DBConn, hasConnectionID bool, sql string, callback func(*sqltypes.Result) error) error {
 	span, ctx := trace.NewSpan(qre.ctx, "QueryExecutor.execStreamSQL")
 	trace.AnnotateSQL(span, sqlparser.Preview(sql))
 	callBackClosingSpan := func(result *sqltypes.Result) error {
@@ -957,8 +957,19 @@ func (qre *QueryExecutor) execStreamSQL(conn *connpool.DBConn, sql string, callb
 	}
 
 	qd := NewQueryDetail(qre.logStats.Ctx, conn)
-	qre.tsv.olapql.Add(qd)
-	defer qre.tsv.olapql.Remove(qd)
+
+	// Add query detail object into QueryExecutor TableServer list w.r.t if it is a transactional or not. Previously we were adding it
+	// to olapql list regardless but that resulted in issues like (https://github.com/planetscale/vitess-private/issues/548),
+	// where long-running stream queries which can be stateful (or transactional) weren't getting cleaned up during unserveCommon>handleShutdownGracePeriod
+	// in state_manager.go. This change will ensure that long-running streaming stateful queries get gracefully shutdown during ServingTypeChange.
+	if hasConnectionID {
+		qre.tsv.olapql.Add(qd)
+		defer qre.tsv.olapql.Remove(qd)
+	} else {
+		// if in transaction
+		qre.tsv.statefulql.Add(qd)
+		defer qre.tsv.statefulql.Remove(qd)
+	}
 
 	start := time.Now()
 	err := conn.Stream(ctx, sql, callBackClosingSpan, allocStreamResult, int(qre.tsv.qe.streamBufferSize.Get()), sqltypes.IncludeFieldsOrDefault(qre.options))

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -959,9 +959,9 @@ func (qre *QueryExecutor) execStreamSQL(conn *connpool.DBConn, isTransaction boo
 	qd := NewQueryDetail(qre.logStats.Ctx, conn)
 
 	// Add query detail object into QueryExecutor TableServer list w.r.t if it is a transactional or not. Previously we were adding it
-	// to olapql list regardless but that resulted in issues like (https://github.com/planetscale/vitess-private/issues/548),
-	// where long-running stream queries which can be stateful (or transactional) weren't getting cleaned up during unserveCommon>handleShutdownGracePeriod
-	// in state_manager.go. This change will ensure that long-running streaming stateful queries get gracefully shutdown during ServingTypeChange
+	// to olapql list regardless but that resulted in problems, where long-running stream queries which can be stateful (or transactional)
+	// weren't getting cleaned up during unserveCommon>handleShutdownGracePeriod in state_manager.go.
+	// This change will ensure that long-running streaming stateful queries get gracefully shutdown during ServingTypeChange
 	// once their grace period is over.
 	if isTransaction {
 		qre.tsv.statefulql.Add(qd)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -963,8 +963,6 @@ func (qre *QueryExecutor) execStreamSQL(conn *connpool.DBConn, isTransaction boo
 	// where long-running stream queries which can be stateful (or transactional) weren't getting cleaned up during unserveCommon>handleShutdownGracePeriod
 	// in state_manager.go. This change will ensure that long-running streaming stateful queries get gracefully shutdown during ServingTypeChange
 	// once their grace period is over.
-	qre.tsv.olapql.Add(qd)
-	defer qre.tsv.olapql.Remove(qd)
 	if isTransaction {
 		qre.tsv.statefulql.Add(qd)
 		defer qre.tsv.statefulql.Remove(qd)


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>

## Description

This is a bug where long running streaming queries with transaction fails to shutdown gracefully. Previously during execStreamSQL we were adding query to OLAP queryList regardless of whether it is transactional or not. With this change we put streaming transaction queries to stateful list, which result it in graceful shutdown of these queries during handleShutdownGracePeriod  if it exceeds the grace period.

I decided to pass isTransaction as parameter to execStreamSQL because I don't want execStreamSQL to have a logic of isTransaction. Let me know if you feel otherwise. 


## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
