### PR TITLE
Fix handling of unsigned and zerofill in parser and normalization

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -282,6 +282,12 @@ func (c *CreateTableEntity) normalizeColumnOptions() {
 		// doesn't mean anything anymore.
 		if _, ok := integralTypes[col.Type.Type]; ok {
 			col.Type.Length = nil
+			// Remove zerofill for integral types but keep the behavior that this marks the value
+			// as unsigned
+			if col.Type.Zerofill {
+				col.Type.Zerofill = false
+				col.Type.Unsigned = true
+			}
 		}
 
 		if _, ok := charsetTypes[col.Type.Type]; ok {

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -613,10 +613,10 @@ func (ct *ColumnType) Format(buf *TrackedBuffer) {
 	}
 
 	if ct.Unsigned {
-		buf.astPrintf(ct, " %s", keywordStrings[UNSIGNED])
+		buf.astPrintf(ct, " %#s", keywordStrings[UNSIGNED])
 	}
 	if ct.Zerofill {
-		buf.astPrintf(ct, " %s", keywordStrings[ZEROFILL])
+		buf.astPrintf(ct, " %#s", keywordStrings[ZEROFILL])
 	}
 	if ct.Charset != "" {
 		buf.astPrintf(ct, " %s %s %#s", keywordStrings[CHARACTER], keywordStrings[SET], ct.Charset)

--- a/go/vt/sqlparser/tracked_buffer_test.go
+++ b/go/vt/sqlparser/tracked_buffer_test.go
@@ -73,6 +73,14 @@ func TestCanonicalOutput(t *testing.T) {
 			"CREATE TABLE `a` (\n\t`id` int,\n\tPRIMARY KEY (`id`)\n)",
 		},
 		{
+			"create table `a`(`id` int unsigned, primary key(`id`))",
+			"CREATE TABLE `a` (\n\t`id` int unsigned,\n\tPRIMARY KEY (`id`)\n)",
+		},
+		{
+			"create table `a`(`id` int zerofill, primary key(`id`))",
+			"CREATE TABLE `a` (\n\t`id` int zerofill,\n\tPRIMARY KEY (`id`)\n)",
+		},
+		{
 			"create table `a`(`id` int primary key)",
 			"CREATE TABLE `a` (\n\t`id` int PRIMARY KEY\n)",
 		},
@@ -110,7 +118,7 @@ func TestCanonicalOutput(t *testing.T) {
 		},
 		{
 			"alter table t2 modify column id bigint unsigned primary key",
-			"ALTER TABLE `t2` MODIFY COLUMN `id` bigint UNSIGNED PRIMARY KEY",
+			"ALTER TABLE `t2` MODIFY COLUMN `id` bigint unsigned PRIMARY KEY",
 		},
 		{
 			"alter table t1 modify column a int first, modify column b int after a",


### PR DESCRIPTION
In the parser when generating a query, unsigned and zerofill are always rendered lowercase in canonical MySQL output.

Additionally, zerofill is deprecated for integer values similar to the length. Zerofill does still have a side effect though which is that it also does mark the field as unsigned.

The normalization now removes the zerofill attribute, but sets unsigned to true if it was used to keep this side effect.

Also see https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html for the reference documentation on how this works.

## Related Issue(s)

- #10203 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required