### PR TITLE
Flaky test fix: TestFoundRows

### DIFF
--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -273,4 +274,24 @@ func (vtgate *VtgateProcess) GetVars() (map[string]interface{}, error) {
 		return resultMap, nil
 	}
 	return nil, fmt.Errorf("unsuccessful response")
+}
+
+// ReadVSchema reads the vschema from the vtgate endpoint for it and returns
+// a pointer to the interface. To read this vschema, the caller must convert it to a map
+func (vtgate *VtgateProcess) ReadVSchema() (*interface{}, error) {
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	resp, err := httpClient.Get(vtgate.VSchemaURL)
+	if err != nil {
+		return nil, err
+	}
+	res, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var results interface{}
+	err = json.Unmarshal(res, &results)
+	if err != nil {
+		return nil, err
+	}
+	return &results, nil
 }

--- a/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go
+++ b/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go
@@ -18,14 +18,15 @@ package foundrows
 
 import (
 	"context"
+	"fmt"
 	"testing"
-
-	"vitess.io/vitess/go/test/endtoend/vtgate/utils"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/vtgate/utils"
 )
 
 func TestFoundRows(t *testing.T) {
@@ -40,6 +41,11 @@ func TestFoundRows(t *testing.T) {
 
 	utils.Exec(t, conn, "insert into t2(id3,id4) values(1,2), (2,2), (3,3), (4,3), (5,3)")
 
+	// Wait for schema tracking to run and mark t2 as authoritative before we try out the queries.
+	// Some of the queries depend on schema tracking to run successfully to be able to replace the StarExpr
+	// in the select clause with the definitive column list.
+	err = waitForT2Authoritative(t)
+	require.NoError(t, err)
 	runTests := func(workload string) {
 		utils.AssertFoundRowsValue(t, conn, "select * from t2", workload, 5)
 		utils.AssertFoundRowsValue(t, conn, "select * from t2 order by id3 limit 2", workload, 2)
@@ -57,4 +63,39 @@ func TestFoundRows(t *testing.T) {
 	utils.Exec(t, conn, "set workload = oltp")
 	utils.Exec(t, conn, "delete from t2")
 	utils.Exec(t, conn, "delete from t2_id4_idx")
+}
+
+// waitForT2Authoritative waits for the table t2 to become authoritative
+func waitForT2Authoritative(t *testing.T) error {
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("schema tracking didn't mark table t2 as authoritative until timeout")
+		default:
+			time.Sleep(1 * time.Second)
+			res, err := clusterInstance.VtgateProcess.ReadVSchema()
+			require.NoError(t, err, res)
+			t2Map := getTableT2Map(res)
+			authoritative, fieldPresent := t2Map["column_list_authoritative"]
+			if !fieldPresent {
+				continue
+			}
+			authoritativeBool, isBool := authoritative.(bool)
+			if !isBool || !authoritativeBool {
+				continue
+			}
+			return nil
+		}
+	}
+}
+
+func getTableT2Map(res *interface{}) map[string]interface{} {
+	t2Map := convertToMap(convertToMap(convertToMap(convertToMap(convertToMap(*res)["keyspaces"])[KeyspaceName])["tables"])["t2"])
+	return t2Map
+}
+
+func convertToMap(input interface{}) map[string]interface{} {
+	output, _ := input.(map[string]interface{})
+	return output
 }

--- a/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go
+++ b/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go
@@ -96,6 +96,6 @@ func getTableT2Map(res *interface{}) map[string]interface{} {
 }
 
 func convertToMap(input interface{}) map[string]interface{} {
-	output, _ := input.(map[string]interface{})
+	output := input.(map[string]interface{})
 	return output
 }


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

The test `TestFoundRows` runs queries that are dependent on schema tracking running successfully before the queries are executed. This however, makes the test flaky since some times, schema tracking doesn't run before we execute the queries, which leads to errors.
This PR fixes this issue, by waiting for the schema-tracking to run and mark the table used as authoritative before we run any queries against it.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported -> Forward port required
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
