### PR TITLE
CI: fix flaky test via extended timeout in vrepl_stress_suite

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
@@ -371,6 +371,7 @@ const (
 	maxTableRows                  = 4096
 	maxConcurrency                = 15
 	singleConnectionSleepInterval = 5 * time.Millisecond
+	waitForStatusTimeout          = 120 * time.Second
 )
 
 func resetOpOrder() {
@@ -573,7 +574,7 @@ func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy str
 
 	status := schema.OnlineDDLStatusComplete
 	if !strategySetting.Strategy.IsDirect() {
-		status = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 60*time.Second, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+		status = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, waitForStatusTimeout, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 		fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 	}
 


### PR DESCRIPTION

## Description

Discussion: https://github.com/vitessio/vitess/issues/8969#issuecomment-1120394834

Gonna create this PR as `Draft` and run `vrepl_stress_suite` multiple times to see if this fixes the flakiness. The tests have been stable for months, and recently became flaky. First suspicion is GitHub CI runners getting slower.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/8969#issuecomment-1120394834

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
