### PR TITLE
[vtadmin] Remove explicit Dial-ing for vtctldclient proxy

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -92,7 +92,7 @@ func startTracing(cmd *cobra.Command) {
 }
 
 func run(cmd *cobra.Command, args []string) {
-	bootSpan, _ := trace.NewSpan(context.Background(), "vtadmin.boot")
+	bootSpan, ctx := trace.NewSpan(context.Background(), "vtadmin.boot")
 	defer bootSpan.Finish()
 
 	configs := clusterFileConfig.Combine(defaultClusterConfig, clusterConfigs)
@@ -120,7 +120,7 @@ func run(cmd *cobra.Command, args []string) {
 	}
 
 	for i, cfg := range configs {
-		cluster, err := cfg.Cluster()
+		cluster, err := cfg.Cluster(ctx)
 		if err != nil {
 			bootSpan.Finish()
 			fatal(err)

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -389,10 +389,6 @@ func (api *API) CreateKeyspace(ctx context.Context, req *vtadminpb.CreateKeyspac
 		return nil, err
 	}
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	ks, err := c.CreateKeyspace(ctx, req.Options)
 	if err != nil {
 		return nil, err
@@ -419,10 +415,6 @@ func (api *API) CreateShard(ctx context.Context, req *vtadminpb.CreateShardReque
 		return nil, err
 	}
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	return c.CreateShard(ctx, req.Options)
 }
 
@@ -442,10 +434,6 @@ func (api *API) DeleteKeyspace(ctx context.Context, req *vtadminpb.DeleteKeyspac
 		return nil, err
 	}
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	return c.DeleteKeyspace(ctx, req.Options)
 }
 
@@ -462,10 +450,6 @@ func (api *API) DeleteShards(ctx context.Context, req *vtadminpb.DeleteShardsReq
 
 	c, err := api.getClusterForRequest(req.ClusterId)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := c.Vtctld.Dial(ctx); err != nil {
 		return nil, err
 	}
 
@@ -958,10 +942,6 @@ func (api *API) DeleteTablet(ctx context.Context, req *vtadminpb.DeleteTabletReq
 
 	cluster.AnnotateSpan(c, span)
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	_, err = c.Vtctld.DeleteTablets(ctx, &vtctldatapb.DeleteTabletsRequest{
 		TabletAliases: []*topodatapb.TabletAlias{
 			tablet.Tablet.Alias,
@@ -991,10 +971,6 @@ func (api *API) ReparentTablet(ctx context.Context, req *vtadminpb.ReparentTable
 
 	cluster.AnnotateSpan(c, span)
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	r, err := c.Vtctld.ReparentTablet(ctx, &vtctldatapb.ReparentTabletRequest{
 		Tablet: tablet.Tablet.Alias,
 	})
@@ -1022,10 +998,6 @@ func (api *API) RunHealthCheck(ctx context.Context, req *vtadminpb.RunHealthChec
 	}
 
 	cluster.AnnotateSpan(c, span)
-
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
 
 	_, err = c.Vtctld.RunHealthCheck(ctx, &vtctldatapb.RunHealthCheckRequest{
 		TabletAlias: tablet.Tablet.Alias,
@@ -1055,10 +1027,6 @@ func (api *API) PingTablet(ctx context.Context, req *vtadminpb.PingTabletRequest
 
 	cluster.AnnotateSpan(c, span)
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	_, err = c.Vtctld.PingTablet(ctx, &vtctldatapb.PingTabletRequest{
 		TabletAlias: tablet.Tablet.Alias,
 	})
@@ -1086,10 +1054,6 @@ func (api *API) SetReadOnly(ctx context.Context, req *vtadminpb.SetReadOnlyReque
 	}
 
 	cluster.AnnotateSpan(c, span)
-
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
 
 	_, err = c.Vtctld.SetWritable(ctx, &vtctldatapb.SetWritableRequest{
 		TabletAlias: tablet.Tablet.Alias,
@@ -1120,10 +1084,6 @@ func (api *API) SetReadWrite(ctx context.Context, req *vtadminpb.SetReadWriteReq
 
 	cluster.AnnotateSpan(c, span)
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	_, err = c.Vtctld.SetWritable(ctx, &vtctldatapb.SetWritableRequest{
 		TabletAlias: tablet.Tablet.Alias,
 		Writable:    true,
@@ -1153,10 +1113,6 @@ func (api *API) StartReplication(ctx context.Context, req *vtadminpb.StartReplic
 
 	cluster.AnnotateSpan(c, span)
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	_, err = c.Vtctld.StartReplication(ctx, &vtctldatapb.StartReplicationRequest{
 		TabletAlias: tablet.Tablet.Alias,
 	})
@@ -1184,10 +1140,6 @@ func (api *API) StopReplication(ctx context.Context, req *vtadminpb.StopReplicat
 	}
 
 	cluster.AnnotateSpan(c, span)
-
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
 
 	_, err = c.Vtctld.StopReplication(ctx, &vtctldatapb.StopReplicationRequest{
 		TabletAlias: tablet.Tablet.Alias,
@@ -1263,10 +1215,6 @@ func (api *API) GetVSchema(ctx context.Context, req *vtadminpb.GetVSchemaRequest
 		return nil, nil
 	}
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	return c.GetVSchema(ctx, req.Keyspace)
 }
 
@@ -1306,11 +1254,6 @@ func (api *API) GetVSchemas(ctx context.Context, req *vtadminpb.GetVSchemasReque
 			defer span.Finish()
 
 			cluster.AnnotateSpan(c, span)
-
-			if err := c.Vtctld.Dial(ctx); err != nil {
-				rec.RecordError(fmt.Errorf("Vtctld.Dial(cluster = %s): %w", c.ID, err))
-				return
-			}
 
 			getKeyspacesSpan, getKeyspacesCtx := trace.NewSpan(ctx, "Cluster.GetKeyspaces")
 			cluster.AnnotateSpan(c, getKeyspacesSpan)
@@ -1510,10 +1453,6 @@ func (api *API) RefreshState(ctx context.Context, req *vtadminpb.RefreshStateReq
 
 	cluster.AnnotateSpan(c, span)
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	_, err = c.Vtctld.RefreshState(ctx, &vtctldatapb.RefreshStateRequest{
 		TabletAlias: tablet.Tablet.Alias,
 	})
@@ -1565,10 +1504,6 @@ func (api *API) ValidateSchemaKeyspace(ctx context.Context, req *vtadminpb.Valid
 		return nil, nil
 	}
 
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
-
 	res, err := c.Vtctld.ValidateSchemaKeyspace(ctx, &vtctldatapb.ValidateSchemaKeyspaceRequest{
 		Keyspace: req.Keyspace,
 	})
@@ -1592,10 +1527,6 @@ func (api *API) ValidateVersionKeyspace(ctx context.Context, req *vtadminpb.Vali
 
 	if !api.authz.IsAuthorized(ctx, c.ID, rbac.KeyspaceResource, rbac.PutAction) {
 		return nil, nil
-	}
-
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
 	}
 
 	res, err := c.Vtctld.ValidateVersionKeyspace(ctx, &vtctldatapb.ValidateVersionKeyspaceRequest{
@@ -1646,10 +1577,6 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 	}
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(tablet.Tablet.Alias))
-
-	if err := c.Vtctld.Dial(ctx); err != nil {
-		return nil, err
-	}
 
 	var (
 		wg sync.WaitGroup
@@ -1723,9 +1650,7 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 	go func(c *cluster.Cluster) {
 		defer wg.Done()
 
-		shards, err := c.FindAllShardsInKeyspace(ctx, req.Keyspace, cluster.FindAllShardsInKeyspaceOptions{
-			SkipDial: true,
-		})
+		shards, err := c.FindAllShardsInKeyspace(ctx, req.Keyspace, cluster.FindAllShardsInKeyspaceOptions{})
 		if err != nil {
 			er.RecordError(err)
 			return

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -233,7 +233,7 @@ func (api *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if clusterCookie, err := r.Cookie("cluster"); err == nil {
 		urlDecoded, err := url.QueryUnescape(clusterCookie.Value)
 		if err == nil {
-			c, id, err := dynamic.ClusterFromString(urlDecoded)
+			c, id, err := dynamic.ClusterFromString(r.Context(), urlDecoded)
 			if id != "" {
 				if err != nil {
 					log.Warningf("failed to extract valid cluster from cookie; attempting to use existing cluster with id=%s; error: %s", id, err)

--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -4856,7 +4856,7 @@ func TestServeHTTP(t *testing.T) {
 				"discovery": "{\"vtctlds\": [{\"host\":{\"fqdn\": \"localhost:15000\", \"hostname\": \"localhost:15999\"}}], \"vtgates\": [{\"host\": {\"hostname\": \"localhost:15991\"}}]}",
 			},
 		},
-	}.Cluster()
+	}.Cluster(context.Background())
 
 	tests := []struct {
 		name                  string

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -80,7 +80,7 @@ type Cluster struct {
 }
 
 // New creates a new Cluster from a Config.
-func New(cfg Config) (*Cluster, error) {
+func New(ctx context.Context, cfg Config) (*Cluster, error) {
 	cluster := &Cluster{
 		ID:   cfg.ID,
 		Name: cfg.Name,
@@ -117,7 +117,7 @@ func New(cfg Config) (*Cluster, error) {
 	}
 
 	cluster.DB = vtsql.New(vtsqlCfg)
-	cluster.Vtctld, err = vtctldclient.New(vtctldCfg)
+	cluster.Vtctld, err = vtctldclient.New(ctx, vtctldCfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating vtctldclient: %w", err)
 	}

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -113,7 +113,10 @@ func New(cfg Config) (*Cluster, error) {
 	}
 
 	cluster.DB = vtsql.New(vtsqlCfg)
-	cluster.Vtctld = vtctldclient.New(vtctldCfg)
+	cluster.Vtctld, err = vtctldclient.New(vtctldCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error creating vtctldclient: %w", err)
+	}
 
 	if cfg.TabletFQDNTmplStr != "" {
 		cluster.TabletFQDNTmpl, err = template.New(cluster.ID + "-tablet-fqdn").Parse(cfg.TabletFQDNTmplStr)

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -112,6 +112,10 @@ func New(cfg Config) (*Cluster, error) {
 		return nil, fmt.Errorf("error creating vtctldclient proxy config: %w", err)
 	}
 
+	for _, opt := range cfg.vtctldConfigOpts {
+		vtctldCfg = opt(vtctldCfg)
+	}
+
 	cluster.DB = vtsql.New(vtsqlCfg)
 	cluster.Vtctld, err = vtctldclient.New(vtctldCfg)
 	if err != nil {

--- a/go/vt/vtadmin/cluster/cluster_internal_test.go
+++ b/go/vt/vtadmin/cluster/cluster_internal_test.go
@@ -121,7 +121,6 @@ func Test_getShardSets(t *testing.T) {
 		},
 		topoReadPool: pools.NewRPCPool(5, 0, nil),
 	}
-	require.NoError(t, c.Vtctld.Dial(context.Background()))
 
 	tests := []struct {
 		name           string

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -165,8 +165,6 @@ func TestCreateKeyspace(t *testing.T) {
 			t.Parallel()
 
 			cluster := testutil.BuildCluster(t, tt.cfg)
-			err := cluster.Vtctld.Dial(ctx)
-			require.NoError(t, err, "could not dial test vtctld")
 
 			resp, err := cluster.CreateKeyspace(ctx, tt.req)
 			if tt.shouldErr {
@@ -263,10 +261,7 @@ func TestCreateShard(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.tc.Cluster.Vtctld.Dial(ctx)
-			require.NoError(t, err, "could not dial in-process vtctld")
-
-			_, err = tt.tc.Cluster.CreateShard(ctx, tt.req)
+			_, err := tt.tc.Cluster.CreateShard(ctx, tt.req)
 			if tt.shouldErr {
 				assert.Error(t, err)
 			} else {
@@ -356,8 +351,6 @@ func TestDeleteKeyspace(t *testing.T) {
 			t.Parallel()
 
 			cluster := testutil.BuildCluster(t, tt.cfg)
-			err := cluster.Vtctld.Dial(ctx)
-			require.NoError(t, err, "could not dial test vtctld")
 
 			resp, err := cluster.DeleteKeyspace(ctx, tt.req)
 			if tt.shouldErr {
@@ -487,9 +480,6 @@ func TestDeleteShards(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.tc.Cluster.Vtctld.Dial(ctx)
-			require.NoError(t, err, "could not dial in-process vtctld")
-
 			if tt.setup != nil {
 				func() {
 					t.Helper()
@@ -497,7 +487,7 @@ func TestDeleteShards(t *testing.T) {
 				}()
 			}
 
-			_, err = tt.tc.Cluster.DeleteShards(ctx, tt.req)
+			_, err := tt.tc.Cluster.DeleteShards(ctx, tt.req)
 			if tt.shouldErr {
 				assert.Error(t, err)
 			} else {
@@ -1369,9 +1359,6 @@ func TestGetSchema(t *testing.T) {
 				DBConfig:     testutil.Dbcfg{},
 			})
 
-			err := c.Vtctld.Dial(ctx)
-			require.NoError(t, err, "could not dial test vtctld")
-
 			schema, err := c.GetSchema(ctx, "testkeyspace", cluster.GetSchemaOptions{
 				BaseRequest: tt.req,
 			})
@@ -1422,9 +1409,6 @@ func TestGetSchema(t *testing.T) {
 			},
 			VtctldClient: vtctld,
 		})
-
-		err := c.Vtctld.Dial(ctx)
-		require.NoError(t, err, "could not dial test vtctld")
 
 		_, _ = c.GetSchema(ctx, "testkeyspace", cluster.GetSchemaOptions{
 			BaseRequest: req,
@@ -2599,8 +2583,6 @@ func TestGetShardReplicationPositions(t *testing.T) {
 			t.Parallel()
 
 			c := testutil.BuildCluster(t, tt.cfg)
-			err := c.Vtctld.Dial(ctx)
-			require.NoError(t, err, "failed to dial test vtctld")
 
 			resp, err := c.GetShardReplicationPositions(ctx, tt.req)
 			if tt.shouldErr {
@@ -2716,8 +2698,6 @@ func TestGetVSchema(t *testing.T) {
 			t.Parallel()
 
 			cluster := testutil.BuildCluster(t, tt.cfg)
-			err := cluster.Vtctld.Dial(ctx)
-			require.NoError(t, err, "could not dial test vtctld")
 
 			vschema, err := cluster.GetVSchema(ctx, tt.keyspace)
 			if tt.shouldErr {

--- a/go/vt/vtadmin/cluster/config.go
+++ b/go/vt/vtadmin/cluster/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"context"
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
@@ -67,8 +68,8 @@ type Config struct {
 }
 
 // Cluster returns a new cluster instance from the given config.
-func (cfg Config) Cluster() (*Cluster, error) {
-	return New(cfg)
+func (cfg Config) Cluster(ctx context.Context) (*Cluster, error) {
+	return New(ctx, cfg)
 }
 
 // String is part of the flag.Value interface.

--- a/go/vt/vtadmin/cluster/config.go
+++ b/go/vt/vtadmin/cluster/config.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/pools"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtadmin/errors"
+	"vitess.io/vitess/go/vt/vtadmin/vtctldclient"
 )
 
 var (
@@ -61,6 +62,8 @@ type Config struct {
 	TopoRWPoolConfig       *RPCPoolConfig
 	TopoReadPoolConfig     *RPCPoolConfig
 	WorkflowReadPoolConfig *RPCPoolConfig
+
+	vtctldConfigOpts []vtctldclient.ConfigOption
 }
 
 // Cluster returns a new cluster instance from the given config.
@@ -354,4 +357,14 @@ func (cfg *RPCPoolConfig) parseFlag(name string, val string) (err error) {
 	}
 
 	return nil
+}
+
+// WithVtctldTestConfigOptions returns a new Config with the given vtctldclient
+// ConfigOptions appended to any existing ConfigOptions in the current Config.
+//
+// It should be used in tests only, and is exported to for use in the
+// vtadmin/testutil package.
+func (cfg Config) WithVtctldTestConfigOptions(opts ...vtctldclient.ConfigOption) Config {
+	cfg.vtctldConfigOpts = append(cfg.vtctldConfigOpts, opts...)
+	return cfg
 }

--- a/go/vt/vtadmin/cluster/dynamic/cluster.go
+++ b/go/vt/vtadmin/cluster/dynamic/cluster.go
@@ -1,6 +1,7 @@
 package dynamic
 
 import (
+	"context"
 	"encoding/base64"
 	"strings"
 
@@ -19,7 +20,7 @@ import (
 //
 // Therefore, callers should handle the return values as follows:
 //
-//		c, id, err := dynamic.ClusterFromString(s)
+//		c, id, err := dynamic.ClusterFromString(ctx, s)
 //		if id == "" {
 //			// handle err, do not use `c`.
 //		}
@@ -29,12 +30,12 @@ import (
 //		// Use `c` (or existing cluster with ID == `id`) based on the dynamic cluster
 //		api.WithCluster(c, id).DoAThing()
 //
-func ClusterFromString(s string) (c *cluster.Cluster, id string, err error) {
+func ClusterFromString(ctx context.Context, s string) (c *cluster.Cluster, id string, err error) {
 	cfg, id, err := cluster.LoadConfig(base64.NewDecoder(base64.StdEncoding, strings.NewReader(s)), "json")
 	if err != nil {
 		return nil, id, err
 	}
 
-	c, err = cfg.Cluster()
+	c, err = cfg.Cluster(ctx)
 	return c, id, err
 }

--- a/go/vt/vtadmin/cluster/dynamic/cluster_test.go
+++ b/go/vt/vtadmin/cluster/dynamic/cluster_test.go
@@ -1,6 +1,7 @@
 package dynamic
 
 import (
+	"context"
 	"encoding/base32"
 	"encoding/base64"
 	"testing"
@@ -62,7 +63,7 @@ func TestClusterFromString(t *testing.T) {
 
 			enc := tt.encoder([]byte(tt.s))
 
-			c, id, err := ClusterFromString(enc)
+			c, id, err := ClusterFromString(context.Background(), enc)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				assert.Nil(t, c, "when err != nil, cluster must be nil")

--- a/go/vt/vtadmin/cluster/dynamic/interceptors.go
+++ b/go/vt/vtadmin/cluster/dynamic/interceptors.go
@@ -86,7 +86,7 @@ func clusterFromIncomingContextMetadata(ctx context.Context) (*cluster.Cluster, 
 		return nil, "", false, nil
 	}
 
-	c, id, err := ClusterFromString(clusterMetadata[0])
+	c, id, err := ClusterFromString(ctx, clusterMetadata[0])
 	return c, id, true, err
 }
 

--- a/go/vt/vtadmin/testutil/cluster.go
+++ b/go/vt/vtadmin/testutil/cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testutil
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"sync"
@@ -104,7 +105,10 @@ func BuildCluster(t testing.TB, cfg TestClusterConfig) *cluster.Cluster {
 
 	m.Lock()
 	testdisco = disco
-	c, err := cluster.New(clusterConf)
+	c, err := cluster.New(
+		context.Background(), // consider updating this function to allow callers to provide a context.
+		clusterConf,
+	)
 	m.Unlock()
 
 	require.NoError(t, err, "failed to create cluster from configs %+v %+v", clusterConf, cfg)

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -80,7 +80,7 @@ type ClientProxy struct {
 //
 // It does not open a connection to a vtctld; users must call Dial before first
 // use.
-func New(cfg *Config) (*ClientProxy, error) {
+func New(ctx context.Context, cfg *Config) (*ClientProxy, error) {
 	dialFunc := cfg.dialFunc
 	if dialFunc == nil {
 		dialFunc = grpcvtctldclient.NewWithDialOpts
@@ -95,7 +95,7 @@ func New(cfg *Config) (*ClientProxy, error) {
 		closed:   true,
 	}
 
-	if err := proxy.Dial(context.TODO() /* TODO: thread ctx from startup => cluster.New => here */); err != nil {
+	if err := proxy.Dial(ctx); err != nil {
 		return nil, err
 	}
 

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -85,14 +85,21 @@ func New(cfg *Config) (*ClientProxy, error) {
 	if dialFunc == nil {
 		dialFunc = grpcvtctldclient.NewWithDialOpts
 	}
-	return &ClientProxy{
+
+	proxy := ClientProxy{
 		cfg:      cfg,
 		cluster:  cfg.Cluster,
 		creds:    cfg.Credentials,
 		dialFunc: dialFunc,
 		resolver: cfg.ResolverOptions.NewBuilder(cfg.Cluster.Id),
 		closed:   true,
-	}, nil
+	}
+
+	if err := proxy.Dial(context.TODO() /* TODO: thread ctx from startup => cluster.New => here */); err != nil {
+		return nil, err
+	}
+
+	return &proxy, nil
 }
 
 // Dial is part of the Proxy interface.

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -80,7 +80,7 @@ type ClientProxy struct {
 //
 // It does not open a connection to a vtctld; users must call Dial before first
 // use.
-func New(cfg *Config) *ClientProxy {
+func New(cfg *Config) (*ClientProxy, error) {
 	return &ClientProxy{
 		cfg:      cfg,
 		cluster:  cfg.Cluster,
@@ -88,7 +88,7 @@ func New(cfg *Config) *ClientProxy {
 		DialFunc: grpcvtctldclient.NewWithDialOpts,
 		resolver: cfg.ResolverOptions.NewBuilder(cfg.Cluster.Id),
 		closed:   true,
-	}
+	}, nil
 }
 
 // Dial is part of the Proxy interface.

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -19,13 +19,13 @@ package vtctldclient
 import (
 	"context"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	grpcresolver "google.golang.org/grpc/resolver"
 
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery/fakediscovery"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
@@ -94,40 +94,30 @@ func TestDial(t *testing.T) {
 
 	defer proxy.Close() // prevents grpc-core from logging a bunch of "connection errors" after deferred listener.Close() above.
 
-	err = proxy.Dial(context.Background())
-	assert.NoError(t, err)
-
 	resp, err := proxy.GetKeyspace(context.Background(), &vtctldatapb.GetKeyspaceRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, listener.Addr().String(), resp.Keyspace.Name)
 }
 
-// testResolverBuilder wraps a grpcresolver.Builder to return *testResolvers
-// with a channel to detect calls to ResolveNow in tests.
-type testResolverBuilder struct {
-	grpcresolver.Builder
-	fired chan struct{}
+type testdisco struct {
+	*fakediscovery.Fake
+	notify chan struct{}
+	fired  chan struct{}
+	m      sync.Mutex
 }
 
-func (b *testResolverBuilder) Build(target grpcresolver.Target, cc grpcresolver.ClientConn, opts grpcresolver.BuildOptions) (grpcresolver.Resolver, error) {
-	r, err := b.Builder.Build(target, cc, opts)
-	if err != nil {
-		return nil, err
+func (d *testdisco) DiscoverVtctldAddrs(ctx context.Context, tags []string) ([]string, error) {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	select {
+	case <-d.notify:
+		defer func() {
+			go func() { d.fired <- struct{}{} }()
+		}()
+	default:
 	}
-
-	return &testResolver{r, b.fired}, nil
-}
-
-// testResolver wraps a grpcresolver.Resolver to signal when ResolveNow is
-// called in tests.
-type testResolver struct {
-	grpcresolver.Resolver
-	fired chan struct{}
-}
-
-func (r *testResolver) ResolveNow(o grpcresolver.ResolveNowOptions) {
-	r.Resolver.ResolveNow(o)
-	r.fired <- struct{}{}
+	return d.Fake.DiscoverVtctldAddrs(ctx, tags)
 }
 
 // TestRedial tests that vtadmin-api is able to recover from a lost connection to
@@ -151,33 +141,33 @@ func TestRedial(t *testing.T) {
 	go server2.Serve(listener2)
 	defer server2.Stop()
 
+	reResolveFired := make(chan struct{}, 1)
+
 	// Register both vtctlds with VTAdmin
-	disco := fakediscovery.New()
+	disco := &testdisco{
+		Fake:   fakediscovery.New(),
+		notify: make(chan struct{}),
+		fired:  reResolveFired,
+	}
 	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
 		Hostname: listener1.Addr().String(),
 	}, &vtadminpb.Vtctld{
 		Hostname: listener2.Addr().String(),
 	})
 
-	reResolveFired := make(chan struct{})
 	proxy, err := New(&Config{
 		Cluster: &vtadminpb.Cluster{
 			Id:   "test",
 			Name: "testcluster",
 		},
 		ResolverOptions: &resolver.Options{
-			Discovery:        disco,
-			DiscoveryTimeout: 50 * time.Millisecond,
+			Discovery:            disco,
+			DiscoveryTimeout:     50 * time.Millisecond,
+			MinDiscoveryInterval: 0,
+			BackoffStrategy:      "none",
 		},
 	})
 	require.NoError(t, err)
-
-	// wrap the resolver builder to test that re-resolve has fired as expected.
-	proxy.resolver = &testResolverBuilder{Builder: proxy.resolver, fired: reResolveFired}
-
-	// Check for a successful connection to whichever vtctld we discover first.
-	err = proxy.Dial(context.Background())
-	assert.NoError(t, err)
 
 	// vtadmin's fakediscovery package discovers vtctlds in random order. Rather
 	// than force some cumbersome sequential logic, we can just do a switcheroo
@@ -185,6 +175,7 @@ func TestRedial(t *testing.T) {
 	var currentVtctld *grpc.Server
 	var nextAddr string
 
+	// Check for a successful connection to whichever vtctld we discover first.
 	resp, err := proxy.GetKeyspace(context.Background(), &vtctldatapb.GetKeyspaceRequest{})
 	require.NoError(t, err)
 
@@ -201,29 +192,38 @@ func TestRedial(t *testing.T) {
 		t.Fatalf("invalid proxy host %s", proxyHost)
 	}
 
-	// Remove the shut down vtctld from VTAdmin's service discovery (clumsily).
-	// Otherwise, when redialing, we may redial the vtctld that we just shut down.
+	// Shut down the vtctld we're connected to, then await re-resolution.
+
+	// 1. First, block calls to DiscoverVtctldAddrs so we don't race with the
+	// background resolver watcher.
+	disco.m.Lock()
+
+	// 2. Force an ungraceful shutdown of the gRPC server to which we're
+	// connected.
+	currentVtctld.Stop()
+
+	// 3. Remove the shut down vtctld from VTAdmin's service discovery
+	// (clumsily). Otherwise, when redialing, we may redial the vtctld that we
+	// just shut down.
 	disco.Clear()
 	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{
 		Hostname: nextAddr,
 	})
 
-	// Force an ungraceful shutdown of the gRPC server to which we're connected
-	currentVtctld.Stop()
+	// 4. Notify our wrapped DiscoverVtctldAddrs function to start signaling on
+	// its `fired` channel when called.
+	close(disco.notify)
+	// 5. Unblock calls to DiscoverVtctldAddrs, and move on to our assertions.
+	disco.m.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
+	maxWait := time.Second
 	select {
 	case <-reResolveFired:
-	case <-ctx.Done():
-		require.FailNowf(t, "forced shutdown of vtctld should trigger grpc re-resolution", ctx.Err().Error())
+	case <-time.After(maxWait):
+		require.FailNowf(t, "forced shutdown of vtctld should trigger grpc re-resolution", "did not receive re-resolve signal within %s", maxWait)
 	}
 
-	// Finally, check that we discover, dial + establish a new connection to the remaining vtctld.
-	err = proxy.Dial(context.Background())
-	assert.NoError(t, err)
-
+	// Finally, check that we discover + establish a new connection to the remaining vtctld.
 	resp, err = proxy.GetKeyspace(context.Background(), &vtctldatapb.GetKeyspaceRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, nextAddr, resp.Keyspace.Name)

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -80,7 +80,7 @@ func TestDial(t *testing.T) {
 		Hostname: listener.Addr().String(),
 	})
 
-	proxy, err := New(&Config{
+	proxy, err := New(context.Background(), &Config{
 		Cluster: &vtadminpb.Cluster{
 			Id:   "test",
 			Name: "testcluster",
@@ -155,7 +155,7 @@ func TestRedial(t *testing.T) {
 		Hostname: listener2.Addr().String(),
 	})
 
-	proxy, err := New(&Config{
+	proxy, err := New(context.Background(), &Config{
 		Cluster: &vtadminpb.Cluster{
 			Id:   "test",
 			Name: "testcluster",

--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -80,7 +80,7 @@ func TestDial(t *testing.T) {
 		Hostname: listener.Addr().String(),
 	})
 
-	proxy := New(&Config{
+	proxy, err := New(&Config{
 		Cluster: &vtadminpb.Cluster{
 			Id:   "test",
 			Name: "testcluster",
@@ -90,6 +90,8 @@ func TestDial(t *testing.T) {
 			DiscoveryTimeout: 50 * time.Millisecond,
 		},
 	})
+	require.NoError(t, err)
+
 	defer proxy.Close() // prevents grpc-core from logging a bunch of "connection errors" after deferred listener.Close() above.
 
 	err = proxy.Dial(context.Background())
@@ -158,7 +160,7 @@ func TestRedial(t *testing.T) {
 	})
 
 	reResolveFired := make(chan struct{})
-	proxy := New(&Config{
+	proxy, err := New(&Config{
 		Cluster: &vtadminpb.Cluster{
 			Id:   "test",
 			Name: "testcluster",
@@ -168,6 +170,7 @@ func TestRedial(t *testing.T) {
 			DiscoveryTimeout: 50 * time.Millisecond,
 		},
 	})
+	require.NoError(t, err)
 
 	// wrap the resolver builder to test that re-resolve has fired as expected.
 	proxy.resolver = &testResolverBuilder{Builder: proxy.resolver, fired: reResolveFired}


### PR DESCRIPTION
## Description

(sorry this is lorge, i can break it up in a few stages if that's helpful!)

TODO add more detailed description here

### change breakdown
- refactor Dial/Redial tests to operate under the new model
- thread contexts from startup all the way through to `vtctldclient.New`
- remove all explicit Dial calls
- remove `Dial` from the interface

### testing

- all unit tests pass (with both `-count=50` and `-race` so i'm feeling good)
- can run the local example

## Related Issue(s)

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required (leaving this unchecked until i write an actual PR description)

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
