### PR TITLE
fix endtoend onlineddl flakyness caused by --heartbeat_on_demand_duration

### DIFF
--- a/go/test/endtoend/onlineddl/ghost/onlineddl_ghost_test.go
+++ b/go/test/endtoend/onlineddl/ghost/onlineddl_ghost_test.go
@@ -167,7 +167,7 @@ func TestMain(m *testing.M) {
 			"--throttle_threshold", "1s",
 			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
-			"--heartbeat_on_demand_duration", "5s",
+			"--heartbeat_on_demand_duration", "15s",
 			"--migration_check_interval", "5s",
 			"--gh-ost-path", os.Getenv("VITESS_ENDTOEND_GH_OST_PATH"), // leave env variable empty/unset to get the default behavior. Override in Mac.
 		}

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -171,7 +171,7 @@ func TestMain(m *testing.M) {
 			"--throttle_threshold", "1s",
 			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
-			"--heartbeat_on_demand_duration", "5s",
+			"--heartbeat_on_demand_duration", "15s",
 			"--migration_check_interval", "5s",
 		}
 		clusterInstance.VtGateExtraArgs = []string{


### PR DESCRIPTION

## Description

Looking into flakiness introduced by https://github.com/vitessio/vitess/pull/10198
I first want to unblock pending PRs; will then investigate to see why this is caused.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/10198

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required
