### PR TITLE
[vtadmin] Removing explicit Dial-ing for vtsql proxy

### DIFF
--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -105,6 +105,10 @@ func New(ctx context.Context, cfg Config) (*Cluster, error) {
 		return nil, fmt.Errorf("error creating vtsql connection config: %w", err)
 	}
 
+	for _, opt := range cfg.vtsqlConfigOpts {
+		vtsqlCfg = opt(vtsqlCfg)
+	}
+
 	vtctldargs := buildPFlagSlice(cfg.VtctldFlags)
 
 	vtctldCfg, err := vtctldclient.Parse(protocluster, disco, vtctldargs)

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -891,10 +891,6 @@ func (c *Cluster) GetTablets(ctx context.Context) ([]*vtadminpb.Tablet, error) {
 }
 
 func (c *Cluster) getTablets(ctx context.Context) ([]*vtadminpb.Tablet, error) {
-	if err := c.DB.Dial(ctx, ""); err != nil {
-		return nil, err
-	}
-
 	rows, err := c.DB.ShowTablets(ctx)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -116,7 +116,11 @@ func New(ctx context.Context, cfg Config) (*Cluster, error) {
 		vtctldCfg = opt(vtctldCfg)
 	}
 
-	cluster.DB = vtsql.New(vtsqlCfg)
+	cluster.DB, err = vtsql.New(ctx, vtsqlCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error creating vtsql proxy: %w", err)
+	}
+
 	cluster.Vtctld, err = vtctldclient.New(ctx, vtctldCfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating vtctldclient: %w", err)

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -2604,7 +2604,10 @@ func TestGetTablets(t *testing.T) {
 	disco := fakediscovery.New()
 	disco.AddTaggedGates(nil, &vtadminpb.VTGate{Hostname: "gate"})
 
-	db, err := vtsql.New(context.Background(), &vtsql.Config{
+	dialerWrapper := vtsql.WithDialFunc(func(c vitessdriver.Configuration) (*sql.DB, error) {
+		return nil, assert.AnError
+	})
+	db, err := vtsql.New(context.Background(), dialerWrapper(&vtsql.Config{
 		Cluster: &vtadminpb.Cluster{
 			Id:   "c1",
 			Name: "one",
@@ -2612,11 +2615,8 @@ func TestGetTablets(t *testing.T) {
 		ResolverOptions: &resolver.Options{
 			Discovery: disco,
 		},
-	})
+	}))
 	require.NoError(t, err)
-	db.DialFunc = func(cfg vitessdriver.Configuration) (*sql.DB, error) {
-		return nil, assert.AnError
-	}
 
 	c := &cluster.Cluster{DB: db}
 	_, err = c.GetTablets(context.Background())

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -18,7 +18,6 @@ package cluster_test
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -33,14 +32,10 @@ import (
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/topo"
-	"vitess.io/vitess/go/vt/vitessdriver"
 	"vitess.io/vitess/go/vt/vtadmin/cluster"
-	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery/fakediscovery"
-	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 	vtadminerrors "vitess.io/vitess/go/vt/vtadmin/errors"
 	"vitess.io/vitess/go/vt/vtadmin/testutil"
 	"vitess.io/vitess/go/vt/vtadmin/vtctldclient/fakevtctldclient"
-	"vitess.io/vitess/go/vt/vtadmin/vtsql"
 	"vitess.io/vitess/go/vt/vtctl/vtctldclient"
 
 	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
@@ -2594,33 +2589,6 @@ func TestGetShardReplicationPositions(t *testing.T) {
 			assert.Equal(t, tt.expected, resp)
 		})
 	}
-}
-
-// This test only validates the error handling on dialing database connections.
-// Other cases are covered by one or both of TestFindTablets and TestFindTablet.
-func TestGetTablets(t *testing.T) {
-	t.Parallel()
-
-	disco := fakediscovery.New()
-	disco.AddTaggedGates(nil, &vtadminpb.VTGate{Hostname: "gate"})
-
-	dialerWrapper := vtsql.WithDialFunc(func(c vitessdriver.Configuration) (*sql.DB, error) {
-		return nil, assert.AnError
-	})
-	db, err := vtsql.New(context.Background(), dialerWrapper(&vtsql.Config{
-		Cluster: &vtadminpb.Cluster{
-			Id:   "c1",
-			Name: "one",
-		},
-		ResolverOptions: &resolver.Options{
-			Discovery: disco,
-		},
-	}))
-	require.NoError(t, err)
-
-	c := &cluster.Cluster{DB: db}
-	_, err = c.GetTablets(context.Background())
-	assert.Error(t, err)
 }
 
 func TestGetVSchema(t *testing.T) {

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -2604,7 +2604,7 @@ func TestGetTablets(t *testing.T) {
 	disco := fakediscovery.New()
 	disco.AddTaggedGates(nil, &vtadminpb.VTGate{Hostname: "gate"})
 
-	db := vtsql.New(&vtsql.Config{
+	db, err := vtsql.New(context.Background(), &vtsql.Config{
 		Cluster: &vtadminpb.Cluster{
 			Id:   "c1",
 			Name: "one",
@@ -2613,12 +2613,13 @@ func TestGetTablets(t *testing.T) {
 			Discovery: disco,
 		},
 	})
+	require.NoError(t, err)
 	db.DialFunc = func(cfg vitessdriver.Configuration) (*sql.DB, error) {
 		return nil, assert.AnError
 	}
 
 	c := &cluster.Cluster{DB: db}
-	_, err := c.GetTablets(context.Background())
+	_, err = c.GetTablets(context.Background())
 	assert.Error(t, err)
 }
 

--- a/go/vt/vtadmin/cluster/config.go
+++ b/go/vt/vtadmin/cluster/config.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtadmin/errors"
 	"vitess.io/vitess/go/vt/vtadmin/vtctldclient"
+	"vitess.io/vitess/go/vt/vtadmin/vtsql"
 )
 
 var (
@@ -65,6 +66,7 @@ type Config struct {
 	WorkflowReadPoolConfig *RPCPoolConfig
 
 	vtctldConfigOpts []vtctldclient.ConfigOption
+	vtsqlConfigOpts  []vtsql.ConfigOption
 }
 
 // Cluster returns a new cluster instance from the given config.
@@ -367,5 +369,15 @@ func (cfg *RPCPoolConfig) parseFlag(name string, val string) (err error) {
 // vtadmin/testutil package.
 func (cfg Config) WithVtctldTestConfigOptions(opts ...vtctldclient.ConfigOption) Config {
 	cfg.vtctldConfigOpts = append(cfg.vtctldConfigOpts, opts...)
+	return cfg
+}
+
+// WithVtSQLTestConfigOptions returns a new Config with the given vtsql
+// ConfigOptions appended to any existing ConfigOptions in the current Config.
+//
+// It should be used in tests only, and is exported to for use in the
+// vtadmin/testutil package.
+func (cfg Config) WithVtSQLTestConfigOptions(opts ...vtsql.ConfigOption) Config {
+	cfg.vtsqlConfigOpts = append(cfg.vtsqlConfigOpts, opts...)
 	return cfg
 }

--- a/go/vt/vtadmin/testutil/cluster.go
+++ b/go/vt/vtadmin/testutil/cluster.go
@@ -95,24 +95,6 @@ func BuildCluster(t testing.TB, cfg TestClusterConfig) *cluster.Cluster {
 	disco.AddTaggedGates(nil, &vtadminpb.VTGate{Hostname: fmt.Sprintf("%s-%s-gate", cfg.Cluster.Name, cfg.Cluster.Id)})
 	disco.AddTaggedVtctlds(nil, &vtadminpb.Vtctld{Hostname: "doesn't matter"})
 
-	clusterConf := cluster.Config{
-		ID:            cfg.Cluster.Id,
-		Name:          cfg.Cluster.Name,
-		DiscoveryImpl: discoveryTestImplName,
-	}.WithVtctldTestConfigOptions(vtadminvtctldclient.WithDialFunc(func(addr string, ff grpcclient.FailFast, opts ...grpc.DialOption) (vtctldclient.VtctldClient, error) {
-		return cfg.VtctldClient, nil
-	}))
-
-	m.Lock()
-	testdisco = disco
-	c, err := cluster.New(
-		context.Background(), // consider updating this function to allow callers to provide a context.
-		clusterConf,
-	)
-	m.Unlock()
-
-	require.NoError(t, err, "failed to create cluster from configs %+v %+v", clusterConf, cfg)
-
 	tablets := make([]*vtadminpb.Tablet, len(cfg.Tablets))
 	for i, t := range cfg.Tablets {
 		tablet := &vtadminpb.Tablet{
@@ -124,10 +106,25 @@ func BuildCluster(t testing.TB, cfg TestClusterConfig) *cluster.Cluster {
 		tablets[i] = tablet
 	}
 
-	db := c.DB.(*vtsql.VTGateProxy)
-	db.DialFunc = func(_ vitessdriver.Configuration) (*sql.DB, error) {
+	clusterConf := cluster.Config{
+		ID:            cfg.Cluster.Id,
+		Name:          cfg.Cluster.Name,
+		DiscoveryImpl: discoveryTestImplName,
+	}.WithVtctldTestConfigOptions(vtadminvtctldclient.WithDialFunc(func(addr string, ff grpcclient.FailFast, opts ...grpc.DialOption) (vtctldclient.VtctldClient, error) {
+		return cfg.VtctldClient, nil
+	})).WithVtSQLTestConfigOptions(vtsql.WithDialFunc(func(c vitessdriver.Configuration) (*sql.DB, error) {
 		return sql.OpenDB(&fakevtsql.Connector{Tablets: tablets, ShouldErr: cfg.DBConfig.ShouldErr}), nil
-	}
+	}))
+
+	m.Lock()
+	testdisco = disco
+	c, err := cluster.New(
+		context.Background(), // consider updating this function to allow callers to provide a context.
+		clusterConf,
+	)
+	m.Unlock()
+
+	require.NoError(t, err, "failed to create cluster from configs %+v %+v", clusterConf, cfg)
 
 	return c
 }

--- a/go/vt/vtadmin/vtsql/config.go
+++ b/go/vt/vtadmin/vtsql/config.go
@@ -17,11 +17,13 @@ limitations under the License.
 package vtsql
 
 import (
+	"database/sql"
 	"fmt"
 
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/grpcclient"
+	"vitess.io/vitess/go/vt/vitessdriver"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 	"vitess.io/vitess/go/vt/vtadmin/credentials"
@@ -39,6 +41,24 @@ type Config struct {
 
 	Cluster         *vtadminpb.Cluster
 	ResolverOptions *resolver.Options
+
+	dialFunc func(c vitessdriver.Configuration) (*sql.DB, error)
+}
+
+// ConfigOption is a function that mutates a Config. It should return the same
+// Config structure, in a builder-pattern style.
+type ConfigOption func(cfg *Config) *Config
+
+// WithDialFunc returns a ConfigOption that applies the given dial function to
+// a Config.
+//
+// It is used to support dependency injection in tests, and needs to be exported
+// for higher-level tests (for example, package vtadmin/cluster).
+func WithDialFunc(f func(c vitessdriver.Configuration) (*sql.DB, error)) ConfigOption {
+	return func(cfg *Config) *Config {
+		cfg.dialFunc = f
+		return cfg
+	}
 }
 
 // Parse returns a new config with the given cluster ID and name, after

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -92,14 +92,14 @@ var ErrConnClosed = errors.New("use of closed connection")
 //
 // It does not open a connection to a vtgate; users must call Dial before first
 // use.
-func New(cfg *Config) *VTGateProxy {
+func New(ctx context.Context, cfg *Config) (*VTGateProxy, error) {
 	return &VTGateProxy{
 		cluster:  cfg.Cluster,
 		creds:    cfg.Credentials,
 		cfg:      cfg,
 		DialFunc: vitessdriver.OpenWithConfiguration,
 		resolver: cfg.ResolverOptions.NewBuilder(cfg.Cluster.Id),
-	}
+	}, nil
 }
 
 // getQueryContext returns a new context with the correct effective and immediate

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -98,13 +98,19 @@ func New(ctx context.Context, cfg *Config) (*VTGateProxy, error) {
 		dialFunc = vitessdriver.OpenWithConfiguration
 	}
 
-	return &VTGateProxy{
+	proxy := VTGateProxy{
 		cluster:  cfg.Cluster,
 		creds:    cfg.Credentials,
 		cfg:      cfg,
 		dialFunc: dialFunc,
 		resolver: cfg.ResolverOptions.NewBuilder(cfg.Cluster.Id),
-	}, nil
+	}
+
+	if err := proxy.Dial(ctx, ""); err != nil {
+		return nil, err
+	}
+
+	return &proxy, nil
 }
 
 // getQueryContext returns a new context with the correct effective and immediate

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -29,6 +29,7 @@ import (
 
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vitessdriver"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
 	"vitess.io/vitess/go/vt/vtadmin/debug"
@@ -151,6 +152,8 @@ func (vtgate *VTGateProxy) dial(ctx context.Context, target string, opts ...grpc
 	if err != nil {
 		return fmt.Errorf("error dialing vtgate: %w", err)
 	}
+
+	log.Infof("Established gRPC connection to vtgate\n")
 
 	vtgate.m.Lock()
 	defer vtgate.m.Unlock()

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -203,18 +203,12 @@ func (vtgate *VTGateProxy) Close() error {
 	vtgate.m.Lock()
 	defer vtgate.m.Unlock()
 
-	return vtgate.closeLocked()
-}
-
-func (vtgate *VTGateProxy) closeLocked() error {
 	if vtgate.conn == nil {
 		return nil
 	}
 
-	err := vtgate.conn.Close()
-	vtgate.conn = nil
-
-	return err
+	defer func() { vtgate.conn = nil }()
+	return vtgate.conn.Close()
 }
 
 // Debug implements debug.Debuggable for VTGateProxy.

--- a/go/vt/vtadmin/vtsql/vtsql_test.go
+++ b/go/vt/vtadmin/vtsql/vtsql_test.go
@@ -18,22 +18,15 @@ package vtsql
 
 import (
 	"context"
-	"database/sql"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/grpcclient"
-	"vitess.io/vitess/go/vt/vitessdriver"
-	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery/fakediscovery"
-	"vitess.io/vitess/go/vt/vtadmin/cluster/resolver"
-	"vitess.io/vitess/go/vt/vtadmin/vtsql/fakevtsql"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
@@ -86,92 +79,4 @@ func Test_getQueryContext(t *testing.T) {
 	assert.NotEqual(t, callerctx, outctx, "getQueryContext should override an existing callerid in the context")
 	assertEffectiveCaller(t, callerid.EffectiveCallerIDFromContext(outctx), "efuser", "vtadmin", "")
 	assertImmediateCaller(t, callerid.ImmediateCallerIDFromContext(outctx), "imuser")
-}
-
-func TestDial(t *testing.T) {
-	t.Helper()
-
-	tests := []struct {
-		name      string
-		disco     *fakediscovery.Fake
-		gates     []*vtadminpb.VTGate
-		proxy     *VTGateProxy
-		dialer    func(cfg vitessdriver.Configuration) (*sql.DB, error)
-		shouldErr bool
-	}{
-		{
-			name: "existing conn",
-			proxy: &VTGateProxy{
-				cluster: &vtadminpb.Cluster{},
-				conn:    sql.OpenDB(&fakevtsql.Connector{}),
-			},
-			shouldErr: false,
-		},
-		{
-			name:  "dialer error",
-			disco: fakediscovery.New(),
-			gates: []*vtadminpb.VTGate{
-				{
-					Hostname: "gate",
-				},
-			},
-			proxy: &VTGateProxy{
-				cluster: &vtadminpb.Cluster{Id: "test"},
-				DialFunc: func(cfg vitessdriver.Configuration) (*sql.DB, error) {
-					return nil, assert.AnError
-				},
-			},
-			shouldErr: true,
-		},
-		{
-			name:  "success",
-			disco: fakediscovery.New(),
-			gates: []*vtadminpb.VTGate{
-				{
-					Hostname: "gate",
-				},
-			},
-			proxy: &VTGateProxy{
-				cluster: &vtadminpb.Cluster{Id: "test"},
-				creds: &StaticAuthCredentials{
-					StaticAuthClientCreds: &grpcclient.StaticAuthClientCreds{
-						Username: "user",
-						Password: "pass",
-					},
-				},
-				DialFunc: func(cfg vitessdriver.Configuration) (*sql.DB, error) {
-					return sql.OpenDB(&fakevtsql.Connector{}), nil
-				},
-			},
-		},
-	}
-
-	ctx := context.Background()
-
-	for _, tt := range tests {
-		tt := tt
-
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			if tt.disco != nil {
-				if len(tt.gates) > 0 {
-					tt.disco.AddTaggedGates(nil, tt.gates...)
-				}
-			}
-
-			tt.proxy.resolver = (&resolver.Options{
-				Discovery:        tt.disco,
-				DiscoveryTimeout: 50 * time.Millisecond,
-			}).NewBuilder(tt.proxy.cluster.Id)
-
-			err := tt.proxy.Dial(ctx, "")
-			if tt.shouldErr {
-				assert.Error(t, err)
-				return
-			}
-
-			assert.NoError(t, err)
-		})
-	}
 }


### PR DESCRIPTION
## Description

This builds on #10233, but for vtsql this time (it's based on the same branch, so it should be merged _after_ that PR).

It's the same changes, applied in the same order (config options, context plumbing through the call stack, etc etc) but applied to the `DB` interface and `VTGateProxy` type instead. In addition:

- make `vtgateconn`'s private `drivers` map thread safe. this was tripping the race detector during tests (see 69cf2f2975585025aea1cc7ab58d35aa1d5b4dfa)

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
