### PR TITLE
Add convenience functions for working with schemadiff objects

### DIFF
--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -241,6 +241,46 @@ func (s *Schema) EntityNames() []string {
 	return names
 }
 
+// Tables returns this schema's tables in good order (may be applied without error)
+func (s *Schema) Tables() []*CreateTableEntity {
+	var tables []*CreateTableEntity
+	for _, entity := range s.sorted {
+		if table, ok := entity.(*CreateTableEntity); ok {
+			tables = append(tables, table)
+		}
+	}
+	return tables
+}
+
+// TableNames is a convenience function that returns just the names of tables, in good order
+func (s *Schema) TableNames() []string {
+	names := []string{}
+	for _, e := range s.Tables() {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// Tables returns this schema's views in good order (may be applied without error)
+func (s *Schema) Views() []*CreateViewEntity {
+	var views []*CreateViewEntity
+	for _, entity := range s.sorted {
+		if view, ok := entity.(*CreateViewEntity); ok {
+			views = append(views, view)
+		}
+	}
+	return views
+}
+
+// ViewNames is a convenience function that returns just the names of views, in good order
+func (s *Schema) ViewNames() []string {
+	names := []string{}
+	for _, e := range s.Views() {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
 // Diff compares this schema with another schema, and sees what it takes to make this schema look
 // like the other. It returns a list of diffs.
 func (s *Schema) Diff(other *Schema, hints *DiffHints) (diffs []EntityDiff, err error) {
@@ -289,6 +329,22 @@ func (s *Schema) Diff(other *Schema, hints *DiffHints) (diffs []EntityDiff, err 
 // Entity returns an entity by name, or nil if nonexistent
 func (s *Schema) Entity(name string) Entity {
 	return s.named[name]
+}
+
+// Table returns a table by name, or nil if nonexistent
+func (s *Schema) Table(name string) *CreateTableEntity {
+	if table, ok := s.named[name].(*CreateTableEntity); ok {
+		return table
+	}
+	return nil
+}
+
+// View returns a view by name, or nil if nonexistent
+func (s *Schema) View(name string) *CreateViewEntity {
+	if view, ok := s.named[name].(*CreateViewEntity); ok {
+		return view
+	}
+	return nil
 }
 
 // ToStatements returns an ordered list of statements which can be applied to create the schema

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -53,6 +53,24 @@ var expectSortedNames = []string{
 	"v6", // level 3
 }
 
+var expectSortedTableNames = []string{
+	"t1",
+	"t2",
+	"t3",
+	"t5",
+}
+
+var expectSortedViewNames = []string{
+	"v0", // level 1 ("dual" is an implicit table)
+	"v3", // level 1
+	"v9", // level 1 (no source table)
+	"v1", // level 2
+	"v2", // level 2
+	"v4", // level 2
+	"v5", // level 2
+	"v6", // level 3
+}
+
 var toSQL = "CREATE TABLE `t1` (\n\t`id` int\n);\nCREATE TABLE `t2` (\n\t`id` int\n);\nCREATE TABLE `t3` (\n\t`id` int\n);\nCREATE TABLE `t5` (\n\t`id` int\n);\nCREATE VIEW `v0` AS SELECT 1 FROM `dual`;\nCREATE VIEW `v3` AS SELECT * FROM `t3` AS `t3`;\nCREATE VIEW `v9` AS SELECT 1 FROM `dual`;\nCREATE VIEW `v1` AS SELECT * FROM `v3`;\nCREATE VIEW `v2` AS SELECT * FROM `v3`, `t2`;\nCREATE VIEW `v4` AS SELECT * FROM `t2` AS `something_else`, `v3`;\nCREATE VIEW `v5` AS SELECT * FROM `t1`, (SELECT * FROM `v3`) AS `some_alias`;\nCREATE VIEW `v6` AS SELECT * FROM `v4`;\n"
 
 func TestNewSchemaFromQueries(t *testing.T) {
@@ -61,6 +79,8 @@ func TestNewSchemaFromQueries(t *testing.T) {
 	assert.NotNil(t, schema)
 
 	assert.Equal(t, expectSortedNames, schema.EntityNames())
+	assert.Equal(t, expectSortedTableNames, schema.TableNames())
+	assert.Equal(t, expectSortedViewNames, schema.ViewNames())
 }
 
 func TestNewSchemaFromSQL(t *testing.T) {
@@ -69,6 +89,8 @@ func TestNewSchemaFromSQL(t *testing.T) {
 	assert.NotNil(t, schema)
 
 	assert.Equal(t, expectSortedNames, schema.EntityNames())
+	assert.Equal(t, expectSortedTableNames, schema.TableNames())
+	assert.Equal(t, expectSortedViewNames, schema.ViewNames())
 }
 
 func TestNewSchemaFromQueriesWithDuplicate(t *testing.T) {

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -55,6 +55,14 @@ func (d *AlterTableEntityDiff) Statement() sqlparser.Statement {
 	return d.alterTable
 }
 
+// AlterTable returns the underlying sqlparser.AlterTable that was generated for the diff.
+func (d *AlterTableEntityDiff) AlterTable() *sqlparser.AlterTable {
+	if d == nil {
+		return nil
+	}
+	return d.alterTable
+}
+
 // StatementString implements EntityDiff
 func (d *AlterTableEntityDiff) StatementString() (s string) {
 	if stmt := d.Statement(); stmt != nil {
@@ -88,6 +96,14 @@ func (d *CreateTableEntityDiff) Entities() (from Entity, to Entity) {
 
 // Statement implements EntityDiff
 func (d *CreateTableEntityDiff) Statement() sqlparser.Statement {
+	if d == nil {
+		return nil
+	}
+	return d.createTable
+}
+
+// CreateTable returns the underlying sqlparser.CreateTable that was generated for the diff.
+func (d *CreateTableEntityDiff) CreateTable() *sqlparser.CreateTable {
 	if d == nil {
 		return nil
 	}
@@ -128,6 +144,14 @@ func (d *DropTableEntityDiff) Entities() (from Entity, to Entity) {
 
 // Statement implements EntityDiff
 func (d *DropTableEntityDiff) Statement() sqlparser.Statement {
+	if d == nil {
+		return nil
+	}
+	return d.dropTable
+}
+
+// DropTable returns the underlying sqlparser.DropTable that was generated for the diff.
+func (d *DropTableEntityDiff) DropTable() *sqlparser.DropTable {
 	if d == nil {
 		return nil
 	}

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -45,6 +45,14 @@ func (d *AlterViewEntityDiff) Statement() sqlparser.Statement {
 	return d.alterView
 }
 
+// AlterView returns the underlying sqlparser.AlterView that was generated for the diff.
+func (d *AlterViewEntityDiff) AlterView() *sqlparser.AlterView {
+	if d == nil {
+		return nil
+	}
+	return d.alterView
+}
+
 // StatementString implements EntityDiff
 func (d *AlterViewEntityDiff) StatementString() (s string) {
 	if stmt := d.Statement(); stmt != nil {
@@ -78,6 +86,14 @@ func (d *CreateViewEntityDiff) Entities() (from Entity, to Entity) {
 
 // Statement implements EntityDiff
 func (d *CreateViewEntityDiff) Statement() sqlparser.Statement {
+	if d == nil {
+		return nil
+	}
+	return d.createView
+}
+
+// CreateView returns the underlying sqlparser.CreateView that was generated for the diff.
+func (d *CreateViewEntityDiff) CreateView() *sqlparser.CreateView {
 	if d == nil {
 		return nil
 	}
@@ -118,6 +134,14 @@ func (d *DropViewEntityDiff) Entities() (from Entity, to Entity) {
 
 // Statement implements EntityDiff
 func (d *DropViewEntityDiff) Statement() sqlparser.Statement {
+	if d == nil {
+		return nil
+	}
+	return d.dropView
+}
+
+// DropView returns the underlying sqlparser.DropView that was generated for the diff.
+func (d *DropViewEntityDiff) DropView() *sqlparser.DropView {
 	if d == nil {
 		return nil
 	}


### PR DESCRIPTION
This adds a number of convenience methods to schemadiff that are useful when working with schema related objects and inspecting what a schema looks like.

It avoids having to do some casts often when for example you only care about getting a table from a schema (and not views).

The diff methods are useful when getting the underlying object so you don't have to grab it with `Statement()` and then cast it again to the real underlying `sqlparser` object.

## Related Issue(s)

#10203 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required