### PR TITLE
sqlparser: failing to parse functional indexes

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -3889,6 +3889,17 @@ func TestCreateTable(t *testing.T) {
 	key by_email (email(10), username)
 )`,
 		},
+		// key conditionals
+		{
+			input: `create table t (
+	id int auto_increment,
+	username varchar(64),
+	nickname varchar(64),
+	email varchar(64),
+	primary key (id),
+	key email_idx(email, (if(username = '', nickname, username)))
+)`,
+		},
 		// foreign keys
 		{
 			input: `create table t (


### PR DESCRIPTION
## Description

Functional indexes have been introduced in MySQL `8.0`. Some overview in [this blog post](https://www.percona.com/blog/mysql-8-0-functional-indexes).

Added to this PR a test case that fails parsing, by way of example:

```sql
create table t (
	id int auto_increment,
	username varchar(64),
	nickname varchar(64),
	email varchar(64),
	primary key (id),
	key email_idx(email, (if(username = '', nickname, username)))
);
```

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required
