### PR TITLE
Revert to using XtraBackup 2.4-latest now that 2.4.26 is out

### DIFF
--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -12,10 +12,8 @@ env:
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
   # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
   # If this is NOT set then the latest version available will be used.
-  XTRABACKUP_VERSION: "2.4.24-1"
+  #XTRABACKUP_VERSION: "2.4.24-1"
 
 jobs:
   build:

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -12,10 +12,8 @@ env:
   GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
   # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
   # If this is NOT set then the latest version available will be used.
-  XTRABACKUP_VERSION: "2.4.24-1"
+  #XTRABACKUP_VERSION: "2.4.24-1"
 
 jobs:
   build:

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -10,10 +10,8 @@ env:
   GITHUB_PR_HEAD_SHA: "${{`{{ github.event.pull_request.head.sha }}`}}"
 {{if .InstallXtraBackup}}
   # This is used if we need to pin the xtrabackup version used in tests.
-  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
-  #   https://jira.percona.com/browse/PXB-2756
   # If this is NOT set then the latest version available will be used.
-  XTRABACKUP_VERSION: "2.4.24-1"
+  #XTRABACKUP_VERSION: "2.4.24-1"
 {{end}}
 
 jobs:


### PR DESCRIPTION
## Description

The [XtraBackup 2.4.26 release](https://docs.percona.com/percona-xtrabackup/2.4/release-notes/2.4/2.4.26.html) fixes [the SEGFAULTs we encountered with 2.4.25](https://jira.percona.com/browse/PXB-2756), which led to us [pinning the version at 2.4.24 temporarily](https://github.com/vitessio/vitess/pull/10194).

ℹ️ NOTE: I'm leaving the version pinning code in place so that we can easily pin it again in the future if needed (it also provides a template for how we could pin the version of other packages).

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/10194

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests are not required
-   [x] Documentation is not required