### PR TITLE
Fix formatting of character set annotation on string literals

### DIFF
--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -1236,7 +1236,7 @@ func (node *UnaryExpr) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *IntroducerExpr) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "%s %v", node.CharacterSet, node.Expr)
+	buf.astPrintf(node, "%#s %v", node.CharacterSet, node.Expr)
 }
 
 // Format formats the node.

--- a/go/vt/sqlparser/tracked_buffer_test.go
+++ b/go/vt/sqlparser/tracked_buffer_test.go
@@ -164,6 +164,10 @@ func TestCanonicalOutput(t *testing.T) {
 			"create table a (e set('red','green','blue','orange','yellow'))",
 			"CREATE TABLE `a` (\n\t`e` set('red', 'green', 'blue', 'orange', 'yellow')\n)",
 		},
+		{
+			"create table entries (uid varchar(53) not null, namespace varchar(254) not null, spec json default null, primary key (namespace, uid), key entries_spec_updatedAt ((json_value(spec, _utf8mb4 '$.updatedAt'))))",
+			"CREATE TABLE `entries` (\n\t`uid` varchar(53) NOT NULL,\n\t`namespace` varchar(254) NOT NULL,\n\t`spec` json DEFAULT NULL,\n\tPRIMARY KEY (`namespace`, `uid`),\n\tKEY `entries_spec_updatedAt` ((JSON_VALUE(`spec`, _utf8mb4 '$.updatedAt')))\n)",
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Like other character sets, these are lowercase in canonical MySQL output, so that should be matched here.

## Related Issue(s)

#10203 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required