### PR TITLE
schemadiff: use ParseStrictDDL whenever expecting a DDL statement

### DIFF
--- a/go/vt/schemadiff/diff.go
+++ b/go/vt/schemadiff/diff.go
@@ -22,7 +22,7 @@ func DiffCreateTablesQueries(query1 string, query2 string, hints *DiffHints) (En
 	var fromCreateTable *sqlparser.CreateTable
 	var ok bool
 	if query1 != "" {
-		stmt, err := sqlparser.Parse(query1)
+		stmt, err := sqlparser.ParseStrictDDL(query1)
 		if err != nil {
 			return nil, err
 		}
@@ -33,7 +33,7 @@ func DiffCreateTablesQueries(query1 string, query2 string, hints *DiffHints) (En
 	}
 	var toCreateTable *sqlparser.CreateTable
 	if query2 != "" {
-		stmt, err := sqlparser.Parse(query2)
+		stmt, err := sqlparser.ParseStrictDDL(query2)
 		if err != nil {
 			return nil, err
 		}
@@ -76,7 +76,7 @@ func DiffCreateViewsQueries(query1 string, query2 string, hints *DiffHints) (Ent
 	var fromCreateView *sqlparser.CreateView
 	var ok bool
 	if query1 != "" {
-		stmt, err := sqlparser.Parse(query1)
+		stmt, err := sqlparser.ParseStrictDDL(query1)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +87,7 @@ func DiffCreateViewsQueries(query1 string, query2 string, hints *DiffHints) (Ent
 	}
 	var toCreateView *sqlparser.CreateView
 	if query2 != "" {
-		stmt, err := sqlparser.Parse(query2)
+		stmt, err := sqlparser.ParseStrictDDL(query2)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -77,7 +77,7 @@ func TestDiffTables(t *testing.T) {
 		t.Run(ts.name, func(t *testing.T) {
 			var fromCreateTable *sqlparser.CreateTable
 			if ts.from != "" {
-				fromStmt, err := sqlparser.Parse(ts.from)
+				fromStmt, err := sqlparser.ParseStrictDDL(ts.from)
 				assert.NoError(t, err)
 				var ok bool
 				fromCreateTable, ok = fromStmt.(*sqlparser.CreateTable)
@@ -85,7 +85,7 @@ func TestDiffTables(t *testing.T) {
 			}
 			var toCreateTable *sqlparser.CreateTable
 			if ts.to != "" {
-				toStmt, err := sqlparser.Parse(ts.to)
+				toStmt, err := sqlparser.ParseStrictDDL(ts.to)
 				assert.NoError(t, err)
 				var ok bool
 				toCreateTable, ok = toStmt.(*sqlparser.CreateTable)
@@ -205,7 +205,7 @@ func TestDiffViews(t *testing.T) {
 		t.Run(ts.name, func(t *testing.T) {
 			var fromCreateView *sqlparser.CreateView
 			if ts.from != "" {
-				fromStmt, err := sqlparser.Parse(ts.from)
+				fromStmt, err := sqlparser.ParseStrictDDL(ts.from)
 				assert.NoError(t, err)
 				var ok bool
 				fromCreateView, ok = fromStmt.(*sqlparser.CreateView)
@@ -213,7 +213,7 @@ func TestDiffViews(t *testing.T) {
 			}
 			var toCreateView *sqlparser.CreateView
 			if ts.to != "" {
-				toStmt, err := sqlparser.Parse(ts.to)
+				toStmt, err := sqlparser.ParseStrictDDL(ts.to)
 				assert.NoError(t, err)
 				var ok bool
 				toCreateView, ok = toStmt.(*sqlparser.CreateView)

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -712,12 +712,12 @@ func TestCreateTableDiff(t *testing.T) {
 	standardHints := DiffHints{}
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {
-			fromStmt, err := sqlparser.Parse(ts.from)
+			fromStmt, err := sqlparser.ParseStrictDDL(ts.from)
 			require.NoError(t, err)
 			fromCreateTable, ok := fromStmt.(*sqlparser.CreateTable)
 			require.True(t, ok)
 
-			toStmt, err := sqlparser.Parse(ts.to)
+			toStmt, err := sqlparser.ParseStrictDDL(ts.to)
 			require.NoError(t, err)
 			toCreateTable, ok := toStmt.(*sqlparser.CreateTable)
 			require.True(t, ok)
@@ -878,12 +878,12 @@ func TestValidate(t *testing.T) {
 	hints := DiffHints{}
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {
-			stmt, err := sqlparser.Parse(ts.from)
+			stmt, err := sqlparser.ParseStrictDDL(ts.from)
 			require.NoError(t, err)
 			fromCreateTable, ok := stmt.(*sqlparser.CreateTable)
 			require.True(t, ok)
 
-			stmt, err = sqlparser.Parse(ts.alter)
+			stmt, err = sqlparser.ParseStrictDDL(ts.alter)
 			require.NoError(t, err)
 			alterTable, ok := stmt.(*sqlparser.AlterTable)
 			require.True(t, ok)
@@ -902,7 +902,7 @@ func TestValidate(t *testing.T) {
 				require.True(t, ok)
 				applied = c.normalize()
 
-				stmt, err := sqlparser.Parse(ts.to)
+				stmt, err := sqlparser.ParseStrictDDL(ts.to)
 				require.NoError(t, err)
 				toCreateTable, ok := stmt.(*sqlparser.CreateTable)
 				require.True(t, ok)
@@ -1056,7 +1056,7 @@ func TestNormalize(t *testing.T) {
 	}
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {
-			stmt, err := sqlparser.Parse(ts.from)
+			stmt, err := sqlparser.ParseStrictDDL(ts.from)
 			require.NoError(t, err)
 			fromCreateTable, ok := stmt.(*sqlparser.CreateTable)
 			require.True(t, ok)

--- a/go/vt/schemadiff/view_test.go
+++ b/go/vt/schemadiff/view_test.go
@@ -148,12 +148,12 @@ func TestCreateViewDiff(t *testing.T) {
 	hints := &DiffHints{}
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {
-			fromStmt, err := sqlparser.Parse(ts.from)
+			fromStmt, err := sqlparser.ParseStrictDDL(ts.from)
 			assert.NoError(t, err)
 			fromCreateView, ok := fromStmt.(*sqlparser.CreateView)
 			assert.True(t, ok)
 
-			toStmt, err := sqlparser.Parse(ts.to)
+			toStmt, err := sqlparser.ParseStrictDDL(ts.to)
 			assert.NoError(t, err)
 			toCreateView, ok := toStmt.(*sqlparser.CreateView)
 			assert.True(t, ok)


### PR DESCRIPTION

## Description

`sqlparser.ParseStrictDDL()` is safer to use than `sqlparser.Parse()` when the input is known to be a `DDLStatement`. `ParseStrictDDL()` rejects an incomplete parse. This is the behavior we want in `schemadiff` because `schemadiff` needs to have a well formed AST, manipulate it, validate it, etc.

## Related Issue(s)

- tracking: #10203 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required
