### PR TITLE
Fix to --heartbeat_on_demand_duration race condition

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -171,6 +171,7 @@ func TestMain(m *testing.M) {
 			"--throttle_threshold", "1s",
 			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
+			"--heartbeat_on_demand_duration", "5s",
 			"--migration_check_interval", "5s",
 		}
 		clusterInstance.VtGateExtraArgs = []string{

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -45,6 +45,9 @@ var (
 	httpClient       = throttlebase.SetupHTTPClient(time.Second)
 	throttlerAppName = "vreplication"
 
+	normalMigrationWait   = 20 * time.Second
+	extendedMigrationWait = 20 * time.Second
+
 	hostname              = "localhost"
 	keyspaceName          = "ks"
 	cell                  = "zone1"
@@ -318,7 +321,7 @@ func TestSchemaChange(t *testing.T) {
 		// Issue a complete and wait for successful completion
 		onlineddl.CheckCompleteMigration(t, &vtParams, shards, uuid, true)
 		// This part may take a while, because we depend on vreplicatoin polling
-		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 60*time.Second, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, extendedMigrationWait, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 		fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 
@@ -334,7 +337,7 @@ func TestSchemaChange(t *testing.T) {
 			defer unthrottleApp(shards[i].Vttablets[0], throttlerAppName)
 		}
 		uuid := testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", true)
-		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 20*time.Second, schema.OnlineDDLStatusRunning)
+		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusRunning)
 		testRows(t)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, true)
 		time.Sleep(2 * time.Second)
@@ -351,7 +354,7 @@ func TestSchemaChange(t *testing.T) {
 			defer unthrottleApp(shards[i].Vttablets[0], throttlerAppName)
 		}
 		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "vitess", providedUUID, providedMigrationContext, "vtgate", "test_val", "", true)
-		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 20*time.Second, schema.OnlineDDLStatusRunning)
+		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusRunning)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning)
 		testRows(t)
 		for i := range shards {
@@ -359,7 +362,7 @@ func TestSchemaChange(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Contains(t, body, throttlerAppName)
 		}
-		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 20*time.Second, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 	})
 
@@ -445,10 +448,10 @@ func TestSchemaChange(t *testing.T) {
 			uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "vitess", providedUUID, providedMigrationContext, "vtgate", "test_val", "", true)
 
 			t.Run("wait for migration and vreplication to run", func(t *testing.T) {
-				_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 20*time.Second, schema.OnlineDDLStatusRunning)
+				_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusRunning)
 				onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning)
 				time.Sleep(5 * time.Second) // wait for _vt.vreplication to be created
-				vreplStatus := onlineddl.WaitForVReplicationStatus(t, &vtParams, shards, uuid, 20*time.Second, "Copying")
+				vreplStatus := onlineddl.WaitForVReplicationStatus(t, &vtParams, shards, uuid, normalMigrationWait, "Copying")
 				require.Equal(t, "Copying", vreplStatus)
 				// again see that we're still 'running'
 				onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning)
@@ -496,7 +499,7 @@ func TestSchemaChange(t *testing.T) {
 					assert.Contains(t, body, throttlerAppName)
 				}
 
-				_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 30*time.Second, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+				_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, extendedMigrationWait, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 				onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 			})
 
@@ -567,7 +570,7 @@ func TestSchemaChange(t *testing.T) {
 		// Issue a complete and wait for successful completion
 		onlineddl.CheckCompleteMigration(t, &vtParams, shards, uuid, true)
 		// This part may take a while, because we depend on vreplicatoin polling
-		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 60*time.Second, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, extendedMigrationWait, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 		fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
@@ -678,7 +681,7 @@ func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy str
 		skipWait = true
 	}
 	if !skipWait {
-		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 20*time.Second, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 		fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 	}
 

--- a/go/vt/vttablet/tabletserver/repltracker/writer.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer.go
@@ -74,10 +74,11 @@ type heartbeatWriter struct {
 	allPrivsPool *dbconnpool.ConnectionPool
 	ticks        *timer.Timer
 
-	onDemandDuration                time.Duration
-	concurrentHeartbeatRequests     int64
-	requestHeartbeatsReentranceFlag int64
-	onDemandMu                      sync.Mutex
+	onDemandDuration            time.Duration
+	onDemandMu                  sync.Mutex
+	concurrentHeartbeatRequests int64
+	onDemandRequestTicks        int64
+	onDemandLastRequestTick     int64
 }
 
 // newHeartbeatWriter creates a new heartbeatWriter.
@@ -89,7 +90,7 @@ func newHeartbeatWriter(env tabletenv.Env, alias *topodatapb.TabletAlias) *heart
 		return &heartbeatWriter{}
 	}
 	heartbeatInterval := config.ReplicationTracker.HeartbeatIntervalSeconds.Get()
-	return &heartbeatWriter{
+	w := &heartbeatWriter{
 		env:              env,
 		enabled:          true,
 		tabletAlias:      proto.Clone(alias).(*topodatapb.TabletAlias),
@@ -103,6 +104,21 @@ func newHeartbeatWriter(env tabletenv.Env, alias *topodatapb.TabletAlias) *heart
 		appPool:      dbconnpool.NewConnectionPool("HeartbeatWriteAppPool", 2, *mysqlctl.DbaIdleTimeout, *mysqlctl.PoolDynamicHostnameResolution),
 		allPrivsPool: dbconnpool.NewConnectionPool("HeartbeatWriteAllPrivsPool", 2, *mysqlctl.DbaIdleTimeout, *mysqlctl.PoolDynamicHostnameResolution),
 	}
+	if w.onDemandDuration > 0 {
+		// see RequestHeartbeats() for use of onDemandRequestTicks
+		// it's basically a mechnism to rate limit operation RequestHeartbeats().
+		// and selectively drop excessive requests.
+		w.allowNextHeartbeatRequest()
+		go func() {
+			// this will allow up to 1 request per (w.onDemandDuration / 4) to pass through
+			tick := time.NewTicker(w.onDemandDuration / 4)
+			defer tick.Stop()
+			for range tick.C {
+				w.allowNextHeartbeatRequest()
+			}
+		}()
+	}
+	return w
 }
 
 // InitDBConfig initializes the target name for the heartbeatWriter.
@@ -134,7 +150,11 @@ func (w *heartbeatWriter) Open() {
 	if w.onDemandDuration == 0 {
 		w.enableWrites(true)
 		// when onDemandDuration > 0 we only enable writes per request
+	} else {
+		// A one-time kick off of heartbeats upon Open()
+		go w.RequestHeartbeats()
 	}
+
 	w.isOpen = true
 }
 
@@ -222,9 +242,24 @@ func (w *heartbeatWriter) enableWrites(enable bool) {
 		w.ticks.Start(w.writeHeartbeat)
 	} else {
 		w.ticks.Stop()
+		if w.onDemandDuration > 0 {
+			// Let the next RequestHeartbeats() go through
+			w.allowNextHeartbeatRequest()
+		}
 	}
 }
 
+// allowNextHeartbeatRequest ensures that the next call to RequestHeartbeats() passes through and
+// is not dropped.
+func (w *heartbeatWriter) allowNextHeartbeatRequest() {
+	atomic.AddInt64(&w.onDemandRequestTicks, 1)
+}
+
+// RequestHeartbeats implements heartbeat.HeartbeatWriter.RequestHeartbeats()
+// A client (such as the throttler) may call this function as frequently as it wishes, to request
+// for a heartbeat "lease".
+// This function will selectively and silently drop some such requests, depending on arrival rate.
+// This function is safe to call concurrently from goroutines
 func (w *heartbeatWriter) RequestHeartbeats() {
 	if w.onDemandDuration == 0 {
 		// heartbeats are not by demand. Therefore they are just coming in on their own (if enabled)
@@ -233,12 +268,13 @@ func (w *heartbeatWriter) RequestHeartbeats() {
 	// In this function we're going to create a timer to activate heartbeats by-demand. Creating a timer has a cost.
 	// Now, this function can be spammed by clients (the lag throttler). We therefore only allow this function to
 	// actually operate once per X seconds (1/4 of onDemandDuration as a reasonable oversampling value):
-	if atomic.CompareAndSwapInt64(&w.requestHeartbeatsReentranceFlag, 0, 1) {
-		defer time.AfterFunc(w.onDemandDuration/4, func() { atomic.StoreInt64(&w.requestHeartbeatsReentranceFlag, 0) })
-	} else {
-		// An instance of this function is already running
+	if atomic.LoadInt64(&w.onDemandLastRequestTick) >= atomic.LoadInt64(&w.onDemandRequestTicks) {
+		// Too many requests. We're dropping this one.
 		return
 	}
+	atomic.StoreInt64(&w.onDemandLastRequestTick, atomic.LoadInt64(&w.onDemandRequestTicks))
+
+	// OK, the request passed through.
 
 	w.onDemandMu.Lock()
 	defer w.onDemandMu.Unlock()
@@ -247,13 +283,11 @@ func (w *heartbeatWriter) RequestHeartbeats() {
 	// activate heartbeats for the duration of onDemandDuration, and then turn heartbeats off.
 	// However, there may be multiple clients interested in heartbeats, or maybe the same single client
 	// requesting heartbeats again and again. So we keep track of how many _concurrent_ requests we have.
-	// We enable heartbeats as soon as we have a single concurrent request; we turn heartbeats off once
+	// We enable heartbeats as soon as we have a request; we turn heartbeats off once
 	// we have zero concurrent requests
+	w.enableWrites(true)
 	w.concurrentHeartbeatRequests++
-	if w.concurrentHeartbeatRequests == 1 {
-		// means we previously had 0 clients interested in heartbeats.
-		w.enableWrites(true)
-	}
+
 	time.AfterFunc(w.onDemandDuration, func() {
 		w.onDemandMu.Lock()
 		defer w.onDemandMu.Unlock()
@@ -262,5 +296,6 @@ func (w *heartbeatWriter) RequestHeartbeats() {
 			// means there are currently no more clients interested in heartbeats
 			w.enableWrites(false)
 		}
+		w.allowNextHeartbeatRequest()
 	})
 }

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -260,6 +260,7 @@ func (throttler *Throttler) Open() error {
 		// since we just resume now, speed up the tickers by forcng an immediate tick
 		go t.TickNow()
 	}
+	go throttler.heartbeatWriter.RequestHeartbeats()
 
 	return nil
 }

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -400,6 +400,7 @@ func (throttler *Throttler) Operate(ctx context.Context) {
 					if transitionedIntoLeader {
 						// transitioned into leadership, let's speed up the next 'refresh' and 'collect' ticks
 						go mysqlRefreshTicker.TickNow()
+						go throttler.heartbeatWriter.RequestHeartbeats()
 					}
 				}()
 			}


### PR DESCRIPTION
## Description

#10198 introduced `--heartbeat_on_demand_duration` flag. The flag was added to multiple `onlineddl` `endtoend` testing workflows. A couple, but specifically `onlineddl_vrepl` started exhibiting recurring failures.

The flag is opt-in so no hard done to anyone. So no pressure other than CI jobs failing. https://github.com/vitessio/vitess/pull/10236 was first merged to revert the CI changes.

I was happy to then be able to reproduce the issue on a local dev env. As always with GitHub CI, it's about thresholds and execution speed, and I was able to figure out a configuration setup that makes the problem reproducible.

I'm also happy to have pinpointed the problem. There was a race condition.

- on one hand, `RequestHeartbeats()` calls were selectively accepted/dropped - as expected
- on the other hand, an unrelated call to `Close()` stopped heartbeats
- leading to the situation where the heartbeat writer thought it should keep rejecting calls to `RequestHeartbeats()` (based on thinking it just recently let a request through, so why bother letting another one), while at the same time heartbeats were disabled. Thus, the heartbeat writer was not producing any heartbeats when it should have.

The solution: any turning off of heartbeats now explicitly ensure the next call to `RequestHeartbeats()` is allowed to pass through. Another change is that any time a request does pass through, it just goes ahead and enables the heartbeats regardless of how many such requests are pending.

Anyway. Re-added `--heartbeat_on_demand_duration` in `onlineddl_vrepl` and in `onlineddl_ghost`. This is tested not only with normal migrations, but also with tablet reparenting. 


## Related Issue(s)

- https://github.com/vitessio/vitess/pull/10236
- #10198 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required
