### PR TITLE
evalengine: proper float to integer conversions

### DIFF
--- a/go/vt/vtgate/evalengine/integration/comparison_test.go
+++ b/go/vt/vtgate/evalengine/integration/comparison_test.go
@@ -317,6 +317,7 @@ func TestNumericTypes(t *testing.T) {
 		`-9223372036854775807`, // -MaxInt64
 		`-9223372036854775808`, // MinInt64
 		`-9223372036854775809`,
+		`18446744073709540000e0`,
 	}
 
 	var conn = mysqlconn(t)
@@ -391,6 +392,7 @@ func TestFloatFormatting(t *testing.T) {
 		`0xfffffffffffffffe`,
 		`0xffffffffffffffff0`,
 		`0x1fffffffffffffff`,
+		"18446744073709540000e0",
 	}
 
 	var conn = mysqlconn(t)
@@ -530,6 +532,8 @@ func TestConversionOperators(t *testing.T) {
 		`0x0`, `0x1`, `0xff`, `X'00'`, `X'01'`, `X'ff'`,
 		"NULL",
 		"0xFF666F6F626172FF", "0x666F6F626172FF", "0xFF666F6F626172",
+		"18446744073709540000e0",
+		"-18446744073709540000e0",
 	}
 	var right = []string{
 		"BINARY", "BINARY(1)", "BINARY(0)", "BINARY(16)", "BINARY(-1)",


### PR DESCRIPTION
## Description

Did you know that `float64` to `uint64` conversion is implementation defined behavior in Go? That's right. `float64(-2.0)` returns different results between x64 and an M1 Mac using ARM64. @systay noticed this.

Fortunately for us it is also undefined behavior in C and C++ so I've reverse engineered the trick they're using there by trial and error: it's the most obvious solution. Explained below:

```
		// We want to convert a float64 to its uint64 representation.
		// However, the cast `uint64(f)`, when f < 0, is actually implementation-defined
		// behavior in Go, so we cannot use it here.
		// The most noticeable example of this are M1 Macs with their ARM64 chipsets, where
		// the underflow is clamped at 0:
		//
		//		GOARCH=amd64 | uint64(-2.0) == 18446744073709551614
		// 		GOARCH=arm64 | uint64(-2.0) == 0
		//
		// The most obvious way to keep this well-defined is to do a two-step conversion:
		//		float64 -> int64 -> uint64
		// where every step of the conversion is well-defined. However, this conversion overflows
		// a range of floats, those larger than MaxInt64 but that would still fit in a 64-bit unsigned
		// integer. What's the right way to handle this overflow?
		//
		// Fortunately for us, the `uint64(f)` conversion for negative numbers is also undefined
		// behavior in C and C++, so MySQL is already handling this case! From running this
		// integration test, we can verify that MySQL is using a two-step conversion and it's clamping
		// the value to MaxInt64 on overflow:
		//
		//		mysql> SELECT CAST(18446744073709540000e0 AS UNSIGNED);
		//		+------------------------------------------+
		//		| CAST(18446744073709540000e0 AS UNSIGNED) |
		//		+------------------------------------------+
		//		|                      9223372036854775807 |
		//		+------------------------------------------+
		//
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
