### PR TITLE
Check for vtadmin JS types drift in CI

### DIFF
--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -23,6 +23,7 @@ jobs:
             - 'Makefile'
             - 'go/vt/proto/**'
             - 'proto/*.proto'
+            - 'web/vtadmin/src/proto/**'
 
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -1,0 +1,48 @@
+name: check_make_vtadmin_web_proto
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Check Make VTAdmin Web Proto
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: frouioui/paths-filter@main
+      id: changes
+      with:
+        token: ''
+        filters: |
+          proto_changes:
+            - 'bootstrap.sh'
+            - 'tools/**'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'Makefile'
+            - 'go/vt/proto/**'
+            - 'proto/*.proto'
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      if: steps.changes.outputs.proto_changes == 'true'
+      with:
+        go-version: 1.18.1
+
+    - name: Setup Node
+      if: steps.changes.outputs.proto_changes == 'true'
+      uses: actions/setup-node@v2
+      with:
+        # node-version should match package.json
+        node-version: '16.13.0'
+
+    - name: Install npm dependencies
+      if: steps.changes.outputs.proto_changes == 'true'
+      run: npm ci
+      working-directory: ./web/vtadmin
+
+    - name: check_make_vtadmin_web_proto
+      if: steps.changes.outputs.proto_changes == 'true'
+      run: |
+        tools/check_make_vtadmin_web_proto.sh

--- a/tools/check_make_vtadmin_web_proto.sh
+++ b/tools/check_make_vtadmin_web_proto.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source build.env
+
+first_output=$(git status --porcelain)
+
+make vtadmin_web_proto_types
+
+second_output=$(git status --porcelain)
+
+diff=$(diff <( echo "$first_output") <( echo "$second_output"))
+
+if [[ "$diff" != "" ]]; then
+  echo "ERROR: Regenerated vtadmin web proto files do not match the current version."
+  echo -e "List of files containing differences:\n$diff"
+  exit 1
+fi
+
+echo "VTAdmin Web Protos are up to date"


### PR DESCRIPTION
## Description

This pull request adds the `check_make_vtadmin_web_ proto` workflow to the CI. The workflow checks that the generated vtadmin javascript types files are in sync with the proto files. This is done by running the `make vtadmin_web_proto_types` command and diffing `git status`'s output before and after.

If there is a diff (a drift), the workflow lists the files that are not in accordance: in this case the generated vtadmin proto files.

I manually tested this action by adding a dummy field to a proto and testing it both locally and in CI.

## Related Issues

#9001

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

