### PR TITLE
fix: concatenate engine primitive

### DIFF
--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -92,7 +92,7 @@ func TestUnionAll(t *testing.T) {
 			mcmp.AssertMatches("select id1 from t1 where id1 = 1 union all select id1 from t1 where id1 = 4", "[[INT64(1)]]")
 
 			// union all between two different tables
-			mcmp.AssertMatches("(select id1,id2 from t1 order by id1) union all (select id3,id4 from t2 order by id3)",
+			mcmp.AssertMatchesNoOrder("(select id1,id2 from t1 order by id1) union all (select id3,id4 from t2 order by id3)",
 				"[[INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(4) INT64(4)]]")
 
 			// union all between two different tables
@@ -100,7 +100,7 @@ func TestUnionAll(t *testing.T) {
 			assert.Equal(t, 4, len(result.Rows))
 
 			// union all between two different tables
-			mcmp.AssertMatches("select tbl2.id1 FROM  ((select id1 from t1 order by id1 limit 5) union all (select id1 from t1 order by id1 desc limit 5)) as tbl1 INNER JOIN t1 as tbl2  ON tbl1.id1 = tbl2.id1",
+			mcmp.AssertMatchesNoOrder("select tbl2.id1 FROM  ((select id1 from t1 order by id1 limit 5) union all (select id1 from t1 order by id1 desc limit 5)) as tbl1 INNER JOIN t1 as tbl2  ON tbl1.id1 = tbl2.id1",
 				"[[INT64(1)] [INT64(2)] [INT64(2)] [INT64(1)]]")
 
 			// union all between two select unique in tables

--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -49,35 +49,6 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	}
 }
 
-func TestUnionAll(t *testing.T) {
-	mcmp, closer := start(t)
-	defer closer()
-
-	mcmp.Exec("insert into t1(id1, id2) values(1, 1), (2, 2)")
-	mcmp.Exec("insert into t2(id3, id4) values(3, 3), (4, 4)")
-
-	// union all between two selectuniqueequal
-	mcmp.AssertMatches("select id1 from t1 where id1 = 1 union all select id1 from t1 where id1 = 4", "[[INT64(1)]]")
-
-	// union all between two different tables
-	mcmp.AssertMatches("(select id1,id2 from t1 order by id1) union all (select id3,id4 from t2 order by id3)",
-		"[[INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(4) INT64(4)]]")
-
-	// union all between two different tables
-	result := mcmp.Exec("(select id1,id2 from t1) union all (select id3,id4 from t2)")
-	assert.Equal(t, 4, len(result.Rows))
-
-	// union all between two different tables
-	mcmp.AssertMatches("select tbl2.id1 FROM  ((select id1 from t1 order by id1 limit 5) union all (select id1 from t1 order by id1 desc limit 5)) as tbl1 INNER JOIN t1 as tbl2  ON tbl1.id1 = tbl2.id1",
-		"[[INT64(1)] [INT64(2)] [INT64(2)] [INT64(1)]]")
-
-	mcmp.Exec("insert into t1(id1, id2) values(3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8)")
-
-	// union all between two select unique in tables
-	mcmp.AssertMatchesNoOrder("select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8) union all select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8)",
-		"[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(5)] [INT64(4)] [INT64(6)] [INT64(7)] [INT64(8)] [INT64(1)] [INT64(2)] [INT64(3)] [INT64(5)] [INT64(4)] [INT64(6)] [INT64(7)] [INT64(8)]]")
-}
-
 func TestUnionDistinct(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()
@@ -107,39 +78,41 @@ func TestUnionDistinct(t *testing.T) {
 	}
 }
 
-func TestUnionAllOlap(t *testing.T) {
+func TestUnionAll(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()
 
 	mcmp.Exec("insert into t1(id1, id2) values(1, 1), (2, 2)")
 	mcmp.Exec("insert into t2(id3, id4) values(3, 3), (4, 4)")
 
-	utils.Exec(t, mcmp.VtConn, "set workload = olap")
+	for _, workload := range []string{"oltp", "olap"} {
+		t.Run(workload, func(t *testing.T) {
+			utils.Exec(t, mcmp.VtConn, "set workload = "+workload)
+			// union all between two selectuniqueequal
+			mcmp.AssertMatches("select id1 from t1 where id1 = 1 union all select id1 from t1 where id1 = 4", "[[INT64(1)]]")
 
-	// union all between two selectuniqueequal
-	mcmp.AssertMatches("select id1 from t1 where id1 = 1 union all select id1 from t1 where id1 = 4", "[[INT64(1)]]")
+			// union all between two different tables
+			mcmp.AssertMatches("(select id1,id2 from t1 order by id1) union all (select id3,id4 from t2 order by id3)",
+				"[[INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(4) INT64(4)]]")
 
-	// union all between two different tables
-	// union all between two different tables
-	result := mcmp.Exec("(select id1,id2 from t1 order by id1) union all (select id3,id4 from t2 order by id3)")
-	assert.Equal(t, 4, len(result.Rows))
+			// union all between two different tables
+			result := mcmp.Exec("(select id1,id2 from t1) union all (select id3,id4 from t2)")
+			assert.Equal(t, 4, len(result.Rows))
 
-	// union all between two different tables
-	result = mcmp.Exec("(select id1,id2 from t1) union all (select id3,id4 from t2)")
-	assert.Equal(t, 4, len(result.Rows))
+			// union all between two different tables
+			mcmp.AssertMatches("select tbl2.id1 FROM  ((select id1 from t1 order by id1 limit 5) union all (select id1 from t1 order by id1 desc limit 5)) as tbl1 INNER JOIN t1 as tbl2  ON tbl1.id1 = tbl2.id1",
+				"[[INT64(1)] [INT64(2)] [INT64(2)] [INT64(1)]]")
 
-	// union all between two different tables
-	result = mcmp.Exec("select tbl2.id1 FROM ((select id1 from t1 order by id1 limit 5) union all (select id1 from t1 order by id1 desc limit 5)) as tbl1 INNER JOIN t1 as tbl2  ON tbl1.id1 = tbl2.id1")
-	assert.Equal(t, 4, len(result.Rows))
+			// union all between two select unique in tables
+			mcmp.AssertMatchesNoOrder("select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8) union all select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8)",
+				"[[INT64(1)] [INT64(2)] [INT64(1)] [INT64(2)]]")
 
-	utils.Exec(t, mcmp.VtConn, "set workload = oltp")
-	mcmp.Exec("insert into t1(id1, id2) values(3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8)")
-	utils.Exec(t, mcmp.VtConn, "set workload = olap")
+			// 4 tables union all
+			mcmp.AssertMatchesNoOrder("select id1, id2 from t1 where id1 = 1 union all select id3,id4 from t2 where id3 = 3 union all select id1, id2 from t1 where id1 = 2 union all select id3,id4 from t2 where id3 = 4",
+				"[[INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(4) INT64(4)]]")
+		})
 
-	// union all between two selectuniquein tables
-	mcmp.AssertMatchesNoOrder("select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8) union all select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8)",
-		"[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(5)] [INT64(4)] [INT64(6)] [INT64(7)] [INT64(8)] [INT64(1)] [INT64(2)] [INT64(3)] [INT64(5)] [INT64(4)] [INT64(6)] [INT64(7)] [INT64(8)]]")
-
+	}
 }
 
 func TestUnion(t *testing.T) {

--- a/go/vt/vtgate/engine/concatenate_test.go
+++ b/go/vt/vtgate/engine/concatenate_test.go
@@ -142,10 +142,10 @@ func TestConcatenate_WithErrors(t *testing.T) {
 		}, nil,
 	)
 	ctx := context.Background()
-	_, err := concatenate.TryExecute(&noopVCursor{ctx: ctx}, nil, true)
+	_, err := concatenate.TryExecute(newNoopVCursor(ctx), nil, true)
 	require.EqualError(t, err, strFailed)
 
-	_, err = wrapStreamExecute(concatenate, &noopVCursor{ctx: ctx}, nil, true)
+	_, err = wrapStreamExecute(concatenate, newNoopVCursor(ctx), nil, true)
 	require.EqualError(t, err, strFailed)
 
 	concatenate = NewConcatenate(
@@ -155,8 +155,8 @@ func TestConcatenate_WithErrors(t *testing.T) {
 			&fakePrimitive{results: []*sqltypes.Result{fake, fake}},
 		}, nil)
 
-	_, err = concatenate.TryExecute(&noopVCursor{ctx: ctx}, nil, true)
+	_, err = concatenate.TryExecute(newNoopVCursor(ctx), nil, true)
 	require.EqualError(t, err, strFailed)
-	_, err = wrapStreamExecute(concatenate, &noopVCursor{ctx: ctx}, nil, true)
+	_, err = wrapStreamExecute(concatenate, newNoopVCursor(ctx), nil, true)
 	require.EqualError(t, err, strFailed)
 }

--- a/go/vt/vtgate/engine/concatenate_test.go
+++ b/go/vt/vtgate/engine/concatenate_test.go
@@ -107,7 +107,7 @@ func TestConcatenate_NoErrors(t *testing.T) {
 		concatenate := NewConcatenate(sources, tc.ignoreTypes)
 
 		t.Run(tc.testName+"-Execute", func(t *testing.T) {
-			qr, err := concatenate.TryExecute(&noopVCursor{ctx: context.Background()}, nil, true)
+			qr, err := concatenate.TryExecute(newNoopVCursor(context.Background()), nil, true)
 			if tc.expectedError == "" {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedResult, qr)
@@ -118,7 +118,7 @@ func TestConcatenate_NoErrors(t *testing.T) {
 		})
 
 		t.Run(tc.testName+"-StreamExecute", func(t *testing.T) {
-			qr, err := wrapStreamExecute(concatenate, &noopVCursor{ctx: context.Background()}, nil, true)
+			qr, err := wrapStreamExecute(concatenate, newNoopVCursor(context.Background()), nil, true)
 			if tc.expectedError == "" {
 				require.NoError(t, err)
 				require.Equal(t, utils.SortString(fmt.Sprintf("%v", tc.expectedResult.Rows)), utils.SortString(fmt.Sprintf("%v", qr.Rows)))

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -51,7 +51,18 @@ var _ SessionActions = (*noopVCursor)(nil)
 
 // noopVCursor is used to build other vcursors.
 type noopVCursor struct {
-	ctx context.Context
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func newNoopVCursor(ctx context.Context) *noopVCursor {
+	n := &noopVCursor{}
+	n.ctx, n.cancel = context.WithCancel(ctx)
+	return n
+}
+
+func (t *noopVCursor) CancelContext() {
+	t.cancel()
 }
 
 func (t *noopVCursor) SetExec(name string, value string) error {

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -52,6 +52,9 @@ type (
 		// Context returns the context of the current request.
 		Context() context.Context
 
+		// CancelContext cancels the highest level context and its children.
+		CancelContext()
+
 		GetKeyspace() string
 		// MaxMemoryRows returns the maxMemoryRows flag value.
 		MaxMemoryRows() int


### PR DESCRIPTION
## Description
Engine primitives communicate with each other all the time. When they do, the context passed between them is not passed explicitly as a method call argument as is normally done in golang code. Instead it's baked into one of the fields of the `vcursor` instance that engine primitives receive when executing.

The problem with this setup is when we concurrently call multiple children, like UNION does. The way that the context was shared between primitives means that sometimes, by mistake, one primitive would cancel another primitives context.

This manifested as intermittent errors when doing queries containing lots of UNION code.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
