### PR TITLE
Make the tests explicit for the SET variables for MySQL 5.7

### DIFF
--- a/go/vt/vtgate/engine/set_test.go
+++ b/go/vt/vtgate/engine/set_test.go
@@ -359,7 +359,8 @@ func TestSetTable(t *testing.T) {
 			"a,b|B,a,A,B,b,a",
 		)},
 	}, {
-		testName: "sql_mode change - changed additional",
+		testName:     "sql_mode change - changed additional - MySQL57",
+		mysqlVersion: "50709",
 		setOps: []SetOp{
 			&SysVarReservedConn{
 				Name:          "sql_mode",
@@ -378,7 +379,8 @@ func TestSetTable(t *testing.T) {
 			"a,b|B,a,A,B,b,a,c",
 		)},
 	}, {
-		testName: "sql_mode change - changed less",
+		testName:     "sql_mode change - changed less - MySQL57",
+		mysqlVersion: "50709",
 		setOps: []SetOp{
 			&SysVarReservedConn{
 				Name:          "sql_mode",
@@ -414,7 +416,8 @@ func TestSetTable(t *testing.T) {
 			"|",
 		)},
 	}, {
-		testName: "sql_mode change - empty orig",
+		testName:     "sql_mode change - empty orig - MySQL57",
+		mysqlVersion: "50709",
 		setOps: []SetOp{
 			&SysVarReservedConn{
 				Name:          "sql_mode",


### PR DESCRIPTION
These tests are specific for behavior on MySQL 5.7 and right now depend on the default defined in the sqlparser.

In order to be able at some point in the future change the default sqlparser version, these tests should be explicit which behavior is verified against which MySQL version.

There are already tests that explicit test things for MySQL 8.0, so also explicitly set MySQL 5.7 if we need to as well.

## Related Issue(s)

Found when working on #10203 and looking at what it takes to update the default sqlparser version at some point in the future.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required