### PR TITLE
[vtadmin] Add "Replication Status" view to Tablet page

### DIFF
--- a/web/vtadmin/src/api/http.ts
+++ b/web/vtadmin/src/api/http.ts
@@ -481,8 +481,6 @@ export const fetchShardReplicationPositions = async ({
     keyspaces = [],
     keyspaceShards = [],
 }: FetchShardReplicationPositionsParams) => {
-    // As an easy enhancement for later, we can also validate the request parameters on the front-end
-    // instead of defaulting to '', to save a round trip.
     const req = new URLSearchParams();
     clusterIDs.forEach((c) => c && req.append('cluster', c));
     keyspaces.forEach((k) => k && req.append('keyspace', k));

--- a/web/vtadmin/src/api/http.ts
+++ b/web/vtadmin/src/api/http.ts
@@ -469,3 +469,28 @@ export const validateVersionKeyspace = async ({ clusterID, keyspace }: ValidateV
 
     return vtctldata.ValidateVersionKeyspaceResponse.create(result);
 };
+
+export interface FetchShardReplicationPositionsParams {
+    clusterIDs?: (string | null | undefined)[];
+    keyspaces?: (string | null | undefined)[];
+    keyspaceShards?: (string | null | undefined)[];
+}
+
+export const fetchShardReplicationPositions = async ({
+    clusterIDs = [],
+    keyspaces = [],
+    keyspaceShards = [],
+}: FetchShardReplicationPositionsParams) => {
+    // As an easy enhancement for later, we can also validate the request parameters on the front-end
+    // instead of defaulting to '', to save a round trip.
+    const req = new URLSearchParams();
+    clusterIDs.forEach((c) => c && req.append('cluster', c));
+    keyspaces.forEach((k) => k && req.append('keyspace', k));
+    keyspaceShards.forEach((s) => s && req.append('keyspace_shard', s));
+
+    const { result } = await vtfetch(`/api/shard_replication_positions?${req}`);
+    const err = pb.GetShardReplicationPositionsResponse.verify(result);
+    if (err) throw Error(err);
+
+    return pb.GetShardReplicationPositionsResponse.create(result);
+};

--- a/web/vtadmin/src/components/routes/tablet/Tablet.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Tablet.tsx
@@ -32,6 +32,7 @@ import { TabContainer } from '../../tabs/TabContainer';
 import Advanced from './Advanced';
 import style from './Tablet.module.scss';
 import { TabletCharts } from './TabletCharts';
+import { TabletReplication } from './TabletReplication';
 
 interface RouteParams {
     alias: string;
@@ -103,6 +104,7 @@ export const Tablet = () => {
             <ContentContainer>
                 <TabContainer>
                     <Tab text="QPS" to={`${url}/qps`} />
+                    <Tab text="Replication Status" to={`${url}/replication`} />
                     <Tab text="JSON" to={`${url}/json`} />
 
                     <ReadOnlyGate>
@@ -113,6 +115,10 @@ export const Tablet = () => {
                 <Switch>
                     <Route path={`${path}/qps`}>
                         <TabletCharts alias={alias} clusterID={clusterID} />
+                    </Route>
+
+                    <Route path={`${path}/replication`}>
+                        <TabletReplication tablet={tablet} />
                     </Route>
 
                     <Route path={`${path}/json`}>

--- a/web/vtadmin/src/components/routes/tablet/TabletReplication.tsx
+++ b/web/vtadmin/src/components/routes/tablet/TabletReplication.tsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isEmpty } from 'lodash-es';
+import { useShardReplicationPositions } from '../../../hooks/api';
+import { vtadmin as pb } from '../../../proto/vtadmin';
+import { formatAlias, formatPaddedAlias } from '../../../util/tablets';
+import { Code } from '../../Code';
+import { QueryErrorPlaceholder } from '../../placeholders/QueryErrorPlaceholder';
+import { QueryLoadingPlaceholder } from '../../placeholders/QueryLoadingPlaceholder';
+
+interface Props {
+    tablet?: pb.Tablet;
+}
+
+export const TabletReplication: React.FC<Props> = ({ tablet }) => {
+    const clusterID = tablet?.cluster?.id;
+    const keyspace = tablet?.tablet?.keyspace;
+    const shard = tablet?.tablet?.shard;
+    const keyspaceShard = keyspace && shard ? `${keyspace}/${shard}` : null;
+    const alias = formatAlias(tablet?.tablet?.alias);
+    const paddedAlias = tablet ? formatPaddedAlias(tablet.tablet?.alias) : null;
+
+    const q = useShardReplicationPositions({
+        clusterIDs: [clusterID],
+        keyspaces: [keyspace],
+        keyspaceShards: [keyspaceShard],
+    });
+
+    // Loading of the tablet itself is (for now) handled by the parent component,
+    // so allow it to handle the loading display, too.
+    if (!tablet) {
+        return null;
+    }
+
+    const positionsForShard = q.data?.replication_positions.find(
+        (p) => p.cluster?.id === clusterID && p.keyspace === keyspace && p.shard === shard
+    );
+
+    const replicationStatuses = positionsForShard?.position_info?.replication_statuses;
+    const replicationStatus = replicationStatuses && paddedAlias ? replicationStatuses[paddedAlias] : null;
+
+    let content = null;
+    if (q.isSuccess) {
+        content = isEmpty(replicationStatus) ? (
+            <div className="text-center text-secondary my-12">No replication status for {alias}</div>
+        ) : (
+            <Code code={JSON.stringify(replicationStatus, null, 2)} />
+        );
+    }
+
+    return (
+        <div>
+            <QueryLoadingPlaceholder query={q} />
+            <QueryErrorPlaceholder query={q} />
+            {content}
+        </div>
+    );
+};

--- a/web/vtadmin/src/hooks/api.ts
+++ b/web/vtadmin/src/hooks/api.ts
@@ -57,6 +57,7 @@ import {
     ValidateSchemaKeyspaceParams,
     ValidateVersionKeyspaceParams,
     validateVersionKeyspace,
+    fetchShardReplicationPositions,
 } from '../api/http';
 import { vtadmin as pb } from '../proto/vtadmin';
 import { formatAlias } from '../util/tablets';
@@ -187,6 +188,15 @@ export const useSetReadWrite = (
         return setReadWrite(params);
     }, options);
 };
+
+/**
+ * useShardReplicationPositions is a query hook that shows the replication status
+ * of each replica machine in the shard graph.
+ */
+export const useShardReplicationPositions = (
+    params: Parameters<typeof fetchShardReplicationPositions>[0],
+    options?: UseQueryOptions<pb.GetShardReplicationPositionsResponse, Error> | undefined
+) => useQuery(['shard_replication_positions', params], () => fetchShardReplicationPositions(params), options);
 
 /**
  * useStartReplication starts replication on the specified tablet.

--- a/web/vtadmin/src/util/tablets.test.ts
+++ b/web/vtadmin/src/util/tablets.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as tablets from './tablets';
+
+describe('formatPaddedAlias', () => {
+    it('pads with leading zeroes', () => {
+        expect(
+            tablets.formatPaddedAlias({
+                cell: 'zone1',
+                uid: 100,
+            })
+        ).toEqual('zone1-0000000100');
+    });
+
+    it('handles null input', () => {
+        expect(tablets.formatPaddedAlias(null)).toEqual(null);
+    });
+
+    it('handles invalid cell', () => {
+        expect(
+            tablets.formatPaddedAlias({
+                cell: null,
+                uid: 100,
+            })
+        ).toEqual(null);
+    });
+
+    it('handles invalid uid', () => {
+        expect(
+            tablets.formatPaddedAlias({
+                cell: 'zone1',
+                uid: null,
+            })
+        ).toEqual(null);
+    });
+});

--- a/web/vtadmin/src/util/tablets.ts
+++ b/web/vtadmin/src/util/tablets.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { invertBy } from 'lodash-es';
+import { invertBy, padStart } from 'lodash-es';
 import { topodata, vtadmin as pb } from '../proto/vtadmin';
 
 /**
@@ -33,6 +33,15 @@ export const TABLET_TYPES = Object.entries(invertBy(topodata.TabletType)).reduce
  */
 export const formatAlias = <A extends topodata.ITabletAlias>(alias: A | null | undefined) =>
     alias?.uid ? `${alias.cell}-${alias.uid}` : null;
+
+/**
+ * formatAlias formats a tablet.alias object as a single string,
+ * with the uid left-padded with zeroes.
+ *
+ * This function can be removed once https://github.com/vitessio/vitess/issues/8751 is complete.
+ */
+export const formatPaddedAlias = <A extends topodata.ITabletAlias>(alias: A | null | undefined) =>
+    alias?.cell && alias?.uid ? `${alias.cell}-${padStart(alias.uid.toString(), 10, '0')}` : null;
 
 export const formatType = (t: pb.Tablet) => t.tablet?.type && TABLET_TYPES[t.tablet?.type];
 


### PR DESCRIPTION
## Description

T'isn't the prettiest, by any means. I have plans to enhance this with a nice tabular display, but this is on par with the vtctld2 UI so we can call it ✨ an MVP. ✨ 

The biggest divergence, in the parity sense, is that the vtctld2 UI displays replication positions for an entire shard, on its equivalent of the shard detail page. It also requires several clicks since it's hidden behind a modal and a confirmation. 

![image](https://user-images.githubusercontent.com/855595/167841913-1cf249d8-09a2-452a-938b-205545ada937.png)


One thing the vtctld2 UI does that is nice is show the command it uses. Will have to think about a nice way to show that in VTAdmin overall, since we could apply that pattern in many places.

Anyway. Here's what this looks like for RDONLY/REPLICA tablets:

<img width="1904" alt="Screen Shot 2022-05-11 at 7 09 49 AM" src="https://user-images.githubusercontent.com/855595/167840885-3ff20c52-6f3c-449e-a78f-7609b655aef4.png">

And a primary:

<img width="1904" alt="Screen Shot 2022-05-11 at 7 09 44 AM" src="https://user-images.githubusercontent.com/855595/167840890-092556a0-c61e-414f-8c5f-75a4f5ce4c60.png">

And finally, when a tablet doesn't have any replication status. In this case, the tablet is the primary tablet in a shard that is messed up. (Specifically, the RDONLY and REPLICA tablets came up as non-serving when I ran the local example, which was not on purpose, but useful in this instance!) 

<img width="1904" alt="Screen Shot 2022-05-11 at 7 09 38 AM" src="https://user-images.githubusercontent.com/855595/167840893-4c0f2106-1606-47ab-a71b-b21989d23ba2.png">


## Related Issue(s)

Closes #8719

`formatPaddedAlias` was added as a stopgap until we get around to https://github.com/vitessio/vitess/issues/8751. It was required for this PR since `shard_replication_positions` keys on the _padded_ alias, like this:

```js
{
  "result": {
    "replication_positions": [
      {
        "cluster": {
          "id": "local",
          "name": "local"
        },
        "keyspace": "customer",
        "shard": "0",
        "position_info": {
          "replication_statuses": {
            "zone1-0000000200": { // <--- like this
              "position": "MySQL56/97b40be6-d08a-11ec-ba75-6e8242c51720:1-82"
            },
        // etc. 
```

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A
