### PR TITLE
Fix `tabletmanager_throttler` flakyness: increase wait time

### DIFF
--- a/go/test/endtoend/tabletmanager/throttler/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler/throttler_test.go
@@ -73,10 +73,10 @@ var (
 )
 
 const (
-	throttlerInitWait            = 15 * time.Second
+	throttlerInitWait            = 30 * time.Second
 	accumulateLagWait            = 2 * time.Second
-	throttlerRefreshIntervalWait = 12 * time.Second
-	replicationCatchUpWait       = 5 * time.Second
+	throttlerRefreshIntervalWait = 20 * time.Second
+	replicationCatchUpWait       = 10 * time.Second
 	onDemandHeartbeatDuration    = 5 * time.Second
 )
 

--- a/go/test/endtoend/tabletmanager/throttler/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler/throttler_test.go
@@ -73,7 +73,7 @@ var (
 )
 
 const (
-	throttlerInitWait            = 10 * time.Second
+	throttlerInitWait            = 15 * time.Second
 	accumulateLagWait            = 2 * time.Second
 	throttlerRefreshIntervalWait = 12 * time.Second
 	replicationCatchUpWait       = 5 * time.Second


### PR DESCRIPTION

## Description

Quick fix to `tabletmanager_throttler` test that increases a timeout to reduce flakiness. The change to timeout is legit an immaterial to the overall test, and can combat some race condition or slowness in some test envs.



## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

