### PR TITLE
CI: Add query retries to vttablet process

### DIFF
--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -414,8 +414,25 @@ func (vttablet *VttabletProcess) QueryTabletWithDB(query string, dbname string) 
 	return executeQuery(conn, query)
 }
 
+// executeQuery will retry the query up to 10 times with a small sleep in between each try.
+// This allows the tests to be more robust in the face of transient failures.
 func executeQuery(dbConn *mysql.Conn, query string) (*sqltypes.Result, error) {
-	return dbConn.ExecuteFetch(query, 10000, true)
+	var (
+		err    error
+		result *sqltypes.Result
+	)
+	retries := 10
+	retryDelay := 1 * time.Second
+	for i := 1; i <= retries; i++ {
+		log.Infof("Executing query %s on %s (attempt %d of %d)", query, i, retries)
+		result, err = dbConn.ExecuteFetch(query, 10000, true)
+		if err == nil {
+			break
+		}
+		time.Sleep(retryDelay)
+	}
+
+	return result, err
 }
 
 // GetDBVar returns first matching database variable's value
@@ -465,7 +482,7 @@ func (vttablet *VttabletProcess) WaitForVReplicationToCatchup(t testing.TB, work
 		for duration > 0 {
 			log.Infof("Executing query %s on %s", query, vttablet.Name)
 			lastChecked = time.Now()
-			qr, err := conn.ExecuteFetch(query, 1000, true)
+			qr, err := executeQuery(conn, query)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -514,7 +531,7 @@ func (vttablet *VttabletProcess) BulkLoad(t testing.TB, db, table string, bulkIn
 	defer conn.Close()
 
 	query := fmt.Sprintf("LOAD DATA INFILE '%s' INTO TABLE `%s` FIELDS TERMINATED BY ',' ENCLOSED BY '\"'", tmpbulk.Name(), table)
-	_, err = conn.ExecuteFetch(query, 1, false)
+	_, err = executeQuery(conn, query)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

This should reduce some CI flakes due to ephemeral issues. For example, I've periodically seen failures in `TestV2WorkflowsAcrossDBVersions/reshardMerchant3to1Merge` here ([recent failure](https://github.com/vitessio/vitess/runs/6393037092?check_suite_focus=true#step:10:1008)):
```
I0511 17:42:11.027619   17525 vttablet_process.go:466] Executing query select count(*) from _vt.vreplication where workflow = "m3m1" and db_name = "vt_merchant-type" and pos = '' on zone1-2000
1029
    vttablet_process.go:470: Deadlock found when trying to get lock; try restarting transaction (errno 1213) (sqlstate 40001) during query: select count(*) from _vt.vreplication where workflow = "m3m1" and db_name = "vt_merchant-type" and pos = ''
```

That can happen because when we get any error we fail today: https://github.com/vitessio/vitess/blob/c7579d0ab44b2296f6de9f1766898cc24733ff8b/go/test/endtoend/cluster/vttablet_process.go#L466-L471

This PR adds automatic retries to deal with any ephemeral issues like this — similar to what was previously done for the vtctlclient_process commands in the e2e tests in https://github.com/vitessio/vitess/pull/10051. 

## Related Issue(s)
 - https://github.com/vitessio/vitess/pull/10051

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests are not required
-   [x] Documentation is not required