### PR TITLE
Do not cache plans that are invalid because of `--no_scatter`

### DIFF
--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -2987,6 +2987,11 @@ func TestSelectScatterFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "scatter")
 
+	// Run the test again, to ensure it behaves the same for a cached query
+	_, err = executorExecSession(executor, "select id from user", nil, sess)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scatter")
+
 	_, err = executorExecSession(executor, "select /*vt+ ALLOW_SCATTER */ id from user", nil, sess)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Signed-off-by: Jacques Grove <aquarapid@gmail.com>

## Description

When using the `vtgate` `--no_scatter` flag (or the comment directive equivalent), we expect all scatter queries to fail.
However, we cache the plan for the scatter before checking the query for validity (i.e. if using the no-scatter flag or comment, return an appropriate error).  When the query is repeated, we pull it from the cache and return it, never checking for the no-scatter flag or comment.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

