### PR TITLE
[13.0] partial dml execution logic enhancement

### DIFF
--- a/go/vt/vtexplain/testdata/multi-output/updatesharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/updatesharded-output.txt
@@ -85,19 +85,17 @@ begin
 update user set nickname='alice' where id=1
 
 1 ks_sharded/-40: begin
-1 ks_sharded/-40: savepoint x1
 1 ks_sharded/-40: update `user` set nickname = 'alice' where id = 1 limit 10001
 
 ----------------------------------------------------------------------
 update user set nickname='bob' where id=1
 
-2 ks_sharded/-40: savepoint x2
-3 ks_sharded/-40: update `user` set nickname = 'bob' where id = 1 limit 10001
+2 ks_sharded/-40: update `user` set nickname = 'bob' where id = 1 limit 10001
 
 ----------------------------------------------------------------------
 commit
 
-4 ks_sharded/-40: commit
+3 ks_sharded/-40: commit
 
 ----------------------------------------------------------------------
 begin
@@ -107,22 +105,38 @@ begin
 update user set nickname='alice' where id=1
 
 1 ks_sharded/-40: begin
-1 ks_sharded/-40: savepoint x3
 1 ks_sharded/-40: update `user` set nickname = 'alice' where id = 1 limit 10001
 
 ----------------------------------------------------------------------
 update user set nickname='bob' where id=3
 
-2 ks_sharded/-40: savepoint x4
-3 ks_sharded/40-80: begin
-3 ks_sharded/40-80: savepoint x3
-3 ks_sharded/40-80: savepoint x4
-3 ks_sharded/40-80: update `user` set nickname = 'bob' where id = 3 limit 10001
+2 ks_sharded/40-80: begin
+2 ks_sharded/40-80: update `user` set nickname = 'bob' where id = 3 limit 10001
 
 ----------------------------------------------------------------------
 commit
 
-4 ks_sharded/-40: commit
-5 ks_sharded/40-80: commit
+3 ks_sharded/-40: commit
+4 ks_sharded/40-80: commit
+
+----------------------------------------------------------------------
+begin
+
+
+----------------------------------------------------------------------
+update user set nickname='alice' where id in (1,4)
+
+1 ks_sharded/-40: begin
+1 ks_sharded/-40: savepoint x1
+1 ks_sharded/-40: update `user` set nickname = 'alice' where id in (1, 4) limit 10001
+1 ks_sharded/c0-: begin
+1 ks_sharded/c0-: savepoint x1
+1 ks_sharded/c0-: update `user` set nickname = 'alice' where id in (1, 4) limit 10001
+
+----------------------------------------------------------------------
+commit
+
+2 ks_sharded/-40: commit
+3 ks_sharded/c0-: commit
 
 ----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/updatesharded-queries.sql
+++ b/go/vt/vtexplain/testdata/updatesharded-queries.sql
@@ -26,3 +26,8 @@ begin;
 update user set nickname='alice' where id=1;
 update user set nickname='bob' where id=3;
 commit;
+
+/* update in a transaction with single query going to multiple shard */
+begin;
+update user set nickname='alice' where id in (1,4);
+commit;

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -798,7 +798,8 @@ func TestInsertSharded(t *testing.T) {
 	logChan := QueryLogger.Subscribe("Test")
 	defer QueryLogger.Unsubscribe(logChan)
 
-	_, err := executorExec(executor, "insert into user(id, v, name) values (1, 2, 'myname')", nil)
+	session := &vtgatepb.Session{}
+	_, err := executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), "insert into user(id, v, name) values (1, 2, 'myname')", nil)
 	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into `user`(id, v, `name`) values (:_Id_0, 2, :_name_0)",
@@ -825,7 +826,7 @@ func TestInsertSharded(t *testing.T) {
 
 	sbc1.Queries = nil
 	sbclookup.Queries = nil
-	_, err = executorExec(executor, "insert into user(id, v, name) values (3, 2, 'myname2')", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), "insert into user(id, v, name) values (3, 2, 'myname2')", nil)
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into `user`(id, v, `name`) values (:_Id_0, 2, :_name_0)",
@@ -850,7 +851,7 @@ func TestInsertSharded(t *testing.T) {
 	testQueryLog(t, logChan, "TestExecute", "INSERT", "insert into user(id, v, name) values (3, 2, 'myname2')", 1)
 
 	sbc1.Queries = nil
-	_, err = executorExec(executor, "insert into user2(id, name, lastname) values (2, 'myname', 'mylastname')", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), "insert into user2(id, name, lastname) values (2, 'myname', 'mylastname')", nil)
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into user2(id, `name`, lastname) values (:_id_0, :_name_0, :_lastname_0)",
@@ -870,7 +871,7 @@ func TestInsertSharded(t *testing.T) {
 	sbc1.Queries = nil
 	sbc2.Queries = nil
 	sbclookup.Queries = nil
-	_, err = executorExec(executor, "insert into user(id, v, name) values (1, 2, _binary 'myname')", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), "insert into user(id, v, name) values (1, 2, _binary 'myname')", nil)
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into `user`(id, v, `name`) values (:_Id_0, :vtg2, :_name_0)",

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -702,26 +702,8 @@ var testPlannedQueries = map[string]bool{}
 func testQueryLog(t *testing.T, logChan chan interface{}, method, stmtType, sql string, shardQueries int) *LogStats {
 	t.Helper()
 
-	return testQueryLogWithSavepoint(t, logChan, method, stmtType, sql, shardQueries, false /* checkSavepoint */)
-}
-
-func testQueryLogWithSavepoint(t *testing.T, logChan chan interface{}, method, stmtType, sql string, shardQueries int, checkSavepoint bool) *LogStats {
-	t.Helper()
-
-	var logStats *LogStats
-
-	if checkSavepoint {
-		logStats = getQueryLog(logChan)
-		require.NotNil(t, logStats)
-	} else {
-		for {
-			logStats = getQueryLog(logChan)
-			require.NotNil(t, logStats)
-			if logStats.Method != "MarkSavepoint" {
-				break
-			}
-		}
-	}
+	logStats := getQueryLog(logChan)
+	require.NotNil(t, logStats)
 
 	var log bytes.Buffer
 	streamlog.GetFormatter(QueryLogger)(&log, nil, logStats)
@@ -735,11 +717,9 @@ func testQueryLogWithSavepoint(t *testing.T, logChan chan interface{}, method, s
 	checkEqualQuery := true
 	// The internal savepoints are created with uuids so the value of it not known to assert.
 	// Therefore, the equal query check is ignored.
-	if checkSavepoint {
-		switch stmtType {
-		case "SAVEPOINT", "SAVEPOINT_ROLLBACK", "RELEASE":
-			checkEqualQuery = false
-		}
+	switch stmtType {
+	case "SAVEPOINT", "SAVEPOINT_ROLLBACK", "RELEASE":
+		checkEqualQuery = false
 	}
 	// only test the durations if there is no error (fields[16])
 	if fields[16] == "\"\"" {

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -45,6 +45,7 @@ type SafeSession struct {
 	// executed. If there was a subsequent failure, if we have a savepoint we rollback to that.
 	// Otherwise, the transaction is rolled back.
 	rollbackOnPartialExec string
+	savepointName         string
 
 	// this is a signal that found_rows has already been handles by the primitives,
 	// and doesn't have to be updated by the executor
@@ -88,8 +89,16 @@ type savepointState int
 
 const (
 	savepointStateNotSet = savepointState(iota)
-	savepointNeeded
+	// savepointNotNeeded - savepoint is not required
 	savepointNotNeeded
+	// savepointNeeded - savepoint may be required
+	savepointNeeded
+	// savepointSet - savepoint is set on the session
+	savepointSet
+	// savepointRollbackSet - rollback to savepoint is set on the session
+	savepointRollbackSet
+	// savepointRollback - rollback happened on the savepoint
+	savepointRollback
 )
 
 // NewSafeSession returns a new SafeSession based on the Session
@@ -206,12 +215,55 @@ func (session *SafeSession) SetSavepointState(spNeed bool) {
 	}
 }
 
-// InsertSavepoints returns true if we should insert savepoints.
-func (session *SafeSession) InsertSavepoints() bool {
+// CanAddSavepoint returns true if we should insert savepoint and there is no existing savepoint.
+func (session *SafeSession) CanAddSavepoint() bool {
 	session.mu.Lock()
 	defer session.mu.Unlock()
 
 	return session.savepointState == savepointNeeded
+}
+
+// SetSavepoint stores the savepoint name to session.
+func (session *SafeSession) SetSavepoint(name string) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	session.savepointName = name
+	session.savepointState = savepointSet
+}
+
+// SetRollbackCommand stores the rollback command to session and executed if required.
+func (session *SafeSession) SetRollbackCommand() {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	// if the rollback already happened on the savepoint. There is nothing to set or execute on later.
+	if session.savepointState == savepointRollback {
+		return
+	}
+
+	if session.savepointState == savepointSet {
+		session.rollbackOnPartialExec = fmt.Sprintf("rollback to %s", session.savepointName)
+	} else {
+		session.rollbackOnPartialExec = txRollback
+	}
+	session.savepointState = savepointRollbackSet
+}
+
+// SavepointRollback updates the state that transaction was rolledback to the savepoint stored in the session.
+func (session *SafeSession) SavepointRollback() {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	session.savepointState = savepointRollback
+}
+
+// IsRollbackSet returns true if rollback to savepoint can be done.
+func (session *SafeSession) IsRollbackSet() bool {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	return session.savepointState == savepointRollbackSet
 }
 
 // SetCommitOrder sets the commit order.


### PR DESCRIPTION
Backport of https://github.com/vitessio/vitess/pull/10223

This PR reduces the effect of creating unnecessary calls to vttablet to create savepoints. The logic of savepoints in transactions was introduced in 13.0 as part of MySQL compatibility work where any cross-shard query fails it should not rollback the transaction (old behavior) instead should only rollback the effect of the query (current behavior). This boosts the Vitess query-serving performance by 7%.
