### PR TITLE
vtorc: more auditing in GracefulPrimaryTakeover

### DIFF
--- a/go/vt/orchestrator/logic/topology_recovery.go
+++ b/go/vt/orchestrator/logic/topology_recovery.go
@@ -1604,13 +1604,22 @@ func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey
 		return nil, err
 	}
 	topologyRecovery, err = AttemptRecoveryRegistration(&analysisEntry, false /*failIfFailedInstanceInActiveRecovery*/, false /*failIfClusterInActiveRecovery*/)
-	if topologyRecovery == nil || err != nil {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("could not register recovery on %+v. Unable to issue PlannedReparentShard.", analysisEntry.AnalyzedInstanceKey))
+	if err != nil {
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("could not register recovery on %+v. Unable to issue PlannedReparentShard. err=%v", analysisEntry.AnalyzedInstanceKey, err))
 		return topologyRecovery, err
 	}
+	if topologyRecovery == nil {
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("could not register recovery on %+v. Unable to issue PlannedReparentShard. Recovery is nil", analysisEntry.AnalyzedInstanceKey))
+		return nil, nil
+	}
+	// recovery is now registered. From now on this process owns the recovery and other processes will notbe able to run
+	// a recovery for some time.
+	// Let's audit anything that happens from this point on, including any early return
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("registered recovery on %+v. Recovery: %+v", analysisEntry.AnalyzedInstanceKey, topologyRecovery))
 
 	primaryTablet, err := inst.ReadTablet(clusterPrimary.Key)
 	if err != nil {
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("rerror reading primary tablet %+v: %+v", clusterPrimary.Key, err))
 		return topologyRecovery, err
 	}
 	if designatedKey != nil && !designatedKey.IsValid() {
@@ -1621,6 +1630,7 @@ func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey
 	if designatedKey != nil {
 		designatedTablet, err := inst.ReadTablet(*designatedKey)
 		if err != nil {
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("rerror reading designated tablet %+v: %+v", *designatedKey, err))
 			return topologyRecovery, err
 		}
 		designatedTabletAlias = designatedTablet.Alias


### PR DESCRIPTION

## Description

The team tackled some `GracefulPrimaryTakeover` CI scenarios which were difficult to interpret. This PR adds some auditing in `GracefulPrimaryTakeover`, in particular around `AttemptRecoveryRegistration()`. In fact, any code path following `AttemptRecoveryRegistration()` must be audited; any early return must be visible, because those code paths can block the next recovery attempt.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

