### PR TITLE
BugFix: Resolve Recoveries at the end

### DIFF
--- a/go/test/endtoend/cluster/vtorc_process.go
+++ b/go/test/endtoend/cluster/vtorc_process.go
@@ -71,7 +71,9 @@ func (config *VtorcConfiguration) AddDefaults(webPort int) {
 	config.MySQLTopologyPassword = "orc_client_user_password"
 	config.MySQLReplicaUser = "vt_repl"
 	config.MySQLReplicaPassword = ""
-	config.RecoveryPeriodBlockSeconds = 1
+	if config.RecoveryPeriodBlockSeconds == 0 {
+		config.RecoveryPeriodBlockSeconds = 1
+	}
 	config.InstancePollSeconds = 1
 	config.ListenAddress = fmt.Sprintf(":%d", webPort)
 }

--- a/go/test/endtoend/vtorc/gracefultakeover/graceful_takeover_test.go
+++ b/go/test/endtoend/vtorc/gracefultakeover/graceful_takeover_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/vtorc/utils"
@@ -33,6 +34,7 @@ func TestGracefulPrimaryTakeover(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 0, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
+		RecoveryPeriodBlockSeconds:            5,
 	}, 1)
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
@@ -51,10 +53,20 @@ func TestGracefulPrimaryTakeover(t *testing.T) {
 	}
 	assert.NotNil(t, replica, "could not find replica tablet")
 
-	// check that the replication is setup correctly before we failover
+	// check that the replication is setup correctly before we set read-only
 	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{replica}, 10*time.Second)
 
-	status, _ := utils.MakeAPICallUntilRegistered(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover/localhost/%d/localhost/%d", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, curPrimary.MySQLPort, replica.MySQLPort))
+	// Run a failure on the current primary before, just to check that we are able to
+	// register another recovery right after fixing this first
+	// Make the current primary database read-only.
+	_, err := utils.RunSQL(t, "set global read_only=ON", curPrimary, "")
+	require.NoError(t, err)
+
+	// wait for repair
+	match := utils.WaitForReadOnlyValue(t, curPrimary, 0)
+	require.True(t, match)
+
+	status, _ := utils.MakeAPICall(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover/localhost/%d/localhost/%d", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, curPrimary.MySQLPort, replica.MySQLPort))
 	assert.Equal(t, 200, status)
 
 	// check that the replica gets promoted
@@ -90,7 +102,7 @@ func TestGracefulPrimaryTakeoverNoTarget(t *testing.T) {
 	// check that the replication is setup correctly before we failover
 	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{replica}, 10*time.Second)
 
-	status, _ := utils.MakeAPICallUntilRegistered(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover/localhost/%d/", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, curPrimary.MySQLPort))
+	status, _ := utils.MakeAPICall(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover/localhost/%d/", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, curPrimary.MySQLPort))
 	assert.Equal(t, 200, status)
 
 	// check that the replica gets promoted
@@ -129,14 +141,14 @@ func TestGracefulPrimaryTakeoverAuto(t *testing.T) {
 	// check that the replication is setup correctly before we failover
 	utils.CheckReplication(t, clusterInfo, primary, []*cluster.Vttablet{replica, rdonly}, 10*time.Second)
 
-	status, _ := utils.MakeAPICallUntilRegistered(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover-auto/localhost/%d/localhost/%d", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, primary.MySQLPort, replica.MySQLPort))
+	status, _ := utils.MakeAPICall(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover-auto/localhost/%d/localhost/%d", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, primary.MySQLPort, replica.MySQLPort))
 	assert.Equal(t, 200, status)
 
 	// check that the replica gets promoted
 	utils.CheckPrimaryTablet(t, clusterInfo, replica, true)
 	utils.VerifyWritesSucceed(t, clusterInfo, replica, []*cluster.Vttablet{primary, rdonly}, 10*time.Second)
 
-	status, _ = utils.MakeAPICallUntilRegistered(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover-auto/localhost/%d/", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, replica.MySQLPort))
+	status, _ = utils.MakeAPICall(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover-auto/localhost/%d/", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, replica.MySQLPort))
 	assert.Equal(t, 200, status)
 
 	// check that the primary gets promoted back
@@ -171,7 +183,7 @@ func TestGracefulPrimaryTakeoverFailCrossCell(t *testing.T) {
 	// newly started tablet does not replicate from anyone yet, we will allow orchestrator to fix this too
 	utils.CheckReplication(t, clusterInfo, primary, []*cluster.Vttablet{crossCellReplica1, rdonly}, 25*time.Second)
 
-	status, response := utils.MakeAPICallUntilRegistered(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover/localhost/%d/localhost/%d", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, primary.MySQLPort, crossCellReplica1.MySQLPort))
+	status, response := utils.MakeAPICall(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover/localhost/%d/localhost/%d", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, primary.MySQLPort, crossCellReplica1.MySQLPort))
 	assert.Equal(t, 500, status)
 	assert.Contains(t, response, "GracefulPrimaryTakeover: constraint failure")
 

--- a/go/test/endtoend/vtorc/gracefultakeover/graceful_takeover_test.go
+++ b/go/test/endtoend/vtorc/gracefultakeover/graceful_takeover_test.go
@@ -66,6 +66,12 @@ func TestGracefulPrimaryTakeover(t *testing.T) {
 	match := utils.WaitForReadOnlyValue(t, curPrimary, 0)
 	require.True(t, match)
 
+	// this is added to reduce flakiness. We need to wait for 1 second before calling
+	// Graceful primray takeover to ensure that the recovery is registered. If the second recovery
+	// ran in less than 1 second, then trying to acknowledge completed recoveries fails because
+	// we try to set the same end timestamp on the recovery of first 2 failures which fails the unique constraint
+	time.Sleep(1 * time.Second)
+
 	status, _ := utils.MakeAPICall(t, fmt.Sprintf("http://localhost:%d/api/graceful-primary-takeover/localhost/%d/localhost/%d", clusterInfo.ClusterInstance.VtorcProcesses[0].WebPort, curPrimary.MySQLPort, replica.MySQLPort))
 	assert.Equal(t, 200, status)
 

--- a/go/vt/orchestrator/logic/topology_recovery.go
+++ b/go/vt/orchestrator/logic/topology_recovery.go
@@ -635,6 +635,11 @@ func recoverPrimaryHasPrimary(ctx context.Context, analysisEntry inst.Replicatio
 		return false, nil, err
 	}
 	log.Infof("Analysis: %v, will fix incorrect primaryship %+v", analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey)
+	// This has to be done in the end; whether successful or not, we should mark that the recovery is done.
+	// So that after the active period passes, we are able to run other recoveries.
+	defer func() {
+		resolveRecovery(topologyRecovery, nil)
+	}()
 
 	// Reset replication on current primary.
 	_, err = inst.ResetReplicationOperation(&analysisEntry.AnalyzedInstanceKey)
@@ -668,6 +673,12 @@ func recoverDeadPrimary(ctx context.Context, analysisEntry inst.ReplicationAnaly
 		return false, nil, err
 	}
 	log.Infof("Analysis: %v, deadprimary %+v", analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey)
+	var promotedReplica *inst.Instance
+	// This has to be done in the end; whether successful or not, we should mark that the recovery is done.
+	// So that after the active period passes, we are able to run other recoveries.
+	defer func() {
+		resolveRecovery(topologyRecovery, promotedReplica)
+	}()
 
 	ev, err := reparentutil.NewEmergencyReparenter(ts, tmclient.NewTabletManagerClient(), logutil.NewCallbackLogger(func(event *logutilpb.Event) {
 		level := event.GetLevel()
@@ -693,7 +704,6 @@ func recoverDeadPrimary(ctx context.Context, analysisEntry inst.ReplicationAnaly
 
 	// We should refresh the tablet information again to update our information.
 	RefreshTablets(true /* forceRefresh */)
-	var promotedReplica *inst.Instance
 	if ev.NewPrimary != nil {
 		promotedReplica, _, _ = inst.ReadInstance(&inst.InstanceKey{
 			Hostname: ev.NewPrimary.MysqlHostname,
@@ -710,8 +720,6 @@ func postErsCompletion(topologyRecovery *TopologyRecovery, analysisEntry inst.Re
 		AuditTopologyRecovery(topologyRecovery, message)
 		inst.AuditOperation("recover-dead-primary", &analysisEntry.AnalyzedInstanceKey, message)
 	}
-	// And this is the end; whether successful or not, we're done.
-	resolveRecovery(topologyRecovery, promotedReplica)
 	// Now, see whether we are successful or not. From this point there's no going back.
 	if promotedReplica != nil {
 		// Success!
@@ -1119,13 +1127,6 @@ func RecoverDeadCoPrimary(topologyRecovery *TopologyRecovery, skipProcesses bool
 
 // checkAndRecoverGenericProblem is a general-purpose recovery function
 func checkAndRecoverLockedSemiSyncPrimary(ctx context.Context, analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
-
-	topologyRecovery, err = AttemptRecoveryRegistration(&analysisEntry, true, true)
-	if topologyRecovery == nil {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another RecoverLockedSemiSyncPrimary.", analysisEntry.AnalyzedInstanceKey))
-		return false, nil, err
-	}
-
 	return false, nil, nil
 }
 
@@ -1608,6 +1609,12 @@ func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey
 		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("could not register recovery on %+v. Unable to issue PlannedReparentShard.", analysisEntry.AnalyzedInstanceKey))
 		return topologyRecovery, err
 	}
+	var promotedReplica *inst.Instance
+	// This has to be done in the end; whether successful or not, we should mark that the recovery is done.
+	// So that after the active period passes, we are able to run other recoveries.
+	defer func() {
+		resolveRecovery(topologyRecovery, promotedReplica)
+	}()
 
 	primaryTablet, err := inst.ReadTablet(clusterPrimary.Key)
 	if err != nil {
@@ -1660,7 +1667,6 @@ func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey
 	// For example, if we do not refresh the tablets forcefully and the new primary is found in the cache then its source key is not updated and this spawns off
 	// PrimaryHasPrimary analysis which runs ERS
 	RefreshTablets(true /* forceRefresh */)
-	var promotedReplica *inst.Instance
 	if ev.NewPrimary != nil {
 		promotedReplica, _, _ = inst.ReadInstance(&inst.InstanceKey{
 			Hostname: ev.NewPrimary.MysqlHostname,
@@ -1677,8 +1683,6 @@ func postPrsCompletion(topologyRecovery *TopologyRecovery, analysisEntry inst.Re
 		AuditTopologyRecovery(topologyRecovery, message)
 		inst.AuditOperation(string(analysisEntry.Analysis), &analysisEntry.AnalyzedInstanceKey, message)
 	}
-	// And this is the end; whether successful or not, we're done.
-	resolveRecovery(topologyRecovery, promotedReplica)
 	// Now, see whether we are successful or not. From this point there's no going back.
 	if promotedReplica != nil {
 		// Success!
@@ -1721,6 +1725,13 @@ func electNewPrimary(ctx context.Context, analysisEntry inst.ReplicationAnalysis
 	}
 	log.Infof("Analysis: %v, will elect a new primary: %v", analysisEntry.Analysis, analysisEntry.SuggestedClusterAlias)
 
+	var promotedReplica *inst.Instance
+	// This has to be done in the end; whether successful or not, we should mark that the recovery is done.
+	// So that after the active period passes, we are able to run other recoveries.
+	defer func() {
+		resolveRecovery(topologyRecovery, promotedReplica)
+	}()
+
 	analyzedTablet, err := inst.ReadTablet(analysisEntry.AnalyzedInstanceKey)
 	if err != nil {
 		return false, topologyRecovery, err
@@ -1750,7 +1761,6 @@ func electNewPrimary(ctx context.Context, analysisEntry inst.ReplicationAnalysis
 	// For example, if we do not refresh the tablets forcefully and the new primary is found in the cache then its source key is not updated and this spawns off
 	// PrimaryHasPrimary analysis which runs ERS
 	RefreshTablets(true /* forceRefresh */)
-	var promotedReplica *inst.Instance
 	if ev.NewPrimary != nil {
 		promotedReplica, _, _ = inst.ReadInstance(&inst.InstanceKey{
 			Hostname: ev.NewPrimary.MysqlHostname,
@@ -1769,6 +1779,11 @@ func fixPrimary(ctx context.Context, analysisEntry inst.ReplicationAnalysis, can
 		return false, nil, err
 	}
 	log.Infof("Analysis: %v, will fix primary to read-write %+v", analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey)
+	// This has to be done in the end; whether successful or not, we should mark that the recovery is done.
+	// So that after the active period passes, we are able to run other recoveries.
+	defer func() {
+		resolveRecovery(topologyRecovery, nil)
+	}()
 
 	// TODO(sougou): this code pattern has reached DRY limits. Reuse.
 	count := inst.SemiSyncAckers(analysisEntry.AnalyzedInstanceKey)
@@ -1792,6 +1807,11 @@ func fixReplica(ctx context.Context, analysisEntry inst.ReplicationAnalysis, can
 		return false, nil, err
 	}
 	log.Infof("Analysis: %v, will fix replica %+v", analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey)
+	// This has to be done in the end; whether successful or not, we should mark that the recovery is done.
+	// So that after the active period passes, we are able to run other recoveries.
+	defer func() {
+		resolveRecovery(topologyRecovery, nil)
+	}()
 
 	if _, err := inst.SetReadOnly(&analysisEntry.AnalyzedInstanceKey, true); err != nil {
 		return false, topologyRecovery, err


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Whenever we `AttemptRecoveryRegistration`, we should also be eventually calling `resolveRecovery` when our recovery completes, irrespective of it failing or not.

We weren't doing this in 2 places, `fixReplica` and `fixPrimary`. This caused the following failure - 

- We ran a `fixReplica` failure on tablet A.
- We didn't resolve the recovery on tablet A.
- We called `GracefulPrimaryTakeover` API on tablet A. This API call should succeed as it does not wait for any tablets in active recovery.
- However, this call blocks because we haven't resolved a previous recovery, so it is still assumed to be in progress.
- We wait until `ClearActiveRecoveries` removes all the old recoveries.

This behaviour is incorrect, as we are making an API call wait for the duration of `RecoveryPeriodBlockSeconds` since the last recovery, even though during registration we don't want to fail for them. We should only fail if a recovery is actually in progress.

The fix for this problem is simple, we should be calling `resolveRecovery` at the end of our recovery function. This PR fixes this and refactors the places that call `AttemptRecoveryRegistration` to defer a function call to `resolveRecovery` to ensure that it is always run. (Other than panics ofcourse :3)

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
