### PR TITLE
Allow updating the subsequent diff

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -89,6 +89,18 @@ func (d *AlterTableEntityDiff) SubsequentDiff() EntityDiff {
 	return d.subsequentDiff
 }
 
+// SetSubsequentDiff implements EntityDiff
+func (d *AlterTableEntityDiff) SetSubsequentDiff(subDiff EntityDiff) {
+	if d == nil {
+		return
+	}
+	if subTableDiff, ok := subDiff.(*AlterTableEntityDiff); ok {
+		d.subsequentDiff = subTableDiff
+	} else {
+		d.subsequentDiff = nil
+	}
+}
+
 // addSubsequentDiff adds a subsequent diff to the tail of the diff sequence
 func (d *AlterTableEntityDiff) addSubsequentDiff(diff *AlterTableEntityDiff) {
 	if d.subsequentDiff == nil {
@@ -150,6 +162,10 @@ func (d *CreateTableEntityDiff) SubsequentDiff() EntityDiff {
 	return nil
 }
 
+// SetSubsequentDiff implements EntityDiff
+func (d *CreateTableEntityDiff) SetSubsequentDiff(EntityDiff) {
+}
+
 //
 type DropTableEntityDiff struct {
 	from      *CreateTableEntity
@@ -201,6 +217,10 @@ func (d *DropTableEntityDiff) CanonicalStatementString() (s string) {
 // SubsequentDiff implements EntityDiff
 func (d *DropTableEntityDiff) SubsequentDiff() EntityDiff {
 	return nil
+}
+
+// SetSubsequentDiff implements EntityDiff
+func (d *DropTableEntityDiff) SetSubsequentDiff(EntityDiff) {
 }
 
 // CreateTableEntity stands for a TABLE construct. It contains the table's CREATE statement.

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -87,6 +87,8 @@ type EntityDiff interface {
 	CanonicalStatementString() string
 	// SubsequentDiff returns a followup diff to this one, if exists
 	SubsequentDiff() EntityDiff
+	// SetSubsequentDiff updates the existing subsequent diff to the given one
+	SetSubsequentDiff(EntityDiff)
 }
 
 const (

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -74,7 +74,10 @@ func (d *AlterViewEntityDiff) SubsequentDiff() EntityDiff {
 	return nil
 }
 
-//
+// SetSubsequentDiff implements EntityDiff
+func (d *AlterViewEntityDiff) SetSubsequentDiff(EntityDiff) {
+}
+
 type CreateViewEntityDiff struct {
 	createView *sqlparser.CreateView
 }
@@ -84,7 +87,7 @@ func (d *CreateViewEntityDiff) IsEmpty() bool {
 	return d.Statement() == nil
 }
 
-// IsEmpty implements EntityDiff
+// Entities implements EntityDiff
 func (d *CreateViewEntityDiff) Entities() (from Entity, to Entity) {
 	return nil, &CreateViewEntity{CreateView: *d.createView}
 }
@@ -126,7 +129,10 @@ func (d *CreateViewEntityDiff) SubsequentDiff() EntityDiff {
 	return nil
 }
 
-//
+// SetSubsequentDiff implements EntityDiff
+func (d *CreateViewEntityDiff) SetSubsequentDiff(EntityDiff) {
+}
+
 type DropViewEntityDiff struct {
 	from     *CreateViewEntity
 	dropView *sqlparser.DropView
@@ -137,7 +143,7 @@ func (d *DropViewEntityDiff) IsEmpty() bool {
 	return d.Statement() == nil
 }
 
-// IsEmpty implements EntityDiff
+// Entities implements EntityDiff
 func (d *DropViewEntityDiff) Entities() (from Entity, to Entity) {
 	return d.from, nil
 }
@@ -179,6 +185,10 @@ func (d *DropViewEntityDiff) SubsequentDiff() EntityDiff {
 	return nil
 }
 
+// SetSubsequentDiff implements EntityDiff
+func (d *DropViewEntityDiff) SetSubsequentDiff(EntityDiff) {
+}
+
 // CreateViewEntity stands for a VIEW construct. It contains the view's CREATE statement.
 type CreateViewEntity struct {
 	sqlparser.CreateView
@@ -202,7 +212,7 @@ func (c *CreateViewEntity) Diff(other Entity, hints *DiffHints) (EntityDiff, err
 	return c.ViewDiff(otherCreateView, hints)
 }
 
-// Diff compares this view statement with another view statement, and sees what it takes to
+// ViewDiff compares this view statement with another view statement, and sees what it takes to
 // change this view to look like the other view.
 // It returns an AlterView statement if changes are found, or nil if not.
 // the other view may be of different name; its name is ignored.


### PR DESCRIPTION
In case of more complex diffing and comparison logic, it can be needed to update the subsequent statements to filter out any duplicates between two chains of changes.

Having this method allows for updating the chain in these cases.

## Related Issue(s)

Part of #10203 work

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required