### PR TITLE
[vtadmin] Rehome DangerAction component in a common folder

### DIFF
--- a/web/vtadmin/src/components/DangerAction.tsx
+++ b/web/vtadmin/src/components/DangerAction.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { UseMutationResult } from 'react-query';
-import { Icon, Icons } from '../../Icon';
-import { TextInput } from '../../TextInput';
+import { Icon, Icons } from './Icon';
+import { TextInput } from './TextInput';
 
 type Mutation = UseMutationResult & {
     mutate: () => void;

--- a/web/vtadmin/src/components/DangerAction.tsx
+++ b/web/vtadmin/src/components/DangerAction.tsx
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import React, { useState } from 'react';
 import { UseMutationResult } from 'react-query';
 import { Icon, Icons } from './Icon';

--- a/web/vtadmin/src/components/DangerAction.tsx
+++ b/web/vtadmin/src/components/DangerAction.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { useState } from 'react';
 import { UseMutationResult } from 'react-query';
 import { Icon, Icons } from './Icon';

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { UseMutationResult } from 'react-query';
 import { useHistory, useParams } from 'react-router-dom';

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -11,9 +11,9 @@ import {
 } from '../../../hooks/api';
 import { vtadmin } from '../../../proto/vtadmin';
 import { isPrimary } from '../../../util/tablets';
+import DangerAction from '../../DangerAction';
 import { Icon, Icons } from '../../Icon';
 import { success, warn } from '../../Snackbar';
-import DangerAction from './DangerAction';
 
 interface AdvancedProps {
     tablet: vtadmin.Tablet | undefined;


### PR DESCRIPTION
## Description

A tiny little refactor (prefactor?!) as a precursor to #8732, since I'm going to be using that `DangerAction` component on the Shard page. Also added a couple of missing copyrights. 

## Related Issue(s)

Prefactor for #8732

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A
