### PR TITLE
Add additional normalization rules for schemadiff

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -239,7 +239,7 @@ func NewCreateTableEntity(c *sqlparser.CreateTable) *CreateTableEntity {
 // - table option case (upper/lower/special)
 // The function returns this receiver as courtesy
 func (c *CreateTableEntity) normalize() *CreateTableEntity {
-	c.normalizeUnnamedKeys()
+	c.normalizeKeys()
 	c.normalizeUnnamedConstraints()
 	c.normalizeTableOptions()
 	c.normalizeColumnOptions()
@@ -346,6 +346,11 @@ func (c *CreateTableEntity) normalizeColumnOptions() {
 			}
 		}
 
+		if col.Type.Options.Invisible != nil && !*col.Type.Options.Invisible {
+			// If a column is marked `VISIBLE`, that's the same as the default.
+			col.Type.Options.Invisible = nil
+		}
+
 		// Map any charset aliases to the real charset. This applies mainly right
 		// now to utf8 being an alias for utf8mb3.
 		if charset, ok := charsetAliases[col.Type.Charset]; ok {
@@ -421,7 +426,7 @@ func (c *CreateTableEntity) normalizePartitionOptions() {
 	}
 }
 
-func (c *CreateTableEntity) normalizeUnnamedKeys() {
+func (c *CreateTableEntity) normalizeKeys() {
 	// let's ensure all keys have names
 	keyNameExists := map[string]bool{}
 	// first, we iterate and take note for all keys that do already have names
@@ -430,8 +435,8 @@ func (c *CreateTableEntity) normalizeUnnamedKeys() {
 			keyNameExists[name] = true
 		}
 	}
-	// now, let's look at keys that do not have names, and assign them new names
 	for _, key := range c.CreateTable.TableSpec.Indexes {
+		// now, let's look at keys that do not have names, and assign them new names
 		if name := key.Info.Name.String(); name == "" {
 			// we know there must be at least one column covered by this key
 			var colName string
@@ -459,6 +464,21 @@ func (c *CreateTableEntity) normalizeUnnamedKeys() {
 			key.Info.Name = sqlparser.NewColIdent(suggestedKeyName)
 			keyNameExists[suggestedKeyName] = true
 		}
+
+		// Drop options that are the same as the default.
+		keptOptions := make([]*sqlparser.IndexOption, 0, len(key.Options))
+		for _, option := range key.Options {
+			switch strings.ToUpper(option.Name) {
+			case "USING":
+				if strings.EqualFold(option.String, "BTREE") {
+					continue
+				}
+			case "VISIBLE":
+				continue
+			}
+			keptOptions = append(keptOptions, option)
+		}
+		key.Options = keptOptions
 	}
 }
 

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -1229,6 +1229,36 @@ func TestNormalize(t *testing.T) {
 			from: "create table t1 (id int primary key, i int, foreign key (i) references parent(id))",
 			to:   "CREATE TABLE `t1` (\n\t`id` int PRIMARY KEY,\n\t`i` int,\n\tCONSTRAINT `t1_ibfk_1` FOREIGN KEY (`i`) REFERENCES `parent` (`id`)\n)",
 		},
+		{
+			name: "drops default index type",
+			from: "create table t (id int primary key, i1 int, key i1_idx(i1) using btree)",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i1` int,\n\tKEY `i1_idx` (`i1`)\n)",
+		},
+		{
+			name: "does not drop non-default index type",
+			from: "create table t (id int primary key, i1 int, key i1_idx(i1) using hash)",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i1` int,\n\tKEY `i1_idx` (`i1`) USING HASH\n)",
+		},
+		{
+			name: "drops default index visibility",
+			from: "create table t (id int primary key, i1 int, key i1_idx(i1) visible)",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i1` int,\n\tKEY `i1_idx` (`i1`)\n)",
+		},
+		{
+			name: "drops non-default index visibility",
+			from: "create table t (id int primary key, i1 int, key i1_idx(i1) invisible)",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i1` int,\n\tKEY `i1_idx` (`i1`) INVISIBLE\n)",
+		},
+		{
+			name: "drops default column visibility",
+			from: "create table t (id int primary key, i1 int visible)",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i1` int\n)",
+		},
+		{
+			name: "drops non-default column visibility",
+			from: "create table t (id int primary key, i1 int invisible)",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i1` int INVISIBLE\n)",
+		},
 	}
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -17,6 +17,8 @@ limitations under the License.
 package schemadiff
 
 import (
+	"strings"
+
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
@@ -195,7 +197,20 @@ type CreateViewEntity struct {
 }
 
 func NewCreateViewEntity(c *sqlparser.CreateView) *CreateViewEntity {
-	return &CreateViewEntity{CreateView: *c}
+	entity := &CreateViewEntity{CreateView: *c}
+	entity.normalize()
+	return entity
+}
+
+func (c *CreateViewEntity) normalize() {
+	// Drop the default algorithm
+	if strings.EqualFold(c.CreateView.Algorithm, "undefined") {
+		c.CreateView.Algorithm = ""
+	}
+	// Drop the default security model
+	if strings.EqualFold(c.CreateView.Security, "definer") {
+		c.CreateView.Security = ""
+	}
 }
 
 // Name implements Entity interface


### PR DESCRIPTION
This adds additional normalization rules for schemadiff to reduce churn around default options and to remove things that are not supported.

- `USING BTREE` on an index is the default, so we drop that if specified.
- `VISIBLE` is the default for columns & indexes, so this is dropped when specified.
- `ALGORITHM = undefined` is the default for a `CREATE VIEW` so this is dropped when specified.
- `SQL SECURITY DEFINER` is the default for a `CREATE VIEW` so this is dropped when specified.

## Related Issue(s)

Part of #10203

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required