### PR TITLE
Add a failing test case showing Gen4 planner failure.

### DIFF
--- a/go/test/endtoend/vtgate/lookup_test.go
+++ b/go/test/endtoend/vtgate/lookup_test.go
@@ -77,6 +77,20 @@ func TestUnownedLookupInsertChecksKeyspaceIdsAreMatching(t *testing.T) {
 	utils.Exec(t, conn, "delete from t9 WHERE parent_id = 1")
 }
 
+func TestUnownedLookupSelectNull(t *testing.T) {
+	defer cluster.PanicHandler(t)
+
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	utils.Exec(t, conn, "select * from t8 WHERE t9_id IS NULL")
+
+	// Cleanup
+	utils.Exec(t, conn, "delete from t9 WHERE parent_id = 1")
+}
+
 func TestConsistentLookup(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Description

This test case shows a (recent) regression in the query planner for queries that use `IS NULL` condition on an unowned lookup vindex column.

```
=== RUN   TestUnownedLookupSelectNull
    lookup_test.go:88: 
                Error Trace:    utils.go:105
                                                        lookup_test.go:88
                Error:          Received unexpected error:
                                v3 and Gen4 failed with different errors: v3: [lookup.Map: Code: INTERNAL
                                Gen4 failed while v3 did not: target: ks.80-.primary: vttablet: rpc error: code = InvalidArgument desc = missing bind var __vals (CallerID: userData1)
                                ], Gen4: [lookup.Map: Code: INTERNAL
                                Gen4 failed while v3 did not: target: ks.-80.primary: vttablet: rpc error: code = InvalidArgument desc = missing bind var __vals (CallerID: userData1)
                                ] (errno 1815) (sqlstate HY000) during query: select * from t8 WHERE t9_id IS NULL
                Test:           TestUnownedLookupSelectNull
                Messages:       for query: select * from t8 WHERE t9_id IS NULL
--- FAIL: TestUnownedLookupSelectNull (0.12s)
```

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
