### PR TITLE
[vtadmin] Fix warning 'div cannot appear as a descendant of p'

### DIFF
--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -236,9 +236,9 @@ const Advanced: React.FC<AdvancedProps> = ({ tablet }) => {
                                     </div>
                                 }
                                 description={
-                                    <div>
+                                    <>
                                         Set tablet <span className="font-bold">{alias}</span> to read-only.
-                                    </div>
+                                    </>
                                 }
                                 action="set tablet to read-only"
                                 mutation={setReadOnlyMutation as UseMutationResult}
@@ -257,9 +257,9 @@ const Advanced: React.FC<AdvancedProps> = ({ tablet }) => {
                                     </div>
                                 }
                                 description={
-                                    <div>
+                                    <>
                                         Set tablet <span className="font-bold">{alias}</span> to read-write.
-                                    </div>
+                                    </>
                                 }
                                 action="set tablet to read-only"
                                 mutation={setReadWriteMutation as UseMutationResult}
@@ -282,10 +282,10 @@ const Advanced: React.FC<AdvancedProps> = ({ tablet }) => {
                             </div>
                         }
                         description={
-                            <div>
+                            <>
                                 Delete tablet <span className="font-bold">{alias}</span>. Doing so will remove it from
                                 the topology, but vttablet and MySQL won't be touched.
-                            </div>
+                            </>
                         }
                         action="delete the tablet"
                         mutation={deleteTabletMutation as UseMutationResult}


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

A small fix for the warnings on the tablet "Advanced" tab (e.g., http://localhost:14201/tablet/local/zone1-101/advanced)

<img width="1904" alt="Screen Shot 2022-05-14 at 8 36 53 AM" src="https://user-images.githubusercontent.com/855595/168426092-eecc6b4d-4bad-4c9d-8277-616e5780198f.png">

## Related Issue(s)

Relates to #9401

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A