### PR TITLE
Mark web/vtadmin/src/proto/** as generated files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+web/vtadmin/src/proto/** linguist-generated=true


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

This adds a .gitattributes file and flags the files in [web/vtadmin/src/proto/](https://github.com/vitessio/vitess/tree/main/web/vtadmin/src/proto) as "generated files" to hide them by default in GitHub's diff view. These are the JS/TS bindings produced by `make vtadmin_web_proto_types`, so these files don't require manual review. (Doubly so now that we have CI in place to validate them thanks to #10256!) 

This feature is documented here: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

Here's a before and after of what it looks for an unrelated branch of mine:

<img width="1904" alt="Screen Shot 2022-05-14 at 9 29 09 AM" src="https://user-images.githubusercontent.com/855595/168428018-8d2a864c-426c-471e-8e0f-fc623d987672.png">

<img width="1904" alt="Screen Shot 2022-05-14 at 9 22 13 AM" src="https://user-images.githubusercontent.com/855595/168428023-7d183f48-0349-4c2f-93f6-18371b021753.png">


## Related Issue(s)

N/A

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A
