### PR TITLE
Add VS Code's __debug_bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tags
 
 # vscode
 .vscode/
+__debug_bin
 
 # C build dirs
 **/build


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

When running go programs in VS Code's debugger, it rather vexingly plops a `__debug_bin` file in the working tree. This file should never be committed, but it's very easy to do accidentally! Ask me how I know! 😎 

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A
