### PR TITLE
Deprecate flag --online_ddl_check_interval

### DIFF
--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -68,7 +68,7 @@ The heartbeats are generated according to `--heartbeat_interval`.
 
 #### Deprecation of --online_ddl_check_interval
 
-The flag `--online_ddl_check_interval` is deprecated and will be removed in `v15`. It has been unsued in `v13`.
+The flag `--online_ddl_check_interval` is deprecated and will be removed in `v15`. It has been unused in `v13`.
 
 ### Online DDL changes
 

--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -68,7 +68,7 @@ The heartbeats are generated according to `--heartbeat_interval`.
 
 #### Deprecation of --online_ddl_check_interval
 
-The flag `--online_ddl_check_interval` is deperecated and will be removed in `v15`.
+The flag `--online_ddl_check_interval` is deprecated and will be removed in `v15`. It has been unsued in `v13`.
 
 ### Online DDL changes
 

--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -66,6 +66,10 @@ When `--heartbeat_on_demand_duration` has a positive value, then heartbeats are 
 
 The heartbeats are generated according to `--heartbeat_interval`.
 
+#### Deprecation of --online_ddl_check_interval
+
+The flag `--online_ddl_check_interval` is deperecated and will be removed in `v15`.
+
 ### Online DDL changes
 
 See new SQL syntax for controlling/viewing throttling fomr Online DDL, down below.

--- a/go/flags/endtoend/flags_test.go
+++ b/go/flags/endtoend/flags_test.go
@@ -1029,6 +1029,8 @@ var (
 	socket file to use for remote mysqlctl actions (empty for local actions)
   --onclose_timeout duration
 	wait no more than this for OnClose handlers before stopping (default 1ns)
+  --online_ddl_check_interval duration
+	deprecated. Will be removed in next Vitess version
   --onterm_timeout duration
 	wait no more than this for OnTermSync handlers before stopping (default 10s)
   --opentsdb_uri string

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -216,7 +216,7 @@ func NewExecutor(env tabletenv.Env, tabletAlias *topodatapb.TabletAlias, ts *top
 ) *Executor {
 
 	if *deprecatedOnlineDDLCheckInterval != 0 {
-		log.Warningf("the flag '--online_ddl_check_interval' is deprecated and will be removed in future versions")
+		log.Warningf("the flag '--online_ddl_check_interval' is deprecated and will be removed in future versions. It is currently unused.")
 	}
 	return &Executor{
 		env:         env,

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -110,6 +110,9 @@ var migrationCheckInterval = flag.Duration("migration_check_interval", 1*time.Mi
 var retainOnlineDDLTables = flag.Duration("retain_online_ddl_tables", 24*time.Hour, "How long should vttablet keep an old migrated table before purging it")
 var migrationNextCheckIntervals = []time.Duration{1 * time.Second, 5 * time.Second, 10 * time.Second, 20 * time.Second}
 
+// deprecated, only here for backwards compatibility:
+var deprecatedOnlineDDLCheckInterval = flag.Duration("online_ddl_check_interval", 0, "deprecated. Will be removed in next Vitess version")
+
 const (
 	maxPasswordLength                        = 32 // MySQL's *replication* password may not exceed 32 characters
 	staleMigrationMinutes                    = 10
@@ -211,6 +214,10 @@ func NewExecutor(env tabletenv.Env, tabletAlias *topodatapb.TabletAlias, ts *top
 	tabletTypeFunc func() topodatapb.TabletType,
 	toggleBufferTableFunc func(cancelCtx context.Context, tableName string, bufferQueries bool),
 ) *Executor {
+
+	if *deprecatedOnlineDDLCheckInterval != 0 {
+		log.Warningf("the flag '--online_ddl_check_interval' is deprecated and will be removed in future versions")
+	}
 	return &Executor{
 		env:         env,
 		tabletAlias: proto.Clone(tabletAlias).(*topodatapb.TabletAlias),


### PR DESCRIPTION

## Description

The flag `` was removed in https://github.com/vitessio/vitess/pull/9816 as part of removal of all `vtctld` logic for online DDL.

https://github.com/vitessio/vitess/pull/9816/files#diff-54b6f6d46473450637d28b579e506030060f186bb1cee4d61fea8a8b4fa99b93L45-L47

However, we did not deprecate it in an orderly fashion.

This PR re-introduces the flag, and 


## Related Issue(s)

https://github.com/vitessio/vitess/pull/9816
## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

cc @rsajwani @deepthi 