### PR TITLE
v14 release notes: Online DDL is production ready

### DIFF
--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -82,9 +82,9 @@ Online DDL is no longer experimental (with the exception of `pt-osc` strategy). 
 - Postponed migrations
 - and all other functionality
 
-Are all considered production ready.
+Are all considered production-ready.
 
-`pt-osc` streategy (online DDL via 3rd party `pt-online-schema-change`) remains experimental.
+`pt-osc` strategy (online DDL via 3rd party `pt-online-schema-change`) remains experimental.
 
 #### Throttling
 

--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -68,7 +68,27 @@ The heartbeats are generated according to `--heartbeat_interval`.
 
 ### Online DDL changes
 
-See new SQL syntax for controlling/viewing throttling fomr Online DDL, down below.
+#### Online DDL is generally available
+
+Online DDL is no longer experimental (with the exception of `pt-osc` strategy). Specifically:
+
+- Managed schema changes, the scheduler, the backing tables
+- Supporting SQL syntax
+- `vitess` strategy (online DDL via VReplication)
+- `gh-ost` strategy (online DDL via 3rd party `gh-ost`)
+- Recoverable migrations
+- Revertible migrations
+- Declarative migrations
+- Postponed migrations
+- and all other functionality
+
+Are all considered production ready.
+
+`pt-osc` streategy (online DDL via 3rd party `pt-online-schema-change`) remains experimental.
+
+#### Throttling
+
+See new SQL syntax for controlling/viewing throttling for Online DDL, down below.
 
 #### ddl_strategy: 'vitess'
 


### PR DESCRIPTION
## Description

Aligning with https://github.com/vitessio/website/pull/1020, we point out in `v14` release notes that Online DDL is generally available and no longer experimental (exception: `pt-osc` remains experimental)

## Related Issue(s)

- https://github.com/vitessio/website/pull/1020
- #6926 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
