### PR TITLE
Remove internal savepoint post query execution

### DIFF
--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -626,7 +626,11 @@ func assertQueriesWithSavepoint(t *testing.T, sbc *sandboxconn.SandboxConn, want
 			if !strings.HasPrefix(expected, "savepoint") {
 				t.Fatal("savepoint expected")
 			}
-			savepointStore[expected[10:]] = got[10:]
+			if sp, exists := savepointStore[expected[10:]]; exists {
+				assert.Equal(t, sp, got[10:])
+			} else {
+				savepointStore[expected[10:]] = got[10:]
+			}
 			continue
 		}
 		if strings.HasPrefix(got, "rollback to") {

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -18,6 +18,7 @@ package vtgate
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -713,5 +714,22 @@ func (session *SafeSession) getSessions() []*vtgatepb.Session_ShardSession {
 		return session.PostSessions
 	default:
 		return session.ShardSessions
+	}
+}
+
+func (session *SafeSession) RemoveInternalSavepoint() {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	if session.savepointName == "" {
+		return
+	}
+	sCount := len(session.Savepoints)
+	if sCount == 0 {
+		return
+	}
+	sLast := sCount - 1
+	if strings.Contains(session.Savepoints[sLast], session.savepointName) {
+		session.Savepoints = session.Savepoints[0:sLast]
 	}
 }

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -509,3 +509,117 @@ func TestErrorIssuesRollback(t *testing.T) {
 	}
 	sbc.MustFailCodes[vtrpcpb.Code_ALREADY_EXISTS] = 0
 }
+
+var shardedVSchema = `
+{
+	"sharded": true,
+	"vindexes": {
+		"hash_index": {
+			"type": "hash"
+		}
+	},
+	"tables": {
+		"user_extra": {
+			"column_vindexes": [
+				{
+					"column": "user_id",
+					"name": "hash_index"
+				}
+			]
+		}
+	}
+}
+`
+
+func TestMultiInternalSavepointVtGate(t *testing.T) {
+	s := createSandbox(KsTestSharded)
+	s.ShardSpec = "-40-80-"
+	s.VSchema = shardedVSchema
+	srvSchema := getSandboxSrvVSchema()
+	rpcVTGate.executor.vm.VSchemaUpdate(srvSchema, nil)
+	hcVTGateTest.Reset()
+
+	sbc1 := hcVTGateTest.AddTestTablet("aa", "1.1.1.1", 1, KsTestSharded, "-40", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc2 := hcVTGateTest.AddTestTablet("aa", "1.1.1.1", 2, KsTestSharded, "40-80", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc3 := hcVTGateTest.AddTestTablet("aa", "1.1.1.1", 3, KsTestSharded, "80-", topodatapb.TabletType_PRIMARY, true, 1, nil)
+
+	logChan := QueryLogger.Subscribe("Test")
+	defer QueryLogger.Unsubscribe(logChan)
+
+	session := &vtgatepb.Session{Autocommit: true}
+	require.True(t, session.GetAutocommit())
+	require.False(t, session.InTransaction)
+
+	var err error
+	session, _, err = rpcVTGate.Execute(context.Background(), session, "begin", nil)
+	require.NoError(t, err)
+	require.True(t, session.GetAutocommit())
+	require.True(t, session.InTransaction)
+
+	// this query goes to multiple shards so internal savepoint will be created.
+	session, _, err = rpcVTGate.Execute(context.Background(), session, "insert into user_extra(user_id) values (1), (3)", nil)
+	require.NoError(t, err)
+	require.True(t, session.GetAutocommit())
+	require.True(t, session.InTransaction)
+
+	wantQ := []*querypb.BoundQuery{{
+		Sql:           "savepoint x",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}, {
+		Sql: "insert into user_extra(user_id) values (:_user_id_0)",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_user_id_0": sqltypes.Int64BindVariable(1),
+			"_user_id_1": sqltypes.Int64BindVariable(3),
+			"vtg1":       sqltypes.Int64BindVariable(1),
+			"vtg2":       sqltypes.Int64BindVariable(3),
+		},
+	}}
+	assertQueriesWithSavepoint(t, sbc1, wantQ)
+	wantQ[1].Sql = "insert into user_extra(user_id) values (:_user_id_1)"
+	assertQueriesWithSavepoint(t, sbc2, wantQ)
+	assert.Len(t, sbc3.Queries, 0)
+	// internal savepoint should be removed.
+	assert.Len(t, session.Savepoints, 0)
+	sbc1.Queries = nil
+	sbc2.Queries = nil
+
+	// multi shard so new savepoint will be created.
+	session, _, err = rpcVTGate.Execute(context.Background(), session, "insert into user_extra(user_id) values (2), (4)", nil)
+	require.NoError(t, err)
+	wantQ = []*querypb.BoundQuery{{
+		Sql:           "savepoint x",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}, {
+		Sql: "insert into user_extra(user_id) values (:_user_id_1)",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_user_id_0": sqltypes.Int64BindVariable(2),
+			"_user_id_1": sqltypes.Int64BindVariable(4),
+			"vtg1":       sqltypes.Int64BindVariable(2),
+			"vtg2":       sqltypes.Int64BindVariable(4),
+		},
+	}}
+	assertQueriesWithSavepoint(t, sbc3, wantQ)
+	// internal savepoint should be removed.
+	assert.Len(t, session.Savepoints, 0)
+	sbc2.Queries = nil
+	sbc3.Queries = nil
+
+	// single shard so no savepoint will be created and neither any old savepoint will be executed
+	session, _, err = rpcVTGate.Execute(context.Background(), session, "insert into user_extra(user_id) values (5)", nil)
+	require.NoError(t, err)
+	wantQ = []*querypb.BoundQuery{{
+		Sql: "insert into user_extra(user_id) values (:_user_id_0)",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_user_id_0": sqltypes.Int64BindVariable(5),
+			"vtg1":       sqltypes.Int64BindVariable(5),
+		},
+	}}
+	assertQueriesWithSavepoint(t, sbc2, wantQ)
+
+	testQueryLog(t, logChan, "Execute", "BEGIN", "begin", 0)
+	testQueryLog(t, logChan, "MarkSavepoint", "SAVEPOINT", "savepoint x", 0)
+	testQueryLog(t, logChan, "Execute", "INSERT", "insert into user_extra(user_id) values (:vtg1), (:vtg2)", 2)
+	testQueryLog(t, logChan, "MarkSavepoint", "SAVEPOINT", "savepoint y", 2)
+	testQueryLog(t, logChan, "Execute", "INSERT", "insert into user_extra(user_id) values (:vtg1), (:vtg2)", 2)
+	testQueryLog(t, logChan, "Execute", "INSERT", "insert into user_extra(user_id) values (:vtg1)", 1)
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR removed the internal savepoint created during the execution of a DML when the query execution is complete.

When a query is executed and it is detected that it will go to multiple shard then vitess created an internal savepoint for that transaction.
Once the query execution is complete that savepoint has no purpose.

Other things about keeping that savepoint around is that the next query if it goes to different shard then the old internal savepoint will also be sent along and created which has no use for the current query.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
