### PR TITLE
[vtadmin] Add CreateKeyspace bindings + form UI

### DIFF
--- a/web/vtadmin/package-lock.json
+++ b/web/vtadmin/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@bugsnag/js": "^7.10.1",
         "@headlessui/react": "^1.4.2",
-        "@testing-library/user-event": "^12.6.0",
         "@types/classnames": "^2.2.11",
         "@types/jest": "^26.0.19",
         "@types/node": "^12.19.9",
@@ -44,6 +43,7 @@
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^11.2.5",
         "@testing-library/react-hooks": "^5.0.3",
+        "@testing-library/user-event": "^14.2.0",
         "@types/lodash-es": "^4.17.4",
         "autoprefixer": "^10.4.2",
         "msw": "^0.36.8",
@@ -3764,6 +3764,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.29.0.tgz",
       "integrity": "sha512-0hhuJSmw/zLc6ewR9cVm84TehuTd7tbqBX9pRNSp8znJ9gTmSgesdbiGZtt8R6dL+2rgaPFp9Yjr7IU1HWm49w==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3782,6 +3783,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3796,6 +3798,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3811,6 +3814,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3821,12 +3825,14 @@
     "node_modules/@testing-library/dom/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/@testing-library/dom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3835,6 +3841,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4015,14 +4022,12 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.6.0.tgz",
-      "integrity": "sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.0.tgz",
+      "integrity": "sha512-+hIlG4nJS6ivZrKnOP7OGsDu9Fxmryj9vCl8x0ZINtTJcCHs2zLsYif5GzuRiBF2ck5GZG2aQr7Msg+EHlnYVQ==",
+      "dev": true,
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {
@@ -4076,7 +4081,8 @@
     "node_modules/@types/aria-query": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
-      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A=="
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
@@ -8097,7 +8103,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
-      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g=="
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
+      "dev": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -14558,6 +14565,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -23749,6 +23757,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.29.0.tgz",
       "integrity": "sha512-0hhuJSmw/zLc6ewR9cVm84TehuTd7tbqBX9pRNSp8znJ9gTmSgesdbiGZtt8R6dL+2rgaPFp9Yjr7IU1HWm49w==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -23764,6 +23773,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -23772,6 +23782,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -23781,6 +23792,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -23788,17 +23800,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -23931,12 +23946,11 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.6.0.tgz",
-      "integrity": "sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.5"
-      }
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.0.tgz",
+      "integrity": "sha512-+hIlG4nJS6ivZrKnOP7OGsDu9Fxmryj9vCl8x0ZINtTJcCHs2zLsYif5GzuRiBF2ck5GZG2aQr7Msg+EHlnYVQ==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -23979,7 +23993,8 @@
     "@types/aria-query": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
-      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A=="
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.18",
@@ -26988,7 +27003,8 @@
     "dom-accessibility-api": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
-      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g=="
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -31747,7 +31763,8 @@
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
     },
     "magic-string": {
       "version": "0.25.7",

--- a/web/vtadmin/package.json
+++ b/web/vtadmin/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@bugsnag/js": "^7.10.1",
     "@headlessui/react": "^1.4.2",
-    "@testing-library/user-event": "^12.6.0",
     "@types/classnames": "^2.2.11",
     "@types/jest": "^26.0.19",
     "@types/node": "^12.19.9",
@@ -82,6 +81,7 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/react-hooks": "^5.0.3",
+    "@testing-library/user-event": "^14.2.0",
     "@types/lodash-es": "^4.17.4",
     "autoprefixer": "^10.4.2",
     "msw": "^0.36.8",

--- a/web/vtadmin/src/api/http.ts
+++ b/web/vtadmin/src/api/http.ts
@@ -194,6 +194,23 @@ export const fetchKeyspaces = async () =>
         },
     });
 
+export interface CreateKeyspaceParams {
+    clusterID: string;
+    options: vtctldata.ICreateKeyspaceRequest;
+}
+
+export const createKeyspace = async (params: CreateKeyspaceParams) => {
+    const { result } = await vtfetch(`/api/keyspace/${params.clusterID}`, {
+        body: JSON.stringify(params.options),
+        method: 'post',
+    });
+
+    const err = pb.CreateKeyspaceResponse.verify(result);
+    if (err) throw Error(err);
+
+    return pb.CreateKeyspaceResponse.create(result);
+};
+
 export const fetchSchemas = async () =>
     vtfetchEntities({
         endpoint: '/api/schemas',

--- a/web/vtadmin/src/components/App.tsx
+++ b/web/vtadmin/src/components/App.tsx
@@ -36,6 +36,8 @@ import { Backups } from './routes/Backups';
 import { Shard } from './routes/shard/Shard';
 import { Vtctlds } from './routes/Vtctlds';
 import { SnackbarContainer } from './Snackbar';
+import { isReadOnlyMode } from '../util/env';
+import { CreateKeyspace } from './routes/createKeyspace/CreateKeyspace';
 
 export const App = () => {
     return (
@@ -59,9 +61,15 @@ export const App = () => {
                             <Gates />
                         </Route>
 
-                        <Route path="/keyspaces">
+                        <Route exact path="/keyspaces">
                             <Keyspaces />
                         </Route>
+
+                        {!isReadOnlyMode() && (
+                            <Route exact path="/keyspaces/create">
+                                <CreateKeyspace />
+                            </Route>
+                        )}
 
                         <Route path="/keyspace/:clusterID/:keyspace/shard/:shard">
                             <Shard />

--- a/web/vtadmin/src/components/forms/FormError.tsx
+++ b/web/vtadmin/src/components/forms/FormError.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Icon, Icons } from '../Icon';
+
+interface Props {
+    title: string;
+    error: Error | null | undefined;
+}
+
+export const FormError: React.FC<Props> = ({ error, title }) => {
+    return (
+        <div className="bg-red-50 p-8 rounded-md my-12" role="alert">
+            <div className="text-md font-bold mb-4">
+                <Icon className="inline fill-red-700 h-[20px] align-text-top" icon={Icons.alertFail} /> {title}
+            </div>
+            <div className="font-mono">{error?.message}</div>
+        </div>
+    );
+};

--- a/web/vtadmin/src/components/inputs/Select.tsx
+++ b/web/vtadmin/src/components/inputs/Select.tsx
@@ -22,7 +22,9 @@ import style from './Select.module.scss';
 import { Icon, Icons } from '../Icon';
 
 interface Props<T> {
+    className?: string;
     disabled?: boolean;
+    inputClassName?: string;
     items: T[];
     itemToString?: (item: T | null) => string;
     label: string;
@@ -40,7 +42,9 @@ interface Props<T> {
  * and allows for fine-grained rendering control. :)
  */
 export const Select = <T,>({
+    className,
     disabled,
+    inputClassName,
     itemToString,
     items,
     label,
@@ -81,7 +85,7 @@ export const Select = <T,>({
         selectedItem,
     });
 
-    const containerClass = cx(style.container, {
+    const containerClass = cx(style.container, className, {
         [style.large]: size === 'large',
         [style.open]: isOpen,
         [style.placeholder]: !selectedItem,
@@ -122,7 +126,7 @@ export const Select = <T,>({
             emptyContent = <div className={style.emptyPlaceholder}>{emptyContent || 'No items'}</div>;
         }
         content = (
-            <div className={style.emptyContainer} {...getMenuProps()}>
+            <div className={style.emptyContainer} {...getMenuProps()} data-testid="select-empty">
                 {emptyContent}
             </div>
         );
@@ -131,7 +135,12 @@ export const Select = <T,>({
     return (
         <div className={containerClass}>
             <Label {...getLabelProps()} label={label} />
-            <button type="button" {...getToggleButtonProps()} className={style.toggle} disabled={disabled}>
+            <button
+                type="button"
+                {...getToggleButtonProps()}
+                className={cx(style.toggle, inputClassName)}
+                disabled={disabled}
+            >
                 {selectedItem ? _renderItem(selectedItem) : placeholder}
                 <Icon className={style.chevron} icon={isOpen ? Icons.chevronUp : Icons.chevronDown} />
             </button>

--- a/web/vtadmin/src/components/routes/Keyspaces.tsx
+++ b/web/vtadmin/src/components/routes/Keyspaces.tsx
@@ -32,6 +32,7 @@ import { KeyspaceLink } from '../links/KeyspaceLink';
 import KeyspaceActions from './keyspaces/KeyspaceActions';
 import { ReadOnlyGate } from '../ReadOnlyGate';
 import { isReadOnlyMode } from '../../util/env';
+import { Link } from 'react-router-dom';
 
 export const Keyspaces = () => {
     useDocumentTitle('Keyspaces');
@@ -88,7 +89,16 @@ export const Keyspaces = () => {
     return (
         <div>
             <WorkspaceHeader>
-                <WorkspaceTitle>Keyspaces</WorkspaceTitle>
+                <div className="flex items-top justify-between max-w-screen-md">
+                    <WorkspaceTitle>Keyspaces</WorkspaceTitle>
+                    <ReadOnlyGate>
+                        <div>
+                            <Link className="btn btn-secondary btn-md" to="/keyspaces/create">
+                                Create a Keyspace
+                            </Link>
+                        </div>
+                    </ReadOnlyGate>
+                </div>
             </WorkspaceHeader>
             <ContentContainer>
                 <DataFilter

--- a/web/vtadmin/src/components/routes/createKeyspace/CreateKeyspace.test.tsx
+++ b/web/vtadmin/src/components/routes/createKeyspace/CreateKeyspace.test.tsx
@@ -31,6 +31,11 @@ const TEST_PROCESS_ENV = {
     REACT_APP_VTADMIN_API_ADDRESS: '',
 };
 
+// This integration test verifies the behaviour from the form UI
+// all the way down to the network level (which we mock with msw).
+// It's a very comprehensive test (good!), but does make some assumptions
+// about UI structure (boo!), which means this test is rather brittle
+// to UI changes (e.g., like how the Select works, adding new form fields, etc.)
 describe('CreateKeyspace integration test', () => {
     const server = setupServer();
 

--- a/web/vtadmin/src/components/routes/createKeyspace/CreateKeyspace.test.tsx
+++ b/web/vtadmin/src/components/routes/createKeyspace/CreateKeyspace.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createMemoryHistory } from 'history';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Router } from 'react-router-dom';
+
+import { CreateKeyspace } from './CreateKeyspace';
+import { vtadmin } from '../../../proto/vtadmin';
+import * as Snackbar from '../../Snackbar';
+
+const ORIGINAL_PROCESS_ENV = process.env;
+const TEST_PROCESS_ENV = {
+    ...process.env,
+    REACT_APP_VTADMIN_API_ADDRESS: '',
+};
+
+describe('CreateKeyspace integration test', () => {
+    const server = setupServer();
+
+    beforeAll(() => {
+        process.env = { ...TEST_PROCESS_ENV } as NodeJS.ProcessEnv;
+    });
+
+    afterEach(() => {
+        process.env = { ...TEST_PROCESS_ENV } as NodeJS.ProcessEnv;
+    });
+
+    afterAll(() => {
+        process.env = { ...ORIGINAL_PROCESS_ENV };
+        server.close();
+    });
+
+    it('successfully creates a keyspace', async () => {
+        jest.spyOn(global, 'fetch');
+        jest.spyOn(Snackbar, 'success');
+
+        const cluster = { id: 'local', name: 'local' };
+
+        server.use(
+            rest.get('/api/clusters', (req, res, ctx) => {
+                return res(ctx.json({ result: { clusters: [cluster] }, ok: true }));
+            }),
+            rest.post('/api/keyspace/:clusterID', (req, res, ctx) => {
+                const data: vtadmin.ICreateKeyspaceResponse = {
+                    keyspace: {
+                        cluster: { id: cluster.id, name: cluster.name },
+                        keyspace: { name: 'some-keyspace' },
+                    },
+                };
+                return res(ctx.json({ result: data, ok: true }));
+            })
+        );
+        server.listen();
+
+        const history = createMemoryHistory();
+        jest.spyOn(history, 'push');
+
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+        });
+
+        // Finally, render the view
+        render(
+            <Router history={history}>
+                <QueryClientProvider client={queryClient}>
+                    <CreateKeyspace />
+                </QueryClientProvider>
+            </Router>
+        );
+
+        // Wait for initial queries to load. Given that the "initial queries" for this
+        // page are presently only the call to GET /api/clusters, checking that the
+        // Select is populated with the clusters from the response defined above is
+        // sufficient, albeit clumsy. This will need to be reworked in a future where
+        // we add more queries that fire on form load (e.g., to fetch all keyspaces.)
+        await waitFor(() => {
+            expect(screen.queryByTestId('select-empty')).toBeNull();
+        });
+
+        // Reset the fetch mock after the initial queries have completed so that
+        // form submission assertions are easier.
+        (global.fetch as any).mockClear();
+
+        // From here on we can proceed with filling out the form fields.
+        const user = userEvent.setup();
+        await user.click(screen.getByText('local (local)'));
+        await user.type(screen.getByLabelText('Keyspace Name'), 'some-keyspace');
+        await user.type(screen.getByLabelText('Sharding Column Name'), 'some-column-name');
+
+        // Submit the form
+        const submitButton = screen.getByText('Create Keyspace', {
+            selector: 'button[type="submit"]',
+        });
+        await user.click(submitButton);
+
+        // Assert that the client sent the correct API request
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith('/api/keyspace/local', {
+            credentials: undefined,
+            body: JSON.stringify({
+                name: 'some-keyspace',
+                sharding_column_name: 'some-column-name',
+            }),
+            method: 'post',
+        });
+
+        // Validate form UI loading state, while the API request is "in flight"
+        expect(submitButton).toHaveTextContent('Creating Keyspace...');
+        expect(submitButton).toHaveAttribute('disabled');
+
+        // Wait for the API request to complete
+        await waitFor(() => {
+            expect(submitButton).toHaveTextContent('Create Keyspace');
+        });
+
+        // Validate redirect to the new keyspace's detail page
+        expect(history.push).toHaveBeenCalledTimes(1);
+        expect(history.push).toHaveBeenCalledWith('/keyspace/local/some-keyspace');
+
+        // Validate that snackbar was triggered
+        expect(Snackbar.success).toHaveBeenCalledTimes(1);
+        expect(Snackbar.success).toHaveBeenCalledWith('Created keyspace some-keyspace', { autoClose: 1600 });
+    });
+});

--- a/web/vtadmin/src/components/routes/createKeyspace/CreateKeyspace.tsx
+++ b/web/vtadmin/src/components/routes/createKeyspace/CreateKeyspace.tsx
@@ -129,7 +129,9 @@ export const CreateKeyspace = () => {
                                     value={formData.shardingColumnName || ''}
                                 />
                             </Label>
-                            <span className="text-sm">The name of the column to use for sharding operations.</span>
+                            <span className="text-sm">
+                                Optional. The name of the column to use for sharding operations.
+                            </span>
                         </div>
                     </details>
 

--- a/web/vtadmin/src/components/routes/createKeyspace/CreateKeyspace.tsx
+++ b/web/vtadmin/src/components/routes/createKeyspace/CreateKeyspace.tsx
@@ -122,13 +122,15 @@ export const CreateKeyspace = () => {
 
                     <details>
                         <summary className="font-semibold cursor-pointer">Advanced options</summary>
-                        <Label className="block my-8" label="Sharding Column Name">
-                            <TextInput
-                                onChange={(e) => setFormData({ ...formData, shardingColumnName: e.target.value })}
-                                value={formData.shardingColumnName || ''}
-                            />
-                        </Label>
-                        <span className="text-sm">The name of the column to use for sharding operations.</span>
+                        <div className="my-8">
+                            <Label className="block" label="Sharding Column Name">
+                                <TextInput
+                                    onChange={(e) => setFormData({ ...formData, shardingColumnName: e.target.value })}
+                                    value={formData.shardingColumnName || ''}
+                                />
+                            </Label>
+                            <span className="text-sm">The name of the column to use for sharding operations.</span>
+                        </div>
                     </details>
 
                     {mutation.isError && !mutation.isLoading && (

--- a/web/vtadmin/src/components/routes/createKeyspace/CreateKeyspace.tsx
+++ b/web/vtadmin/src/components/routes/createKeyspace/CreateKeyspace.tsx
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useState } from 'react';
+import { useQueryClient } from 'react-query';
+import { Link, useHistory } from 'react-router-dom';
+
+import { useClusters, useCreateKeyspace } from '../../../hooks/api';
+import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
+import { Label } from '../../inputs/Label';
+import { Select } from '../../inputs/Select';
+import { ContentContainer } from '../../layout/ContentContainer';
+import { NavCrumbs } from '../../layout/NavCrumbs';
+import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
+import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
+import { TextInput } from '../../TextInput';
+import { success } from '../../Snackbar';
+import { FormError } from '../../forms/FormError';
+
+interface FormData {
+    clusterID: string;
+    keyspaceName: string;
+    shardingColumnName: string;
+}
+
+const DEFAULT_FORM_DATA: FormData = {
+    clusterID: '',
+    keyspaceName: '',
+    shardingColumnName: '',
+};
+
+export const CreateKeyspace = () => {
+    useDocumentTitle('Create a Keyspace');
+
+    const queryClient = useQueryClient();
+    const history = useHistory();
+
+    const [formData, setFormData] = useState<FormData>(DEFAULT_FORM_DATA);
+
+    const { data: clusters = [], ...clustersQuery } = useClusters();
+
+    const mutation = useCreateKeyspace(
+        {
+            clusterID: formData.clusterID,
+            options: {
+                name: formData.keyspaceName,
+                sharding_column_name: formData.shardingColumnName,
+            },
+        },
+        {
+            onSuccess: (res) => {
+                queryClient.invalidateQueries('keyspaces');
+                success(`Created keyspace ${res?.keyspace?.keyspace?.name}`, { autoClose: 1600 });
+                history.push(`/keyspace/${res?.keyspace?.cluster?.id}/${res?.keyspace?.keyspace?.name}`);
+            },
+        }
+    );
+
+    let selectedCluster = null;
+    if (!!formData.clusterID) {
+        selectedCluster = clusters.find((c) => c.id === formData.clusterID);
+    }
+
+    const isValid = !!selectedCluster && !!formData.keyspaceName;
+    const isDisabled = !isValid || mutation.isLoading;
+
+    const onSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+        e.preventDefault();
+        mutation.mutate();
+    };
+
+    return (
+        <div>
+            <WorkspaceHeader>
+                <NavCrumbs>
+                    <Link to="/keyspaces">Keyspaces</Link>
+                </NavCrumbs>
+
+                <WorkspaceTitle>Create a Keyspace</WorkspaceTitle>
+            </WorkspaceHeader>
+
+            <ContentContainer className="max-w-screen-sm">
+                <form onSubmit={onSubmit}>
+                    <Select
+                        className="block w-full"
+                        disabled={clustersQuery.isLoading}
+                        inputClassName="block w-full"
+                        itemToString={(cluster) => cluster?.name || ''}
+                        items={clusters}
+                        label="Cluster"
+                        onChange={(c) => setFormData({ ...formData, clusterID: c?.id || '' })}
+                        placeholder={clustersQuery.isLoading ? 'Loading clusters...' : 'Select a cluster'}
+                        renderItem={(c) => `${c?.name} (${c?.id})`}
+                        selectedItem={selectedCluster}
+                    />
+
+                    {clustersQuery.isError && (
+                        <FormError
+                            error={clustersQuery.error}
+                            title="Couldn't load clusters. Please reload the page to try again."
+                        />
+                    )}
+
+                    <Label className="block my-8" label="Keyspace Name">
+                        <TextInput
+                            onChange={(e) => setFormData({ ...formData, keyspaceName: e.target.value })}
+                            value={formData.keyspaceName || ''}
+                        />
+                    </Label>
+
+                    <details>
+                        <summary className="font-semibold cursor-pointer">Advanced options</summary>
+                        <Label className="block my-8" label="Sharding Column Name">
+                            <TextInput
+                                onChange={(e) => setFormData({ ...formData, shardingColumnName: e.target.value })}
+                                value={formData.shardingColumnName || ''}
+                            />
+                        </Label>
+                        <span className="text-sm">The name of the column to use for sharding operations.</span>
+                    </details>
+
+                    {mutation.isError && !mutation.isLoading && (
+                        <FormError error={mutation.error} title="Couldn't create keyspace. Please try again." />
+                    )}
+
+                    <div className="my-12">
+                        <button className="btn" disabled={isDisabled} type="submit">
+                            {mutation.isLoading ? 'Creating Keyspace...' : 'Create Keyspace'}
+                        </button>
+                    </div>
+                </form>
+            </ContentContainer>
+        </div>
+    );
+};

--- a/web/vtadmin/src/hooks/api.ts
+++ b/web/vtadmin/src/hooks/api.ts
@@ -58,6 +58,7 @@ import {
     ValidateVersionKeyspaceParams,
     validateVersionKeyspace,
     fetchShardReplicationPositions,
+    createKeyspace,
 } from '../api/http';
 import { vtadmin as pb } from '../proto/vtadmin';
 import { formatAlias } from '../util/tablets';
@@ -97,6 +98,18 @@ export const useKeyspace = (
         },
         ...options,
     });
+};
+
+/**
+ * useCreateKeyspace is a mutation query hook that creates a keyspace.
+ */
+export const useCreateKeyspace = (
+    params: Parameters<typeof createKeyspace>[0],
+    options: UseMutationOptions<Awaited<ReturnType<typeof createKeyspace>>, Error>
+) => {
+    return useMutation<Awaited<ReturnType<typeof createKeyspace>>, Error>(() => {
+        return createKeyspace(params);
+    }, options);
 };
 
 /**


### PR DESCRIPTION
## Description

Adds a form to create a new keyspace. For vtctld2 parity, this includes the `sharding_column_name` input.

![create-keyspace3](https://user-images.githubusercontent.com/855595/168577787-fb25fd07-cd52-4b45-a1b5-3aac31cc0345.gif)

A few caveats/follow-ups I'll mention:

-  I didn't include the `CreateKeyspace -force` functionality since it's rather spicy + I'd like to do a bit more research first in order to write proper help text. 

- As you can see in the gif, the Keyspace detail page looks very bare (broken, in fact!) for keyspaces without any shards. The "better empty table state" is a widespread issue so I won't address it here. 

- `CreateKeyspace.test.tsx` is a beast of a test but it does (I think!) a pretty thorough job of testing the "golden path" for this form. 

## Related Issue(s)

Closes #8703 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A