### PR TITLE
[vtadmin] Further generalize DangerAction component

### DIFF
--- a/web/vtadmin/src/components/DangerAction.test.tsx
+++ b/web/vtadmin/src/components/DangerAction.test.tsx
@@ -71,7 +71,7 @@ describe('DangerAction', () => {
             <QueryClientProvider client={queryClient}>
                 <Wrapper
                     confirmationValue="zone1-101"
-                    description={<>Hello world!</>}
+                    description="Do an action."
                     documentationLink="https://test.com"
                     loadedText="Do Action"
                     loadingText="Doing Action..."

--- a/web/vtadmin/src/components/DangerAction.test.tsx
+++ b/web/vtadmin/src/components/DangerAction.test.tsx
@@ -70,8 +70,7 @@ describe('DangerAction', () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <Wrapper
-                    action="complete an action"
-                    alias="zone1-101"
+                    confirmationValue="zone1-101"
                     description={<>Hello world!</>}
                     documentationLink="https://test.com"
                     loadedText="Do Action"

--- a/web/vtadmin/src/components/DangerAction.test.tsx
+++ b/web/vtadmin/src/components/DangerAction.test.tsx
@@ -86,11 +86,10 @@ describe('DangerAction', () => {
         const input = screen.getByRole('textbox');
 
         // Enter the confirmation text
-        expect(button).toHaveAttribute('disabled');
-        await userEvent.type(input, 'zone1-101');
+        await user.type(input, 'zone1-101');
         expect(button).not.toHaveAttribute('disabled');
 
-        await userEvent.click(button);
+        await user.click(button);
 
         // Validate form while API request is in flight
         expect(button).toHaveTextContent('Doing Action...');
@@ -100,5 +99,38 @@ describe('DangerAction', () => {
 
         // Wait for API request to complete
         await waitFor(() => expect(button).toHaveTextContent('Do Action'));
+    });
+
+    it('enables form submission if and only if input matches confirmation', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Wrapper
+                    confirmationValue="zone1-101"
+                    description={<>Hello world!</>}
+                    documentationLink="https://test.com"
+                    loadedText="Do Action"
+                    loadingText="Doing Action..."
+                    title="A Title"
+                />
+            </QueryClientProvider>
+        );
+
+        const user = userEvent.setup();
+
+        const button = screen.getByRole('button');
+        const input = screen.getByRole('textbox');
+
+        expect(button).toHaveAttribute('disabled');
+
+        const invalidInputs = [' ', 'zone-100', 'zone1'];
+        for (let i = 0; i < invalidInputs.length; i++) {
+            await user.clear(input);
+            await user.type(input, invalidInputs[i]);
+            expect(button).toHaveAttribute('disabled');
+        }
+
+        await user.clear(input);
+        await user.type(input, 'zone1-101');
+        expect(button).not.toHaveAttribute('disabled');
     });
 });

--- a/web/vtadmin/src/components/DangerAction.test.tsx
+++ b/web/vtadmin/src/components/DangerAction.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { QueryClient, QueryClientProvider, useMutation } from 'react-query';
+
+import DangerAction, { DangerActionProps } from './DangerAction';
+
+const ORIGINAL_PROCESS_ENV = process.env;
+const TEST_PROCESS_ENV = {
+    ...process.env,
+    REACT_APP_VTADMIN_API_ADDRESS: '',
+};
+
+describe('DangerAction', () => {
+    const server = setupServer(
+        rest.post('/api/test', (req, res, ctx) => {
+            return res(ctx.json({ ok: true }));
+        })
+    );
+
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+
+    /**
+     * The useMutation query hook must be defined in the body of a function
+     * that is _within_ the context of a QueryClientProvider. This Wrapper component
+     * provides such a function and should be `render`ed in the context QueryClientProvider.
+     */
+    const Wrapper: React.FC<Omit<DangerActionProps, 'mutation'>> = (props) => {
+        const mutation = useMutation(() => fetch('/api/test', { method: 'post' }));
+        return <DangerAction {...props} mutation={mutation as any} />;
+    };
+
+    beforeAll(() => {
+        process.env = { ...TEST_PROCESS_ENV } as NodeJS.ProcessEnv;
+        server.listen();
+    });
+
+    afterEach(() => {
+        process.env = { ...TEST_PROCESS_ENV } as NodeJS.ProcessEnv;
+        jest.clearAllMocks();
+    });
+
+    afterAll(() => {
+        process.env = { ...ORIGINAL_PROCESS_ENV };
+        server.close();
+    });
+
+    it('initiates the mutation', async () => {
+        jest.spyOn(global, 'fetch');
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Wrapper
+                    action="complete an action"
+                    alias="zone1-101"
+                    description={<>Hello world!</>}
+                    documentationLink="https://test.com"
+                    loadedText="Do Action"
+                    loadingText="Doing Action..."
+                    primary={false}
+                    primaryDescription={<>A warning goes here.</>}
+                    title="A Title"
+                />
+            </QueryClientProvider>
+        );
+
+        const user = userEvent.setup();
+
+        const button = screen.getByRole('button');
+        const input = screen.getByRole('textbox');
+
+        // Enter the confirmation text
+        expect(button).toHaveAttribute('disabled');
+        await userEvent.type(input, 'zone1-101');
+        expect(button).not.toHaveAttribute('disabled');
+
+        await userEvent.click(button);
+
+        // Validate form while API request is in flight
+        expect(button).toHaveTextContent('Doing Action...');
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith('/api/test', { method: 'post' });
+
+        // Wait for API request to complete
+        await waitFor(() => expect(button).toHaveTextContent('Do Action'));
+    });
+});

--- a/web/vtadmin/src/components/DangerAction.test.tsx
+++ b/web/vtadmin/src/components/DangerAction.test.tsx
@@ -75,8 +75,6 @@ describe('DangerAction', () => {
                     documentationLink="https://test.com"
                     loadedText="Do Action"
                     loadingText="Doing Action..."
-                    primary={false}
-                    primaryDescription={<>A warning goes here.</>}
                     title="A Title"
                 />
             </QueryClientProvider>

--- a/web/vtadmin/src/components/DangerAction.tsx
+++ b/web/vtadmin/src/components/DangerAction.tsx
@@ -16,6 +16,7 @@
 
 import React, { useState } from 'react';
 import { UseMutationResult } from 'react-query';
+
 import { Icon, Icons } from './Icon';
 import { TextInput } from './TextInput';
 
@@ -24,17 +25,14 @@ type Mutation = UseMutationResult & {
 };
 
 export interface DangerActionProps {
-    // Required
+    confirmationPrompt?: React.ReactNode;
     confirmationValue: string;
-    description: JSX.Element;
+    description: React.ReactNode;
     documentationLink: string;
     loadingText: string;
     loadedText: string;
     mutation: UseMutationResult;
     title: string;
-
-    // Optional
-    confirmationPrompt?: React.ReactNode;
     warnings?: React.ReactNodeArray;
 }
 

--- a/web/vtadmin/src/components/DangerAction.tsx
+++ b/web/vtadmin/src/components/DangerAction.tsx
@@ -35,6 +35,11 @@ export interface DangerActionProps {
     warnings?: React.ReactNodeArray;
 }
 
+/**
+ * DangerAction is a panel used for initiating mutations on entity pages.
+ * When rendering multiple DangerAction components, ensure they are in
+ * a surrounding <div> to ensure the first: and last: CSS selectors work.
+ */
 const DangerAction: React.FC<DangerActionProps> = ({
     confirmationValue,
     title,
@@ -48,7 +53,10 @@ const DangerAction: React.FC<DangerActionProps> = ({
     const [typedAlias, setTypedAlias] = useState('');
 
     return (
-        <div className="p-8" title={title}>
+        <div
+            className="p-9 pb-12 last:border-b border border-red-400 border-b-0 first:rounded-t-lg last:rounded-b-lg"
+            title={title}
+        >
             <div className="flex justify-between items-center">
                 <p className="text-base font-bold m-0 text-gray-900">{title}</p>
                 <a

--- a/web/vtadmin/src/components/DangerAction.tsx
+++ b/web/vtadmin/src/components/DangerAction.tsx
@@ -31,12 +31,11 @@ export interface DangerActionProps {
     loadingText: string;
     loadedText: string;
     mutation: UseMutationResult;
-    primary: boolean;
-    primaryDescription: JSX.Element;
     title: string;
 
     // Optional
     confirmationPrompt?: React.ReactNode;
+    warnings?: React.ReactNodeArray;
 }
 
 const DangerAction: React.FC<DangerActionProps> = ({
@@ -45,11 +44,10 @@ const DangerAction: React.FC<DangerActionProps> = ({
     title,
     description,
     documentationLink,
-    primary,
-    primaryDescription,
     mutation,
     loadingText,
     loadedText,
+    warnings = [],
 }) => {
     const [typedAlias, setTypedAlias] = useState('');
 
@@ -68,11 +66,15 @@ const DangerAction: React.FC<DangerActionProps> = ({
                 </a>
             </div>
             <p className="text-base mt-0">{description}</p>
-            {primary && (
-                <div className="text-danger flex items-center">
-                    <Icon icon={Icons.alertFail} className="fill-current text-danger inline mr-2" />
-                    {primaryDescription}
-                </div>
+
+            {warnings.map(
+                (warning, i) =>
+                    warning && (
+                        <div className="text-danger flex items-center" key={i}>
+                            <Icon icon={Icons.alertFail} className="fill-current text-danger inline mr-2" />
+                            {warning}
+                        </div>
+                    )
             )}
 
             <p className="text-base">

--- a/web/vtadmin/src/components/DangerAction.tsx
+++ b/web/vtadmin/src/components/DangerAction.tsx
@@ -24,26 +24,29 @@ type Mutation = UseMutationResult & {
 };
 
 export interface DangerActionProps {
-    title: string;
-    action: string;
+    // Required
+    confirmationValue: string;
     description: JSX.Element;
-    primary: boolean;
-    primaryDescription: JSX.Element;
-    alias: string;
-    mutation: UseMutationResult;
+    documentationLink: string;
     loadingText: string;
     loadedText: string;
-    documentationLink: string;
+    mutation: UseMutationResult;
+    primary: boolean;
+    primaryDescription: JSX.Element;
+    title: string;
+
+    // Optional
+    confirmationPrompt?: React.ReactNode;
 }
 
 const DangerAction: React.FC<DangerActionProps> = ({
+    confirmationPrompt,
+    confirmationValue,
     title,
     description,
-    action,
     documentationLink,
     primary,
     primaryDescription,
-    alias,
     mutation,
     loadingText,
     loadedText,
@@ -72,13 +75,19 @@ const DangerAction: React.FC<DangerActionProps> = ({
                 </div>
             )}
 
-            <p className="text-base">Please type the tablet's alias to {action}:</p>
+            <p className="text-base">
+                {confirmationPrompt || (
+                    <>
+                        Please type <span className="font-bold">{confirmationValue}</span> to complete this action:
+                    </>
+                )}
+            </p>
             <div className="w-1/3">
-                <TextInput placeholder="zone-xxx" value={typedAlias} onChange={(e) => setTypedAlias(e.target.value)} />
+                <TextInput value={typedAlias} onChange={(e) => setTypedAlias(e.target.value)} />
             </div>
             <button
                 className="btn btn-secondary btn-danger mt-4"
-                disabled={typedAlias !== alias || mutation.isLoading}
+                disabled={typedAlias !== confirmationValue || mutation.isLoading}
                 onClick={() => {
                     (mutation as Mutation).mutate();
                     setTypedAlias('');

--- a/web/vtadmin/src/components/DangerAction.tsx
+++ b/web/vtadmin/src/components/DangerAction.tsx
@@ -25,7 +25,6 @@ type Mutation = UseMutationResult & {
 };
 
 export interface DangerActionProps {
-    confirmationPrompt?: React.ReactNode;
     confirmationValue: string;
     description: React.ReactNode;
     documentationLink: string;
@@ -37,7 +36,6 @@ export interface DangerActionProps {
 }
 
 const DangerAction: React.FC<DangerActionProps> = ({
-    confirmationPrompt,
     confirmationValue,
     title,
     description,
@@ -76,11 +74,7 @@ const DangerAction: React.FC<DangerActionProps> = ({
             )}
 
             <p className="text-base">
-                {confirmationPrompt || (
-                    <>
-                        Please type <span className="font-bold">{confirmationValue}</span> to complete this action:
-                    </>
-                )}
+                Please type <span className="font-bold">{confirmationValue}</span> confirm.
             </p>
             <div className="w-1/3">
                 <TextInput value={typedAlias} onChange={(e) => setTypedAlias(e.target.value)} />

--- a/web/vtadmin/src/components/DangerAction.tsx
+++ b/web/vtadmin/src/components/DangerAction.tsx
@@ -23,7 +23,7 @@ type Mutation = UseMutationResult & {
     mutate: () => void;
 };
 
-interface DangerActionProps {
+export interface DangerActionProps {
     title: string;
     action: string;
     description: JSX.Element;

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -239,12 +239,6 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                         Set tablet <span className="font-bold">{alias}</span> to read-only.
                                     </>
                                 }
-                                confirmationPrompt={
-                                    <>
-                                        Please type <span className="font-semibold font-mono">{alias}</span> to set the
-                                        tablet to read-only:
-                                    </>
-                                }
                                 mutation={setReadOnlyMutation as UseMutationResult}
                                 loadingText="Setting..."
                                 loadedText="Set to read-only"
@@ -260,12 +254,6 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 description={
                                     <>
                                         Set tablet <span className="font-bold">{alias}</span> to read-write.
-                                    </>
-                                }
-                                confirmationPrompt={
-                                    <>
-                                        Please type <span className="font-semibold font-mono">{alias}</span> to set the
-                                        tablet to read-write:
                                     </>
                                 }
                                 mutation={setReadWriteMutation as UseMutationResult}
@@ -292,12 +280,6 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                             <>
                                 Delete tablet <span className="font-bold">{alias}</span>. Doing so will remove it from
                                 the topology, but vttablet and MySQL won't be touched.
-                            </>
-                        }
-                        confirmationPrompt={
-                            <>
-                                Please type <span className="font-semibold font-mono">{alias}</span> to delete the
-                                tablet.
                             </>
                         }
                         mutation={deleteTabletMutation as UseMutationResult}

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -232,11 +232,9 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 confirmationValue={alias}
                                 title="Set Read-Only"
                                 documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadonly"
-                                primaryDescription={
-                                    <div>
-                                        This will disable writing on the primary tablet {alias}. Use with caution.
-                                    </div>
-                                }
+                                warnings={[
+                                    <>This will disable writing on the primary tablet {alias}. Use with caution.</>,
+                                ]}
                                 description={
                                     <>
                                         Set tablet <span className="font-bold">{alias}</span> to read-only.
@@ -251,18 +249,15 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 mutation={setReadOnlyMutation as UseMutationResult}
                                 loadingText="Setting..."
                                 loadedText="Set to read-only"
-                                primary={primary}
                             />
                             <div className="border-red-400 border-b w-full" />
                             <DangerAction
                                 confirmationValue={alias}
                                 title="Set Read-Write"
                                 documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadwrite"
-                                primaryDescription={
-                                    <div>
-                                        This will re-enable writing on the primary tablet {alias}. Use with caution.
-                                    </div>
-                                }
+                                warnings={[
+                                    <>This will re-enable writing on the primary tablet {alias}. Use with caution.</>,
+                                ]}
                                 description={
                                     <>
                                         Set tablet <span className="font-bold">{alias}</span> to read-write.
@@ -277,7 +272,6 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 mutation={setReadWriteMutation as UseMutationResult}
                                 loadingText="Setting..."
                                 loadedText="Set to read-write"
-                                primary={primary}
                             />
                             <div className="border-red-400 border-b w-full" />
                         </div>
@@ -286,13 +280,15 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                         confirmationValue={alias}
                         title="Delete Tablet"
                         documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#deletetablet"
-                        primaryDescription={
-                            <div>
-                                Tablet {alias} is the primary tablet. Flag{' '}
-                                <span className="font-mono bg-red-100 p-1 text-sm">-allow_primary=true</span> will be
-                                applied in order to delete the primary tablet.
-                            </div>
-                        }
+                        warnings={[
+                            primary && (
+                                <>
+                                    Tablet {alias} is the primary tablet. Flag{' '}
+                                    <span className="font-mono bg-red-100 p-1 text-sm">-allow_primary=true</span> will
+                                    be applied in order to delete the primary tablet.
+                                </>
+                            ),
+                        ]}
                         description={
                             <>
                                 Delete tablet <span className="font-bold">{alias}</span>. Doing so will remove it from
@@ -308,7 +304,6 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                         mutation={deleteTabletMutation as UseMutationResult}
                         loadingText="Deleting..."
                         loadedText="Delete"
-                        primary={primary}
                     />
                 </div>
             </div>

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -229,6 +229,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                         <div>
                             <div className="border-red-400 border-b w-full" />
                             <DangerAction
+                                confirmationValue={alias}
                                 title="Set Read-Only"
                                 documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadonly"
                                 primaryDescription={
@@ -241,15 +242,20 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                         Set tablet <span className="font-bold">{alias}</span> to read-only.
                                     </>
                                 }
-                                action="set tablet to read-only"
+                                confirmationPrompt={
+                                    <>
+                                        Please type <span className="font-semibold font-mono">{alias}</span> to set the
+                                        tablet to read-only:
+                                    </>
+                                }
                                 mutation={setReadOnlyMutation as UseMutationResult}
                                 loadingText="Setting..."
                                 loadedText="Set to read-only"
                                 primary={primary}
-                                alias={alias}
                             />
                             <div className="border-red-400 border-b w-full" />
                             <DangerAction
+                                confirmationValue={alias}
                                 title="Set Read-Write"
                                 documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadwrite"
                                 primaryDescription={
@@ -262,17 +268,22 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                         Set tablet <span className="font-bold">{alias}</span> to read-write.
                                     </>
                                 }
-                                action="set tablet to read-only"
+                                confirmationPrompt={
+                                    <>
+                                        Please type <span className="font-semibold font-mono">{alias}</span> to set the
+                                        tablet to read-write:
+                                    </>
+                                }
                                 mutation={setReadWriteMutation as UseMutationResult}
                                 loadingText="Setting..."
                                 loadedText="Set to read-write"
                                 primary={primary}
-                                alias={alias}
                             />
                             <div className="border-red-400 border-b w-full" />
                         </div>
                     )}
                     <DangerAction
+                        confirmationValue={alias}
                         title="Delete Tablet"
                         documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#deletetablet"
                         primaryDescription={
@@ -288,12 +299,16 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 the topology, but vttablet and MySQL won't be touched.
                             </>
                         }
-                        action="delete the tablet"
+                        confirmationPrompt={
+                            <>
+                                Please type <span className="font-semibold font-mono">{alias}</span> to delete the
+                                tablet.
+                            </>
+                        }
                         mutation={deleteTabletMutation as UseMutationResult}
                         loadingText="Deleting..."
                         loadedText="Delete"
                         primary={primary}
-                        alias={alias}
                     />
                 </div>
             </div>

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -232,7 +232,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 title="Set Read-Only"
                                 documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadonly"
                                 warnings={[
-                                    <>This will disable writing on the primary tablet {alias}. Use with caution.</>,
+                                    `This will disable writing on the primary tablet ${alias}. Use with caution.`,
                                 ]}
                                 description={
                                     <>
@@ -249,7 +249,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 title="Set Read-Write"
                                 documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadwrite"
                                 warnings={[
-                                    <>This will re-enable writing on the primary tablet {alias}. Use with caution.</>,
+                                    `This will re-enable writing on the primary tablet ${alias}. Use with caution.`,
                                 ]}
                                 description={
                                     <>

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -224,9 +224,9 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
             </div>
             <div className="my-8">
                 <h3 className="mb-4">Danger</h3>
-                <div className="border border-danger rounded-lg">
+                <div>
                     {primary && (
-                        <div>
+                        <>
                             <DangerAction
                                 confirmationValue={alias}
                                 title="Set Read-Only"
@@ -243,7 +243,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 loadingText="Setting..."
                                 loadedText="Set to read-only"
                             />
-                            <div className="border-red-400 border-b w-full" />
+
                             <DangerAction
                                 confirmationValue={alias}
                                 title="Set Read-Write"
@@ -260,8 +260,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 loadingText="Setting..."
                                 loadedText="Set to read-write"
                             />
-                            <div className="border-red-400 border-b w-full" />
-                        </div>
+                        </>
                     )}
                     <DangerAction
                         confirmationValue={alias}

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -227,7 +227,6 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                 <div className="border border-danger rounded-lg">
                     {primary && (
                         <div>
-                            <div className="border-red-400 border-b w-full" />
                             <DangerAction
                                 confirmationValue={alias}
                                 title="Set Read-Only"


### PR DESCRIPTION
## Description

The same DangerAction we know and love, but (further) generalized for use in contexts other than the Tablet page. This is another prefactor for deleting a shard (#8732), which is up next. 

![delete-tablet](https://user-images.githubusercontent.com/855595/168638427-ccedb177-b4a1-4feb-a145-a8c5cad137e4.gif)

(The tablet in the above gif doesn't disappear right away; this is expected + noted in the snackbar notification.)

Obligatory Top Gun reference:

![image](https://user-images.githubusercontent.com/855595/168639189-70071c14-6540-45d0-a7a8-395c280568f6.png)


## Related Issue(s)

- Prefactor for #8732 
- Follow-up to #10293 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A
