### PR TITLE
The flag --online_ddl_check_interval belongs in vtctld

### DIFF
--- a/go/flags/endtoend/flags_test.go
+++ b/go/flags/endtoend/flags_test.go
@@ -1029,8 +1029,6 @@ var (
 	socket file to use for remote mysqlctl actions (empty for local actions)
   --onclose_timeout duration
 	wait no more than this for OnClose handlers before stopping (default 1ns)
-  --online_ddl_check_interval duration
-	deprecated. Will be removed in next Vitess version
   --onterm_timeout duration
 	wait no more than this for OnTermSync handlers before stopping (default 10s)
   --opentsdb_uri string

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -46,6 +46,9 @@ var (
 
 	_ = flag.String("web_dir", "", "NOT USED, here for backward compatibility")
 	_ = flag.String("web_dir2", "", "NOT USED, here for backward compatibility")
+
+	// deprecated, only here for backwards compatibility:
+	deprecatedOnlineDDLCheckInterval = flag.Duration("online_ddl_check_interval", 0, "deprecated. Will be removed in next Vitess version")
 )
 
 const (
@@ -54,6 +57,10 @@ const (
 
 // InitVtctld initializes all the vtctld functionality.
 func InitVtctld(ts *topo.Server) error {
+	if *deprecatedOnlineDDLCheckInterval != 0 {
+		log.Warningf("the flag '--online_ddl_check_interval' is deprecated and will be removed in future versions. It is currently unused.")
+	}
+
 	err := reparentutil.SetDurabilityPolicy("none")
 	if err != nil {
 		log.Errorf("error in setting durability policy: %v", err)

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -110,9 +110,6 @@ var migrationCheckInterval = flag.Duration("migration_check_interval", 1*time.Mi
 var retainOnlineDDLTables = flag.Duration("retain_online_ddl_tables", 24*time.Hour, "How long should vttablet keep an old migrated table before purging it")
 var migrationNextCheckIntervals = []time.Duration{1 * time.Second, 5 * time.Second, 10 * time.Second, 20 * time.Second}
 
-// deprecated, only here for backwards compatibility:
-var deprecatedOnlineDDLCheckInterval = flag.Duration("online_ddl_check_interval", 0, "deprecated. Will be removed in next Vitess version")
-
 const (
 	maxPasswordLength                        = 32 // MySQL's *replication* password may not exceed 32 characters
 	staleMigrationMinutes                    = 10
@@ -214,10 +211,6 @@ func NewExecutor(env tabletenv.Env, tabletAlias *topodatapb.TabletAlias, ts *top
 	tabletTypeFunc func() topodatapb.TabletType,
 	toggleBufferTableFunc func(cancelCtx context.Context, tableName string, bufferQueries bool),
 ) *Executor {
-
-	if *deprecatedOnlineDDLCheckInterval != 0 {
-		log.Warningf("the flag '--online_ddl_check_interval' is deprecated and will be removed in future versions. It is currently unused.")
-	}
 	return &Executor{
 		env:         env,
 		tabletAlias: proto.Clone(tabletAlias).(*topodatapb.TabletAlias),


### PR DESCRIPTION
Signed-off-by: Shlomi Noach <2607934+shlomi-noach@users.noreply.github.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description


https://github.com/vitessio/vitess/pull/10308  reintroduced `--online_ddl_check_interval` for backwards compatibility, but erroneously in `vttablet` rather than in `vtctld`. This PR hopefully sets things straight by reintroducing the flag in `vtctld`.

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/10308 
- #9816 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
