### PR TITLE
[vtadmin] Further generalize DangerAction into ActionPanel

### DIFF
--- a/web/vtadmin/src/components/ActionPanel.test.tsx
+++ b/web/vtadmin/src/components/ActionPanel.test.tsx
@@ -133,4 +133,48 @@ describe('ActionPanel', () => {
         await user.type(input, 'zone1-101');
         expect(button).not.toHaveAttribute('disabled');
     });
+
+    it('does not render confirmation if "confirmationValue" not set', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Wrapper
+                    description={<>Hello world!</>}
+                    documentationLink="https://test.com"
+                    loadedText="Do Action"
+                    loadingText="Doing Action..."
+                    title="A Title"
+                />
+            </QueryClientProvider>
+        );
+
+        const user = userEvent.setup();
+
+        const button = screen.getByRole('button');
+        const input = screen.queryByRole('textbox');
+
+        expect(input).toBeNull();
+        expect(button).not.toHaveAttribute('disabled');
+    });
+
+    it('disables interaction when "disabled" prop is set', () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Wrapper
+                    confirmationValue="zone1-101"
+                    description={<>Hello world!</>}
+                    disabled
+                    documentationLink="https://test.com"
+                    loadedText="Do Action"
+                    loadingText="Doing Action..."
+                    title="A Title"
+                />
+            </QueryClientProvider>
+        );
+
+        const button = screen.getByRole('button');
+        const input = screen.queryByRole('textbox');
+
+        expect(input).toBeNull();
+        expect(button).toHaveAttribute('disabled');
+    });
 });

--- a/web/vtadmin/src/components/ActionPanel.test.tsx
+++ b/web/vtadmin/src/components/ActionPanel.test.tsx
@@ -20,7 +20,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { QueryClient, QueryClientProvider, useMutation } from 'react-query';
 
-import DangerAction, { DangerActionProps } from './DangerAction';
+import ActionPanel, { ActionPanelProps } from './ActionPanel';
 
 const ORIGINAL_PROCESS_ENV = process.env;
 const TEST_PROCESS_ENV = {
@@ -28,7 +28,7 @@ const TEST_PROCESS_ENV = {
     REACT_APP_VTADMIN_API_ADDRESS: '',
 };
 
-describe('DangerAction', () => {
+describe('ActionPanel', () => {
     const server = setupServer(
         rest.post('/api/test', (req, res, ctx) => {
             return res(ctx.json({ ok: true }));
@@ -44,9 +44,9 @@ describe('DangerAction', () => {
      * that is _within_ the context of a QueryClientProvider. This Wrapper component
      * provides such a function and should be `render`ed in the context QueryClientProvider.
      */
-    const Wrapper: React.FC<Omit<DangerActionProps, 'mutation'>> = (props) => {
+    const Wrapper: React.FC<Omit<ActionPanelProps, 'mutation'>> = (props) => {
         const mutation = useMutation(() => fetch('/api/test', { method: 'post' }));
-        return <DangerAction {...props} mutation={mutation as any} />;
+        return <ActionPanel {...props} mutation={mutation as any} />;
     };
 
     beforeAll(() => {

--- a/web/vtadmin/src/components/ActionPanel.test.tsx
+++ b/web/vtadmin/src/components/ActionPanel.test.tsx
@@ -147,8 +147,6 @@ describe('ActionPanel', () => {
             </QueryClientProvider>
         );
 
-        const user = userEvent.setup();
-
         const button = screen.getByRole('button');
         const input = screen.queryByRole('textbox');
 

--- a/web/vtadmin/src/components/ActionPanel.tsx
+++ b/web/vtadmin/src/components/ActionPanel.tsx
@@ -54,11 +54,12 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
     loadedText,
     warnings = [],
 }) => {
-    const [typedAlias, setTypedAlias] = useState('');
+    const [typedConfirmation, setTypedConfirmation] = useState('');
 
     const requiresConfirmation = typeof confirmationValue === 'string' && !!confirmationValue;
 
-    const isDisabled = !!disabled || mutation.isLoading || (requiresConfirmation && typedAlias !== confirmationValue);
+    const isDisabled =
+        !!disabled || mutation.isLoading || (requiresConfirmation && typedConfirmation !== confirmationValue);
 
     return (
         <div
@@ -97,7 +98,7 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
                         Please type <span className="font-bold">{confirmationValue}</span> confirm.
                     </p>
                     <div className="w-1/3">
-                        <TextInput value={typedAlias} onChange={(e) => setTypedAlias(e.target.value)} />
+                        <TextInput value={typedConfirmation} onChange={(e) => setTypedConfirmation(e.target.value)} />
                     </div>
                 </>
             )}
@@ -107,7 +108,7 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
                 disabled={isDisabled}
                 onClick={() => {
                     (mutation as Mutation).mutate();
-                    setTypedAlias('');
+                    setTypedConfirmation('');
                 }}
             >
                 {mutation.isLoading ? loadingText : loadedText}

--- a/web/vtadmin/src/components/ActionPanel.tsx
+++ b/web/vtadmin/src/components/ActionPanel.tsx
@@ -92,7 +92,8 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
                     )
             )}
 
-            {requiresConfirmation && (
+            {/* Don't render the confirmation input if "disabled" prop is set */}
+            {requiresConfirmation && !disabled && (
                 <>
                     <p className="text-base">
                         Please type <span className="font-bold">{confirmationValue}</span> confirm.

--- a/web/vtadmin/src/components/ActionPanel.tsx
+++ b/web/vtadmin/src/components/ActionPanel.tsx
@@ -26,6 +26,7 @@ type Mutation = UseMutationResult & {
 
 export interface ActionPanelProps {
     confirmationValue?: string;
+    danger?: boolean;
     description: React.ReactNode;
     disabled?: boolean;
     documentationLink: string;
@@ -43,6 +44,7 @@ export interface ActionPanelProps {
  */
 const ActionPanel: React.FC<ActionPanelProps> = ({
     confirmationValue,
+    danger,
     disabled,
     title,
     description,
@@ -60,7 +62,9 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
 
     return (
         <div
-            className="p-9 pb-12 last:border-b border border-red-400 border-b-0 first:rounded-t-lg last:rounded-b-lg"
+            className={`p-9 pb-12 last:border-b border ${
+                danger ? 'border-red-400' : 'border-gray-400'
+            } border-b-0 first:rounded-t-lg last:rounded-b-lg`}
             title={title}
         >
             <div className="flex justify-between items-center">
@@ -99,7 +103,7 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
             )}
 
             <button
-                className="btn btn-secondary btn-danger mt-4"
+                className={`btn btn-secondary ${danger && 'btn-danger'} mt-4`}
                 disabled={isDisabled}
                 onClick={() => {
                     (mutation as Mutation).mutate();

--- a/web/vtadmin/src/components/ActionPanel.tsx
+++ b/web/vtadmin/src/components/ActionPanel.tsx
@@ -24,7 +24,7 @@ type Mutation = UseMutationResult & {
     mutate: () => void;
 };
 
-export interface DangerActionProps {
+export interface ActionPanelProps {
     confirmationValue: string;
     description: React.ReactNode;
     documentationLink: string;
@@ -36,11 +36,11 @@ export interface DangerActionProps {
 }
 
 /**
- * DangerAction is a panel used for initiating mutations on entity pages.
- * When rendering multiple DangerAction components, ensure they are in
+ * ActionPanel is a panel used for initiating mutations on entity pages.
+ * When rendering multiple ActionPanel components, ensure they are in
  * a surrounding <div> to ensure the first: and last: CSS selectors work.
  */
-const DangerAction: React.FC<DangerActionProps> = ({
+const ActionPanel: React.FC<ActionPanelProps> = ({
     confirmationValue,
     title,
     description,
@@ -101,4 +101,4 @@ const DangerAction: React.FC<DangerActionProps> = ({
     );
 };
 
-export default DangerAction;
+export default ActionPanel;

--- a/web/vtadmin/src/components/ActionPanel.tsx
+++ b/web/vtadmin/src/components/ActionPanel.tsx
@@ -25,8 +25,9 @@ type Mutation = UseMutationResult & {
 };
 
 export interface ActionPanelProps {
-    confirmationValue: string;
+    confirmationValue?: string;
     description: React.ReactNode;
+    disabled?: boolean;
     documentationLink: string;
     loadingText: string;
     loadedText: string;
@@ -42,6 +43,7 @@ export interface ActionPanelProps {
  */
 const ActionPanel: React.FC<ActionPanelProps> = ({
     confirmationValue,
+    disabled,
     title,
     description,
     documentationLink,
@@ -51,6 +53,10 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
     warnings = [],
 }) => {
     const [typedAlias, setTypedAlias] = useState('');
+
+    const requiresConfirmation = typeof confirmationValue === 'string' && !!confirmationValue;
+
+    const isDisabled = !!disabled || mutation.isLoading || (requiresConfirmation && typedAlias !== confirmationValue);
 
     return (
         <div
@@ -81,15 +87,20 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
                     )
             )}
 
-            <p className="text-base">
-                Please type <span className="font-bold">{confirmationValue}</span> confirm.
-            </p>
-            <div className="w-1/3">
-                <TextInput value={typedAlias} onChange={(e) => setTypedAlias(e.target.value)} />
-            </div>
+            {requiresConfirmation && (
+                <>
+                    <p className="text-base">
+                        Please type <span className="font-bold">{confirmationValue}</span> confirm.
+                    </p>
+                    <div className="w-1/3">
+                        <TextInput value={typedAlias} onChange={(e) => setTypedAlias(e.target.value)} />
+                    </div>
+                </>
+            )}
+
             <button
                 className="btn btn-secondary btn-danger mt-4"
-                disabled={typedAlias !== confirmationValue || mutation.isLoading}
+                disabled={isDisabled}
                 onClick={() => {
                     (mutation as Mutation).mutate();
                     setTypedAlias('');

--- a/web/vtadmin/src/components/routes/tablet/Advanced.test.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.test.tsx
@@ -252,7 +252,7 @@ describe('Advanced', () => {
                 });
             });
 
-            it('deletes the tablet with allow_master=true if primary', async () => {
+            it('deletes the tablet with allow_primary=true if primary', async () => {
                 const tablet = makePrimaryTablet();
                 renderHelper(
                     <Advanced

--- a/web/vtadmin/src/components/routes/tablet/Advanced.test.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.test.tsx
@@ -84,70 +84,207 @@ describe('Advanced', () => {
         process.env = { ...ORIGINAL_PROCESS_ENV };
     });
 
-    describe('Delete', () => {
-        it('deletes the tablet', async () => {
-            const tablet = makeTablet();
-            renderHelper(
-                <Advanced
-                    alias={formatAlias(tablet.tablet?.alias) as string}
-                    clusterID={tablet.cluster?.id as string}
-                    tablet={tablet}
-                />
-            );
+    describe('Advanced tablet actions', () => {
+        describe('Start Replication', () => {
+            it('starts replication', async () => {
+                const tablet = makeTablet();
+                const alias = formatAlias(tablet.tablet?.alias) as string;
+                renderHelper(<Advanced alias={alias} clusterID={tablet.cluster?.id as string} tablet={tablet} />);
 
-            const container = screen.getByTitle('Delete Tablet');
-            const button = within(container).getByRole('button');
-            const input = within(container).getByRole('textbox');
+                const container = screen.getByTitle('Start Replication');
+                const button = within(container).getByRole('button');
 
-            expect(button).toHaveAttribute('disabled');
+                // This action does not require confirmation
+                const input = within(container).queryByRole('textbox');
+                expect(input).toBeNull();
 
-            fireEvent.change(input, { target: { value: 'zone1-101' } });
-            expect(button).not.toHaveAttribute('disabled');
+                expect(button).not.toHaveAttribute('disabled');
 
-            fireEvent.click(button);
+                fireEvent.click(button);
 
-            await waitFor(() => {
-                expect(global.fetch).toHaveBeenCalledTimes(1);
+                await waitFor(() => {
+                    expect(global.fetch).toHaveBeenCalledTimes(1);
+                });
+
+                expect(global.fetch).toHaveBeenCalledWith(
+                    `/api/tablet/${alias}/start_replication?cluster=some-cluster-id`,
+                    {
+                        credentials: undefined,
+                        method: 'put',
+                    }
+                );
             });
 
-            expect(global.fetch).toHaveBeenCalledWith('/api/tablet/zone1-101?cluster=some-cluster-id', {
-                credentials: undefined,
-                method: 'delete',
+            it('prevents starting replication if primary', () => {
+                const tablet = makePrimaryTablet();
+                renderHelper(
+                    <Advanced
+                        alias={formatAlias(tablet.tablet?.alias) as string}
+                        clusterID={tablet.cluster?.id as string}
+                        tablet={tablet}
+                    />
+                );
+
+                const container = screen.getByTitle('Start Replication');
+                const button = within(container).getByRole('button');
+                expect(button).toHaveAttribute('disabled');
             });
         });
 
-        it('deletes the tablet with allow_master=true if primary', async () => {
-            const tablet = makePrimaryTablet();
-            renderHelper(
-                <Advanced
-                    alias={formatAlias(tablet.tablet?.alias) as string}
-                    clusterID={tablet.cluster?.id as string}
-                    tablet={tablet}
-                />
-            );
+        describe('Stop Replication', () => {
+            it('stops replication', async () => {
+                const tablet = makeTablet();
+                const alias = formatAlias(tablet.tablet?.alias) as string;
+                renderHelper(<Advanced alias={alias} clusterID={tablet.cluster?.id as string} tablet={tablet} />);
 
-            const container = screen.getByTitle('Delete Tablet');
-            const button = within(container).getByRole('button');
-            const input = within(container).getByRole('textbox');
+                const container = screen.getByTitle('Stop Replication');
+                const button = within(container).getByRole('button');
 
-            expect(button).toHaveAttribute('disabled');
+                // This action does not require confirmation
+                const input = within(container).queryByRole('textbox');
+                expect(input).toBeNull();
 
-            fireEvent.change(input, { target: { value: 'zone1-101' } });
-            expect(button).not.toHaveAttribute('disabled');
+                expect(button).not.toHaveAttribute('disabled');
 
-            fireEvent.click(button);
+                fireEvent.click(button);
 
-            await waitFor(() => {
-                expect(global.fetch).toHaveBeenCalledTimes(1);
+                await waitFor(() => {
+                    expect(global.fetch).toHaveBeenCalledTimes(1);
+                });
+
+                expect(global.fetch).toHaveBeenCalledWith(
+                    `/api/tablet/${alias}/stop_replication?cluster=some-cluster-id`,
+                    {
+                        credentials: undefined,
+                        method: 'put',
+                    }
+                );
             });
 
-            expect(global.fetch).toHaveBeenCalledWith(
-                '/api/tablet/zone1-101?cluster=some-cluster-id&allow_primary=true',
-                {
+            it('prevents stopping replication if primary', () => {
+                const tablet = makePrimaryTablet();
+                renderHelper(
+                    <Advanced
+                        alias={formatAlias(tablet.tablet?.alias) as string}
+                        clusterID={tablet.cluster?.id as string}
+                        tablet={tablet}
+                    />
+                );
+
+                const container = screen.getByTitle('Stop Replication');
+                const button = within(container).getByRole('button');
+                expect(button).toHaveAttribute('disabled');
+            });
+        });
+
+        describe('Reparent', () => {
+            it('reparents', async () => {
+                const tablet = makeTablet();
+                const alias = formatAlias(tablet.tablet?.alias) as string;
+                renderHelper(<Advanced alias={alias} clusterID={tablet.cluster?.id as string} tablet={tablet} />);
+
+                const container = screen.getByTitle('Reparent');
+                const button = within(container).getByRole('button');
+
+                // This action does not require confirmation
+                const input = within(container).queryByRole('textbox');
+                expect(input).toBeNull();
+
+                expect(button).not.toHaveAttribute('disabled');
+
+                fireEvent.click(button);
+
+                await waitFor(() => {
+                    expect(global.fetch).toHaveBeenCalledTimes(1);
+                });
+
+                expect(global.fetch).toHaveBeenCalledWith(`/api/tablet/${alias}/reparent`, {
+                    credentials: undefined,
+                    method: 'put',
+                });
+            });
+
+            it('prevents reparenting if primary', () => {
+                const tablet = makePrimaryTablet();
+                renderHelper(
+                    <Advanced
+                        alias={formatAlias(tablet.tablet?.alias) as string}
+                        clusterID={tablet.cluster?.id as string}
+                        tablet={tablet}
+                    />
+                );
+
+                const container = screen.getByTitle('Reparent');
+                const button = within(container).getByRole('button');
+                expect(button).toHaveAttribute('disabled');
+            });
+        });
+
+        describe('Delete', () => {
+            it('deletes the tablet', async () => {
+                const tablet = makeTablet();
+                renderHelper(
+                    <Advanced
+                        alias={formatAlias(tablet.tablet?.alias) as string}
+                        clusterID={tablet.cluster?.id as string}
+                        tablet={tablet}
+                    />
+                );
+
+                const container = screen.getByTitle('Delete Tablet');
+                const button = within(container).getByRole('button');
+                const input = within(container).getByRole('textbox');
+
+                expect(button).toHaveAttribute('disabled');
+
+                fireEvent.change(input, { target: { value: 'zone1-101' } });
+                expect(button).not.toHaveAttribute('disabled');
+
+                fireEvent.click(button);
+
+                await waitFor(() => {
+                    expect(global.fetch).toHaveBeenCalledTimes(1);
+                });
+
+                expect(global.fetch).toHaveBeenCalledWith('/api/tablet/zone1-101?cluster=some-cluster-id', {
                     credentials: undefined,
                     method: 'delete',
-                }
-            );
+                });
+            });
+
+            it('deletes the tablet with allow_master=true if primary', async () => {
+                const tablet = makePrimaryTablet();
+                renderHelper(
+                    <Advanced
+                        alias={formatAlias(tablet.tablet?.alias) as string}
+                        clusterID={tablet.cluster?.id as string}
+                        tablet={tablet}
+                    />
+                );
+
+                const container = screen.getByTitle('Delete Tablet');
+                const button = within(container).getByRole('button');
+                const input = within(container).getByRole('textbox');
+
+                expect(button).toHaveAttribute('disabled');
+
+                fireEvent.change(input, { target: { value: 'zone1-101' } });
+                expect(button).not.toHaveAttribute('disabled');
+
+                fireEvent.click(button);
+
+                await waitFor(() => {
+                    expect(global.fetch).toHaveBeenCalledTimes(1);
+                });
+
+                expect(global.fetch).toHaveBeenCalledWith(
+                    '/api/tablet/zone1-101?cluster=some-cluster-id&allow_primary=true',
+                    {
+                        credentials: undefined,
+                        method: 'delete',
+                    }
+                );
+            });
         });
     });
 });

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -110,7 +110,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
             <div className="my-8">
                 <h3 className="mb-4">Replication</h3>
                 <div className="w-full border rounded-lg border-gray-400">
-                    <div className="p-8 border-b border-gray-400">
+                    <div title="Start Replication" className="p-8 border-b border-gray-400">
                         <div className="flex justify-between items-center">
                             <p className="text-base font-bold m-0 text-gray-900">Start Replication</p>
                             <a
@@ -145,7 +145,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                             Start replication
                         </button>
                     </div>
-                    <div className="p-8">
+                    <div title="Stop Replication" className="p-8">
                         <div className="flex justify-between items-center">
                             <p className="text-base font-bold m-0 text-gray-900">Stop Replication</p>
                             <a
@@ -185,7 +185,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
             <div className="my-8">
                 <h3 className="mb-4">Reparent</h3>
                 <div className="w-full border rounded-lg border-gray-400">
-                    <div className="p-8 border-b border-gray-400">
+                    <div title="Reparent" className="p-8 border-b border-gray-400">
                         <div className="flex justify-between items-center">
                             <p className="text-base font-bold m-0 text-gray-900">Reparent Tablet</p>
                             <a

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -29,7 +29,6 @@ import {
 import { topodata, vtadmin } from '../../../proto/vtadmin';
 import { isPrimary } from '../../../util/tablets';
 import ActionPanel from '../../ActionPanel';
-import { Icon, Icons } from '../../Icon';
 import { success, warn } from '../../Snackbar';
 
 interface AdvancedProps {

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -177,6 +177,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                         <>
                             <ActionPanel
                                 confirmationValue={alias}
+                                danger
                                 title="Set Read-Only"
                                 documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadonly"
                                 warnings={[
@@ -194,6 +195,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
 
                             <ActionPanel
                                 confirmationValue={alias}
+                                danger
                                 title="Set Read-Write"
                                 documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadwrite"
                                 warnings={[
@@ -212,6 +214,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                     )}
                     <ActionPanel
                         confirmationValue={alias}
+                        danger
                         title="Delete Tablet"
                         documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#deletetablet"
                         warnings={[

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../../hooks/api';
 import { topodata, vtadmin } from '../../../proto/vtadmin';
 import { isPrimary } from '../../../util/tablets';
-import DangerAction from '../../DangerAction';
+import ActionPanel from '../../ActionPanel';
 import { Icon, Icons } from '../../Icon';
 import { success, warn } from '../../Snackbar';
 
@@ -227,7 +227,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                 <div>
                     {primary && (
                         <>
-                            <DangerAction
+                            <ActionPanel
                                 confirmationValue={alias}
                                 title="Set Read-Only"
                                 documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadonly"
@@ -244,7 +244,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 loadedText="Set to read-only"
                             />
 
-                            <DangerAction
+                            <ActionPanel
                                 confirmationValue={alias}
                                 title="Set Read-Write"
                                 documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadwrite"
@@ -262,7 +262,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                             />
                         </>
                     )}
-                    <DangerAction
+                    <ActionPanel
                         confirmationValue={alias}
                         title="Delete Tablet"
                         documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#deletetablet"

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -155,9 +155,9 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                         confirmationValue=""
                         description={
                             <>
-                                This will run the underlying database command to start replication on tablet{' '}
-                                <span className="font-bold">{alias}</span>. For example, in mysql 8, this will be{' '}
-                                <span className="font-mono text-sm p-1 bg-gray-100">start replication</span>.
+                                Reconnect replication for tablet <span className="font-bold">{alias}</span> to the
+                                current primary tablet. This only works if the current replication position matches the
+                                last known reparent action.
                             </>
                         }
                         disabled={primary}
@@ -178,45 +178,54 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                             <ActionPanel
                                 confirmationValue={alias}
                                 danger
-                                title="Set Read-Only"
-                                documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadonly"
-                                warnings={[
-                                    `This will disable writing on the primary tablet ${alias}. Use with caution.`,
-                                ]}
                                 description={
                                     <>
                                         Set tablet <span className="font-bold">{alias}</span> to read-only.
                                     </>
                                 }
-                                mutation={setReadOnlyMutation as UseMutationResult}
+                                documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadonly"
                                 loadingText="Setting..."
                                 loadedText="Set to read-only"
+                                mutation={setReadOnlyMutation as UseMutationResult}
+                                title="Set Read-Only"
+                                warnings={[
+                                    `This will disable writing on the primary tablet ${alias}. Use with caution.`,
+                                ]}
                             />
 
                             <ActionPanel
                                 confirmationValue={alias}
                                 danger
-                                title="Set Read-Write"
-                                documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadwrite"
-                                warnings={[
-                                    `This will re-enable writing on the primary tablet ${alias}. Use with caution.`,
-                                ]}
                                 description={
                                     <>
                                         Set tablet <span className="font-bold">{alias}</span> to read-write.
                                     </>
                                 }
+                                documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#setreadwrite"
                                 mutation={setReadWriteMutation as UseMutationResult}
                                 loadingText="Setting..."
                                 loadedText="Set to read-write"
+                                title="Set Read-Write"
+                                warnings={[
+                                    `This will re-enable writing on the primary tablet ${alias}. Use with caution.`,
+                                ]}
                             />
                         </>
                     )}
                     <ActionPanel
                         confirmationValue={alias}
                         danger
-                        title="Delete Tablet"
+                        description={
+                            <>
+                                Delete tablet <span className="font-bold">{alias}</span>. Doing so will remove it from
+                                the topology, but vttablet and MySQL won't be touched.
+                            </>
+                        }
                         documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#deletetablet"
+                        loadingText="Deleting..."
+                        loadedText="Delete"
+                        mutation={deleteTabletMutation as UseMutationResult}
+                        title="Delete Tablet"
                         warnings={[
                             primary && (
                                 <>
@@ -226,15 +235,6 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                                 </>
                             ),
                         ]}
-                        description={
-                            <>
-                                Delete tablet <span className="font-bold">{alias}</span>. Doing so will remove it from
-                                the topology, but vttablet and MySQL won't be touched.
-                            </>
-                        }
-                        mutation={deleteTabletMutation as UseMutationResult}
-                        loadingText="Deleting..."
-                        loadedText="Delete"
                     />
                 </div>
             </div>

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -109,117 +109,65 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
         <div className="pt-4">
             <div className="my-8">
                 <h3 className="mb-4">Replication</h3>
-                <div className="w-full border rounded-lg border-gray-400">
-                    <div title="Start Replication" className="p-8 border-b border-gray-400">
-                        <div className="flex justify-between items-center">
-                            <p className="text-base font-bold m-0 text-gray-900">Start Replication</p>
-                            <a
-                                href="https://vitess.io/docs/reference/programs/vtctl/tablets/#startreplication"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-gray-900 ml-1"
-                            >
-                                <span className="text-sm font-semibold text-gray-900">Documentation</span>
-                                <Icon
-                                    icon={Icons.open}
-                                    className="h-6 w-6 ml-1 inline-block text-gray-900 fill-current"
-                                />
-                            </a>
-                        </div>
-                        <p className="text-base m-0">
-                            This will run the underlying database command to start replication on tablet{' '}
-                            <span className="font-bold">{alias}</span>. For example, in mysql 8, this will be{' '}
-                            <span className="font-mono text-sm p-1 bg-gray-100">start replication</span>.
-                        </p>
-                        {primary && (
-                            <p className="text-danger">
-                                <Icon icon={Icons.alertFail} className="fill-current text-danger inline mr-2" />
-                                Command StartTablet cannot be run on the primary tablet.
-                            </p>
-                        )}
-                        <button
-                            onClick={() => startReplicationMutation.mutate()}
-                            className="btn btn-secondary mt-4"
-                            disabled={primary || startReplicationMutation.isLoading}
-                        >
-                            Start replication
-                        </button>
-                    </div>
-                    <div title="Stop Replication" className="p-8">
-                        <div className="flex justify-between items-center">
-                            <p className="text-base font-bold m-0 text-gray-900">Stop Replication</p>
-                            <a
-                                href="https://vitess.io/docs/reference/programs/vtctl/tablets/#stopreplication"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-gray-900"
-                            >
-                                <span className="text-sm font-semibold text-gray-900">Documentation</span>{' '}
-                                <Icon
-                                    icon={Icons.open}
-                                    className="ml-1 inline-block h-6 w-6 text-gray-900 fill-current"
-                                />
-                            </a>
-                        </div>
-                        <p className="text-base m-0">
-                            This will run the underlying database command to stop replication on tablet{' '}
-                            <span className="font-bold">{alias}</span>. For example, in mysql 8, this will be{' '}
-                            <span className="font-mono text-sm p-1 bg-gray-100">stop replication</span>.
-                        </p>
-                        {primary && (
-                            <p className="text-danger">
-                                <Icon icon={Icons.alertFail} className="fill-current text-danger inline mr-2" />
-                                Command StopTablet cannot be run on the primary tablet.
-                            </p>
-                        )}
-                        <button
-                            onClick={() => stopReplicationMutation.mutate()}
-                            className="btn btn-secondary mt-4"
-                            disabled={primary || stopReplicationMutation.isLoading}
-                        >
-                            Stop replication
-                        </button>
-                    </div>
+                <div>
+                    <ActionPanel
+                        confirmationValue=""
+                        description={
+                            <>
+                                This will run the underlying database command to start replication on tablet{' '}
+                                <span className="font-bold">{alias}</span>. For example, in mysql 8, this will be{' '}
+                                <span className="font-mono text-sm p-1 bg-gray-100">start replication</span>.
+                            </>
+                        }
+                        disabled={primary}
+                        documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#startreplication"
+                        loadedText="Start Replication"
+                        loadingText="Starting Replication..."
+                        mutation={startReplicationMutation as UseMutationResult}
+                        title="Start Replication"
+                        warnings={[primary && 'Command StartTablet cannot be run on the primary tablet.']}
+                    />
+
+                    <ActionPanel
+                        confirmationValue=""
+                        description={
+                            <>
+                                This will run the underlying database command to stop replication on tablet{' '}
+                                <span className="font-bold">{alias}</span>. For example, in mysql 8, this will be{' '}
+                                <span className="font-mono text-sm p-1 bg-gray-100">stop replication</span>.
+                            </>
+                        }
+                        disabled={primary}
+                        documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#stopreplication"
+                        loadedText="Stop Replication"
+                        loadingText="Stopping Replication..."
+                        mutation={stopReplicationMutation as UseMutationResult}
+                        title="Stop Replication"
+                        warnings={[primary && 'Command StopTablet cannot be run on the primary tablet.']}
+                    />
                 </div>
             </div>
+
             <div className="my-8">
                 <h3 className="mb-4">Reparent</h3>
-                <div className="w-full border rounded-lg border-gray-400">
-                    <div title="Reparent" className="p-8 border-b border-gray-400">
-                        <div className="flex justify-between items-center">
-                            <p className="text-base font-bold m-0 text-gray-900">Reparent Tablet</p>
-                            <a
-                                href="https://vitess.io/docs/reference/programs/vtctl/tablets/#reparenttablet"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-gray-900 ml-1"
-                            >
-                                <span className="text-sm font-semibold text-gray-900">Documentation</span>
-                                <Icon
-                                    icon={Icons.open}
-                                    className="ml-1 h-6 w-6 inline-block text-gray-900 fill-current"
-                                />
-                            </a>
-                        </div>
-                        <p className="text-base m-0">
-                            Reconnect replication for tablet <span className="font-bold">{alias}</span> to the current
-                            primary tablet. This only works if the current replication position matches the last known
-                            reparent action.
-                        </p>
-                        {primary && (
-                            <p className="text-danger">
-                                <Icon icon={Icons.alertFail} className="fill-current text-danger inline mr-2" />
-                                Command ReparentTablet cannot be run on the primary tablet.
-                            </p>
-                        )}
-                        <button
-                            className="btn btn-secondary mt-4"
-                            disabled={primary || reparentTabletMutation.isLoading}
-                            onClick={() => reparentTabletMutation.mutate()}
-                        >
-                            Reparent tablet
-                        </button>
-                    </div>
+                <div>
+                    <ActionPanel
+                        confirmationValue=""
+                        description={
+                            <>
+                                This will run the underlying database command to start replication on tablet{' '}
+                                <span className="font-bold">{alias}</span>. For example, in mysql 8, this will be{' '}
+                                <span className="font-mono text-sm p-1 bg-gray-100">start replication</span>.
+                            </>
+                        }
+                        disabled={primary}
+                        documentationLink="https://vitess.io/docs/reference/programs/vtctl/tablets/#reparenttablet"
+                        loadedText="Reparent"
+                        loadingText="Reparenting..."
+                        mutation={reparentTabletMutation as UseMutationResult}
+                        title="Reparent"
+                        warnings={[primary && 'Command ReparentTablet cannot be run on the primary tablet.']}
+                    />
                 </div>
             </div>
             <div className="my-8">

--- a/web/vtadmin/src/components/routes/tablet/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Advanced.tsx
@@ -124,7 +124,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                         loadingText="Starting Replication..."
                         mutation={startReplicationMutation as UseMutationResult}
                         title="Start Replication"
-                        warnings={[primary && 'Command StartTablet cannot be run on the primary tablet.']}
+                        warnings={[primary && 'Command StartReplication cannot be run on the primary tablet.']}
                     />
 
                     <ActionPanel
@@ -142,7 +142,7 @@ const Advanced: React.FC<AdvancedProps> = ({ alias, clusterID, tablet }) => {
                         loadingText="Stopping Replication..."
                         mutation={stopReplicationMutation as UseMutationResult}
                         title="Stop Replication"
-                        warnings={[primary && 'Command StopTablet cannot be run on the primary tablet.']}
+                        warnings={[primary && 'Command StopReplication cannot be run on the primary tablet.']}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## Description

Further adventures in generalizing the DangerAction component! The original is very well-written + made these refactors nice and straightforward. :chef-kiss: 

- Renames the component from `DangerAction` to `ActionPanel`, and adds a `danger` prop to preserve the scary styling when necessary. 🎃 
- Updates all of the mutation triggers on the `tablet/advanced` page to use `ActionPanel` in its less scary form.
- Makes the confirmation input optional.
- Adds a `disabled` prop
- Lots more tests

Using `ActionPanel` under the hood, everything works as before:

![tablet-actions-2](https://user-images.githubusercontent.com/855595/168860535-782acf6d-f4b4-49f0-8202-ee788138628d.gif)

## Related Issue(s)

- Continuation of #10319 
- Prefactor for #8723, #8738

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A
