### PR TITLE
schemadiff: validate columns referenced by generated columns

### DIFF
--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -1103,6 +1103,12 @@ func TestValidate(t *testing.T) {
 			alter:     "alter table t add column neg int as (0-i)",
 			expectErr: ErrInvalidColumnInGeneratedColumn,
 		},
+		{
+			name:  "add generated column referencing existent column",
+			from:  "create table t (id int, i int not null default 0, primary key (id))",
+			alter: "alter table t add column neg int as (0-i)",
+			to:    "create table t (id int, i int not null default 0, neg int as (0-i), primary key (id))",
+		},
 	}
 	hints := DiffHints{}
 	for _, ts := range tt {

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -1091,6 +1091,18 @@ func TestValidate(t *testing.T) {
 			alter: "alter table t alter index i_idx invisible",
 			to:    "create table t (id int primary key, i int, key i_idx(i) invisible)",
 		},
+		{
+			name:      "drop column used by a generated column",
+			from:      "create table t (id int, i int, neg int as (0-i), primary key (id))",
+			alter:     "alter table t drop column i",
+			expectErr: ErrInvalidColumnInGeneratedColumn,
+		},
+		{
+			name:      "add generated column referencing nonexistent column",
+			from:      "create table t (id int, primary key (id))",
+			alter:     "alter table t add column neg int as (0-i)",
+			expectErr: ErrInvalidColumnInGeneratedColumn,
+		},
 	}
 	hints := DiffHints{}
 	for _, ts := range tt {

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -54,6 +54,7 @@ var (
 	ErrApplyNoPartitions         = errors.New("no partitions found")
 
 	ErrInvalidColumnInKey               = errors.New("invalid column referenced by key")
+	ErrInvalidColumnInGeneratedColumn   = errors.New("invalid column referenced by generated column")
 	ErrInvalidColumnInPartition         = errors.New("invalid column referenced by partition")
 	ErrMissingParitionColumnInUniqueKey = errors.New("unique key must include all columns in a parititioning function")
 )


### PR DESCRIPTION


## Description

As part of `validate()` process, we now look into any existing generated column, and verify they only reference existing columns.

## Related Issue(s)

- #10203 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

