### PR TITLE
[vtadmin] Add keyspace/advanced view + ReloadSchemaKeyspace control

### DIFF
--- a/web/vtadmin/src/components/routes/keyspace/Advanced.test.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Advanced.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Advanced } from './Advanced';
+
+const ORIGINAL_PROCESS_ENV = process.env;
+const TEST_PROCESS_ENV = {
+    ...process.env,
+    REACT_APP_VTADMIN_API_ADDRESS: '',
+};
+
+describe('Advanced keyspace actions', () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+
+    beforeAll(() => {
+        process.env = { ...TEST_PROCESS_ENV } as NodeJS.ProcessEnv;
+        jest.spyOn(global, 'fetch');
+    });
+
+    beforeEach(() => {
+        process.env = { ...TEST_PROCESS_ENV } as NodeJS.ProcessEnv;
+        jest.clearAllMocks();
+    });
+
+    afterAll(() => {
+        process.env = { ...ORIGINAL_PROCESS_ENV };
+    });
+
+    describe('Reload Schema', () => {
+        it('reloads the schema', async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <Advanced clusterID="some-cluster" name="some-keyspace" />
+                </QueryClientProvider>
+            );
+
+            const container = screen.getByTitle('Reload Schema');
+            const button = within(container).getByRole('button');
+            expect(button).not.toHaveAttribute('disabled');
+
+            const user = userEvent.setup();
+            user.click(button);
+
+            await waitFor(() => {
+                expect(global.fetch).toHaveBeenCalledTimes(1);
+            });
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                `/api/schemas/reload?cluster=some-cluster&keyspace=some-keyspace`,
+                {
+                    credentials: undefined,
+                    method: 'put',
+                }
+            );
+        });
+    });
+});

--- a/web/vtadmin/src/components/routes/keyspace/Advanced.test.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Advanced.test.tsx
@@ -80,6 +80,11 @@ describe('Advanced keyspace actions', () => {
                 expect(screen.queryByText('Loading...')).toBeNull();
             });
 
+            expect(global.fetch).toHaveBeenCalledTimes(1);
+            expect(global.fetch).toHaveBeenCalledWith(`/api/keyspace/some-cluster/some-keyspace`, {
+                credentials: undefined,
+            });
+
             jest.clearAllMocks();
 
             const container = screen.getByTitle('Reload Schema');

--- a/web/vtadmin/src/components/routes/keyspace/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Advanced.tsx
@@ -16,8 +16,9 @@
 
 import { UseMutationResult } from 'react-query';
 
-import { useReloadSchema } from '../../../hooks/api';
+import { useKeyspace, useReloadSchema } from '../../../hooks/api';
 import ActionPanel from '../../ActionPanel';
+import { QueryLoadingPlaceholder } from '../../placeholders/QueryLoadingPlaceholder';
 import { success, warn } from '../../Snackbar';
 
 interface Props {
@@ -26,6 +27,10 @@ interface Props {
 }
 
 export const Advanced: React.FC<Props> = ({ clusterID, name }) => {
+    const kq = useKeyspace({ clusterID, name });
+
+    const { data: keyspace } = kq;
+
     const reloadSchemaMutation = useReloadSchema(
         {
             clusterIDs: [clusterID],
@@ -43,21 +48,26 @@ export const Advanced: React.FC<Props> = ({ clusterID, name }) => {
         <div className="pt-4">
             <div className="my-8">
                 <h3 className="mb-4">Schemas</h3>
-                <div>
-                    <ActionPanel
-                        description={
-                            <>
-                                Reloads the schema on all the tablets in the <span className="font-bold">{name}</span>{' '}
-                                keyspace.
-                            </>
-                        }
-                        documentationLink="https://vitess.io/docs/13.0/reference/programs/vtctl/schema-version-permissions/#reloadschemakeyspace"
-                        loadedText="Reload Schema"
-                        loadingText="Reloading Schema..."
-                        mutation={reloadSchemaMutation as UseMutationResult}
-                        title="Reload Schema"
-                    />
-                </div>
+
+                <QueryLoadingPlaceholder query={kq} />
+
+                {keyspace && (
+                    <div>
+                        <ActionPanel
+                            description={
+                                <>
+                                    Reloads the schema on all the tablets in the{' '}
+                                    <span className="font-bold">{name}</span> keyspace.
+                                </>
+                            }
+                            documentationLink="https://vitess.io/docs/13.0/reference/programs/vtctl/schema-version-permissions/#reloadschemakeyspace"
+                            loadedText="Reload Schema"
+                            loadingText="Reloading Schema..."
+                            mutation={reloadSchemaMutation as UseMutationResult}
+                            title="Reload Schema"
+                        />
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/web/vtadmin/src/components/routes/keyspace/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Advanced.tsx
@@ -56,7 +56,7 @@ export const Advanced: React.FC<Props> = ({ clusterID, name }) => {
                         <ActionPanel
                             description={
                                 <>
-                                    Reloads the schema on all the tablets in the{' '}
+                                    Reloads the schema on all the tablets, except the primary tablet, in the{' '}
                                     <span className="font-bold">{name}</span> keyspace.
                                 </>
                             }

--- a/web/vtadmin/src/components/routes/keyspace/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Advanced.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2022 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UseMutationResult } from 'react-query';
+
+import { useReloadSchema } from '../../../hooks/api';
+import ActionPanel from '../../ActionPanel';
+import { success, warn } from '../../Snackbar';
+
+interface Props {
+    clusterID: string;
+    name: string;
+}
+
+export const Advanced: React.FC<Props> = ({ clusterID, name }) => {
+    const reloadSchemaMutation = useReloadSchema(
+        {
+            clusterIDs: [clusterID],
+            keyspaces: [name],
+        },
+        {
+            onError: (error) => warn(`There was an error reloading the schemas in the ${name} keyspace: ${error}`),
+            onSuccess: () => {
+                success(`Successfully reloaded schemas in the ${name} keyspace.`, { autoClose: 1600 });
+            },
+        }
+    );
+
+    return (
+        <div className="pt-4">
+            <div className="my-8">
+                <h3 className="mb-4">Schemas</h3>
+                <div>
+                    <ActionPanel
+                        description={
+                            <>
+                                Reloads the schema on all the tablets in the <span className="font-bold">{name}</span>{' '}
+                                keyspace.
+                            </>
+                        }
+                        documentationLink="https://vitess.io/docs/13.0/reference/programs/vtctl/schema-version-permissions/#reloadschemakeyspace"
+                        loadedText="Reload Schema"
+                        loadingText="Reloading Schema..."
+                        mutation={reloadSchemaMutation as UseMutationResult}
+                        title="Reload Schema"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/web/vtadmin/src/components/routes/keyspace/Keyspace.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Keyspace.tsx
@@ -18,14 +18,17 @@ import { Link, Redirect, Route } from 'react-router-dom';
 
 import { useKeyspace } from '../../../hooks/api';
 import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
+import { isReadOnlyMode } from '../../../util/env';
 import { Code } from '../../Code';
 import { ContentContainer } from '../../layout/ContentContainer';
 import { NavCrumbs } from '../../layout/NavCrumbs';
 import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
 import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
 import { QueryLoadingPlaceholder } from '../../placeholders/QueryLoadingPlaceholder';
+import { ReadOnlyGate } from '../../ReadOnlyGate';
 import { Tab } from '../../tabs/Tab';
 import { TabContainer } from '../../tabs/TabContainer';
+import { Advanced } from './Advanced';
 import style from './Keyspace.module.scss';
 import { KeyspaceShards } from './KeyspaceShards';
 import { KeyspaceVSchema } from './KeyspaceVSchema';
@@ -91,6 +94,10 @@ export const Keyspace = () => {
                     <Tab text="Shards" to={`${url}/shards`} />
                     <Tab text="VSchema" to={`${url}/vschema`} />
                     <Tab text="JSON" to={`${url}/json`} />
+
+                    <ReadOnlyGate>
+                        <Tab text="Advanced" to={`${url}/advanced`} />
+                    </ReadOnlyGate>
                 </TabContainer>
 
                 <Switch>
@@ -106,6 +113,12 @@ export const Keyspace = () => {
                         <QueryLoadingPlaceholder query={kq} />
                         <Code code={JSON.stringify(keyspace, null, 2)} />
                     </Route>
+
+                    {!isReadOnlyMode() && (
+                        <Route path={`${path}/advanced`}>
+                            <Advanced clusterID={clusterID} name={name} />
+                        </Route>
+                    )}
 
                     <Redirect exact from={path} to={{ pathname: `${path}/shards`, search }} />
                 </Switch>

--- a/web/vtadmin/src/hooks/api.ts
+++ b/web/vtadmin/src/hooks/api.ts
@@ -59,6 +59,7 @@ import {
     validateVersionKeyspace,
     fetchShardReplicationPositions,
     createKeyspace,
+    reloadSchema,
 } from '../api/http';
 import { vtadmin as pb } from '../proto/vtadmin';
 import { formatAlias } from '../util/tablets';
@@ -428,4 +429,18 @@ export const useWorkflow = (
         },
         ...options,
     });
+};
+
+/**
+ *
+ * useReloadSchema is a mutate hook that reloads schemas in one or more
+ * keyspaces, shards, or tablets in the cluster, depending on the request parameters.
+ */
+export const useReloadSchema = (
+    params: Parameters<typeof reloadSchema>[0],
+    options?: UseMutationOptions<Awaited<ReturnType<typeof reloadSchema>>, Error>
+) => {
+    return useMutation<Awaited<ReturnType<typeof reloadSchema>>, Error>(() => {
+        return reloadSchema(params);
+    }, options);
 };

--- a/web/vtadmin/src/hooks/api.ts
+++ b/web/vtadmin/src/hooks/api.ts
@@ -432,7 +432,6 @@ export const useWorkflow = (
 };
 
 /**
- *
  * useReloadSchema is a mutate hook that reloads schemas in one or more
  * keyspaces, shards, or tablets in the cluster, depending on the request parameters.
  */


### PR DESCRIPTION
## Description

Part of https://github.com/vitessio/vitess/issues/8738

This adds a very straightforward UI control that maps to the [ReloadSchemaKeyspace](https://vitess.io/docs/13.0/reference/programs/vtctl/schema-version-permissions/#reloadschemakeyspace) command by way of the `/api/schemas/reload` endpoint added in https://github.com/vitessio/vitess/pull/10300. 

The copy in the gifs below is ever so slightly out of date; I've updated it to the following to account for not including the `include_primary` parameter:

> Reloads the schema on all the tablets, **except the primary tablet** ...

![reloadschema](https://user-images.githubusercontent.com/855595/168910936-72926a9a-511a-4421-a6ab-edf459317374.gif)

Here's the flow for the keyspace/advanced route when a keyspace doesn't exist. (I think there are opportunities to be more consistent about this particular error flow across VTAdmin, as some polish before GA.) 

![keyspace-doesnt-exist](https://user-images.githubusercontent.com/855595/168911460-7f40846f-4ab1-4763-95f3-aa06d0a290d2.gif)

I have an [open question](https://vitess.slack.com/archives/C0PQY0PTK/p1652820868858439) about whether it's worth adding a checkbox to control the `include_primary` parameter. 

I'll also need to add a `concurrency` input for parity with vtctld2. That'll require some reworking, so this felt like a good + PR-sized stopping point while I marinate on that. 

## Related Issue(s)

Part of #8738 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A