### PR TITLE
[vtadmin] Add prom metrics endpoint support

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -169,6 +169,9 @@ func main() {
 	// HTTP server flags
 	rootCmd.Flags().BoolVar(&httpOpts.DisableCompression, "http-no-compress", false, "whether to disable compression of HTTP API responses")
 	rootCmd.Flags().BoolVar(&httpOpts.DisableDebug, "http-no-debug", false, "whether to disable /debug/pprof/* and /debug/env HTTP endpoints")
+	rootCmd.Flags().StringVar(&opts.MetricsEndpoint, "http-metrics-endpoint", "/metrics",
+		"HTTP endpoint to expose prometheus metrics on. Omit to disable scraping metrics. "+
+			"Using a path used by VTAdmin's http API is unsupported and causes undefined behavior.")
 	rootCmd.Flags().Var(&debug.OmitEnv, "http-debug-omit-env", "name of an environment variable to omit from /debug/env, if http debug endpoints are enabled. specify multiple times to omit multiple env vars")
 	rootCmd.Flags().Var(&debug.SanitizeEnv, "http-debug-sanitize-env", "name of an environment variable to sanitize in /debug/env, if http debug endpoints are enabled. specify multiple times to sanitize multiple env vars")
 	rootCmd.Flags().StringSliceVar(&httpOpts.CORSOrigins, "http-origin", []string{}, "repeated, comma-separated flag of allowed CORS origins. omit to disable CORS")

--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -169,11 +169,11 @@ func main() {
 	// HTTP server flags
 	rootCmd.Flags().BoolVar(&httpOpts.DisableCompression, "http-no-compress", false, "whether to disable compression of HTTP API responses")
 	rootCmd.Flags().BoolVar(&httpOpts.DisableDebug, "http-no-debug", false, "whether to disable /debug/pprof/* and /debug/env HTTP endpoints")
+	rootCmd.Flags().Var(&debug.OmitEnv, "http-debug-omit-env", "name of an environment variable to omit from /debug/env, if http debug endpoints are enabled. specify multiple times to omit multiple env vars")
+	rootCmd.Flags().Var(&debug.SanitizeEnv, "http-debug-sanitize-env", "name of an environment variable to sanitize in /debug/env, if http debug endpoints are enabled. specify multiple times to sanitize multiple env vars")
 	rootCmd.Flags().StringVar(&opts.MetricsEndpoint, "http-metrics-endpoint", "/metrics",
 		"HTTP endpoint to expose prometheus metrics on. Omit to disable scraping metrics. "+
 			"Using a path used by VTAdmin's http API is unsupported and causes undefined behavior.")
-	rootCmd.Flags().Var(&debug.OmitEnv, "http-debug-omit-env", "name of an environment variable to omit from /debug/env, if http debug endpoints are enabled. specify multiple times to omit multiple env vars")
-	rootCmd.Flags().Var(&debug.SanitizeEnv, "http-debug-sanitize-env", "name of an environment variable to sanitize in /debug/env, if http debug endpoints are enabled. specify multiple times to sanitize multiple env vars")
 	rootCmd.Flags().StringSliceVar(&httpOpts.CORSOrigins, "http-origin", []string{}, "repeated, comma-separated flag of allowed CORS origins. omit to disable CORS")
 	rootCmd.Flags().StringVar(&httpOpts.ExperimentalOptions.TabletURLTmpl,
 		"http-tablet-url-tmpl",

--- a/go/vt/vtadmin/grpcserver/server.go
+++ b/go/vt/vtadmin/grpcserver/server.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -32,6 +33,7 @@ import (
 	otgrpc "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/soheilhy/cmux"
 	"google.golang.org/grpc"
 	channelz "google.golang.org/grpc/channelz/service"
@@ -67,6 +69,15 @@ type Options struct {
 	// EnableChannelz specifies whether to register the channelz service on the
 	// gRPC server.
 	EnableChannelz bool
+
+	// MetricsEndpoint is the route to serve promhttp metrics on, including
+	// those collected be grpc_prometheus interceptors.
+	//
+	// It is the user's responsibility to ensure this does not conflict with
+	// other endpoints.
+	//
+	// Omit to not export metrics.
+	MetricsEndpoint string
 
 	StreamInterceptors []grpc.StreamServerInterceptor
 	UnaryInterceptors  []grpc.UnaryServerInterceptor
@@ -194,6 +205,15 @@ func (s *Server) ListenAndServe() error { // nolint:funlen
 		log.Warning(err)
 		shutdown <- err
 	}()
+
+	if s.opts.MetricsEndpoint != "" {
+		if !strings.HasPrefix(s.opts.MetricsEndpoint, "/") {
+			s.opts.MetricsEndpoint = "/" + s.opts.MetricsEndpoint
+		}
+
+		grpc_prometheus.Register(s.gRPCServer)
+		s.router.Handle(s.opts.MetricsEndpoint, promhttp.Handler())
+	}
 
 	// Start the servers
 	go func() {


### PR DESCRIPTION
## Description

This PR adds (yet another) new config option to specify an endpoint to serve prom metrics on, via HTTP. It also adds the missing `grpc_prom.Register` call.


I threw together a quick grpc client and made a GetClusters call, and then:

```
➜  vitess git:(andrew/vtadmin-goes-to-prom) ✗ curl -s localhost:14200/metrics | grep "OK.*GetClusters"
grpc_server_handled_total{grpc_code="OK",grpc_method="GetClusters",grpc_service="vtadmin.VTAdmin",grpc_type="unary"} 1
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required => I will follow up with a docs PR for the website!!

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
