### PR TITLE
Fix schema tracking issue when `PRIMARY` tablet changes

### DIFF
--- a/go/test/endtoend/vtgate/schematracker/sharded_prs/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded_prs/st_sharded_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shardedprs
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+
+	"vitess.io/vitess/go/test/endtoend/utils"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	KeyspaceName    = "ks"
+	Cell            = "test"
+	SchemaSQL       = `
+create table t2(
+	id3 bigint,
+	id4 bigint,
+	primary key(id3)
+) Engine=InnoDB;
+
+create table t2_id4_idx(
+	id bigint not null auto_increment,
+	id4 bigint,
+	id3 bigint,
+	primary key(id),
+	key idx_id4(id4)
+) Engine=InnoDB;
+
+create table t8(
+	id8 bigint,
+	testId bigint,
+	primary key(id8)
+) Engine=InnoDB;
+`
+
+	VSchema = `
+{
+  "sharded": true,
+  "vindexes": {
+    "unicode_loose_xxhash" : {
+	  "type": "unicode_loose_xxhash"
+    },
+    "unicode_loose_md5" : {
+	  "type": "unicode_loose_md5"
+    },
+    "hash": {
+      "type": "hash"
+    },
+    "xxhash": {
+      "type": "xxhash"
+    },
+    "t2_id4_idx": {
+      "type": "lookup_hash",
+      "params": {
+        "table": "t2_id4_idx",
+        "from": "id4",
+        "to": "id3",
+        "autocommit": "true"
+      },
+      "owner": "t2"
+    }
+  },
+  "tables": {
+    "t2": {
+      "column_vindexes": [
+        {
+          "column": "id3",
+          "name": "hash"
+        },
+        {
+          "column": "id4",
+          "name": "t2_id4_idx"
+        }
+      ]
+    },
+    "t2_id4_idx": {
+      "column_vindexes": [
+        {
+          "column": "id4",
+          "name": "hash"
+        }
+      ]
+    },
+    "t8": {
+      "column_vindexes": [
+        {
+          "column": "id8",
+          "name": "hash"
+        }
+      ]
+    }
+  }
+}`
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(Cell, "localhost")
+		defer clusterInstance.Teardown()
+
+		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal", "--schema_change_signal_user", "userData1"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-schema-change-signal", "--queryserver-config-schema-change-signal-interval", "5", "--queryserver-config-strict-table-acl", "--queryserver-config-acl-exempt-acl", "userData1", "--table-acl-config", "dummy.json"}
+
+		// Start topo server
+		err := clusterInstance.StartTopo()
+		if err != nil {
+			return 1
+		}
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      KeyspaceName,
+			SchemaSQL: SchemaSQL,
+			VSchema:   VSchema,
+		}
+		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 3, true)
+		if err != nil {
+			return 1
+		}
+
+		// Start vtgate
+		err = clusterInstance.StartVtgate()
+		if err != nil {
+			return 1
+		}
+
+		err = waitForVTGateAndVTTablet()
+		if err != nil {
+			fmt.Println(err)
+			return 1
+		}
+
+		// PRS on the second VTTablet of each shard
+		// This is supposed to change the primary tablet in the shards, meaning that a different tablet
+		// will be responsible for sending schema tracking updates.
+		for _, shard := range clusterInstance.Keyspaces[0].Shards {
+			err := clusterInstance.VtctlclientProcess.InitializeShard(KeyspaceName, shard.Name, Cell, shard.Vttablets[1].TabletUID)
+			if err != nil {
+				fmt.Println(err)
+				return 1
+			}
+		}
+
+		err = waitForVTGateAndVTTablet()
+		if err != nil {
+			fmt.Println(err)
+			return 1
+		}
+
+		vtParams = mysql.ConnParams{
+			Host: clusterInstance.Hostname,
+			Port: clusterInstance.VtgateMySQLPort,
+		}
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func waitForVTGateAndVTTablet() error {
+	timeout := time.After(5 * time.Minute)
+	for {
+		select {
+		case <-timeout:
+			return vterrors.New(vtrpcpb.Code_INTERNAL, "timeout")
+		default:
+			err := clusterInstance.WaitForTabletsToHealthyInVtgate()
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+}
+
+func TestAddColumn(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_ = utils.Exec(t, conn, `alter table t2 add column aaa int`)
+	time.Sleep(10 * time.Second)
+	_ = utils.Exec(t, conn, "select aaa from t2")
+}

--- a/go/vt/discovery/tablet_health_check.go
+++ b/go/vt/discovery/tablet_health_check.go
@@ -177,6 +177,12 @@ func (thc *tabletHealthCheck) processResponse(hc *HealthCheckImpl, shr *query.St
 		serving = false
 	}
 
+	ti, err := hc.ts.GetTablet(thc.ctx, thc.Tablet.Alias)
+	if err != nil {
+		return fmt.Errorf("could not get tablet info from topo: %v", err)
+	}
+	thc.Tablet = ti.Tablet
+
 	if shr.TabletAlias != nil && !proto.Equal(shr.TabletAlias, thc.Tablet.Alias) {
 		// TabletAlias change means that the host:port has been taken over by another tablet
 		// We cancel / exit the healthcheck for this tablet right away

--- a/go/vt/vtgate/schema/update_controller.go
+++ b/go/vt/vtgate/schema/update_controller.go
@@ -119,7 +119,7 @@ func (u *updateController) getItemFromQueueLocked() *discovery.TabletHealth {
 
 func (u *updateController) add(th *discovery.TabletHealth) {
 	// For non-primary tablet health, there is no schema tracking.
-	if th.Tablet.Type != topodatapb.TabletType_PRIMARY {
+	if th.Target.TabletType != topodatapb.TabletType_PRIMARY {
 		return
 	}
 

--- a/test/config.json
+++ b/test/config.json
@@ -777,6 +777,15 @@
 			"RetryMax": 1,
 			"Tags": ["upgrade_downgrade_query_serving"]
 		},
+		"vtgate_schematracker_sharded_prs": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/schematracker/sharded_prs"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_schema_tracker",
+			"RetryMax": 1,
+			"Tags": ["upgrade_downgrade_query_serving"]
+		},
 		"vtgate_schematracker_unsharded": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/schematracker/unsharded"],


### PR DESCRIPTION
## Description

Hola, hola! 👋 This Pull Request fixes a nasty bug in our schema tracking feature (🙃). What's the bug? When creating a Vitess cluster and enabling schema tracking, the new VTTablets are added to the Topology. The VTGate then picks up the new changes from the Topology and sees that a bunch of new VTTablets was added. It saves the state of those VTTablets and starts reading the stream of healthcheck from them. Any updates to those VTTablets are sent to VTGate through that stream using a `StreamHealthResponse` structure. In VTGate, the data structure that keeps track of a VTTablet's health is `tabletHealthCheck`, that structure keeps track of both the `current` and `target` tablet type (`primary`, `replica`, ...). The `target` tablet type is updated every time we receive a healthcheck from the VTTablet, however, the `current` is **never** updated (😱) ... So what's the link with schema tracking? In the schema tracking code, whenever we receive an update, the first thing we check is _"is the healthcheck coming from a `primary` VTTablet?"_, if the answer to that question is _"no"_ then we dismiss the update and ignore it. And... how do we check the tablet type? By looking at the `current` tablet type, which is never updated. Meaning that, in a scenario where we have 2 VTTablets (`A` and `B`) in each shard, where `A` is the `primary` by default, if at one point we do a PRS ([Planned Reparent Shard](https://vitess.io/docs/user-guides/configuration-advanced/reparenting/)), the `primary` VTTablet will change to be `B`, however, the VTGate will not update the current tablet type of both VTTablets, thus, it will keep thinking that the primary VTTablet is `A` even though it is `B`. Meaning that when `B` sends a valid schema tracking update, VTGate ignores it.

This Pull Request proposes an end-to-end test that reproduces the issue, and two fixes:
- The first one (a6b5ca28a0d745ec0b59d1bca21f4583dcca5955) keeps track of the `current` tablet type in VTGate.
- The second one (3dd05e0b70d6cccb98390497159162ba2e28f293) uses the `target` tablet type in the schema tracker. In VTTablet, we also use the `target` tablet type to check whether the VTTablet has to send the schema tracking update or not.

## Related Issue(s)

- Couldn't find any, don't hesitate to link them though


## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
