### PR TITLE
Remove normalization of integral length types

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -308,6 +308,17 @@ func TestDiffSchemas(t *testing.T) {
 			},
 		},
 		{
+			name: "change of table column int length",
+			from: "create table t(id int primary key, i int(10))",
+			to:   "create table t(id int primary key, i int(11))",
+			diffs: []string{
+				"alter table t modify column i int(11)",
+			},
+			cdiffs: []string{
+				"ALTER TABLE `t` MODIFY COLUMN `i` int(11)",
+			},
+		},
+		{
 			name: "change of table columns, added",
 			from: "create table t(id int primary key)",
 			to:   "create table t(id int primary key, i int)",

--- a/go/vt/schemadiff/mysql.go
+++ b/go/vt/schemadiff/mysql.go
@@ -21,14 +21,6 @@ var engineCasing = map[string]string{
 	"MYISAM": "MyISAM",
 }
 
-var integralTypes = map[string]bool{
-	"tinyint":   true,
-	"smallint":  true,
-	"mediumint": true,
-	"int":       true,
-	"bigint":    true,
-}
-
 var charsetTypes = map[string]bool{
 	"char":       true,
 	"varchar":    true,

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -351,18 +351,6 @@ func (c *CreateTableEntity) normalizeColumnOptions() {
 			col.Type.Charset.Name = charset
 		}
 
-		// Remove any lengths for integral types since it is deprecated there and
-		// doesn't mean anything anymore.
-		if _, ok := integralTypes[col.Type.Type]; ok {
-			col.Type.Length = nil
-			// Remove zerofill for integral types but keep the behavior that this marks the value
-			// as unsigned
-			if col.Type.Zerofill {
-				col.Type.Zerofill = false
-				col.Type.Unsigned = true
-			}
-		}
-
 		if _, ok := charsetTypes[col.Type.Type]; ok {
 			// If the charset is explicitly configured and it mismatches, we don't normalize
 			// anything for charsets or collations and move on.

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -1195,17 +1195,17 @@ func TestNormalize(t *testing.T) {
 		{
 			name: "removes int sizes",
 			from: "create table t (id int primary key, i int(11) default null)",
-			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i` int\n)",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i` int(11)\n)",
 		},
 		{
 			name: "removes zerofill and maps to unsigned",
 			from: "create table t (id int primary key, i int zerofill default null)",
-			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i` int unsigned\n)",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i` int zerofill\n)",
 		},
 		{
 			name: "removes int sizes case insensitive",
 			from: "create table t (id int primary key, i INT(11) default null)",
-			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i` int\n)",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i` int(11)\n)",
 		},
 		{
 			name: "removes matching charset",


### PR DESCRIPTION
Integral lengths here don't really have much meaning anymore and it is deprecated and slated to be removed in MySQL. However, applications do depend on these lengths today.

One very specific example is that Ruby on Rails depends on this length for its type mapping. It maps a tinyint(1) to a boolean value, but it doesn't do that just for a tinyint. This means that even if this has no meaning in the MySQL context, it does have meaning in the application context.

Likewise, there's probably cases that depend on zerofill as well, so let's not remove that either.

## Related Issue(s)

Part of #10203

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required