### PR TITLE
OnlineDDL: adding an endtoend test to validate partial shard REVERT

### DIFF
--- a/go/test/endtoend/onlineddl/vtgate_util.go
+++ b/go/test/endtoend/onlineddl/vtgate_util.go
@@ -172,6 +172,10 @@ func CheckMigrationStatus(t *testing.T, vtParams *mysql.ConnParams, shards []clu
 
 // WaitForMigrationStatus waits for a migration to reach either provided statuses (returns immediately), or eventually time out
 func WaitForMigrationStatus(t *testing.T, vtParams *mysql.ConnParams, shards []cluster.Shard, uuid string, timeout time.Duration, expectStatuses ...schema.OnlineDDLStatus) schema.OnlineDDLStatus {
+	shardNames := map[string]bool{}
+	for _, shard := range shards {
+		shardNames[shard.Name] = true
+	}
 	query, err := sqlparser.ParseAndBind("show vitess_migrations like %a",
 		sqltypes.StringBindVariable(uuid),
 	)
@@ -187,6 +191,11 @@ func WaitForMigrationStatus(t *testing.T, vtParams *mysql.ConnParams, shards []c
 		countMatchedShards := 0
 		r := VtgateExecQuery(t, vtParams, query, "")
 		for _, row := range r.Named().Rows {
+			shardName := row["shard"].ToString()
+			if !shardNames[shardName] {
+				// irrelevant shard
+				continue
+			}
 			lastKnownStatus = row["migration_status"].ToString()
 			if row["migration_uuid"].ToString() == uuid && statusesMap[lastKnownStatus] {
 				countMatchedShards++


### PR DESCRIPTION
## Description

This PR adds a `endtoend` test to cover the following scenario:

- a multisharded keyspace
- migration starts on all shards (2 in this test)
- one shard is faster than the other. The migration is complete on one shard, but still running on another.
- migration cancelled by user (obviously only affects the running migration, transitioning it into `failed` state)
- user issues a `REVERT VITESS_MIGRATION`
- revert applied to both shards
- revert is successful on the first shard, where the original migration completed. Revert fails on the 2nd shard, because you can't revert a failed migration
- `SHOW VITESS_MIGRATIONS` returns status for both shards, and correctly indicates the successful and failed revert.

There are no logic changes in this PR. The new test validates existing behavior.

## Related Issue(s)

#6926 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
