### PR TITLE
[vtadmin] Refactor getTabletForAction

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -460,12 +460,7 @@ func (api *API) DeleteTablet(ctx context.Context, req *vtadminpb.DeleteTabletReq
 	span, ctx := trace.NewSpan(ctx, "API.DeleteTablet")
 	defer span.Finish()
 
-	tablet, err := api.getTabletForAction(ctx, span, rbac.DeleteAction, req.Alias, req.ClusterIds)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := api.getClusterForRequest(tablet.Cluster.Id)
+	tablet, c, err := api.getTabletForAction(ctx, span, rbac.DeleteAction, req.Alias, req.ClusterIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1040,7 +1035,8 @@ func (api *API) GetTablet(ctx context.Context, req *vtadminpb.GetTabletRequest) 
 	span, ctx := trace.NewSpan(ctx, "API.GetTablet")
 	defer span.Finish()
 
-	return api.getTabletForAction(ctx, span, rbac.GetAction, req.Alias, req.ClusterIds)
+	t, _, err := api.getTabletForAction(ctx, span, rbac.GetAction, req.Alias, req.ClusterIds)
+	return t, err
 }
 
 // GetTablets is part of the vtadminpb.VTAdminServer interface.
@@ -1332,12 +1328,7 @@ func (api *API) PingTablet(ctx context.Context, req *vtadminpb.PingTabletRequest
 	span, ctx := trace.NewSpan(ctx, "API.PingTablet")
 	defer span.Finish()
 
-	tablet, err := api.getTabletForAction(ctx, span, rbac.PingAction, req.Alias, req.ClusterIds)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := api.getClusterForRequest(tablet.Cluster.Id)
+	tablet, c, err := api.getTabletForAction(ctx, span, rbac.PingAction, req.Alias, req.ClusterIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1363,12 +1354,7 @@ func (api *API) RefreshState(ctx context.Context, req *vtadminpb.RefreshStateReq
 	span, ctx := trace.NewSpan(ctx, "API.RefreshState")
 	defer span.Finish()
 
-	tablet, err := api.getTabletForAction(ctx, span, rbac.PutAction, req.Alias, req.ClusterIds)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := api.getClusterForRequest(tablet.Cluster.Id)
+	tablet, c, err := api.getTabletForAction(ctx, span, rbac.PutAction, req.Alias, req.ClusterIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1434,12 +1420,7 @@ func (api *API) ReparentTablet(ctx context.Context, req *vtadminpb.ReparentTable
 	span, ctx := trace.NewSpan(ctx, "API.ReparentTablet")
 	defer span.Finish()
 
-	tablet, err := api.getTabletForAction(ctx, span, rbac.ReparentTabletAction, req.Alias, req.ClusterIds)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := api.getClusterForRequest(tablet.Cluster.Id)
+	tablet, c, err := api.getTabletForAction(ctx, span, rbac.ReparentTabletAction, req.Alias, req.ClusterIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1452,12 +1433,7 @@ func (api *API) RunHealthCheck(ctx context.Context, req *vtadminpb.RunHealthChec
 	span, ctx := trace.NewSpan(ctx, "API.RunHealthCheck")
 	defer span.Finish()
 
-	tablet, err := api.getTabletForAction(ctx, span, rbac.GetAction, req.Alias, req.ClusterIds)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := api.getClusterForRequest(tablet.Cluster.Id)
+	tablet, c, err := api.getTabletForAction(ctx, span, rbac.GetAction, req.Alias, req.ClusterIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1483,12 +1459,7 @@ func (api *API) SetReadOnly(ctx context.Context, req *vtadminpb.SetReadOnlyReque
 	span, ctx := trace.NewSpan(ctx, "API.SetReadOnly")
 	defer span.Finish()
 
-	tablet, err := api.getTabletForAction(ctx, span, rbac.ManageTabletWritabilityAction, req.Alias, req.ClusterIds)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := api.getClusterForRequest(tablet.Cluster.Id)
+	tablet, c, err := api.getTabletForAction(ctx, span, rbac.ManageTabletWritabilityAction, req.Alias, req.ClusterIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1509,12 +1480,7 @@ func (api *API) SetReadWrite(ctx context.Context, req *vtadminpb.SetReadWriteReq
 	span, ctx := trace.NewSpan(ctx, "API.SetReadWrite")
 	defer span.Finish()
 
-	tablet, err := api.getTabletForAction(ctx, span, rbac.ManageTabletWritabilityAction, req.Alias, req.ClusterIds)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := api.getClusterForRequest(tablet.Cluster.Id)
+	tablet, c, err := api.getTabletForAction(ctx, span, rbac.ManageTabletWritabilityAction, req.Alias, req.ClusterIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1535,12 +1501,7 @@ func (api *API) StartReplication(ctx context.Context, req *vtadminpb.StartReplic
 	span, ctx := trace.NewSpan(ctx, "API.StartReplication")
 	defer span.Finish()
 
-	tablet, err := api.getTabletForAction(ctx, span, rbac.ManageTabletReplicationAction, req.Alias, req.ClusterIds)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := api.getClusterForRequest(tablet.Cluster.Id)
+	tablet, c, err := api.getTabletForAction(ctx, span, rbac.ManageTabletReplicationAction, req.Alias, req.ClusterIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1561,12 +1522,7 @@ func (api *API) StopReplication(ctx context.Context, req *vtadminpb.StopReplicat
 	span, ctx := trace.NewSpan(ctx, "API.StopReplication")
 	defer span.Finish()
 
-	tablet, err := api.getTabletForAction(ctx, span, rbac.ManageTabletReplicationAction, req.Alias, req.ClusterIds)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := api.getClusterForRequest(tablet.Cluster.Id)
+	tablet, c, err := api.getTabletForAction(ctx, span, rbac.ManageTabletReplicationAction, req.Alias, req.ClusterIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1863,22 +1819,38 @@ func (api *API) getClustersForRequest(ids []string) ([]*cluster.Cluster, []strin
 	return clusters, ids
 }
 
-func (api *API) getTabletForAction(ctx context.Context, span trace.Span, action rbac.Action, alias *topodatapb.TabletAlias, clusterIds []string) (*vtadminpb.Tablet, error) {
+func (api *API) getTabletForAction(ctx context.Context, span trace.Span, action rbac.Action, alias *topodatapb.TabletAlias, clusterIDs []string) (*vtadminpb.Tablet, *cluster.Cluster, error) {
+	return api.getTabletForResourceAndAction(ctx, span, rbac.TabletResource, action, alias, clusterIDs)
+}
+
+func (api *API) getTabletForShardAction(ctx context.Context, span trace.Span, action rbac.Action, alias *topodatapb.TabletAlias, clusterIDs []string) (*vtadminpb.Tablet, *cluster.Cluster, error) {
+	return api.getTabletForResourceAndAction(ctx, span, rbac.ShardResource, action, alias, clusterIDs)
+}
+
+func (api *API) getTabletForResourceAndAction(
+	ctx context.Context,
+	span trace.Span,
+	resource rbac.Resource,
+	action rbac.Action,
+	alias *topodatapb.TabletAlias,
+	clusterIDs []string,
+) (*vtadminpb.Tablet, *cluster.Cluster, error) {
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(alias))
 	span.Annotate("tablet_cell", alias.Cell)
 	span.Annotate("tablet_uid", alias.Uid)
 
-	clusters, ids := api.getClustersForRequest(clusterIds)
+	clusters, ids := api.getClustersForRequest(clusterIDs)
 
 	var (
+		m   sync.Mutex
+		wg  sync.WaitGroup
+		rec concurrency.AllErrorRecorder
+
 		tablets []*vtadminpb.Tablet
-		wg      sync.WaitGroup
-		er      concurrency.AllErrorRecorder
-		m       sync.Mutex
 	)
 
 	for _, c := range clusters {
-		if !api.authz.IsAuthorized(ctx, c.ID, rbac.TabletResource, action) {
+		if !api.authz.IsAuthorized(ctx, c.ID, resource, action) {
 			continue
 		}
 
@@ -1891,7 +1863,7 @@ func (api *API) getTabletForAction(ctx context.Context, span trace.Span, action 
 				return topoproto.TabletAliasEqual(t.Tablet.Alias, alias)
 			}, -1)
 			if err != nil {
-				er.RecordError(fmt.Errorf("FindTablets(cluster = %s): %w", c.ID, err))
+				rec.RecordError(fmt.Errorf("FindTablets(cluster = %s): %w", c.ID, err))
 				return
 			}
 
@@ -1903,16 +1875,23 @@ func (api *API) getTabletForAction(ctx context.Context, span trace.Span, action 
 
 	wg.Wait()
 
-	if er.HasErrors() {
-		return nil, er.Error()
+	if rec.HasErrors() {
+		return nil, nil, rec.Error()
 	}
 
 	switch len(tablets) {
 	case 0:
-		return nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "%s: %s, searched clusters = %v", errors.ErrNoTablet, alias, ids)
+		return nil, nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "%s: %s, searched clusters = %v", errors.ErrNoTablet, alias, ids)
 	case 1:
-		return tablets[0], nil
+		t := tablets[0]
+		for _, c := range clusters {
+			if c.ID == t.Cluster.Id {
+				return t, c, nil
+			}
+		}
+
+		return nil, nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "impossible: found tablet from cluster %s but cannot find cluster with that id", t.Cluster.Id)
 	}
 
-	return nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "%s: %s, searched clusters = %v", errors.ErrAmbiguousTablet, alias, ids)
+	return nil, nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "%s: %s, searched clusters = %v", errors.ErrAmbiguousTablet, alias, ids)
 }


### PR DESCRIPTION
## Description

I extracted this out of another PR I'm working on because it's self-contained and useful! (the ShardResource thing is coming from that, by way of explanation). Anyway, onward!

<hr/>

This refactors `getTabletForAction` => `getTabletForResourceAndAction` to support more resource types (`rbac.ShardResource` being my immediate use case), as well as return the `cluster.Cluster` object the tablet was found in.

Returning the cluster directly minimizes the number of times we need
to hold the `clusterMap` mutex, since every request needs to

(1) get the tablet then
(2) get the cluster for that tablet

we already have the cluster, so we iterate twice and return it directly

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
