### PR TITLE
Backport R13: concatenate engine primitive

### DIFF
--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -20,62 +20,40 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/vtgate/utils"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestUnionAll(t *testing.T) {
+func start(t *testing.T) (*mysql.Conn, func()) {
 	conn, err := mysql.Connect(context.Background(), &vtParams)
 	require.NoError(t, err)
-	defer conn.Close()
 
-	// clean up before & after
-	utils.Exec(t, conn, "delete from t1")
-	utils.Exec(t, conn, "delete from t2")
-	defer utils.Exec(t, conn, "delete from t1")
-	defer utils.Exec(t, conn, "delete from t2")
+	deleteAll := func() {
+		_, _ = utils.ExecAllowError(t, conn, "set workload = oltp")
 
-	utils.Exec(t, conn, "insert into t1(id1, id2) values(1, 1), (2, 2)")
-	utils.Exec(t, conn, "insert into t2(id3, id4) values(3, 3), (4, 4)")
+		tables := []string{"t1", "t1_id2_idx", "t2", "t2_id4_idx"}
+		for _, table := range tables {
+			_, _ = utils.ExecAllowError(t, conn, "delete from "+table)
+		}
+	}
 
-	// union all between two selectuniqueequal
-	utils.AssertMatches(t, conn, "select id1 from t1 where id1 = 1 union all select id1 from t1 where id1 = 4", "[[INT64(1)]]")
+	deleteAll()
 
-	// union all between two different tables
-	utils.AssertMatches(t, conn, "(select id1,id2 from t1 order by id1) union all (select id3,id4 from t2 order by id3)",
-		"[[INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(4) INT64(4)]]")
-
-	// union all between two different tables
-	result := utils.Exec(t, conn, "(select id1,id2 from t1) union all (select id3,id4 from t2)")
-	assert.Equal(t, 4, len(result.Rows))
-
-	// union all between two different tables
-	utils.AssertMatches(t, conn, "select tbl2.id1 FROM  ((select id1 from t1 order by id1 limit 5) union all (select id1 from t1 order by id1 desc limit 5)) as tbl1 INNER JOIN t1 as tbl2  ON tbl1.id1 = tbl2.id1",
-		"[[INT64(1)] [INT64(2)] [INT64(2)] [INT64(1)]]")
-
-	utils.Exec(t, conn, "insert into t1(id1, id2) values(3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8)")
-
-	// union all between two select unique in tables
-	utils.AssertMatchesNoOrder(t, conn, "select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8) union all select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8)",
-		"[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(5)] [INT64(4)] [INT64(6)] [INT64(7)] [INT64(8)] [INT64(1)] [INT64(2)] [INT64(3)] [INT64(5)] [INT64(4)] [INT64(6)] [INT64(7)] [INT64(8)]]")
+	return conn, func() {
+		deleteAll()
+		conn.Close()
+		cluster.PanicHandler(t)
+	}
 }
 
 func TestUnionDistinct(t *testing.T) {
-	conn, err := mysql.Connect(context.Background(), &vtParams)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	// clean up before & after
-	utils.Exec(t, conn, "delete from t1")
-	utils.Exec(t, conn, "delete from t2")
-	defer func() {
-		utils.Exec(t, conn, "set workload = oltp")
-		utils.Exec(t, conn, "delete from t1")
-		utils.Exec(t, conn, "delete from t2")
-	}()
+	conn, closer := start(t)
+	defer closer()
 
 	utils.Exec(t, conn, "insert into t1(id1, id2) values (1, 1), (2, 2), (3,3), (4,4)")
 	utils.Exec(t, conn, "insert into t2(id3, id4) values (2, 3), (3, 4), (4,4), (5,5)")
@@ -102,55 +80,46 @@ func TestUnionDistinct(t *testing.T) {
 	}
 }
 
-func TestUnionAllOlap(t *testing.T) {
-	conn, err := mysql.Connect(context.Background(), &vtParams)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	// clean up before & after
-	utils.Exec(t, conn, "delete from t1")
-	utils.Exec(t, conn, "delete from t2")
-	defer func() {
-		utils.Exec(t, conn, "set workload = oltp")
-		utils.Exec(t, conn, "delete from t1")
-		utils.Exec(t, conn, "delete from t2")
-	}()
+func TestUnionAll(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
 
 	utils.Exec(t, conn, "insert into t1(id1, id2) values(1, 1), (2, 2)")
 	utils.Exec(t, conn, "insert into t2(id3, id4) values(3, 3), (4, 4)")
 
-	utils.Exec(t, conn, "set workload = olap")
+	for _, workload := range []string{"oltp", "olap"} {
+		t.Run(workload, func(t *testing.T) {
+			utils.Exec(t, conn, "set workload = "+workload)
+			// union all between two selectuniqueequal
+			utils.AssertMatches(t, conn, "select id1 from t1 where id1 = 1 union all select id1 from t1 where id1 = 4", "[[INT64(1)]]")
 
-	// union all between two selectuniqueequal
-	utils.AssertMatches(t, conn, "select id1 from t1 where id1 = 1 union all select id1 from t1 where id1 = 4", "[[INT64(1)]]")
+			// union all between two different tables
+			utils.AssertMatchesNoOrder(t, conn, "(select id1,id2 from t1 order by id1) union all (select id3,id4 from t2 order by id3)",
+				"[[INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(4) INT64(4)]]")
 
-	// union all between two different tables
-	// union all between two different tables
-	result := utils.Exec(t, conn, "(select id1,id2 from t1 order by id1) union all (select id3,id4 from t2 order by id3)")
-	assert.Equal(t, 4, len(result.Rows))
+			// union all between two different tables
+			result := utils.Exec(t, conn, "(select id1,id2 from t1) union all (select id3,id4 from t2)")
+			assert.Equal(t, 4, len(result.Rows))
 
-	// union all between two different tables
-	result = utils.Exec(t, conn, "(select id1,id2 from t1) union all (select id3,id4 from t2)")
-	assert.Equal(t, 4, len(result.Rows))
+			// union all between two different tables
+			utils.AssertMatchesNoOrder(t, conn, "select tbl2.id1 FROM  ((select id1 from t1 order by id1 limit 5) union all (select id1 from t1 order by id1 desc limit 5)) as tbl1 INNER JOIN t1 as tbl2  ON tbl1.id1 = tbl2.id1",
+				"[[INT64(1)] [INT64(2)] [INT64(2)] [INT64(1)]]")
 
-	// union all between two different tables
-	result = utils.Exec(t, conn, "select tbl2.id1 FROM ((select id1 from t1 order by id1 limit 5) union all (select id1 from t1 order by id1 desc limit 5)) as tbl1 INNER JOIN t1 as tbl2  ON tbl1.id1 = tbl2.id1")
-	assert.Equal(t, 4, len(result.Rows))
+			// union all between two select unique in tables
+			utils.AssertMatchesNoOrder(t, conn, "select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8) union all select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8)",
+				"[[INT64(1)] [INT64(2)] [INT64(1)] [INT64(2)]]")
 
-	utils.Exec(t, conn, "set workload = oltp")
-	utils.Exec(t, conn, "insert into t1(id1, id2) values(3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8)")
-	utils.Exec(t, conn, "set workload = olap")
+			// 4 tables union all
+			utils.AssertMatchesNoOrder(t, conn, "select id1, id2 from t1 where id1 = 1 union all select id3,id4 from t2 where id3 = 3 union all select id1, id2 from t1 where id1 = 2 union all select id3,id4 from t2 where id3 = 4",
+				"[[INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(4) INT64(4)]]")
+		})
 
-	// union all between two selectuniquein tables
-	utils.AssertMatchesNoOrder(t, conn, "select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8) union all select id1 from t1 where id1 in (1, 2, 3, 4, 5, 6, 7, 8)",
-		"[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(5)] [INT64(4)] [INT64(6)] [INT64(7)] [INT64(8)] [INT64(1)] [INT64(2)] [INT64(3)] [INT64(5)] [INT64(4)] [INT64(6)] [INT64(7)] [INT64(8)]]")
-
+	}
 }
 
 func TestUnion(t *testing.T) {
-	conn, err := mysql.Connect(context.Background(), &vtParams)
-	require.NoError(t, err)
-	defer conn.Close()
+	conn, closer := start(t)
+	defer closer()
 
 	utils.AssertMatches(t, conn, `SELECT 1 UNION SELECT 1 UNION SELECT 1`, `[[INT64(1)]]`)
 	utils.AssertMatches(t, conn, `SELECT 1,'a' UNION SELECT 1,'a' UNION SELECT 1,'a' ORDER BY 1`, `[[INT64(1) VARCHAR("a")]]`)

--- a/go/vt/vtgate/engine/concatenate.go
+++ b/go/vt/vtgate/engine/concatenate.go
@@ -120,23 +120,25 @@ func (c *Concatenate) getFields(res []*sqltypes.Result) ([]*querypb.Field, error
 }
 func (c *Concatenate) execSources(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) ([]*sqltypes.Result, error) {
 	results := make([]*sqltypes.Result, len(c.Sources))
-	g, restoreCtx := vcursor.ErrorGroupCancellableContext()
-	defer restoreCtx()
+	var wg sync.WaitGroup
+	var outerErr error
 	for i, source := range c.Sources {
 		currIndex, currSource := i, source
 		vars := copyBindVars(bindVars)
-		g.Go(func() error {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			result, err := vcursor.ExecutePrimitive(currSource, vars, wantfields)
 			if err != nil {
-				return err
+				outerErr = err
+				vcursor.CancelContext()
 			}
 			results[currIndex] = result
-			return nil
-		})
+		}()
 	}
-
-	if err := g.Wait(); err != nil {
-		return nil, err
+	wg.Wait()
+	if outerErr != nil {
+		return nil, outerErr
 	}
 	return results, nil
 }
@@ -144,24 +146,25 @@ func (c *Concatenate) execSources(vcursor VCursor, bindVars map[string]*querypb.
 // TryStreamExecute performs a streaming exec.
 func (c *Concatenate) TryStreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
 	var seenFields []*querypb.Field
-	var wg sync.WaitGroup
-	var cbMu, fieldsMu sync.Mutex
+	var outerErr error
 
-	g, restoreCtx := vcursor.ErrorGroupCancellableContext()
-	defer restoreCtx()
 	var fieldsSent bool
-	wg.Add(1)
+	var cbMu, fieldsMu sync.Mutex
+	var wg, fieldSendWg sync.WaitGroup
+	fieldSendWg.Add(1)
 
 	for i, source := range c.Sources {
+		wg.Add(1)
 		currIndex, currSource := i, source
 
-		g.Go(func() error {
+		go func() {
+			defer wg.Done()
 			err := vcursor.StreamExecutePrimitive(currSource, bindVars, wantfields, func(resultChunk *sqltypes.Result) error {
 				// if we have fields to compare, make sure all the fields are all the same
 				if currIndex == 0 {
 					fieldsMu.Lock()
 					if !fieldsSent {
-						defer wg.Done()
+						defer fieldSendWg.Done()
 						defer fieldsMu.Unlock()
 						seenFields = resultChunk.Fields
 						fieldsSent = true
@@ -170,7 +173,7 @@ func (c *Concatenate) TryStreamExecute(vcursor VCursor, bindVars map[string]*que
 					}
 					fieldsMu.Unlock()
 				}
-				wg.Wait()
+				fieldSendWg.Wait()
 				if resultChunk.Fields != nil {
 					err := compareFields(seenFields, resultChunk.Fields)
 					if err != nil {
@@ -192,19 +195,19 @@ func (c *Concatenate) TryStreamExecute(vcursor VCursor, bindVars map[string]*que
 				fieldsMu.Lock()
 				if !fieldsSent {
 					fieldsSent = true
-					wg.Done()
+					fieldSendWg.Done()
 				}
 				fieldsMu.Unlock()
 			}
-
-			return err
-		})
+			if err != nil {
+				outerErr = err
+				vcursor.CancelContext()
+			}
+		}()
 
 	}
-	if err := g.Wait(); err != nil {
-		return err
-	}
-	return nil
+	wg.Wait()
+	return outerErr
 }
 
 // GetFields fetches the field info.

--- a/go/vt/vtgate/engine/concatenate_test.go
+++ b/go/vt/vtgate/engine/concatenate_test.go
@@ -94,7 +94,7 @@ func TestConcatenate_NoErrors(t *testing.T) {
 		}
 
 		t.Run(tc.testName+"-Execute", func(t *testing.T) {
-			qr, err := concatenate.TryExecute(&noopVCursor{ctx: context.Background()}, nil, true)
+			qr, err := concatenate.TryExecute(newNoopVCursor(context.Background()), nil, true)
 			if tc.expectedError == "" {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedResult, qr)
@@ -105,7 +105,7 @@ func TestConcatenate_NoErrors(t *testing.T) {
 		})
 
 		t.Run(tc.testName+"-StreamExecute", func(t *testing.T) {
-			qr, err := wrapStreamExecute(concatenate, &noopVCursor{ctx: context.Background()}, nil, true)
+			qr, err := wrapStreamExecute(concatenate, newNoopVCursor(context.Background()), nil, true)
 			if tc.expectedError == "" {
 				require.NoError(t, err)
 				require.Equal(t, utils.SortString(fmt.Sprintf("%v", tc.expectedResult.Rows)), utils.SortString(fmt.Sprintf("%v", qr.Rows)))
@@ -129,10 +129,10 @@ func TestConcatenate_WithErrors(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	_, err := concatenate.TryExecute(&noopVCursor{ctx: ctx}, nil, true)
+	_, err := concatenate.TryExecute(newNoopVCursor(ctx), nil, true)
 	require.EqualError(t, err, strFailed)
 
-	_, err = wrapStreamExecute(concatenate, &noopVCursor{ctx: ctx}, nil, true)
+	_, err = wrapStreamExecute(concatenate, newNoopVCursor(ctx), nil, true)
 	require.EqualError(t, err, strFailed)
 
 	concatenate = &Concatenate{
@@ -142,8 +142,8 @@ func TestConcatenate_WithErrors(t *testing.T) {
 			&fakePrimitive{results: []*sqltypes.Result{fake, fake}},
 		},
 	}
-	_, err = concatenate.TryExecute(&noopVCursor{ctx: ctx}, nil, true)
+	_, err = concatenate.TryExecute(newNoopVCursor(ctx), nil, true)
 	require.EqualError(t, err, strFailed)
-	_, err = wrapStreamExecute(concatenate, &noopVCursor{ctx: ctx}, nil, true)
+	_, err = wrapStreamExecute(concatenate, newNoopVCursor(ctx), nil, true)
 	require.EqualError(t, err, strFailed)
 }

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -52,7 +52,18 @@ var _ SessionActions = (*noopVCursor)(nil)
 
 // noopVCursor is used to build other vcursors.
 type noopVCursor struct {
-	ctx context.Context
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func newNoopVCursor(ctx context.Context) *noopVCursor {
+	n := &noopVCursor{}
+	n.ctx, n.cancel = context.WithCancel(ctx)
+	return n
+}
+
+func (t *noopVCursor) CancelContext() {
+	t.cancel()
 }
 
 // SetContextWithValue implements VCursor interface.

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -53,6 +53,9 @@ type (
 		// Context returns the context of the current request.
 		Context() context.Context
 
+		// CancelContext cancels the highest level context and its children.
+		CancelContext()
+
 		GetKeyspace() string
 		// MaxMemoryRows returns the maxMemoryRows flag value.
 		MaxMemoryRows() int

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -88,6 +88,7 @@ type VSchemaOperator interface {
 // packages to call back into VTGate.
 type vcursorImpl struct {
 	ctx            context.Context
+	cancel         context.CancelFunc
 	safeSession    *SafeSession
 	keyspace       string
 	tabletType     topodatapb.TabletType
@@ -154,8 +155,11 @@ func newVCursorImpl(
 		connCollation = collations.Default()
 	}
 
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
 	return &vcursorImpl{
 		ctx:             ctx,
+		cancel:          cancel,
 		safeSession:     safeSession,
 		keyspace:        keyspace,
 		tabletType:      tabletType,
@@ -180,6 +184,11 @@ func (vc *vcursorImpl) ConnCollation() collations.ID {
 // Context returns the current Context.
 func (vc *vcursorImpl) Context() context.Context {
 	return vc.ctx
+}
+
+// CancelContext implements the engine.VCursor interface
+func (vc *vcursorImpl) CancelContext() {
+	vc.cancel()
 }
 
 // MaxMemoryRows returns the maxMemoryRows flag value.


### PR DESCRIPTION
## Description
Engine primitives communicate with each other all the time. When they do, the context passed between them is not passed explicitly as a method call argument as is normally done in golang code. Instead it's baked into one of the fields of the `vcursor` instance that engine primitives receive when executing.

The problem with this setup is when we concurrently call multiple children, like UNION does. The way that the context was shared between primitives means that sometimes, by mistake, one primitive would cancel another primitives context.

This manifested as intermittent errors when doing queries containing lots of UNION code.

## Related Issue(s)
This is a backport of #10257

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
