### PR TITLE
Additional schemadiff improvements for indexes

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -432,6 +432,10 @@ func (c *CreateTableEntity) normalizeKeys() {
 		}
 	}
 	for _, key := range c.CreateTable.TableSpec.Indexes {
+		// Normalize to KEY which matches MySQL behavior for the type.
+		if key.Info.Type == sqlparser.KeywordString(sqlparser.INDEX) {
+			key.Info.Type = sqlparser.KeywordString(sqlparser.KEY)
+		}
 		// now, let's look at keys that do not have names, and assign them new names
 		if name := key.Info.Name.String(); name == "" {
 			// we know there must be at least one column covered by this key

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -402,7 +402,7 @@ func (c *CreateTableEntity) normalizeColumnOptions() {
 }
 
 func isBool(colType sqlparser.ColumnType) bool {
-	return colType.Type == "tinyint" && colType.Length != nil && sqlparser.CanonicalString(colType.Length) == "1"
+	return colType.Type == sqlparser.KeywordString(sqlparser.TINYINT) && colType.Length != nil && sqlparser.CanonicalString(colType.Length) == "1"
 }
 
 func (c *CreateTableEntity) normalizePartitionOptions() {
@@ -1812,7 +1812,7 @@ func (c *CreateTableEntity) validate() error {
 					}
 				}
 				if !colFound {
-					return errors.Wrapf(ErrMissingParitionColumnInUniqueKey, "column: %v not found in key: %v", partitionColName, key.Info.Name.String())
+					return errors.Wrapf(ErrMissingPartitionColumnInUniqueKey, "column: %v not found in key: %v", partitionColName, key.Info.Name.String())
 				}
 			}
 		}

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -1313,6 +1313,11 @@ func TestNormalize(t *testing.T) {
 			to:   "CREATE TABLE `t1` (\n\t`id` int PRIMARY KEY,\n\t`i` int,\n\tCONSTRAINT `t1_ibfk_1` FOREIGN KEY (`i`) REFERENCES `parent` (`id`)\n)",
 		},
 		{
+			name: "uses KEY for indexes",
+			from: "create table t (id int primary key, i1 int, index i1_idx(i1))",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i1` int,\n\tKEY `i1_idx` (`i1`)\n)",
+		},
+		{
 			name: "drops default index type",
 			from: "create table t (id int primary key, i1 int, key i1_idx(i1) using btree)",
 			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i1` int,\n\tKEY `i1_idx` (`i1`)\n)",

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -1005,7 +1005,7 @@ func TestValidate(t *testing.T) {
 			name:      "unique key does not all partitioned columns",
 			from:      "create table t (id int, i int, primary key (id, i)) partition by hash (i) partitions 4",
 			alter:     "alter table t add unique key id_idx(id)",
-			expectErr: ErrMissingParitionColumnInUniqueKey,
+			expectErr: ErrMissingPartitionColumnInUniqueKey,
 		},
 		{
 			name:      "add multiple keys, multi columns, missing column",
@@ -1104,7 +1104,7 @@ func TestValidate(t *testing.T) {
 			expectErr: ErrInvalidColumnInGeneratedColumn,
 		},
 		{
-			name:  "add generated column referencing existent column",
+			name:  "add generated column referencing existing column",
 			from:  "create table t (id int, i int not null default 0, primary key (id))",
 			alter: "alter table t add column neg int as (0-i)",
 			to:    "create table t (id int, i int not null default 0, neg int as (0-i), primary key (id))",

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -960,16 +960,16 @@ func TestValidate(t *testing.T) {
 			to:    "create table t (id int primary key, i int, key some_key(id, i), key i_idx(i))",
 		},
 		{
-			name:  "drop column, affect keys with expression",
-			from:  "create table t (id int primary key, i int, key id_idx((IF(id, 0, 1))), key i_idx((IF(i,0,1))))",
-			alter: "alter table t drop column i",
-			to:    "create table t (id int primary key, key id_idx((IF(id, 0, 1))))",
+			name:      "drop column, affect keys with expression",
+			from:      "create table t (id int primary key, i int, key id_idx((IF(id, 0, 1))), key i_idx((IF(i,0,1))))",
+			alter:     "alter table t drop column i",
+			expectErr: ErrInvalidColumnInKey,
 		},
 		{
-			name:  "drop column, affect keys with expression and multi expressions",
-			from:  "create table t (id int primary key, i int, key id_idx((IF(id, 0, 1))), key i_idx((IF(i,0,1)), (IF(id,2,3))))",
-			alter: "alter table t drop column i",
-			to:    "create table t (id int primary key, key id_idx((IF(id, 0, 1))), key i_idx((IF(id,2,3))))",
+			name:      "drop column, affect keys with expression and multi expressions",
+			from:      "create table t (id int primary key, i int, key id_idx((IF(id, 0, 1))), key i_idx((IF(i,0,1)), (IF(id,2,3))))",
+			alter:     "alter table t drop column i",
+			expectErr: ErrInvalidColumnInKey,
 		},
 		{
 			name:  "add multiple keys, multi columns, ok",
@@ -1108,6 +1108,24 @@ func TestValidate(t *testing.T) {
 			from:  "create table t (id int, i int not null default 0, primary key (id))",
 			alter: "alter table t add column neg int as (0-i)",
 			to:    "create table t (id int, i int not null default 0, neg int as (0-i), primary key (id))",
+		},
+		{
+			name:      "drop column used by a functional index",
+			from:      "create table t (id int, d datetime, primary key (id), key m ((month(d))))",
+			alter:     "alter table t drop column d",
+			expectErr: ErrInvalidColumnInKey,
+		},
+		{
+			name:      "add generated column referencing nonexistent column",
+			from:      "create table t (id int, primary key (id))",
+			alter:     "alter table t add index m ((month(d)))",
+			expectErr: ErrInvalidColumnInKey,
+		},
+		{
+			name:  "add functional index referencing existing column",
+			from:  "create table t (id int, d datetime, primary key (id))",
+			alter: "alter table t add index m ((month(d)))",
+			to:    "create table t (id int, d datetime, primary key (id), key m ((month(d))))",
 		},
 	}
 	hints := DiffHints{}

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -53,10 +53,10 @@ var (
 	ErrApplyDuplicatePartition   = errors.New("duplicate partition")
 	ErrApplyNoPartitions         = errors.New("no partitions found")
 
-	ErrInvalidColumnInKey               = errors.New("invalid column referenced by key")
-	ErrInvalidColumnInGeneratedColumn   = errors.New("invalid column referenced by generated column")
-	ErrInvalidColumnInPartition         = errors.New("invalid column referenced by partition")
-	ErrMissingParitionColumnInUniqueKey = errors.New("unique key must include all columns in a parititioning function")
+	ErrInvalidColumnInKey                = errors.New("invalid column referenced by key")
+	ErrInvalidColumnInGeneratedColumn    = errors.New("invalid column referenced by generated column")
+	ErrInvalidColumnInPartition          = errors.New("invalid column referenced by partition")
+	ErrMissingPartitionColumnInUniqueKey = errors.New("unique key must include all columns in a partitioning function")
 )
 
 // Entity stands for a database object we can diff:


### PR DESCRIPTION
This adds additional improvements for schemadiff. Each commit is a small separate improvement. 

First there are some typo fixes and we switch to using an sqlparser constant for the tinyint instead of the string. Secondly, we add normalization of `index` to `key`, to match how MySQL behaves and to ensure that alter statements like `add index` result in a schema that is the same as `add key`.

Lastly, we add validation of column references in function indexes very similarly as in https://github.com/vitessio/vitess/pull/10328. This change also updates behavior for dropping a column when a functional index is present, since that should be blocked:

```
mysql> create table t (id int primary key, i int, key id_idx((IF(id, 0, 1))), key i_idx((IF(i,0,1))));
Query OK, 0 rows affected (0.02 sec)

mysql> alter table t drop column i;
ERROR 3837 (HY000): Column 'i' has a functional index dependency and cannot be dropped or renamed.
```

## Related Issue(s)

Part of #10203

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required