### PR TITLE
Fix failure when Unowned lookup IS NULL

### DIFF
--- a/go/test/endtoend/vtgate/lookup_test.go
+++ b/go/test/endtoend/vtgate/lookup_test.go
@@ -77,6 +77,20 @@ func TestUnownedLookupInsertChecksKeyspaceIdsAreMatching(t *testing.T) {
 	utils.Exec(t, conn, "delete from t9 WHERE parent_id = 1")
 }
 
+func TestUnownedLookupSelectNull(t *testing.T) {
+	defer cluster.PanicHandler(t)
+
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	utils.Exec(t, conn, "select * from t8 WHERE t9_id IS NULL")
+
+	// Cleanup
+	utils.Exec(t, conn, "delete from t9 WHERE parent_id = 1")
+}
+
 func TestConsistentLookup(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	ctx := context.Background()

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -1826,6 +1826,16 @@ func (ae *AliasedExpr) ColumnName() string {
 	return String(ae.Expr)
 }
 
+// AllAggregation returns true if all the expressions contain aggregation
+func (s SelectExprs) AllAggregation() bool {
+	for _, k := range s {
+		if !ContainsAggregation(k) {
+			return false
+		}
+	}
+	return true
+}
+
 func isExprLiteral(expr Expr) bool {
 	switch expr := expr.(type) {
 	case *Literal:

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -575,10 +575,7 @@ func (er *astRewriter) existsRewrite(cursor *Cursor, node *ExistsExpr) {
 			return
 		}
 
-		allAggregation := forAll(node.SelectExprs, func(s SelectExpr) bool {
-			return ContainsAggregation(s)
-		})
-		if allAggregation && len(node.GroupBy) == 0 {
+		if len(node.GroupBy) == 0 && node.SelectExprs.AllAggregation() {
 			// in these situations, we are guaranteed to always get a non-empty result,
 			// so we can replace the EXISTS with a literal true
 			cursor.Replace(BoolVal(true))
@@ -591,15 +588,6 @@ func (er *astRewriter) existsRewrite(cursor *Cursor, node *ExistsExpr) {
 		}
 		node.GroupBy = nil
 	}
-}
-
-func forAll(coll SelectExprs, test func(SelectExpr) bool) bool {
-	for _, k := range coll {
-		if !test(k) {
-			return false
-		}
-	}
-	return true
 }
 
 func bindVarExpression(name string) Expr {

--- a/go/vt/vtgate/planbuilder/gen4_planner.go
+++ b/go/vt/vtgate/planbuilder/gen4_planner.go
@@ -95,12 +95,14 @@ func gen4SelectStmtPlanner(
 	}
 
 	primitive := plan.Primitive()
-	if rb, ok := primitive.(*engine.Route); ok {
+	if rb, ok := primitive.(*engine.Route); ok && isSel {
 		// this is done because engine.Route doesn't handle the empty result well
 		// if it doesn't find a shard to send the query to.
 		// All other engine primitives can handle this, so we only need it when
 		// Route is the last (and only) instruction before the user sees a result
-		rb.NoRoutesSpecialHandling = true
+		if isOnlyDual(sel) || (len(sel.GroupBy) == 0 && sel.SelectExprs.AllAggregation()) {
+			rb.NoRoutesSpecialHandling = true
+		}
 	}
 
 	return primitive, nil


### PR DESCRIPTION
## Description
We should not use the `NoRoutesSpecialHandling` mode for vindex lookup queries.
This PR changes when we apply this special handling mode. Before, we did it for all plans that were single routes, with this change we are more conservative and only use it in one of two situations:

1. All select expressions are aggregations, and we have no grouping defined. These queries should not return empty result when nothing matches the WHERE clause, instead they need to return special empty values. Think `select count(*) from tbl`.
2. When the query is a `dual` query. If we have been able to merge a `dual` query with a subquery, we need to run the query and return something, even if no routes can be found to match the subquery predicates. This is because the `dual` table always returns a single row. Example of this would be `select exists(select 1 from tbl where foo = 43)`

## Related Issue(s)

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
