### PR TITLE
Release notes documents for `v12.0.4` on `main`

### DIFF
--- a/doc/releasenotes/12_0_4_release_notes.md
+++ b/doc/releasenotes/12_0_4_release_notes.md
@@ -1,4 +1,19 @@
 # Release of Vitess v12.0.4
+## Major Changes
+
+### Cluster management
+
+A race condition #9819 that happens when running `PlannedReparentShard` was fixed through #9859.
+
+### Query Serving
+
+Two major bugs on `UNION` are fixed via this release. The first one, #10257, solves an issue around the `UNION` executor,
+where the execution context was not handled properly in a concurrent environment. The second one, #9945, was detected by
+one of our `UNION` tests becoming flaky in the CI, it got solved by #9979, which focuses on improve the concurrency of `UNION`
+executions.
+
+A panic when ordering results in descending order on a `hash` vindex is also fixed. The original issue can be found here #10019. 
+
 ## Changelog
 
 ### Bug fixes

--- a/doc/releasenotes/12_0_4_release_notes.md
+++ b/doc/releasenotes/12_0_4_release_notes.md
@@ -1,0 +1,14 @@
+# Release of Vitess v12.0.4
+## Changelog
+
+### Bug fixes
+#### Cluster management
+* Fix the race between PromoteReplica and replication manager tick #9859
+#### Query Serving
+* Route explain tab plan to the proper Keyspace #10028
+* Diverse fixes to UNION planning and execution #10344
+
+
+The release includes 5 commits (excluding merges)
+
+Thanks to all our contributors: @GuptaManan100, @frouioui, @systay

--- a/doc/releasenotes/12_0_4_release_notes.md
+++ b/doc/releasenotes/12_0_4_release_notes.md
@@ -9,7 +9,7 @@ A race condition #9819 that happens when running `PlannedReparentShard` was fixe
 
 Two major bugs on `UNION` are fixed via this release. The first one, #10257, solves an issue around the `UNION` executor,
 where the execution context was not handled properly in a concurrent environment. The second one, #9945, was detected by
-one of our `UNION` tests becoming flaky in the CI, it got solved by #9979, which focuses on improve the concurrency of `UNION`
+one of our `UNION` tests becoming flaky in the CI, it got solved by #9979, which focuses on improving the concurrency of `UNION`
 executions.
 
 A panic when ordering results in descending order on a `hash` vindex is also fixed. The original issue can be found here #10019. 
@@ -20,8 +20,8 @@ A panic when ordering results in descending order on a `hash` vindex is also fix
 #### Cluster management
 * Fix the race between PromoteReplica and replication manager tick #9859
 #### Query Serving
-* Route explain tab plan to the proper Keyspace #10028
-* Diverse fixes to UNION planning and execution #10344
+* Route explain table plan to the proper Keyspace #10028
+* Multiple fixes to UNION planning and execution #10344
 
 
 The release includes 5 commits (excluding merges)


### PR DESCRIPTION
## Description

This PR is a follow-up of [Release `v12.0.4`](https://github.com/vitessio/vitess/releases/tag/v12.0.4). The release notes are updated.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
