### PR TITLE
[vtadmin] cluster Closer implementation + dynamic Cluster bugfix

### DIFF
--- a/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
+++ b/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
@@ -119,6 +119,9 @@ type VtctldClient struct {
 // incorrectly.
 var _ vtctldclient.VtctldClient = (*VtctldClient)(nil)
 
+// Close is part of the vtctldclient.VtctldClient interface.
+func (fake *VtctldClient) Close() error { return nil }
+
 // CreateKeyspace is part of the vtctldclient.VtctldClient interface.
 func (fake *VtctldClient) CreateKeyspace(ctx context.Context, req *vtctldatapb.CreateKeyspaceRequest, opts ...grpc.CallOption) (*vtctldatapb.CreateKeyspaceResponse, error) {
 	if fake.CreateKeyspaceShouldErr {


### PR DESCRIPTION
## Description

This PR enhances the `io.Closer` implementation of Cluster to also cleanly close any open gRPC connections (to vtgate/vtctld) and then use this when evicted old dynamic clusters, as well as address an issue in `api.clusters` management which I'll discuss in a bit!

The change is in 4 parts:
1. vtsql.Close was mutating `vtgate.conn`, which query-related methods would check and return `ErrConnClosed` if it was `nil`. This causes data races (ty `go test -race`). No one was explicitly relying on that named error anyway, so I removed it in favor of just letting queries fail if the gRPC connection gets closed out from under them (which produces a similar error string).

    a. Then, to continue supporting an `is_connected` field in the debug info, I added a `closed` flag which _is_ guarded by the mutex, and only touched in `dial` / `Close` / `Debug`, and most importantly _never_ in the hot path for queries.

2. Update `Cluster.Close` to close Vtctld + DB connections. Borrrrrrring
3. Update `EvictDynamicCluster` to `Close` a cluster before losing the reference to it. Not doing this was fine before, but after I added background resolvers and the schema cache, it would mean leaking both connections and goroutines as clusters are evicted over the lifetime of a vtadmin-api process.
4. While doing (3) I realized the way we were managing the `clusters` slice only worked if the cluster being evicted _happened_ to already be in slot 0; otherwise, we'd lose whatever cluster was in that slot for good and end up in a weird state. So I changed the logic to skip over `clusterIndex` rather than doing the `clusters[0]; clusters[1:]`.

    a. N.B. The following would also have worked:

    ```go
    api.clusters[0], api.clusters[clusterIndex] = api.clusters[clusterIndex], api.clusters[0]
    api.clusters = api.clusters[1:]
    // sort.ClustersBy(...)
    ```

## Related Issue(s)

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
