### PR TITLE
Structured schemadiff errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pires/go-proxyproto v0.6.1
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a
 	github.com/planetscale/vtprotobuf v0.3.0
 	github.com/prometheus/client_golang v1.11.0

--- a/go/vt/schemadiff/diff.go
+++ b/go/vt/schemadiff/diff.go
@@ -58,22 +58,30 @@ func DiffCreateTablesQueries(query1 string, query2 string, hints *DiffHints) (En
 // Either or both of the CreateTable statements can be nil. Based on this, the diff could be
 // nil, CreateTable, DropTable or AlterTable
 func DiffTables(create1 *sqlparser.CreateTable, create2 *sqlparser.CreateTable, hints *DiffHints) (EntityDiff, error) {
-	if create1 != nil && !create1.IsFullyParsed() {
-		return nil, &NotFullyParsedError{Entity: create1.Table.Name.String(), Statement: sqlparser.CanonicalString(create1)}
-	}
-	if create2 != nil && !create2.IsFullyParsed() {
-		return nil, &NotFullyParsedError{Entity: create2.Table.Name.String(), Statement: sqlparser.CanonicalString(create2)}
-	}
 	switch {
 	case create1 == nil && create2 == nil:
 		return nil, nil
 	case create1 == nil:
-		return NewCreateTableEntity(create2).Create(), nil
+		c2, err := NewCreateTableEntity(create2)
+		if err != nil {
+			return nil, err
+		}
+		return c2.Create(), nil
 	case create2 == nil:
-		return NewCreateTableEntity(create1).Drop(), nil
+		c1, err := NewCreateTableEntity(create1)
+		if err != nil {
+			return nil, err
+		}
+		return c1.Drop(), nil
 	default:
-		c1 := NewCreateTableEntity(create1)
-		c2 := NewCreateTableEntity(create2)
+		c1, err := NewCreateTableEntity(create1)
+		if err != nil {
+			return nil, err
+		}
+		c2, err := NewCreateTableEntity(create2)
+		if err != nil {
+			return nil, err
+		}
 		return c1.Diff(c2, hints)
 	}
 }
@@ -108,26 +116,34 @@ func DiffCreateViewsQueries(query1 string, query2 string, hints *DiffHints) (Ent
 	return DiffViews(fromCreateView, toCreateView, hints)
 }
 
-// DiffTables compares two views and returns the diff from view1 to view2
+// DiffViews compares two views and returns the diff from view1 to view2
 // Either or both of the CreateView statements can be nil. Based on this, the diff could be
 // nil, CreateView, DropView or AlterView
 func DiffViews(create1 *sqlparser.CreateView, create2 *sqlparser.CreateView, hints *DiffHints) (EntityDiff, error) {
-	if create1 != nil && !create1.IsFullyParsed() {
-		return nil, &NotFullyParsedError{Entity: create1.ViewName.Name.String(), Statement: sqlparser.CanonicalString(create1)}
-	}
-	if create2 != nil && !create2.IsFullyParsed() {
-		return nil, &NotFullyParsedError{Entity: create2.ViewName.Name.String(), Statement: sqlparser.CanonicalString(create2)}
-	}
 	switch {
 	case create1 == nil && create2 == nil:
 		return nil, nil
 	case create1 == nil:
-		return NewCreateViewEntity(create2).Create(), nil
+		c2, err := NewCreateViewEntity(create2)
+		if err != nil {
+			return nil, err
+		}
+		return c2.Create(), nil
 	case create2 == nil:
-		return NewCreateViewEntity(create1).Drop(), nil
+		c1, err := NewCreateViewEntity(create1)
+		if err != nil {
+			return nil, err
+		}
+		return c1.Drop(), nil
 	default:
-		c1 := NewCreateViewEntity(create1)
-		c2 := NewCreateViewEntity(create2)
+		c1, err := NewCreateViewEntity(create1)
+		if err != nil {
+			return nil, err
+		}
+		c2, err := NewCreateViewEntity(create2)
+		if err != nil {
+			return nil, err
+		}
 		return c1.Diff(c2, hints)
 	}
 }

--- a/go/vt/schemadiff/diff.go
+++ b/go/vt/schemadiff/diff.go
@@ -59,10 +59,10 @@ func DiffCreateTablesQueries(query1 string, query2 string, hints *DiffHints) (En
 // nil, CreateTable, DropTable or AlterTable
 func DiffTables(create1 *sqlparser.CreateTable, create2 *sqlparser.CreateTable, hints *DiffHints) (EntityDiff, error) {
 	if create1 != nil && !create1.IsFullyParsed() {
-		return nil, ErrNotFullyParsed
+		return nil, &NotFullyParsedError{Entity: create1.Table.Name.String(), Statement: sqlparser.CanonicalString(create1)}
 	}
 	if create2 != nil && !create2.IsFullyParsed() {
-		return nil, ErrNotFullyParsed
+		return nil, &NotFullyParsedError{Entity: create2.Table.Name.String(), Statement: sqlparser.CanonicalString(create2)}
 	}
 	switch {
 	case create1 == nil && create2 == nil:
@@ -113,10 +113,10 @@ func DiffCreateViewsQueries(query1 string, query2 string, hints *DiffHints) (Ent
 // nil, CreateView, DropView or AlterView
 func DiffViews(create1 *sqlparser.CreateView, create2 *sqlparser.CreateView, hints *DiffHints) (EntityDiff, error) {
 	if create1 != nil && !create1.IsFullyParsed() {
-		return nil, ErrNotFullyParsed
+		return nil, &NotFullyParsedError{Entity: create1.ViewName.Name.String(), Statement: sqlparser.CanonicalString(create1)}
 	}
 	if create2 != nil && !create2.IsFullyParsed() {
-		return nil, ErrNotFullyParsed
+		return nil, &NotFullyParsedError{Entity: create2.ViewName.Name.String(), Statement: sqlparser.CanonicalString(create2)}
 	}
 	switch {
 	case create1 == nil && create2 == nil:

--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -526,7 +526,7 @@ func TestDiffSchemas(t *testing.T) {
 			name:        "unsupported statement",
 			from:        "create table t(id int)",
 			to:          "drop table t",
-			expectError: ErrUnsupportedStatement.Error(),
+			expectError: (&UnsupportedStatementError{Statement: "DROP TABLE `t`"}).Error(),
 		},
 		{
 			name: "create, alter, drop tables and views",

--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -120,7 +120,7 @@ func TestDiffTables(t *testing.T) {
 					assert.Equal(t, ts.action, action)
 
 					// validate we can parse back the statement
-					_, err = sqlparser.Parse(diff)
+					_, err = sqlparser.ParseStrictDDL(diff)
 					assert.NoError(t, err)
 
 					eFrom, eTo := d.Entities()
@@ -139,7 +139,7 @@ func TestDiffTables(t *testing.T) {
 					assert.Equal(t, ts.action, action)
 
 					// validate we can parse back the statement
-					_, err = sqlparser.Parse(canonicalDiff)
+					_, err = sqlparser.ParseStrictDDL(canonicalDiff)
 					assert.NoError(t, err)
 				}
 				// let's also check dq, and also validate that dq's statement is identical to d's
@@ -248,7 +248,7 @@ func TestDiffViews(t *testing.T) {
 					assert.Equal(t, ts.action, action)
 
 					// validate we can parse back the statement
-					_, err = sqlparser.Parse(diff)
+					_, err = sqlparser.ParseStrictDDL(diff)
 					assert.NoError(t, err)
 
 					eFrom, eTo := d.Entities()
@@ -267,7 +267,7 @@ func TestDiffViews(t *testing.T) {
 					assert.Equal(t, ts.action, action)
 
 					// validate we can parse back the statement
-					_, err = sqlparser.Parse(canonicalDiff)
+					_, err = sqlparser.ParseStrictDDL(canonicalDiff)
 					assert.NoError(t, err)
 				}
 
@@ -577,11 +577,11 @@ func TestDiffSchemas(t *testing.T) {
 
 				// validate we can parse back the diff statements
 				for _, s := range statements {
-					_, err := sqlparser.Parse(s)
+					_, err := sqlparser.ParseStrictDDL(s)
 					assert.NoError(t, err)
 				}
 				for _, s := range cstatements {
-					_, err := sqlparser.Parse(s)
+					_, err := sqlparser.ParseStrictDDL(s)
 					assert.NoError(t, err)
 				}
 

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -1,0 +1,37 @@
+package schemadiff
+
+import "errors"
+
+var (
+	ErrEntityTypeMismatch             = errors.New("mismatched entity type")
+	ErrStrictIndexOrderingUnsupported = errors.New("strict index ordering is unsupported")
+	ErrUnsupportedTableOption         = errors.New("unsupported table option")
+	ErrUnexpectedDiffAction           = errors.New("unexpected diff action")
+	ErrUnexpectedTableSpec            = errors.New("unexpected table spec")
+	ErrNotFullyParsed                 = errors.New("unable to fully parse statement")
+	ErrExpectedCreateTable            = errors.New("expected a CREATE TABLE statement")
+	ErrExpectedCreateView             = errors.New("expected a CREATE VIEW statement")
+	ErrUnsupportedEntity              = errors.New("unsupported entity type")
+	ErrUnsupportedStatement           = errors.New("unsupported statement")
+	ErrDuplicateName                  = errors.New("duplicate name")
+	ErrViewDependencyUnresolved       = errors.New("views have unresolved/loop dependencies")
+
+	ErrUnsupportedApplyOperation = errors.New("unsupported Apply operation")
+	ErrApplyTableNotFound        = errors.New("table not found")
+	ErrApplyViewNotFound         = errors.New("view not found")
+	ErrApplyKeyNotFound          = errors.New("key not found")
+	ErrApplyColumnNotFound       = errors.New("column not found")
+	ErrApplyDuplicateTableOrView = errors.New("duplicate table or view")
+	ErrApplyDuplicateKey         = errors.New("duplicate key")
+	ErrApplyDuplicateColumn      = errors.New("duplicate column")
+	ErrApplyConstraintNotFound   = errors.New("constraint not found")
+	ErrApplyDuplicateConstraint  = errors.New("duplicate constraint")
+	ErrApplyPartitionNotFound    = errors.New("partition not found")
+	ErrApplyDuplicatePartition   = errors.New("duplicate partition")
+	ErrApplyNoPartitions         = errors.New("no partitions found")
+
+	ErrInvalidColumnInKey                = errors.New("invalid column referenced by key")
+	ErrInvalidColumnInGeneratedColumn    = errors.New("invalid column referenced by generated column")
+	ErrInvalidColumnInPartition          = errors.New("invalid column referenced by partition")
+	ErrMissingPartitionColumnInUniqueKey = errors.New("unique key must include all columns in a partitioning function")
+)

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -20,21 +20,130 @@ var (
 	ErrUnsupportedStatement           = errors.New("unsupported statement")
 	ErrDuplicateName                  = errors.New("duplicate name")
 	ErrViewDependencyUnresolved       = errors.New("views have unresolved/loop dependencies")
-
-	ErrUnsupportedApplyOperation = errors.New("unsupported Apply operation")
-	ErrApplyTableNotFound        = errors.New("table not found")
-	ErrApplyViewNotFound         = errors.New("view not found")
-	ErrApplyKeyNotFound          = errors.New("key not found")
-	ErrApplyColumnNotFound       = errors.New("column not found")
-	ErrApplyDuplicateTableOrView = errors.New("duplicate table or view")
-	ErrApplyDuplicateKey         = errors.New("duplicate key")
-	ErrApplyDuplicateColumn      = errors.New("duplicate column")
-	ErrApplyConstraintNotFound   = errors.New("constraint not found")
-	ErrApplyDuplicateConstraint  = errors.New("duplicate constraint")
-	ErrApplyPartitionNotFound    = errors.New("partition not found")
-	ErrApplyDuplicatePartition   = errors.New("duplicate partition")
-	ErrApplyNoPartitions         = errors.New("no partitions found")
 )
+
+type UnsupportedApplyOperationError struct {
+	Statement string
+}
+
+func (e *UnsupportedApplyOperationError) Error() string {
+	return fmt.Sprintf("unsupported operation: %s", e.Statement)
+}
+
+type ApplyTableNotFoundError struct {
+	Table string
+}
+
+func (e *ApplyTableNotFoundError) Error() string {
+	return fmt.Sprintf("table %s not found", sqlescape.EscapeID(e.Table))
+}
+
+type ApplyViewNotFoundError struct {
+	View string
+}
+
+func (e *ApplyViewNotFoundError) Error() string {
+	return fmt.Sprintf("view %s not found", sqlescape.EscapeID(e.View))
+}
+
+type ApplyKeyNotFoundError struct {
+	Table string
+	Key   string
+}
+
+func (e *ApplyKeyNotFoundError) Error() string {
+	return fmt.Sprintf("key %s not found in table %s", sqlescape.EscapeID(e.Key), sqlescape.EscapeID(e.Table))
+}
+
+type ApplyColumnNotFoundError struct {
+	Table  string
+	Column string
+}
+
+func (e *ApplyColumnNotFoundError) Error() string {
+	return fmt.Sprintf("column %s not found in table %s", sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.Table))
+}
+
+type ApplyColumnAfterNotFoundError struct {
+	Table       string
+	Column      string
+	AfterColumn string
+}
+
+func (e *ApplyColumnAfterNotFoundError) Error() string {
+	return fmt.Sprintf("column %s can't be after non-existing column %s in table %s",
+		sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.AfterColumn), sqlescape.EscapeID(e.Table))
+}
+
+type ApplyDuplicateEntityError struct {
+	Entity string
+}
+
+func (e *ApplyDuplicateEntityError) Error() string {
+	return fmt.Sprintf("duplicate entity %s", sqlescape.EscapeID(e.Entity))
+}
+
+type ApplyDuplicateKeyError struct {
+	Table string
+	Key   string
+}
+
+func (e *ApplyDuplicateKeyError) Error() string {
+	return fmt.Sprintf("duplicate key %s in table %s", sqlescape.EscapeID(e.Key), sqlescape.EscapeID(e.Table))
+}
+
+type ApplyDuplicateColumnError struct {
+	Table  string
+	Column string
+}
+
+func (e *ApplyDuplicateColumnError) Error() string {
+	return fmt.Sprintf("duplicate column %s in table %s", sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.Table))
+}
+
+type ApplyConstraintNotFoundError struct {
+	Table      string
+	Constraint string
+}
+
+func (e *ApplyConstraintNotFoundError) Error() string {
+	return fmt.Sprintf("constraint %s not found in table %s", sqlescape.EscapeID(e.Constraint), sqlescape.EscapeID(e.Table))
+}
+
+type ApplyDuplicateConstraintError struct {
+	Table      string
+	Constraint string
+}
+
+func (e *ApplyDuplicateConstraintError) Error() string {
+	return fmt.Sprintf("duplicate constraint %s in table %s", sqlescape.EscapeID(e.Constraint), sqlescape.EscapeID(e.Table))
+}
+
+type ApplyPartitionNotFoundError struct {
+	Table     string
+	Partition string
+}
+
+func (e *ApplyPartitionNotFoundError) Error() string {
+	return fmt.Sprintf("partition %s not found in table %s", sqlescape.EscapeID(e.Partition), sqlescape.EscapeID(e.Table))
+}
+
+type ApplyDuplicatePartitionError struct {
+	Table     string
+	Partition string
+}
+
+func (e *ApplyDuplicatePartitionError) Error() string {
+	return fmt.Sprintf("duplicate partition %s in table %s", sqlescape.EscapeID(e.Partition), sqlescape.EscapeID(e.Table))
+}
+
+type ApplyNoPartitionsError struct {
+	Table string
+}
+
+func (e *ApplyNoPartitionsError) Error() string {
+	return fmt.Sprintf("no partitions in table %s", sqlescape.EscapeID(e.Table))
+}
 
 type InvalidColumnInKeyError struct {
 	Table  string

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -10,17 +10,47 @@ import (
 var (
 	ErrEntityTypeMismatch             = errors.New("mismatched entity type")
 	ErrStrictIndexOrderingUnsupported = errors.New("strict index ordering is unsupported")
-	ErrUnsupportedTableOption         = errors.New("unsupported table option")
 	ErrUnexpectedDiffAction           = errors.New("unexpected diff action")
 	ErrUnexpectedTableSpec            = errors.New("unexpected table spec")
-	ErrNotFullyParsed                 = errors.New("unable to fully parse statement")
 	ErrExpectedCreateTable            = errors.New("expected a CREATE TABLE statement")
 	ErrExpectedCreateView             = errors.New("expected a CREATE VIEW statement")
-	ErrUnsupportedEntity              = errors.New("unsupported entity type")
-	ErrUnsupportedStatement           = errors.New("unsupported statement")
-	ErrDuplicateName                  = errors.New("duplicate name")
 	ErrViewDependencyUnresolved       = errors.New("views have unresolved/loop dependencies")
 )
+
+type UnsupportedEntityError struct {
+	Entity    string
+	Statement string
+}
+
+func (e *UnsupportedEntityError) Error() string {
+	return fmt.Sprintf("entity %s is not supported: %s", sqlescape.EscapeID(e.Entity), e.Statement)
+}
+
+type NotFullyParsedError struct {
+	Entity    string
+	Statement string
+}
+
+func (e *NotFullyParsedError) Error() string {
+	return fmt.Sprintf("entity %s is not fully parsed: %s", sqlescape.EscapeID(e.Entity), e.Statement)
+}
+
+type UnsupportedTableOptionError struct {
+	Table  string
+	Option string
+}
+
+func (e *UnsupportedTableOptionError) Error() string {
+	return fmt.Sprintf("unsupported option %s on table %s", e.Option, sqlescape.EscapeID(e.Table))
+}
+
+type UnsupportedStatementError struct {
+	Statement string
+}
+
+func (e *UnsupportedStatementError) Error() string {
+	return fmt.Sprintf("unsupported statement: %s", e.Statement)
+}
 
 type UnsupportedApplyOperationError struct {
 	Statement string

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -1,6 +1,11 @@
 package schemadiff
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+
+	"vitess.io/vitess/go/sqlescape"
+)
 
 var (
 	ErrEntityTypeMismatch             = errors.New("mismatched entity type")
@@ -29,9 +34,47 @@ var (
 	ErrApplyPartitionNotFound    = errors.New("partition not found")
 	ErrApplyDuplicatePartition   = errors.New("duplicate partition")
 	ErrApplyNoPartitions         = errors.New("no partitions found")
-
-	ErrInvalidColumnInKey                = errors.New("invalid column referenced by key")
-	ErrInvalidColumnInGeneratedColumn    = errors.New("invalid column referenced by generated column")
-	ErrInvalidColumnInPartition          = errors.New("invalid column referenced by partition")
-	ErrMissingPartitionColumnInUniqueKey = errors.New("unique key must include all columns in a partitioning function")
 )
+
+type InvalidColumnInKeyError struct {
+	Table  string
+	Column string
+	Key    string
+}
+
+func (e *InvalidColumnInKeyError) Error() string {
+	return fmt.Sprintf("invalid column %s referenced by key %s in table %s",
+		sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.Key), sqlescape.EscapeID(e.Table))
+}
+
+type InvalidColumnInGeneratedColumnError struct {
+	Table           string
+	Column          string
+	GeneratedColumn string
+}
+
+func (e *InvalidColumnInGeneratedColumnError) Error() string {
+	return fmt.Sprintf("invalid column %s referenced by generated column %s in table %s",
+		sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.GeneratedColumn), sqlescape.EscapeID(e.Table))
+}
+
+type InvalidColumnInPartitionError struct {
+	Table  string
+	Column string
+}
+
+func (e *InvalidColumnInPartitionError) Error() string {
+	return fmt.Sprintf("invalid column %s referenced by partition in table %s",
+		sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.Table))
+}
+
+type MissingPartitionColumnInUniqueKeyError struct {
+	Table     string
+	Column    string
+	UniqueKey string
+}
+
+func (e *MissingPartitionColumnInUniqueKeyError) Error() string {
+	return fmt.Sprintf("invalid column %s referenced by unique key %s in table %s",
+		sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.UniqueKey), sqlescape.EscapeID(e.Table))
+}

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -74,9 +74,17 @@ func NewSchemaFromStatements(statements []sqlparser.Statement) (*Schema, error) 
 	for _, s := range statements {
 		switch stmt := s.(type) {
 		case *sqlparser.CreateTable:
-			entities = append(entities, NewCreateTableEntity(stmt))
+			c, err := NewCreateTableEntity(stmt)
+			if err != nil {
+				return nil, err
+			}
+			entities = append(entities, c)
 		case *sqlparser.CreateView:
-			entities = append(entities, NewCreateViewEntity(stmt))
+			v, err := NewCreateViewEntity(stmt)
+			if err != nil {
+				return nil, err
+			}
+			entities = append(entities, v)
 		default:
 			return nil, &UnsupportedStatementError{Statement: sqlparser.CanonicalString(s)}
 		}

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -384,7 +384,7 @@ func (s *Schema) apply(diffs []EntityDiff) error {
 			// We expect the table to not exist
 			name := diff.createTable.Table.Name.String()
 			if _, ok := s.named[name]; ok {
-				return ErrApplyDuplicateTableOrView
+				return &ApplyDuplicateEntityError{Entity: name}
 			}
 			s.tables = append(s.tables, &CreateTableEntity{CreateTable: *diff.createTable})
 			_, s.named[name] = diff.Entities()
@@ -392,7 +392,7 @@ func (s *Schema) apply(diffs []EntityDiff) error {
 			// We expect the view to not exist
 			name := diff.createView.ViewName.Name.String()
 			if _, ok := s.named[name]; ok {
-				return ErrApplyDuplicateTableOrView
+				return &ApplyDuplicateEntityError{Entity: name}
 			}
 			s.views = append(s.views, &CreateViewEntity{CreateView: *diff.createView})
 			_, s.named[name] = diff.Entities()
@@ -408,7 +408,7 @@ func (s *Schema) apply(diffs []EntityDiff) error {
 				}
 			}
 			if !found {
-				return ErrApplyTableNotFound
+				return &ApplyTableNotFoundError{Table: diff.from.Table.Name.String()}
 			}
 		case *DropViewEntityDiff:
 			// We expect the view to exist
@@ -422,7 +422,7 @@ func (s *Schema) apply(diffs []EntityDiff) error {
 				}
 			}
 			if !found {
-				return ErrApplyViewNotFound
+				return &ApplyViewNotFoundError{View: diff.from.ViewName.Name.String()}
 			}
 		case *AlterTableEntityDiff:
 			// We expect the table to exist
@@ -444,7 +444,7 @@ func (s *Schema) apply(diffs []EntityDiff) error {
 				}
 			}
 			if !found {
-				return ErrApplyTableNotFound
+				return &ApplyTableNotFoundError{Table: diff.from.Table.Name.String()}
 			}
 		case *AlterViewEntityDiff:
 			// We expect the view to exist
@@ -466,10 +466,10 @@ func (s *Schema) apply(diffs []EntityDiff) error {
 				}
 			}
 			if !found {
-				return ErrApplyViewNotFound
+				return &ApplyViewNotFoundError{View: diff.from.ViewName.Name.String()}
 			}
 		default:
-			return ErrUnsupportedApplyOperation
+			return &UnsupportedApplyOperationError{Statement: diff.CanonicalStatementString()}
 		}
 	}
 	if err := s.normalize(); err != nil {

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -18,12 +18,11 @@ package schemadiff
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 )

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -100,7 +100,7 @@ func TestNewSchemaFromQueriesWithDuplicate(t *testing.T) {
 	)
 	_, err := NewSchemaFromQueries(queries)
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrDuplicateName)
+	assert.EqualError(t, err, (&ApplyDuplicateEntityError{Entity: "v2"}).Error())
 }
 
 func TestNewSchemaFromQueriesUnresolved(t *testing.T) {

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -1459,7 +1459,7 @@ func (c *CreateTableEntity) apply(diff *AlterTableEntityDiff) error {
 			}
 			for colName := range getKeyColumnNames(opt.IndexDefinition) {
 				if !columnExists[colName] {
-					return errors.Wrapf(ErrInvalidColumnInKey, "key: %v, column: %v", keyName, colName)
+					return &InvalidColumnInKeyError{Table: c.Name(), Column: colName, Key: keyName}
 				}
 			}
 			c.TableSpec.Indexes = append(c.TableSpec.Indexes, opt.IndexDefinition)
@@ -1737,7 +1737,7 @@ func (c *CreateTableEntity) validate() error {
 	for _, key := range c.CreateTable.TableSpec.Indexes {
 		for colName := range getKeyColumnNames(key) {
 			if !columnExists[colName] {
-				return errors.Wrapf(ErrInvalidColumnInKey, "key: %v, column: %v", key.Info.Name.String(), colName)
+				return &InvalidColumnInKeyError{Table: c.Name(), Column: colName, Key: key.Info.Name.String()}
 			}
 		}
 	}
@@ -1757,7 +1757,7 @@ func (c *CreateTableEntity) validate() error {
 			}
 			for _, referencedColName := range referencedColumns {
 				if !columnExists[referencedColName] {
-					return errors.Wrapf(ErrInvalidColumnInGeneratedColumn, "generated column: %v, referenced column: %v", col.Name.String(), referencedColName)
+					return &InvalidColumnInGeneratedColumnError{Table: c.Name(), Column: referencedColName, GeneratedColumn: col.Name.String()}
 				}
 			}
 		}
@@ -1778,7 +1778,7 @@ func (c *CreateTableEntity) validate() error {
 			}
 			for _, referencedColName := range referencedColumns {
 				if !columnExists[referencedColName] {
-					return errors.Wrapf(ErrInvalidColumnInKey, "functional index: %v, referenced column: %v", idx.Info.Name.String(), referencedColName)
+					return &InvalidColumnInKeyError{Table: c.Name(), Column: referencedColName, Key: idx.Info.Name.String()}
 				}
 			}
 		}
@@ -1811,7 +1811,7 @@ func (c *CreateTableEntity) validate() error {
 		for _, partitionColName := range partitionColNames {
 			// Validate columns exists in table:
 			if !columnExists[partitionColName] {
-				return errors.Wrapf(ErrInvalidColumnInPartition, "column: %v", partitionColName)
+				return &InvalidColumnInPartitionError{Table: c.Name(), Column: partitionColName}
 			}
 
 			// Validate all unique keys include this column:
@@ -1828,7 +1828,7 @@ func (c *CreateTableEntity) validate() error {
 					}
 				}
 				if !colFound {
-					return errors.Wrapf(ErrMissingPartitionColumnInUniqueKey, "column: %v not found in key: %v", partitionColName, key.Info.Name.String())
+					return &MissingPartitionColumnInUniqueKeyError{Table: c.Name(), Column: partitionColName, UniqueKey: key.Info.Name.String()}
 				}
 			}
 		}

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -903,7 +903,7 @@ func TestValidate(t *testing.T) {
 			name:      "duplicate existing column",
 			from:      "create table t (id int primary key, id varchar(10))",
 			alter:     "alter table t add column i int",
-			expectErr: ErrApplyDuplicateColumn,
+			expectErr: &ApplyDuplicateColumnError{Table: "t", Column: "id"},
 		},
 		{
 			name:  "add key",
@@ -1029,13 +1029,13 @@ func TestValidate(t *testing.T) {
 			name:      "add range partition, duplicate",
 			from:      "create table t (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20))",
 			alter:     "alter table t add partition (partition p2 values less than (30))",
-			expectErr: ErrApplyDuplicatePartition,
+			expectErr: &ApplyDuplicatePartitionError{Table: "t", Partition: "p2"},
 		},
 		{
 			name:      "add range partition, no partitioning",
 			from:      "create table t (id int primary key)",
 			alter:     "alter table t add partition (partition p2 values less than (30))",
-			expectErr: ErrApplyNoPartitions,
+			expectErr: &ApplyNoPartitionsError{Table: "t"},
 		},
 		{
 			name:  "drop range partition",
@@ -1047,13 +1047,13 @@ func TestValidate(t *testing.T) {
 			name:      "drop range partition, not found",
 			from:      "create table t (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20))",
 			alter:     "alter table t drop partition p7",
-			expectErr: ErrApplyPartitionNotFound,
+			expectErr: &ApplyPartitionNotFoundError{Table: "t", Partition: "p7"},
 		},
 		{
 			name:      "duplicate existing partition name",
 			from:      "create table t1 (id int primary key) partition by range (id) (partition p1 values less than (10), partition p2 values less than (20), partition p2 values less than (30))",
 			alter:     "alter table t add column i int",
-			expectErr: ErrApplyDuplicatePartition,
+			expectErr: &ApplyDuplicatePartitionError{Table: "t1", Partition: "p2"},
 		},
 		{
 			name:  "change to visible with alter column",

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -17,46 +17,7 @@ limitations under the License.
 package schemadiff
 
 import (
-	"errors"
-
 	"vitess.io/vitess/go/vt/sqlparser"
-)
-
-var (
-	ErrEntityTypeMismatch                          = errors.New("mismatched entity type")
-	ErrStrictIndexOrderingUnsupported              = errors.New("strict index ordering is unsupported")
-	ErrRangeRotattionStatementsStrategyUnsupported = errors.New("range rotation statement strategy unsupported")
-	ErrUnsupportedTableOption                      = errors.New("unsupported table option")
-	ErrUnexpectedDiffAction                        = errors.New("unexpected diff action")
-	ErrUnexpectedTableSpec                         = errors.New("unexpected table spec")
-	ErrNotFullyParsed                              = errors.New("unable to fully parse statement")
-	ErrExpectedCreateTable                         = errors.New("expected a CREATE TABLE statement")
-	ErrExpectedCreateView                          = errors.New("expected a CREATE VIEW statement")
-	ErrUnsupportedEntity                           = errors.New("unsupported entity type")
-	ErrUnsupportedStatement                        = errors.New("unsupported statement")
-	ErrDuplicateName                               = errors.New("duplicate name")
-	ErrViewDependencyUnresolved                    = errors.New("views have unresolved/loop dependencies")
-	ErrTooManyPartitionChanges                     = errors.New("too many partition changes")
-	ErrMixedPartitionAndNonPartitionChanges        = errors.New("mixed partition and non-partition changes")
-
-	ErrUnsupportedApplyOperation = errors.New("unsupported Apply operation")
-	ErrApplyTableNotFound        = errors.New("table not found")
-	ErrApplyViewNotFound         = errors.New("view not found")
-	ErrApplyKeyNotFound          = errors.New("key not found")
-	ErrApplyColumnNotFound       = errors.New("column not found")
-	ErrApplyDuplicateTableOrView = errors.New("duplicate table or view")
-	ErrApplyDuplicateKey         = errors.New("duplicate key")
-	ErrApplyDuplicateColumn      = errors.New("duplicate column")
-	ErrApplyConstraintNotFound   = errors.New("constraint not found")
-	ErrApplyDuplicateConstraint  = errors.New("duplicate constraint")
-	ErrApplyPartitionNotFound    = errors.New("partition not found")
-	ErrApplyDuplicatePartition   = errors.New("duplicate partition")
-	ErrApplyNoPartitions         = errors.New("no partitions found")
-
-	ErrInvalidColumnInKey                = errors.New("invalid column referenced by key")
-	ErrInvalidColumnInGeneratedColumn    = errors.New("invalid column referenced by generated column")
-	ErrInvalidColumnInPartition          = errors.New("invalid column referenced by partition")
-	ErrMissingPartitionColumnInUniqueKey = errors.New("unique key must include all columns in a partitioning function")
 )
 
 // Entity stands for a database object we can diff:

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -196,10 +196,13 @@ type CreateViewEntity struct {
 	sqlparser.CreateView
 }
 
-func NewCreateViewEntity(c *sqlparser.CreateView) *CreateViewEntity {
+func NewCreateViewEntity(c *sqlparser.CreateView) (*CreateViewEntity, error) {
+	if !c.IsFullyParsed() {
+		return nil, &NotFullyParsedError{Entity: c.ViewName.Name.String(), Statement: sqlparser.CanonicalString(c)}
+	}
 	entity := &CreateViewEntity{CreateView: *c}
 	entity.normalize()
-	return entity
+	return entity, nil
 }
 
 func (c *CreateViewEntity) normalize() {

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -236,10 +236,10 @@ func (c *CreateViewEntity) ViewDiff(other *CreateViewEntity, hints *DiffHints) (
 	otherStmt.ViewName = c.CreateView.ViewName
 
 	if !c.CreateView.IsFullyParsed() {
-		return nil, ErrNotFullyParsed
+		return nil, &NotFullyParsedError{Entity: c.Name(), Statement: sqlparser.CanonicalString(&c.CreateView)}
 	}
 	if !otherStmt.IsFullyParsed() {
-		return nil, ErrNotFullyParsed
+		return nil, &NotFullyParsedError{Entity: c.Name(), Statement: sqlparser.CanonicalString(&otherStmt)}
 	}
 
 	format := sqlparser.CanonicalString(&c.CreateView)

--- a/go/vt/schemadiff/view_test.go
+++ b/go/vt/schemadiff/view_test.go
@@ -158,8 +158,10 @@ func TestCreateViewDiff(t *testing.T) {
 			toCreateView, ok := toStmt.(*sqlparser.CreateView)
 			assert.True(t, ok)
 
-			c := NewCreateViewEntity(fromCreateView)
-			other := NewCreateViewEntity(toCreateView)
+			c, err := NewCreateViewEntity(fromCreateView)
+			require.NoError(t, err)
+			other, err := NewCreateViewEntity(toCreateView)
+			require.NoError(t, err)
 			alter, err := c.Diff(other, hints)
 			switch {
 			case ts.isError:
@@ -175,7 +177,7 @@ func TestCreateViewDiff(t *testing.T) {
 					diff := alter.StatementString()
 					assert.Equal(t, ts.diff, diff)
 					// validate we can parse back the statement
-					_, err := sqlparser.Parse(diff)
+					_, err := sqlparser.ParseStrictDDL(diff)
 					assert.NoError(t, err)
 
 					eFrom, eTo := alter.Entities()
@@ -197,7 +199,7 @@ func TestCreateViewDiff(t *testing.T) {
 				{
 					cdiff := alter.CanonicalStatementString()
 					assert.Equal(t, ts.cdiff, cdiff)
-					_, err := sqlparser.Parse(cdiff)
+					_, err := sqlparser.ParseStrictDDL(cdiff)
 					assert.NoError(t, err)
 				}
 			}
@@ -244,7 +246,8 @@ func TestNormalizeView(t *testing.T) {
 			fromCreateView, ok := stmt.(*sqlparser.CreateView)
 			require.True(t, ok)
 
-			from := NewCreateViewEntity(fromCreateView)
+			from, err := NewCreateViewEntity(fromCreateView)
+			require.NoError(t, err)
 			assert.Equal(t, ts.to, sqlparser.CanonicalString(from))
 		})
 	}

--- a/go/vt/wrangler/resharder.go
+++ b/go/vt/wrangler/resharder.go
@@ -18,6 +18,7 @@ package wrangler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -27,8 +28,6 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/vtctl/workflow"
-
-	"github.com/pkg/errors"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"


### PR DESCRIPTION
These changes more all the schemadiff errors we expose for consumers to be structured. With structured errors it's possible to get access to more specifics from an error, like which table, column, index etc. is affected by the issue. This allows better structured error reporting to the user.

The changes here are best reviewed commit by commit, with first some refactoring and cleanup and then changes to the new structured error types. 

It also address some small typos and an issue with how it was still possible to have schemadiff panic so it moves some checks around strict DDL parsing as well.

## Related Issue(s)

Part of #10203

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required