### PR TITLE
Add validation of check constraints

### DIFF
--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -217,3 +217,14 @@ func (e *MissingPartitionColumnInUniqueKeyError) Error() string {
 	return fmt.Sprintf("invalid column %s referenced by unique key %s in table %s",
 		sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.UniqueKey), sqlescape.EscapeID(e.Table))
 }
+
+type InvalidColumnInCheckConstraintError struct {
+	Table      string
+	Constraint string
+	Column     string
+}
+
+func (e *InvalidColumnInCheckConstraintError) Error() string {
+	return fmt.Sprintf("invalid column %s referenced by check constraint %s in table %s",
+		sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.Constraint), sqlescape.EscapeID(e.Table))
+}


### PR DESCRIPTION
This adds validation of check constraints to schemadiff. It verifies that all referenced columns are actually present in the table.

Additionally, this implements the specific logic that a check constraint which references only a single column will automatically be dropped by MySQL when that column is dropped.

Any check that references multiple columns won't be dropped automatically and a drop column for such a column will fail. This is also matched in the behavior here.

## Related Issue(s)

Part of #10203

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
