### PR TITLE
schemadiff: validate columns referenced by FOREIGN KEY

### DIFF
--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -228,3 +228,14 @@ func (e *InvalidColumnInCheckConstraintError) Error() string {
 	return fmt.Sprintf("invalid column %s referenced by check constraint %s in table %s",
 		sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.Constraint), sqlescape.EscapeID(e.Table))
 }
+
+type InvalidColumnInForeignKeyConstraintError struct {
+	Table      string
+	Constraint string
+	Column     string
+}
+
+func (e *InvalidColumnInForeignKeyConstraintError) Error() string {
+	return fmt.Sprintf("invalid column %s referenced by foreign key constraint %s in table %s",
+		sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.Constraint), sqlescape.EscapeID(e.Table))
+}


### PR DESCRIPTION

## Description

This PR validates that columns covered by a foreign key do in fact exist. Note that this validation only applies to _current_ table, and does not validate the _referenced columns_ in the parent table.

## Related Issue(s)

#10203 
#10189 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
