### PR TITLE
Sanitize log messages

### DIFF
--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/vt/vtgate/errorsanitizer"
+
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -283,7 +285,7 @@ func (sb *shardBuffer) startBufferingLocked(err error) {
 		sb.buf.config.Window,
 		sb.buf.config.Size,
 		sb.buf.config.MaxFailoverDuration,
-		err,
+		errorsanitizer.NormalizeError(err.Error()),
 	)
 }
 

--- a/go/vt/vtgate/errorsanitizer/errorSanitizer.go
+++ b/go/vt/vtgate/errorsanitizer/errorSanitizer.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errorsanitizer
+
+import (
+	"regexp"
+)
+
+const (
+	// Truncate errors longer than this
+	maxErrorLength = 256
+)
+
+var (
+	// Remove any BindVars or Sql, and anything after it
+	reTruncateError = regexp.MustCompile(`[,:] BindVars:|[,:] Sql:`)
+
+	// Keep code = foo, Duplicate entry, or syntax error, but remove anything after it
+	reTruncateErrorAfter = regexp.MustCompile(`code = \S+|Duplicate entry|syntax error at position \d+`)
+)
+
+func NormalizeError(str string) string {
+	if idx := reTruncateError.FindStringIndex(str); idx != nil {
+		str = str[0:idx[0]]
+	}
+	if idx := reTruncateErrorAfter.FindStringIndex(str); idx != nil {
+		str = str[0:idx[1]]
+	}
+	if len(str) > maxErrorLength {
+		return str[0:maxErrorLength]
+	}
+	return str
+}

--- a/go/vt/vtgate/errorsanitizer/errorSanitizer_test.go
+++ b/go/vt/vtgate/errorsanitizer/errorSanitizer_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errorsanitizer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorNormalization(t *testing.T) {
+	testCases := []struct {
+		name, input, output string
+	}{
+		{
+			"no change",
+			"nothing to normalize here",
+			"nothing to normalize here",
+		},
+		{
+			"truncates after 'code ='",
+			`target: mars.-.primary: vttablet: rpc error: code = InvalidArgument desc = Unknown system variable 'query_response_time_stats' (errno 1193) (sqlstate HY000) (CallerID: planetscale-admin): Sql: \"select @@query_response_time_stats from dual\", BindVars: {}: 2760`,
+			`target: mars.-.primary: vttablet: rpc error: code = InvalidArgument`,
+		},
+		{
+			"truncates after 'Duplicate entry'",
+			`target: keep3rv1.-.primary: vttablet: Duplicate entry '0' for key 'stats.id' (errno 1062) (sqlstate 23000) (CallerID: planetscale-admin): Sql: \"insert into stats(jobs, work_done, keepers, rewarded_kp3r, bonded_kp3r) values (:v1, :v2, :v3, :v4, :v5)\", BindVars: {v1: \"type:VARBINARY value:\\\"0\\\"\"v2: \"type:VARBINARY value:\\\"1\\\"\"v3: \"type:VARBINARY value:\\\"0\\\"\"v4: \"type:VARBINARY value:\\\"0\\\"\"v5: \"type:VARBINARY value:\\\"0\\\"\"}`,
+			`target: keep3rv1.-.primary: vttablet: Duplicate entry`,
+		},
+		{
+			"truncates after 'syntax error'",
+			`syntax error at position 42 near 'WHERE'`,
+			`syntax error at position 42`,
+		},
+		{
+			"removes Sql after colon",
+			`target: workmade.-.primary: vttablet: Data too long for column 'signupIpAddress' at row 1 (errno 1406) (sqlstate 22001) (CallerID: planetscale-admin): Sql: \"insert into User(id, firstName, lastName, password, phone, email, citizenship, dob, address_street1, address_city, address_state, address_zip, address_country, piiSsn, signupIpAddress, createdAt, updatedAt) values (:v1, :v2, :v3, :v4, :v5, :v6, :v7, :v8, :v9, :v10, :v11, :v12, :v13, :v14, :v15, :v16, :v17)\", BindVars: {v1: \"type:VARBINARY value:\\\"$guid\\\"\"v10: \"type:VARBINARY value:\\\"$city\\\"\"v11: \"type:VARBINARY value:\\\"$state\\\"\"v12: \"type:VARBINARY value:\\\"$zip\\\"\"v13: \"type:VARBINARY value:\\\"$country\\\"\"v14: \"type:VARBINARY value:\\\"$tok\\\"\"v15: \"type:VARBINARY value:\\\"$ips\\\"\"v16: \"type:VARCHAR value:\\\"$ts\\\"\"v17: \"type:VARCHAR value:\\\"$ts\\\"\"v2: \"type:VARBINARY value:\\\"$firstname\\\"\"v3: \"type:VARBINARY value:\\\"$lastname\\\"\"v4: \"type:VARBINARY value:\\\"$blob\\\"\"v5: \"type:VARBINARY value:\\\"$phone\\\"\"v6: \"type:VARBINARY value:\\\"$email\\\"\"v7: \"type:VARBINARY value:\\\"$country\\\"\"v8: \"type:VARBINARY value:\\\"$birthday\\\"\"v9: \"type:VARBINARY value:\\\"$address\\\"\"}: 1`,
+			`target: workmade.-.primary: vttablet: Data too long for column 'signupIpAddress' at row 1 (errno 1406) (sqlstate 22001) (CallerID: planetscale-admin)`,
+		},
+		{
+			"removes Sql after comma",
+			`target: workmade.-.primary: vttablet: Data too long for column 'signupIpAddress' at row 1 (errno 1406) (sqlstate 22001) (CallerID: planetscale-admin): Junk: "whatever", Sql: \"insert into User(id, firstName, lastName, password, phone, email, citizenship, dob, address_street1, address_city, address_state, address_zip, address_country, piiSsn, signupIpAddress, createdAt, updatedAt) values (:v1, :v2, :v3, :v4, :v5, :v6, :v7, :v8, :v9, :v10, :v11, :v12, :v13, :v14, :v15, :v16, :v17)\", BindVars: {v1: \"type:VARBINARY value:\\\"$guid\\\"\"v10: \"type:VARBINARY value:\\\"$city\\\"\"v11: \"type:VARBINARY value:\\\"$state\\\"\"v12: \"type:VARBINARY value:\\\"$zip\\\"\"v13: \"type:VARBINARY value:\\\"$country\\\"\"v14: \"type:VARBINARY value:\\\"$tok\\\"\"v15: \"type:VARBINARY value:\\\"$ips\\\"\"v16: \"type:VARCHAR value:\\\"$ts\\\"\"v17: \"type:VARCHAR value:\\\"$ts\\\"\"v2: \"type:VARBINARY value:\\\"$firstname\\\"\"v3: \"type:VARBINARY value:\\\"$lastname\\\"\"v4: \"type:VARBINARY value:\\\"$blob\\\"\"v5: \"type:VARBINARY value:\\\"$phone\\\"\"v6: \"type:VARBINARY value:\\\"$email\\\"\"v7: \"type:VARBINARY value:\\\"$country\\\"\"v8: \"type:VARBINARY value:\\\"$birthday\\\"\"v9: \"type:VARBINARY value:\\\"$address\\\"\"}: 1`,
+			`target: workmade.-.primary: vttablet: Data too long for column 'signupIpAddress' at row 1 (errno 1406) (sqlstate 22001) (CallerID: planetscale-admin): Junk: "whatever"`,
+		},
+		{
+			"removes BindVars after colon",
+			`target: workmade.-.primary: vttablet: Data too long for column 'signupIpAddress' at row 1 (errno 1406) (sqlstate 22001) (CallerID: planetscale-admin): BindVars: {v1: \"type:VARBINARY value:\\\"$guid\\\"\"v10: \"type:VARBINARY value:\\\"$city\\\"\"v11: \"type:VARBINARY value:\\\"$state\\\"\"v12: \"type:VARBINARY value:\\\"$zip\\\"\"v13: \"type:VARBINARY value:\\\"$country\\\"\"v14: \"type:VARBINARY value:\\\"$tok\\\"\"v15: \"type:VARBINARY value:\\\"$ips\\\"\"v16: \"type:VARCHAR value:\\\"$ts\\\"\"v17: \"type:VARCHAR value:\\\"$ts\\\"\"v2: \"type:VARBINARY value:\\\"$firstname\\\"\"v3: \"type:VARBINARY value:\\\"$lastname\\\"\"v4: \"type:VARBINARY value:\\\"$blob\\\"\"v5: \"type:VARBINARY value:\\\"$phone\\\"\"v6: \"type:VARBINARY value:\\\"$email\\\"\"v7: \"type:VARBINARY value:\\\"$country\\\"\"v8: \"type:VARBINARY value:\\\"$birthday\\\"\"v9: \"type:VARBINARY value:\\\"$address\\\"\"}: 1`,
+			`target: workmade.-.primary: vttablet: Data too long for column 'signupIpAddress' at row 1 (errno 1406) (sqlstate 22001) (CallerID: planetscale-admin)`,
+		},
+		{
+			"removes BindVars after comma",
+			`target: workmade.-.primary: vttablet: Data too long for column 'signupIpAddress' at row 1 (errno 1406) (sqlstate 22001) (CallerID: planetscale-admin): Junk: "whatever", BindVars: {v1: \"type:VARBINARY value:\\\"$guid\\\"\"v10: \"type:VARBINARY value:\\\"$city\\\"\"v11: \"type:VARBINARY value:\\\"$state\\\"\"v12: \"type:VARBINARY value:\\\"$zip\\\"\"v13: \"type:VARBINARY value:\\\"$country\\\"\"v14: \"type:VARBINARY value:\\\"$tok\\\"\"v15: \"type:VARBINARY value:\\\"$ips\\\"\"v16: \"type:VARCHAR value:\\\"$ts\\\"\"v17: \"type:VARCHAR value:\\\"$ts\\\"\"v2: \"type:VARBINARY value:\\\"$firstname\\\"\"v3: \"type:VARBINARY value:\\\"$lastname\\\"\"v4: \"type:VARBINARY value:\\\"$blob\\\"\"v5: \"type:VARBINARY value:\\\"$phone\\\"\"v6: \"type:VARBINARY value:\\\"$email\\\"\"v7: \"type:VARBINARY value:\\\"$country\\\"\"v8: \"type:VARBINARY value:\\\"$birthday\\\"\"v9: \"type:VARBINARY value:\\\"$address\\\"\"}: 1`,
+			`target: workmade.-.primary: vttablet: Data too long for column 'signupIpAddress' at row 1 (errno 1406) (sqlstate 22001) (CallerID: planetscale-admin): Junk: "whatever"`,
+		},
+		{
+			"truncates very long strings",
+			"Doloribus quo ullam labore nostrum nihil dolore nemo. Ad molestiae ab at dolores et. Iusto adipisci tempora et quia blanditiis et.  Velit alias eos quia et velit. Impedit ipsa itaque facilis repellendus. Quidem fuga sit voluptas minus. Neque amet et necessitatibus voluptatum. Voluptatem eum consequatur et dolor. Nulla deserunt quia cum ea hic architecto.  Eum et sed quo et officia nostrum eos. Nam quisquam et dolor repellat. Ea aperiam iste et.  Sint commodi non ut non occaecati velit. Architecto et fuga alias blanditiis consequatur qui ipsa magnam. Ea velit mollitia sed eligendi dolor et. Commodi et non sint optio asperiores.  Et dolores id corrupti voluptatum quasi voluptatem ipsam voluptatem. Dolorum et natus fugit. Ad id ea laudantium adipisci molestiae ratione eum quisquam.",
+			"Doloribus quo ullam labore nostrum nihil dolore nemo. Ad molestiae ab at dolores et. Iusto adipisci tempora et quia blanditiis et.  Velit alias eos quia et velit. Impedit ipsa itaque facilis repellendus. Quidem fuga sit voluptas minus. Neque amet et necess",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := NormalizeError(tc.input)
+			assert.Equal(t, tc.output, op)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>

## Description

This is an effort to sanitize and redact PII from error logging.

Important Note: I am not able to use *terseErrors (vtgate-config-terse-errors) , given its defined in vtgate package and using it in shared_buffer.go results in circular dependency. It will require some refactoring which I believe we can do in separate task.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
