### PR TITLE
Tablet throttler: serve metrics on /throttler/metrics

### DIFF
--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -134,6 +134,30 @@ API endpoint `/throttler/throttle-app` now accepts a `ratio` query argument, a f
 - `1` means "always throttle"
 - any numbr in between is allowd. For example, `0.3` means "throttle in 0.3 probability", ie on a per request and based on a dice roll, there's a `30%` change a request is denied. Overall we can expect about `30%` of requests to be denied. Example: `/throttler/throttle-app?app=vreplication&ratio=0.25`
 
+API endpoint `/throttler/metrics` exposes internal metrics, such as number of hits and errors per app per check type. Example:
+
+```shell
+$ curl -s 'http://127.0.0.1:15100/throttler/metrics' | jq . | grep throttler
+  "throttler.aggregated.mysql.self": 0.123279,
+  "throttler.aggregated.mysql.shard": 0.92436,
+  "throttler.check.8a3b5a56_dce5_11ec_a840_0a43f95f28a3:vreplication:online-ddl.mysql.shard.total": 4,
+  "throttler.check.8a3b5a56_dce5_11ec_a840_0a43f95f28a3:vreplication:online-ddl.total": 4,
+  "throttler.check.any.error": 47,
+  "throttler.check.any.mysql.self.error": 23,
+  "throttler.check.any.mysql.self.total": 307,
+  "throttler.check.any.mysql.shard.error": 24,
+  "throttler.check.any.mysql.shard.total": 311,
+  "throttler.check.any.total": 618,
+  "throttler.check.freno.error": 47,
+  "throttler.check.freno.mysql.self.error": 23,
+  "throttler.check.freno.mysql.self.total": 307,
+  "throttler.check.freno.mysql.shard.error": 24,
+  "throttler.check.freno.mysql.shard.total": 307,
+  "throttler.check.freno.total": 614,
+  "throttler.check.mysql.self.seconds_since_healthy": 0,
+  "throttler.check.mysql.shard.seconds_since_healthy": 0
+```
+
 See new SQL syntax for controlling/viewing throttling, down below.
 
 ### New Syntax

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -31,6 +31,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics/exp"
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/acl"
@@ -1727,6 +1729,10 @@ func (tsv *TabletServer) registerThrottlerThrottleAppHandler() {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(throttledApps)
+	})
+	tsv.exporter.HandleFunc("/throttler/metrics", func(w http.ResponseWriter, r *http.Request) {
+		handler := exp.ExpHandler(metrics.DefaultRegistry)
+		handler.ServeHTTP(w, r)
 	})
 }
 

--- a/go/vt/vttablet/tabletserver/throttle/check.go
+++ b/go/vt/vttablet/tabletserver/throttle/check.go
@@ -118,18 +118,18 @@ func (check *ThrottlerCheck) Check(ctx context.Context, appName string, storeTyp
 	atomic.StoreInt64(&check.throttler.lastCheckTimeNano, time.Now().UnixNano())
 
 	go func(statusCode int) {
-		metrics.GetOrRegisterCounter("check.any.total", nil).Inc(1)
-		metrics.GetOrRegisterCounter(fmt.Sprintf("check.%s.total", appName), nil).Inc(1)
+		metrics.GetOrRegisterCounter("throttler.check.any.total", nil).Inc(1)
+		metrics.GetOrRegisterCounter(fmt.Sprintf("throttler.check.%s.total", appName), nil).Inc(1)
 
-		metrics.GetOrRegisterCounter(fmt.Sprintf("check.any.%s.%s.total", storeType, storeName), nil).Inc(1)
-		metrics.GetOrRegisterCounter(fmt.Sprintf("check.%s.%s.%s.total", appName, storeType, storeName), nil).Inc(1)
+		metrics.GetOrRegisterCounter(fmt.Sprintf("throttler.check.any.%s.%s.total", storeType, storeName), nil).Inc(1)
+		metrics.GetOrRegisterCounter(fmt.Sprintf("throttler.check.%s.%s.%s.total", appName, storeType, storeName), nil).Inc(1)
 
 		if statusCode != http.StatusOK {
-			metrics.GetOrRegisterCounter("check.any.error", nil).Inc(1)
-			metrics.GetOrRegisterCounter(fmt.Sprintf("check.%s.error", appName), nil).Inc(1)
+			metrics.GetOrRegisterCounter("throttler.check.any.error", nil).Inc(1)
+			metrics.GetOrRegisterCounter(fmt.Sprintf("throttler.check.%s.error", appName), nil).Inc(1)
 
-			metrics.GetOrRegisterCounter(fmt.Sprintf("check.any.%s.%s.error", storeType, storeName), nil).Inc(1)
-			metrics.GetOrRegisterCounter(fmt.Sprintf("check.%s.%s.%s.error", appName, storeType, storeName), nil).Inc(1)
+			metrics.GetOrRegisterCounter(fmt.Sprintf("throttler.check.any.%s.%s.error", storeType, storeName), nil).Inc(1)
+			metrics.GetOrRegisterCounter(fmt.Sprintf("throttler.check.%s.%s.%s.error", appName, storeType, storeName), nil).Inc(1)
 		}
 
 		check.throttler.markRecentApp(appName, remoteAddr)
@@ -161,7 +161,7 @@ func (check *ThrottlerCheck) localCheck(ctx context.Context, metricName string) 
 		check.throttler.markMetricHealthy(metricName)
 	}
 	if timeSinceHealthy, found := check.throttler.timeSinceMetricHealthy(metricName); found {
-		metrics.GetOrRegisterGauge(fmt.Sprintf("check.%s.%s.seconds_since_healthy", storeType, storeName), nil).Update(int64(timeSinceHealthy.Seconds()))
+		metrics.GetOrRegisterGauge(fmt.Sprintf("throttler.check.%s.%s.seconds_since_healthy", storeType, storeName), nil).Update(int64(timeSinceHealthy.Seconds()))
 	}
 
 	return checkResult
@@ -173,7 +173,7 @@ func (check *ThrottlerCheck) reportAggregated(metricName string, metricResult ba
 		return
 	}
 	if value, err := metricResult.Get(); err == nil {
-		metrics.GetOrRegisterGaugeFloat64(fmt.Sprintf("aggregated.%s.%s", storeType, storeName), nil).Update(value)
+		metrics.GetOrRegisterGaugeFloat64(fmt.Sprintf("throttler.aggregated.%s.%s", storeType, storeName), nil).Update(value)
 	}
 }
 


### PR DESCRIPTION

## Description

This PR adds a `/throttler/metrics` API endpoint to `vttablet`, which exposes some Throttler metrics. For example:

```shell
$ curl -s 'http://127.0.0.1:15100/throttler/metrics' | jq . | grep throttler
  "throttler.aggregated.mysql.self": 0.123279,
  "throttler.aggregated.mysql.shard": 0.92436,
  "throttler.check.8a3b5a56_dce5_11ec_a840_0a43f95f28a3:vreplication:online-ddl.mysql.shard.total": 4,
  "throttler.check.8a3b5a56_dce5_11ec_a840_0a43f95f28a3:vreplication:online-ddl.total": 4,
  "throttler.check.any.error": 47,
  "throttler.check.any.mysql.self.error": 23,
  "throttler.check.any.mysql.self.total": 307,
  "throttler.check.any.mysql.shard.error": 24,
  "throttler.check.any.mysql.shard.total": 311,
  "throttler.check.any.total": 618,
  "throttler.check.freno.error": 47,
  "throttler.check.freno.mysql.self.error": 23,
  "throttler.check.freno.mysql.self.total": 307,
  "throttler.check.freno.mysql.shard.error": 24,
  "throttler.check.freno.mysql.shard.total": 307,
  "throttler.check.freno.total": 614,
  "throttler.check.mysql.self.seconds_since_healthy": 0,
  "throttler.check.mysql.shard.seconds_since_healthy": 0
```

The above shows us the aggregated metrics for existing metrics (first two lines), then check results for each app:

- `total` means how many checks were made by the app
- `error` are how many times the throttler returned with non-success, out of `total`
- `any` is a combination of all apps
- `mysql.shard` are checks for shard lag (the standard `/throttler/check` API call)
- `mysql.self` are checks for the state of the specific tablet's MySQL (`/throttler/check-self` API call)

## Related Issue(s)

#10045 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
