### PR TITLE
Revert the keep-data flag default value to false

### DIFF
--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -46,7 +46,7 @@ const (
 )
 
 var (
-	keepData           = flag.Bool("keep-data", true, "don't delete the per-test VTDATAROOT subfolders")
+	keepData           = flag.Bool("keep-data", false, "don't delete the per-test VTDATAROOT subfolders")
 	topoFlavor         = flag.String("topo-flavor", "etcd2", "choose a topo server from etcd2, zk2 or consul")
 	isCoverage         = flag.Bool("is-coverage", false, "whether coverage is required")
 	forceVTDATAROOT    = flag.String("force-vtdataroot", "", "force path for VTDATAROOT, which may already be populated")


### PR DESCRIPTION


## Description

We have recently noticed CI failures, complaining with `no space left on device`. In order to fix this issue, we are reverting the change we made to the default value of `-keep-data` flag. For the self-hosted runners, this flag is being provided as part of the command, so no change is required there.
After this change, GitHub-runners will not keep the data of the runs (it wasn't helping before either, since we couldn't access them), but the self-hosted runners will continue to do so.

## Related Issue(s)
- Failures like https://github.com/vitessio/vitess/runs/6580642446?check_suite_focus=true
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
