### PR TITLE
Add local devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,62 @@
+/*
+A devcontainer capable of running the local examples (in ../examples/local),
+including vtadmin-api and vtadmin-web.
+
+Note that all paths are relative to the .devcontainer directory, so ".." is the
+repository root.
+
+To run:
+1. In vscode's command palette, select "Remote-Containers: Open Folder in Container"
+2. Select the root vitess checkout from the file finder.
+3. Wait for the container to build. This can take a while.
+   ....... keep waiting
+   At this point vscode will open a new window which is the devcontainer.
+4. Accept the prompt to install go-tools (gopls, staticcheck, and so on).
+   You can also use the command palette from this window to install/update them
+   just like you would in any old vscode instance.
+5. To run the local example:
+   a. cd examples/local
+   b. ./101_initial_cluster.sh
+   c. HOST=127.0.0.1 ./scripts/vtadmin-up.sh
+
+   (N.B.) In 5c, we override HOST because port forwarding happens on 127.0.0.1,
+   *not* localhost, which vtadmin-api and vtadmin-web need to be aware of to
+   accomodate CORS.
+
+   d. Open your browser and behold vtadmin!
+*/
+
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/docker-existing-dockerfile
+{
+	"name": "Vitess - local",
+	"context": "..",
+	"dockerFile": "../docker/local/Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"golang.go",
+		"zxh404.vscode-proto3",
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Note: when postCreateCommand is a single string, it is run with a shell.
+	// When an array of strings, it is run as a single command without a shell
+	// (andrew: I _guess_ joined by &&, or equivalent?).
+	"postCreateCommand": [
+	],
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vitess"
+}

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -4,7 +4,7 @@ ARG image="vitess/bootstrap:${bootstrap_version}-common"
 FROM "${image}"
 
 RUN apt-get update
-RUN apt-get install -y sudo curl vim jq
+RUN apt-get install -y sudo curl vim jq git
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh
@@ -12,7 +12,9 @@ RUN /vt/dist/install_dependencies.sh mysql57
 
 COPY docker/local/install_local_dependencies.sh /vt/dist/install_local_dependencies.sh
 RUN /vt/dist/install_local_dependencies.sh
+
 RUN echo "source /vt/local/env.sh" >> /etc/bash.bashrc
+RUN chsh -s /bin/bash vitess
 
 # Allows some docker builds to disable CGO
 ARG CGO_ENABLED=0
@@ -36,5 +38,9 @@ COPY examples/local /vt/local
 
 RUN mkdir /vt/common
 COPY examples/common /vt/common
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+RUN ["bash", "-c", "echo 'source $HOME/.nvm/nvm.sh' >> $HOME/.bashrc"]
+RUN ["bash", "-c", "source $HOME/.nvm/nvm.sh; nvm install v16.13.0"]
 
 CMD cd /vt/local && ./101_initial_cluster.sh && /bin/bash

--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -5,12 +5,13 @@ source ./env.sh
 log_dir="${VTDATAROOT}/tmp"
 web_dir="../../web/vtadmin"
 
+host=${HOST:-localhost}
 vtadmin_api_port=14200
 vtadmin_web_port=14201
 
 vtadmin \
   --addr ":${vtadmin_api_port}" \
-  --http-origin "http://localhost:${vtadmin_web_port}" \
+  --http-origin "http://${host}:${vtadmin_web_port}" \
   --http-tablet-url-tmpl "http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
   --tracer "opentracing-jaeger" \
   --grpc-tracing \
@@ -27,7 +28,7 @@ echo ${vtadmin_api_pid} > "${log_dir}/vtadmin-api.pid"
 
 echo "\
 vtadmin-api is running!
-  - API: http://localhost:${vtadmin_api_port}
+  - API: http://${host}:${vtadmin_api_port}
   - Logs: ${log_dir}/vtadmin-api.out
   - PID: ${vtadmin_api_pid}
 "
@@ -37,7 +38,7 @@ vtadmin-api is running!
 # other Vitess components.)
 npm --prefix $web_dir --silent install
 
-REACT_APP_VTADMIN_API_ADDRESS="http://localhost:${vtadmin_api_port}" \
+REACT_APP_VTADMIN_API_ADDRESS="http://${host}:${vtadmin_api_port}" \
   REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS="true" \
   npm run --prefix $web_dir build
 
@@ -49,7 +50,7 @@ echo ${vtadmin_web_pid} > "${log_dir}/vtadmin-web.pid"
 
 echo "\
 vtadmin-web is running!
-  - Browser: http://localhost:${vtadmin_web_port}
+  - Browser: http://${host}:${vtadmin_web_port}
   - Logs: ${log_dir}/vtadmin-web.out
   - PID: ${vtadmin_web_pid}
 "


### PR DESCRIPTION
## Description

**Disclaimer!** I have never done this before, and I'm not sure about to do devcontainers in a project as large and multifaceted as vitess, but this is both useful and working (plus, if I may humbly add, pretty cool), so I wanted to at least try to contribute it back up.

This adds a devcontainer capable of running the local examples (including vtadmin!), edit Go files and run tests, and commit changes (N.B. the source tree is volume-mounted so you can also just commit outside the devcontainer, if we have Feelings about that `git` installation).

You'll have to kinda take my word for it, but here's safari on my laptop pointed at vtadmin-web running with the full local example inside a devcontainer spawned from this branch.

<img width="1139" alt="Screen Shot 2022-05-25 at 3 08 17 PM" src="https://user-images.githubusercontent.com/4276638/170551208-0908b61e-7174-43df-a9e2-19be7ab92701.png">

My understanding is that we can also use this container for code-spaces, to do in-browser/cloud Vitess development, which is potentially very cool.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
