### PR TITLE
vt/wrangler: fix deleting primary tablet if `Shard` does not exist

### DIFF
--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -46,7 +46,7 @@ func (wr *Wrangler) DeleteTablet(ctx context.Context, tabletAlias *topodatapb.Ta
 	}
 
 	wasPrimary, err := wr.isPrimaryTablet(ctx, ti)
-	if err != nil {
+	if err != nil && !topo.IsErrType(err, topo.NoNode) {
 		return err
 	}
 


### PR DESCRIPTION
This PR makes sure that `wrangler.DeleteTablet()` no longer returns an error when deleting a Primary if a `Shard` no longer exists. A `Shard` might not exist, when for example someone explicitly deletes it before calling `wrangler.DeleteTablet()`. By making this change, the `wrangler.DeleteTablet()` function is also idempotent, and safe to use in reconciling loops (such as in Kubernetes Operators).
