### PR TITLE
Refactor Durability Policy implementation and usage to read the durability policy from the keyspace

### DIFF
--- a/examples/legacy_local/101_initial_cluster.sh
+++ b/examples/legacy_local/101_initial_cluster.sh
@@ -37,6 +37,9 @@ for i in 100 101 102; do
  CELL=zone1 KEYSPACE=commerce TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
+# set the correct durability policy for the keyspace
+vtctldclient --server localhost:15999 SetKeyspaceDurabilityPolicy --durability-policy=semi_sync commerce
+
 # set one of the replicas to primary
 vtctlclient --server localhost:15999 InitShardPrimary -- --force commerce/0 zone1-100
 

--- a/examples/legacy_local/201_customer_keyspace.sh
+++ b/examples/legacy_local/201_customer_keyspace.sh
@@ -16,5 +16,5 @@
 
 # this script creates a new keyspace in preparation for vertical resharding
 
-vtctlclient --server localhost:15999 CreateKeyspace -- --served_from='primary:commerce,replica:commerce,rdonly:commerce' customer
+vtctldclient --server localhost:15999 CreateKeyspace --served-from='primary:commerce,replica:commerce,rdonly:commerce' --durability-policy=semi_sync customer
 

--- a/examples/legacy_local/scripts/vtctld-up.sh
+++ b/examples/legacy_local/scripts/vtctld-up.sh
@@ -28,7 +28,7 @@ vtctld \
  --cell $cell \
  --workflow_manager_init \
  --workflow_manager_use_election \
- --service_map 'grpc-vtctl' \
+ --service_map 'grpc-vtctl,grpc-vtctld' \
  --backup_storage_implementation file \
  --file_backup_storage_root $VTDATAROOT/backups \
  --log_dir $VTDATAROOT/tmp \

--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -39,6 +39,9 @@ for i in 100 101 102; do
 	CELL=zone1 KEYSPACE=commerce TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
+# set the correct durability policy for the keyspace
+vtctldclient --server localhost:15999 SetKeyspaceDurabilityPolicy --durability-policy=semi_sync commerce
+
 # set one of the replicas to primary
 vtctldclient PlannedReparentShard commerce/0 --new-primary zone1-100
 

--- a/examples/local/201_customer_tablets.sh
+++ b/examples/local/201_customer_tablets.sh
@@ -25,4 +25,7 @@ for i in 200 201 202; do
 	CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
+# set the correct durability policy for the keyspace
+vtctldclient --server localhost:15999 SetKeyspaceDurabilityPolicy --durability-policy=semi_sync customer
+
 vtctldclient InitShardPrimary --force customer/0 zone1-200

--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -39,7 +39,6 @@ import (
 	"vitess.io/vitess/go/vt/vtctl"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver"
 	"vitess.io/vitess/go/vt/vtctl/localvtctldclient"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 	"vitess.io/vitess/go/vt/workflow"
 	"vitess.io/vitess/go/vt/wrangler"
@@ -98,11 +97,6 @@ func main() {
 		syslogger.Info(startMsg) // nolint:errcheck
 	} else {
 		log.Warningf("cannot connect to syslog: %v", err)
-	}
-
-	if err := reparentutil.SetDurabilityPolicy("none"); err != nil {
-		log.Errorf("error in setting durability policy: %v", err)
-		exit.Return(1)
 	}
 
 	closer := trace.StartTracing("vtctl")

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -37,7 +37,6 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/worker"
 
 	// Include deprecation warnings for soon-to-be-unsupported flag invocations.
@@ -85,11 +84,6 @@ func main() {
 	if *servenv.Version {
 		servenv.AppVersion.Print()
 		os.Exit(0)
-	}
-
-	if err := reparentutil.SetDurabilityPolicy("none"); err != nil {
-		log.Errorf("error in setting durability policy: %v", err)
-		exit.Return(1)
 	}
 
 	ts := topo.Open()

--- a/go/test/endtoend/backup/transform/backup_transform_utils.go
+++ b/go/test/endtoend/backup/transform/backup_transform_utils.go
@@ -149,6 +149,11 @@ func TestMainSetup(m *testing.M, useMysqlctld bool) {
 				return 1, err
 			}
 		}
+		vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", localCluster.VtctldProcess.GrpcPort, localCluster.TmpDirectory)
+		_, err = vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
+		if err != nil {
+			return 1, err
+		}
 
 		// create database for primary and replica
 		for _, tablet := range []cluster.Vttablet{*primary, *replica1} {

--- a/go/test/endtoend/backup/vtbackup/main_test.go
+++ b/go/test/endtoend/backup/vtbackup/main_test.go
@@ -79,6 +79,11 @@ func TestMain(m *testing.M) {
 			},
 		}
 		shard := &localCluster.Keyspaces[0].Shards[0]
+		vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", localCluster.VtctldProcess.GrpcPort, localCluster.TmpDirectory)
+		_, err = vtctldClientProcess.ExecuteCommandWithOutput("CreateKeyspace", keyspaceName, "--durability-policy=semi_sync")
+		if err != nil {
+			return 1, err
+		}
 
 		// Create a new init_db.sql file that sets up passwords for all users.
 		// Then we use a db-credentials-file with the passwords.

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -187,6 +187,11 @@ func LaunchCluster(setupType int, streamMode string, stripes int) (int, error) {
 	if err := localCluster.VtctlclientProcess.InitTablet(replica1, cell, keyspaceName, hostname, shard.Name); err != nil {
 		return 1, err
 	}
+	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", localCluster.VtctldProcess.GrpcPort, localCluster.TmpDirectory)
+	_, err = vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
+	if err != nil {
+		return 1, err
+	}
 
 	for _, tablet := range []cluster.Vttablet{*primary, *replica1} {
 		if err := tablet.VttabletProcess.CreateDB(keyspaceName); err != nil {

--- a/go/test/endtoend/recovery/pitr/shardedpitr_test.go
+++ b/go/test/endtoend/recovery/pitr/shardedpitr_test.go
@@ -409,6 +409,9 @@ func initializeCluster(t *testing.T) {
 
 	err = clusterInstance.SetupCluster(keyspace, []cluster.Shard{*shard, *shard0, *shard1})
 	require.NoError(t, err)
+	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
+	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
+	require.NoError(t, err, out)
 	// Start MySql
 	var mysqlCtlProcessList []*exec.Cmd
 	for _, shard := range clusterInstance.Keyspaces[0].Shards {

--- a/go/test/endtoend/recovery/pitrtls/shardedpitr_tls_test.go
+++ b/go/test/endtoend/recovery/pitrtls/shardedpitr_tls_test.go
@@ -146,6 +146,9 @@ func initializeCluster(t *testing.T) {
 
 	err = clusterInstance.SetupCluster(keyspace, []cluster.Shard{*shard, *shard0, *shard1})
 	require.NoError(t, err)
+	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
+	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
+	require.NoError(t, err, out)
 	// Start MySql
 	var mysqlCtlProcessList []*exec.Cmd
 	for _, shard := range clusterInstance.Keyspaces[0].Shards {

--- a/go/test/endtoend/recovery/shardedrecovery/sharded_recovery_test.go
+++ b/go/test/endtoend/recovery/shardedrecovery/sharded_recovery_test.go
@@ -510,6 +510,9 @@ func initializeCluster(t *testing.T) (int, error) {
 
 	err = localCluster.SetupCluster(keyspace, []cluster.Shard{*shard, *shard0, *shard1})
 	require.NoError(t, err)
+	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", localCluster.VtctldProcess.GrpcPort, localCluster.TmpDirectory)
+	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
+	require.NoError(t, err, out)
 	// Start MySql
 	var mysqlCtlProcessList []*exec.Cmd
 	for _, shard := range localCluster.Keyspaces[0].Shards {

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -154,6 +154,11 @@ SET GLOBAL old_alter_table = ON;
 			}
 		}
 
+		vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", localCluster.VtctldProcess.GrpcPort, localCluster.TmpDirectory)
+		_, err = vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
+		if err != nil {
+			return 1, err
+		}
 		if err := localCluster.VtctlclientProcess.InitializeShard(keyspaceName, shard.Name, cell, primary.TabletUID); err != nil {
 			return 1, err
 		}

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -396,6 +396,9 @@ func TestERSForInitialization(t *testing.T) {
 	// Initialize Cluster
 	err = clusterInstance.SetupCluster(keyspace, []cluster.Shard{*shard})
 	require.NoError(t, err)
+	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
+	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspace.Name, "--durability-policy=semi_sync")
+	require.NoError(t, err, out)
 
 	//Start MySql
 	var mysqlCtlProcessList []*exec.Cmd

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -396,9 +396,11 @@ func TestERSForInitialization(t *testing.T) {
 	// Initialize Cluster
 	err = clusterInstance.SetupCluster(keyspace, []cluster.Shard{*shard})
 	require.NoError(t, err)
-	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
-	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspace.Name, "--durability-policy=semi_sync")
-	require.NoError(t, err, out)
+	if clusterInstance.VtctlMajorVersion >= 14 {
+		vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
+		out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspace.Name, "--durability-policy=semi_sync")
+		require.NoError(t, err, out)
+	}
 
 	//Start MySql
 	var mysqlCtlProcessList []*exec.Cmd

--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -30,11 +30,6 @@ import (
 // ERS TESTS
 
 func TestRecoverWithMultipleFailures(t *testing.T) {
-	// This test is skipped until we have a way to specify the durability_policies again
-	// Since we removed the usage of durability_policies
-	// ERS will not have the information required to figure out that these multiple failures
-	// can be tolerated
-	t.Skip()
 	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, true)
 	defer utils.TeardownCluster(clusterInstance)
@@ -63,11 +58,6 @@ func TestRecoverWithMultipleFailures(t *testing.T) {
 // TestERSFailFast tests that ERS will fail fast if it cannot find any tablet which can be safely promoted instead of promoting
 // a tablet and hanging while inserting a row in the reparent journal on getting semi-sync ACKs
 func TestERSFailFast(t *testing.T) {
-	// This test is skipped until we have a way to specify the durability_policies again
-	// Since we removed the usage of durability_policies
-	// ERS will not have the information required to figure out that the promoted primary
-	// wont be able to make progress
-	t.Skip()
 	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, true)
 	defer utils.TeardownCluster(clusterInstance)

--- a/go/test/endtoend/sharding/initialsharding/sharding_util.go
+++ b/go/test/endtoend/sharding/initialsharding/sharding_util.go
@@ -112,12 +112,19 @@ func ClusterWrapper(isMulti bool) (int, error) {
 		return 1, err
 	}
 	ClusterInstance.Keyspaces = append(ClusterInstance.Keyspaces, cluster.Keyspace{Name: keyspaceName1})
+	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", ClusterInstance.VtctldProcess.GrpcPort, ClusterInstance.TmpDirectory)
+	if _, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName1, "--durability-policy=semi_sync"); err != nil {
+		return 1, err
+	}
 
 	if isMulti {
 		if err := ClusterInstance.VtctlProcess.CreateKeyspace(keyspaceName2); err != nil {
 			return 1, err
 		}
 		ClusterInstance.Keyspaces = append(ClusterInstance.Keyspaces, cluster.Keyspace{Name: keyspaceName2})
+		if _, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName2, "--durability-policy=semi_sync"); err != nil {
+			return 1, err
+		}
 	}
 
 	initClusterForInitialSharding(keyspaceName1, []string{"0"}, 3, true, isMulti)

--- a/go/test/endtoend/sharding/mergesharding/mergesharding_base.go
+++ b/go/test/endtoend/sharding/mergesharding/mergesharding_base.go
@@ -161,6 +161,10 @@ func TestMergesharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	require.NoError(t, err)
 	assert.Equal(t, len(clusterInstance.Keyspaces[0].Shards), 4)
 
+	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
+	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
+	require.NoError(t, err, out)
+
 	//Start MySql
 	var mysqlCtlProcessList []*exec.Cmd
 	for _, shard := range clusterInstance.Keyspaces[0].Shards {

--- a/go/test/endtoend/sharding/resharding/resharding_base.go
+++ b/go/test/endtoend/sharding/resharding/resharding_base.go
@@ -251,6 +251,10 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	require.Nil(t, err)
 	assert.Equal(t, len(clusterInstance.Keyspaces[0].Shards), 4)
 
+	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
+	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
+	require.NoError(t, err, out)
+
 	//Start MySql
 	var mysqlCtlProcessList []*exec.Cmd
 	for _, shard := range clusterInstance.Keyspaces[0].Shards {

--- a/go/test/endtoend/vault/vault_test.go
+++ b/go/test/endtoend/vault/vault_test.go
@@ -246,6 +246,9 @@ func initializeClusterLate(t *testing.T) {
 
 	err := clusterInstance.SetupCluster(keyspace, []cluster.Shard{*shard})
 	require.NoError(t, err)
+	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
+	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
+	require.NoError(t, err, out)
 
 	// Start MySQL
 	var mysqlCtlProcessList []*exec.Cmd

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -802,6 +802,10 @@ func SetupNewClusterSemiSync(t *testing.T) *VtOrcClusterInfo {
 	}
 
 	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
+
+	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, fmt.Sprintf("--durability-policy=semi_sync"))
+	require.NoError(t, err, out)
+
 	clusterInfo := &VtOrcClusterInfo{
 		ClusterInstance:     clusterInstance,
 		Ts:                  nil,

--- a/go/vt/orchestrator/inst/analysis.go
+++ b/go/vt/orchestrator/inst/analysis.go
@@ -122,6 +122,7 @@ type ReplicationAnalysis struct {
 	ClusterDetails                            ClusterInfo
 	AnalyzedInstanceDataCenter                string
 	AnalyzedInstanceRegion                    string
+	AnalyzedKeyspace                          string
 	AnalyzedInstancePhysicalEnvironment       string
 	AnalyzedInstanceBinlogCoordinates         BinlogCoordinates
 	IsPrimary                                 bool

--- a/go/vt/orchestrator/inst/analysis_dao.go
+++ b/go/vt/orchestrator/inst/analysis_dao.go
@@ -504,11 +504,11 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			a.Analysis = PrimaryIsReadOnly
 			a.Description = "Primary is read-only"
 			//
-		} else if a.IsClusterPrimary && reparentutil.SemiSyncAckers(tablet) != 0 && !a.SemiSyncPrimaryEnabled {
+		} else if a.IsClusterPrimary && reparentutil.SemiSyncAckers(nil, tablet) != 0 && !a.SemiSyncPrimaryEnabled {
 			a.Analysis = PrimarySemiSyncMustBeSet
 			a.Description = "Primary semi-sync must be set"
 			//
-		} else if a.IsClusterPrimary && reparentutil.SemiSyncAckers(tablet) == 0 && a.SemiSyncPrimaryEnabled {
+		} else if a.IsClusterPrimary && reparentutil.SemiSyncAckers(nil, tablet) == 0 && a.SemiSyncPrimaryEnabled {
 			a.Analysis = PrimarySemiSyncMustNotBeSet
 			a.Description = "Primary semi-sync must not be set"
 			//
@@ -532,11 +532,11 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			a.Analysis = ReplicationStopped
 			a.Description = "Replication is stopped"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && reparentutil.IsReplicaSemiSync(primaryTablet, tablet) && !a.SemiSyncReplicaEnabled {
+		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && reparentutil.IsReplicaSemiSync(nil, primaryTablet, tablet) && !a.SemiSyncReplicaEnabled {
 			a.Analysis = ReplicaSemiSyncMustBeSet
 			a.Description = "Replica semi-sync must be set"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && !reparentutil.IsReplicaSemiSync(primaryTablet, tablet) && a.SemiSyncReplicaEnabled {
+		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && !reparentutil.IsReplicaSemiSync(nil, primaryTablet, tablet) && a.SemiSyncReplicaEnabled {
 			a.Analysis = ReplicaSemiSyncMustNotBeSet
 			a.Description = "Replica semi-sync must not be set"
 			//

--- a/go/vt/orchestrator/inst/analysis_dao.go
+++ b/go/vt/orchestrator/inst/analysis_dao.go
@@ -29,7 +29,6 @@ import (
 	"vitess.io/vitess/go/vt/orchestrator/util"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 
 	"github.com/patrickmn/go-cache"
 	"github.com/rcrowley/go-metrics"
@@ -385,6 +384,7 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		}
 
 		a.TabletType = tablet.Type
+		a.AnalyzedKeyspace = tablet.Keyspace
 		a.PrimaryTimeStamp = m.GetTime("primary_timestamp")
 
 		a.IsPrimary = m.GetBool("is_primary")
@@ -504,11 +504,11 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			a.Analysis = PrimaryIsReadOnly
 			a.Description = "Primary is read-only"
 			//
-		} else if a.IsClusterPrimary && reparentutil.SemiSyncAckers(nil, tablet) != 0 && !a.SemiSyncPrimaryEnabled {
+		} else if a.IsClusterPrimary && SemiSyncAckers(tablet) != 0 && !a.SemiSyncPrimaryEnabled {
 			a.Analysis = PrimarySemiSyncMustBeSet
 			a.Description = "Primary semi-sync must be set"
 			//
-		} else if a.IsClusterPrimary && reparentutil.SemiSyncAckers(nil, tablet) == 0 && a.SemiSyncPrimaryEnabled {
+		} else if a.IsClusterPrimary && SemiSyncAckers(tablet) == 0 && a.SemiSyncPrimaryEnabled {
 			a.Analysis = PrimarySemiSyncMustNotBeSet
 			a.Description = "Primary semi-sync must not be set"
 			//
@@ -532,11 +532,11 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			a.Analysis = ReplicationStopped
 			a.Description = "Replication is stopped"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && reparentutil.IsReplicaSemiSync(nil, primaryTablet, tablet) && !a.SemiSyncReplicaEnabled {
+		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && IsReplicaSemiSync(primaryTablet, tablet) && !a.SemiSyncReplicaEnabled {
 			a.Analysis = ReplicaSemiSyncMustBeSet
 			a.Description = "Replica semi-sync must be set"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && !reparentutil.IsReplicaSemiSync(nil, primaryTablet, tablet) && a.SemiSyncReplicaEnabled {
+		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && !IsReplicaSemiSync(primaryTablet, tablet) && a.SemiSyncReplicaEnabled {
 			a.Analysis = ReplicaSemiSyncMustNotBeSet
 			a.Description = "Replica semi-sync must not be set"
 			//

--- a/go/vt/orchestrator/inst/analysis_dao_test.go
+++ b/go/vt/orchestrator/inst/analysis_dao_test.go
@@ -438,6 +438,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 			if tt.durability == "" {
 				tt.durability = "none"
 			}
+			SetDurabilityPolicy(tt.durability)
 
 			var rowMaps []sqlutils.RowMap
 			for _, analysis := range tt.info {

--- a/go/vt/orchestrator/inst/analysis_dao_test.go
+++ b/go/vt/orchestrator/inst/analysis_dao_test.go
@@ -25,7 +25,6 @@ import (
 	"vitess.io/vitess/go/vt/orchestrator/external/golib/sqlutils"
 	"vitess.io/vitess/go/vt/orchestrator/test"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 )
 
 func TestGetReplicationAnalysis(t *testing.T) {
@@ -439,8 +438,6 @@ func TestGetReplicationAnalysis(t *testing.T) {
 			if tt.durability == "" {
 				tt.durability = "none"
 			}
-			err := reparentutil.SetDurabilityPolicy(tt.durability)
-			require.NoError(t, err)
 
 			var rowMaps []sqlutils.RowMap
 			for _, analysis := range tt.info {

--- a/go/vt/orchestrator/inst/durability.go
+++ b/go/vt/orchestrator/inst/durability.go
@@ -17,28 +17,65 @@ limitations under the License.
 package inst
 
 import (
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/promotionrule"
 )
 
+var (
+	// durabilityPolicy is the durability policy in use for VTOrc
+	durabilityPolicy reparentutil.Durabler
+)
+
+// SetDurabilityPolicy is used to set the durability policy for VTOrc once during startup
+func SetDurabilityPolicy(name string) (err error) {
+	durabilityPolicy, err = reparentutil.GetDurabilityPolicy(name)
+	return err
+}
+
 // IsReplicaSemiSync returns the replica semi-sync setting for the instance.
-func IsReplicaSemiSync(primaryKey, replicaKey InstanceKey) bool {
-	primary, err := ReadTablet(primaryKey)
+func IsReplicaSemiSync[V InstanceKey | *topodatapb.Tablet](primaryInstance V, replicaInstance V) bool {
+	primary, err := getTablet(primaryInstance)
 	if err != nil {
 		return false
 	}
-	replica, err := ReadTablet(replicaKey)
+	replica, err := getTablet(replicaInstance)
 	if err != nil {
 		return false
 	}
-	return reparentutil.IsReplicaSemiSync(nil, primary, replica)
+	return reparentutil.IsReplicaSemiSync(durabilityPolicy, primary, replica)
 }
 
 // SemiSyncAckers returns the primary semi-sync setting for the instance.
 // 0 means none. Non-zero specifies the number of required ackers.
-func SemiSyncAckers(instanceKey InstanceKey) int {
-	primary, err := ReadTablet(instanceKey)
+func SemiSyncAckers[V InstanceKey | *topodatapb.Tablet](instance V) int {
+	primary, err := getTablet(instance)
 	if err != nil {
 		return 0
 	}
-	return reparentutil.SemiSyncAckers(nil, primary)
+	return reparentutil.SemiSyncAckers(durabilityPolicy, primary)
+}
+
+// PromotionRule returns the promotion rule for the instance.
+func PromotionRule[V InstanceKey | *topodatapb.Tablet](instance V) promotionrule.CandidatePromotionRule {
+	tablet, err := getTablet(instance)
+	if err != nil {
+		return promotionrule.MustNot
+	}
+	return reparentutil.PromotionRule(durabilityPolicy, tablet)
+}
+
+func getTablet[V InstanceKey | *topodatapb.Tablet](instance V) (*topodatapb.Tablet, error) {
+	var instanceTablet *topodatapb.Tablet
+	var err error
+	switch node := any(instance).(type) {
+	case InstanceKey:
+		instanceTablet, err = ReadTablet(node)
+		if err != nil {
+			return nil, err
+		}
+	case *topodatapb.Tablet:
+		instanceTablet = node
+	}
+	return instanceTablet, nil
 }

--- a/go/vt/orchestrator/inst/durability.go
+++ b/go/vt/orchestrator/inst/durability.go
@@ -30,7 +30,7 @@ func IsReplicaSemiSync(primaryKey, replicaKey InstanceKey) bool {
 	if err != nil {
 		return false
 	}
-	return reparentutil.IsReplicaSemiSync(primary, replica)
+	return reparentutil.IsReplicaSemiSync(nil, primary, replica)
 }
 
 // SemiSyncAckers returns the primary semi-sync setting for the instance.
@@ -40,5 +40,5 @@ func SemiSyncAckers(instanceKey InstanceKey) int {
 	if err != nil {
 		return 0
 	}
-	return reparentutil.SemiSyncAckers(primary)
+	return reparentutil.SemiSyncAckers(nil, primary)
 }

--- a/go/vt/orchestrator/inst/instance_dao.go
+++ b/go/vt/orchestrator/inst/instance_dao.go
@@ -50,7 +50,6 @@ import (
 	"vitess.io/vitess/go/vt/orchestrator/kv"
 	"vitess.io/vitess/go/vt/orchestrator/metrics/query"
 	"vitess.io/vitess/go/vt/orchestrator/util"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil/promotionrule"
 )
 
@@ -686,7 +685,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 	// We need to update candidate_database_instance.
 	// We register the rule even if it hasn't changed,
 	// to bump the last_suggested time.
-	instance.PromotionRule = reparentutil.PromotionRule(nil, tablet)
+	instance.PromotionRule = PromotionRule(tablet)
 	err = RegisterCandidateInstance(NewCandidateDatabaseInstance(instanceKey, instance.PromotionRule).WithCurrentTime())
 	logReadTopologyInstanceError(instanceKey, "RegisterCandidateInstance", err)
 

--- a/go/vt/orchestrator/inst/instance_dao.go
+++ b/go/vt/orchestrator/inst/instance_dao.go
@@ -686,7 +686,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 	// We need to update candidate_database_instance.
 	// We register the rule even if it hasn't changed,
 	// to bump the last_suggested time.
-	instance.PromotionRule = reparentutil.PromotionRule(tablet)
+	instance.PromotionRule = reparentutil.PromotionRule(nil, tablet)
 	err = RegisterCandidateInstance(NewCandidateDatabaseInstance(instanceKey, instance.PromotionRule).WithCurrentTime())
 	logReadTopologyInstanceError(instanceKey, "RegisterCandidateInstance", err)
 

--- a/go/vt/orchestrator/logic/orchestrator.go
+++ b/go/vt/orchestrator/logic/orchestrator.go
@@ -413,6 +413,11 @@ func ContinuousDiscovery() {
 	go ometrics.InitMetrics()
 	go acceptSignals()
 	go kv.InitKVStores()
+	err := inst.SetDurabilityPolicy(config.Config.Durability)
+	if err != nil {
+		log.Infof("Error setting the durability policy: %v", err)
+		os.Exit(1)
+	}
 
 	if *config.RuntimeCLIFlags.GrabElection {
 		process.GrabElection()

--- a/go/vt/orchestrator/logic/orchestrator.go
+++ b/go/vt/orchestrator/logic/orchestrator.go
@@ -37,7 +37,6 @@ import (
 	ometrics "vitess.io/vitess/go/vt/orchestrator/metrics"
 	"vitess.io/vitess/go/vt/orchestrator/process"
 	"vitess.io/vitess/go/vt/orchestrator/util"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 )
 
 const (
@@ -414,7 +413,6 @@ func ContinuousDiscovery() {
 	go ometrics.InitMetrics()
 	go acceptSignals()
 	go kv.InitKVStores()
-	reparentutil.SetDurabilityPolicy(config.Config.Durability)
 
 	if *config.RuntimeCLIFlags.GrabElection {
 		process.GrabElection()

--- a/go/vt/orchestrator/logic/topology_recovery.go
+++ b/go/vt/orchestrator/logic/topology_recovery.go
@@ -1370,11 +1370,20 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 	// changes, we should be checking that this failure is indeed needed to be fixed. We do this after locking the shard to be sure
 	// that the data that we use now is up-to-date.
 	if isActionableRecovery {
+		ksInfo, err := ts.GetKeyspace(ctx, analysisEntry.AnalyzedKeyspace)
+		if err != nil {
+			return false, nil, err
+		}
+		if ksInfo.GetDurabilityPolicy() != "" && ksInfo.GetDurabilityPolicy() != config.Config.Durability {
+			log.Errorf("executeCheckAndRecoverFunction: Analysis: %+v, InstanceKey: %+v: Keyspace has a different durability policy configured than this vtorc instance: %v",
+				analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey, analysisEntry.AnalyzedKeyspace)
+		}
+
 		// TODO (@GuptaManan100): Refresh only the shard tablet information instead of all the tablets
 		RefreshTablets(true /* forceRefresh */)
 		alreadyFixed, err := checkIfAlreadyFixed(analysisEntry)
 		if err != nil {
-			log.Errorf("CheckAndRecover: Analysis: %+v, InstanceKey: %+v, candidateInstanceKey: %+v, "+"skipProcesses: %v: error while trying to find if the problem is already fixed: %v",
+			log.Errorf("executeCheckAndRecoverFunction: Analysis: %+v, InstanceKey: %+v, candidateInstanceKey: %+v, "+"skipProcesses: %v: error while trying to find if the problem is already fixed: %v",
 				analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey, candidateInstanceKey, skipProcesses, err)
 			return false, nil, err
 		}

--- a/go/vt/orchestrator/logic/topology_recovery.go
+++ b/go/vt/orchestrator/logic/topology_recovery.go
@@ -1375,8 +1375,9 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 			return false, nil, err
 		}
 		if ksInfo.GetDurabilityPolicy() != "" && ksInfo.GetDurabilityPolicy() != config.Config.Durability {
-			log.Errorf("executeCheckAndRecoverFunction: Analysis: %+v, InstanceKey: %+v: Keyspace has a different durability policy configured than this vtorc instance: %v",
+			err = log.Errorf("executeCheckAndRecoverFunction: Analysis: %+v, InstanceKey: %+v: Keyspace has a different durability policy configured than this vtorc instance: %v",
 				analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey, analysisEntry.AnalyzedKeyspace)
+			return false, nil, err
 		}
 
 		// TODO (@GuptaManan100): Refresh only the shard tablet information instead of all the tablets

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -194,6 +194,20 @@ func (ts *Server) GetKeyspace(ctx context.Context, keyspace string) (*KeyspaceIn
 	}, nil
 }
 
+// GetKeyspaceDurability reads the given keyspace and returns its durabilty policy
+func (ts *Server) GetKeyspaceDurability(ctx context.Context, keyspace string) (string, error) {
+	keyspaceInfo, err := ts.GetKeyspace(ctx, keyspace)
+	if err != nil {
+		return "", err
+	}
+	// Get the durability policy from the keyspace information
+	// If it is unspecified, use the default durability which is "none" for backward compatibility
+	if keyspaceInfo.GetDurabilityPolicy() != "" {
+		return keyspaceInfo.GetDurabilityPolicy(), nil
+	}
+	return "none", nil
+}
+
 // UpdateKeyspace updates the keyspace data. It checks the keyspace is locked.
 func (ts *Server) UpdateKeyspace(ctx context.Context, ki *KeyspaceInfo) error {
 	// make sure it is locked first

--- a/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
@@ -29,7 +29,6 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vttablet/tabletservermock"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 	"vitess.io/vitess/go/vt/wrangler"
@@ -43,7 +42,6 @@ func TestInitShardPrimary(t *testing.T) {
 	ts := memorytopo.NewServer("cell1")
 	tmc := tmclient.NewTabletManagerClient()
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmc)
-	_ = reparentutil.SetDurabilityPolicy("none")
 
 	primaryDb := fakesqldb.New(t)
 	primaryDb.AddQuery("create database if not exists `vt_test_keyspace`", &sqltypes.Result{InsertID: 0, RowsAffected: 0})
@@ -103,7 +101,6 @@ func TestInitShardPrimaryNoFormerPrimary(t *testing.T) {
 	ts := memorytopo.NewServer("cell1")
 	tmc := tmclient.NewTabletManagerClient()
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmc)
-	_ = reparentutil.SetDurabilityPolicy("none")
 
 	primaryDb := fakesqldb.New(t)
 	primaryDb.AddQuery("create database if not exists `vt_test_keyspace`", &sqltypes.Result{InsertID: 0, RowsAffected: 0})

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -472,6 +472,15 @@ func (s *VtctldServer) ChangeTabletType(ctx context.Context, req *vtctldatapb.Ch
 		return nil, err
 	}
 
+	durabilityName, err := s.ts.GetKeyspaceDurability(ctx, tablet.Keyspace)
+	if err != nil {
+		return nil, err
+	}
+	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
+	if err != nil {
+		return nil, err
+	}
+
 	if !shard.HasPrimary() {
 		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no primary tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
 	}
@@ -493,7 +502,7 @@ func (s *VtctldServer) ChangeTabletType(ctx context.Context, req *vtctldatapb.Ch
 	// Since we want to check the durability rules for the desired state and not before we make that change
 	expectedTablet := proto.Clone(tablet.Tablet).(*topodatapb.Tablet)
 	expectedTablet.Type = req.DbType
-	err = s.tmc.ChangeType(ctx, tablet.Tablet, req.DbType, reparentutil.IsReplicaSemiSync(nil, shardPrimary.Tablet, expectedTablet))
+	err = s.tmc.ChangeType(ctx, tablet.Tablet, req.DbType, reparentutil.IsReplicaSemiSync(durability, shardPrimary.Tablet, expectedTablet))
 	if err != nil {
 		return nil, err
 	}
@@ -1737,6 +1746,15 @@ func (s *VtctldServer) InitShardPrimaryLocked(
 	}
 	ev.ShardInfo = *shardInfo
 
+	durabilityName, err := s.ts.GetKeyspaceDurability(ctx, req.Keyspace)
+	if err != nil {
+		return err
+	}
+	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
+	if err != nil {
+		return err
+	}
+
 	event.DispatchUpdate(ev, "reading tablet map")
 	tabletMap, err := s.ts.GetTabletMapForShard(ctx, req.Keyspace, req.Shard)
 	if err != nil {
@@ -1816,7 +1834,7 @@ func (s *VtctldServer) InitShardPrimaryLocked(
 	// position
 	logger.Infof("initializing primary on %v", topoproto.TabletAliasString(req.PrimaryElectTabletAlias))
 	event.DispatchUpdate(ev, "initializing primary")
-	rp, err := tmc.InitPrimary(ctx, primaryElectTabletInfo.Tablet, reparentutil.SemiSyncAckers(nil, primaryElectTabletInfo.Tablet) > 0)
+	rp, err := tmc.InitPrimary(ctx, primaryElectTabletInfo.Tablet, reparentutil.SemiSyncAckers(durability, primaryElectTabletInfo.Tablet) > 0)
 	if err != nil {
 		return err
 	}
@@ -1857,7 +1875,7 @@ func (s *VtctldServer) InitShardPrimaryLocked(
 			go func(alias string, tabletInfo *topo.TabletInfo) {
 				defer wgReplicas.Done()
 				logger.Infof("initializing replica %v", alias)
-				if err := tmc.InitReplica(replCtx, tabletInfo.Tablet, req.PrimaryElectTabletAlias, rp, now, reparentutil.IsReplicaSemiSync(nil, primaryElectTabletInfo.Tablet, tabletInfo.Tablet)); err != nil {
+				if err := tmc.InitReplica(replCtx, tabletInfo.Tablet, req.PrimaryElectTabletAlias, rp, now, reparentutil.IsReplicaSemiSync(durability, primaryElectTabletInfo.Tablet, tabletInfo.Tablet)); err != nil {
 					rec.RecordError(fmt.Errorf("tablet %v InitReplica failed: %v", alias, err))
 				}
 			}(alias, tabletInfo)
@@ -2302,7 +2320,16 @@ func (s *VtctldServer) ReparentTablet(ctx context.Context, req *vtctldatapb.Repa
 		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "cannot ReparentTablet current shard primary (%v) onto itself", topoproto.TabletAliasString(req.Tablet))
 	}
 
-	if err := s.tmc.SetReplicationSource(ctx, tablet.Tablet, shard.PrimaryAlias, 0, "", false, reparentutil.IsReplicaSemiSync(nil, shardPrimary.Tablet, tablet.Tablet)); err != nil {
+	durabilityName, err := s.ts.GetKeyspaceDurability(ctx, tablet.Keyspace)
+	if err != nil {
+		return nil, err
+	}
+	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.tmc.SetReplicationSource(ctx, tablet.Tablet, shard.PrimaryAlias, 0, "", false, reparentutil.IsReplicaSemiSync(durability, shardPrimary.Tablet, tablet.Tablet)); err != nil {
 		return nil, err
 	}
 
@@ -3004,7 +3031,16 @@ func (s *VtctldServer) StartReplication(ctx context.Context, req *vtctldatapb.St
 		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary %v and replica %v not in same keypace shard (%v/%v)", topoproto.TabletAliasString(shard.PrimaryAlias), topoproto.TabletAliasString(tablet.Alias), tablet.Keyspace, tablet.Shard)
 	}
 
-	if err := s.tmc.StartReplication(ctx, tablet.Tablet, reparentutil.IsReplicaSemiSync(nil, shardPrimary.Tablet, tablet.Tablet)); err != nil {
+	durabilityName, err := s.ts.GetKeyspaceDurability(ctx, tablet.Keyspace)
+	if err != nil {
+		return nil, err
+	}
+	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.tmc.StartReplication(ctx, tablet.Tablet, reparentutil.IsReplicaSemiSync(durability, shardPrimary.Tablet, tablet.Tablet)); err != nil {
 		log.Errorf("StartReplication: failed to start replication on %v: %v", alias, err)
 		return nil, err
 	}
@@ -3093,7 +3129,16 @@ func (s *VtctldServer) TabletExternallyReparented(ctx context.Context, req *vtct
 
 	event.DispatchUpdate(ev, "starting external reparent")
 
-	if err := s.tmc.ChangeType(ctx, tablet.Tablet, topodatapb.TabletType_PRIMARY, reparentutil.SemiSyncAckers(nil, tablet.Tablet) > 0); err != nil {
+	durabilityName, err := s.ts.GetKeyspaceDurability(ctx, tablet.Keyspace)
+	if err != nil {
+		return nil, err
+	}
+	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.tmc.ChangeType(ctx, tablet.Tablet, topodatapb.TabletType_PRIMARY, reparentutil.SemiSyncAckers(durability, tablet.Tablet) > 0); err != nil {
 		log.Warningf("ChangeType(%v, PRIMARY): %v", topoproto.TabletAliasString(req.Tablet), err)
 		return nil, err
 	}

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -41,7 +41,6 @@ import (
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver/testutil"
 	"vitess.io/vitess/go/vt/vtctl/localvtctldclient"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 
 	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
@@ -70,7 +69,6 @@ func init() {
 	tmclient.RegisterTabletManagerClientFactory("grpcvtctldserver.test", func() tmclient.TabletManagerClient {
 		return nil
 	})
-	_ = reparentutil.SetDurabilityPolicy("none")
 }
 
 func TestAddCellInfo(t *testing.T) {

--- a/go/vt/vtctl/grpcvtctldserver/testutil/util.go
+++ b/go/vt/vtctl/grpcvtctldserver/testutil/util.go
@@ -205,25 +205,6 @@ func AddTablets(ctx context.Context, t *testing.T, ts *topo.Server, opts *AddTab
 	}
 }
 
-// SetKeyspaceDurability sets the durability policy of a given keyspace
-func SetKeyspaceDurability(ctx context.Context, t *testing.T, ts *topo.Server, keyspace, durability string) {
-	ctx, unlock, lockErr := ts.LockKeyspace(ctx, keyspace, "testutil.SetKeyspaceDurability")
-	if lockErr != nil {
-		return
-	}
-
-	var err error
-	defer unlock(&err)
-
-	ki, err := ts.GetKeyspace(ctx, keyspace)
-	require.NoError(t, err)
-
-	ki.DurabilityPolicy = durability
-
-	err = ts.UpdateKeyspace(ctx, ki)
-	require.NoError(t, err)
-}
-
 // AddShards adds a list of shards to the topology, failing a test if any of the
 // shard records could not be created. It also ensures that every shard's
 // keyspace exists, or creates an empty keyspace if that shard's keyspace does

--- a/go/vt/vtctl/grpcvtctldserver/testutil/util.go
+++ b/go/vt/vtctl/grpcvtctldserver/testutil/util.go
@@ -205,6 +205,25 @@ func AddTablets(ctx context.Context, t *testing.T, ts *topo.Server, opts *AddTab
 	}
 }
 
+// SetKeyspaceDurability sets the durability policy of a given keyspace
+func SetKeyspaceDurability(ctx context.Context, t *testing.T, ts *topo.Server, keyspace, durability string) {
+	ctx, unlock, lockErr := ts.LockKeyspace(ctx, keyspace, "testutil.SetKeyspaceDurability")
+	if lockErr != nil {
+		return
+	}
+
+	var err error
+	defer unlock(&err)
+
+	ki, err := ts.GetKeyspace(ctx, keyspace)
+	require.NoError(t, err)
+
+	ki.DurabilityPolicy = durability
+
+	err = ts.UpdateKeyspace(ctx, ki)
+	require.NoError(t, err)
+}
+
 // AddShards adds a list of shards to the topology, failing a test if any of the
 // shard records could not be created. It also ensures that every shard's
 // keyspace exists, or creates an empty keyspace if that shard's keyspace does

--- a/go/vt/vtctl/reparentutil/durability.go
+++ b/go/vt/vtctl/reparentutil/durability.go
@@ -55,7 +55,7 @@ func init() {
 
 // Durabler is the interface which is used to get the promotion rules for candidates and the semi sync setup
 type Durabler interface {
-	// PromotionRule represents the precedence in which we want to tablets to be promoted.
+	// promotionRule represents the precedence in which we want to tablets to be promoted.
 	// The higher the promotion rule of a tablet, the more we want it to be promoted in case of a failover
 	promotionRule(*topodatapb.Tablet) promotionrule.CandidatePromotionRule
 	// semiSyncAckers represents the number of semi-sync ackers required for a given tablet if it were to become the PRIMARY instance

--- a/go/vt/vtctl/reparentutil/durability.go
+++ b/go/vt/vtctl/reparentutil/durability.go
@@ -18,12 +18,10 @@ package reparentutil
 
 import (
 	"fmt"
-	"sync"
-
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	"vitess.io/vitess/go/vt/topo/topoproto"
 
 	"vitess.io/vitess/go/vt/log"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil/promotionrule"
 )
 
@@ -37,10 +35,6 @@ type NewDurabler func() Durabler
 var (
 	// durabilityPolicies is a map that stores the functions needed to create a new Durabler
 	durabilityPolicies = make(map[string]NewDurabler)
-	// curDurabilityPolicy is the current durability policy in use
-	curDurabilityPolicy Durabler
-	// curDurabilityPolicyMutex is the mutex protecting the curDurabilityPolicy variable
-	curDurabilityPolicyMutex sync.Mutex
 )
 
 func init() {
@@ -78,19 +72,6 @@ func RegisterDurability(name string, newDurablerFunc NewDurabler) {
 }
 
 //=======================================================================
-
-// SetDurabilityPolicy is used to set the durability policy from the registered policies
-func SetDurabilityPolicy(name string) error {
-	newDurabilityCreationFunc, found := durabilityPolicies[name]
-	if !found {
-		return fmt.Errorf("durability policy %v not found", name)
-	}
-	log.Infof("Setting durability policy to %v", name)
-	curDurabilityPolicyMutex.Lock()
-	defer curDurabilityPolicyMutex.Unlock()
-	curDurabilityPolicy = newDurabilityCreationFunc()
-	return nil
-}
 
 // GetDurabilityPolicy is used to get a new durability policy from the registered policies
 func GetDurabilityPolicy(name string) (Durabler, error) {

--- a/go/vt/vtctl/reparentutil/durability.go
+++ b/go/vt/vtctl/reparentutil/durability.go
@@ -92,6 +92,16 @@ func SetDurabilityPolicy(name string) error {
 	return nil
 }
 
+// GetDurabilityPolicy is used to get a new durability policy from the registered policies
+func GetDurabilityPolicy(name string) (Durabler, error) {
+	newDurabilityCreationFunc, found := durabilityPolicies[name]
+	if !found {
+		return nil, fmt.Errorf("durability policy %v not found", name)
+	}
+	log.Infof("Getting a new durability policy for %v", name)
+	return newDurabilityCreationFunc(), nil
+}
+
 // CheckDurabilityPolicyExists is used to check if the durability policy is part of the registered policies
 func CheckDurabilityPolicyExists(name string) bool {
 	_, found := durabilityPolicies[name]

--- a/go/vt/vtctl/reparentutil/durability.go
+++ b/go/vt/vtctl/reparentutil/durability.go
@@ -109,34 +109,28 @@ func CheckDurabilityPolicyExists(name string) bool {
 }
 
 // PromotionRule returns the promotion rule for the instance.
-func PromotionRule(tablet *topodatapb.Tablet) promotionrule.CandidatePromotionRule {
+func PromotionRule(durability Durabler, tablet *topodatapb.Tablet) promotionrule.CandidatePromotionRule {
 	// Prevent panics.
 	if tablet == nil || tablet.Alias == nil {
 		return promotionrule.MustNot
 	}
-	curDurabilityPolicyMutex.Lock()
-	defer curDurabilityPolicyMutex.Unlock()
-	return curDurabilityPolicy.promotionRule(tablet)
+	return durability.promotionRule(tablet)
 }
 
 // SemiSyncAckers returns the primary semi-sync setting for the instance.
 // 0 means none. Non-zero specifies the number of required ackers.
-func SemiSyncAckers(tablet *topodatapb.Tablet) int {
-	curDurabilityPolicyMutex.Lock()
-	defer curDurabilityPolicyMutex.Unlock()
-	return curDurabilityPolicy.semiSyncAckers(tablet)
+func SemiSyncAckers(durability Durabler, tablet *topodatapb.Tablet) int {
+	return durability.semiSyncAckers(tablet)
 }
 
 // IsReplicaSemiSync returns the replica semi-sync setting from the tablet record.
 // Prefer using this function if tablet record is available.
-func IsReplicaSemiSync(primary, replica *topodatapb.Tablet) bool {
+func IsReplicaSemiSync(durability Durabler, primary, replica *topodatapb.Tablet) bool {
 	// Prevent panics.
 	if primary == nil || primary.Alias == nil || replica == nil || replica.Alias == nil {
 		return false
 	}
-	curDurabilityPolicyMutex.Lock()
-	defer curDurabilityPolicyMutex.Unlock()
-	return curDurabilityPolicy.isReplicaSemiSync(primary, replica)
+	return durability.isReplicaSemiSync(primary, replica)
 }
 
 //=======================================================================

--- a/go/vt/vtctl/reparentutil/durability_funcs.go
+++ b/go/vt/vtctl/reparentutil/durability_funcs.go
@@ -28,7 +28,7 @@ func SemiSyncAckersForPrimary(primary *topodatapb.Tablet, allTablets []*topodata
 		if topoproto.TabletAliasEqual(primary.Alias, tablet.Alias) {
 			continue
 		}
-		if IsReplicaSemiSync(primary, tablet) {
+		if IsReplicaSemiSync(nil, primary, tablet) {
 			semiSyncAckers = append(semiSyncAckers, tablet)
 		}
 	}
@@ -51,7 +51,7 @@ func haveRevokedForTablet(primaryEligible *topodatapb.Tablet, tabletsReached []*
 	allSemiSyncAckers := SemiSyncAckersForPrimary(primaryEligible, allTablets)
 
 	// numOfSemiSyncAcksRequired is the number of semi sync Acks that the primaryEligible tablet requires
-	numOfSemiSyncAcksRequired := SemiSyncAckers(primaryEligible)
+	numOfSemiSyncAcksRequired := SemiSyncAckers(nil, primaryEligible)
 
 	// if we have reached enough semi-sync Acking tablets such that the primaryEligible cannot accept a write
 	// we have revoked from the tablet
@@ -63,7 +63,7 @@ func haveRevokedForTablet(primaryEligible *topodatapb.Tablet, tabletsReached []*
 // from all the primary eligible tablets (prevent them from accepting any new writes)
 func haveRevoked(tabletsReached []*topodatapb.Tablet, allTablets []*topodatapb.Tablet) bool {
 	for _, tablet := range allTablets {
-		if PromotionRule(tablet) == promotionrule.MustNot {
+		if PromotionRule(nil, tablet) == promotionrule.MustNot {
 			continue
 		}
 		if !haveRevokedForTablet(tablet, tabletsReached, allTablets) {
@@ -85,7 +85,7 @@ func canEstablishForTablet(primaryEligible *topodatapb.Tablet, tabletsReached []
 	semiSyncAckersReached := SemiSyncAckersForPrimary(primaryEligible, tabletsReached)
 
 	// numOfSemiSyncAcksRequired is the number of semi sync Acks that the primaryEligible tablet requires
-	numOfSemiSyncAcksRequired := SemiSyncAckers(primaryEligible)
+	numOfSemiSyncAcksRequired := SemiSyncAckers(nil, primaryEligible)
 
 	// if we have reached enough semi-sync Acking tablets such that the primaryEligible can accept a write
 	// we can safely promote this tablet

--- a/go/vt/vtctl/reparentutil/durability_funcs.go
+++ b/go/vt/vtctl/reparentutil/durability_funcs.go
@@ -23,12 +23,12 @@ import (
 )
 
 // SemiSyncAckersForPrimary returns the list of tablets which are capable of sending Semi-Sync Acks for the given primary tablet
-func SemiSyncAckersForPrimary(primary *topodatapb.Tablet, allTablets []*topodatapb.Tablet) (semiSyncAckers []*topodatapb.Tablet) {
+func SemiSyncAckersForPrimary(durability Durabler, primary *topodatapb.Tablet, allTablets []*topodatapb.Tablet) (semiSyncAckers []*topodatapb.Tablet) {
 	for _, tablet := range allTablets {
 		if topoproto.TabletAliasEqual(primary.Alias, tablet.Alias) {
 			continue
 		}
-		if IsReplicaSemiSync(nil, primary, tablet) {
+		if IsReplicaSemiSync(durability, primary, tablet) {
 			semiSyncAckers = append(semiSyncAckers, tablet)
 		}
 	}
@@ -37,7 +37,7 @@ func SemiSyncAckersForPrimary(primary *topodatapb.Tablet, allTablets []*topodata
 
 // haveRevokedForTablet checks whether we have reached enough tablets such that the given primary eligible tablet cannot accept any new writes
 // The tablets reached should have their replication stopped and must be set to read only.
-func haveRevokedForTablet(primaryEligible *topodatapb.Tablet, tabletsReached []*topodatapb.Tablet, allTablets []*topodatapb.Tablet) bool {
+func haveRevokedForTablet(durability Durabler, primaryEligible *topodatapb.Tablet, tabletsReached []*topodatapb.Tablet, allTablets []*topodatapb.Tablet) bool {
 	// if we have reached the primaryEligible tablet and stopped its replication and marked it read only, then it will not
 	// accept any new writes
 	if topoproto.IsTabletInList(primaryEligible, tabletsReached) {
@@ -45,13 +45,13 @@ func haveRevokedForTablet(primaryEligible *topodatapb.Tablet, tabletsReached []*
 	}
 
 	// semiSyncAckersReached is the list of reachable tablets capable of sending semi sync Acks for the given primaryEligible tablet
-	semiSyncAckersReached := SemiSyncAckersForPrimary(primaryEligible, tabletsReached)
+	semiSyncAckersReached := SemiSyncAckersForPrimary(durability, primaryEligible, tabletsReached)
 
 	// allSemiSyncAckers is the list of reachable tablets capable of sending semi sync Acks for the given primaryEligible tablet
-	allSemiSyncAckers := SemiSyncAckersForPrimary(primaryEligible, allTablets)
+	allSemiSyncAckers := SemiSyncAckersForPrimary(durability, primaryEligible, allTablets)
 
 	// numOfSemiSyncAcksRequired is the number of semi sync Acks that the primaryEligible tablet requires
-	numOfSemiSyncAcksRequired := SemiSyncAckers(nil, primaryEligible)
+	numOfSemiSyncAcksRequired := SemiSyncAckers(durability, primaryEligible)
 
 	// if we have reached enough semi-sync Acking tablets such that the primaryEligible cannot accept a write
 	// we have revoked from the tablet
@@ -61,12 +61,12 @@ func haveRevokedForTablet(primaryEligible *topodatapb.Tablet, tabletsReached []*
 // haveRevoked checks whether we have reached enough tablets to guarantee that no tablet eligible to become a primary can accept any write
 // All the tablets reached must have their replication stopped and set to read only for us to guarantee that we have revoked access
 // from all the primary eligible tablets (prevent them from accepting any new writes)
-func haveRevoked(tabletsReached []*topodatapb.Tablet, allTablets []*topodatapb.Tablet) bool {
+func haveRevoked(durability Durabler, tabletsReached []*topodatapb.Tablet, allTablets []*topodatapb.Tablet) bool {
 	for _, tablet := range allTablets {
-		if PromotionRule(nil, tablet) == promotionrule.MustNot {
+		if PromotionRule(durability, tablet) == promotionrule.MustNot {
 			continue
 		}
-		if !haveRevokedForTablet(tablet, tabletsReached, allTablets) {
+		if !haveRevokedForTablet(durability, tablet, tabletsReached, allTablets) {
 			return false
 		}
 	}
@@ -74,7 +74,7 @@ func haveRevoked(tabletsReached []*topodatapb.Tablet, allTablets []*topodatapb.T
 }
 
 // canEstablishForTablet checks whether we have reached enough tablets to say that the given primary eligible tablet will be able to accept new writes
-func canEstablishForTablet(primaryEligible *topodatapb.Tablet, tabletsReached []*topodatapb.Tablet) bool {
+func canEstablishForTablet(durability Durabler, primaryEligible *topodatapb.Tablet, tabletsReached []*topodatapb.Tablet) bool {
 	// if we have not reached the primaryEligible tablet, then it cannot be considered eligible to accept writes
 	// since it might have been stopped
 	if !topoproto.IsTabletInList(primaryEligible, tabletsReached) {
@@ -82,10 +82,10 @@ func canEstablishForTablet(primaryEligible *topodatapb.Tablet, tabletsReached []
 	}
 
 	// semiSyncAckersReached is the list of reachable tablets capable of sending semi sync Acks for the given primaryEligible tablet
-	semiSyncAckersReached := SemiSyncAckersForPrimary(primaryEligible, tabletsReached)
+	semiSyncAckersReached := SemiSyncAckersForPrimary(durability, primaryEligible, tabletsReached)
 
 	// numOfSemiSyncAcksRequired is the number of semi sync Acks that the primaryEligible tablet requires
-	numOfSemiSyncAcksRequired := SemiSyncAckers(nil, primaryEligible)
+	numOfSemiSyncAcksRequired := SemiSyncAckers(durability, primaryEligible)
 
 	// if we have reached enough semi-sync Acking tablets such that the primaryEligible can accept a write
 	// we can safely promote this tablet

--- a/go/vt/vtctl/reparentutil/durability_funcs_test.go
+++ b/go/vt/vtctl/reparentutil/durability_funcs_test.go
@@ -99,9 +99,9 @@ func TestSemiSyncAckersForPrimary(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := SetDurabilityPolicy(tt.durabilityPolicy)
+			durability, err := GetDurabilityPolicy(tt.durabilityPolicy)
 			require.NoError(t, err, "error setting durability policy")
-			semiSyncAckers := SemiSyncAckersForPrimary(tt.primary, tt.allTablets)
+			semiSyncAckers := SemiSyncAckersForPrimary(durability, tt.primary, tt.allTablets)
 			require.Equal(t, tt.wantSemiSyncAckers, semiSyncAckers)
 		})
 	}
@@ -197,9 +197,9 @@ func Test_haveRevokedForTablet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := SetDurabilityPolicy(tt.durabilityPolicy)
+			durability, err := GetDurabilityPolicy(tt.durabilityPolicy)
 			require.NoError(t, err)
-			out := haveRevokedForTablet(tt.primaryEligible, tt.tabletsReached, tt.allTablets)
+			out := haveRevokedForTablet(durability, tt.primaryEligible, tt.tabletsReached, tt.allTablets)
 			require.Equal(t, tt.revoked, out)
 		})
 	}
@@ -307,9 +307,9 @@ func Test_haveRevoked(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := SetDurabilityPolicy(tt.durabilityPolicy)
+			durability, err := GetDurabilityPolicy(tt.durabilityPolicy)
 			require.NoError(t, err)
-			out := haveRevoked(tt.tabletsReached, tt.allTablets)
+			out := haveRevoked(durability, tt.tabletsReached, tt.allTablets)
 			require.Equal(t, tt.revoked, out)
 		})
 	}
@@ -375,9 +375,9 @@ func Test_canEstablishForTablet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("'%s' durability policy - %s", tt.durabilityPolicy, tt.name), func(t *testing.T) {
-			err := SetDurabilityPolicy(tt.durabilityPolicy)
+			durability, err := GetDurabilityPolicy(tt.durabilityPolicy)
 			require.NoError(t, err)
-			require.Equalf(t, tt.canEstablish, canEstablishForTablet(tt.primaryEligible, tt.tabletsReached), "canEstablishForTablet(%v, %v)", tt.primaryEligible, tt.tabletsReached)
+			require.Equalf(t, tt.canEstablish, canEstablishForTablet(durability, tt.primaryEligible, tt.tabletsReached), "canEstablishForTablet(%v, %v)", tt.primaryEligible, tt.tabletsReached)
 		})
 	}
 }

--- a/go/vt/vtctl/reparentutil/durability_test.go
+++ b/go/vt/vtctl/reparentutil/durability_test.go
@@ -29,10 +29,10 @@ import (
 )
 
 func TestDurabilityNone(t *testing.T) {
-	err := SetDurabilityPolicy("none")
+	durability, err := GetDurabilityPolicy("none")
 	require.NoError(t, err)
 
-	promoteRule := PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule := PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -40,9 +40,9 @@ func TestDurabilityNone(t *testing.T) {
 		Type: topodatapb.TabletType_PRIMARY,
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
-	assert.Equal(t, promotionrule.MustNot, PromotionRule(nil, nil))
+	assert.Equal(t, promotionrule.MustNot, PromotionRule(durability, nil))
 
-	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule = PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -51,7 +51,7 @@ func TestDurabilityNone(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
 
-	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule = PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -60,7 +60,7 @@ func TestDurabilityNone(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
 
-	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule = PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -68,15 +68,15 @@ func TestDurabilityNone(t *testing.T) {
 		Type: topodatapb.TabletType_SPARE,
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
-	assert.Equal(t, 0, SemiSyncAckers(nil, nil))
-	assert.Equal(t, false, IsReplicaSemiSync(nil, nil, nil))
+	assert.Equal(t, 0, SemiSyncAckers(durability, nil))
+	assert.Equal(t, false, IsReplicaSemiSync(durability, nil, nil))
 }
 
 func TestDurabilitySemiSync(t *testing.T) {
-	err := SetDurabilityPolicy("semi_sync")
+	durability, err := GetDurabilityPolicy("semi_sync")
 	require.NoError(t, err)
 
-	promoteRule := PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule := PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -85,7 +85,7 @@ func TestDurabilitySemiSync(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
 
-	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule = PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -94,7 +94,7 @@ func TestDurabilitySemiSync(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
 
-	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule = PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -103,7 +103,7 @@ func TestDurabilitySemiSync(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
 
-	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule = PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -111,8 +111,8 @@ func TestDurabilitySemiSync(t *testing.T) {
 		Type: topodatapb.TabletType_SPARE,
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
-	assert.Equal(t, 1, SemiSyncAckers(nil, nil))
-	assert.Equal(t, true, IsReplicaSemiSync(nil, &topodatapb.Tablet{
+	assert.Equal(t, 1, SemiSyncAckers(durability, nil))
+	assert.Equal(t, true, IsReplicaSemiSync(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  101,
@@ -125,7 +125,7 @@ func TestDurabilitySemiSync(t *testing.T) {
 		},
 		Type: topodatapb.TabletType_REPLICA,
 	}))
-	assert.Equal(t, false, IsReplicaSemiSync(nil, &topodatapb.Tablet{
+	assert.Equal(t, false, IsReplicaSemiSync(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  101,
@@ -141,10 +141,10 @@ func TestDurabilitySemiSync(t *testing.T) {
 }
 
 func TestDurabilityCrossCell(t *testing.T) {
-	err := SetDurabilityPolicy("cross_cell")
+	durability, err := GetDurabilityPolicy("cross_cell")
 	require.NoError(t, err)
 
-	promoteRule := PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule := PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -153,7 +153,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
 
-	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule = PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -162,7 +162,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
 
-	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule = PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -171,7 +171,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
 
-	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
+	promoteRule = PromotionRule(durability, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -179,8 +179,8 @@ func TestDurabilityCrossCell(t *testing.T) {
 		Type: topodatapb.TabletType_SPARE,
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
-	assert.Equal(t, 1, SemiSyncAckers(nil, nil))
-	assert.Equal(t, false, IsReplicaSemiSync(nil, &topodatapb.Tablet{
+	assert.Equal(t, 1, SemiSyncAckers(durability, nil))
+	assert.Equal(t, false, IsReplicaSemiSync(durability, &topodatapb.Tablet{
 		Type: topodatapb.TabletType_PRIMARY,
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
@@ -191,7 +191,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 			Cell: "cell1",
 		},
 	}))
-	assert.Equal(t, true, IsReplicaSemiSync(nil, &topodatapb.Tablet{
+	assert.Equal(t, true, IsReplicaSemiSync(durability, &topodatapb.Tablet{
 		Type: topodatapb.TabletType_PRIMARY,
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
@@ -202,7 +202,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 			Cell: "cell2",
 		},
 	}))
-	assert.Equal(t, false, IsReplicaSemiSync(nil, &topodatapb.Tablet{
+	assert.Equal(t, false, IsReplicaSemiSync(durability, &topodatapb.Tablet{
 		Type: topodatapb.TabletType_PRIMARY,
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
@@ -216,7 +216,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	err := SetDurabilityPolicy("unknown")
+	_, err := GetDurabilityPolicy("unknown")
 	assert.EqualError(t, err, "durability policy unknown not found")
 }
 

--- a/go/vt/vtctl/reparentutil/durability_test.go
+++ b/go/vt/vtctl/reparentutil/durability_test.go
@@ -32,7 +32,7 @@ func TestDurabilityNone(t *testing.T) {
 	err := SetDurabilityPolicy("none")
 	require.NoError(t, err)
 
-	promoteRule := PromotionRule(&topodatapb.Tablet{
+	promoteRule := PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -40,9 +40,9 @@ func TestDurabilityNone(t *testing.T) {
 		Type: topodatapb.TabletType_PRIMARY,
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
-	assert.Equal(t, promotionrule.MustNot, PromotionRule(nil))
+	assert.Equal(t, promotionrule.MustNot, PromotionRule(nil, nil))
 
-	promoteRule = PromotionRule(&topodatapb.Tablet{
+	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -51,7 +51,7 @@ func TestDurabilityNone(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
 
-	promoteRule = PromotionRule(&topodatapb.Tablet{
+	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -60,7 +60,7 @@ func TestDurabilityNone(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
 
-	promoteRule = PromotionRule(&topodatapb.Tablet{
+	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -68,15 +68,15 @@ func TestDurabilityNone(t *testing.T) {
 		Type: topodatapb.TabletType_SPARE,
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
-	assert.Equal(t, 0, SemiSyncAckers(nil))
-	assert.Equal(t, false, IsReplicaSemiSync(nil, nil))
+	assert.Equal(t, 0, SemiSyncAckers(nil, nil))
+	assert.Equal(t, false, IsReplicaSemiSync(nil, nil, nil))
 }
 
 func TestDurabilitySemiSync(t *testing.T) {
 	err := SetDurabilityPolicy("semi_sync")
 	require.NoError(t, err)
 
-	promoteRule := PromotionRule(&topodatapb.Tablet{
+	promoteRule := PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -85,7 +85,7 @@ func TestDurabilitySemiSync(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
 
-	promoteRule = PromotionRule(&topodatapb.Tablet{
+	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -94,7 +94,7 @@ func TestDurabilitySemiSync(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
 
-	promoteRule = PromotionRule(&topodatapb.Tablet{
+	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -103,7 +103,7 @@ func TestDurabilitySemiSync(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
 
-	promoteRule = PromotionRule(&topodatapb.Tablet{
+	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -111,8 +111,8 @@ func TestDurabilitySemiSync(t *testing.T) {
 		Type: topodatapb.TabletType_SPARE,
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
-	assert.Equal(t, 1, SemiSyncAckers(nil))
-	assert.Equal(t, true, IsReplicaSemiSync(&topodatapb.Tablet{
+	assert.Equal(t, 1, SemiSyncAckers(nil, nil))
+	assert.Equal(t, true, IsReplicaSemiSync(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  101,
@@ -125,7 +125,7 @@ func TestDurabilitySemiSync(t *testing.T) {
 		},
 		Type: topodatapb.TabletType_REPLICA,
 	}))
-	assert.Equal(t, false, IsReplicaSemiSync(&topodatapb.Tablet{
+	assert.Equal(t, false, IsReplicaSemiSync(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  101,
@@ -144,7 +144,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 	err := SetDurabilityPolicy("cross_cell")
 	require.NoError(t, err)
 
-	promoteRule := PromotionRule(&topodatapb.Tablet{
+	promoteRule := PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -153,7 +153,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
 
-	promoteRule = PromotionRule(&topodatapb.Tablet{
+	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -162,7 +162,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.Neutral, promoteRule)
 
-	promoteRule = PromotionRule(&topodatapb.Tablet{
+	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -171,7 +171,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
 
-	promoteRule = PromotionRule(&topodatapb.Tablet{
+	promoteRule = PromotionRule(nil, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
 			Uid:  100,
@@ -179,8 +179,8 @@ func TestDurabilityCrossCell(t *testing.T) {
 		Type: topodatapb.TabletType_SPARE,
 	})
 	assert.Equal(t, promotionrule.MustNot, promoteRule)
-	assert.Equal(t, 1, SemiSyncAckers(nil))
-	assert.Equal(t, false, IsReplicaSemiSync(&topodatapb.Tablet{
+	assert.Equal(t, 1, SemiSyncAckers(nil, nil))
+	assert.Equal(t, false, IsReplicaSemiSync(nil, &topodatapb.Tablet{
 		Type: topodatapb.TabletType_PRIMARY,
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
@@ -191,7 +191,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 			Cell: "cell1",
 		},
 	}))
-	assert.Equal(t, true, IsReplicaSemiSync(&topodatapb.Tablet{
+	assert.Equal(t, true, IsReplicaSemiSync(nil, &topodatapb.Tablet{
 		Type: topodatapb.TabletType_PRIMARY,
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",
@@ -202,7 +202,7 @@ func TestDurabilityCrossCell(t *testing.T) {
 			Cell: "cell2",
 		},
 	}))
-	assert.Equal(t, false, IsReplicaSemiSync(&topodatapb.Tablet{
+	assert.Equal(t, false, IsReplicaSemiSync(nil, &topodatapb.Tablet{
 		Type: topodatapb.TabletType_PRIMARY,
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -63,6 +63,7 @@ type EmergencyReparentOptions struct {
 	// Private options managed internally. We use value passing to avoid leaking
 	// these details back out.
 	lockAction string
+	durability Durabler
 }
 
 // counters for Emergency Reparent Shard
@@ -161,6 +162,16 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	}
 	ev.ShardInfo = *shardInfo
 
+	keyspaceDurability, err := erp.ts.GetKeyspaceDurability(ctx, keyspace)
+	if err != nil {
+		return err
+	}
+
+	opts.durability, err = GetDurabilityPolicy(keyspaceDurability)
+	if err != nil {
+		return err
+	}
+
 	// get the previous primary according to the topology server,
 	// we use this information to choose the best candidate in the same cell
 	// and to undo promotion in case of failure
@@ -180,7 +191,7 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	}
 
 	// Stop replication on all the tablets and build their status map
-	stoppedReplicationSnapshot, err = stopReplicationAndBuildStatusMaps(ctx, erp.tmc, ev, tabletMap, opts.WaitReplicasTimeout, opts.IgnoreReplicas, opts.NewPrimaryAlias, erp.logger)
+	stoppedReplicationSnapshot, err = stopReplicationAndBuildStatusMaps(ctx, erp.tmc, ev, tabletMap, opts.WaitReplicasTimeout, opts.IgnoreReplicas, opts.NewPrimaryAlias, opts.durability, erp.logger)
 	if err != nil {
 		return vterrors.Wrapf(err, "failed to stop replication and build status maps: %v", err)
 	}
@@ -372,7 +383,7 @@ func (erp *EmergencyReparenter) findMostAdvanced(
 	}
 
 	// sort the tablets for finding the best intermediate source in ERS
-	err = sortTabletsForReparent(validTablets, tabletPositions, nil)
+	err = sortTabletsForReparent(validTablets, tabletPositions, opts.durability)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -515,7 +526,7 @@ func (erp *EmergencyReparenter) reparentReplicas(
 			forceStart = fs
 		}
 
-		err := erp.tmc.SetReplicationSource(replCtx, ti.Tablet, newPrimaryTablet.Alias, 0, "", forceStart, IsReplicaSemiSync(nil, newPrimaryTablet, ti.Tablet))
+		err := erp.tmc.SetReplicationSource(replCtx, ti.Tablet, newPrimaryTablet.Alias, 0, "", forceStart, IsReplicaSemiSync(opts.durability, newPrimaryTablet, ti.Tablet))
 		if err != nil {
 			err = vterrors.Wrapf(err, "tablet %v SetReplicationSource failed: %v", alias, err)
 			rec.RecordError(err)
@@ -660,7 +671,7 @@ func (erp *EmergencyReparenter) identifyPrimaryCandidate(
 	// If the intermediate source has the same promotion rules as some other tablets, then we prioritize using
 	// the intermediate source since we won't have to wait for the new candidate to catch up!
 	for _, promotionRule := range promotionrule.AllPromotionRules() {
-		candidates := getTabletsWithPromotionRules(validCandidates, promotionRule)
+		candidates := getTabletsWithPromotionRules(opts.durability, validCandidates, promotionRule)
 		candidate = findCandidate(intermediateSource, candidates)
 		if candidate != nil {
 			return candidate, nil
@@ -684,11 +695,11 @@ func (erp *EmergencyReparenter) promoteNewPrimary(
 	if ev.ShardInfo.PrimaryAlias == nil {
 		erp.logger.Infof("setting up %v as new primary for an uninitialized cluster", newPrimary.Alias)
 		// we call InitPrimary when the PrimaryAlias in the ShardInfo is empty. This happens when we have an uninitialized cluster.
-		_, err = erp.tmc.InitPrimary(ctx, newPrimary, SemiSyncAckers(nil, newPrimary) > 0)
+		_, err = erp.tmc.InitPrimary(ctx, newPrimary, SemiSyncAckers(opts.durability, newPrimary) > 0)
 	} else {
 		erp.logger.Infof("starting promotion for the new primary - %v", newPrimary.Alias)
 		// we call PromoteReplica which changes the tablet type, fixes the semi-sync, set the primary to read-write and flushes the binlogs
-		_, err = erp.tmc.PromoteReplica(ctx, newPrimary, SemiSyncAckers(nil, newPrimary) > 0)
+		_, err = erp.tmc.PromoteReplica(ctx, newPrimary, SemiSyncAckers(opts.durability, newPrimary) > 0)
 	}
 	if err != nil {
 		return vterrors.Wrapf(err, "primary-elect tablet %v failed to be upgraded to primary: %v", newPrimary.Alias, err)
@@ -708,7 +719,7 @@ func (erp *EmergencyReparenter) filterValidCandidates(validTablets []*topodatapb
 	for _, tablet := range validTablets {
 		tabletAliasStr := topoproto.TabletAliasString(tablet.Alias)
 		// Remove tablets which have MustNot promote rule since they must never be promoted
-		if PromotionRule(nil, tablet) == promotionrule.MustNot {
+		if PromotionRule(opts.durability, tablet) == promotionrule.MustNot {
 			erp.logger.Infof("Removing %s from list of valid candidates for promotion because it has the Must Not promote rule", tabletAliasStr)
 			if opts.NewPrimaryAlias != nil && topoproto.TabletAliasEqual(opts.NewPrimaryAlias, tablet.Alias) {
 				return nil, vterrors.Errorf(vtrpc.Code_ABORTED, "proposed primary %s has a must not promotion rule", topoproto.TabletAliasString(opts.NewPrimaryAlias))
@@ -724,7 +735,7 @@ func (erp *EmergencyReparenter) filterValidCandidates(validTablets []*topodatapb
 			continue
 		}
 		// Remove any tablet which cannot make forward progress using the list of tablets we have reached
-		if !canEstablishForTablet(tablet, tabletsReachable) {
+		if !canEstablishForTablet(opts.durability, tablet, tabletsReachable) {
 			erp.logger.Infof("Removing %s from list of valid candidates for promotion because it will not be able to make forward progress on promotion with the tablets currently reachable", tabletAliasStr)
 			if opts.NewPrimaryAlias != nil && topoproto.TabletAliasEqual(opts.NewPrimaryAlias, tablet.Alias) {
 				return nil, vterrors.Errorf(vtrpc.Code_ABORTED, "proposed primary %s will not be able to make forward progress on being promoted", topoproto.TabletAliasString(opts.NewPrimaryAlias))

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -372,7 +372,7 @@ func (erp *EmergencyReparenter) findMostAdvanced(
 	}
 
 	// sort the tablets for finding the best intermediate source in ERS
-	err = sortTabletsForReparent(validTablets, tabletPositions)
+	err = sortTabletsForReparent(validTablets, tabletPositions, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -31,9 +31,9 @@ import (
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
-
 	"vitess.io/vitess/go/vt/topotools/events"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver/testutil"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/reparenttestutil"
 
 	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -1931,7 +1931,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 
 			testutil.AddShards(ctx, t, tt.ts, tt.shards...)
 			testutil.AddTablets(ctx, t, tt.ts, nil, tt.tablets...)
-			testutil.SetKeyspaceDurability(ctx, t, tt.ts, tt.keyspace, tt.durability)
+			reparenttestutil.SetKeyspaceDurability(ctx, t, tt.ts, tt.keyspace, tt.durability)
 
 			if !tt.unlockTopo {
 				lctx, unlock, lerr := tt.ts.LockShard(ctx, tt.keyspace, tt.shard, "test lock")
@@ -2751,7 +2751,6 @@ func TestEmergencyReparenterCounters(t *testing.T) {
 	ersCounter.Set(0)
 	ersSuccessCounter.Set(0)
 	ersFailureCounter.Set(0)
-	_ = SetDurabilityPolicy("none")
 
 	emergencyReparentOps := EmergencyReparentOptions{}
 	tmc := &testutil.TabletManagerClient{

--- a/go/vt/vtctl/reparentutil/planned_reparenter.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter.go
@@ -59,6 +59,7 @@ type PlannedReparentOptions struct {
 	// back out to the caller.
 
 	lockAction string
+	durability Durabler
 }
 
 // NewPlannedReparenter returns a new PlannedReparenter object, ready to perform
@@ -163,7 +164,7 @@ func (pr *PlannedReparenter) preflightChecks(
 
 		event.DispatchUpdate(ev, "searching for primary candidate")
 
-		opts.NewPrimaryAlias, err = ChooseNewPrimary(ctx, pr.tmc, &ev.ShardInfo, tabletMap, opts.AvoidPrimaryAlias, opts.WaitReplicasTimeout, pr.logger)
+		opts.NewPrimaryAlias, err = ChooseNewPrimary(ctx, pr.tmc, &ev.ShardInfo, tabletMap, opts.AvoidPrimaryAlias, opts.WaitReplicasTimeout, opts.durability, pr.logger)
 		if err != nil {
 			return true, err
 		}
@@ -229,7 +230,7 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 	setSourceCtx, setSourceCancel := context.WithTimeout(ctx, opts.WaitReplicasTimeout)
 	defer setSourceCancel()
 
-	if err := pr.tmc.SetReplicationSource(setSourceCtx, primaryElect, currentPrimary.Alias, 0, snapshotPos, true, IsReplicaSemiSync(nil, currentPrimary.Tablet, primaryElect)); err != nil {
+	if err := pr.tmc.SetReplicationSource(setSourceCtx, primaryElect, currentPrimary.Alias, 0, snapshotPos, true, IsReplicaSemiSync(opts.durability, currentPrimary.Tablet, primaryElect)); err != nil {
 		return "", vterrors.Wrapf(err, "replication on primary-elect %v did not catch up in time; replication must be healthy to perform PlannedReparent", primaryElectAliasStr)
 	}
 
@@ -277,7 +278,7 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 		undoCtx, undoCancel := context.WithTimeout(context.Background(), *topo.RemoteOperationTimeout)
 		defer undoCancel()
 
-		if undoErr := pr.tmc.UndoDemotePrimary(undoCtx, currentPrimary.Tablet, SemiSyncAckers(nil, currentPrimary.Tablet) > 0); undoErr != nil {
+		if undoErr := pr.tmc.UndoDemotePrimary(undoCtx, currentPrimary.Tablet, SemiSyncAckers(opts.durability, currentPrimary.Tablet) > 0); undoErr != nil {
 			pr.logger.Warningf("encountered error while performing UndoDemotePrimary(%v): %v", currentPrimary.AliasString(), undoErr)
 			finalWaitErr = vterrors.Wrapf(finalWaitErr, "encountered error while performing UndoDemotePrimary(%v): %v", currentPrimary.AliasString(), undoErr)
 		}
@@ -290,7 +291,7 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 	promoteCtx, promoteCancel := context.WithTimeout(ctx, opts.WaitReplicasTimeout)
 	defer promoteCancel()
 
-	rp, err := pr.tmc.PromoteReplica(promoteCtx, primaryElect, SemiSyncAckers(nil, primaryElect) > 0)
+	rp, err := pr.tmc.PromoteReplica(promoteCtx, primaryElect, SemiSyncAckers(opts.durability, primaryElect) > 0)
 	if err != nil {
 		return "", vterrors.Wrapf(err, "primary-elect tablet %v failed to be promoted to primary; please try again", primaryElectAliasStr)
 	}
@@ -321,7 +322,7 @@ func (pr *PlannedReparenter) performInitialPromotion(
 	// This is done to guarantee safety, in the sense that the semi-sync is on before we start accepting writes.
 	// However, during initialization, it is likely that the database would not be created in the MySQL instance.
 	// Therefore, we have to first set read-write mode, create the database and then fix semi-sync, otherwise we get blocked.
-	rp, err := pr.tmc.InitPrimary(promoteCtx, primaryElect, SemiSyncAckers(nil, primaryElect) > 0)
+	rp, err := pr.tmc.InitPrimary(promoteCtx, primaryElect, SemiSyncAckers(opts.durability, primaryElect) > 0)
 	if err != nil {
 		return "", vterrors.Wrapf(err, "primary-elect tablet %v failed to be promoted to primary; please try again", primaryElectAliasStr)
 	}
@@ -366,6 +367,7 @@ func (pr *PlannedReparenter) performPotentialPromotion(
 	shard string,
 	primaryElect *topodatapb.Tablet,
 	tabletMap map[string]*topo.TabletInfo,
+	opts PlannedReparentOptions,
 ) (string, error) {
 	primaryElectAliasStr := topoproto.TabletAliasString(primaryElect.Alias)
 
@@ -487,7 +489,7 @@ func (pr *PlannedReparenter) performPotentialPromotion(
 	promoteCtx, promoteCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer promoteCancel()
 
-	rp, err := pr.tmc.PromoteReplica(promoteCtx, primaryElect, SemiSyncAckers(nil, primaryElect) > 0)
+	rp, err := pr.tmc.PromoteReplica(promoteCtx, primaryElect, SemiSyncAckers(opts.durability, primaryElect) > 0)
 	if err != nil {
 		return "", vterrors.Wrapf(err, "failed to promote %v to primary", primaryElectAliasStr)
 	}
@@ -503,6 +505,16 @@ func (pr *PlannedReparenter) reparentShardLocked(
 	opts PlannedReparentOptions,
 ) error {
 	shardInfo, err := pr.ts.GetShard(ctx, keyspace, shard)
+	if err != nil {
+		return err
+	}
+
+	keyspaceDurability, err := pr.ts.GetKeyspaceDurability(ctx, keyspace)
+	if err != nil {
+		return err
+	}
+
+	opts.durability, err = GetDurabilityPolicy(keyspaceDurability)
 	if err != nil {
 		return err
 	}
@@ -573,7 +585,7 @@ func (pr *PlannedReparenter) reparentShardLocked(
 	case currentPrimary == nil && ev.ShardInfo.PrimaryAlias != nil:
 		// Case (2): no clear current primary. Try to find a safe promotion
 		// candidate, and promote to it.
-		reparentJournalPos, err = pr.performPotentialPromotion(ctx, keyspace, shard, ev.NewPrimary, tabletMap)
+		reparentJournalPos, err = pr.performPotentialPromotion(ctx, keyspace, shard, ev.NewPrimary, tabletMap, opts)
 	case topoproto.TabletAliasEqual(currentPrimary.Alias, opts.NewPrimaryAlias):
 		// Case (3): desired new primary is the current primary. Attempt to fix
 		// up replicas to recover from a previous partial promotion.
@@ -654,7 +666,7 @@ func (pr *PlannedReparenter) reparentTablets(
 			// that it needs to start replication after transitioning from
 			// PRIMARY => REPLICA.
 			forceStartReplication := false
-			if err := pr.tmc.SetReplicationSource(replCtx, tablet, ev.NewPrimary.Alias, reparentJournalTimestamp, "", forceStartReplication, IsReplicaSemiSync(nil, ev.NewPrimary, tablet)); err != nil {
+			if err := pr.tmc.SetReplicationSource(replCtx, tablet, ev.NewPrimary.Alias, reparentJournalTimestamp, "", forceStartReplication, IsReplicaSemiSync(opts.durability, ev.NewPrimary, tablet)); err != nil {
 				rec.RecordError(vterrors.Wrapf(err, "tablet %v failed to SetReplicationSource(%v): %v", alias, primaryElectAliasStr, err))
 			}
 		}(alias, tabletInfo.Tablet)

--- a/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
@@ -1641,6 +1641,10 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 				ctx = _ctx
 			}
 
+			durability, err := GetDurabilityPolicy("none")
+			require.NoError(t, err)
+			tt.opts.durability = durability
+
 			pos, err := pr.performGracefulPromotion(
 				ctx,
 				tt.ev,
@@ -1790,10 +1794,12 @@ func TestPlannedReparenter_performInitialPromotion(t *testing.T) {
 				ctx = _ctx
 			}
 
+			durability, err := GetDurabilityPolicy("none")
+			require.NoError(t, err)
 			pos, err := pr.performInitialPromotion(
 				ctx,
 				tt.primaryElect,
-				PlannedReparentOptions{},
+				PlannedReparentOptions{durability: durability},
 			)
 
 			if tt.shouldErr {
@@ -2505,7 +2511,9 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 				ctx = _ctx
 			}
 
-			rp, err := pr.performPotentialPromotion(ctx, tt.keyspace, tt.shard, tt.primaryElect, tt.tabletMap)
+			durability, err := GetDurabilityPolicy("none")
+			require.NoError(t, err)
+			rp, err := pr.performPotentialPromotion(ctx, tt.keyspace, tt.shard, tt.primaryElect, tt.tabletMap, PlannedReparentOptions{durability: durability})
 			if tt.shouldErr {
 				assert.Error(t, err)
 
@@ -3578,7 +3586,10 @@ func TestPlannedReparenter_reparentTablets(t *testing.T) {
 			t.Parallel()
 
 			pr := NewPlannedReparenter(nil, tt.tmc, logger)
-			err := pr.reparentTablets(ctx, tt.ev, tt.reparentJournalPosition, tt.tabletMap, tt.opts)
+			durability, err := GetDurabilityPolicy("none")
+			require.NoError(t, err)
+			tt.opts.durability = durability
+			err = pr.reparentTablets(ctx, tt.ev, tt.reparentJournalPosition, tt.tabletMap, tt.opts)
 			if tt.shouldErr {
 				assert.Error(t, err)
 

--- a/go/vt/vtctl/reparentutil/reparent_sorter.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter.go
@@ -29,15 +29,17 @@ import (
 // reparentSorter sorts tablets by GTID positions and Promotion rules aimed at finding the best
 // candidate for intermediate promotion in emergency reparent shard, and the new primary in planned reparent shard
 type reparentSorter struct {
-	tablets   []*topodatapb.Tablet
-	positions []mysql.Position
+	tablets    []*topodatapb.Tablet
+	positions  []mysql.Position
+	durability Durabler
 }
 
 // newReparentSorter creates a new reparentSorter
-func newReparentSorter(tablets []*topodatapb.Tablet, positions []mysql.Position) *reparentSorter {
+func newReparentSorter(tablets []*topodatapb.Tablet, positions []mysql.Position, durability Durabler) *reparentSorter {
 	return &reparentSorter{
-		tablets:   tablets,
-		positions: positions,
+		tablets:    tablets,
+		positions:  positions,
+		durability: durability,
 	}
 }
 
@@ -75,20 +77,20 @@ func (rs *reparentSorter) Less(i, j int) bool {
 
 	// at this point, both have the same GTIDs
 	// so we check their promotion rules
-	jPromotionRule := PromotionRule(nil, rs.tablets[j])
-	iPromotionRule := PromotionRule(nil, rs.tablets[i])
+	jPromotionRule := PromotionRule(rs.durability, rs.tablets[j])
+	iPromotionRule := PromotionRule(rs.durability, rs.tablets[i])
 	return !jPromotionRule.BetterThan(iPromotionRule)
 }
 
 // sortTabletsForReparent sorts the tablets, given their positions for emergency reparent shard and planned reparent shard.
 // Tablets are sorted first by their replication positions, with ties broken by the promotion rules.
-func sortTabletsForReparent(tablets []*topodatapb.Tablet, positions []mysql.Position) error {
+func sortTabletsForReparent(tablets []*topodatapb.Tablet, positions []mysql.Position, durability Durabler) error {
 	// throw an error internal error in case of unequal number of tablets and positions
 	// fail-safe code prevents panic in sorting in case the lengths are unequal
 	if len(tablets) != len(positions) {
 		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unequal number of tablets and positions")
 	}
 
-	sort.Sort(newReparentSorter(tablets, positions))
+	sort.Sort(newReparentSorter(tablets, positions, durability))
 	return nil
 }

--- a/go/vt/vtctl/reparentutil/reparent_sorter.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter.go
@@ -75,8 +75,8 @@ func (rs *reparentSorter) Less(i, j int) bool {
 
 	// at this point, both have the same GTIDs
 	// so we check their promotion rules
-	jPromotionRule := PromotionRule(rs.tablets[j])
-	iPromotionRule := PromotionRule(rs.tablets[i])
+	jPromotionRule := PromotionRule(nil, rs.tablets[j])
+	iPromotionRule := PromotionRule(nil, rs.tablets[i])
 	return !jPromotionRule.BetterThan(iPromotionRule)
 }
 

--- a/go/vt/vtctl/reparentutil/reparent_sorter_test.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter_test.go
@@ -122,11 +122,11 @@ func TestReparentSorter(t *testing.T) {
 		},
 	}
 
-	err := SetDurabilityPolicy("none")
+	durability, err := GetDurabilityPolicy("none")
 	require.NoError(t, err)
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			err := sortTabletsForReparent(testcase.tablets, testcase.positions)
+			err := sortTabletsForReparent(testcase.tablets, testcase.positions, durability)
 			if testcase.containsErr != "" {
 				require.EqualError(t, err, testcase.containsErr)
 			} else {

--- a/go/vt/vtctl/reparentutil/reparenttestutil/util.go
+++ b/go/vt/vtctl/reparentutil/reparenttestutil/util.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package reparenttestutil contains utility functions for writing tests
+package reparenttestutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/topo"
+)
+
+// SetKeyspaceDurability sets the durability policy of a given keyspace. This function should only be used in test code
+// To make it explicit and prevent any future errors, we are taking a testing.T argument, even though we could have returned the error
+func SetKeyspaceDurability(ctx context.Context, t *testing.T, ts *topo.Server, keyspace, durability string) {
+	ctx, unlock, lockErr := ts.LockKeyspace(ctx, keyspace, "testutil.SetKeyspaceDurability")
+	if lockErr != nil {
+		return
+	}
+
+	var err error
+	defer unlock(&err)
+
+	ki, err := ts.GetKeyspace(ctx, keyspace)
+	require.NoError(t, err)
+
+	ki.DurabilityPolicy = durability
+
+	err = ts.UpdateKeyspace(ctx, ki)
+	require.NoError(t, err)
+}

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -182,7 +182,7 @@ func SetReplicationSource(ctx context.Context, ts *topo.Server, tmc tmclient.Tab
 		return nil
 	}
 
-	isSemiSync := IsReplicaSemiSync(shardPrimary.Tablet, tablet)
+	isSemiSync := IsReplicaSemiSync(nil, shardPrimary.Tablet, tablet)
 	return tmc.SetReplicationSource(ctx, tablet, shardPrimary.Alias, 0, "", false, isSemiSync)
 }
 

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -182,7 +182,16 @@ func SetReplicationSource(ctx context.Context, ts *topo.Server, tmc tmclient.Tab
 		return nil
 	}
 
-	isSemiSync := IsReplicaSemiSync(nil, shardPrimary.Tablet, tablet)
+	durabilityName, err := ts.GetKeyspaceDurability(ctx, tablet.Keyspace)
+	if err != nil {
+		return err
+	}
+	durability, err := GetDurabilityPolicy(durabilityName)
+	if err != nil {
+		return err
+	}
+
+	isSemiSync := IsReplicaSemiSync(durability, shardPrimary.Tablet, tablet)
 	return tmc.SetReplicationSource(ctx, tablet, shardPrimary.Alias, 0, "", false, isSemiSync)
 }
 

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -206,6 +206,7 @@ func stopReplicationAndBuildStatusMaps(
 	waitReplicasTimeout time.Duration,
 	ignoredTablets sets.String,
 	tabletToWaitFor *topodatapb.TabletAlias,
+	durability Durabler,
 	logger logutil.Logger,
 ) (*replicationSnapshot, error) {
 	event.DispatchUpdate(ev, "stop replication on all replicas")
@@ -308,7 +309,7 @@ func stopReplicationAndBuildStatusMaps(
 		return res, nil
 	}
 	// check that the tablets we were able to reach are sufficient for us to guarantee that no new write will be accepted by any tablet
-	revokeSuccessful := haveRevoked(res.reachableTablets, allTablets)
+	revokeSuccessful := haveRevoked(durability, res.reachableTablets, allTablets)
 	if !revokeSuccessful {
 		return nil, vterrors.Wrapf(errRecorder.Error(), "could not reach sufficient tablets to guarantee safety: %v", errRecorder.Error())
 	}

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -1108,9 +1108,9 @@ func Test_stopReplicationAndBuildStatusMaps(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			err := SetDurabilityPolicy(tt.durability)
+			durability, err := GetDurabilityPolicy(tt.durability)
 			require.NoError(t, err)
-			res, err := stopReplicationAndBuildStatusMaps(ctx, tt.tmc, &events.Reparent{}, tt.tabletMap, tt.waitReplicasTimeout, tt.ignoredTablets, tt.tabletToWaitFor, logger)
+			res, err := stopReplicationAndBuildStatusMaps(ctx, tt.tmc, &events.Reparent{}, tt.tabletMap, tt.waitReplicasTimeout, tt.ignoredTablets, tt.tabletToWaitFor, durability, logger)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -297,7 +297,7 @@ func findCandidate(
 // getTabletsWithPromotionRules gets the tablets with the given promotion rule from the list of tablets
 func getTabletsWithPromotionRules(tablets []*topodatapb.Tablet, rule promotionrule.CandidatePromotionRule) (res []*topodatapb.Tablet) {
 	for _, candidate := range tablets {
-		promotionRule := PromotionRule(candidate)
+		promotionRule := PromotionRule(nil, candidate)
 		if promotionRule == rule {
 			res = append(res, candidate)
 		}

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -296,9 +296,9 @@ func findCandidate(
 }
 
 // getTabletsWithPromotionRules gets the tablets with the given promotion rule from the list of tablets
-func getTabletsWithPromotionRules(tablets []*topodatapb.Tablet, rule promotionrule.CandidatePromotionRule) (res []*topodatapb.Tablet) {
+func getTabletsWithPromotionRules(durability Durabler, tablets []*topodatapb.Tablet, rule promotionrule.CandidatePromotionRule) (res []*topodatapb.Tablet) {
 	for _, candidate := range tablets {
-		promotionRule := PromotionRule(nil, candidate)
+		promotionRule := PromotionRule(durability, candidate)
 		if promotionRule == rule {
 			res = append(res, candidate)
 		}

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -55,6 +55,7 @@ func ChooseNewPrimary(
 	tabletMap map[string]*topo.TabletInfo,
 	avoidPrimaryAlias *topodatapb.TabletAlias,
 	waitReplicasTimeout time.Duration,
+	durability Durabler,
 	// (TODO:@ajm188) it's a little gross we need to pass this, maybe embed in the context?
 	logger logutil.Logger,
 ) (*topodatapb.TabletAlias, error) {
@@ -106,7 +107,7 @@ func ChooseNewPrimary(
 	}
 
 	// sort the tablets for finding the best primary
-	err := sortTabletsForReparent(validTablets, tabletPositions)
+	err := sortTabletsForReparent(validTablets, tabletPositions, durability)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -433,13 +433,15 @@ func TestChooseNewPrimary(t *testing.T) {
 		},
 	}
 
+	durability, err := GetDurabilityPolicy("none")
+	require.NoError(t, err)
 	for _, tt := range tests {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := ChooseNewPrimary(ctx, tt.tmc, tt.shardInfo, tt.tabletMap, tt.avoidPrimaryAlias, time.Millisecond*50, logger)
+			actual, err := ChooseNewPrimary(ctx, tt.tmc, tt.shardInfo, tt.tabletMap, tt.avoidPrimaryAlias, time.Millisecond*50, durability, logger)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -1208,10 +1208,10 @@ func Test_getTabletsWithPromotionRules(t *testing.T) {
 			filteredTablets: nil,
 		},
 	}
-	_ = SetDurabilityPolicy("none")
+	durability, _ := GetDurabilityPolicy("none")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := getTabletsWithPromotionRules(tt.tablets, tt.rule)
+			res := getTabletsWithPromotionRules(durability, tt.tablets, tt.rule)
 			require.EqualValues(t, tt.filteredTablets, res)
 		})
 	}

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -31,7 +31,6 @@ import (
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/topo"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/wrangler"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -59,12 +58,6 @@ const (
 func InitVtctld(ts *topo.Server) error {
 	if *deprecatedOnlineDDLCheckInterval != 0 {
 		log.Warningf("the flag '--online_ddl_check_interval' is deprecated and will be removed in future versions. It is currently unused.")
-	}
-
-	err := reparentutil.SetDurabilityPolicy("none")
-	if err != nil {
-		log.Errorf("error in setting durability policy: %v", err)
-		return err
 	}
 
 	actionRepo := NewActionRepository(ts)

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -28,7 +28,6 @@ import (
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/topotools"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vttablet/grpcqueryservice"
 	"vitess.io/vitess/go/vt/vttablet/queryservice/fakes"
 	"vitess.io/vitess/go/vt/wrangler/testlib"
@@ -55,10 +54,6 @@ func createVerticalSplitCloneDestinationFakeDb(t *testing.T, name string, insert
 	}
 
 	return f
-}
-
-func init() {
-	_ = reparentutil.SetDurabilityPolicy("none")
 }
 
 // TestVerticalSplitClone will run VerticalSplitClone in the combined

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -133,6 +133,15 @@ func (wr *Wrangler) TabletExternallyReparented(ctx context.Context, newPrimaryAl
 	if tablet.Type != topodatapb.TabletType_PRIMARY {
 		log.Infof("TabletExternallyReparented: executing tablet type change to PRIMARY")
 
+		durabilityName, err := wr.ts.GetKeyspaceDurability(ctx, tablet.Keyspace)
+		if err != nil {
+			return err
+		}
+		durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
+		if err != nil {
+			return err
+		}
+
 		// Create a reusable Reparent event with available info.
 		ev := &events.Reparent{
 			ShardInfo:  *si,
@@ -149,7 +158,7 @@ func (wr *Wrangler) TabletExternallyReparented(ctx context.Context, newPrimaryAl
 		}()
 		event.DispatchUpdate(ev, "starting external reparent")
 
-		if err := wr.tmc.ChangeType(ctx, tablet, topodatapb.TabletType_PRIMARY, reparentutil.SemiSyncAckers(nil, tablet) > 0); err != nil {
+		if err := wr.tmc.ChangeType(ctx, tablet, topodatapb.TabletType_PRIMARY, reparentutil.SemiSyncAckers(durability, tablet) > 0); err != nil {
 			log.Warningf("Error calling ChangeType on new primary %v: %v", topoproto.TabletAliasString(newPrimaryAlias), err)
 			return err
 		}

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -149,7 +149,7 @@ func (wr *Wrangler) TabletExternallyReparented(ctx context.Context, newPrimaryAl
 		}()
 		event.DispatchUpdate(ev, "starting external reparent")
 
-		if err := wr.tmc.ChangeType(ctx, tablet, topodatapb.TabletType_PRIMARY, reparentutil.SemiSyncAckers(tablet) > 0); err != nil {
+		if err := wr.tmc.ChangeType(ctx, tablet, topodatapb.TabletType_PRIMARY, reparentutil.SemiSyncAckers(nil, tablet) > 0); err != nil {
 			log.Warningf("Error calling ChangeType on new primary %v: %v", topoproto.TabletAliasString(newPrimaryAlias), err)
 			return err
 		}

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -138,7 +138,7 @@ func (wr *Wrangler) shouldSendSemiSyncAck(ctx context.Context, tablet *topodatap
 	if err != nil {
 		return false, err
 	}
-	return reparentutil.IsReplicaSemiSync(shardPrimary.Tablet, tablet), nil
+	return reparentutil.IsReplicaSemiSync(nil, shardPrimary.Tablet, tablet), nil
 }
 
 func (wr *Wrangler) getShardPrimaryForTablet(ctx context.Context, tablet *topodatapb.Tablet) (*topo.TabletInfo, error) {

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -138,7 +138,17 @@ func (wr *Wrangler) shouldSendSemiSyncAck(ctx context.Context, tablet *topodatap
 	if err != nil {
 		return false, err
 	}
-	return reparentutil.IsReplicaSemiSync(nil, shardPrimary.Tablet, tablet), nil
+
+	durabilityName, err := wr.ts.GetKeyspaceDurability(ctx, tablet.Keyspace)
+	if err != nil {
+		return false, err
+	}
+	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
+	if err != nil {
+		return false, err
+	}
+
+	return reparentutil.IsReplicaSemiSync(durability, shardPrimary.Tablet, tablet), nil
 }
 
 func (wr *Wrangler) getShardPrimaryForTablet(ctx context.Context, tablet *topodatapb.Tablet) (*topo.TabletInfo, error) {

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -41,7 +41,6 @@ import (
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 	"vitess.io/vitess/go/vt/wrangler"
 
@@ -49,7 +48,6 @@ import (
 )
 
 func TestBackupRestore(t *testing.T) {
-	_ = reparentutil.SetDurabilityPolicy("none")
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -264,7 +262,6 @@ func TestBackupRestore(t *testing.T) {
 // While doing a backup or a restore, we wait for a change of the replica's position before completing the action
 // This is because otherwise ReplicationLagSeconds is not accurate and the tablet may go into SERVING when it should not
 func TestBackupRestoreLagged(t *testing.T) {
-	_ = reparentutil.SetDurabilityPolicy("none")
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -471,7 +468,6 @@ func TestBackupRestoreLagged(t *testing.T) {
 }
 
 func TestRestoreUnreachablePrimary(t *testing.T) {
-	_ = reparentutil.SetDurabilityPolicy("none")
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -631,7 +627,6 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 }
 
 func TestDisableActiveReparents(t *testing.T) {
-	_ = reparentutil.SetDurabilityPolicy("none")
 	*mysqlctl.DisableActiveReparents = true
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -31,7 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/reparenttestutil"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 	"vitess.io/vitess/go/vt/wrangler"
 
@@ -44,7 +44,6 @@ func TestEmergencyReparentShard(t *testing.T) {
 		discovery.SetTabletPickerRetryDelay(delay)
 	}()
 	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
-	_ = reparentutil.SetDurabilityPolicy("semi_sync")
 
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
@@ -56,6 +55,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 	goodReplica2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
+	reparenttestutil.SetKeyspaceDurability(context.Background(), t, ts, "test_keyspace", "semi_sync")
 
 	oldPrimary.FakeMysqlDaemon.Replicating = false
 	oldPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
@@ -194,7 +194,6 @@ func TestEmergencyReparentShardPrimaryElectNotBest(t *testing.T) {
 		discovery.SetTabletPickerRetryDelay(delay)
 	}()
 	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
-	_ = reparentutil.SetDurabilityPolicy("semi_sync")
 
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
@@ -203,6 +202,7 @@ func TestEmergencyReparentShardPrimaryElectNotBest(t *testing.T) {
 	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, nil)
 	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	moreAdvancedReplica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
+	reparenttestutil.SetKeyspaceDurability(context.Background(), t, ts, "test_keyspace", "semi_sync")
 
 	// new primary
 	newPrimary.FakeMysqlDaemon.Replicating = true

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -22,17 +22,15 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/vt/vtctl/reparentutil"
-
-	"vitess.io/vitess/go/vt/discovery"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/reparenttestutil"
 	"vitess.io/vitess/go/vt/vttablet/tabletservermock"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 	"vitess.io/vitess/go/vt/wrangler"
@@ -640,7 +638,6 @@ func TestPlannedReparentShardRelayLogError(t *testing.T) {
 // is not replicating to start with (IO_Thread is not running) and we
 // simulate an error from the attempt to start replication
 func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
-	_ = reparentutil.SetDurabilityPolicy("semi_sync")
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -655,6 +652,7 @@ func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
 	// Create a primary, a couple good replicas
 	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
+	reparenttestutil.SetKeyspaceDurability(context.Background(), t, ts, "test_keyspace", "semi_sync")
 
 	// old primary
 	primary.FakeMysqlDaemon.ReadOnly = false

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -54,6 +54,7 @@ func TestPlannedReparentShardNoPrimaryProvided(t *testing.T) {
 	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, nil)
 	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell2", 2, topodatapb.TabletType_REPLICA, nil)
+	reparenttestutil.SetKeyspaceDurability(context.Background(), t, ts, "test_keyspace", "semi_sync")
 
 	// new primary
 	newPrimary.FakeMysqlDaemon.ReadOnly = true
@@ -165,6 +166,7 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 	goodReplica2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
+	reparenttestutil.SetKeyspaceDurability(context.Background(), t, ts, "test_keyspace", "semi_sync")
 
 	// new primary
 	newPrimary.FakeMysqlDaemon.ReadOnly = true
@@ -289,6 +291,7 @@ func TestPlannedReparentInitialization(t *testing.T) {
 	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 	goodReplica2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
+	reparenttestutil.SetKeyspaceDurability(context.Background(), t, ts, "test_keyspace", "semi_sync")
 
 	// new primary
 	newPrimary.FakeMysqlDaemon.ReadOnly = true

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/reparenttestutil"
+
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 
@@ -129,6 +131,7 @@ func TestReparentTablet(t *testing.T) {
 	}
 	primary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_PRIMARY, nil)
 	replica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
+	reparenttestutil.SetKeyspaceDurability(context.Background(), t, ts, "test_keyspace", "semi_sync")
 
 	// mark the primary inside the shard
 	if _, err := ts.UpdateShardFields(ctx, "test_keyspace", "0", func(si *topo.ShardInfo) error {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR exports the Durabler interface and moves away from the architecture of having a single global durability policy for a binary.
All the RPCs that need to use the durability policy, now first consult the topo server to read the keyspace information to find the durability_policy. Once they have the durability policy, they get a new Durabler and use that for all the other operations needing durability policies.

As part of the PR, changes to the local and legacy local examples has also been made to set the correct durability policies for the keyspaces that they create.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #8975 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required - https://github.com/vitessio/vitess/pull/10392

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
