### PR TITLE
Replace 'CREATE TABLE LIKE' with programmatic copy

### DIFF
--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -507,7 +507,6 @@ const (
 	`
 	sqlDropTrigger      = "DROP TRIGGER IF EXISTS `%a`.`%a`"
 	sqlShowTablesLike   = "SHOW TABLES LIKE '%a'"
-	sqlCreateTableLike  = "CREATE TABLE `%a` LIKE `%a`"
 	sqlDropTable        = "DROP TABLE `%a`"
 	sqlShowColumnsFrom  = "SHOW COLUMNS FROM `%a`"
 	sqlShowTableStatus  = "SHOW TABLE STATUS LIKE '%a'"


### PR DESCRIPTION

## Description

Followup to #10315 and #10369 

In #10369 we address the issue of constraint names being unique across the schema, and we introduce a programmatic alternative to `CREATE TABLE LIKE`.

In #10315 we rotate partitions, and use `CREATE TABLE LIKE`.

This PR follows up on both by refactoring and generalizing a `createTableLike()` function that now applies in "normal" `vitess` migrations as well as in "fast rotation" migrations.

The scenario where this PR has effect, is when we do a fast-rotate on a range partition table **that happens** to also have (check) constraints.

## Related Issue(s)

- #6926 
- #10315 
- #10369 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
