### PR TITLE
Fix schema engine close and ticks race

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -248,7 +248,7 @@ func (se *Engine) Close() {
 	se.isOpen = false
 
 	// Unlock the mutex. If there is a tick blocked on this lock,
-	// then it will run and we wait for the Stop function to finish it's execution
+	// then it will run and we wait for the Stop function to finish its execution
 	se.mu.Unlock()
 	<-ticksWaitChan
 	log.Info("Schema Engine: closed")

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -229,6 +229,13 @@ func (se *Engine) Close() {
 		return
 	}
 
+	se.closeLocked()
+	log.Info("Schema Engine: closed")
+}
+
+// closeLocked closes the schema engine. It is meant to be called after locking the mutex of the schema engine.
+// It also unlocks the engine when it returns.
+func (se *Engine) closeLocked() {
 	// Close the Timer in a separate go routine because
 	// there might be a tick after we have acquired the lock above
 	// but before closing the timer, in which case Stop function will wait for the
@@ -251,7 +258,6 @@ func (se *Engine) Close() {
 	// then it will run and we wait for the Stop function to finish its execution
 	se.mu.Unlock()
 	<-ticksWaitChan
-	log.Info("Schema Engine: closed")
 }
 
 // MakeNonPrimary clears the sequence caches to make sure that

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -504,15 +504,25 @@ func TestSchemaEngineCloseTickRace(t *testing.T) {
 	err := se.Open()
 	require.NoError(t, err)
 
-	// Emulate the command of se.Close(), but with a wait in between
-	// to ensure that a reload-tick happens after locking the mutex but before
-	// stopping the ticks
-	se.mu.Lock()
-	defer se.mu.Unlock()
 	time.Sleep(200 * time.Millisecond)
 	finished := make(chan bool)
 	go func() {
-		se.ticks.Stop()
+		{
+			// Emulate the command of se.Close(), but with a wait in between
+			// to ensure that a reload-tick happens after locking the mutex but before
+			// stopping the ticks
+			se.mu.Lock()
+			// Code copied from Close function, so that we can add the wait for
+			// 200 milliseconds and be sure that the timer tick happens after acquiring the lock
+			// in Close function
+			ticksWaitChan := make(chan bool, 0)
+			go func() {
+				se.ticks.Stop()
+				ticksWaitChan <- true
+			}()
+			se.mu.Unlock()
+			<-ticksWaitChan
+		}
 		finished <- true
 	}()
 	// Wait until the ticks are stopped or 2 seonds have expired.

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -511,17 +511,10 @@ func TestSchemaEngineCloseTickRace(t *testing.T) {
 			// to ensure that a reload-tick happens after locking the mutex but before
 			// stopping the ticks
 			se.mu.Lock()
-			// Code copied from Close function, so that we can add the wait for
-			// 200 milliseconds and be sure that the timer tick happens after acquiring the lock
-			// in Close function
+			// We wait for 200 milliseconds to be sure that the timer tick happens after acquiring the lock
+			// before we call closeLocked function
 			time.Sleep(200 * time.Millisecond)
-			ticksWaitChan := make(chan bool, 0)
-			go func() {
-				se.ticks.Stop()
-				ticksWaitChan <- true
-			}()
-			se.mu.Unlock()
-			<-ticksWaitChan
+			se.closeLocked()
 		}
 		finished <- true
 	}()

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -504,7 +504,6 @@ func TestSchemaEngineCloseTickRace(t *testing.T) {
 	err := se.Open()
 	require.NoError(t, err)
 
-	time.Sleep(200 * time.Millisecond)
 	finished := make(chan bool)
 	go func() {
 		{
@@ -515,6 +514,7 @@ func TestSchemaEngineCloseTickRace(t *testing.T) {
 			// Code copied from Close function, so that we can add the wait for
 			// 200 milliseconds and be sure that the timer tick happens after acquiring the lock
 			// in Close function
+			time.Sleep(200 * time.Millisecond)
 			ticksWaitChan := make(chan bool, 0)
 			go func() {
 				se.ticks.Stop()


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

We had found a deadlock which resulted in schema Engine close being blocked. 
The steps that led to the deadlock are - 
 * We start the schema engine shutdown (engine.Close())
 * we take the schema engine mutex lock, and start the rest of the schema engine shutdown
 * but before we can get to stopping the timer for the schema reload
 * the timer starts up and executes engine.ReloadAt, which tries to take the schema engine mutex lock (waits).
 * At this point engine.Close() tries to stop the timer, but since the timer is executing, that waits for the execution to complete.  And we have a deadlock.

This PR adds a unit test for this failure and also fixes it. 

The proposed fix is to try and stop the timer in a separate go routine and wait for it to finish **after** releasing the mutex lock. What this accomplishes is that, if there is a `engine.ReloadAt` function blocked on the lock, it will start running and consequently unblock the Stop function as well. 
As far the outward guarantees of the Close functions go, they remain the same with the function only returning after the timer has stopped.
The part that has changed is that the timer is being closed in a go routine and we could have already released the lock by the time we actually stop the timer (This is what prevents the deadlock). Which means that there could be a call to Open on the schema engine which could acquire the lock and try and access the timer in parallel. But this is also safe, because the timer has its own locking and will block.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported No
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
