### PR TITLE
feat: do not use lookup vindexes for IS NULL predicates

### DIFF
--- a/go/vt/vtgate/planbuilder/physical/route.go
+++ b/go/vt/vtgate/planbuilder/physical/route.go
@@ -711,6 +711,12 @@ func (r *Route) planIsExpr(ctx *plancontext.PlanningContext, node *sqlparser.IsE
 	if val == nil {
 		return false
 	}
+	opcodeF := func(vindex *vindexes.ColumnVindex) engine.Opcode {
+		if _, ok := vindex.Vindex.(vindexes.Lookup); ok {
+			return engine.Scatter
+		}
+		return equalOrEqualUnique(vindex)
+	}
 
-	return r.haveMatchingVindex(ctx, node, vdValue, column, val, equalOrEqualUnique, justTheVindex)
+	return r.haveMatchingVindex(ctx, node, vdValue, column, val, opcodeF, justTheVindex)
 }

--- a/go/vt/vtgate/planbuilder/physical/route.go
+++ b/go/vt/vtgate/planbuilder/physical/route.go
@@ -309,7 +309,7 @@ func (r *Route) haveMatchingVindex(
 				// single column vindex - just add the option
 				routeOpcode := opcode(v.ColVindex)
 				vindex := vfunc(v.ColVindex)
-				if vindex == nil {
+				if vindex == nil || routeOpcode == engine.Scatter {
 					continue
 				}
 				v.Options = append(v.Options, &VindexOption{

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -2138,11 +2138,7 @@ Gen4 plan same as above
     },
     "FieldQuery": "select id from music where 1 != 1",
     "Query": "select id from music where id is null",
-    "Table": "music",
-    "Values": [
-      "NULL"
-    ],
-    "Vindex": "music_user_map"
+    "Table": "music"
   }
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -2126,7 +2126,25 @@ Gen4 plan same as above
     "Vindex": "music_user_map"
   }
 }
-Gen4 plan same as above
+{
+  "QueryType": "SELECT",
+  "Original": "select id from music where id is null",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from music where 1 != 1",
+    "Query": "select id from music where id is null",
+    "Table": "music",
+    "Values": [
+      "NULL"
+    ],
+    "Vindex": "music_user_map"
+  }
+}
 
 # SELECT with IS NOT NULL
 "select id from music where id is not null"
@@ -4047,6 +4065,47 @@ Gen4 plan same as above
     "Table": "`user`",
     "Values": [
       "(INT64(1), INT64(2), INT64(3), INT64(4))"
+    ],
+    "Vindex": "user_index"
+  }
+}
+
+# Don't pick a vindex for an IS NULL predicate if it's a lookup vindex
+"select id from music where id is null and user_id in (1,2)"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from music where id is null and user_id in (1,2)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from music where 1 != 1",
+    "Query": "select id from music where id is null and user_id in (1, 2)",
+    "Table": "music",
+    "Values": [
+      "NULL"
+    ],
+    "Vindex": "music_user_map"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select id from music where id is null and user_id in (1,2)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from music where 1 != 1",
+    "Query": "select id from music where id is null and user_id in ::__vals",
+    "Table": "music",
+    "Values": [
+      "(INT64(1), INT64(2))"
     ],
     "Vindex": "user_index"
   }


### PR DESCRIPTION
## Description
When a query is using a `IS NULL` predicate against a lookup vindex column, we should have a very hight cost for these, since they will always need to do a scatter query. The lookup table is keyed by the column and so does not support `null` values.

## Related Issue(s)
#10346

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
