### PR TITLE
Fix commands in readme files to use double dashes for arguments

### DIFF
--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -97,7 +97,7 @@ This step is carried out by the **schemaload** container
 
 We need to create a few tables into our new cluster. To do that, we can run the `ApplySchema` command.	
 ```	
-vitess/examples/compose$ ./lvtctl.sh ApplySchema -sql "$(cat tables/create_messages.sql)" test_keyspace	
+vitess/examples/compose$ ./lvtctl.sh ApplySchema -- --sql "$(cat tables/create_messages.sql)" test_keyspace	
 ```
 
 ### Create Vschema	
@@ -105,7 +105,7 @@ This step is carried out by the **schemaload** container
 
 Create Vschema
 ```	
-vitess/examples/compose$ ./lvtctl.sh ApplyVschema -vschema '{"sharded": false }' test_keyspace	
+vitess/examples/compose$ ./lvtctl.sh ApplyVschema -- --vschema '{"sharded": false }' test_keyspace	
 ```
 
 ### Connect to vgate and run queries

--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -19,14 +19,14 @@ mysql --table < ../common/select_commerce_data.sql
 ./201_customer_tablets.sh
 
 # Initiate move tables
-vtctlclient MoveTables -source commerce -tables 'customer,corder' Create customer.commerce2customer
+vtctlclient MoveTables -- --source commerce --tables 'customer,corder' Create customer.commerce2customer
 
 # Validate
 vtctlclient VDiff customer.commerce2customer
 
 # Cut-over
-vtctlclient MoveTables -tablet_types=rdonly,replica SwitchTraffic customer.commerce2customer
-vtctlclient MoveTables -tablet_types=primary SwitchTraffic customer.commerce2customer
+vtctlclient MoveTables -- --tablet_types=rdonly,replica SwitchTraffic customer.commerce2customer
+vtctlclient MoveTables -- --tablet_types=primary SwitchTraffic customer.commerce2customer
 
 # Clean-up
 vtctlclient MoveTables Complete customer.commerce2customer
@@ -36,18 +36,18 @@ vtctlclient MoveTables Complete customer.commerce2customer
 ./302_new_shards.sh
 
 # Reshard
-vtctlclient Reshard -source_shards '0' -target_shards '-80,80-' Create customer.cust2cust
+vtctlclient Reshard -- --source_shards '0' --target_shards '-80,80-' Create customer.cust2cust
 
 # Validate
 vtctlclient VDiff customer.cust2cust
 
 # Cut-over
-vtctlclient Reshard -tablet_types=rdonly,replica SwitchTraffic customer.cust2cust
-vtctlclient Reshard -tablet_types=primary SwitchTraffic customer.cust2cust
+vtctlclient Reshard -- --tablet_types=rdonly,replica SwitchTraffic customer.cust2cust
+vtctlclient Reshard -- --tablet_types=primary SwitchTraffic customer.cust2cust
 
 # Down shard 0
 ./306_down_shard_0.sh
-vtctlclient DeleteShard -recursive customer/0
+vtctlclient DeleteShard -- --recursive customer/0
 
 # Down cluster
 ./401_teardown.sh

--- a/examples/operator/README.md
+++ b/examples/operator/README.md
@@ -23,9 +23,9 @@ kubectl apply -f 101_initial_cluster.yaml
 # Port-forward vtctld and vtgate and apply schema and vschema
 ./pf.sh &
 alias mysql="mysql -h 127.0.0.1 -P 15306 -u user"
-alias vtctlclient="vtctlclient -server localhost:15999 -alsologtostderr"
-vtctlclient ApplySchema -sql="$(cat create_commerce_schema.sql)" commerce
-vtctlclient ApplyVSchema -vschema="$(cat vschema_commerce_initial.json)" commerce
+alias vtctlclient="vtctlclient --server localhost:15999 --alsologtostderr"
+vtctlclient ApplySchema -- --sql="$(cat create_commerce_schema.sql)" commerce
+vtctlclient ApplyVSchema -- --vschema="$(cat vschema_commerce_initial.json)" commerce
 
 # Insert and verify data
 mysql < ../common/insert_commerce_data.sql
@@ -35,34 +35,34 @@ mysql --table < ../common/select_commerce_data.sql
 kubectl apply -f 201_customer_tablets.yaml
 
 # Initiate move tables
-vtctlclient MoveTables -source commerce -tables 'customer,corder' Create customer.commerce2customer
+vtctlclient MoveTables -- --source commerce --tables 'customer,corder' Create customer.commerce2customer
 
 # Validate
 vtctlclient VDiff customer.commerce2customer
 
 # Cut-over
-vtctlclient MoveTables -tablet_types=rdonly,replica SwitchTraffic customer.commerce2customer
-vtctlclient MoveTables -tablet_types=primary SwitchTraffic customer.commerce2customer
+vtctlclient MoveTables -- --tablet_types=rdonly,replica SwitchTraffic customer.commerce2customer
+vtctlclient MoveTables -- --tablet_types=primary SwitchTraffic customer.commerce2customer
 
 # Clean-up
 vtctlclient MoveTables Complete customer.commerce2customer
 
 # Prepare for resharding
-vtctlclient ApplySchema -sql="$(cat create_commerce_seq.sql)" commerce
-vtctlclient ApplyVSchema -vschema="$(cat vschema_commerce_seq.json)" commerce
-vtctlclient ApplySchema -sql="$(cat create_customer_sharded.sql)" customer
-vtctlclient ApplyVSchema -vschema="$(cat vschema_customer_sharded.json)" customer
+vtctlclient ApplySchema -- --sql="$(cat create_commerce_seq.sql)" commerce
+vtctlclient ApplyVSchema -- --vschema="$(cat vschema_commerce_seq.json)" commerce
+vtctlclient ApplySchema -- --sql="$(cat create_customer_sharded.sql)" customer
+vtctlclient ApplyVSchema -- --vschema="$(cat vschema_customer_sharded.json)" customer
 kubectl apply -f 302_new_shards.yaml
 
 # Reshard
-vtctlclient Reshard -source_shards '-' -target_shards '-80,80-' Create customer.cust2cust
+vtctlclient Reshard -- --source_shards '-' --target_shards '-80,80-' Create customer.cust2cust
 
 # Validate
 vtctlclient VDiff customer.cust2cust
 
 # Cut-over
-vtctlclient Reshard -tablet_types=rdonly,replica SwitchTraffic customer.cust2cust
-vtctlclient Reshard -tablet_types=primary SwitchTraffic customer.cust2cust
+vtctlclient Reshard -- --tablet_types=rdonly,replica SwitchTraffic customer.cust2cust
+vtctlclient Reshard -- --tablet_types=primary SwitchTraffic customer.cust2cust
 
 # Down shard 0
 vtctlclient Reshard Complete customer.cust2cust


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Continuation of #9875. Fixes the commands in the readme files.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#9733 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
