### PR TITLE
fix: filter was not using the vcursor buffering execution

### DIFF
--- a/go/vt/vtgate/engine/filter.go
+++ b/go/vt/vtgate/engine/filter.go
@@ -53,7 +53,7 @@ func (f *Filter) GetTableName() string {
 
 // TryExecute satisfies the Primitive interface.
 func (f *Filter) TryExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	result, err := f.Input.TryExecute(vcursor, bindVars, wantfields)
+	result, err := vcursor.ExecutePrimitive(f.Input, bindVars, wantfields)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,8 @@ func (f *Filter) TryStreamExecute(vcursor VCursor, bindVars map[string]*querypb.
 		results.Rows = rows
 		return callback(results)
 	}
-	return f.Input.TryStreamExecute(vcursor, bindVars, wantfields, filter)
+
+	return vcursor.StreamExecutePrimitive(f.Input, bindVars, wantfields, filter)
 }
 
 // GetFields implements the Primitive interface.


### PR DESCRIPTION
## Description
Very small fix for an engine primitive. It was not executing it's input using the buffering execution offered by the vcursor.

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
