### PR TITLE
fix: check that all keyspaces loaded successfully before using them

### DIFF
--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -196,7 +196,7 @@ func Init(vSchemaStr, sqlSchema, ksShardMapStr string, opts *Options) (*VTExplai
 	vte.setGlobalTabletEnv(tabletEnv)
 	err = vte.initVtgateExecutor(vSchemaStr, ksShardMapStr, opts)
 	if err != nil {
-		return nil, fmt.Errorf("initVtgateExecutor: %v", err)
+		return nil, fmt.Errorf("initVtgateExecutor: %v", err.Error())
 	}
 
 	return vte, nil

--- a/go/vt/vtexplain/vtexplain_test.go
+++ b/go/vt/vtexplain/vtexplain_test.go
@@ -341,14 +341,8 @@ func TestInit(t *testing.T) {
 	vschema := `{
   "ks1": {
     "sharded": true,
-    "vindexes": {
-      "hash": {
-        "type": "hash"
-      }
-    },
     "tables": {
-      "table_missing_primary_vindex": {
-      }
+      "table_missing_primary_vindex": {}
     }
   }
 }`

--- a/go/vt/vtexplain/vtexplain_test.go
+++ b/go/vt/vtexplain/vtexplain_test.go
@@ -337,6 +337,27 @@ func TestUsingKeyspaceShardMap(t *testing.T) {
 	}
 }
 
+func TestInit(t *testing.T) {
+	vschema := `{
+  "ks1": {
+    "sharded": true,
+    "vindexes": {
+      "hash": {
+        "type": "hash"
+      }
+    },
+    "tables": {
+      "table_missing_primary_vindex": {
+      }
+    }
+  }
+}`
+	schema := "create table table_missing_primary_vindex (id int primary key)"
+	_, err := Init(vschema, schema, "", defaultTestOpts())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing primary col vindex")
+}
+
 type vtexplainTestTopoVersion struct{}
 
 func (vtexplain *vtexplainTestTopoVersion) String() string { return "vtexplain-test-topo" }

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -104,9 +104,9 @@ func (vte *VTExplain) buildTopology(opts *Options, vschemaStr string, ksShardMap
 		return err
 	}
 	schema := vindexes.BuildVSchema(&srvVSchema)
-	for _, ksSchema := range schema.Keyspaces {
+	for ks, ksSchema := range schema.Keyspaces {
 		if ksSchema.Error != nil {
-			return ksSchema.Error
+			return vterrors.Wrapf(ksSchema.Error, "vschema failed to load on keyspace [%s]", ks)
 		}
 	}
 	vte.explainTopo.Keyspaces = srvVSchema.Keyspaces

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -25,6 +25,8 @@ import (
 	"sort"
 	"strings"
 
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+
 	"vitess.io/vitess/go/cache"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -100,6 +102,12 @@ func (vte *VTExplain) buildTopology(opts *Options, vschemaStr string, ksShardMap
 	err := json2.Unmarshal([]byte(wrappedStr), &srvVSchema)
 	if err != nil {
 		return err
+	}
+	schema := vindexes.BuildVSchema(&srvVSchema)
+	for _, ksSchema := range schema.Keyspaces {
+		if ksSchema.Error != nil {
+			return ksSchema.Error
+		}
 	}
 	vte.explainTopo.Keyspaces = srvVSchema.Keyspaces
 


### PR DESCRIPTION
## Description
vtexplain was not checking if the keyspaces in the vschema were loaded correctly before using it.

## Related Issue(s)
Fixes #10020

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes
