### PR TITLE
fix: check that all keyspaces loaded successfully before using them

### DIFF
--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -166,7 +166,7 @@ func Init(vSchemaStr, sqlSchema, ksShardMapStr string, opts *Options) error {
 
 	err = initVtgateExecutor(vSchemaStr, ksShardMapStr, opts)
 	if err != nil {
-		return fmt.Errorf("initVtgateExecutor: %v", err)
+		return fmt.Errorf("initVtgateExecutor: %v", err.Error())
 	}
 
 	return nil

--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -327,6 +327,21 @@ func TestUsingKeyspaceShardMap(t *testing.T) {
 	}
 }
 
+func TestInit(t *testing.T) {
+	vschema := `{
+  "ks1": {
+    "sharded": true,
+    "tables": {
+      "table_missing_primary_vindex": {}
+    }
+  }
+}`
+	schema := "create table table_missing_primary_vindex (id int primary key)"
+	err := Init(vschema, schema, "", defaultTestOpts())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing primary col vindex")
+}
+
 type vtexplainTestTopoVersion struct{}
 
 func (vtexplain *vtexplainTestTopoVersion) String() string { return "vtexplain-test-topo" }

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -25,6 +25,8 @@ import (
 	"sort"
 	"strings"
 
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+
 	"vitess.io/vitess/go/cache"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -111,6 +113,12 @@ func buildTopology(opts *Options, vschemaStr string, ksShardMapStr string, numSh
 	err := json2.Unmarshal([]byte(wrappedStr), &srvVSchema)
 	if err != nil {
 		return err
+	}
+	schema := vindexes.BuildVSchema(&srvVSchema)
+	for ks, ksSchema := range schema.Keyspaces {
+		if ksSchema.Error != nil {
+			return vterrors.Wrapf(ksSchema.Error, "vschema failed to load on keyspace [%s]", ks)
+		}
 	}
 	explainTopo.Keyspaces = srvVSchema.Keyspaces
 


### PR DESCRIPTION
## Description
vtexplain was not checking if the keyspaces in the vschema were loaded correctly before using it.

## Related Issue(s)
Fixes #10020
Backport of #10396

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required