### PR TITLE
Update vtctl help output to use double dashes for long flag names

### DIFF
--- a/examples/are-you-alive/schemas/README.md
+++ b/examples/are-you-alive/schemas/README.md
@@ -4,6 +4,6 @@ MySQL schemas and Vitess schemas that must be applied to your cluster to use
 this test helper.  They should be applied using `vtctlclient` like this:
 
 ```
-vtctlclient --server "<vtctld_server>" ApplySchema --sql "$(cat create_test_table.sql)" <database_name>
-vtctlclient --server "<vtctld_server>" ApplyVSchema --vschema "$(cat vschema.json)" <database_name>
+vtctlclient --server "<vtctld_server>" ApplySchema -- --sql "$(cat create_test_table.sql)" <database_name>
+vtctlclient --server "<vtctld_server>" ApplyVSchema -- --vschema "$(cat vschema.json)" <database_name>
 ```

--- a/examples/are-you-alive/schemas/README.md
+++ b/examples/are-you-alive/schemas/README.md
@@ -4,6 +4,6 @@ MySQL schemas and Vitess schemas that must be applied to your cluster to use
 this test helper.  They should be applied using `vtctlclient` like this:
 
 ```
-vtctlclient -server "<vtctld_server>" ApplySchema -sql "$(cat create_test_table.sql)" <database_name>
-vtctlclient -server "<vtctld_server>" ApplyVSchema -vschema "$(cat vschema.json)" <database_name>
+vtctlclient --server "<vtctld_server>" ApplySchema --sql "$(cat create_test_table.sql)" <database_name>
+vtctlclient --server "<vtctld_server>" ApplyVSchema --vschema "$(cat vschema.json)" <database_name>
 ```

--- a/examples/compose/lvtctl.sh
+++ b/examples/compose/lvtctl.sh
@@ -21,4 +21,4 @@ if [[ "$OSTYPE" == "msys" ]]; then
 fi
 
 # This is a convenience script to run vtctlclient against the local example.
-exec $tty docker-compose exec ${CS:-vtctld} vtctlclient -server vtctld:15999 "$@"
+exec $tty docker-compose exec ${CS:-vtctld} vtctlclient --server vtctld:15999 "$@"

--- a/examples/local/backups/start_cluster.sh
+++ b/examples/local/backups/start_cluster.sh
@@ -42,8 +42,8 @@ done
 vtctldclient InitShardPrimary --force commerce/0 zone1-100
 
 # create the schema for commerce
-vtctlclient ApplySchema -sql-file backups/create_commerce_schema.sql commerce
-vtctlclient ApplyVSchema -vschema_file ./vschema_commerce_seq.json commerce
+vtctlclient ApplySchema -- --sql-file backups/create_commerce_schema.sql commerce
+vtctlclient ApplyVSchema -- --vschema_file ./vschema_commerce_seq.json commerce
 
 
 # start vttablets for keyspace customer
@@ -61,8 +61,8 @@ vtctldclient InitShardPrimary --force customer/-80 zone1-200
 vtctldclient InitShardPrimary --force customer/80- zone1-300
 
 # create the schema for customer
-vtctlclient ApplySchema -sql-file backups/create_customer_schema.sql customer
-vtctlclient ApplyVSchema -vschema_file ./vschema_customer_sharded.json customer
+vtctlclient ApplySchema -- --sql-file backups/create_customer_schema.sql customer
+vtctlclient ApplyVSchema -- --vschema_file ./vschema_customer_sharded.json customer
 
 
 # start vtgate

--- a/examples/local/backups/stop_tablets.sh
+++ b/examples/local/backups/stop_tablets.sh
@@ -20,7 +20,7 @@
 source ./env.sh
 
 for tablet in 100 200 300; do
-  if vtctlclient -action_timeout 1s -server localhost:15999 GetTablet zone1-$tablet >/dev/null 2>&1; then
+  if vtctlclient --action_timeout 1s --server localhost:15999 GetTablet zone1-$tablet >/dev/null 2>&1; then
     # The zero tablet is up. Try to shutdown 0-2 tablet + mysqlctl
     for i in 0 1 2; do
       uid=$(($tablet + $i))
@@ -29,7 +29,7 @@ for tablet in 100 200 300; do
       echo "Shutting down mysql zone1-$uid"
       CELL=zone1 TABLET_UID=$uid ./scripts/mysqlctl-down.sh
       echo "Removing tablet directory zone1-$uid"
-      vtctlclient DeleteTablet -allow_primary=true zone1-$uid
+      vtctlclient DeleteTablet -- --allow_primary=true zone1-$uid
       rm -Rf $VTDATAROOT/vt_0000000$uid
     done
   fi

--- a/examples/local/orc_test.sh
+++ b/examples/local/orc_test.sh
@@ -31,7 +31,7 @@ fi
 # start vtctld
 CELL=zone1 ./scripts/vtctld-up.sh
 
-vtctlclient AddCellInfo -root /vitess/zone2 -server_address "${ETCD_SERVER}" zone2
+vtctlclient AddCellInfo -- --root /vitess/zone2 --server_address "${ETCD_SERVER}" zone2
 
 # start vttablets for keyspace commerce
 for i in 100 101 102; do
@@ -45,10 +45,10 @@ for i in 110 111; do
 done
 
 # create the schema
-#vtctlclient ApplySchema -sql-file create_commerce_schema.sql commerce
+#vtctlclient ApplySchema -- --sql-file create_commerce_schema.sql commerce
 
 # create the vschema
-#vtctlclient ApplyVSchema -vschema_file vschema_commerce_initial.json commerce
+#vtctlclient ApplyVSchema -- --vschema_file vschema_commerce_initial.json commerce
 
 # start vtgate
 CELL=zone1 ./scripts/vtgate-up.sh

--- a/examples/operator/pf.sh
+++ b/examples/operator/pf.sh
@@ -6,7 +6,7 @@ kubectl port-forward --address localhost "$(kubectl get service --selector="plan
 process_id2=$!
 sleep 2
 echo "You may point your browser to http://localhost:15000, use the following aliases as shortcuts:"
-echo 'alias vtctlclient="vtctlclient -server=localhost:15999 -logtostderr"'
+echo 'alias vtctlclient="vtctlclient --server=localhost:15999 --logtostderr"'
 echo 'alias mysql="mysql -h 127.0.0.1 -P 15306 -u user"'
 echo "Hit Ctrl-C to stop the port forwards"
 wait $process_id1

--- a/examples/region_sharding/201_main_sharded.sh
+++ b/examples/region_sharding/201_main_sharded.sh
@@ -20,7 +20,7 @@ source ./env.sh
 vtctldclient ApplyVSchema --vschema-file main_vschema_sharded.json main
 
 # optional: create the schema needed for lookup vindex
-#vtctlclient ApplySchema -sql-file create_lookup_schema.sql main
+#vtctlclient ApplySchema --sql-file create_lookup_schema.sql main
 
 # create the lookup vindex
 vtctlclient CreateLookupVindex -- --tablet_types=PRIMARY main "$(cat lookup_vindex.json)"

--- a/go/test/endtoend/keyspace/keyspace_test.go
+++ b/go/test/endtoend/keyspace/keyspace_test.go
@@ -284,10 +284,10 @@ func TestDeleteKeyspace(t *testing.T) {
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("CreateKeyspace", "test_delete_keyspace_removekscell")
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("CreateShard", "test_delete_keyspace_removekscell/0")
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("CreateShard", "test_delete_keyspace_removekscell/1")
-	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "-port=1234", "-keyspace=test_delete_keyspace_removekscell", "-shard=0", "zone1-0000000100", "primary")
-	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "-port=1234", "-keyspace=test_delete_keyspace_removekscell", "-shard=1", "zone1-0000000101", "primary")
-	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "-port=1234", "-keyspace=test_delete_keyspace_removekscell", "-shard=0", "zone2-0000000100", "replica")
-	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "-port=1234", "-keyspace=test_delete_keyspace_removekscell", "-shard=1", "zone2-0000000101", "replica")
+	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "--port=1234", "-keyspace=test_delete_keyspace_removekscell", "--shard=0", "zone1-0000000100", "primary")
+	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "--port=1234", "-keyspace=test_delete_keyspace_removekscell", "--shard=1", "zone1-0000000101", "primary")
+	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "--port=1234", "-keyspace=test_delete_keyspace_removekscell", "--shard=0", "zone2-0000000100", "replica")
+	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "--port=1234", "-keyspace=test_delete_keyspace_removekscell", "--shard=1", "zone2-0000000101", "replica")
 
 	// Create the serving/replication entries and check that they exist,  so we can later check they're deleted.
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", "test_delete_keyspace_removekscell")
@@ -298,7 +298,7 @@ func TestDeleteKeyspace(t *testing.T) {
 
 	// Just remove the shard from one cell (including tablets),
 	// but leaving the global records and other cells/shards alone.
-	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("RemoveShardCell", "-recursive", "test_delete_keyspace_removekscell/0", "zone2")
+	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("RemoveShardCell", "--recursive", "test_delete_keyspace_removekscell/0", "zone2")
 
 	//Check that the shard is gone from zone2.
 	srvKeyspaceZone2 := getSrvKeyspace(t, cell2, "test_delete_keyspace_removekscell")
@@ -331,7 +331,7 @@ func TestDeleteKeyspace(t *testing.T) {
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("GetSrvKeyspace", "zone2", "test_delete_keyspace_removekscell")
 
 	// Add it back to do another test.
-	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "-port=1234", "-keyspace=test_delete_keyspace_removekscell", "-shard=0", "zone2-0000000100", "replica")
+	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("InitTablet", "--port=1234", "--keyspace=test_delete_keyspace_removekscell", "--shard=0", "zone2-0000000100", "replica")
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", "test_delete_keyspace_removekscell")
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("GetShardReplication", "zone2", "test_delete_keyspace_removekscell/0")
 

--- a/go/test/endtoend/vtgate/reservedconn/reconnect3/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/reconnect3/main_test.go
@@ -88,7 +88,7 @@ func TestMysqlDownServingChange(t *testing.T) {
 	require.NoError(t,
 		primaryTablet.MysqlctlProcess.Stop())
 	require.NoError(t,
-		clusterInstance.VtctlclientProcess.ExecuteCommand("EmergencyReparentShard", "--keyspace_shard", "ks/0"))
+		clusterInstance.VtctlclientProcess.ExecuteCommand("EmergencyReparentShard", "--", "--keyspace_shard", "ks/0"))
 
 	// This should work without any error.
 	_ = utils.Exec(t, conn, "select /*vt+ PLANNER=gen4 */ * from test")

--- a/go/test/endtoend/vtgate/reservedconn/reconnect3/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/reconnect3/main_test.go
@@ -88,7 +88,7 @@ func TestMysqlDownServingChange(t *testing.T) {
 	require.NoError(t,
 		primaryTablet.MysqlctlProcess.Stop())
 	require.NoError(t,
-		clusterInstance.VtctlclientProcess.ExecuteCommand("EmergencyReparentShard", "-keyspace_shard", "ks/0"))
+		clusterInstance.VtctlclientProcess.ExecuteCommand("EmergencyReparentShard", "--keyspace_shard", "ks/0"))
 
 	// This should work without any error.
 	_ = utils.Exec(t, conn, "select /*vt+ PLANNER=gen4 */ * from test")

--- a/go/test/endtoend/vtgate/reservedconn/reconnect4/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/reconnect4/main_test.go
@@ -90,7 +90,7 @@ func TestVttabletDownServingChange(t *testing.T) {
 	// kill vttablet process
 	_ = primaryTablet.VttabletProcess.TearDown()
 	require.NoError(t,
-		clusterInstance.VtctlclientProcess.ExecuteCommand("EmergencyReparentShard", "--keyspace_shard", "ks/0"))
+		clusterInstance.VtctlclientProcess.ExecuteCommand("EmergencyReparentShard", "--", "--keyspace_shard", "ks/0"))
 
 	// This should work without any error.
 	_ = utils.Exec(t, conn, "select /*vt+ PLANNER=gen4 */ * from test")

--- a/go/test/endtoend/vtgate/reservedconn/reconnect4/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/reconnect4/main_test.go
@@ -90,7 +90,7 @@ func TestVttabletDownServingChange(t *testing.T) {
 	// kill vttablet process
 	_ = primaryTablet.VttabletProcess.TearDown()
 	require.NoError(t,
-		clusterInstance.VtctlclientProcess.ExecuteCommand("EmergencyReparentShard", "-keyspace_shard", "ks/0"))
+		clusterInstance.VtctlclientProcess.ExecuteCommand("EmergencyReparentShard", "--keyspace_shard", "ks/0"))
 
 	// This should work without any error.
 	_ = utils.Exec(t, conn, "select /*vt+ PLANNER=gen4 */ * from test")

--- a/go/vt/vtctl/backup.go
+++ b/go/vt/vtctl/backup.go
@@ -46,7 +46,7 @@ func init() {
 	addCommand("Shards", command{
 		name:   "BackupShard",
 		method: commandBackupShard,
-		params: "[-allow_primary=false] <keyspace/shard>",
+		params: "[--allow_primary=false] <keyspace/shard>",
 		help:   "Chooses a tablet and creates a backup for a shard.",
 	})
 	addCommand("Shards", command{
@@ -59,13 +59,13 @@ func init() {
 	addCommand("Tablets", command{
 		name:   "Backup",
 		method: commandBackup,
-		params: "[-concurrency=4] [-allow_primary=false] <tablet alias>",
+		params: "[--concurrency=4] [--allow_primary=false] <tablet alias>",
 		help:   "Stops mysqld and uses the BackupStorage service to store a new backup. This function also remembers if the tablet was replicating so that it can restore the same state after the backup completes.",
 	})
 	addCommand("Tablets", command{
 		name:   "RestoreFromBackup",
 		method: commandRestoreFromBackup,
-		params: "[-backup_timestamp=yyyy-MM-dd.HHmmss] <tablet alias>",
+		params: "[--backup_timestamp=yyyy-MM-dd.HHmmss] <tablet alias>",
 		help:   "Stops mysqld and restores the data from the latest backup or if a timestamp is specified then the most recent backup at or before that time.",
 	})
 }

--- a/go/vt/vtctl/cell_info.go
+++ b/go/vt/vtctl/cell_info.go
@@ -38,21 +38,21 @@ func init() {
 	addCommand(cellsGroupName, command{
 		name:   "AddCellInfo",
 		method: commandAddCellInfo,
-		params: "[-server_address <addr>] [-root <root>] <cell>",
+		params: "[--server_address <addr>] [--root <root>] <cell>",
 		help:   "Registers a local topology service in a new cell by creating the CellInfo with the provided parameters. The address will be used to connect to the topology service, and we'll put Vitess data starting at the provided root.",
 	})
 
 	addCommand(cellsGroupName, command{
 		name:   "UpdateCellInfo",
 		method: commandUpdateCellInfo,
-		params: "[-server_address <addr>] [-root <root>] <cell>",
+		params: "[--server_address <addr>] [--root <root>] <cell>",
 		help:   "Updates the content of a CellInfo with the provided parameters. If a value is empty, it is not updated. The CellInfo will be created if it doesn't exist.",
 	})
 
 	addCommand(cellsGroupName, command{
 		name:   "DeleteCellInfo",
 		method: commandDeleteCellInfo,
-		params: "[-force] <cell>",
+		params: "[--force] <cell>",
 		help:   "Deletes the CellInfo for the provided cell. The cell cannot be referenced by any Shard record.",
 	})
 

--- a/go/vt/vtctl/cells_aliases.go
+++ b/go/vt/vtctl/cells_aliases.go
@@ -38,14 +38,14 @@ func init() {
 	addCommand(cellsAliasesGroupName, command{
 		name:   "AddCellsAlias",
 		method: commandAddCellsAlias,
-		params: "[-cells <cell,cell2...>] <alias>",
+		params: "[--cells <cell,cell2...>] <alias>",
 		help:   "Defines a group of cells within which replica/rdonly traffic can be routed across cells. Between cells that are not in the same group (alias), only primary traffic can be routed.",
 	})
 
 	addCommand(cellsAliasesGroupName, command{
 		name:   "UpdateCellsAlias",
 		method: commandUpdateCellsAlias,
-		params: "[-cells <cell,cell2,...>] <alias>",
+		params: "[--cells <cell,cell2,...>] <alias>",
 		help:   "Updates the content of a CellsAlias with the provided parameters. If a value is empty, it is not updated. The CellsAlias will be created if it doesn't exist.",
 	})
 

--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -55,7 +55,7 @@ func init() {
 	addCommand(queriesGroupName, command{
 		name:       "VtGateExecute",
 		method:     commandVtGateExecute,
-		params:     "-server <vtgate> [-bind_variables <JSON map>] [-keyspace <default keyspace>] [-tablet_type <tablet type>] [-options <proto text options>] [-json] <sql>",
+		params:     "--server <vtgate> [--bind_variables <JSON map>] [--keyspace <default keyspace>] [--tablet_type <tablet type>] [--options <proto text options>] [--json] <sql>",
 		help:       "Executes the given SQL query with the provided bound variables against the vtgate server.",
 		deprecated: true,
 	})
@@ -64,36 +64,36 @@ func init() {
 	addCommand(queriesGroupName, command{
 		name:         "VtTabletExecute",
 		method:       commandVtTabletExecute,
-		params:       "[-username <TableACL user>] [-transaction_id <transaction_id>] [-options <proto text options>] [-json] <tablet alias> <sql>",
-		help:         "Executes the given query on the given tablet. -transaction_id is optional. Use VtTabletBegin to start a transaction.",
+		params:       "[--username <TableACL user>] [--transaction_id <transaction_id>] [--options <proto text options>] [--json] <tablet alias> <sql>",
+		help:         "Executes the given query on the given tablet. --transaction_id is optional. Use VtTabletBegin to start a transaction.",
 		deprecated:   true,
 		deprecatedBy: "ExecuteFetchAsApp",
 	})
 	addCommand(queriesGroupName, command{
 		name:       "VtTabletBegin",
 		method:     commandVtTabletBegin,
-		params:     "[-username <TableACL user>] <tablet alias>",
+		params:     "[--username <TableACL user>] <tablet alias>",
 		help:       "Starts a transaction on the provided server.",
 		deprecated: true,
 	})
 	addCommand(queriesGroupName, command{
 		name:       "VtTabletCommit",
 		method:     commandVtTabletCommit,
-		params:     "[-username <TableACL user>] <transaction_id>",
+		params:     "[--username <TableACL user>] <transaction_id>",
 		help:       "Commits the given transaction on the provided server.",
 		deprecated: true,
 	})
 	addCommand(queriesGroupName, command{
 		name:       "VtTabletRollback",
 		method:     commandVtTabletRollback,
-		params:     "[-username <TableACL user>] <tablet alias> <transaction_id>",
+		params:     "[--username <TableACL user>] <tablet alias> <transaction_id>",
 		help:       "Rollbacks the given transaction on the provided server.",
 		deprecated: true,
 	})
 	addCommand(queriesGroupName, command{
 		name:       "VtTabletStreamHealth",
 		method:     commandVtTabletStreamHealth,
-		params:     "[-count <count, default 1>] <tablet alias>",
+		params:     "[--count <count, default 1>] <tablet alias>",
 		help:       "Executes the StreamHealth streaming query to a vttablet process. Will stop after getting <count> answers.",
 		deprecated: true,
 	})

--- a/go/vt/vtctl/throttler.go
+++ b/go/vt/vtctl/throttler.go
@@ -41,7 +41,7 @@ const (
 )
 
 // This file contains the commands to control the throttler which is used during
-// resharding (vtworker) and by filtered replication (vttablet).
+// resharding and by filtered replication (vttablet).
 
 func init() {
 	addCommandGroup(throttlerGroupName)
@@ -49,7 +49,7 @@ func init() {
 	addCommand(throttlerGroupName, command{
 		name:         "ThrottlerMaxRates",
 		method:       commandThrottlerMaxRates,
-		params:       "--server <vtworker or vttablet>",
+		params:       "--server <vttablet>",
 		help:         "Returns the current max rate of all active resharding throttlers on the server.",
 		deprecated:   true,
 		deprecatedBy: "the new Reshard/MoveTables workflows",
@@ -57,7 +57,7 @@ func init() {
 	addCommand(throttlerGroupName, command{
 		name:         "ThrottlerSetMaxRate",
 		method:       commandThrottlerSetMaxRate,
-		params:       "--server <vtworker or vttablet> <rate>",
+		params:       "--server <vttablet> <rate>",
 		help:         "Sets the max rate for all active resharding throttlers on the server.",
 		deprecated:   true,
 		deprecatedBy: "the new Reshard/MoveTables workflows",
@@ -66,7 +66,7 @@ func init() {
 	addCommand(throttlerGroupName, command{
 		name:         "GetThrottlerConfiguration",
 		method:       commandGetThrottlerConfiguration,
-		params:       "--server <vtworker or vttablet> [<throttler name>]",
+		params:       "--server <vttablet> [<throttler name>]",
 		help:         "Returns the current configuration of the MaxReplicationLag module. If no throttler name is specified, the configuration of all throttlers will be returned.",
 		deprecated:   true,
 		deprecatedBy: "the new Reshard/MoveTables workflows",
@@ -76,7 +76,7 @@ func init() {
 		method: commandUpdateThrottlerConfiguration,
 		// Note: <configuration protobuf text> is put in quotes to tell the user
 		// that the value must be quoted such that it's one argument only.
-		params:       `--server <vtworker or vttablet> [--copy_zero_values] "<configuration protobuf text>" [<throttler name>]`,
+		params:       `--server <vttablet> [--copy_zero_values] "<configuration protobuf text>" [<throttler name>]`,
 		help:         "Updates the configuration of the MaxReplicationLag module. The configuration must be specified as protobuf text. If a field is omitted or has a zero value, it will be ignored unless --copy_zero_values is specified. If no throttler name is specified, all throttlers will be updated.",
 		deprecated:   true,
 		deprecatedBy: "the new Reshard/MoveTables workflows",
@@ -84,7 +84,7 @@ func init() {
 	addCommand(throttlerGroupName, command{
 		name:         "ResetThrottlerConfiguration",
 		method:       commandResetThrottlerConfiguration,
-		params:       "--server <vtworker or vttablet> [<throttler name>]",
+		params:       "--server <vttablet> [<throttler name>]",
 		help:         "Resets the current configuration of the MaxReplicationLag module. If no throttler name is specified, the configuration of all throttlers will be reset.",
 		deprecated:   true,
 		deprecatedBy: "the new Reshard/MoveTables workflows",
@@ -92,7 +92,7 @@ func init() {
 }
 
 func commandThrottlerMaxRates(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	server := subFlags.String("server", "", "vtworker or vttablet to connect to")
+	server := subFlags.String("server", "", "vttablet to connect to")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func commandThrottlerMaxRates(ctx context.Context, wr *wrangler.Wrangler, subFla
 }
 
 func commandThrottlerSetMaxRate(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	server := subFlags.String("server", "", "vtworker or vttablet to connect to")
+	server := subFlags.String("server", "", "vttablet to connect to")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func commandThrottlerSetMaxRate(ctx context.Context, wr *wrangler.Wrangler, subF
 }
 
 func commandGetThrottlerConfiguration(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	server := subFlags.String("server", "", "vtworker or vttablet to connect to")
+	server := subFlags.String("server", "", "vttablet to connect to")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ func commandGetThrottlerConfiguration(ctx context.Context, wr *wrangler.Wrangler
 }
 
 func commandUpdateThrottlerConfiguration(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	server := subFlags.String("server", "", "vtworker or vttablet to connect to")
+	server := subFlags.String("server", "", "vttablet to connect to")
 	copyZeroValues := subFlags.Bool("copy_zero_values", false, "If true, fields with zero values will be copied as well")
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -270,7 +270,7 @@ func commandUpdateThrottlerConfiguration(ctx context.Context, wr *wrangler.Wrang
 }
 
 func commandResetThrottlerConfiguration(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	server := subFlags.String("server", "", "vtworker or vttablet to connect to")
+	server := subFlags.String("server", "", "vttablet to connect to")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}

--- a/go/vt/vtctl/throttler.go
+++ b/go/vt/vtctl/throttler.go
@@ -49,7 +49,7 @@ func init() {
 	addCommand(throttlerGroupName, command{
 		name:         "ThrottlerMaxRates",
 		method:       commandThrottlerMaxRates,
-		params:       "-server <vtworker or vttablet>",
+		params:       "--server <vtworker or vttablet>",
 		help:         "Returns the current max rate of all active resharding throttlers on the server.",
 		deprecated:   true,
 		deprecatedBy: "the new Reshard/MoveTables workflows",
@@ -57,7 +57,7 @@ func init() {
 	addCommand(throttlerGroupName, command{
 		name:         "ThrottlerSetMaxRate",
 		method:       commandThrottlerSetMaxRate,
-		params:       "-server <vtworker or vttablet> <rate>",
+		params:       "--server <vtworker or vttablet> <rate>",
 		help:         "Sets the max rate for all active resharding throttlers on the server.",
 		deprecated:   true,
 		deprecatedBy: "the new Reshard/MoveTables workflows",
@@ -66,7 +66,7 @@ func init() {
 	addCommand(throttlerGroupName, command{
 		name:         "GetThrottlerConfiguration",
 		method:       commandGetThrottlerConfiguration,
-		params:       "-server <vtworker or vttablet> [<throttler name>]",
+		params:       "--server <vtworker or vttablet> [<throttler name>]",
 		help:         "Returns the current configuration of the MaxReplicationLag module. If no throttler name is specified, the configuration of all throttlers will be returned.",
 		deprecated:   true,
 		deprecatedBy: "the new Reshard/MoveTables workflows",
@@ -76,15 +76,15 @@ func init() {
 		method: commandUpdateThrottlerConfiguration,
 		// Note: <configuration protobuf text> is put in quotes to tell the user
 		// that the value must be quoted such that it's one argument only.
-		params:       `-server <vtworker or vttablet> [-copy_zero_values] "<configuration protobuf text>" [<throttler name>]`,
-		help:         "Updates the configuration of the MaxReplicationLag module. The configuration must be specified as protobuf text. If a field is omitted or has a zero value, it will be ignored unless -copy_zero_values is specified. If no throttler name is specified, all throttlers will be updated.",
+		params:       `--server <vtworker or vttablet> [--copy_zero_values] "<configuration protobuf text>" [<throttler name>]`,
+		help:         "Updates the configuration of the MaxReplicationLag module. The configuration must be specified as protobuf text. If a field is omitted or has a zero value, it will be ignored unless --copy_zero_values is specified. If no throttler name is specified, all throttlers will be updated.",
 		deprecated:   true,
 		deprecatedBy: "the new Reshard/MoveTables workflows",
 	})
 	addCommand(throttlerGroupName, command{
 		name:         "ResetThrottlerConfiguration",
 		method:       commandResetThrottlerConfiguration,
-		params:       "-server <vtworker or vttablet> [<throttler name>]",
+		params:       "--server <vtworker or vttablet> [<throttler name>]",
 		help:         "Resets the current configuration of the MaxReplicationLag module. If no throttler name is specified, the configuration of all throttlers will be reset.",
 		deprecated:   true,
 		deprecatedBy: "the new Reshard/MoveTables workflows",

--- a/go/vt/vtctl/topo.go
+++ b/go/vt/vtctl/topo.go
@@ -45,14 +45,14 @@ func init() {
 	addCommand(topoGroupName, command{
 		name:   "TopoCat",
 		method: commandTopoCat,
-		params: "[-cell <cell>] [-decode_proto] [-decode_proto_json] [-long] <path> [<path>...]",
+		params: "[--cell <cell>] [--decode_proto] [--decode_proto_json] [--long] <path> [<path>...]",
 		help:   "Retrieves the file(s) at <path> from the topo service, and displays it. It can resolve wildcards, and decode the proto-encoded data.",
 	})
 
 	addCommand(topoGroupName, command{
 		name:   "TopoCp",
 		method: commandTopoCp,
-		params: "[-cell <cell>] [-to_topo] <src> <dst>",
+		params: "[--cell <cell>] [--to_topo] <src> <dst>",
 		help:   "Copies a file from topo to local file structure, or the other way around",
 	})
 }

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -192,7 +192,7 @@ var commands = []commandGroup{
 			{
 				name:   "DeleteTablet",
 				method: commandDeleteTablet,
-				params: "[-allow_primary] <tablet alias> ...",
+				params: "[--allow_primary] <tablet alias> ...",
 				help:   "Deletes tablet(s) from the topology.",
 			},
 			{

--- a/go/vt/vtctl/workflow.go
+++ b/go/vt/vtctl/workflow.go
@@ -41,7 +41,7 @@ func init() {
 	addCommand(workflowsGroupName, command{
 		name:   "WorkflowCreate",
 		method: commandWorkflowCreate,
-		params: "[-skip_start] <factoryName> [parameters...]",
+		params: "[--skip_start] <factoryName> [parameters...]",
 		help:   "Creates the workflow with the provided parameters. The workflow is also started, unless -skip_start is specified.",
 	})
 	addCommand(workflowsGroupName, command{

--- a/test/client_test.sh
+++ b/test/client_test.sh
@@ -30,10 +30,10 @@ for i in 100 101 102; do
  CELL=test KEYSPACE=test_keyspace TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
-vtctlclient -server localhost:15999 InitShardPrimary -force test_keyspace/0 test-100
+vtctlclient --server localhost:15999 InitShardPrimary -- --force test_keyspace/0 test-100
 
-vtctlclient -server localhost:15999 ApplySchema -sql-file create_test_table.sql test_keyspace
-vtctlclient -server localhost:15999 RebuildVSchemaGraph
+vtctlclient --server localhost:15999 ApplySchema -- --sql-file create_test_table.sql test_keyspace
+vtctlclient --server localhost:15999 RebuildVSchemaGraph
 
 CELL=test ./scripts/vtgate-up.sh
 


### PR DESCRIPTION
## Description

I did an audit of the vtctl related code and updated all `vtctl`/`vtctlclient` related help output to use the new flag syntax (primarily double dashes for long flag names) where it was not already done.

I also updated any related `vtctl`/`vtctlclient` usage code in our examples and tests that still needed it.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests are not required
-   [x] Documentation is not required