### PR TITLE
topo: cache CellInfo along with conn

### DIFF
--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -1,0 +1,74 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
+
+name: Cluster (topo_connection_cache)
+on: [push]
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (topo_connection_cache)')
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Run endtoend tests on Cluster (topo_connection_cache)
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Configure git private repo access
+      env:
+        GITHUB_TOKEN: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
+      run: |
+        git config --global --add url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.9
+
+    - name: Set up python
+      uses: actions/setup-python@v2
+
+    - name: Tune the OS
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+        # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
+        echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
+        sudo sysctl -p /etc/sysctl.conf
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        # Get key to latest MySQL repo
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+
+        # Setup MySQL 8.0
+        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+        sudo apt-get update
+
+        # Install everything else we need, and configure
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata xz-utils
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        go mod download
+
+    - name: Run cluster endtoend test
+      timeout-minutes: 30
+      run: |
+        # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
+        # which musn't be more than 107 characters long.
+        export VTDATAROOT="/tmp/"
+        source build.env
+
+        set -x
+
+        eatmydata -- go run test.go -docker=false -follow -shard topo_connection_cache | tee -a output.txt
+
+    - name: Print test output
+      run: |
+        # print test output
+        cat output.txt
+      if: always()

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -1,10 +1,15 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (topo_connection_cache)
-on: [push]
+on: [push, pull_request]
 concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (topo_connection_cache)')
   cancel-in-progress: true
+
+env:
+  LAUNCHABLE_ORGANIZATION: "vitess"
+  LAUNCHABLE_WORKSPACE: "vitess-app"
+  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
 jobs:
   build:
@@ -12,50 +17,73 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - name: Configure git private repo access
-      env:
-        GITHUB_TOKEN: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
-      run: |
-        git config --global --add url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: frouioui/paths-filter@main
+      id: changes
+      with:
+        token: ''
+        filters: |
+          end_to_end:
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+            - '.github/workflows/**'
 
     - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.9
+        go-version: 1.18.1
 
     - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-python@v2
 
     - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Get dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
       run: |
-        # Get key to latest MySQL repo
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-
-        # Setup MySQL 8.0
-        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
-        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
-        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
-
-        # Install everything else we need, and configure
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata xz-utils
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
         sudo service mysql stop
         sudo service etcd stop
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
+        # install JUnit report formatter
+        go install github.com/jstemmer/go-junit-report@latest
+
+    - name: Setup launchable dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
+      run: |
+        # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
+        pip3 install --user launchable~=1.0 > /dev/null
+
+        # verify that launchable setup is all correct.
+        launchable verify || true
+
+        # Tell Launchable about the build you are producing and testing
+        launchable record build --name "$GITHUB_RUN_ID" --source .
+
     - name: Run cluster endtoend test
+      if: steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 30
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
@@ -65,10 +93,14 @@ jobs:
 
         set -x
 
-        eatmydata -- go run test.go -docker=false -follow -shard topo_connection_cache | tee -a output.txt
+        # run the tests however you normally do, then produce a JUnit XML file
+        eatmydata -- go run test.go -docker=false -follow -shard topo_connection_cache | tee -a output.txt | go-junit-report -set-exit-code > report.xml
 
-    - name: Print test output
+    - name: Print test output and Record test result in launchable
+      if: steps.changes.outputs.end_to_end == 'true' && always()
       run: |
+        # send recorded tests to launchable
+        launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
+
         # print test output
         cat output.txt
-      if: always()

--- a/go/test/endtoend/topoconncache/main_test.go
+++ b/go/test/endtoend/topoconncache/main_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This test cell aliases feature
+
+We start with no aliases and assert that vtgates can't route to replicas/rondly tablets.
+Then we add an alias, and these tablets should be routable
+*/
+
+package topoconncache
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	cell1           = "zone1"
+	cell2           = "zone2"
+	hostname        = "localhost"
+	keyspaceName    = "ks"
+	tableName       = "test_table"
+	sqlSchema       = `
+					create table %s(
+					id bigint(20) unsigned auto_increment,
+					msg varchar(64),
+					primary key (id),
+					index by_msg (msg)
+					) Engine=InnoDB
+`
+	commonTabletArg = []string{
+		"--vreplication_healthcheck_topology_refresh", "1s",
+		"--vreplication_healthcheck_retry_delay", "1s",
+		"--vreplication_retry_delay", "1s",
+		"--degraded_threshold", "5s",
+		"--lock_tables_timeout", "5s",
+		"--watch_replication_stream",
+		"--enable_replication_reporter",
+		"--serving_state_grace_period", "1s",
+		"--binlog_player_protocol", "grpc",
+		"--enable-autocommit",
+	}
+	vSchema = `
+		{
+		  "sharded": true,
+		  "vindexes": {
+			"hash_index": {
+			  "type": "hash"
+			}
+		  },
+		  "tables": {
+			"%s": {
+			   "column_vindexes": [
+				{
+				  "column": "id",
+				  "name": "hash_index"
+				}
+			  ]
+			}
+		  }
+		}
+`
+	shard1Primary *cluster.Vttablet
+	shard1Replica *cluster.Vttablet
+	shard1Rdonly  *cluster.Vttablet
+	shard2Primary *cluster.Vttablet
+	shard2Replica *cluster.Vttablet
+	shard2Rdonly  *cluster.Vttablet
+
+	shard1 cluster.Shard
+	shard2 cluster.Shard
+)
+
+/* This end-to-end test validates the cache fix in topo/server.go inside ConnForCell.
+The issue was, if we delete and add back a cell with same name but at different path, the map of cells
+in server.go returned the connection object of the previous cell instead of newly-created one
+with the same name.
+Topology: We create a keyspace with two shards , having 3 tablets each. Primaries belong
+to 'zone1' and replicas/rdonly belongs to cell2.
+*/
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitcode, err := func() (int, error) {
+		clusterInstance = cluster.NewCluster(cell1, hostname)
+		defer clusterInstance.Teardown()
+		clusterInstance.Keyspaces = append(clusterInstance.Keyspaces, cluster.Keyspace{
+			Name: keyspaceName,
+		})
+
+		// Start topo server
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1, err
+		}
+
+		// Adding another cell in the same cluster
+		err := clusterInstance.TopoProcess.ManageTopoDir("mkdir", "/vitess/"+cell2)
+		if err != nil {
+			return 1, err
+		}
+		err = clusterInstance.VtctlProcess.AddCellInfo(cell2)
+		if err != nil {
+			return 1, err
+		}
+
+		shard1Primary = clusterInstance.NewVttabletInstance("primary", 0, cell1)
+		shard1Replica = clusterInstance.NewVttabletInstance("replica", 0, cell2)
+		shard1Rdonly = clusterInstance.NewVttabletInstance("rdonly", 0, cell2)
+
+		shard2Primary = clusterInstance.NewVttabletInstance("primary", 0, cell1)
+		shard2Replica = clusterInstance.NewVttabletInstance("replica", 0, cell2)
+		shard2Rdonly = clusterInstance.NewVttabletInstance("rdonly", 0, cell2)
+
+		var mysqlProcs []*exec.Cmd
+		for _, tablet := range []*cluster.Vttablet{shard1Primary, shard1Replica, shard1Rdonly, shard2Primary, shard2Replica, shard2Rdonly} {
+			tablet.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, clusterInstance.TmpDirectory)
+			tablet.VttabletProcess = cluster.VttabletProcessInstance(tablet.HTTPPort,
+				tablet.GrpcPort,
+				tablet.TabletUID,
+				tablet.Cell,
+				"",
+				keyspaceName,
+				clusterInstance.VtctldProcess.Port,
+				tablet.Type,
+				clusterInstance.TopoPort,
+				hostname,
+				clusterInstance.TmpDirectory,
+				commonTabletArg,
+				true,
+				clusterInstance.DefaultCharset,
+			)
+			tablet.VttabletProcess.SupportsBackup = true
+			proc, err := tablet.MysqlctlProcess.StartProcess()
+			if err != nil {
+				return 1, err
+			}
+			mysqlProcs = append(mysqlProcs, proc)
+		}
+		for _, proc := range mysqlProcs {
+			if err := proc.Wait(); err != nil {
+				return 1, err
+			}
+		}
+
+		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspaceName); err != nil {
+			return 1, err
+		}
+
+		shard1 = cluster.Shard{
+			Name:      "-80",
+			Vttablets: []*cluster.Vttablet{shard1Primary, shard1Replica, shard1Rdonly},
+		}
+		for idx := range shard1.Vttablets {
+			shard1.Vttablets[idx].VttabletProcess.Shard = shard1.Name
+		}
+		clusterInstance.Keyspaces[0].Shards = append(clusterInstance.Keyspaces[0].Shards, shard1)
+
+		shard2 = cluster.Shard{
+			Name:      "80-",
+			Vttablets: []*cluster.Vttablet{shard2Primary, shard2Replica, shard2Rdonly},
+		}
+		for idx := range shard2.Vttablets {
+			shard2.Vttablets[idx].VttabletProcess.Shard = shard2.Name
+		}
+		clusterInstance.Keyspaces[0].Shards = append(clusterInstance.Keyspaces[0].Shards, shard2)
+
+		for _, tablet := range shard1.Vttablets {
+			if err := tablet.VttabletProcess.Setup(); err != nil {
+				return 1, err
+			}
+		}
+		if err := clusterInstance.VtctlclientProcess.InitializeShard(keyspaceName, shard1.Name, shard1Primary.Cell, shard1Primary.TabletUID); err != nil {
+			return 1, err
+		}
+
+		// run a health check on source replica so it responds to discovery
+		// (for binlog players) and on the source rdonlys (for workers)
+		for _, tablet := range []string{shard1Replica.Alias, shard1Rdonly.Alias} {
+			if err := clusterInstance.VtctlclientProcess.ExecuteCommand("RunHealthCheck", tablet); err != nil {
+				return 1, err
+			}
+		}
+
+		for _, tablet := range shard2.Vttablets {
+			if err := tablet.VttabletProcess.Setup(); err != nil {
+				return 1, err
+			}
+		}
+
+		if err := clusterInstance.VtctlclientProcess.InitializeShard(keyspaceName, shard2.Name, shard2Primary.Cell, shard2Primary.TabletUID); err != nil {
+			return 1, err
+		}
+
+		if err := clusterInstance.VtctlclientProcess.ApplySchema(keyspaceName, fmt.Sprintf(sqlSchema, tableName)); err != nil {
+			return 1, err
+		}
+		if err := clusterInstance.VtctlclientProcess.ApplyVSchema(keyspaceName, fmt.Sprintf(vSchema, tableName)); err != nil {
+			return 1, err
+		}
+
+		_ = clusterInstance.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", keyspaceName)
+
+		return m.Run(), nil
+	}()
+	if err != nil {
+		fmt.Printf("%v\n", err)
+		os.Exit(1)
+	} else {
+		os.Exit(exitcode)
+	}
+}
+
+func testURL(t *testing.T, url string, testCaseName string) {
+	statusCode := getStatusForURL(url)
+	if got, want := statusCode, 200; got != want {
+		t.Errorf("\nurl: %v\nstatus code: %v \nwant %v for %s", url, got, want, testCaseName)
+	}
+}
+
+// getStatusForUrl returns the status code for the URL
+func getStatusForURL(url string) int {
+	resp, _ := http.Get(url)
+	if resp != nil {
+		return resp.StatusCode
+	}
+	return 0
+}

--- a/go/test/endtoend/topoconncache/topo_conn_cache_test.go
+++ b/go/test/endtoend/topoconncache/topo_conn_cache_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package topoconncache
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+/*
+1. In steady state check the numbers of tablets through 'ListAllTablets'.
+2. Now delete 'zone2' and 'ListAllTablets' should return only primary tablets
+3. Add the cell back with same name but at different location in topo.
+4. 'ListAllTablets' should return all the new tablets.
+*/
+func TestVtctldListAllTablets(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	url := fmt.Sprintf("http://%s:%d/api/keyspaces/", clusterInstance.Hostname, clusterInstance.VtctldHTTPPort)
+	testURL(t, url, "keyspace url")
+
+	healthCheckURL := fmt.Sprintf("http://%s:%d/debug/health/", clusterInstance.Hostname, clusterInstance.VtctldHTTPPort)
+	testURL(t, healthCheckURL, "vtctld health check url")
+
+	testListAllTablets(t)
+	deleteCell(t)
+	addCellback(t)
+}
+
+func testListAllTablets(t *testing.T) {
+	// first w/o any filters, aside from cell
+	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ListAllTablets")
+	require.Nil(t, err)
+
+	tablets := getAllTablets()
+	tabletsFromCMD := strings.Split(result, "\n")
+	tabletCountFromCMD := 0
+	for _, line := range tabletsFromCMD {
+		if len(line) > 0 {
+			tabletCountFromCMD = tabletCountFromCMD + 1
+			assert.Contains(t, tablets, strings.Split(line, " ")[0])
+		}
+	}
+	assert.Equal(t, len(tablets), tabletCountFromCMD)
+}
+
+func deleteCell(t *testing.T) {
+	// delete all tablets for cell2
+	deleteTablet(t, shard1Replica)
+	deleteTablet(t, shard2Replica)
+	deleteTablet(t, shard1Rdonly)
+	deleteTablet(t, shard2Rdonly)
+
+	// Delete cell2 info from topo
+	res, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("DeleteCellInfo", "--force", cell2)
+	t.Log(res)
+	require.Nil(t, err)
+
+	// update clusterInstance to remaining vttablets and shards
+	shard1.Vttablets = []*cluster.Vttablet{shard1Primary}
+	shard2.Vttablets = []*cluster.Vttablet{shard2Primary}
+	clusterInstance.Keyspaces[0].Shards = []cluster.Shard{shard1, shard2}
+
+	// Now list all tablets
+	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ListAllTablets")
+	require.Nil(t, err)
+
+	tablets := getAllTablets()
+	tabletsFromCMD := strings.Split(result, "\n")
+	tabletCountFromCMD := 0
+
+	for _, line := range tabletsFromCMD {
+		if len(line) > 0 {
+			tabletCountFromCMD = tabletCountFromCMD + 1
+			assert.Contains(t, tablets, strings.Split(line, " ")[0])
+		}
+	}
+	assert.Equal(t, len(tablets), tabletCountFromCMD)
+}
+
+func deleteTablet(t *testing.T, tablet *cluster.Vttablet) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(tablet *cluster.Vttablet) {
+		defer wg.Done()
+		_ = tablet.VttabletProcess.TearDown()
+		_ = tablet.MysqlctlProcess.Stop()
+		tablet.MysqlctlProcess.CleanupFiles(tablet.TabletUID)
+	}(tablet)
+	wg.Wait()
+
+	err := clusterInstance.VtctlclientProcess.ExecuteCommand("DeleteTablet", tablet.Alias)
+	require.Nil(t, err)
+}
+
+func addCellback(t *testing.T) {
+	// creating new cell , with same name as previously deleted one but at a different root path.
+	clusterInstance.VtctlProcess.TopoRootPath = "/org1/obj1/"
+
+	err := clusterInstance.VtctlProcess.AddCellInfo(cell2)
+	require.Nil(t, err)
+
+	// create new vttablets
+	shard1Replica = clusterInstance.NewVttabletInstance("replica", 0, cell2)
+	shard1Rdonly = clusterInstance.NewVttabletInstance("rdonly", 0, cell2)
+	shard2Replica = clusterInstance.NewVttabletInstance("replica", 0, cell2)
+	shard2Rdonly = clusterInstance.NewVttabletInstance("rdonly", 0, cell2)
+
+	// update clusterInstance to new vttablets and shards
+	shard1.Vttablets = []*cluster.Vttablet{shard1Primary, shard1Replica, shard1Rdonly}
+	shard2.Vttablets = []*cluster.Vttablet{shard2Primary, shard2Replica, shard2Rdonly}
+	clusterInstance.Keyspaces[0].Shards = []cluster.Shard{shard1, shard2}
+
+	// create sql process for vttablets
+	var mysqlProcs []*exec.Cmd
+	for _, tablet := range []*cluster.Vttablet{shard1Replica, shard1Rdonly, shard2Replica, shard2Rdonly} {
+		tablet.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, clusterInstance.TmpDirectory)
+		tablet.VttabletProcess = cluster.VttabletProcessInstance(tablet.HTTPPort,
+			tablet.GrpcPort,
+			tablet.TabletUID,
+			tablet.Cell,
+			"",
+			keyspaceName,
+			clusterInstance.VtctldProcess.Port,
+			tablet.Type,
+			clusterInstance.TopoPort,
+			hostname,
+			clusterInstance.TmpDirectory,
+			commonTabletArg,
+			true,
+			clusterInstance.DefaultCharset,
+		)
+		tablet.VttabletProcess.SupportsBackup = true
+		proc, err := tablet.MysqlctlProcess.StartProcess()
+		if err != nil {
+			require.Nil(t, err)
+		}
+		mysqlProcs = append(mysqlProcs, proc)
+	}
+	for _, proc := range mysqlProcs {
+		if err := proc.Wait(); err != nil {
+			require.Nil(t, err)
+		}
+	}
+
+	for _, tablet := range []*cluster.Vttablet{shard1Replica, shard1Rdonly} {
+		tablet.VttabletProcess.Shard = shard1.Name
+		if err := tablet.VttabletProcess.Setup(); err != nil {
+			require.Nil(t, err)
+		}
+	}
+
+	for _, tablet := range []*cluster.Vttablet{shard2Replica, shard2Rdonly} {
+		tablet.VttabletProcess.Shard = shard2.Name
+		if err := tablet.VttabletProcess.Setup(); err != nil {
+			require.Nil(t, err)
+		}
+	}
+
+	shard1.Vttablets = append(shard1.Vttablets, shard1Replica)
+	shard1.Vttablets = append(shard1.Vttablets, shard1Rdonly)
+	shard2.Vttablets = append(shard2.Vttablets, shard2Replica)
+	shard2.Vttablets = append(shard2.Vttablets, shard1Rdonly)
+
+	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ListAllTablets")
+	require.Nil(t, err)
+
+	tablets := getAllTablets()
+	tabletsFromCMD := strings.Split(result, "\n")
+	tabletCountFromCMD := 0
+	for _, line := range tabletsFromCMD {
+		if len(line) > 0 {
+			tabletCountFromCMD = tabletCountFromCMD + 1
+			assert.Contains(t, tablets, strings.Split(line, " ")[0])
+		}
+	}
+	assert.Equal(t, len(tablets), tabletCountFromCMD)
+}
+
+func getAllTablets() []string {
+	tablets := make([]string, 0)
+	for _, ks := range clusterInstance.Keyspaces {
+		for _, shard := range ks.Shards {
+			for _, tablet := range shard.Vttablets {
+				tablets = append(tablets, tablet.Alias)
+			}
+		}
+	}
+	return tablets
+}

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -47,6 +47,8 @@ import (
 	"fmt"
 	"sync"
 
+	"vitess.io/vitess/go/vt/proto/topodata"
+
 	"context"
 
 	"vitess.io/vitess/go/vt/vterrors"
@@ -56,7 +58,7 @@ import (
 
 const (
 	// GlobalCell is the name of the global cell.  It is special
-	// as it contains the global topology, and references the other cells.
+	// as it contains the global topology, and references the other cellConns.
 	GlobalCell = "global"
 
 	// GlobalReadOnlyCell is the name of the global read-only cell
@@ -98,7 +100,7 @@ type Factory interface {
 	// HasGlobalReadOnlyCell returns true if the global cell
 	// has read-only replicas of the topology data. The global topology
 	// is usually more expensive to read from / write to, as it is
-	// replicated over many cells. Some topology services provide
+	// replicated over many cellConns. Some topology services provide
 	// more efficient way to read the data, like Observer servers
 	// for Zookeeper. If this returns true, we will maintain
 	// two connections for the global topology: the 'global' cell
@@ -135,12 +137,17 @@ type Server struct {
 
 	// mu protects the following fields.
 	mu sync.Mutex
-	// cells contains clients configured to talk to a list of
+	// cellConns contains clients configured to talk to a list of
 	// topo instances representing local topo clusters. These
 	// should be accessed with the ConnForCell() method, which
 	// will read the list of addresses for that cell from the
 	// global cluster and create clients as needed.
-	cells map[string]Conn
+	cellConns map[string]cellConn
+}
+
+type cellConn struct {
+	cellInfo *topodata.CellInfo
+	conn     Conn
 }
 
 type cellsToAliasesMap struct {
@@ -203,7 +210,7 @@ func NewWithFactory(factory Factory, serverAddress, root string) (*Server, error
 		globalCell:         conn,
 		globalReadOnlyCell: connReadOnly,
 		factory:            factory,
-		cells:              make(map[string]Conn),
+		cellConns:          make(map[string]cellConn),
 	}, nil
 }
 
@@ -234,46 +241,46 @@ func Open() *Server {
 }
 
 // ConnForCell returns a Conn object for the given cell.
-// It caches Conn objects from previously requested cells.
+// It caches Conn objects from previously requested cellConns.
 func (ts *Server) ConnForCell(ctx context.Context, cell string) (Conn, error) {
 	// Global cell is the easy case.
 	if cell == GlobalCell {
 		return ts.globalCell, nil
 	}
 
-	// Return a cached client if present.
-	ts.mu.Lock()
-	conn, ok := ts.cells[cell]
-	ts.mu.Unlock()
-	if ok {
-		return conn, nil
-	}
-
 	// Fetch cell cluster addresses from the global cluster.
-	// These can proceed concurrently (we've released the lock).
 	// We can use the GlobalReadOnlyCell for this call.
 	ci, err := ts.GetCellInfo(ctx, cell, false /*strongRead*/)
 	if err != nil {
 		return nil, err
 	}
 
-	// Connect to the cell topo server, while holding the lock.
-	// This ensures only one connection is established at any given time.
+	// Return a cached client if present.
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
-
-	// Check if another goroutine beat us to creating a client for
-	// this cell.
-	if conn, ok = ts.cells[cell]; ok {
-		return conn, nil
+	cc, ok := ts.cellConns[cell]
+	if ok {
+		// Client exists in cache.
+		// Let's verify that it is the same cell as we are looking for.
+		// The cell name can be re-used with a different ServerAddress and/or Root
+		// in which case we should get a new connection and update the cache
+		if ci.ServerAddress == cc.cellInfo.ServerAddress && ci.Root == cc.cellInfo.Root {
+			return cc.conn, nil
+		}
+		// Close the cached connection, we don't need it anymore
+		if cc.conn != nil {
+			cc.conn.Close()
+		}
 	}
 
-	// Create the connection.
-	conn, err = ts.factory.Create(cell, ci.ServerAddress, ci.Root)
+	// Connect to the cell topo server, while holding the lock.
+	// This ensures only one connection is established at any given time.
+	// Create the connection and cache it
+	conn, err := ts.factory.Create(cell, ci.ServerAddress, ci.Root)
 	switch {
 	case err == nil:
 		conn = NewStatsConn(cell, conn)
-		ts.cells[cell] = conn
+		ts.cellConns[cell] = cellConn{ci, conn}
 		return conn, nil
 	case IsErrType(err, NoNode):
 		err = vterrors.Wrap(err, fmt.Sprintf("failed to create topo connection to %v, %v", ci.ServerAddress, ci.Root))
@@ -322,10 +329,10 @@ func (ts *Server) Close() {
 	ts.globalReadOnlyCell = nil
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
-	for _, conn := range ts.cells {
-		conn.Close()
+	for _, cc := range ts.cellConns {
+		cc.conn.Close()
 	}
-	ts.cells = make(map[string]Conn)
+	ts.cellConns = make(map[string]cellConn)
 }
 
 func (ts *Server) clearCellAliasesCache() {
@@ -362,10 +369,10 @@ func (ts *Server) SetReadOnly(readOnly bool) error {
 	}
 	globalCellConn.SetReadOnly(readOnly)
 
-	for _, conn := range ts.cells {
-		localCellConn, ok := conn.(*StatsConn)
+	for _, cc := range ts.cellConns {
+		localCellConn, ok := cc.conn.(*StatsConn)
 		if !ok {
-			return fmt.Errorf("invalid local cell connection type, expected StatsConn but found: %T", conn)
+			return fmt.Errorf("invalid local cell connection type, expected StatsConn but found: %T", cc.conn)
 		}
 		localCellConn.SetReadOnly(true)
 	}
@@ -383,10 +390,10 @@ func (ts *Server) IsReadOnly() (bool, error) {
 		return false, nil
 	}
 
-	for _, conn := range ts.cells {
-		localCellConn, ok := conn.(*StatsConn)
+	for _, cc := range ts.cellConns {
+		localCellConn, ok := cc.conn.(*StatsConn)
 		if !ok {
-			return false, fmt.Errorf("invalid local cell connection type, expected StatsConn but found: %T", conn)
+			return false, fmt.Errorf("invalid local cell connection type, expected StatsConn but found: %T", cc.conn)
 		}
 		if !localCellConn.IsReadOnly() {
 			return false, nil

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -58,7 +58,7 @@ import (
 
 const (
 	// GlobalCell is the name of the global cell.  It is special
-	// as it contains the global topology, and references the other cellConns.
+	// as it contains the global topology, and references the other cells.
 	GlobalCell = "global"
 
 	// GlobalReadOnlyCell is the name of the global read-only cell
@@ -100,7 +100,7 @@ type Factory interface {
 	// HasGlobalReadOnlyCell returns true if the global cell
 	// has read-only replicas of the topology data. The global topology
 	// is usually more expensive to read from / write to, as it is
-	// replicated over many cellConns. Some topology services provide
+	// replicated over many cells. Some topology services provide
 	// more efficient way to read the data, like Observer servers
 	// for Zookeeper. If this returns true, we will maintain
 	// two connections for the global topology: the 'global' cell
@@ -241,7 +241,7 @@ func Open() *Server {
 }
 
 // ConnForCell returns a Conn object for the given cell.
-// It caches Conn objects from previously requested cellConns.
+// It caches Conn objects from previously requested cells.
 func (ts *Server) ConnForCell(ctx context.Context, cell string) (Conn, error) {
 	// Global cell is the easy case.
 	if cell == GlobalCell {

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -130,6 +130,7 @@ var (
 		"vtorc",
 		"vtorc_8.0",
 		"schemadiff_vrepl",
+		"topo_connection_cache",
 	}
 
 	clusterSelfHostedList = []string{

--- a/test/config.json
+++ b/test/config.json
@@ -1229,15 +1229,6 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
-		"vreplication_source_time_zone": {
-			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestMoveTablesTZ"],
-			"Command": [],
-			"Manual": false,
-			"Shard": "vreplication_migrate",
-			"RetryMax": 1,
-			"Tags": []
-		},
 		"topo_connection_cache": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/topoconncache", "-run", "TestVtctldListAllTablets"],

--- a/test/config.json
+++ b/test/config.json
@@ -1228,6 +1228,24 @@
 			"Shard": "vreplication_migrate",
 			"RetryMax": 1,
 			"Tags": []
+		},
+		"vreplication_source_time_zone": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestMoveTablesTZ"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vreplication_migrate",
+			"RetryMax": 1,
+			"Tags": []
+		},
+		"topo_connection_cache": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/topoconncache", "-run", "TestVtctldListAllTablets"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "topo_connection_cache",
+			"RetryMax": 1,
+			"Tags": []
 		}
 	}
 }


### PR DESCRIPTION
Co-authored-by: Rameez Sajwani <rameezwazirali@hotmail.com>
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>

## Description

Issue: vtctlclient ListAllTablets does not show those tablets in cells that were deleted and re-added with same name.
The root cause is that we cache connections to cells by name, and the name is being re-used.

We are fixing this by caching the CellInfo along with conn so that we can verify that it is the exact "same" cell before using the cached connection.

## Repro

We create a cell "abc" with some rootPath like path1/abc. Then we delete it, and create it again with the same name but a different path like path2/abc.
The vtctld cache will continue to contains a connection with path path1/abc which no longer exists.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required