### PR TITLE
feat: make v3 not plan IS NULL queries against a lookup vindex

### DIFF
--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -696,6 +696,10 @@ func (rb *route) computeISPlan(pb *primitiveBuilder, comparison *sqlparser.IsExp
 	if vindex == nil {
 		return engine.Scatter, nil, nil
 	}
+	if _, isLookup := vindex.(vindexes.Lookup); isLookup {
+		// the lookup table is keyed by the lookup value, so it does not support nulls
+		return engine.Scatter, nil, nil
+	}
 	if vindex.IsUnique() {
 		return engine.EqualUnique, vindex, &sqlparser.NullVal{}
 	}

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -2112,25 +2112,6 @@ Gen4 plan same as above
   "Original": "select id from music where id is null",
   "Instructions": {
     "OperatorType": "Route",
-    "Variant": "EqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where id is null",
-    "Table": "music",
-    "Values": [
-      "NULL"
-    ],
-    "Vindex": "music_user_map"
-  }
-}
-{
-  "QueryType": "SELECT",
-  "Original": "select id from music where id is null",
-  "Instructions": {
-    "OperatorType": "Route",
     "Variant": "Scatter",
     "Keyspace": {
       "Name": "user",
@@ -2141,6 +2122,7 @@ Gen4 plan same as above
     "Table": "music"
   }
 }
+Gen4 plan same as above
 
 # SELECT with IS NOT NULL
 "select id from music where id is not null"
@@ -4073,25 +4055,6 @@ Gen4 plan same as above
   "Original": "select id from music where id is null and user_id in (1,2)",
   "Instructions": {
     "OperatorType": "Route",
-    "Variant": "EqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where id is null and user_id in (1, 2)",
-    "Table": "music",
-    "Values": [
-      "NULL"
-    ],
-    "Vindex": "music_user_map"
-  }
-}
-{
-  "QueryType": "SELECT",
-  "Original": "select id from music where id is null and user_id in (1,2)",
-  "Instructions": {
-    "OperatorType": "Route",
     "Variant": "IN",
     "Keyspace": {
       "Name": "user",
@@ -4106,3 +4069,4 @@ Gen4 plan same as above
     "Vindex": "user_index"
   }
 }
+Gen4 plan same as above


### PR DESCRIPTION
## Description
Does the same thing that we did for gen4 recently - do not plan vindex lookup queries against null values, since they are not supported.

## Related Issue(s)
Gen4 change: #10388


## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
l