### PR TITLE
Improve performance of the `DetectSchemaChange` query

### DIFF
--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -56,48 +56,31 @@ CREATE TABLE if not exists _vt.schemacopy (
 	column_key varchar(3) NOT NULL,
 	PRIMARY KEY (table_schema, table_name, ordinal_position))`
 
-	detectNewColumns = `
-select ISC.table_name
-from information_schema.columns as ISC
-	 left join _vt.schemacopy as c on 
-		ISC.table_name = c.table_name and 
-		ISC.table_schema=c.table_schema and 
-		ISC.ordinal_position = c.ordinal_position
-where ISC.table_schema = database() AND c.table_schema is null`
-
-	detectChangeColumns = `
-select ISC.table_name
-from information_schema.columns as ISC
-	  join _vt.schemacopy as c on 
-		ISC.table_name = c.table_name and 
-		ISC.table_schema=c.table_schema and 
-		ISC.ordinal_position = c.ordinal_position
-where ISC.table_schema = database() 
-	AND (not(c.column_name <=> ISC.column_name) 
-	OR not(ISC.character_set_name <=> c.character_set_name) 
-	OR not(ISC.collation_name <=> c.collation_name) 
-	OR not(ISC.data_type <=> c.data_type) 
-	OR not(ISC.column_key <=> c.column_key))`
-
-	detectRemoveColumns = `
-select c.table_name
-from information_schema.columns as ISC
-	  right join _vt.schemacopy as c on 
-		ISC.table_name = c.table_name and 
-		ISC.table_schema=c.table_schema and 
-		ISC.ordinal_position = c.ordinal_position
-where c.table_schema = database() AND ISC.table_schema is null`
-
 	// DetectSchemaChange query detects if there is any schema change from previous copy.
-	DetectSchemaChange = detectChangeColumns + " UNION " + detectNewColumns + " UNION " + detectRemoveColumns
+	DetectSchemaChange = `
+SELECT DISTINCT table_name
+FROM (
+	SELECT table_name, column_name, ordinal_position, character_set_name, collation_name, data_type, column_key
+	FROM information_schema.columns
+	WHERE table_schema = database()
+
+	UNION ALL
+
+	SELECT table_name, column_name, ordinal_position, character_set_name, collation_name, data_type, column_key
+	FROM _vt.schemacopy c
+	WHERE table_schema = database()
+) _inner
+GROUP BY table_name, column_name, ordinal_position, character_set_name, collation_name, data_type, column_key
+HAVING COUNT(*) = 1
+`
 
 	// ClearSchemaCopy query clears the schemacopy table.
 	ClearSchemaCopy = `delete from _vt.schemacopy where table_schema = database()`
 
 	// InsertIntoSchemaCopy query copies over the schema information from information_schema.columns table.
-	InsertIntoSchemaCopy = `insert _vt.schemacopy 
-select table_schema, table_name, column_name, ordinal_position, character_set_name, collation_name, data_type, column_key 
-from information_schema.columns 
+	InsertIntoSchemaCopy = `insert _vt.schemacopy
+select table_schema, table_name, column_name, ordinal_position, character_set_name, collation_name, data_type, column_key
+from information_schema.columns
 where table_schema = database()`
 
 	// fetchColumns are the columns we fetch
@@ -105,15 +88,15 @@ where table_schema = database()`
 
 	// FetchUpdatedTables queries fetches all information about updated tables
 	FetchUpdatedTables = `select  ` + fetchColumns + `
-from _vt.schemacopy 
-where table_schema = database() and 
-	table_name in ::tableNames 
+from _vt.schemacopy
+where table_schema = database() and
+	table_name in ::tableNames
 order by table_name, ordinal_position`
 
 	// FetchTables queries fetches all information about tables
-	FetchTables = `select ` + fetchColumns + ` 
-from _vt.schemacopy 
-where table_schema = database() 
+	FetchTables = `select ` + fetchColumns + `
+from _vt.schemacopy
+where table_schema = database()
 order by table_name, ordinal_position`
 
 	// GetColumnNamesQueryPatternForTable is used for mocking queries in unit tests


### PR DESCRIPTION
## Description

Accessing the `information_schema.columns` table is expensive in MySQL 5.7, especially when it's accessed in a nested loop (e.g. via a `JOIN`). The query to detect schema changes was accessing `information_schema.columns` multiple times, which could easily add up to execution times of 0.5 seconds per query on my test system.

This pull request proposes a replacement query that is more careful about accessing `information_schema.columns` (and `_vt.schemacopy`) only once to determine all tables that have been modified and need to be re-cached.

## Related Issue(s)

See https://github.com/vitessio/vitess/pull/9632 for a similar optimization made previously.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
