### PR TITLE
replace planner-version with planner_version in vtexplain

### DIFF
--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -70,6 +70,10 @@ The heartbeats are generated according to `--heartbeat_interval`.
 
 The flag `--online_ddl_check_interval` is deprecated and will be removed in `v15`. It has been unused in `v13`.
 
+#### Deprecation of --planner-version for vtexplain
+
+The flag `--planner-version` is deprecated and will be removed in `v15`. Instead, please use `--planer_version`.
+
 ### Online DDL changes
 
 #### Online DDL is generally available
@@ -183,15 +187,3 @@ The throttler now checks in with the heartbeat writer to request heartbeats, any
 When `--heartbeat_on_demand_duration` is not set, there is no change in behavior.
 
 When `--heartbeat_on_demand_duration` is set to a positive value, then the throttler ensures that the heartbeat writer generated heartbeats for at least the following duration. This also means at the first throttler check, it's possible that heartbeats are idle, and so the first check will fail. As heartbeats start running, followup checks will get a more accurate lag evaluation and will respond accordingly. In a sense, it's a "cold engine" scenario, where the engine takes time to start up, and then runs smoothly.
-
-### Compatibility
-
-#### Join with `USING`
-
-In previous versions of Vitess our planners (v3 and Gen4) were rewriting the `USING` condition of a join to an `ON` condition.
-This rewriting was causing an incompatible behavior with MySQL due to how MySQL handles queries with `ON` and `USING` differently.
-
-Thanks to this rewriting we were previously able to plan sharded queries with an `USING` condition. This is no longer the case.
-Queries with an `USING` condition that need to be sent to a sharded keyspace are no longer supported and will return an `unsupported` planner error.
-
-This change was made through pull request [#9767](https://github.com/vitessio/vitess/pull/9767).

--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -151,6 +151,7 @@ func parseAndRun() error {
 		if plannerVersionStr != nil && *badPlannerVersion != *plannerVersionStr {
 			return fmt.Errorf("can't specify planner-version and planner_version with different versions")
 		}
+		log.Warningf("planner-version is deprecated. please use planner_version instead")
 		plannerVersionStr = badPlannerVersion
 	}
 	plannerVersion, _ := plancontext.PlannerNameToVersion(*plannerVersionStr)

--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -50,7 +50,8 @@ var (
 	normalize          = flag.Bool("normalize", false, "Whether to enable vtgate normalization")
 	outputMode         = flag.String("output-mode", "text", "Output in human-friendly text or json")
 	dbName             = flag.String("dbname", "", "Optional database target to override normal routing")
-	plannerVersionStr  = flag.String("planner-version", "gen4", "Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4")
+	badPlannerVersion  = flag.String("planner-version", "", "Deprecated flag. Use planner_version instead")
+	plannerVersionStr  = flag.String("planner_version", "gen4", "Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4")
 
 	// vtexplainFlags lists all the flags that should show in usage
 	vtexplainFlags = []string{
@@ -146,6 +147,12 @@ func parseAndRun() error {
 		return err
 	}
 
+	if badPlannerVersion != nil {
+		if plannerVersionStr != nil && *badPlannerVersion != *plannerVersionStr {
+			return fmt.Errorf("can't specify planner-version and planner_version with different versions")
+		}
+		plannerVersionStr = badPlannerVersion
+	}
 	plannerVersion, _ := plancontext.PlannerNameToVersion(*plannerVersionStr)
 	if plannerVersion != querypb.ExecuteOptions_V3 && plannerVersion != querypb.ExecuteOptions_Gen4 {
 		return fmt.Errorf("invalid value specified for planner-version of '%s' -- valid values are V3 and Gen4", *plannerVersionStr)


### PR DESCRIPTION
## Description
vtexplain mistakenly used `planner-version` instead of `planner_version`, note the underscore vs the hyphen.

We want to keep the same flag that the vtgate is using, so this PR changes it to use the new flag.

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
