### PR TITLE
v3: Fix issue when no routes are found from a lookup

### DIFF
--- a/go/test/endtoend/vtgate/sec_vind/main_test.go
+++ b/go/test/endtoend/vtgate/sec_vind/main_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"context"
+	_ "embed"
+	"flag"
+	"os"
+	"testing"
+
+	"vitess.io/vitess/go/test/endtoend/utils"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	KeyspaceName    = "ks"
+	Cell            = "test"
+	//go:embed schema.sql
+	SchemaSQL string
+
+	//go:embed vschema.json
+	VSchema string
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(Cell, "localhost")
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		err := clusterInstance.StartTopo()
+		if err != nil {
+			return 1
+		}
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      KeyspaceName,
+			SchemaSQL: SchemaSQL,
+			VSchema:   VSchema,
+		}
+		err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 1, true)
+		if err != nil {
+			return 1
+		}
+
+		// Start vtgate
+		err = clusterInstance.StartVtgate()
+		if err != nil {
+			return 1
+		}
+		vtParams = mysql.ConnParams{
+			Host: clusterInstance.Hostname,
+			Port: clusterInstance.VtgateMySQLPort,
+		}
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func start(t *testing.T) (*mysql.Conn, func()) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+
+	deleteAll := func() {
+		_, _ = utils.ExecAllowError(t, conn, "set workload = oltp")
+
+		tables := []string{"t1", "lookup_t1"}
+		for _, table := range tables {
+			_, _ = utils.ExecAllowError(t, conn, "delete from "+table)
+		}
+	}
+
+	deleteAll()
+
+	return conn, func() {
+		deleteAll()
+		conn.Close()
+		cluster.PanicHandler(t)
+	}
+}
+
+func TestInAgainstSecondaryVindex(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	utils.AssertMatches(t, conn, `select 1 from t1 where c2 in ("abc")`, "[]")
+}

--- a/go/test/endtoend/vtgate/sec_vind/schema.sql
+++ b/go/test/endtoend/vtgate/sec_vind/schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE t1 (
+                    c1 bigint unsigned NOT NULL,
+                    c2 varchar(16) NOT NULL,
+                    PRIMARY KEY (c1)
+) ENGINE InnoDB;
+
+CREATE TABLE lookup_t1 (
+                           c2 varchar(16) NOT NULL,
+                           keyspace_id varbinary(16) NOT NULL,
+                           PRIMARY KEY (c2)
+) ENGINE InnoDB;

--- a/go/test/endtoend/vtgate/sec_vind/vschema.json
+++ b/go/test/endtoend/vtgate/sec_vind/vschema.json
@@ -1,0 +1,39 @@
+{
+  "sharded": true,
+  "vindexes": {
+    "lookup_idx": {
+      "type": "lookup",
+      "params": {
+        "from": "c2",
+        "to": "keyspace_id",
+        "table": "lookup_t1"
+      },
+      "owner": "t1"
+    },
+    "xxhash": {
+      "type": "xxhash"
+    }
+  },
+  "tables": {
+    "t1": {
+      "columnVindexes": [
+        {
+          "column": "c1",
+          "name": "xxhash"
+        },
+        {
+          "column": "c2",
+          "name": "lookup_idx"
+        }
+      ]
+    },
+    "lookup_t1": {
+      "columnVindexes": [
+        {
+          "column": "c2",
+          "name": "xxhash"
+        }
+      ]
+    }
+  }
+}

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -1106,7 +1106,7 @@ func TestSelectBindvars(t *testing.T) {
 	})
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "select id from `user` where `name` in ::__vals",
+		Sql: "select id from `user` where 1 != 1",
 		BindVariables: map[string]*querypb.BindVariable{
 			"name1": sqltypes.BytesBindVariable([]byte("foo1")),
 			"name2": sqltypes.BytesBindVariable([]byte("foo2")),
@@ -1137,7 +1137,7 @@ func TestSelectBindvars(t *testing.T) {
 
 	// When there are no matching rows in the vindex, vtgate still needs the field info
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "select id from `user` where `name` = :name",
+		Sql: "select id from `user` where 1 != 1",
 		BindVariables: map[string]*querypb.BindVariable{
 			"name": sqltypes.StringBindVariable("nonexistent"),
 		},

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -79,7 +79,9 @@ func buildSelectPlan(query string) stmtPlanner {
 			// if it doesn't find a shard to send the query to.
 			// All other engine primitives can handle this, so we only need it when
 			// Route is the last (and only) instruction before the user sees a result
-			rb.NoRoutesSpecialHandling = true
+			if isOnlyDual(sel) || (len(sel.GroupBy) == 0 && sel.SelectExprs.AllAggregation()) {
+				rb.NoRoutesSpecialHandling = true
+			}
 		}
 
 		return primitive, nil

--- a/test/config.json
+++ b/test/config.json
@@ -1020,6 +1020,15 @@
 			"RetryMax": 2,
 			"Tags": []
 		},
+		"vindex_secondary": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/sec_vind"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_vindex_heavy",
+			"RetryMax": 2,
+			"Tags": []
+		},
 		"web_test": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtctldweb"],


### PR DESCRIPTION
## Description
In a recent change (#10152), we introduced a special mode handling when no routes are found for a query. 
This introduced an issue that was later fixed for gen4 (#10346), but here I missed fixing the same issue for v3.

Needs to be backported to R13 since the above changes were backported.

## Related Issue(s)
#10152 Bug introduced
#10346 Bug fixed for Gen4
Fixes #10301

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
