### PR TITLE
Use Durability Policy in the topo server in VTOrc and deprecate Durability config

### DIFF
--- a/examples/compose/orchestrator/default.json
+++ b/examples/compose/orchestrator/default.json
@@ -1,7 +1,6 @@
 {
   "Debug": true,
   "EnableSyslog": false,
-  "Durability" : "none",
   "ListenAddress": ":3000",
   "MySQLTopologyUser": "orc_client_user",
   "MySQLTopologyPassword": "orc_client_user_password",

--- a/examples/operator/vtorc_example.yaml
+++ b/examples/operator/vtorc_example.yaml
@@ -200,7 +200,6 @@ stringData:
   orc_config.json: |
     {
       "Debug": true,
-      "Durability": "none",
       "MySQLTopologyUser": "orc_client_user",
       "MySQLTopologyPassword": "orc_client_user_password",
       "MySQLReplicaUser": "vt_repl",

--- a/go/test/endtoend/cluster/vtorc_process.go
+++ b/go/test/endtoend/cluster/vtorc_process.go
@@ -54,7 +54,6 @@ type VtorcConfiguration struct {
 	InstancePollSeconds                   int
 	PreventCrossDataCenterPrimaryFailover bool   `json:",omitempty"`
 	LockShardTimeoutSeconds               int    `json:",omitempty"`
-	Durability                            string `json:",omitempty"`
 	ReplicationLagQuery                   string `json:",omitempty"`
 	FailPrimaryPromotionOnLagMinutes      int    `json:",omitempty"`
 }

--- a/go/test/endtoend/vtorc/general/vtorc_test.go
+++ b/go/test/endtoend/vtorc/general/vtorc_test.go
@@ -40,7 +40,7 @@ func TestPrimaryElection(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 1, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 2)
+	}, 2, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -67,7 +67,7 @@ func TestSingleKeyspace(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 1, 1, []string{"--clusters_to_watch", "ks"}, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -83,7 +83,7 @@ func TestKeyspaceShard(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 1, 1, []string{"--clusters_to_watch", "ks/0"}, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -96,7 +96,7 @@ func TestPrimaryReadOnly(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 0, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -118,7 +118,7 @@ func TestReplicaReadWrite(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 0, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -148,7 +148,7 @@ func TestStopReplication(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 0, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -182,7 +182,7 @@ func TestReplicationFromOtherReplica(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 3, 0, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -230,7 +230,7 @@ func TestRepairAfterTER(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 0, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -263,7 +263,7 @@ func TestCircularReplication(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 0, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -307,7 +307,6 @@ func TestSemiSync(t *testing.T) {
 	newCluster := utils.SetupNewClusterSemiSync(t)
 	utils.StartVtorcs(t, newCluster, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-		Durability:                            "semi_sync",
 	}, 1)
 	defer func() {
 		utils.StopVtorcs(t, newCluster)
@@ -373,7 +372,7 @@ func TestVtorcWithPrs(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 4, 0, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 

--- a/go/test/endtoend/vtorc/gracefultakeover/graceful_takeover_test.go
+++ b/go/test/endtoend/vtorc/gracefultakeover/graceful_takeover_test.go
@@ -35,7 +35,7 @@ func TestGracefulPrimaryTakeover(t *testing.T) {
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 0, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
 		RecoveryPeriodBlockSeconds:            5,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -87,7 +87,7 @@ func TestGracefulPrimaryTakeoverNoTarget(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 0, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -122,7 +122,7 @@ func TestGracefulPrimaryTakeoverAuto(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 1, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 
@@ -168,7 +168,7 @@ func TestGracefulPrimaryTakeoverFailCrossCell(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 1, 1, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 

--- a/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
@@ -34,7 +34,7 @@ func TestDownPrimary(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 1, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 	// find primary from topo
@@ -78,7 +78,7 @@ func TestCrossDataCenterFailure(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 1, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 	// find primary from topo
@@ -123,7 +123,7 @@ func TestCrossDataCenterFailureError(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 1, 1, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 	// find primary from topo
@@ -169,7 +169,7 @@ func TestLostRdonlyOnPrimaryFailure(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 2, nil, cluster.VtorcConfiguration{
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 	// find primary from topo
@@ -251,7 +251,7 @@ func TestPromotionLagSuccess(t *testing.T) {
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 1, nil, cluster.VtorcConfiguration{
 		ReplicationLagQuery:              "select 59",
 		FailPrimaryPromotionOnLagMinutes: 1,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 	// find primary from topo
@@ -300,7 +300,7 @@ func TestPromotionLagFailure(t *testing.T) {
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 3, 1, nil, cluster.VtorcConfiguration{
 		ReplicationLagQuery:              "select 61",
 		FailPrimaryPromotionOnLagMinutes: 1,
-	}, 1)
+	}, 1, "")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 	// find primary from topo
@@ -351,8 +351,7 @@ func TestDownPrimaryPromotionRule(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 1, nil, cluster.VtorcConfiguration{
 		LockShardTimeoutSeconds: 5,
-		Durability:              "test",
-	}, 1)
+	}, 1, "test")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 	// find primary from topo
@@ -399,8 +398,7 @@ func TestDownPrimaryPromotionRuleWithLag(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 1, nil, cluster.VtorcConfiguration{
 		LockShardTimeoutSeconds: 5,
-		Durability:              "test",
-	}, 1)
+	}, 1, "test")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 	// find primary from topo
@@ -479,9 +477,8 @@ func TestDownPrimaryPromotionRuleWithLagCrossCenter(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	utils.SetupVttabletsAndVtorc(t, clusterInfo, 2, 1, nil, cluster.VtorcConfiguration{
 		LockShardTimeoutSeconds:               5,
-		Durability:                            "test",
 		PreventCrossDataCenterPrimaryFailover: true,
-	}, 1)
+	}, 1, "test")
 	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
 	shard0 := &keyspace.Shards[0]
 	// find primary from topo

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -271,7 +271,7 @@ func StopVtorcs(t *testing.T, clusterInfo *VtOrcClusterInfo) {
 }
 
 // SetupVttabletsAndVtorc is used to setup the vttablets and start the orchestrator
-func SetupVttabletsAndVtorc(t *testing.T, clusterInfo *VtOrcClusterInfo, numReplicasReqCell1, numRdonlyReqCell1 int, orcExtraArgs []string, config cluster.VtorcConfiguration, vtorcCount int) {
+func SetupVttabletsAndVtorc(t *testing.T, clusterInfo *VtOrcClusterInfo, numReplicasReqCell1, numRdonlyReqCell1 int, orcExtraArgs []string, config cluster.VtorcConfiguration, vtorcCount int, durability string) {
 	// stop vtorc if it is running
 	StopVtorcs(t, clusterInfo)
 
@@ -313,9 +313,8 @@ func SetupVttabletsAndVtorc(t *testing.T, clusterInfo *VtOrcClusterInfo, numRepl
 		require.NoError(t, err)
 	}
 
-	durability := "none"
-	if config.Durability != "" {
-		durability = config.Durability
+	if durability == "" {
+		durability = "none"
 	}
 	out, err := clusterInfo.VtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, fmt.Sprintf("--durability-policy=%s", durability))
 	require.NoError(t, err, out)
@@ -439,7 +438,7 @@ func CheckReplication(t *testing.T, clusterInfo *VtOrcClusterInfo, primary *clus
 		default:
 			_, err := RunSQL(t, sqlSchema, primary, "")
 			if err != nil {
-				log.Warning("create table failed on primary, will retry")
+				log.Warningf("create table failed on primary - %v, will retry", err)
 				time.Sleep(100 * time.Millisecond)
 				break
 			}

--- a/go/vt/orchestrator/config/config.go
+++ b/go/vt/orchestrator/config/config.go
@@ -68,7 +68,6 @@ type Configuration struct {
 	ListenSocket                                string // Where orchestrator HTTP should listen for unix socket (default: empty; when given, TCP is disabled)
 	HTTPAdvertise                               string // optional, for raft setups, what is the HTTP address this node will advertise to its peers (potentially use where behind NAT or when rerouting ports; example: "http://11.22.33.44:3030")
 	AgentsServerPort                            string // port orchestrator agents talk back to
-	Durability                                  string // The type of durability to enforce. Default is "none". Other values are dictated by registered plugins
 	MySQLTopologyUser                           string // The user VTOrc will use to connect to MySQL instances
 	MySQLTopologyPassword                       string // The password VTOrc will use to connect to MySQL instances
 	MySQLReplicaUser                            string // User to set on replica MySQL instances while configuring replication settings on them. If set, use this credential instead of discovering from mysql. TODO(sougou): deprecate this in favor of fetching from vttablet
@@ -254,7 +253,6 @@ func newConfiguration() *Configuration {
 		ListenSocket:                                "",
 		HTTPAdvertise:                               "",
 		AgentsServerPort:                            ":3001",
-		Durability:                                  "none",
 		StatusEndpoint:                              DefaultStatusAPIEndpoint,
 		StatusOUVerify:                              false,
 		BackendDB:                                   "sqlite",

--- a/go/vt/orchestrator/db/generate_base.go
+++ b/go/vt/orchestrator/db/generate_base.go
@@ -870,4 +870,12 @@ var generateSQLBase = []string{
 	`
 		CREATE INDEX ks_idx_vitess_tablet ON vitess_tablet (keyspace, shard)
 	`,
+	`
+		CREATE TABLE IF NOT EXISTS vitess_keyspace (
+			keyspace varchar(128) CHARACTER SET ascii NOT NULL,
+			keyspace_type smallint(5) NOT NULL,
+			durability_policy varchar(512) CHARACTER SET ascii NOT NULL,
+			PRIMARY KEY (keyspace)
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii
+	`,
 }

--- a/go/vt/orchestrator/inst/analysis_dao.go
+++ b/go/vt/orchestrator/inst/analysis_dao.go
@@ -482,6 +482,10 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 				clusters[a.SuggestedClusterAlias].primaryKey = &a.AnalyzedInstanceKey
 			}
 			durabilityPolicy := m.GetString("durability_policy")
+			if durabilityPolicy == "" {
+				log.Errorf("ignoring keyspace %v because no durability_policy is set. Please set it using SetKeyspaceDurabilityPolicy", a.AnalyzedKeyspace)
+				return nil
+			}
 			durability, err := reparentutil.GetDurabilityPolicy(durabilityPolicy)
 			if err != nil {
 				log.Errorf("can't get the durability policy %v - %v. Skipping keyspace - %v.", durabilityPolicy, err, a.AnalyzedKeyspace)

--- a/go/vt/orchestrator/inst/analysis_dao.go
+++ b/go/vt/orchestrator/inst/analysis_dao.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/vt/orchestrator/util"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 
 	"github.com/patrickmn/go-cache"
 	"github.com/rcrowley/go-metrics"
@@ -58,6 +59,7 @@ func initializeAnalysisDaoPostConfiguration() {
 type clusterAnalysis struct {
 	hasClusterwideAction bool
 	primaryKey           *InstanceKey
+	durability           reparentutil.Durabler
 }
 
 // GetReplicationAnalysis will check for replication problems (dead primary; unreachable primary; etc)
@@ -73,6 +75,9 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		vitess_tablet.port,
 		vitess_tablet.tablet_type,
 		vitess_tablet.primary_timestamp,
+		vitess_keyspace.keyspace AS keyspace,
+		vitess_keyspace.keyspace_type AS keyspace_type,
+		vitess_keyspace.durability_policy AS durability_policy,
 		primary_instance.read_only AS read_only,
 		MIN(primary_instance.data_center) AS data_center,
 		MIN(primary_instance.region) AS region,
@@ -307,6 +312,9 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		) AS count_distinct_logging_major_versions
 	FROM
 		vitess_tablet
+		JOIN vitess_keyspace ON (
+			vitess_tablet.keyspace = vitess_keyspace.keyspace
+		)
 		JOIN database_instance primary_instance ON (
 			vitess_tablet.hostname = primary_instance.hostname
 			AND vitess_tablet.port = primary_instance.port
@@ -384,8 +392,13 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		}
 
 		a.TabletType = tablet.Type
-		a.AnalyzedKeyspace = tablet.Keyspace
+		a.AnalyzedKeyspace = m.GetString("keyspace")
 		a.PrimaryTimeStamp = m.GetTime("primary_timestamp")
+
+		if keyspaceType := topodatapb.KeyspaceType(m.GetInt("keyspace_type")); keyspaceType == topodatapb.KeyspaceType_SNAPSHOT {
+			log.Errorf("keyspace %v is a snapshot keyspace. Skipping.", a.AnalyzedKeyspace)
+			return nil
+		}
 
 		a.IsPrimary = m.GetBool("is_primary")
 		countCoPrimaryReplicas := m.GetUint("count_co_primary_replicas")
@@ -468,11 +481,22 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 				a.IsClusterPrimary = true
 				clusters[a.SuggestedClusterAlias].primaryKey = &a.AnalyzedInstanceKey
 			}
+			durabilityPolicy := m.GetString("durability_policy")
+			durability, err := reparentutil.GetDurabilityPolicy(durabilityPolicy)
+			if err != nil {
+				log.Errorf("can't get the durability policy %v - %v. Skipping keyspace - %v.", durabilityPolicy, err, a.AnalyzedKeyspace)
+				return nil
+			}
+			clusters[a.SuggestedClusterAlias].durability = durability
 		}
 		// ca has clusterwide info
 		ca := clusters[a.SuggestedClusterAlias]
 		if ca.hasClusterwideAction {
 			// We can only take one cluster level action at a time.
+			return nil
+		}
+		if ca.durability == nil {
+			// We failed to load the durability policy, so we shouldn't run any analysis
 			return nil
 		}
 		if a.IsClusterPrimary && !a.LastCheckValid && a.CountReplicas == 0 {
@@ -504,11 +528,11 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			a.Analysis = PrimaryIsReadOnly
 			a.Description = "Primary is read-only"
 			//
-		} else if a.IsClusterPrimary && SemiSyncAckers(tablet) != 0 && !a.SemiSyncPrimaryEnabled {
+		} else if a.IsClusterPrimary && SemiSyncAckers(ca.durability, tablet) != 0 && !a.SemiSyncPrimaryEnabled {
 			a.Analysis = PrimarySemiSyncMustBeSet
 			a.Description = "Primary semi-sync must be set"
 			//
-		} else if a.IsClusterPrimary && SemiSyncAckers(tablet) == 0 && a.SemiSyncPrimaryEnabled {
+		} else if a.IsClusterPrimary && SemiSyncAckers(ca.durability, tablet) == 0 && a.SemiSyncPrimaryEnabled {
 			a.Analysis = PrimarySemiSyncMustNotBeSet
 			a.Description = "Primary semi-sync must not be set"
 			//
@@ -532,11 +556,11 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			a.Analysis = ReplicationStopped
 			a.Description = "Replication is stopped"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && IsReplicaSemiSync(primaryTablet, tablet) && !a.SemiSyncReplicaEnabled {
+		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && IsReplicaSemiSync(ca.durability, primaryTablet, tablet) && !a.SemiSyncReplicaEnabled {
 			a.Analysis = ReplicaSemiSyncMustBeSet
 			a.Description = "Replica semi-sync must be set"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && !IsReplicaSemiSync(primaryTablet, tablet) && a.SemiSyncReplicaEnabled {
+		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && !IsReplicaSemiSync(ca.durability, primaryTablet, tablet) && a.SemiSyncReplicaEnabled {
 			a.Analysis = ReplicaSemiSyncMustNotBeSet
 			a.Description = "Replica semi-sync must not be set"
 			//

--- a/go/vt/orchestrator/inst/analysis_dao_test.go
+++ b/go/vt/orchestrator/inst/analysis_dao_test.go
@@ -31,7 +31,6 @@ func TestGetReplicationAnalysis(t *testing.T) {
 	tests := []struct {
 		name       string
 		info       []*test.InfoForRecoveryAnalysis
-		durability string
 		codeWanted AnalysisCode
 		wantErr    string
 	}{
@@ -47,7 +46,8 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
-				LastCheckValid: 1,
+				DurabilityPolicy: "none",
+				LastCheckValid:   1,
 			}},
 			codeWanted: ClusterHasNoPrimary,
 		}, {
@@ -62,6 +62,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
+				DurabilityPolicy:              "none",
 				LastCheckValid:                0,
 				CountReplicas:                 4,
 				CountValidReplicas:            4,
@@ -81,9 +82,10 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
-				LastCheckValid: 0,
-				CountReplicas:  0,
-				IsPrimary:      1,
+				DurabilityPolicy: "none",
+				LastCheckValid:   0,
+				CountReplicas:    0,
+				IsPrimary:        1,
 			}},
 			codeWanted: DeadPrimaryWithoutReplicas,
 		}, {
@@ -98,9 +100,10 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
-				LastCheckValid: 0,
-				CountReplicas:  3,
-				IsPrimary:      1,
+				DurabilityPolicy: "none",
+				LastCheckValid:   0,
+				CountReplicas:    3,
+				IsPrimary:        1,
 			}},
 			codeWanted: DeadPrimaryAndReplicas,
 		}, {
@@ -115,6 +118,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
+				DurabilityPolicy:              "none",
 				LastCheckValid:                0,
 				CountReplicas:                 4,
 				CountValidReplicas:            2,
@@ -134,6 +138,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
+				DurabilityPolicy:   "none",
 				LastCheckValid:     1,
 				CountReplicas:      4,
 				CountValidReplicas: 4,
@@ -152,6 +157,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
+				DurabilityPolicy:   "none",
 				LastCheckValid:     1,
 				CountReplicas:      4,
 				CountValidReplicas: 4,
@@ -171,6 +177,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
+				DurabilityPolicy:       "none",
 				LastCheckValid:         1,
 				CountReplicas:          4,
 				CountValidReplicas:     4,
@@ -190,13 +197,13 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
+				DurabilityPolicy:       "semi_sync",
 				LastCheckValid:         1,
 				CountReplicas:          4,
 				CountValidReplicas:     4,
 				IsPrimary:              1,
 				SemiSyncPrimaryEnabled: 0,
 			}},
-			durability: "semi_sync",
 			codeWanted: PrimarySemiSyncMustBeSet,
 		}, {
 			name: "NotConnectedToPrimary",
@@ -210,6 +217,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6708,
 				},
+				DurabilityPolicy:              "none",
 				LastCheckValid:                1,
 				CountReplicas:                 4,
 				CountValidReplicas:            4,
@@ -244,6 +252,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6708,
 				},
+				DurabilityPolicy:              "none",
 				LastCheckValid:                1,
 				CountReplicas:                 4,
 				CountValidReplicas:            4,
@@ -261,10 +270,11 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
-				SourceHost:     "localhost",
-				SourcePort:     6708,
-				LastCheckValid: 1,
-				ReadOnly:       0,
+				DurabilityPolicy: "none",
+				SourceHost:       "localhost",
+				SourcePort:       6708,
+				LastCheckValid:   1,
+				ReadOnly:         0,
 			}},
 			codeWanted: ReplicaIsWritable,
 		}, {
@@ -279,6 +289,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6708,
 				},
+				DurabilityPolicy:              "none",
 				LastCheckValid:                1,
 				CountReplicas:                 4,
 				CountValidReplicas:            4,
@@ -296,10 +307,11 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
-				SourceHost:     "localhost",
-				SourcePort:     6706,
-				LastCheckValid: 1,
-				ReadOnly:       1,
+				DurabilityPolicy: "none",
+				SourceHost:       "localhost",
+				SourcePort:       6706,
+				LastCheckValid:   1,
+				ReadOnly:         1,
 			}},
 			codeWanted: ConnectedToWrongPrimary,
 		}, {
@@ -314,6 +326,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6708,
 				},
+				DurabilityPolicy:              "none",
 				LastCheckValid:                1,
 				CountReplicas:                 4,
 				CountValidReplicas:            4,
@@ -331,6 +344,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6709,
 				},
+				DurabilityPolicy:   "none",
 				SourceHost:         "localhost",
 				SourcePort:         6708,
 				LastCheckValid:     1,
@@ -340,8 +354,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 			codeWanted: ReplicationStopped,
 		},
 		{
-			name:       "ReplicaSemiSyncMustBeSet",
-			durability: "semi_sync",
+			name: "ReplicaSemiSyncMustBeSet",
 			info: []*test.InfoForRecoveryAnalysis{{
 				TabletInfo: &topodatapb.Tablet{
 					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
@@ -352,6 +365,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6708,
 				},
+				DurabilityPolicy:              "semi_sync",
 				LastCheckValid:                1,
 				CountReplicas:                 4,
 				CountValidReplicas:            4,
@@ -379,6 +393,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6708,
 				},
+				DurabilityPolicy:       "semi_sync",
 				SourceHost:             "localhost",
 				SourcePort:             6708,
 				LastCheckValid:         1,
@@ -398,6 +413,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6708,
 				},
+				DurabilityPolicy:              "none",
 				LastCheckValid:                1,
 				CountReplicas:                 4,
 				CountValidReplicas:            4,
@@ -424,6 +440,7 @@ func TestGetReplicationAnalysis(t *testing.T) {
 					MysqlHostname: "localhost",
 					MysqlPort:     6708,
 				},
+				DurabilityPolicy:       "none",
 				SourceHost:             "localhost",
 				SourcePort:             6708,
 				LastCheckValid:         1,
@@ -431,15 +448,44 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				SemiSyncReplicaEnabled: 1,
 			}},
 			codeWanted: ReplicaSemiSyncMustNotBeSet,
+		}, {
+			name: "SnapshotKeyspace",
+			info: []*test.InfoForRecoveryAnalysis{{
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_REPLICA,
+					MysqlHostname: "localhost",
+					MysqlPort:     6709,
+				},
+				// Snapshot Keyspace
+				KeyspaceType:     1,
+				DurabilityPolicy: "none",
+				LastCheckValid:   1,
+			}},
+			codeWanted: NoProblem,
+		}, {
+			name: "EmptyDurabilityPolicy",
+			info: []*test.InfoForRecoveryAnalysis{{
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_REPLICA,
+					MysqlHostname: "localhost",
+					MysqlPort:     6709,
+				},
+				LastCheckValid: 1,
+			}},
+			// We will ignore these keyspaces too until the durability policy is set in the topo server
+			codeWanted: NoProblem,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.durability == "" {
-				tt.durability = "none"
-			}
-			SetDurabilityPolicy(tt.durability)
-
 			var rowMaps []sqlutils.RowMap
 			for _, analysis := range tt.info {
 				analysis.SetValuesFromTabletInfo()
@@ -453,6 +499,10 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			if tt.codeWanted == NoProblem {
+				require.Len(t, got, 0)
+				return
+			}
 			require.Len(t, got, 1)
 			require.Equal(t, tt.codeWanted, got[0].Analysis)
 		})

--- a/go/vt/orchestrator/inst/instance_topology_dao.go
+++ b/go/vt/orchestrator/inst/instance_topology_dao.go
@@ -675,7 +675,11 @@ func ChangePrimaryTo(instanceKey *InstanceKey, primaryKey *InstanceKey, primaryB
 		return instance, log.Errore(err)
 	}
 
-	semiSync := IsReplicaSemiSync(*primaryKey, *instanceKey)
+	durability, err := GetDurabilityPolicy(*primaryKey)
+	if err != nil {
+		return instance, log.Errore(err)
+	}
+	semiSync := IsReplicaSemiSync(durability, *primaryKey, *instanceKey)
 	if _, err := ExecInstance(instanceKey, `set global rpl_semi_sync_master_enabled = ?, global rpl_semi_sync_slave_enabled = ?`, false, semiSync); err != nil {
 		return instance, log.Errore(err)
 	}

--- a/go/vt/orchestrator/inst/keyspace_dao.go
+++ b/go/vt/orchestrator/inst/keyspace_dao.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inst
+
+import (
+	"errors"
+
+	"vitess.io/vitess/go/vt/orchestrator/db"
+	"vitess.io/vitess/go/vt/orchestrator/external/golib/sqlutils"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
+)
+
+// ErrKeyspaceNotFound is a fixed error message used when a keyspace is not found in the database.
+var ErrKeyspaceNotFound = errors.New("keyspace not found")
+
+// ReadKeyspace reads the vitess keyspace record.
+func ReadKeyspace(keyspaceName string) (*topo.KeyspaceInfo, error) {
+	query := `
+		select
+			keyspace_type,
+			durability_policy
+		from
+			vitess_keyspace
+		where keyspace=?
+		`
+	args := sqlutils.Args(keyspaceName)
+	keyspace := &topo.KeyspaceInfo{
+		Keyspace: &topodatapb.Keyspace{},
+	}
+	err := db.QueryOrchestrator(query, args, func(row sqlutils.RowMap) error {
+		keyspace.KeyspaceType = topodatapb.KeyspaceType(row.GetInt("keyspace_type"))
+		keyspace.DurabilityPolicy = row.GetString("durability_policy")
+		keyspace.SetKeyspaceName(keyspaceName)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if keyspace.KeyspaceName() == "" {
+		return nil, ErrKeyspaceNotFound
+	}
+	return keyspace, nil
+}
+
+// SaveKeyspace saves the keyspace record against the keyspace name.
+func SaveKeyspace(keyspace *topo.KeyspaceInfo) error {
+	_, err := db.ExecOrchestrator(`
+		replace
+			into vitess_keyspace (
+				keyspace, keyspace_type, durability_policy
+			) values (
+				?, ?, ?
+			)
+		`,
+		keyspace.KeyspaceName(),
+		int(keyspace.KeyspaceType),
+		keyspace.GetDurabilityPolicy(),
+	)
+	return err
+}

--- a/go/vt/orchestrator/inst/keyspace_dao_test.go
+++ b/go/vt/orchestrator/inst/keyspace_dao_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inst
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
+)
+
+func TestSaveAndReadKeyspace(t *testing.T) {
+	tests := []struct {
+		name           string
+		keyspaceName   string
+		keyspace       *topodatapb.Keyspace
+		keyspaceWanted *topodatapb.Keyspace
+		err            string
+	}{
+		{
+			name:         "Success with keyspaceType and durability",
+			keyspaceName: "ks1",
+			keyspace: &topodatapb.Keyspace{
+				KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
+				DurabilityPolicy: "semi_sync",
+			},
+			keyspaceWanted: nil,
+			err:            "",
+		}, {
+			name:         "Success with keyspaceType and no durability",
+			keyspaceName: "ks2",
+			keyspace: &topodatapb.Keyspace{
+				KeyspaceType: topodatapb.KeyspaceType_NORMAL,
+			},
+			keyspaceWanted: nil,
+			err:            "",
+		}, {
+			name:         "Success with snapshot keyspaceType",
+			keyspaceName: "ks3",
+			keyspace: &topodatapb.Keyspace{
+				KeyspaceType: topodatapb.KeyspaceType_SNAPSHOT,
+			},
+			keyspaceWanted: nil,
+			err:            "",
+		}, {
+			name:         "Success with fields that are not stored",
+			keyspaceName: "ks4",
+			keyspace: &topodatapb.Keyspace{
+				KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
+				DurabilityPolicy: "none",
+				BaseKeyspace:     "baseKeyspace",
+			},
+			keyspaceWanted: &topodatapb.Keyspace{
+				KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
+				DurabilityPolicy: "none",
+			},
+			err: "",
+		}, {
+			name:           "No keyspace found",
+			keyspaceName:   "ks5",
+			keyspace:       nil,
+			keyspaceWanted: nil,
+			err:            ErrKeyspaceNotFound.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.keyspaceWanted == nil {
+				tt.keyspaceWanted = tt.keyspace
+			}
+
+			if tt.keyspace != nil {
+				keyspaceInfo := &topo.KeyspaceInfo{
+					Keyspace: tt.keyspace,
+				}
+				keyspaceInfo.SetKeyspaceName(tt.keyspaceName)
+				err := SaveKeyspace(keyspaceInfo)
+				require.NoError(t, err)
+			}
+
+			readKeyspaceInfo, err := ReadKeyspace(tt.keyspaceName)
+			if tt.err != "" {
+				require.EqualError(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+				require.EqualValues(t, tt.keyspaceWanted, readKeyspaceInfo.Keyspace)
+				require.EqualValues(t, tt.keyspaceName, readKeyspaceInfo.KeyspaceName())
+			}
+		})
+	}
+}

--- a/go/vt/orchestrator/inst/keyspace_dao_test.go
+++ b/go/vt/orchestrator/inst/keyspace_dao_test.go
@@ -90,7 +90,6 @@ func TestSaveAndReadKeyspace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			if tt.keyspaceWanted == nil {
 				tt.keyspaceWanted = tt.keyspace
 			}

--- a/go/vt/orchestrator/inst/tablet_dao.go
+++ b/go/vt/orchestrator/inst/tablet_dao.go
@@ -46,7 +46,11 @@ var ErrTabletAliasNil = errors.New("tablet alias is nil")
 // The proactive propagation allows a competing Orchestrator from discovering
 // the successful action of a previous one, which reduces churn.
 func SwitchPrimary(newPrimaryKey, oldPrimaryKey InstanceKey) error {
-	newPrimaryTablet, err := ChangeTabletType(newPrimaryKey, topodatapb.TabletType_PRIMARY, SemiSyncAckers(newPrimaryKey) > 0)
+	durability, err := GetDurabilityPolicy(newPrimaryKey)
+	if err != nil {
+		return err
+	}
+	newPrimaryTablet, err := ChangeTabletType(newPrimaryKey, topodatapb.TabletType_PRIMARY, SemiSyncAckers(durability, newPrimaryKey) > 0)
 	if err != nil {
 		return err
 	}
@@ -80,7 +84,7 @@ func SwitchPrimary(newPrimaryKey, oldPrimaryKey InstanceKey) error {
 		log.Errore(err)
 		return nil
 	}
-	if _, err := ChangeTabletType(oldPrimaryKey, topodatapb.TabletType_REPLICA, IsReplicaSemiSync(newPrimaryKey, oldPrimaryKey)); err != nil {
+	if _, err := ChangeTabletType(oldPrimaryKey, topodatapb.TabletType_REPLICA, IsReplicaSemiSync(durability, newPrimaryKey, oldPrimaryKey)); err != nil {
 		// This is best effort.
 		log.Errore(err)
 	}

--- a/go/vt/orchestrator/logic/keyspace_discovery.go
+++ b/go/vt/orchestrator/logic/keyspace_discovery.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"vitess.io/vitess/go/vt/orchestrator/external/golib/log"
+	"vitess.io/vitess/go/vt/orchestrator/inst"
+	"vitess.io/vitess/go/vt/topo"
+)
+
+// RefreshAllKeyspaces reloads the keyspace information for the keyspaces that vtorc is concerned with.
+func RefreshAllKeyspaces() {
+	var keyspaces []string
+	if *clustersToWatch == "" { // all known keyspaces
+		ctx, cancel := context.WithTimeout(context.Background(), *topo.RemoteOperationTimeout)
+		defer cancel()
+		var err error
+		// Get all the keyspaces
+		keyspaces, err = ts.GetKeyspaces(ctx)
+		if err != nil {
+			log.Errore(err)
+			return
+		}
+	} else {
+		// Parse input and build list of keyspaces
+		inputs := strings.Split(*clustersToWatch, ",")
+		for _, ks := range inputs {
+			if strings.Contains(ks, "/") {
+				// This is a keyspace/shard specification
+				input := strings.Split(ks, "/")
+				keyspaces = append(keyspaces, input[0])
+			} else {
+				// Assume this is a keyspace
+				keyspaces = append(keyspaces, ks)
+			}
+		}
+		if len(keyspaces) == 0 {
+			log.Errorf("Found no keyspaces for input: %v", *clustersToWatch)
+			return
+		}
+	}
+
+	// Sort the list of keyspaces.
+	// The list can have duplicates because the input to clusters to watch may have multiple shards of the same keyspace
+	sort.Strings(keyspaces)
+	refreshCtx, refreshCancel := context.WithTimeout(context.Background(), *topo.RemoteOperationTimeout)
+	defer refreshCancel()
+	var wg sync.WaitGroup
+	for idx, keyspace := range keyspaces {
+		// Check if the current keyspace name is the same as the last one.
+		// If it is, then we know we have already refreshed its information.
+		// We do not need to do it again.
+		if idx != 0 && keyspace == keyspaces[idx-1] {
+			continue
+		}
+		wg.Add(1)
+		go func(keyspace string) {
+			defer wg.Done()
+			_ = refreshKeyspace(refreshCtx, keyspace)
+		}(keyspace)
+	}
+	wg.Wait()
+}
+
+// RefreshKeyspace refreshes the keyspace's information for the given keyspace from the topo
+func RefreshKeyspace(keyspaceName string) error {
+	refreshCtx, refreshCancel := context.WithTimeout(context.Background(), *topo.RemoteOperationTimeout)
+	defer refreshCancel()
+	return refreshKeyspace(refreshCtx, keyspaceName)
+}
+
+// refreshKeyspace is a helper function which reloads the given keyspace's information
+func refreshKeyspace(ctx context.Context, keyspaceName string) error {
+	keyspaceInfo, err := ts.GetKeyspace(ctx, keyspaceName)
+	if err != nil {
+		log.Errore(err)
+		return err
+	}
+	err = inst.SaveKeyspace(keyspaceInfo)
+	if err != nil {
+		log.Errore(err)
+	}
+	return err
+}

--- a/go/vt/orchestrator/logic/keyspace_discovery_test.go
+++ b/go/vt/orchestrator/logic/keyspace_discovery_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/orchestrator/db"
+	"vitess.io/vitess/go/vt/orchestrator/inst"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/topotools"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/reparenttestutil"
+)
+
+var (
+	keyspaceDurabilityNone = &topodatapb.Keyspace{
+		KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
+		DurabilityPolicy: "none",
+	}
+	keyspaceDurabilitySemiSync = &topodatapb.Keyspace{
+		KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
+		DurabilityPolicy: "semi_sync",
+	}
+	keyspaceDurabilityTest = &topodatapb.Keyspace{
+		KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
+		DurabilityPolicy: "test",
+	}
+	keyspaceSnapshot = &topodatapb.Keyspace{
+		KeyspaceType: topodatapb.KeyspaceType_SNAPSHOT,
+	}
+)
+
+func TestRefreshAllKeyspaces(t *testing.T) {
+	// Store the old flags and restore on test completion
+	oldTs := ts
+	oldClustersToWatch := clustersToWatch
+	defer func() {
+		ts = oldTs
+		clustersToWatch = oldClustersToWatch
+	}()
+
+	// Open the orchestrator
+	// After the test completes delete everything from the vitess_keyspace table
+	orcDb, err := db.OpenOrchestrator()
+	require.NoError(t, err)
+	defer func() {
+		_, err = orcDb.Exec("delete from vitess_keyspace")
+		require.NoError(t, err)
+	}()
+
+	ts = memorytopo.NewServer("zone1")
+	keyspaceNames := []string{"ks1", "ks2", "ks3", "ks4"}
+	keyspaces := []*topodatapb.Keyspace{keyspaceDurabilityNone, keyspaceDurabilitySemiSync, keyspaceSnapshot, keyspaceDurabilityTest}
+
+	// Create 4 keyspaces
+	for i, keyspace := range keyspaces {
+		err := ts.CreateKeyspace(context.Background(), keyspaceNames[i], keyspace)
+		require.NoError(t, err)
+	}
+
+	// Set clusters to watch to only watch ks1 and ks3
+	onlyKs1and3 := "ks1/-,ks3/-80,ks3/80-"
+	clustersToWatch = &onlyKs1and3
+	RefreshAllKeyspaces()
+
+	// Verify that we only have ks1 and ks3 in vtorc's db.
+	verifyKeyspaceInfo(t, "ks1", keyspaceDurabilityNone, "")
+	verifyKeyspaceInfo(t, "ks2", nil, "keyspace not found")
+	verifyKeyspaceInfo(t, "ks3", keyspaceSnapshot, "")
+	verifyKeyspaceInfo(t, "ks4", nil, "keyspace not found")
+
+	// Set clusters to watch to watch all keyspaces
+	allKeyspaces := ""
+	clustersToWatch = &allKeyspaces
+	// Change the durability policy of ks1
+	reparenttestutil.SetKeyspaceDurability(context.Background(), t, ts, "ks1", "semi_sync")
+	RefreshAllKeyspaces()
+
+	// Verify that all the keyspaces are correctly reloaded
+	verifyKeyspaceInfo(t, "ks1", keyspaceDurabilitySemiSync, "")
+	verifyKeyspaceInfo(t, "ks2", keyspaceDurabilitySemiSync, "")
+	verifyKeyspaceInfo(t, "ks3", keyspaceSnapshot, "")
+	verifyKeyspaceInfo(t, "ks4", keyspaceDurabilityTest, "")
+}
+
+func TestRefreshKeyspace(t *testing.T) {
+	// Store the old flags and restore on test completion
+	oldTs := ts
+	defer func() {
+		ts = oldTs
+	}()
+
+	// Open the orchestrator
+	// After the test completes delete everything from the vitess_keyspace table
+	orcDb, err := db.OpenOrchestrator()
+	require.NoError(t, err)
+	defer func() {
+		_, err = orcDb.Exec("delete from vitess_keyspace")
+		require.NoError(t, err)
+	}()
+
+	tests := []struct {
+		name           string
+		keyspaceName   string
+		keyspace       *topodatapb.Keyspace
+		ts             *topo.Server
+		keyspaceWanted *topodatapb.Keyspace
+		err            string
+	}{
+		{
+			name:         "Success with keyspaceType and durability",
+			keyspaceName: "ks1",
+			ts:           memorytopo.NewServer("zone1"),
+			keyspace: &topodatapb.Keyspace{
+				KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
+				DurabilityPolicy: "semi_sync",
+			},
+			keyspaceWanted: nil,
+			err:            "",
+		}, {
+			name:         "Success with keyspaceType and no durability",
+			keyspaceName: "ks2",
+			ts:           memorytopo.NewServer("zone1"),
+			keyspace: &topodatapb.Keyspace{
+				KeyspaceType: topodatapb.KeyspaceType_NORMAL,
+			},
+			keyspaceWanted: nil,
+			err:            "",
+		}, {
+			name:         "Success with snapshot keyspaceType",
+			keyspaceName: "ks3",
+			ts:           memorytopo.NewServer("zone1"),
+			keyspace: &topodatapb.Keyspace{
+				KeyspaceType: topodatapb.KeyspaceType_SNAPSHOT,
+			},
+			keyspaceWanted: nil,
+			err:            "",
+		}, {
+			name:         "Success with fields that are not stored",
+			keyspaceName: "ks4",
+			ts:           memorytopo.NewServer("zone1"),
+			keyspace: &topodatapb.Keyspace{
+				KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
+				DurabilityPolicy: "none",
+				BaseKeyspace:     "baseKeyspace",
+			},
+			keyspaceWanted: &topodatapb.Keyspace{
+				KeyspaceType:     topodatapb.KeyspaceType_NORMAL,
+				DurabilityPolicy: "none",
+			},
+			err: "",
+		}, {
+			name:           "No keyspace found",
+			keyspaceName:   "ks5",
+			ts:             memorytopo.NewServer("zone1"),
+			keyspace:       nil,
+			keyspaceWanted: nil,
+			err:            "node doesn't exist: keyspaces/ks5/Keyspace",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.keyspaceWanted == nil {
+				tt.keyspaceWanted = tt.keyspace
+			}
+
+			ts = tt.ts
+			if tt.keyspace != nil {
+				err := ts.CreateKeyspace(context.Background(), tt.keyspaceName, tt.keyspace)
+				require.NoError(t, err)
+			}
+
+			err := RefreshKeyspace(tt.keyspaceName)
+			if tt.err != "" {
+				require.EqualError(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+				verifyKeyspaceInfo(t, tt.keyspaceName, tt.keyspaceWanted, "")
+			}
+		})
+	}
+}
+
+// verifyKeyspaceInfo verifies that the keyspace information read from the orchestrator database
+// is the same as the one provided or reading it gives the same error as expected
+func verifyKeyspaceInfo(t *testing.T, keyspaceName string, keyspace *topodatapb.Keyspace, errString string) {
+	t.Helper()
+	ksInfo, err := inst.ReadKeyspace(keyspaceName)
+	if errString != "" {
+		assert.EqualError(t, err, errString)
+	} else {
+		assert.Equal(t, keyspaceName, ksInfo.KeyspaceName())
+		assert.True(t, topotools.KeyspaceEquality(keyspace, ksInfo.Keyspace))
+	}
+}

--- a/go/vt/orchestrator/logic/orchestrator.go
+++ b/go/vt/orchestrator/logic/orchestrator.go
@@ -507,6 +507,7 @@ func ContinuousDiscovery() {
 				}
 			}()
 		case <-tabletTopoTick:
+			go RefreshAllKeyspaces()
 			go RefreshTablets(false /* forceRefresh */)
 		}
 	}

--- a/go/vt/orchestrator/logic/orchestrator.go
+++ b/go/vt/orchestrator/logic/orchestrator.go
@@ -413,11 +413,6 @@ func ContinuousDiscovery() {
 	go ometrics.InitMetrics()
 	go acceptSignals()
 	go kv.InitKVStores()
-	err := inst.SetDurabilityPolicy(config.Config.Durability)
-	if err != nil {
-		log.Infof("Error setting the durability policy: %v", err)
-		os.Exit(1)
-	}
 
 	if *config.RuntimeCLIFlags.GrabElection {
 		process.GrabElection()

--- a/go/vt/orchestrator/logic/tablet_discovery.go
+++ b/go/vt/orchestrator/logic/tablet_discovery.go
@@ -303,6 +303,10 @@ func tabletDemotePrimary(instanceKey inst.InstanceKey, forward bool) error {
 	if err != nil {
 		return err
 	}
+	durability, err := inst.GetDurabilityPolicy(tablet)
+	if err != nil {
+		return err
+	}
 	tmc := tmclient.NewTabletManagerClient()
 	// TODO(sougou): this should be controllable because we may want
 	// to give a longer timeout for a graceful takeover.
@@ -311,7 +315,7 @@ func tabletDemotePrimary(instanceKey inst.InstanceKey, forward bool) error {
 	if forward {
 		_, err = tmc.DemotePrimary(ctx, tablet)
 	} else {
-		err = tmc.UndoDemotePrimary(ctx, tablet, inst.SemiSyncAckers(instanceKey) > 0)
+		err = tmc.UndoDemotePrimary(ctx, tablet, inst.SemiSyncAckers(durability, instanceKey) > 0)
 	}
 	return err
 }

--- a/go/vt/orchestrator/test/recovery_analysis.go
+++ b/go/vt/orchestrator/test/recovery_analysis.go
@@ -31,6 +31,9 @@ type InfoForRecoveryAnalysis struct {
 	TabletInfo                                *topodatapb.Tablet
 	PrimaryTabletInfo                         *topodatapb.Tablet
 	PrimaryTimestamp                          *time.Time
+	Keyspace                                  string
+	KeyspaceType                              int
+	DurabilityPolicy                          string
 	IsPrimary                                 int
 	IsCoPrimary                               int
 	Hostname                                  string
@@ -115,6 +118,7 @@ func (info *InfoForRecoveryAnalysis) ConvertToRowMap() sqlutils.RowMap {
 	rowMap["data_center"] = sqlutils.CellData{String: info.DataCenter, Valid: true}
 	rowMap["downtime_end_timestamp"] = sqlutils.CellData{String: info.DowntimeEndTimestamp, Valid: true}
 	rowMap["downtime_remaining_seconds"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.DowntimeRemainingSeconds), Valid: true}
+	rowMap["durability_policy"] = sqlutils.CellData{String: info.DurabilityPolicy, Valid: true}
 	rowMap["gtid_mode"] = sqlutils.CellData{String: info.GTIDMode, Valid: true}
 	rowMap["hostname"] = sqlutils.CellData{String: info.Hostname, Valid: true}
 	rowMap["is_binlog_server"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsBinlogServer), Valid: true}
@@ -124,6 +128,7 @@ func (info *InfoForRecoveryAnalysis) ConvertToRowMap() sqlutils.RowMap {
 	rowMap["is_last_check_valid"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.LastCheckValid), Valid: true}
 	rowMap["is_primary"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsPrimary), Valid: true}
 	rowMap["is_stale_binlog_coordinates"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsStaleBinlogCoordinates), Valid: true}
+	rowMap["keyspace_type"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.KeyspaceType), Valid: true}
 	rowMap["last_check_partial_success"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.LastCheckPartialSuccess), Valid: true}
 	rowMap["max_replica_gtid_errant"] = sqlutils.CellData{String: info.MaxReplicaGTIDErrant, Valid: true}
 	rowMap["max_replica_gtid_mode"] = sqlutils.CellData{String: info.MaxReplicaGTIDMode, Valid: true}
@@ -159,6 +164,7 @@ func (info *InfoForRecoveryAnalysis) SetValuesFromTabletInfo() {
 	info.Hostname = info.TabletInfo.MysqlHostname
 	info.Port = int(info.TabletInfo.MysqlPort)
 	info.DataCenter = info.TabletInfo.Alias.Cell
+	info.Keyspace = info.TabletInfo.Keyspace
 	info.ClusterName = fmt.Sprintf("%v:%d", info.TabletInfo.MysqlHostname, info.TabletInfo.MysqlPort)
 	info.ClusterAlias = fmt.Sprintf("%v:%d", info.TabletInfo.MysqlHostname, info.TabletInfo.MysqlPort)
 	info.ClusterDomain = fmt.Sprintf("%v:%d", info.TabletInfo.MysqlHostname, info.TabletInfo.MysqlPort)

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -49,6 +49,11 @@ func (ki *KeyspaceInfo) KeyspaceName() string {
 	return ki.keyspace
 }
 
+// SetKeyspaceName sets the keyspace name
+func (ki *KeyspaceInfo) SetKeyspaceName(name string) {
+	ki.keyspace = name
+}
+
 // GetServedFrom returns a Keyspace_ServedFrom record if it exists.
 func (ki *KeyspaceInfo) GetServedFrom(tabletType topodatapb.TabletType) *topodatapb.Keyspace_ServedFrom {
 	for _, ksf := range ki.ServedFroms {

--- a/go/vt/topotools/keyspace.go
+++ b/go/vt/topotools/keyspace.go
@@ -145,3 +145,36 @@ func UpdateShardRecords(
 
 	return nil
 }
+
+// KeyspaceEquality returns true iff two KeyspaceInformations are identical for testing purposes
+func KeyspaceEquality(left, right *topodatapb.Keyspace) bool {
+	if left.KeyspaceType != right.KeyspaceType {
+		return false
+	}
+	if left.ShardingColumnName != right.ShardingColumnName {
+		return false
+	}
+	if left.ShardingColumnType != right.ShardingColumnType {
+		return false
+	}
+	if len(left.ServedFroms) != len(right.ServedFroms) {
+		return false
+	}
+	for i := range left.ServedFroms {
+		if left.ServedFroms[i] != right.ServedFroms[i] {
+			return false
+		}
+	}
+	if left.KeyspaceType != right.KeyspaceType {
+		return false
+	}
+	if left.BaseKeyspace != right.BaseKeyspace {
+		return false
+	}
+
+	if left.SnapshotTime != right.SnapshotTime {
+		return false
+	}
+
+	return left.DurabilityPolicy == right.DurabilityPolicy
+}

--- a/vitess-mixin/e2e/orchestrator/default.json
+++ b/vitess-mixin/e2e/orchestrator/default.json
@@ -1,7 +1,6 @@
 {
   "Debug": true,
   "EnableSyslog": false,
-  "Durability" : "none",
   "ListenAddress": ":3000",
   "MySQLTopologyUser": "orc_client_user",
   "MySQLTopologyPassword": "orc_client_user_password",


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR continues the work of using the durability policy stored in the topo server started in https://github.com/vitessio/vitess/pull/10392. 
We make changes to VTOrc in this PR to deprecate and remove the `Durability` configuration. Instead VTOrc will now also read the durability policy from the topo server. Since, VTOrc needs this information for running the error analysis, it will also need to store the same in its data store to avoid a call to the topo server on each error analysis tick.
This PR accomplishes all of these changes and makes it so that VTOrc too can work with multiple keyspaces having different durability policies.
This PR also adds the check to VTOrc to ignore snapshot keyspaces when running error analysis

VTOrc will ignore keyspaces which don't have their durability_policy set in the topo server. The upgrade path is to upgrade vtctld first, run `SetKeyspaceDurabilityPolicy` and then upgrade VTOrc. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #8975 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required https://github.com/vitessio/vitess/pull/10392 and website docs - https://github.com/vitessio/website/pull/1040

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
When upgrading to release-14, VTOrc will not work until the durability policy is set in the topo server.