### PR TITLE
[vtadmin] authz tests - getters part1

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -615,6 +615,10 @@ func (api *API) GetBackups(ctx context.Context, req *vtadminpb.GetBackupsRequest
 		backups []*vtadminpb.ClusterBackup
 	)
 
+	if req.RequestOptions == nil {
+		req.RequestOptions = &vtctldatapb.GetBackupsRequest{}
+	}
+
 	for _, c := range clusters {
 		if !api.authz.IsAuthorized(ctx, c.ID, rbac.BackupResource, rbac.GetAction) {
 			continue

--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/vtadmin/testutil"
 	"vitess.io/vitess/go/vt/vtadmin/vtctldclient/fakevtctldclient"
 
+	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
@@ -102,6 +103,7 @@ func TestCreateKeyspace(t *testing.T) {
 		assert.NotNil(t, resp, "actor %+v should be permitted to CreateKeyspace", actor)
 	})
 }
+
 func TestCreateShard(t *testing.T) {
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
@@ -170,6 +172,7 @@ func TestCreateShard(t *testing.T) {
 		assert.NotNil(t, resp, "actor %+v should be permitted to CreateShard", actor)
 	})
 }
+
 func TestDeleteKeyspace(t *testing.T) {
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
@@ -236,6 +239,7 @@ func TestDeleteKeyspace(t *testing.T) {
 		assert.NotNil(t, resp, "actor %+v should be permitted to DeleteKeyspace", actor)
 	})
 }
+
 func TestDeleteShards(t *testing.T) {
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
@@ -312,6 +316,7 @@ func TestDeleteShards(t *testing.T) {
 		assert.NotNil(t, resp, "actor %+v should be permitted to DeleteShards", actor)
 	})
 }
+
 func TestDeleteTablet(t *testing.T) {
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
@@ -380,6 +385,83 @@ func TestDeleteTablet(t *testing.T) {
 		assert.NotNil(t, resp, "actor %+v should be permitted to DeleteTablet", actor)
 	})
 }
+
+func TestGetBackups(t *testing.T) {
+	opts := vtadmin.Options{
+		RBAC: &rbac.Config{
+			Rules: []*struct {
+				Resource string
+				Actions  []string
+				Subjects []string
+				Clusters []string
+			}{
+				{
+					Resource: "Backup",
+					Actions:  []string{"get"},
+					Subjects: []string{"user:allowed-all"},
+					Clusters: []string{"*"},
+				},
+				{
+					Resource: "Backup",
+					Actions:  []string{"get"},
+					Subjects: []string{"user:allowed-other"},
+					Clusters: []string{"other"},
+				},
+			},
+		},
+	}
+	err := opts.RBAC.Reify()
+	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
+
+	api := vtadmin.NewAPI(testClusters(t), opts)
+	t.Cleanup(func() {
+		if err := api.Close(); err != nil {
+			t.Logf("api did not close cleanly: %s", err.Error())
+		}
+	})
+
+	t.Run("unauthorized actor", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "unauthorized"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, _ := api.GetBackups(ctx, &vtadminpb.GetBackupsRequest{})
+		assert.Empty(t, resp.Backups, "actor %+v should not be permitted to GetBackups", actor)
+	})
+
+	t.Run("partial access", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "allowed-other"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, _ := api.GetBackups(ctx, &vtadminpb.GetBackupsRequest{})
+		assert.NotEmpty(t, resp.Backups, "actor %+v should be permitted to GetBackups", actor)
+		assert.Len(t, resp.Backups, 3, "'other' actor should be able to see the 3 backups in cluster 'other'")
+	})
+
+	t.Run("full access", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "allowed-all"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, _ := api.GetBackups(ctx, &vtadminpb.GetBackupsRequest{})
+		assert.NotEmpty(t, resp.Backups, "actor %+v should be permitted to GetBackups", actor)
+		assert.Len(t, resp.Backups, 4, "'all' actor should be able to see backups in all clusters")
+	})
+}
+
 func TestGetClusters(t *testing.T) {
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
@@ -463,12 +545,51 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 				DeleteTabletsResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
+				FindAllShardsInKeyspaceResults: map[string]struct {
+					Response *vtctldatapb.FindAllShardsInKeyspaceResponse
+					Error    error
+				}{
+					"test": {
+						Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
+							Shards: map[string]*vtctldatapb.Shard{
+								"-": {
+									Keyspace: "test",
+									Name:     "-",
+									Shard:    &topodatapb.Shard{},
+								},
+							},
+						},
+					},
+				},
+				GetBackupsResults: map[string]struct {
+					Response *vtctldatapb.GetBackupsResponse
+					Error    error
+				}{
+					"test/-": {
+						Response: &vtctldatapb.GetBackupsResponse{
+							Backups: []*mysqlctlpb.BackupInfo{
+								{},
+							},
+						},
+					},
+				},
 				GetCellInfoNamesResults: &struct {
 					Response *vtctldatapb.GetCellInfoNamesResponse
 					Error    error
 				}{
 					Response: &vtctldatapb.GetCellInfoNamesResponse{
 						Names: []string{"zone1"},
+					},
+				},
+				GetKeyspacesResults: &struct {
+					Keyspaces []*vtctldatapb.Keyspace
+					Error     error
+				}{
+					Keyspaces: []*vtctldatapb.Keyspace{
+						{
+							Name:     "test",
+							Keyspace: &topodatapb.Keyspace{},
+						},
 					},
 				},
 			},
@@ -483,6 +604,53 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 					},
 				},
 			},
+		}, {
+			Cluster: &vtadminpb.Cluster{
+				Id:   "other",
+				Name: "other",
+			},
+			VtctldClient: &fakevtctldclient.VtctldClient{
+				FindAllShardsInKeyspaceResults: map[string]struct {
+					Response *vtctldatapb.FindAllShardsInKeyspaceResponse
+					Error    error
+				}{
+					"otherks": {
+						Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
+							Shards: map[string]*vtctldatapb.Shard{
+								"-": {
+									Keyspace: "otherks",
+									Name:     "-",
+									Shard:    &topodatapb.Shard{},
+								},
+							},
+						},
+					},
+				},
+				GetBackupsResults: map[string]struct {
+					Response *vtctldatapb.GetBackupsResponse
+					Error    error
+				}{
+					"otherks/-": {
+						Response: &vtctldatapb.GetBackupsResponse{
+							Backups: []*mysqlctlpb.BackupInfo{
+								{}, {}, {},
+							},
+						},
+					},
+				},
+				GetKeyspacesResults: &struct {
+					Keyspaces []*vtctldatapb.Keyspace
+					Error     error
+				}{
+					Keyspaces: []*vtctldatapb.Keyspace{
+						{
+							Name:     "otherks",
+							Keyspace: &topodatapb.Keyspace{},
+						},
+					},
+				},
+			},
+			Tablets: []*vtadminpb.Tablet{},
 		},
 	}
 

--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -429,7 +429,8 @@ func TestGetBackups(t *testing.T) {
 			ctx = rbac.NewContext(ctx, actor)
 		}
 
-		resp, _ := api.GetBackups(ctx, &vtadminpb.GetBackupsRequest{})
+		resp, err := api.GetBackups(ctx, &vtadminpb.GetBackupsRequest{})
+		assert.NoError(t, err)
 		assert.Empty(t, resp.Backups, "actor %+v should not be permitted to GetBackups", actor)
 	})
 

--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -75,7 +75,7 @@ func TestFindSchema(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -164,7 +164,7 @@ func TestFindSchema(t *testing.T) {
 						ShouldErr: true,
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -189,7 +189,7 @@ func TestFindSchema(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -224,7 +224,7 @@ func TestFindSchema(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -271,7 +271,7 @@ func TestFindSchema(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -326,7 +326,7 @@ func TestFindSchema(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -372,7 +372,7 @@ func TestFindSchema(t *testing.T) {
 						Name: "cluster2",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -427,7 +427,7 @@ func TestFindSchema(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -473,7 +473,7 @@ func TestFindSchema(t *testing.T) {
 						Name: "cluster2",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -628,7 +628,7 @@ func TestFindSchema(t *testing.T) {
 						},
 					},
 				},
-				GetKeyspacesResults: struct {
+				GetKeyspacesResults: &struct {
 					Keyspaces []*vtctldatapb.Keyspace
 					Error     error
 				}{
@@ -722,7 +722,7 @@ func TestFindSchema(t *testing.T) {
 						},
 					},
 				},
-				GetKeyspacesResults: struct {
+				GetKeyspacesResults: &struct {
 					Keyspaces []*vtctldatapb.Keyspace
 					Error     error
 				}{
@@ -2314,7 +2314,7 @@ func TestGetSchemas(t *testing.T) {
 						},
 					},
 				},
-				GetKeyspacesResults: struct {
+				GetKeyspacesResults: &struct {
 					Keyspaces []*vtctldatapb.Keyspace
 					Error     error
 				}{
@@ -2408,7 +2408,7 @@ func TestGetSchemas(t *testing.T) {
 						},
 					},
 				},
-				GetKeyspacesResults: struct {
+				GetKeyspacesResults: &struct {
 					Keyspaces []*vtctldatapb.Keyspace
 					Error     error
 				}{
@@ -3625,7 +3625,7 @@ func TestGetVSchemas(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -3653,7 +3653,7 @@ func TestGetVSchemas(t *testing.T) {
 						Name: "cluster2",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -3708,7 +3708,7 @@ func TestGetVSchemas(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -3736,7 +3736,7 @@ func TestGetVSchemas(t *testing.T) {
 						Name: "cluster2",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -3785,7 +3785,7 @@ func TestGetVSchemas(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -3813,7 +3813,7 @@ func TestGetVSchemas(t *testing.T) {
 						Name: "cluster2",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -3835,7 +3835,7 @@ func TestGetVSchemas(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -3861,7 +3861,7 @@ func TestGetVSchemas(t *testing.T) {
 						Name: "cluster2",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -4171,7 +4171,7 @@ func TestGetWorkflows(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -4206,7 +4206,7 @@ func TestGetWorkflows(t *testing.T) {
 						Name: "cluster2",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -4287,7 +4287,7 @@ func TestGetWorkflows(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -4322,7 +4322,7 @@ func TestGetWorkflows(t *testing.T) {
 						Name: "cluster2",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -4411,7 +4411,7 @@ func TestGetWorkflows(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -4446,7 +4446,7 @@ func TestGetWorkflows(t *testing.T) {
 						Name: "cluster2",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -4518,7 +4518,7 @@ func TestGetWorkflows(t *testing.T) {
 						Name: "cluster1",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{
@@ -4553,7 +4553,7 @@ func TestGetWorkflows(t *testing.T) {
 						Name: "cluster2",
 					},
 					VtctldClient: &fakevtctldclient.VtctldClient{
-						GetKeyspacesResults: struct {
+						GetKeyspacesResults: &struct {
 							Keyspaces []*vtctldatapb.Keyspace
 							Error     error
 						}{

--- a/go/vt/vtadmin/cluster/cluster_internal_test.go
+++ b/go/vt/vtadmin/cluster/cluster_internal_test.go
@@ -397,7 +397,7 @@ func Test_getShardSets(t *testing.T) {
 						Error: topo.NewError(topo.NoNode, "ks3"), /* we need to fail in a particular way */
 					},
 				},
-				GetKeyspacesResults: struct {
+				GetKeyspacesResults: &struct {
 					Keyspaces []*vtctldatapb.Keyspace
 					Error     error
 				}{
@@ -953,7 +953,7 @@ func Test_reloadKeyspaceSchemas(t *testing.T) {
 				ID:   "test",
 				Name: "test",
 				Vtctld: &fakevtctldclient.VtctldClient{
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{
@@ -1010,7 +1010,7 @@ func Test_reloadKeyspaceSchemas(t *testing.T) {
 				ID:   "test",
 				Name: "test",
 				Vtctld: &fakevtctldclient.VtctldClient{
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{
@@ -1083,7 +1083,7 @@ func Test_reloadKeyspaceSchemas(t *testing.T) {
 				ID:   "test",
 				Name: "test",
 				Vtctld: &fakevtctldclient.VtctldClient{
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{
@@ -1134,7 +1134,7 @@ func Test_reloadKeyspaceSchemas(t *testing.T) {
 				ID:   "test",
 				Name: "test",
 				Vtctld: &fakevtctldclient.VtctldClient{
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{
@@ -1152,7 +1152,7 @@ func Test_reloadKeyspaceSchemas(t *testing.T) {
 				ID:   "test",
 				Name: "test",
 				Vtctld: &fakevtctldclient.VtctldClient{
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{
@@ -1278,7 +1278,7 @@ func Test_reloadShardSchemas(t *testing.T) {
 							},
 						},
 					},
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{
@@ -1406,7 +1406,7 @@ func Test_reloadShardSchemas(t *testing.T) {
 							},
 						},
 					},
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{
@@ -1470,7 +1470,7 @@ func Test_reloadShardSchemas(t *testing.T) {
 							},
 						},
 					},
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -889,7 +889,7 @@ func TestFindWorkflows(t *testing.T) {
 					Name: "cluster1",
 				},
 				VtctldClient: &fakevtctldclient.VtctldClient{
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{
@@ -910,7 +910,7 @@ func TestFindWorkflows(t *testing.T) {
 					Name: "cluster1",
 				},
 				VtctldClient: &fakevtctldclient.VtctldClient{
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{
@@ -933,7 +933,7 @@ func TestFindWorkflows(t *testing.T) {
 					Name: "cluster1",
 				},
 				VtctldClient: &fakevtctldclient.VtctldClient{
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{
@@ -1003,7 +1003,7 @@ func TestFindWorkflows(t *testing.T) {
 					Name: "cluster1",
 				},
 				VtctldClient: &fakevtctldclient.VtctldClient{
-					GetKeyspacesResults: struct {
+					GetKeyspacesResults: &struct {
 						Keyspaces []*vtctldatapb.Keyspace
 						Error     error
 					}{

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -254,7 +254,9 @@
                     "name": "unauthorized actor",
                     "actor": {"name": "unauthorized"},
                     "is_permitted": false,
+                    "include_error_var": true,
                     "assertions": [
+                        "assert.NoError(t, err)",
                         "assert.Empty(t, resp.Backups, $$)"
                     ]
                 },

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -59,6 +59,11 @@
                     "value": "\"otherks/-\": {\nResponse: &vtctldatapb.GetBackupsResponse{\nBackups: []*mysqlctlpb.BackupInfo{\n{}, {}, {},\n},\n},\n},"
                 },
                 {
+                    "field": "GetCellInfoNamesResults",
+                    "type": "&struct{\nResponse *vtctldatapb.GetCellInfoNamesResponse\nError error}",
+                    "value": "Response: &vtctldatapb.GetCellInfoNamesResponse{\nNames: []string{\"other1\"},\n},"
+                },
+                {
                     "field": "GetKeyspacesResults",
                     "type": "&struct{\nKeyspaces []*vtctldatapb.Keyspace\nError error}",
                     "value": "Keyspaces: []*vtctldatapb.Keyspace{\n{\nName: \"otherks\",\nKeyspace: &topodatapb.Keyspace{},\n},\n},"
@@ -276,6 +281,54 @@
                     "assertions": [
                         "assert.NotEmpty(t, resp.Backups, $$)",
                         "assert.Len(t, resp.Backups, 4, \"'all' actor should be able to see backups in all clusters\")"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "GetCellInfos",
+            "rules": [
+                {
+                    "resource": "CellInfo",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-all"],
+                    "clusters": ["*"]
+                },
+                {
+                    "resource": "CellInfo",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-other"],
+                    "clusters": ["other"]
+                }
+            ],
+            "request": "&vtadminpb.GetCellInfosRequest{\nNamesOnly: true,\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "unauthorized"},
+                    "is_permitted": false,
+                    "include_error_var": true,
+                    "assertions": [
+                        "assert.NoError(t, err)",
+                        "assert.Empty(t, resp.CellInfos, $$)"
+                    ]
+                },
+                {
+                    "name": "partial access",
+                    "actor": {"name": "allowed-other"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.CellInfos, $$)",
+                        "assert.ElementsMatch(t, resp.CellInfos, []*vtadminpb.ClusterCellInfo{{Cluster: &vtadminpb.Cluster{Id: \"other\", Name: \"other\"}, Name: \"other1\"}})"
+                    ]
+                },
+                {
+                    "name": "full access",
+                    "actor": {"name": "allowed-all"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.CellInfos, $$)",
+                        "assert.ElementsMatch(t, resp.CellInfos, []*vtadminpb.ClusterCellInfo{{Cluster: &vtadminpb.Cluster{Id: \"test\", Name: \"test\"}, Name: \"zone1\"}, {Cluster: &vtadminpb.Cluster{Id: \"other\", Name: \"other\"}, Name: \"other1\"}})"
                     ]
                 }
             ]

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -16,9 +16,24 @@
                     "value": "\"zone1-0000000100\": nil,"
                 },
                 {
+                    "field": "FindAllShardsInKeyspaceResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.FindAllShardsInKeyspaceResponse\nError error}",
+                    "value": "\"test\": {\nResponse: &vtctldatapb.FindAllShardsInKeyspaceResponse{\nShards: map[string]*vtctldatapb.Shard{\n\"-\": {\nKeyspace: \"test\",\nName: \"-\",\nShard: &topodatapb.Shard{},\n},\n},\n},\n},"
+                },
+                {
+                    "field": "GetBackupsResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.GetBackupsResponse\nError error}",
+                    "value": "\"test/-\": {\nResponse: &vtctldatapb.GetBackupsResponse{\nBackups: []*mysqlctlpb.BackupInfo{\n{},\n},\n},\n},"
+                },
+                {
                     "field": "GetCellInfoNamesResults",
                     "type": "&struct{\nResponse *vtctldatapb.GetCellInfoNamesResponse\nError error}",
                     "value": "Response: &vtctldatapb.GetCellInfoNamesResponse{\nNames: []string{\"zone1\"},\n},"
+                },
+                {
+                    "field": "GetKeyspacesResults",
+                    "type": "&struct{\nKeyspaces []*vtctldatapb.Keyspace\nError error}",
+                    "value": "Keyspaces: []*vtctldatapb.Keyspace{\n{\nName: \"test\",\nKeyspace: &topodatapb.Keyspace{},\n},\n},"
                 }
             ],
             "db_tablet_list": [
@@ -26,6 +41,27 @@
                     "tablet": {
                         "alias": {"cell": "zone1", "uid": 100}
                     }
+                }
+            ]
+        },
+        {
+            "id": "other",
+            "name": "other",
+            "vtctldclient_mock_data": [
+                {
+                    "field": "FindAllShardsInKeyspaceResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.FindAllShardsInKeyspaceResponse\nError error}",
+                    "value": "\"otherks\": {\nResponse: &vtctldatapb.FindAllShardsInKeyspaceResponse{\nShards: map[string]*vtctldatapb.Shard{\n\"-\": {\nKeyspace: \"otherks\",\nName: \"-\",\nShard: &topodatapb.Shard{},\n},\n},\n},\n},"
+                },
+                {
+                    "field": "GetBackupsResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.GetBackupsResponse\nError error}",
+                    "value": "\"otherks/-\": {\nResponse: &vtctldatapb.GetBackupsResponse{\nBackups: []*mysqlctlpb.BackupInfo{\n{}, {}, {},\n},\n},\n},"
+                },
+                {
+                    "field": "GetKeyspacesResults",
+                    "type": "&struct{\nKeyspaces []*vtctldatapb.Keyspace\nError error}",
+                    "value": "Keyspaces: []*vtctldatapb.Keyspace{\n{\nName: \"otherks\",\nKeyspace: &topodatapb.Keyspace{},\n},\n},"
                 }
             ]
         }
@@ -192,6 +228,52 @@
                     "assertions": [
                         "require.NoError(t, err)",
                         "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "GetBackups",
+            "rules": [
+                {
+                    "resource": "Backup",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-all"],
+                    "clusters": ["*"]
+                },
+                {
+                    "resource": "Backup",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-other"],
+                    "clusters": ["other"]
+                }
+            ],
+            "request": "&vtadminpb.GetBackupsRequest{}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "unauthorized"},
+                    "is_permitted": false,
+                    "assertions": [
+                        "assert.Empty(t, resp.Backups, $$)"
+                    ]
+                },
+                {
+                    "name": "partial access",
+                    "actor": {"name": "allowed-other"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.Backups, $$)",
+                        "assert.Len(t, resp.Backups, 3, \"'other' actor should be able to see the 3 backups in cluster 'other'\")"
+                    ]
+                },
+                {
+                    "name": "full access",
+                    "actor": {"name": "allowed-all"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.Backups, $$)",
+                        "assert.Len(t, resp.Backups, 4, \"'all' actor should be able to see backups in all clusters\")"
                     ]
                 }
             ]

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -31,6 +31,11 @@
                     "value": "Response: &vtctldatapb.GetCellInfoNamesResponse{\nNames: []string{\"zone1\"},\n},"
                 },
                 {
+                    "field": "GetCellsAliasesResults",
+                    "type": "&struct{\nResponse *vtctldatapb.GetCellsAliasesResponse\nError error}",
+                    "value": "Response: &vtctldatapb.GetCellsAliasesResponse{\nAliases: map[string]*topodatapb.CellsAlias{\n\"zone\": {\nCells: []string{\"zone1\"}},\n},\n},"
+                },
+                {
                     "field": "GetKeyspacesResults",
                     "type": "&struct{\nKeyspaces []*vtctldatapb.Keyspace\nError error}",
                     "value": "Keyspaces: []*vtctldatapb.Keyspace{\n{\nName: \"test\",\nKeyspace: &topodatapb.Keyspace{},\n},\n},"
@@ -62,6 +67,11 @@
                     "field": "GetCellInfoNamesResults",
                     "type": "&struct{\nResponse *vtctldatapb.GetCellInfoNamesResponse\nError error}",
                     "value": "Response: &vtctldatapb.GetCellInfoNamesResponse{\nNames: []string{\"other1\"},\n},"
+                },
+                {
+                    "field": "GetCellsAliasesResults",
+                    "type": "&struct{\nResponse *vtctldatapb.GetCellsAliasesResponse\nError error}",
+                    "value": "Response: &vtctldatapb.GetCellsAliasesResponse{\nAliases: map[string]*topodatapb.CellsAlias{\n\"other\": {\nCells: []string{\"other1\"}},\n},\n},"
                 },
                 {
                     "field": "GetKeyspacesResults",
@@ -367,6 +377,54 @@
                     "assertions": [
                         "require.NoError(t, err)",
                         "assert.NotEmpty(t, resp.Clusters, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "GetCellsAliases",
+            "rules": [
+                {
+                    "resource": "CellsAlias",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-all"],
+                    "clusters": ["*"]
+                },
+                {
+                    "resource": "CellsAlias",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-other"],
+                    "clusters": ["other"]
+                }
+            ],
+            "request": "&vtadminpb.GetCellsAliasesRequest{}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "unauthorized"},
+                    "is_permitted": false,
+                    "include_error_var": true,
+                    "assertions": [
+                        "assert.NoError(t, err)",
+                        "assert.Empty(t, resp.Aliases, $$)"
+                    ]
+                },
+                {
+                    "name": "partial access",
+                    "actor": {"name": "allowed-other"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.Aliases, $$)",
+                        "assert.ElementsMatch(t, resp.Aliases, []*vtadminpb.ClusterCellsAliases{{Cluster: &vtadminpb.Cluster{Id: \"other\", Name: \"other\"}, Aliases: map[string]*topodatapb.CellsAlias{\"other\": {Cells: []string{\"other1\"}}}}})"
+                    ]
+                },
+                {
+                    "name": "full access",
+                    "actor": {"name": "allowed-all"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.Aliases, $$)",
+                        "assert.ElementsMatch(t, resp.Aliases, []*vtadminpb.ClusterCellsAliases{{Cluster: &vtadminpb.Cluster{Id: \"test\", Name: \"test\"}, Aliases: map[string]*topodatapb.CellsAlias{\"zone\": {Cells: []string{\"zone1\"}}}}, {Cluster: &vtadminpb.Cluster{Id: \"other\", Name: \"other\"}, Aliases: map[string]*topodatapb.CellsAlias{\"other\": {Cells: []string{\"other1\"}}}}})"
                     ]
                 }
             ]

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -49,6 +49,7 @@ import (
 	"vitess.io/vitess/go/vt/vtadmin/testutil"
 	"vitess.io/vitess/go/vt/vtadmin/vtctldclient/fakevtctldclient"
 
+	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
@@ -109,7 +110,7 @@ func Test{{ .Method }}(t *testing.T) {
 	{{ end }}
 	{{- end -}}
 }
-{{- end }}
+{{ end }}
 
 func testClusters(t testing.TB) []*cluster.Cluster {
 	configs := []testutil.TestClusterConfig{

--- a/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
+++ b/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
@@ -52,6 +52,10 @@ type VtctldClient struct {
 		Response *vtctldatapb.FindAllShardsInKeyspaceResponse
 		Error    error
 	}
+	GetBackupsResults map[string]struct {
+		Response *vtctldatapb.GetBackupsResponse
+		Error    error
+	}
 	GetCellInfoNamesResults *struct {
 		Response *vtctldatapb.GetCellInfoNamesResponse
 		Error    error
@@ -68,7 +72,7 @@ type VtctldClient struct {
 		Response *vtctldatapb.GetKeyspaceResponse
 		Error    error
 	}
-	GetKeyspacesResults struct {
+	GetKeyspacesResults *struct {
 		Keyspaces []*vtctldatapb.Keyspace
 		Error     error
 	}
@@ -248,17 +252,18 @@ func (fake *VtctldClient) FindAllShardsInKeyspace(ctx context.Context, req *vtct
 	return nil, fmt.Errorf("%w: no result set for keyspace %s", assert.AnError, req.Keyspace)
 }
 
-// GetKeyspace is part of the vtctldclient.VtctldClient interface.
-func (fake *VtctldClient) GetKeyspace(ctx context.Context, req *vtctldatapb.GetKeyspaceRequest, opts ...grpc.CallOption) (*vtctldatapb.GetKeyspaceResponse, error) {
-	if fake.GetKeyspaceResults == nil {
-		return nil, fmt.Errorf("%w: GetKeyspaceResults not set on fake vtctldclient", assert.AnError)
+// GetBackups is part of the vtctldclient.VtctldClient interface.
+func (fake *VtctldClient) GetBackups(ctx context.Context, req *vtctldatapb.GetBackupsRequest, opts ...grpc.CallOption) (*vtctldatapb.GetBackupsResponse, error) {
+	if fake.GetBackupsResults == nil {
+		return nil, fmt.Errorf("%w: GetBackupsResults not set on fake vtctldclient", assert.AnError)
 	}
 
-	if result, ok := fake.GetKeyspaceResults[req.Keyspace]; ok {
+	key := fmt.Sprintf("%s/%s", req.Keyspace, req.Shard)
+	if result, ok := fake.GetBackupsResults[key]; ok {
 		return result.Response, result.Error
 	}
 
-	return nil, fmt.Errorf("%w: no result set for keyspace %s", assert.AnError, req.Keyspace)
+	return nil, fmt.Errorf("%w: no result set for %s", assert.AnError, key)
 }
 
 // GetCellInfo is part of the vtctldclient.VtctldClient interface.
@@ -277,7 +282,7 @@ func (fake *VtctldClient) GetCellInfo(ctx context.Context, req *vtctldatapb.GetC
 // GetCellInfoNames is part of the vtctldclient.VtctldClient interface.
 func (fake *VtctldClient) GetCellInfoNames(ctx context.Context, req *vtctldatapb.GetCellInfoNamesRequest, opts ...grpc.CallOption) (*vtctldatapb.GetCellInfoNamesResponse, error) {
 	if fake.GetCellInfoNamesResults == nil {
-		return nil, fmt.Errorf("%w: GetCellInfoNames not set of fake vtctldclient", assert.AnError)
+		return nil, fmt.Errorf("%w: GetCellInfoNamesResults not set on fake vtctldclient", assert.AnError)
 	}
 
 	return fake.GetCellInfoNamesResults.Response, fake.GetCellInfoNamesResults.Error
@@ -286,14 +291,31 @@ func (fake *VtctldClient) GetCellInfoNames(ctx context.Context, req *vtctldatapb
 // GetCellsAliases is part of the vtctldclient.VtctldClient interface.
 func (fake *VtctldClient) GetCellsAliases(ctx context.Context, req *vtctldatapb.GetCellsAliasesRequest, opts ...grpc.CallOption) (*vtctldatapb.GetCellsAliasesResponse, error) {
 	if fake.GetCellsAliasesResults == nil {
-		return nil, fmt.Errorf("%w: GetCellsAliases not set of fake vtctldclient", assert.AnError)
+		return nil, fmt.Errorf("%w: GetCellsAliasesResults not set on fake vtctldclient", assert.AnError)
 	}
 
 	return fake.GetCellsAliasesResults.Response, fake.GetCellsAliasesResults.Error
 }
 
+// GetKeyspace is part of the vtctldclient.VtctldClient interface.
+func (fake *VtctldClient) GetKeyspace(ctx context.Context, req *vtctldatapb.GetKeyspaceRequest, opts ...grpc.CallOption) (*vtctldatapb.GetKeyspaceResponse, error) {
+	if fake.GetKeyspaceResults == nil {
+		return nil, fmt.Errorf("%w: GetKeyspaceResults not set on fake vtctldclient", assert.AnError)
+	}
+
+	if result, ok := fake.GetKeyspaceResults[req.Keyspace]; ok {
+		return result.Response, result.Error
+	}
+
+	return nil, fmt.Errorf("%w: no result set for keyspace %s", assert.AnError, req.Keyspace)
+}
+
 // GetKeyspaces is part of the vtctldclient.VtctldClient interface.
 func (fake *VtctldClient) GetKeyspaces(ctx context.Context, req *vtctldatapb.GetKeyspacesRequest, opts ...grpc.CallOption) (*vtctldatapb.GetKeyspacesResponse, error) {
+	if fake.GetKeyspacesResults == nil {
+		return nil, fmt.Errorf("%w: GetKeyspacesResults not set on fake vtctldclient", assert.AnError)
+	}
+
 	if fake.GetKeyspacesResults.Error != nil {
 		return nil, fake.GetKeyspacesResults.Error
 	}


### PR DESCRIPTION


## Description

This adds authz tests for the following RPCs:
- GetBackups
- GetCellInfos
- GetCellsAliases

It also includes a fix for handling where GetBackupsRequest.RequestOptions could be nil, which, in `(*cluster.Cluster).GetBackups` when we annotate the span, could segfault.

## Related Issue(s)

#10397 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
