### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/go/cmd/vttestserver/vttestserver_test.go
+++ b/go/cmd/vttestserver/vttestserver_test.go
@@ -75,9 +75,7 @@ func TestPersistentMode(t *testing.T) {
 	conf := config
 	defer resetFlags(args, conf)
 
-	dir, err := os.MkdirTemp("/tmp", "vttestserver_persistent_mode_")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cluster, err := startPersistentCluster(dir)
 	assert.NoError(t, err)
@@ -224,11 +222,7 @@ func TestMtlsAuth(t *testing.T) {
 	defer resetFlags(args, conf)
 
 	// Our test root.
-	root, err := os.MkdirTemp("", "tlstest")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	// Create the certs and configs.
 	tlstest.CreateCA(root)
@@ -267,11 +261,7 @@ func TestMtlsAuthUnauthorizedFails(t *testing.T) {
 	defer resetFlags(args, conf)
 
 	// Our test root.
-	root, err := os.MkdirTemp("", "tlstest")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	// Create the certs and configs.
 	tlstest.CreateCA(root)

--- a/go/mysql/auth_server_clientcert_test.go
+++ b/go/mysql/auth_server_clientcert_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
-	"os"
 	"path"
 	"reflect"
 	"testing"
@@ -46,11 +45,7 @@ func TestValidCert(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestSSLConnection")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", clientCertUsername)
@@ -131,11 +126,7 @@ func TestNoCert(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestSSLConnection")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 	tlstest.CreateCRL(root, tlstest.CA)

--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -32,8 +33,6 @@ import (
 
 	"vitess.io/vitess/go/vt/tlstest"
 	"vitess.io/vitess/go/vt/vttls"
-
-	"context"
 )
 
 // assertSQLError makes sure we get the right error.
@@ -152,9 +151,7 @@ func TestTLSClientDisabled(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestTLSServer")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", host)
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
@@ -226,9 +223,7 @@ func TestTLSClientPreferredDefault(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestTLSServer")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
@@ -348,9 +343,7 @@ func TestTLSClientVerifyCA(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestTLSServer")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
@@ -433,9 +426,7 @@ func TestTLSClientVerifyIdentity(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestTLSServer")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -17,16 +17,14 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
-	"os"
 	"path"
 	"strings"
 	"testing"
 
 	"vitess.io/vitess/go/test/utils"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/tlstest"
 	"vitess.io/vitess/go/vt/vttls"
@@ -111,11 +109,7 @@ func TestSSLConnection(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestSSLConnection")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")

--- a/go/mysql/server_flaky_test.go
+++ b/go/mysql/server_flaky_test.go
@@ -817,9 +817,7 @@ func TestTLSServer(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestTLSServer")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
@@ -917,9 +915,7 @@ func TestTLSRequired(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestTLSRequired")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
@@ -1009,11 +1005,7 @@ func TestCachingSha2PasswordAuthWithTLS(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestSSLConnection")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")

--- a/go/streamlog/streamlog_flaky_test.go
+++ b/go/streamlog/streamlog_flaky_test.go
@@ -193,10 +193,7 @@ func TestChannel(t *testing.T) {
 func TestFile(t *testing.T) {
 	logger := New("logger", 10)
 
-	dir, err := os.MkdirTemp("", "streamlog_file")
-	if err != nil {
-		t.Fatalf("error getting tempdir: %v", err)
-	}
+	dir := t.TempDir()
 
 	logPath := path.Join(dir, "test.log")
 	logChan, err := logger.LogToFile(logPath, testLogf)

--- a/go/vt/grpcoptionaltls/server_test.go
+++ b/go/vt/grpcoptionaltls/server_test.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -48,13 +47,9 @@ type testCredentials struct {
 	server credentials.TransportCredentials
 }
 
-func createCredentials() (*testCredentials, error) {
+func createCredentials(t *testing.T) (*testCredentials, error) {
 	// Create a temporary directory.
-	certDir, err := os.MkdirTemp("", "optionaltls_grpc_test")
-	if err != nil {
-		return nil, err
-	}
-	defer os.RemoveAll(certDir)
+	certDir := t.TempDir()
 
 	certs := tlstest.CreateClientServerCertPairs(certDir)
 	cert, err := tls.LoadX509KeyPair(certs.ServerCert, certs.ServerKey)
@@ -77,7 +72,7 @@ func TestOptionalTLS(t *testing.T) {
 	testCtx, testCancel := context.WithCancel(context.Background())
 	defer testCancel()
 
-	tc, err := createCredentials()
+	tc, err := createCredentials(t)
 	if err != nil {
 		t.Fatalf("failed to create credentials %v", err)
 	}

--- a/go/vt/mysqlctl/backup_test.go
+++ b/go/vt/mysqlctl/backup_test.go
@@ -25,11 +25,7 @@ import (
 )
 
 func TestFindFilesToBackup(t *testing.T) {
-	root, err := os.MkdirTemp("", "backuptest")
-	if err != nil {
-		t.Fatalf("os.TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	// Initialize the fake mysql root directories
 	innodbDataDir := path.Join(root, "innodb_data")

--- a/go/vt/mysqlctl/filebackupstorage/file_test.go
+++ b/go/vt/mysqlctl/filebackupstorage/file_test.go
@@ -17,11 +17,9 @@ limitations under the License.
 package filebackupstorage
 
 import (
-	"io"
-	"os"
-	"testing"
-
 	"context"
+	"io"
+	"testing"
 )
 
 // This file tests the file BackupStorage engine.
@@ -34,22 +32,12 @@ import (
 // setupFileBackupStorage creates a temporary directory, and
 // returns a FileBackupStorage based on it
 func setupFileBackupStorage(t *testing.T) *FileBackupStorage {
-	root, err := os.MkdirTemp("", "fbstest")
-	if err != nil {
-		t.Fatalf("os.TempDir failed: %v", err)
-	}
-	*FileBackupStorageRoot = root
+	*FileBackupStorageRoot = t.TempDir()
 	return &FileBackupStorage{}
-}
-
-// cleanupFileBackupStorage removes the entire directory
-func cleanupFileBackupStorage(fbs *FileBackupStorage) {
-	os.RemoveAll(*FileBackupStorageRoot)
 }
 
 func TestListBackups(t *testing.T) {
 	fbs := setupFileBackupStorage(t)
-	defer cleanupFileBackupStorage(fbs)
 	ctx := context.Background()
 
 	// verify we have no entry now
@@ -152,7 +140,6 @@ func TestListBackups(t *testing.T) {
 
 func TestFileContents(t *testing.T) {
 	fbs := setupFileBackupStorage(t)
-	defer cleanupFileBackupStorage(fbs)
 	ctx := context.Background()
 
 	dir := "keyspace/shard"

--- a/go/vt/schemamanager/local_controller_test.go
+++ b/go/vt/schemamanager/local_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package schemamanager
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -24,17 +25,11 @@ import (
 	"strings"
 	"testing"
 
-	"context"
-
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 func TestLocalControllerNoSchemaChanges(t *testing.T) {
-	schemaChangeDir, err := os.MkdirTemp("", "localcontroller-test")
-	defer os.RemoveAll(schemaChangeDir)
-	if err != nil {
-		t.Fatalf("failed to create temp schema change dir, error: %v", err)
-	}
+	schemaChangeDir := t.TempDir()
 	controller := NewLocalController(schemaChangeDir)
 	ctx := context.Background()
 	if err := controller.Open(ctx); err != nil {
@@ -58,8 +53,7 @@ func TestLocalControllerOpen(t *testing.T) {
 		t.Fatalf("Open should fail, no such dir, but got: %v", err)
 	}
 
-	schemaChangeDir, _ := os.MkdirTemp("", "localcontroller-test")
-	defer os.RemoveAll(schemaChangeDir)
+	schemaChangeDir := t.TempDir()
 
 	// create a file under schema change dir
 	_, err := os.Create(path.Join(schemaChangeDir, "create_test_table.sql"))
@@ -100,11 +94,7 @@ func TestLocalControllerOpen(t *testing.T) {
 }
 
 func TestLocalControllerSchemaChange(t *testing.T) {
-	schemaChangeDir, err := os.MkdirTemp("", "localcontroller-test")
-	if err != nil {
-		t.Fatalf("failed to create temp schema change dir, error: %v", err)
-	}
-	defer os.RemoveAll(schemaChangeDir)
+	schemaChangeDir := t.TempDir()
 
 	testKeyspaceInputDir := path.Join(schemaChangeDir, "test_keyspace/input")
 	if err := os.MkdirAll(testKeyspaceInputDir, os.ModePerm); err != nil {

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -5472,27 +5472,11 @@ func BenchmarkParse3(b *testing.B) {
 }
 
 func TestValidUnionCases(t *testing.T) {
-	testOutputTempDir, err := os.MkdirTemp("", "parse_test")
-	require.NoError(t, err)
-	defer func() {
-		if !t.Failed() {
-			os.RemoveAll(testOutputTempDir)
-		}
-	}()
-
-	testFile(t, "union_cases.txt", testOutputTempDir)
+	testFile(t, "union_cases.txt", t.TempDir())
 }
 
 func TestValidSelectCases(t *testing.T) {
-	testOutputTempDir, err := os.MkdirTemp("", "parse_test")
-	require.NoError(t, err)
-	defer func() {
-		if !t.Failed() {
-			os.RemoveAll(testOutputTempDir)
-		}
-	}()
-
-	testFile(t, "select_cases.txt", testOutputTempDir)
+	testFile(t, "select_cases.txt", t.TempDir())
 }
 
 type testCase struct {

--- a/go/vt/tlstest/tlstest_test.go
+++ b/go/vt/tlstest/tlstest_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -48,11 +47,7 @@ func TestClientServerWithCombineCerts(t *testing.T) {
 // And then performs a few tests on them.
 func testClientServer(t *testing.T, combineCerts bool) {
 	// Our test root.
-	root, err := os.MkdirTemp("", "tlstest")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	clientServerKeyPairs := CreateClientServerCertPairs(root)
 	serverCA := ""
@@ -240,11 +235,7 @@ func TestClientTLSConfigCaching(t *testing.T) {
 
 func testConfigGeneration(t *testing.T, rootPrefix string, generateConfig func(ClientServerKeyPairs) (*tls.Config, error), getCertPool func(tlsConfig *tls.Config) *x509.CertPool) {
 	// Our test root.
-	root, err := os.MkdirTemp("", rootPrefix)
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	const configsToGenerate = 1
 
@@ -287,11 +278,7 @@ func testConfigGeneration(t *testing.T, rootPrefix string, generateConfig func(C
 
 func testNumberOfCertsWithOrWithoutCombining(t *testing.T, numCertsExpected int, combine bool) {
 	// Our test root.
-	root, err := os.MkdirTemp("", "tlstest")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	clientServerKeyPairs := CreateClientServerCertPairs(root)
 	serverCA := ""
@@ -366,11 +353,7 @@ func assertTLSHandshakeFails(t *testing.T, serverConfig, clientConfig *tls.Confi
 }
 
 func TestClientServerWithRevokedServerCert(t *testing.T) {
-	root, err := os.MkdirTemp("", "tlstest")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	clientServerKeyPairs := CreateClientServerCertPairs(root)
 
@@ -426,11 +409,7 @@ func TestClientServerWithRevokedServerCert(t *testing.T) {
 }
 
 func TestClientServerWithRevokedClientCert(t *testing.T) {
-	root, err := os.MkdirTemp("", "tlstest")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	clientServerKeyPairs := CreateClientServerCertPairs(root)
 

--- a/go/vt/topo/consultopo/server_flaky_test.go
+++ b/go/vt/topo/consultopo/server_flaky_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package consultopo
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -26,8 +27,6 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/vt/log"
-
-	"context"
 
 	"github.com/hashicorp/consul/api"
 
@@ -45,11 +44,7 @@ func startConsul(t *testing.T, authToken string) (*exec.Cmd, string, string) {
 	// Create a temporary config file, as ports cannot all be set
 	// via command line. The file name has to end with '.json' so
 	// we're not using TempFile.
-	configDir, err := os.MkdirTemp("", "consul")
-	if err != nil {
-		t.Fatalf("cannot create temp dir: %v", err)
-	}
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 
 	configFilename := path.Join(configDir, "consul.json")
 	configFile, err := os.OpenFile(configFilename, os.O_RDWR|os.O_CREATE, 0600)

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -36,12 +36,9 @@ import (
 )
 
 // startEtcd starts an etcd subprocess, and waits for it to be ready.
-func startEtcd(t *testing.T) (*exec.Cmd, string, string) {
+func startEtcd(t *testing.T) string {
 	// Create a temporary directory.
-	dataDir, err := os.MkdirTemp("", "etcd")
-	if err != nil {
-		t.Fatalf("cannot create tempdir: %v", err)
-	}
+	dataDir := t.TempDir()
 
 	// Get our two ports to listen to.
 	port := testfiles.GoVtTopoEtcd2topoPort
@@ -58,7 +55,7 @@ func startEtcd(t *testing.T) (*exec.Cmd, string, string) {
 		"-listen-peer-urls", peerAddr,
 		"-initial-cluster", initialCluster,
 		"-data-dir", dataDir)
-	err = cmd.Start()
+	err := cmd.Start()
 	if err != nil {
 		t.Fatalf("failed to start etcd: %v", err)
 	}
@@ -85,17 +82,24 @@ func startEtcd(t *testing.T) (*exec.Cmd, string, string) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	t.Cleanup(func() {
+		// log error
+		if err := cmd.Process.Kill(); err != nil {
+			log.Errorf("cmd.Process.Kill() failed : %v", err)
+		}
+		// log error
+		if err := cmd.Wait(); err != nil {
+			log.Errorf("cmd.wait() failed : %v", err)
+		}
+	})
 
-	return cmd, dataDir, clientAddr
+	return clientAddr
 }
 
 // startEtcdWithTLS starts an etcd subprocess with TLS setup, and waits for it to be ready.
-func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs, func()) {
+func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs) {
 	// Create a temporary directory.
-	dataDir, err := os.MkdirTemp("", "etcd")
-	if err != nil {
-		t.Fatalf("cannot create tempdir: %v", err)
-	}
+	dataDir := t.TempDir()
 
 	// Get our two ports to listen to.
 	port := testfiles.GoVtTopoEtcd2topoPort
@@ -124,7 +128,7 @@ func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs, func
 
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
-	err = cmd.Start()
+	err := cmd.Start()
 	if err != nil {
 		t.Fatalf("failed to start etcd: %v", err)
 	}
@@ -168,8 +172,7 @@ func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs, func
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-
-	stopEtcd := func() {
+	t.Cleanup(func() {
 		// log error
 		if err := cmd.Process.Kill(); err != nil {
 			log.Errorf("cmd.Process.Kill() failed : %v", err)
@@ -178,16 +181,14 @@ func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs, func
 		if err := cmd.Wait(); err != nil {
 			log.Errorf("cmd.wait() failed : %v", err)
 		}
-		os.RemoveAll(dataDir)
-	}
+	})
 
-	return clientAddr, &certs, stopEtcd
+	return clientAddr, &certs
 }
 
 func TestEtcd2TLS(t *testing.T) {
 	// Start a single etcd in the background.
-	clientAddr, certs, stopEtcd := startEtcdWithTLS(t)
-	defer stopEtcd()
+	clientAddr, certs := startEtcdWithTLS(t)
 
 	testIndex := 0
 	testRoot := fmt.Sprintf("/test-%v", testIndex)
@@ -217,12 +218,7 @@ func TestEtcd2TLS(t *testing.T) {
 
 func TestEtcd2Topo(t *testing.T) {
 	// Start a single etcd in the background.
-	cmd, dataDir, clientAddr := startEtcd(t)
-	defer func() {
-		cmd.Process.Kill()
-		cmd.Wait()
-		os.RemoveAll(dataDir)
-	}()
+	clientAddr := startEtcd(t)
 
 	testIndex := 0
 	newServer := func() *topo.Server {

--- a/go/vt/topo/k8stopo/server_flaky_test.go
+++ b/go/vt/topo/k8stopo/server_flaky_test.go
@@ -24,9 +24,8 @@ import (
 	"os/exec"
 	"path"
 	"runtime"
-	"time"
-
 	"testing"
+	"time"
 
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -45,11 +44,7 @@ func TestKubernetesTopo(t *testing.T) {
 	}
 
 	// Create a data dir for test data
-	testDataDir, err := os.MkdirTemp("", "vt-test-k3s")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testDataDir) // clean up
+	testDataDir := t.TempDir()
 
 	// Gen a temp file name for the config
 	testConfig, err := os.CreateTemp("", "vt-test-k3s-config")

--- a/go/vt/vtexplain/vtexplain_test.go
+++ b/go/vt/vtexplain/vtexplain_test.go
@@ -123,8 +123,7 @@ func runTestCase(testcase, mode string, opts *Options, topts *testopts, t *testi
 			t.Errorf("Text output did not match (-want +got):\n%s", diff)
 
 			if testOutputTempDir == "" {
-				testOutputTempDir, err = os.MkdirTemp("", "vtexplain_output")
-				require.NoError(t, err, "error getting tempdir")
+				testOutputTempDir = t.TempDir()
 			}
 			gotFile := fmt.Sprintf("%s/%s-output.txt", testOutputTempDir, testcase)
 			os.WriteFile(gotFile, []byte(explainText), 0644)

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"os"
@@ -29,8 +30,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/trace"
-
-	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
@@ -262,11 +261,7 @@ func TestInitTLSConfigWithServerCA(t *testing.T) {
 
 func testInitTLSConfig(t *testing.T, serverCA bool) {
 	// Create the certs.
-	root, err := os.MkdirTemp("", "TestInitTLSConfig")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 	tlstest.CreateCA(root)
 	tlstest.CreateCRL(root, tlstest.CA)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")

--- a/go/vt/vttablet/filelogger/filelogger_test.go
+++ b/go/vt/vttablet/filelogger/filelogger_test.go
@@ -29,11 +29,7 @@ import (
 
 // TestFileLog sends a stream of five query records to the plugin, and verifies that they are logged.
 func TestFileLog(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filelogger_test")
-	if err != nil {
-		t.Fatalf("error getting tempdir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logPath := path.Join(dir, "test.log")
 	logger, err := Init(logPath)
@@ -84,11 +80,7 @@ func TestFileLogRedacted(t *testing.T) {
 		*streamlog.RedactDebugUIQueries = false
 	}()
 
-	dir, err := os.MkdirTemp("", "filelogger_test")
-	if err != nil {
-		t.Fatalf("error getting tempdir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logPath := path.Join(dir, "test.log")
 	logger, err := Init(logPath)

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testlib
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -28,8 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/vt/discovery"
-
-	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"
@@ -77,9 +76,7 @@ func TestBackupRestore(t *testing.T) {
 	db.AddQueryPattern(`INSERT INTO _vt\.local_metadata .*`, &sqltypes.Result{})
 
 	// Initialize our temp dirs
-	root, err := os.MkdirTemp("", "backuptest")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
@@ -291,9 +288,7 @@ func TestBackupRestoreLagged(t *testing.T) {
 	db.AddQueryPattern(`INSERT INTO _vt\.local_metadata .*`, &sqltypes.Result{})
 
 	// Initialize our temp dirs
-	root, err := os.MkdirTemp("", "backuptest")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
@@ -497,9 +492,7 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 	db.AddQueryPattern(`INSERT INTO _vt\.local_metadata .*`, &sqltypes.Result{})
 
 	// Initialize our temp dirs
-	root, err := os.MkdirTemp("", "backuptest")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
@@ -659,9 +652,7 @@ func TestDisableActiveReparents(t *testing.T) {
 	db.AddQueryPattern(`INSERT INTO _vt\.local_metadata .*`, &sqltypes.Result{})
 
 	// Initialize our temp dirs
-	root, err := os.MkdirTemp("", "backuptest")
-	require.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")

--- a/go/vt/wrangler/testlib/vtctl_topo_test.go
+++ b/go/vt/wrangler/testlib/vtctl_topo_test.go
@@ -17,14 +17,13 @@ limitations under the License.
 package testlib
 
 import (
+	"context"
 	"os"
 	"path"
 	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/proto"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 
@@ -63,11 +62,7 @@ func TestVtctlTopoCommands(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	tmp, err := os.MkdirTemp("", "vtctltopotest")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	// Test TopoCat.
 	testVtctlTopoCommand(t, vp, []string{"TopoCat", "-long", "-decode_proto", "/keyspaces/*/Keyspace"}, `path=/keyspaces/ks1/Keyspace version=V
@@ -78,7 +73,7 @@ sharding_column_name:"col2"
 
 	// Test TopoCp from topo to disk.
 	ksFile := path.Join(tmp, "Keyspace")
-	_, err = vp.RunAndOutput([]string{"TopoCp", "/keyspaces/ks1/Keyspace", ksFile})
+	_, err := vp.RunAndOutput([]string{"TopoCp", "/keyspaces/ks1/Keyspace", ksFile})
 	if err != nil {
 		t.Fatalf("TopoCp(/keyspaces/ks1/Keyspace) failed: %v", err)
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
