### PR TITLE
SwitchTraffic should switch everything when no tablet_types provided

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2501,7 +2501,9 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 		vrwp.Cells = *cells
 		vrwp.TabletTypes = *tabletTypes
 		if vrwp.TabletTypes == "" {
-			vrwp.TabletTypes = "in_order:REPLICA,PRIMARY"
+			// When no tablet types are specified we are supposed to switch all traffic so
+			// we override the normal default for tablet_types.
+			vrwp.TabletTypes = "in_order:RDONLY,REPLICA,PRIMARY"
 		}
 		vrwp.Timeout = *timeout
 		vrwp.EnableReverseReplication = *reverseReplication


### PR DESCRIPTION
## Description

The default `tablet_types` option was errantly changed in https://github.com/vitessio/vitess/pull/10040 where we generally made `in_order:REPLICA,PRIMARY` the default `tablet_types` value in VReplication. For SwitchWrites, we should be switching traffic for all tablet types when none are specified: https://vitess.io/docs/14.0/reference/vreplication/switchtraffic/#--tablet_types

I will also update the v14 docs to the new default here of: `in_order:RDONLY,REPLICA,PRIMARY`

## Related Issue(s)
  - Fixes: https://github.com/vitessio/vitess/issues/10421
  - Follow-up to: https://github.com/vitessio/vitess/pull/10040

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
