### PR TITLE
fix: use vcursor to execute the projection input

### DIFF
--- a/go/vt/vtgate/engine/projection.go
+++ b/go/vt/vtgate/engine/projection.go
@@ -86,7 +86,7 @@ func (p *Projection) TryStreamExecute(vcursor VCursor, bindVars map[string]*quer
 	env := evalengine.EnvWithBindVars(bindVars, vcursor.ConnCollation())
 	var once sync.Once
 	var fields []*querypb.Field
-	return p.Input.TryStreamExecute(vcursor, bindVars, wantfields, func(qr *sqltypes.Result) error {
+	return vcursor.StreamExecutePrimitive(p.Input, bindVars, wantfields, func(qr *sqltypes.Result) error {
 		var err error
 		if wantfields {
 			once.Do(func() {


### PR DESCRIPTION
Signed-off-by: Harshit Gangal <harshit@planetscale.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Input to the engine primitive should not be executed directly and should instream use the vcursor primitive functions to execute them as they handle buffering logic if needed.

This PR fixes it for projection primitive for the bug introduced in #10384 

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
