### PR TITLE
Tablet throttler: dynamic ThrottleMetricThreshold

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/config/config.go
+++ b/go/vt/vttablet/tabletserver/throttle/config/config.go
@@ -27,11 +27,3 @@ type ConfigurationSettings struct {
 	EnableProfiling bool // enable pprof profiling http api
 	Stores          StoresSettings
 }
-
-// PostReadAdjustments validates and fixes config
-func (settings *ConfigurationSettings) PostReadAdjustments() error {
-	if err := settings.Stores.postReadAdjustments(); err != nil {
-		return err
-	}
-	return nil
-}

--- a/go/vt/vttablet/tabletserver/throttle/config/mysql_config.go
+++ b/go/vt/vttablet/tabletserver/throttle/config/mysql_config.go
@@ -6,6 +6,8 @@
 
 package config
 
+import "vitess.io/vitess/go/sync2"
+
 //
 // MySQL-specific configuration
 //
@@ -13,27 +15,22 @@ package config
 // MySQLClusterConfigurationSettings has the settings for a specific MySQL cluster. It derives its information
 // from MySQLConfigurationSettings
 type MySQLClusterConfigurationSettings struct {
-	MetricQuery          string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	CacheMillis          int      // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	ThrottleThreshold    float64  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	Port                 int      // Specify if different than 3306 or if different than specified by MySQLConfigurationSettings
-	IgnoreHostsCount     int      // Number of hosts that can be skipped/ignored even on error or on exceeding thresholds
-	IgnoreHostsThreshold float64  // Threshold beyond which IgnoreHostsCount applies (default: 0)
-	HTTPCheckPort        int      // Specify if different than specified by MySQLConfigurationSettings. -1 to disable HTTP check
-	HTTPCheckPath        string   // Specify if different than specified by MySQLConfigurationSettings
-	IgnoreHosts          []string // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-}
-
-// Hook to implement adjustments after reading each configuration file.
-func (settings *MySQLClusterConfigurationSettings) postReadAdjustments() error {
-	return nil
+	MetricQuery          string               // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	CacheMillis          int                  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	ThrottleThreshold    *sync2.AtomicFloat64 // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	Port                 int                  // Specify if different than 3306 or if different than specified by MySQLConfigurationSettings
+	IgnoreHostsCount     int                  // Number of hosts that can be skipped/ignored even on error or on exceeding thresholds
+	IgnoreHostsThreshold float64              // Threshold beyond which IgnoreHostsCount applies (default: 0)
+	HTTPCheckPort        int                  // Specify if different than specified by MySQLConfigurationSettings. -1 to disable HTTP check
+	HTTPCheckPath        string               // Specify if different than specified by MySQLConfigurationSettings
+	IgnoreHosts          []string             // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 }
 
 // MySQLConfigurationSettings has the general configuration for all MySQL clusters
 type MySQLConfigurationSettings struct {
 	MetricQuery          string
 	CacheMillis          int // optional, if defined then probe result will be cached, and future probes may use cached value
-	ThrottleThreshold    float64
+	ThrottleThreshold    *sync2.AtomicFloat64
 	Port                 int      // Specify if different than 3306; applies to all clusters
 	IgnoreDialTCPErrors  bool     // Skip hosts where a metric cannot be retrieved due to TCP dial errors
 	IgnoreHostsCount     int      // Number of hosts that can be skipped/ignored even on error or on exceeding thresholds
@@ -43,45 +40,4 @@ type MySQLConfigurationSettings struct {
 	IgnoreHosts          []string // If non empty, substrings to indicate hosts to be ignored/skipped
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
-}
-
-// Hook to implement adjustments after reading each configuration file.
-func (settings *MySQLConfigurationSettings) postReadAdjustments() error {
-	// Username & password may be given as plaintext in the config file, or can be delivered
-	// via environment variables. We accept user & password in the form "${SOME_ENV_VARIABLE}"
-	// in which case we get the value from this process' invoking environment.
-
-	for _, clusterSettings := range settings.Clusters {
-		if err := clusterSettings.postReadAdjustments(); err != nil {
-			return err
-		}
-		if clusterSettings.MetricQuery == "" {
-			clusterSettings.MetricQuery = settings.MetricQuery
-		}
-		if clusterSettings.CacheMillis == 0 {
-			clusterSettings.CacheMillis = settings.CacheMillis
-		}
-		if clusterSettings.ThrottleThreshold == 0 {
-			clusterSettings.ThrottleThreshold = settings.ThrottleThreshold
-		}
-		if clusterSettings.Port == 0 {
-			clusterSettings.Port = settings.Port
-		}
-		if clusterSettings.IgnoreHostsCount == 0 {
-			clusterSettings.IgnoreHostsCount = settings.IgnoreHostsCount
-		}
-		if clusterSettings.IgnoreHostsThreshold == 0 {
-			clusterSettings.IgnoreHostsThreshold = settings.IgnoreHostsThreshold
-		}
-		if clusterSettings.HTTPCheckPort == 0 {
-			clusterSettings.HTTPCheckPort = settings.HTTPCheckPort
-		}
-		if clusterSettings.HTTPCheckPath == "" {
-			clusterSettings.HTTPCheckPath = settings.HTTPCheckPath
-		}
-		if len(clusterSettings.IgnoreHosts) == 0 {
-			clusterSettings.IgnoreHosts = settings.IgnoreHosts
-		}
-	}
-	return nil
 }

--- a/go/vt/vttablet/tabletserver/throttle/config/store_config.go
+++ b/go/vt/vttablet/tabletserver/throttle/config/store_config.go
@@ -16,11 +16,3 @@ type StoresSettings struct {
 
 	// Futuristic stores can come here.
 }
-
-// Hook to implement adjustments after reading each configuration file.
-func (settings *StoresSettings) postReadAdjustments() error {
-	if err := settings.MySQL.postReadAdjustments(); err != nil {
-		return err
-	}
-	return nil
-}

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -249,12 +249,12 @@ func (throttler *Throttler) initConfig() {
 
 	config.Instance.Stores.MySQL.Clusters[selfStoreName] = &config.MySQLClusterConfigurationSettings{
 		MetricQuery:       throttler.metricsQuery,
-		ThrottleThreshold: throttler.MetricsThreshold.Get(),
+		ThrottleThreshold: &throttler.MetricsThreshold,
 		IgnoreHostsCount:  0,
 	}
 	config.Instance.Stores.MySQL.Clusters[shardStoreName] = &config.MySQLClusterConfigurationSettings{
 		MetricQuery:       throttler.metricsQuery,
-		ThrottleThreshold: throttler.MetricsThreshold.Get(),
+		ThrottleThreshold: &throttler.MetricsThreshold,
 		IgnoreHostsCount:  0,
 	}
 }
@@ -574,7 +574,7 @@ func (throttler *Throttler) refreshMySQLInventory(ctx context.Context) error {
 		// config may dynamically change, but internal structure (config.Settings().Stores.MySQL.Clusters in our case)
 		// is immutable and can only be _replaced_. Hence, it's safe to read in a goroutine:
 		go func() {
-			throttler.mysqlClusterThresholds.Set(clusterName, clusterSettings.ThrottleThreshold, cache.DefaultExpiration)
+			throttler.mysqlClusterThresholds.Set(clusterName, clusterSettings.ThrottleThreshold.Get(), cache.DefaultExpiration)
 			clusterProbes := &mysql.ClusterProbes{
 				ClusterName:      clusterName,
 				IgnoreHostsCount: clusterSettings.IgnoreHostsCount,


### PR DESCRIPTION
## Description

Fixes https://github.com/vitessio/vitess/issues/10400

The tablet throttler code was contributed at about the same time as https://github.com/vitessio/vitess/pull/7189, and while superficially `/debug/env` supported a dynamic change of `ThrottleMetricThreshold`, the tablet throttler itself did not re-read that value dynamically; it only applied it once upon initialization.

As of this PR, the value is reflected dynamically. A change to `ThrottleMetricThreshold` will be reflected in the throttler's behavior, or can be seen in its API, e.g.:

```shell
% curl -s http://localhost:15100/throttler/check | jq .
{
  "StatusCode": 200,
  "Value": 4,
  "Threshold": 50,
  "Message": ""
}
```

Do note that change may take up to `10sec` to take effect, per [mysqlRefreshInterval](https://github.com/vitessio/vitess/blob/080c0079229aaed4e8d37a7cda359f13d336a393/go/vt/vttablet/tabletserver/throttle/throttler.go#L45).

We also take the opportunity to clean up some unused code.

Best reviewed [ignoring whitespace](https://github.com/vitessio/vitess/pull/10439/files?w=1).

## Related Issue(s)

#10400 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
