### PR TITLE
fixing vrepl_stress_suite flakyness

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
@@ -371,7 +371,7 @@ const (
 	maxTableRows                  = 4096
 	maxConcurrency                = 15
 	singleConnectionSleepInterval = 5 * time.Millisecond
-	waitForStatusTimeout          = 120 * time.Second
+	waitForStatusTimeout          = 180 * time.Second
 )
 
 func resetOpOrder() {


### PR DESCRIPTION
## Description

fixing `Cluster (onlineddl_vrepl_stress_suite) mysql80` flakyness. 


## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

