### PR TITLE
[vtadmin] authz tests - getters part2

### DIFF
--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -39,6 +39,8 @@ import (
 )
 
 func TestCreateKeyspace(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -106,6 +108,8 @@ func TestCreateKeyspace(t *testing.T) {
 }
 
 func TestCreateShard(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -175,6 +179,8 @@ func TestCreateShard(t *testing.T) {
 }
 
 func TestDeleteKeyspace(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -242,6 +248,8 @@ func TestDeleteKeyspace(t *testing.T) {
 }
 
 func TestDeleteShards(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -319,6 +327,8 @@ func TestDeleteShards(t *testing.T) {
 }
 
 func TestDeleteTablet(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -388,6 +398,8 @@ func TestDeleteTablet(t *testing.T) {
 }
 
 func TestGetBackups(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -465,6 +477,8 @@ func TestGetBackups(t *testing.T) {
 }
 
 func TestGetCellInfos(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -548,6 +562,8 @@ func TestGetCellInfos(t *testing.T) {
 }
 
 func TestGetCellsAliases(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -625,6 +641,8 @@ func TestGetCellsAliases(t *testing.T) {
 }
 
 func TestGetClusters(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -694,6 +712,8 @@ func TestGetClusters(t *testing.T) {
 }
 
 func TestGetGates(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -728,7 +748,6 @@ func TestGetGates(t *testing.T) {
 	})
 
 	t.Run("unauthorized actor", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "unauthorized"}
 
 		ctx := context.Background()
@@ -742,7 +761,6 @@ func TestGetGates(t *testing.T) {
 	})
 
 	t.Run("partial access", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "allowed-other"}
 
 		ctx := context.Background()
@@ -757,7 +775,6 @@ func TestGetGates(t *testing.T) {
 	})
 
 	t.Run("full access", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "allowed-all"}
 
 		ctx := context.Background()
@@ -773,6 +790,8 @@ func TestGetGates(t *testing.T) {
 }
 
 func TestGetKeyspace(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {
@@ -836,6 +855,8 @@ func TestGetKeyspace(t *testing.T) {
 }
 
 func TestGetKeyspaces(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct {

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -516,6 +516,64 @@
                     ]
                 }
             ]
+        },
+        {
+            "method": "GetKeyspaces",
+            "rules": [
+                {
+                    "resource": "Keyspace",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-all"],
+                    "clusters": ["*"]
+                },
+                {
+                    "resource": "Keyspace",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-other"],
+                    "clusters": ["other"]
+                }
+            ],
+            "request": "&vtadminpb.GetKeyspacesRequest{}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "unauthorized"},
+                    "is_permitted": false,
+                    "include_error_var": true,
+                    "assertions": [
+                        "assert.NoError(t, err)",
+                        "assert.Empty(t, resp.Keyspaces, $$)"
+                    ]
+                },
+                {
+                    "name": "partial access",
+                    "actor": {"name": "allowed-other"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.Keyspaces, $$)",
+                        "ksMap := map[string][]string{}",
+                        "for _, ks := range resp.Keyspaces {",
+                        "if _, ok := ksMap[ks.Cluster.Id]; !ok {\n ksMap[ks.Cluster.Id] = []string{}\n}",
+                        "ksMap[ks.Cluster.Id] = append(ksMap[ks.Cluster.Id], ks.Keyspace.Name)",
+                        "}",
+                        "assert.Equal(t, ksMap, map[string][]string{\"other\": {\"otherks\"}}, $$)"
+                    ]
+                },
+                {
+                    "name": "full access",
+                    "actor": {"name": "allowed-all"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.Keyspaces, $$)",
+                        "ksMap := map[string][]string{}",
+                        "for _, ks := range resp.Keyspaces {",
+                        "if _, ok := ksMap[ks.Cluster.Id]; !ok {\n ksMap[ks.Cluster.Id] = []string{}\n}",
+                        "ksMap[ks.Cluster.Id] = append(ksMap[ks.Cluster.Id], ks.Keyspace.Name)",
+                        "}",
+                        "assert.Equal(t, ksMap, map[string][]string{\"test\": {\"test\"}, \"other\": {\"otherks\"}}, $$)"
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -344,44 +344,6 @@
             ]
         },
         {
-            "method": "GetClusters",
-            "rules": [
-                {
-                    "resource": "Cluster",
-                    "actions": ["get"],
-                    "subjects": ["user:allowed"],
-                    "clusters": ["*"]
-                }
-            ],
-            "request": "&vtadminpb.GetClustersRequest{}",
-            "cases": [
-                {
-                    "name": "unauthenticated",
-                    "actor": null,
-                    "assertions": [
-                        "assert.Empty(t, resp.Clusters, $$)"
-                    ]
-                },
-                {
-                    "name": "unauthorized actor",
-                    "actor": {"name": "other"},
-                    "assertions": [
-                        "assert.Empty(t, resp.Clusters, $$)"
-                    ]
-                },
-                {
-                    "name": "authorized actor",
-                    "actor": {"name": "allowed"},
-                    "is_permitted": true,
-                    "include_error_var": true,
-                    "assertions": [
-                        "require.NoError(t, err)",
-                        "assert.NotEmpty(t, resp.Clusters, $$)"
-                    ]
-                }
-            ]
-        },
-        {
             "method": "GetCellsAliases",
             "rules": [
                 {
@@ -425,6 +387,44 @@
                     "assertions": [
                         "assert.NotEmpty(t, resp.Aliases, $$)",
                         "assert.ElementsMatch(t, resp.Aliases, []*vtadminpb.ClusterCellsAliases{{Cluster: &vtadminpb.Cluster{Id: \"test\", Name: \"test\"}, Aliases: map[string]*topodatapb.CellsAlias{\"zone\": {Cells: []string{\"zone1\"}}}}, {Cluster: &vtadminpb.Cluster{Id: \"other\", Name: \"other\"}, Aliases: map[string]*topodatapb.CellsAlias{\"other\": {Cells: []string{\"other1\"}}}}})"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "GetClusters",
+            "rules": [
+                {
+                    "resource": "Cluster",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed"],
+                    "clusters": ["*"]
+                }
+            ],
+            "request": "&vtadminpb.GetClustersRequest{}",
+            "cases": [
+                {
+                    "name": "unauthenticated",
+                    "actor": null,
+                    "assertions": [
+                        "assert.Empty(t, resp.Clusters, $$)"
+                    ]
+                },
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "other"},
+                    "assertions": [
+                        "assert.Empty(t, resp.Clusters, $$)"
+                    ]
+                },
+                {
+                    "name": "authorized actor",
+                    "actor": {"name": "allowed"},
+                    "is_permitted": true,
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.NotEmpty(t, resp.Clusters, $$)"
                     ]
                 }
             ]

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -36,6 +36,11 @@
                     "value": "Response: &vtctldatapb.GetCellsAliasesResponse{\nAliases: map[string]*topodatapb.CellsAlias{\n\"zone\": {\nCells: []string{\"zone1\"}},\n},\n},"
                 },
                 {
+                    "field": "GetKeyspaceResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.GetKeyspaceResponse\nError error}",
+                    "value": "\"test\": {\nResponse: &vtctldatapb.GetKeyspaceResponse{\nKeyspace: &vtctldatapb.Keyspace{\nName: \"test\",\nKeyspace: &topodatapb.Keyspace{},\n},\n},\n},"
+                },
+                {
                     "field": "GetKeyspacesResults",
                     "type": "&struct{\nKeyspaces []*vtctldatapb.Keyspace\nError error}",
                     "value": "Keyspaces: []*vtctldatapb.Keyspace{\n{\nName: \"test\",\nKeyspace: &topodatapb.Keyspace{},\n},\n},"
@@ -475,6 +480,39 @@
                         "assert.NotEmpty(t, resp.Gates, $$)",
                         "// testutil.BuildCluster creates exactly one gate per cluster",
                         "assert.Len(t, resp.Gates, 2, \"actor %+v should be able to see VTGate from all clusters\", actor)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "GetKeyspace",
+            "rules": [
+                {
+                    "resource": "Keyspace",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed"],
+                    "clusters": ["*"]
+                }
+            ],
+            "request": "&vtadminpb.GetKeyspaceRequest{\nClusterId: \"test\",\nKeyspace: \"test\",\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "other"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.Nil(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "authorized actor",
+                    "actor": {"name": "allowed"},
+                    "include_error_var": true,
+                    "is_permitted": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.NotNil(t, resp, $$)"
                     ]
                 }
             ]

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -87,6 +87,11 @@
                     "field": "GetKeyspacesResults",
                     "type": "&struct{\nKeyspaces []*vtctldatapb.Keyspace\nError error}",
                     "value": "Keyspaces: []*vtctldatapb.Keyspace{\n{\nName: \"otherks\",\nKeyspace: &topodatapb.Keyspace{},\n},\n},"
+                },
+                {
+                    "field": "GetSrvVSchemaResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.GetSrvVSchemaResponse\nError error}",
+                    "value": "\"other1\": {\nResponse: &vtctldatapb.GetSrvVSchemaResponse{\nSrvVSchema: &vschemapb.SrvVSchema{},\n},\n},"
                 }
             ]
         }
@@ -610,6 +615,63 @@
                     "assertions": [
                         "require.NoError(t, err)",
                         "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "GetSrvVSchemas",
+            "rules": [
+                {
+                    "resource": "SrvVSchema",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-all"],
+                    "clusters": ["*"]
+                },
+                {
+                    "resource": "SrvVSchema",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-other"],
+                    "clusters": ["other"]
+                }
+            ],
+            "request": "&vtadminpb.GetSrvVSchemasRequest{}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "unauthorized"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.Nil(t, resp.SrvVSchemas, $$)"
+                    ]
+                },
+                {
+                    "name": "partial access",
+                    "actor": {"name": "allowed-other"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.SrvVSchemas, $$)",
+                        "clusterCells := map[string][]string{}",
+                        "for _, svs := range resp.SrvVSchemas {",
+                        "if _, ok := clusterCells[svs.Cluster.Id]; !ok {\nclusterCells[svs.Cluster.Id] = []string{}\n}",
+                        "clusterCells[svs.Cluster.Id] = append(clusterCells[svs.Cluster.Id], svs.Cell)",
+                        "}",
+                        "assert.Equal(t, clusterCells, map[string][]string{\"other\": {\"other1\"}}, $$)"
+                    ]
+                },
+                {
+                    "name": "full access",
+                    "actor": {"name": "allowed-all"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.SrvVSchemas, $$)",
+                        "clusterCells := map[string][]string{}",
+                        "for _, svs := range resp.SrvVSchemas {",
+                        "if _, ok := clusterCells[svs.Cluster.Id]; !ok {\nclusterCells[svs.Cluster.Id] = []string{}\n}",
+                        "clusterCells[svs.Cluster.Id] = append(clusterCells[svs.Cluster.Id], svs.Cell)",
+                        "}",
+                        "assert.Equal(t, clusterCells, map[string][]string{\"test\": {\"zone1\"}, \"other\": {\"other1\"}}, $$)"
                     ]
                 }
             ]

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -49,6 +49,11 @@
                     "field": "GetSrvVSchemaResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.GetSrvVSchemaResponse\nError error}",
                     "value": "\"zone1\": {\nResponse: &vtctldatapb.GetSrvVSchemaResponse{\nSrvVSchema: &vschemapb.SrvVSchema{},\n},\n},"
+                },
+                {
+                    "field": "ShardReplicationPositionsResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.ShardReplicationPositionsResponse\nError error}",
+                    "value": "\"test/-\": {\nResponse: &vtctldatapb.ShardReplicationPositionsResponse{},\n},"
                 }
             ],
             "db_tablet_list": [
@@ -92,6 +97,11 @@
                     "field": "GetSrvVSchemaResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.GetSrvVSchemaResponse\nError error}",
                     "value": "\"other1\": {\nResponse: &vtctldatapb.GetSrvVSchemaResponse{\nSrvVSchema: &vschemapb.SrvVSchema{},\n},\n},"
+                },
+                {
+                    "field": "ShardReplicationPositionsResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.ShardReplicationPositionsResponse\nError error}",
+                    "value": "\"otherks/-\": {\nResponse: &vtctldatapb.ShardReplicationPositionsResponse{},\n},"
                 }
             ]
         }
@@ -582,6 +592,64 @@
                         "ksMap[ks.Cluster.Id] = append(ksMap[ks.Cluster.Id], ks.Keyspace.Name)",
                         "}",
                         "assert.Equal(t, ksMap, map[string][]string{\"test\": {\"test\"}, \"other\": {\"otherks\"}}, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "GetShardReplicationPositions",
+            "rules": [
+                {
+                    "resource": "ShardReplicationPosition",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-all"],
+                    "clusters": ["*"]
+                },
+                {
+                    "resource": "ShardReplicationPosition",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-other"],
+                    "clusters": ["other"]
+                }
+            ],
+            "request": "&vtadminpb.GetShardReplicationPositionsRequest{}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "unauthorized"},
+                    "is_permitted": false,
+                    "include_error_var": true,
+                    "assertions": [
+                        "assert.NoError(t, err)",
+                        "assert.Empty(t, resp.ReplicationPositions, $$)"
+                    ]
+                },
+                {
+                    "name": "partial access",
+                    "actor": {"name": "allowed-other"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.ReplicationPositions, $$)",
+                        "posMap := map[string][]string{}",
+                        "for _, pos := range resp.ReplicationPositions {",
+                        "if _, ok := posMap[pos.Cluster.Id]; !ok {\n posMap[pos.Cluster.Id] = []string{}\n}",
+                        "posMap[pos.Cluster.Id] = append(posMap[pos.Cluster.Id], fmt.Sprintf(\"%s/%s\", pos.Keyspace, pos.Shard))",
+                        "}",
+                        "assert.Equal(t, posMap, map[string][]string{\"other\": {\"otherks/-\"}}, $$)"
+                    ]
+                },
+                {
+                    "name": "full access",
+                    "actor": {"name": "allowed-all"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.ReplicationPositions, $$)",
+                        "posMap := map[string][]string{}",
+                        "for _, pos := range resp.ReplicationPositions {",
+                        "if _, ok := posMap[pos.Cluster.Id]; !ok {\n posMap[pos.Cluster.Id] = []string{}\n}",
+                        "posMap[pos.Cluster.Id] = append(posMap[pos.Cluster.Id], fmt.Sprintf(\"%s/%s\", pos.Keyspace, pos.Shard))",
+                        "}",
+                        "assert.Equal(t, posMap, map[string][]string{\"test\": {\"test/-\"}, \"other\": {\"otherks/-\"}}, $$)"
                     ]
                 }
             ]

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -451,6 +451,7 @@
                 }
             ],
             "request": "&vtadminpb.GetGatesRequest{}",
+            "serialize_cases": true,
             "cases": [
                 {
                     "name": "unauthorized actor",

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -428,6 +428,56 @@
                     ]
                 }
             ]
+        },
+        {
+            "method": "GetGates",
+            "rules": [
+                {
+                    "resource": "VTGate",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-all"],
+                    "clusters": ["*"]
+                },
+                {
+                    "resource": "VTGate",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-other"],
+                    "clusters": ["other"]
+                }
+            ],
+            "request": "&vtadminpb.GetGatesRequest{}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "unauthorized"},
+                    "is_permitted": false,
+                    "include_error_var": true,
+                    "assertions": [
+                        "assert.NoError(t, err)",
+                        "assert.Empty(t, resp.Gates, $$)"
+                    ]
+                },
+                {
+                    "name": "partial access",
+                    "actor": {"name": "allowed-other"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.Gates, $$)",
+                        "// testutil.BuildCluster creates exactly one gate per cluster",
+                        "assert.Len(t, resp.Gates, 1, \"actor %+v should only be able to see VTGate from cluster 'other'\", actor)"
+                    ]
+                },
+                {
+                    "name": "full access",
+                    "actor": {"name": "allowed-all"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.Gates, $$)",
+                        "// testutil.BuildCluster creates exactly one gate per cluster",
+                        "assert.Len(t, resp.Gates, 2, \"actor %+v should be able to see VTGate from all clusters\", actor)"
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -44,6 +44,11 @@
                     "field": "GetKeyspacesResults",
                     "type": "&struct{\nKeyspaces []*vtctldatapb.Keyspace\nError error}",
                     "value": "Keyspaces: []*vtctldatapb.Keyspace{\n{\nName: \"test\",\nKeyspace: &topodatapb.Keyspace{},\n},\n},"
+                },
+                {
+                    "field": "GetSrvVSchemaResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.GetSrvVSchemaResponse\nError error}",
+                    "value": "\"zone1\": {\nResponse: &vtctldatapb.GetSrvVSchemaResponse{\nSrvVSchema: &vschemapb.SrvVSchema{},\n},\n},"
                 }
             ],
             "db_tablet_list": [
@@ -572,6 +577,39 @@
                         "ksMap[ks.Cluster.Id] = append(ksMap[ks.Cluster.Id], ks.Keyspace.Name)",
                         "}",
                         "assert.Equal(t, ksMap, map[string][]string{\"test\": {\"test\"}, \"other\": {\"otherks\"}}, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "GetSrvVSchema",
+            "rules": [
+                {
+                    "resource": "SrvVSchema",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed"],
+                    "clusters": ["*"]
+                }
+            ],
+            "request": "&vtadminpb.GetSrvVSchemaRequest{\nClusterId: \"test\",\nCell: \"zone1\",\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "other"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.Nil(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "authorized actor",
+                    "actor": {"name": "allowed"},
+                    "include_error_var": true,
+                    "is_permitted": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.NotNil(t, resp, $$)"
                     ]
                 }
             ]

--- a/go/vt/vtadmin/testutil/authztestgen/main.go
+++ b/go/vt/vtadmin/testutil/authztestgen/main.go
@@ -43,10 +43,11 @@ type ClusterConfig struct {
 }
 
 type Test struct {
-	Method  string        `json:"method"`
-	Rules   []*AuthzRules `json:"rules"`
-	Request string        `json:"request"`
-	Cases   []*TestCase   `json:"cases"`
+	Method         string        `json:"method"`
+	Rules          []*AuthzRules `json:"rules"`
+	Request        string        `json:"request"`
+	SerializeCases bool          `json:"serialize_cases"`
+	Cases          []*TestCase   `json:"cases"`
 }
 
 type TestCase struct {

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -39,6 +39,7 @@ package {{ .Package }}
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -140,6 +141,12 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 					},
 				},
 				{{- end }}
+			},
+			Config: &cluster.Config{
+				TopoReadPoolConfig: &cluster.RPCPoolConfig{
+					Size: 100,
+					WaitTimeout: time.Millisecond * 50,
+				},
 			},
 		},
 		{{- end -}}

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -52,6 +52,7 @@ import (
 
 	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
 )

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -58,6 +58,8 @@ import (
 
 {{ range .Tests }}
 func Test{{ .Method }}(t *testing.T) {
+	t.Parallel()
+
 	opts := vtadmin.Options{
 		RBAC: &rbac.Config{
 			Rules: []*struct{
@@ -90,7 +92,7 @@ func Test{{ .Method }}(t *testing.T) {
 	{{ with $test := . -}}
 	{{ range .Cases }}
 	t.Run("{{ .Name }}", func(t *testing.T) {
-		t.Parallel()
+		{{- if not $test.SerializeCases -}}t.Parallel(){{- end }}
 		{{ getActor .Actor }}
 
 		ctx := context.Background()

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -38,6 +38,7 @@ package {{ .Package }}
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 

--- a/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
+++ b/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
@@ -80,6 +80,10 @@ type VtctldClient struct {
 		Response *vtctldatapb.GetSchemaResponse
 		Error    error
 	}
+	GetSrvVSchemaResults map[string]struct {
+		Response *vtctldatapb.GetSrvVSchemaResponse
+		Error    error
+	}
 	GetVSchemaResults map[string]struct {
 		Response *vtctldatapb.GetVSchemaResponse
 		Error    error
@@ -342,6 +346,19 @@ func (fake *VtctldClient) GetSchema(ctx context.Context, req *vtctldatapb.GetSch
 	}
 
 	return nil, fmt.Errorf("%w: no result set for tablet alias %s", assert.AnError, key)
+}
+
+// GetSrvVSchema is part of the vtctldclient.VtctldClient interface.
+func (fake *VtctldClient) GetSrvVSchema(ctx context.Context, req *vtctldatapb.GetSrvVSchemaRequest, opts ...grpc.CallOption) (*vtctldatapb.GetSrvVSchemaResponse, error) {
+	if fake.GetSrvVSchemaResults == nil {
+		return nil, fmt.Errorf("%w: GetSrvVSchemaResults not set on fake vtctldclient", assert.AnError)
+	}
+
+	if result, ok := fake.GetSrvVSchemaResults[req.Cell]; ok {
+		return result.Response, result.Error
+	}
+
+	return nil, fmt.Errorf("%w: no result set for key %s", assert.AnError, req.Cell)
 }
 
 // GetVSchema is part of the vtctldclient.VtctldClient interface.


### PR DESCRIPTION
## Description

This takes us through `Get[A-S].*` (with the exception of the schema ones, because I'm putting off writing the mock data because it's gonna be annoying (i will do it, though, i promise!))

## Related Issue(s)

#10397 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
