### PR TITLE
Change use_super_read_only default back to false

### DIFF
--- a/go/flags/endtoend/flags_test.go
+++ b/go/flags/endtoend/flags_test.go
@@ -1388,7 +1388,7 @@ max_rate_approach_threshold: 0.9
   --unhealthy_threshold duration
 	replication lag after which a replica is considered unhealthy (default 2h0m0s)
   --use_super_read_only
-	Set super_read_only flag when performing planned failover. (default false)
+	Set super_read_only flag when performing planned failover.
   --v value
 	log level for V logs
   --version

--- a/go/flags/endtoend/flags_test.go
+++ b/go/flags/endtoend/flags_test.go
@@ -1388,7 +1388,7 @@ max_rate_approach_threshold: 0.9
   --unhealthy_threshold duration
 	replication lag after which a replica is considered unhealthy (default 2h0m0s)
   --use_super_read_only
-	Set super_read_only flag when performing planned failover. (default true)
+	Set super_read_only flag when performing planned failover. (default false)
   --v value
 	log level for V logs
   --version

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	enableSemiSync   = flag.Bool("enable_semi_sync", false, "Enable semi-sync when configuring replication, on primary and replica tablets only (rdonly tablets will not ack).")
-	setSuperReadOnly = flag.Bool("use_super_read_only", true, "Set super_read_only flag when performing planned failover.")
+	setSuperReadOnly = flag.Bool("use_super_read_only", false, "Set super_read_only flag when performing planned failover.")
 )
 
 // ReplicationStatus returns the replication status


### PR DESCRIPTION
## Description

In this PR we change the default for the vttablet `--use_super_read_only` flag back to false (it was changed to true in v13 via https://github.com/vitessio/vitess/pull/9312).

We are doing this because when this flag is true you may not be able to restart a replica/rdonly vttablet process. This is because:
  1. The tablet has enabled `super_read_only` in its mysqld because it's a replica tablet.
  2. When a tablet starts up, it attempts to run some DDL statements as the DBA user such as `CREATE DATABASE IF NOT EXISTS _vt` and that will fail with an error because the mysqld has `super_read_only` enabled.
  3. So the tablet will not be able to come back up properly.

We really should be enabling `super_read_only`, both in the config file and in the tablet via this flag, as without that we will in some cases allow errant GTIDs to be generated which are then lying in wait to cause later issues. We will enable it at both layers as part of adding full `super_read_only` support to Vitess in https://github.com/vitessio/vitess/issues/10363 (which is targeted for v15).

## Related Issue(s)
 - Follow-up to: https://github.com/vitessio/vitess/pull/9312
 - Follow-up to: https://github.com/vitessio/vitess/pull/10366
 - Follow-up work: https://github.com/vitessio/vitess/issues/10363

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation is not required as this is already reflected:
```
content/en/docs/13.0/reference/programs/vttablet.md:| -use_super_read_only | boolean | Set super_read_only flag when performing planned failover (default true) |
content/en/docs/14.0/reference/programs/vttablet.md:| --use_super_read_only |  | Set super_read_only flag when performing planned failover. |
```