### PR TITLE
Halve request and double limit for RAM in the example cluster

### DIFF
--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -37,11 +37,11 @@ spec:
       security_policy: read-only
     replicas: 1
     resources:
-      limits:
-        memory: 256Mi
       requests:
         cpu: 100m
         memory: 64Mi
+      limits:
+        memory: 256Mi
 
   keyspaces:
   - name: commerce
@@ -63,18 +63,18 @@ spec:
               extraFlags:
                 db_charset: utf8mb4
               resources:
-                limits:
-                  memory: 512Mi
                 requests:
                   cpu: 100m
                   memory: 128Mi
+                limits:
+                  memory: 512Mi
             mysqld:
               resources:
-                limits:
-                  memory: 512Mi
                 requests:
                   cpu: 100m
                   memory: 128Mi
+                limits:
+                  memory: 512Mi
             dataVolumeClaimTemplate:
               accessModes: ["ReadWriteOnce"]
               resources:

--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -27,9 +27,9 @@ spec:
       resources:
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 128Mi
         limits:
-          memory: 256Mi
+          memory: 512Mi
   vitessDashboard:
     cells:
     - zone1
@@ -38,10 +38,10 @@ spec:
     replicas: 1
     resources:
       limits:
-        memory: 128Mi
+        memory: 256Mi
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 64Mi
 
   keyspaces:
   - name: commerce
@@ -64,17 +64,17 @@ spec:
                 db_charset: utf8mb4
               resources:
                 limits:
-                  memory: 256Mi
+                  memory: 512Mi
                 requests:
                   cpu: 100m
-                  memory: 256Mi
+                  memory: 128Mi
             mysqld:
               resources:
                 limits:
-                  memory: 256Mi
+                  memory: 512Mi
                 requests:
                   cpu: 100m
-                  memory: 256Mi
+                  memory: 128Mi
             dataVolumeClaimTemplate:
               accessModes: ["ReadWriteOnce"]
               resources:


### PR DESCRIPTION
## Description

Here we halve the request and double the limit for RAM in [the example cluster.](https://vitess.io/docs/14.0/get-started/operator/) We do this because:
1. We don't need/want everything to have the [Guaranteed QoS](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed) (request == limit)
2. It's common for mysqld (especially 8.0) to go beyond the old limit and end up in a crash loop

## Related Issue(s)

Fixes: https://github.com/vitessio/vitess/issues/9141

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required