### PR TITLE
Flavor capabilities: MySQL GR and more

### DIFF
--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -49,6 +49,8 @@ const (
 	InstantAddDropVirtualColumnFlavorCapability
 	InstantAddDropColumnFlavorCapability
 	InstantChangeColumnDefaultFlavorCapability
+	MySQLJSONFlavorCapability
+	MySQLUpgradeInServerFlavorCapability
 )
 
 const (

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -319,6 +319,8 @@ func (mysqlFlavor57) baseShowTablesWithSizes() string {
 // supportsCapability is part of the Flavor interface.
 func (mysqlFlavor57) supportsCapability(serverVersion string, capability FlavorCapability) (bool, error) {
 	switch capability {
+	case MySQLJSONFlavorCapability:
+		return true, nil
 	default:
 		return false, nil
 	}
@@ -343,6 +345,10 @@ func (mysqlFlavor80) supportsCapability(serverVersion string, capability FlavorC
 		return ServerVersionAtLeast(serverVersion, 8, 0, 17)
 	case FastDropTableFlavorCapability:
 		return ServerVersionAtLeast(serverVersion, 8, 0, 23)
+	case MySQLJSONFlavorCapability:
+		return true, nil
+	case MySQLUpgradeInServerFlavorCapability:
+		return ServerVersionAtLeast(serverVersion, 8, 0, 16)
 	default:
 		return false, nil
 	}

--- a/go/mysql/flavor_mysqlgr.go
+++ b/go/mysql/flavor_mysqlgr.go
@@ -241,6 +241,21 @@ func (mysqlGRFlavor) baseShowTablesWithSizes() string {
 // supportsCapability is part of the Flavor interface.
 func (mysqlGRFlavor) supportsCapability(serverVersion string, capability FlavorCapability) (bool, error) {
 	switch capability {
+	case InstantDDLFlavorCapability,
+		InstantAddLastColumnFlavorCapability,
+		InstantAddDropVirtualColumnFlavorCapability,
+		InstantChangeColumnDefaultFlavorCapability:
+		return ServerVersionAtLeast(serverVersion, 8, 0, 0)
+	case InstantAddDropColumnFlavorCapability:
+		return ServerVersionAtLeast(serverVersion, 8, 0, 29)
+	case TransactionalGtidExecutedFlavorCapability:
+		return ServerVersionAtLeast(serverVersion, 8, 0, 17)
+	case FastDropTableFlavorCapability:
+		return ServerVersionAtLeast(serverVersion, 8, 0, 23)
+	case MySQLJSONFlavorCapability:
+		return ServerVersionAtLeast(serverVersion, 5, 7, 0)
+	case MySQLUpgradeInServerFlavorCapability:
+		return ServerVersionAtLeast(serverVersion, 8, 0, 16)
 	default:
 		return false, nil
 	}

--- a/go/mysql/flavor_test.go
+++ b/go/mysql/flavor_test.go
@@ -125,6 +125,16 @@ func TestGetFlavor(t *testing.T) {
 			capability: TransactionalGtidExecutedFlavorCapability,
 			isCapable:  false,
 		},
+		{
+			version:    "5.6.7",
+			capability: MySQLJSONFlavorCapability,
+			isCapable:  false,
+		},
+		{
+			version:    "5.7.29",
+			capability: MySQLJSONFlavorCapability,
+			isCapable:  true,
+		},
 	}
 	for _, tc := range testcases {
 		name := fmt.Sprintf("%s %v", tc.version, tc.capability)


### PR DESCRIPTION

## Description

Followup to https://github.com/vitessio/vitess/pull/10445:

- `mysqlGRFlavor` now implements `supportsCapability(...)` for all relevant capabilities
- Added a couple new capabilities

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/10445


## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
