### PR TITLE
Divide query serving upgrade downgrade tests in two groups to limit disk usage per workflow

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -178,7 +178,7 @@ jobs:
         mkdir -p /tmp/vtdataroot
 
         source build.env
-        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving
+        eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_query_serving
 
     # Swap the binaries in the bin. Use vtgate version n-1 and keep vttablet at version n
     - name: Use last release's VTGate
@@ -198,7 +198,7 @@ jobs:
         mkdir -p /tmp/vtdataroot
 
         source build.env
-        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving
+        eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_query_serving
 
     # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n-1
     - name: Use current version VTGate, and other version VTTablet
@@ -220,4 +220,4 @@ jobs:
         mkdir -p /tmp/vtdataroot
 
         source build.env
-        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving
+        eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_query_serving

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -1,10 +1,10 @@
-name: Upgrade Downgrade Testing Query Serving
+name: Upgrade Downgrade Testing Query Serving (Queries)
 on:
   push:
   pull_request:
 
 concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing Query Serving')
+  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing Query Serving (Queries)')
   cancel-in-progress: true
 
 # This test ensures that our end-to-end tests work using Vitess components
@@ -178,7 +178,7 @@ jobs:
         mkdir -p /tmp/vtdataroot
 
         source build.env
-        eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_query_serving
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
 
     # Swap the binaries in the bin. Use vtgate version n-1 and keep vttablet at version n
     - name: Use last release's VTGate
@@ -198,7 +198,7 @@ jobs:
         mkdir -p /tmp/vtdataroot
 
         source build.env
-        eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_query_serving
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
 
     # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n-1
     - name: Use current version VTGate, and other version VTTablet
@@ -220,4 +220,4 @@ jobs:
         mkdir -p /tmp/vtdataroot
 
         source build.env
-        eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_query_serving
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -1,0 +1,223 @@
+name: Upgrade Downgrade Testing Query Serving (Schema)
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing Query Serving (Schema)')
+  cancel-in-progress: true
+
+# This test ensures that our end-to-end tests work using Vitess components
+# (vtgate, vttablet, etc) built on different versions.
+
+jobs:
+  get_upgrade_downgrade_label:
+    if: github.repository == 'vitessio/vitess'
+    name: Get the Upgrade Downgrade pull request label
+    runs-on: ubuntu-latest
+    outputs:
+      hasLabel: ${{ steps.check_label.outputs.hasLabel }}
+
+    steps:
+      - name: Check Label for PR
+        if: github.event_name == 'pull_request'
+        uses: Dreamcodeio/pr-has-label-action@master
+        id: check_label
+        with:
+          label: Skip Upgrade Downgrade
+
+  get_latest_release:
+    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
+    name: Get latest release
+    runs-on: ubuntu-latest
+    needs:
+      - get_upgrade_downgrade_label
+    outputs:
+      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
+
+    steps:
+      - name: Check out to HEAD
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set output with latest release branch
+        id: output-latest-release-branch
+        run: |
+          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
+          echo $latest_release_branch
+          echo "::set-output name=latest_release_branch::${latest_release_branch}"
+
+  upgrade_downgrade_test:
+    if: always() && (needs.get_latest_release.result == 'success')
+    name: Run Upgrade Downgrade Test
+    runs-on: ubuntu-latest
+    needs:
+      - get_upgrade_downgrade_label
+      - get_latest_release
+
+    steps:
+    - name: Check out commit's code
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      uses: frouioui/paths-filter@main
+      id: changes
+      with:
+        token: ''
+        filters: |
+          end_to_end:
+            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+
+    - name: Set up Go
+      if: steps.changes.outputs.end_to_end == 'true'
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.1
+
+    - name: Set up python
+      if: steps.changes.outputs.end_to_end == 'true'
+      uses: actions/setup-python@v2
+
+    - name: Tune the OS
+      if: steps.changes.outputs.end_to_end == 'true'
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+
+    - name: Get base dependencies
+      if: steps.changes.outputs.end_to_end == 'true'
+      run: |
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+        # Uninstall any previously installed MySQL first
+        sudo systemctl stop apparmor
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
+        sudo apt-get -y autoremove
+        sudo apt-get -y autoclean
+        sudo deluser mysql
+        sudo rm -rf /var/lib/mysql
+        sudo rm -rf /etc/mysql
+        # Install mysql80
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+        # Install everything else we need, and configure
+        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+
+        # install JUnit report formatter
+        go install github.com/jstemmer/go-junit-report@latest
+
+        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get install -y gnupg2
+        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get update
+        sudo apt-get install percona-xtrabackup-24
+
+    # Checkout to the last release of Vitess
+    - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+      if: steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ needs.get_latest_release.outputs.latest_release }}
+
+    - name: Get dependencies for the last release
+      if: steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building last release's binaries
+      if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-other/
+        cp -R bin /tmp/vitess-build-other/
+        rm -Rf bin/*
+
+    # Checkout to this build's commit
+    - name: Check out commit's code
+      if: steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@v2
+
+    - name: Get dependencies for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building the binaries for this commit
+      if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-current/
+        cp -R bin /tmp/vitess-build-current/
+
+    # Running a test with vtgate and vttablet using version n
+    - name: Run query serving tests (vtgate=N, vttablet=N)
+      if: steps.changes.outputs.end_to_end == 'true'
+      run: |
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
+
+    # Swap the binaries in the bin. Use vtgate version n-1 and keep vttablet at version n
+    - name: Use last release's VTGate
+      if: steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env
+
+        rm -f $PWD/bin/vtgate
+        cp /tmp/vitess-build-other/bin/vtgate $PWD/bin/vtgate
+        vtgate --version
+
+    # Running a test with vtgate at version n-1 and vttablet at version n
+    - name: Run query serving tests (vtgate=N-1, vttablet=N)
+      if: steps.changes.outputs.end_to_end == 'true'
+      run: |
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
+
+    # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n-1
+    - name: Use current version VTGate, and other version VTTablet
+      if: steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env
+
+        rm -f $PWD/bin/vtgate $PWD/bin/vttablet
+        cp /tmp/vitess-build-current/bin/vtgate $PWD/bin/vtgate
+        cp /tmp/vitess-build-other/bin/vttablet $PWD/bin/vttablet
+        vtgate --version
+        vttablet --version
+
+    # Running a test with vtgate at version n and vttablet at version n-1
+    - name: Run query serving tests (vtgate=N, vttablet=N-1)
+      if: steps.changes.outputs.end_to_end == 'true'
+      run: |
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema

--- a/go/test/endtoend/vtgate/schema/schema_test.go
+++ b/go/test/endtoend/vtgate/schema/schema_test.go
@@ -116,7 +116,7 @@ func TestSchemaChange(t *testing.T) {
 
 func testWithInitialSchema(t *testing.T) {
 	// Create 4 tables
-	var sqlQuery = "" //nolint
+	var sqlQuery = "" // nolint
 	for i := 0; i < totalTableCount; i++ {
 		sqlQuery = fmt.Sprintf(createTable, fmt.Sprintf("vt_select_test_%02d", i))
 		err := clusterInstance.VtctlclientProcess.ApplySchema(keyspaceName, sqlQuery)
@@ -148,13 +148,13 @@ func testWithAlterDatabase(t *testing.T) {
 }
 
 // testWithDropCreateSchema , we should be able to drop and create same schema
-//Tests that a DROP and CREATE table will pass PreflightSchema check.
+// Tests that a DROP and CREATE table will pass PreflightSchema check.
 //
-//PreflightSchema checks each SQL statement separately. When doing so, it must
-//consider previous statements within the same ApplySchema command. For
-//example, a CREATE after DROP must not fail: When CREATE is checked, DROP
-//must have been executed first.
-//See: https://github.com/vitessio/vitess/issues/1731#issuecomment-222914389
+// PreflightSchema checks each SQL statement separately. When doing so, it must
+// consider previous statements within the same ApplySchema command. For
+// example, a CREATE after DROP must not fail: When CREATE is checked, DROP
+// must have been executed first.
+// See: https://github.com/vitessio/vitess/issues/1731#issuecomment-222914389
 func testWithDropCreateSchema(t *testing.T) {
 	dropCreateTable := fmt.Sprintf("DROP TABLE vt_select_test_%02d ;", 2) + fmt.Sprintf(createTable, fmt.Sprintf("vt_select_test_%02d", 2))
 	err := clusterInstance.VtctlclientProcess.ApplySchema(keyspaceName, dropCreateTable)
@@ -207,11 +207,11 @@ func testSchemaChangePreflightErrorPartially(t *testing.T) {
 }
 
 // testDropNonExistentTables applying same schema + new schema should throw error for existing one and also add the new schema
-//If a table does not exist, DROP TABLE should error during preflight
-//because the statement does not change the schema as there is
-//nothing to drop.
-//In case of DROP TABLE IF EXISTS though, it should not error as this
-//is the MySQL behavior the user expects.
+// If a table does not exist, DROP TABLE should error during preflight
+// because the statement does not change the schema as there is
+// nothing to drop.
+// In case of DROP TABLE IF EXISTS though, it should not error as this
+// is the MySQL behavior the user expects.
 func testDropNonExistentTables(t *testing.T) {
 	dropNonExistentTable := "DROP TABLE nonexistent_table;"
 	output, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ApplySchema", "--", "--sql", dropNonExistentTable, keyspaceName)

--- a/test/config.json
+++ b/test/config.json
@@ -694,7 +694,7 @@
 			"Manual": false,
 			"Shard": "vtgate_queries",
 			"RetryMax": 2,
-			"Tags": ["upgrade_downgrade_query_serving"]
+			"Tags": ["upgrade_downgrade_query_serving_queries"]
 		},
 		"vtgate_queries_subquery": {
 			"File": "unused.go",
@@ -703,7 +703,7 @@
 			"Manual": false,
 			"Shard": "vtgate_queries",
 			"RetryMax": 2,
-			"Tags": ["upgrade_downgrade_query_serving"]
+			"Tags": ["upgrade_downgrade_query_serving_queries"]
 		},
 		"vtgate_queries_union": {
 			"File": "unused.go",
@@ -712,7 +712,7 @@
 			"Manual": false,
 			"Shard": "vtgate_queries",
 			"RetryMax": 2,
-			"Tags": ["upgrade_downgrade_query_serving"]
+			"Tags": ["upgrade_downgrade_query_serving_queries"]
 		},
 		"vtgate_queries_insert": {
 			"File": "unused.go",
@@ -748,7 +748,7 @@
 			"Manual": false,
 			"Shard": "vtgate_schema",
 			"RetryMax": 1,
-			"Tags": ["upgrade_downgrade_query_serving"]
+			"Tags": ["upgrade_downgrade_query_serving_schema"]
 		},
 		"vtgate_schematracker_loadkeyspace": {
 			"File": "unused.go",
@@ -775,7 +775,7 @@
 			"Manual": false,
 			"Shard": "vtgate_schema_tracker",
 			"RetryMax": 1,
-			"Tags": ["upgrade_downgrade_query_serving"]
+			"Tags": ["upgrade_downgrade_query_serving_schema"]
 		},
 		"vtgate_schematracker_sharded_prs": {
 			"File": "unused.go",
@@ -784,7 +784,7 @@
 			"Manual": false,
 			"Shard": "vtgate_schema_tracker",
 			"RetryMax": 1,
-			"Tags": ["upgrade_downgrade_query_serving"]
+			"Tags": ["upgrade_downgrade_query_serving_schema"]
 		},
 		"vtgate_schematracker_unsharded": {
 			"File": "unused.go",
@@ -793,7 +793,7 @@
 			"Manual": false,
 			"Shard": "vtgate_schema_tracker",
 			"RetryMax": 1,
-			"Tags": ["upgrade_downgrade_query_serving"]
+			"Tags": ["upgrade_downgrade_query_serving_schema"]
 		},
 		"vtgate_mysql80": {
 			"File": "unused.go",
@@ -919,7 +919,7 @@
 			"Manual": false,
 			"Shard": "vtgate_vschema",
 			"RetryMax": 1,
-			"Tags": ["upgrade_downgrade_query_serving"]
+			"Tags": ["upgrade_downgrade_query_serving_schema"]
 		},
 		"vtgate_readafterwrite": {
 			"File": "unused.go",


### PR DESCRIPTION
## Description

This Pull Request reduces the flakiness recently observed in the query serving upgrade downgrade tests. The disks of the machines would run out of storage, which ultimately fails the tests.

The following error can be observed:

```
Error: No space left on device :
```

The flakiness/overuse of the disks is limited by splitting the query serving upgrade downgrade tests into two distinct groups: `queries` and `schema`. All the tests under `.../vtgate/queries/...` will be grouped in the new workflow `Upgrade Downgrade Testing Query Serving (Queries)`; And all the tests under `.../vtgate/*schema*/...` will be grouped in the workflow `Upgrade Downgrade Testing Query Serving (Schema)`.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
