### PR TITLE
schemadiff: TableRenameStrategy in DiffHints

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -290,6 +290,7 @@ func TestDiffSchemas(t *testing.T) {
 		diffs       []string
 		cdiffs      []string
 		expectError string
+		tableRename int
 	}{
 		{
 			name: "identical tables",
@@ -453,6 +454,71 @@ func TestDiffSchemas(t *testing.T) {
 			},
 		},
 		{
+			name: "identical tables: drop and create",
+			from: "create table t1(id int primary key); create table t2(id int unsigned primary key);",
+			to:   "create table t1(id int primary key); create table t3(id int unsigned primary key);",
+			diffs: []string{
+				"drop table t2",
+				"create table t3 (\n\tid int unsigned primary key\n)",
+			},
+			cdiffs: []string{
+				"DROP TABLE `t2`",
+				"CREATE TABLE `t3` (\n\t`id` int unsigned PRIMARY KEY\n)",
+			},
+		},
+		{
+			name: "identical tables: heuristic rename",
+			from: "create table t1(id int primary key); create table t2a(id int unsigned primary key);",
+			to:   "create table t1(id int primary key); create table t2b(id int unsigned primary key);",
+			diffs: []string{
+				"rename table t2a to t2b",
+			},
+			cdiffs: []string{
+				"RENAME TABLE `t2a` TO `t2b`",
+			},
+			tableRename: TableRenameHeuristicStatement,
+		},
+		{
+			name: "identical tables: drop and create",
+			from: "create table t1a(id int primary key); create table t2a(id int unsigned primary key); create table t3a(id smallint primary key); ",
+			to:   "create table t1b(id bigint primary key); create table t2b(id int unsigned primary key); create table t3b(id int primary key); ",
+			diffs: []string{
+				"drop table t1a",
+				"drop table t2a",
+				"drop table t3a",
+				"create table t1b (\n\tid bigint primary key\n)",
+				"create table t2b (\n\tid int unsigned primary key\n)",
+				"create table t3b (\n\tid int primary key\n)",
+			},
+			cdiffs: []string{
+				"DROP TABLE `t1a`",
+				"DROP TABLE `t2a`",
+				"DROP TABLE `t3a`",
+				"CREATE TABLE `t1b` (\n\t`id` bigint PRIMARY KEY\n)",
+				"CREATE TABLE `t2b` (\n\t`id` int unsigned PRIMARY KEY\n)",
+				"CREATE TABLE `t3b` (\n\t`id` int PRIMARY KEY\n)",
+			},
+		},
+		{
+			name: "identical tables: multiple heuristic rename",
+			from: "create table t1a(id int primary key); create table t2a(id int unsigned primary key); create table t3a(id smallint primary key); ",
+			to:   "create table t1b(id bigint primary key); create table t2b(id int unsigned primary key); create table t3b(id int primary key); ",
+			diffs: []string{
+				"drop table t3a",
+				"create table t1b (\n\tid bigint primary key\n)",
+				"rename table t1a to t3b",
+				"rename table t2a to t2b",
+			},
+			cdiffs: []string{
+				"DROP TABLE `t3a`",
+				"CREATE TABLE `t1b` (\n\t`id` bigint PRIMARY KEY\n)",
+				"RENAME TABLE `t1a` TO `t3b`",
+				"RENAME TABLE `t2a` TO `t2b`",
+			},
+			tableRename: TableRenameHeuristicStatement,
+		},
+		// Views
+		{
 			name: "identical views",
 			from: "create table t(id int); create view v1 as select * from t",
 			to:   "create table t(id int); create view v1 as select * from t",
@@ -536,23 +602,25 @@ func TestDiffSchemas(t *testing.T) {
 				"drop table t1",
 				"drop view v1",
 				"alter table t2 modify column id bigint primary key",
-				"create table t4 (\n\tid int primary key\n)",
 				"alter view v2 as select id from t2",
+				"create table t4 (\n\tid int primary key\n)",
 				"create view v0 as select * from v2, t2",
 			},
 			cdiffs: []string{
 				"DROP TABLE `t1`",
 				"DROP VIEW `v1`",
 				"ALTER TABLE `t2` MODIFY COLUMN `id` bigint PRIMARY KEY",
-				"CREATE TABLE `t4` (\n\t`id` int PRIMARY KEY\n)",
 				"ALTER VIEW `v2` AS SELECT `id` FROM `t2`",
+				"CREATE TABLE `t4` (\n\t`id` int PRIMARY KEY\n)",
 				"CREATE VIEW `v0` AS SELECT * FROM `v2`, `t2`",
 			},
 		},
 	}
-	hints := &DiffHints{}
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {
+			hints := &DiffHints{
+				TableRenameStrategy: ts.tableRename,
+			}
 			diffs, err := DiffSchemasSQL(ts.from, ts.to, hints)
 			if ts.expectError != "" {
 				require.Error(t, err)

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -76,6 +76,11 @@ const (
 	ColumnRenameHeuristicStatement
 )
 
+const (
+	TableRenameAssumeDifferent = iota
+	TableRenameHeuristicStatement
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
 	StrictIndexOrdering     bool
@@ -83,4 +88,5 @@ type DiffHints struct {
 	RangeRotationStrategy   int
 	ConstraintNamesStrategy int
 	ColumnRenameStrategy    int
+	TableRenameStrategy     int
 }


### PR DESCRIPTION

## Description

Similarly to https://github.com/vitessio/vitess/pull/10472 that heuristically identifies renamed columns, this PR heuristically identifies renamed tables.

A new diff hint `TableRenameStrategy` can take the values:

- `TableRenameAssumeDifferent` (default); for backwards compatibility, `schemadiff` does not try to resolve renames. It treats a table rename like a `DROP TABLE` + `CREATE TABLE`
- `TableRenameHeuristicStatement`: `schemadiff` attempts to generate a `RENAME TABLE` statement for what it suspects to be a table rename.

The heuristic is simple: identify what looks to be a `DROP`ped table and what looks to be a `CREATE`d table, see if their schema is identical (other than their names), and turns that into a `RENAME`.
There can be a scenario where multiple dropped tables have the same schema, and multiple created tables again have that same schema -- in which case `schemadiff` picks an arbitrary pairing. This is naive and we will maybe iterate on that in the future.


## Related Issue(s)

- https://github.com/vitessio/vitess/pull/10472
- #10203 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
