### PR TITLE
[vtadmin] Add authz tests for remaining non-schema related actions

### DIFF
--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -2638,6 +2638,71 @@ func TestValidateSchemaKeyspace(t *testing.T) {
 	})
 }
 
+func TestValidateVersionKeyspace(t *testing.T) {
+	t.Parallel()
+
+	opts := vtadmin.Options{
+		RBAC: &rbac.Config{
+			Rules: []*struct {
+				Resource string
+				Actions  []string
+				Subjects []string
+				Clusters []string
+			}{
+				{
+					Resource: "Keyspace",
+					Actions:  []string{"put"},
+					Subjects: []string{"user:allowed"},
+					Clusters: []string{"*"},
+				},
+			},
+		},
+	}
+	err := opts.RBAC.Reify()
+	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
+
+	api := vtadmin.NewAPI(testClusters(t), opts)
+	t.Cleanup(func() {
+		if err := api.Close(); err != nil {
+			t.Logf("api did not close cleanly: %s", err.Error())
+		}
+	})
+
+	t.Run("unauthorized actor", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "other"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, err := api.ValidateVersionKeyspace(ctx, &vtadminpb.ValidateVersionKeyspaceRequest{
+			ClusterId: "test",
+			Keyspace:  "test",
+		})
+		require.NoError(t, err)
+		assert.Nil(t, resp, "actor %+v should not be permitted to ValidateVersionKeyspace", actor)
+	})
+
+	t.Run("authorized actor", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "allowed"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, err := api.ValidateVersionKeyspace(ctx, &vtadminpb.ValidateVersionKeyspaceRequest{
+			ClusterId: "test",
+			Keyspace:  "test",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, resp, "actor %+v should be permitted to ValidateVersionKeyspace", actor)
+	})
+}
+
 func testClusters(t testing.TB) []*cluster.Cluster {
 	configs := []testutil.TestClusterConfig{
 		{
@@ -2828,6 +2893,14 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 				}{
 					"test": {
 						Response: &vtctldatapb.ValidateSchemaKeyspaceResponse{},
+					},
+				},
+				ValidateVersionKeyspaceResults: map[string]struct {
+					Response *vtctldatapb.ValidateVersionKeyspaceResponse
+					Error    error
+				}{
+					"test": {
+						Response: &vtctldatapb.ValidateVersionKeyspaceResponse{},
 					},
 				},
 			},

--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -2806,14 +2806,6 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 						},
 					},
 				},
-				ShardReplicationPositionsResults: map[string]struct {
-					Response *vtctldatapb.ShardReplicationPositionsResponse
-					Error    error
-				}{
-					"test/-": {
-						Response: &vtctldatapb.ShardReplicationPositionsResponse{},
-					},
-				},
 				GetVSchemaResults: map[string]struct {
 					Response *vtctldatapb.GetVSchemaResponse
 					Error    error
@@ -2864,6 +2856,14 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 				},
 				SetWritableResults: map[string]error{
 					"zone1-0000000100": nil,
+				},
+				ShardReplicationPositionsResults: map[string]struct {
+					Response *vtctldatapb.ShardReplicationPositionsResponse
+					Error    error
+				}{
+					"test/-": {
+						Response: &vtctldatapb.ShardReplicationPositionsResponse{},
+					},
 				},
 				StartReplicationResults: map[string]error{
 					"zone1-0000000100": nil,
@@ -2995,14 +2995,6 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 						},
 					},
 				},
-				ShardReplicationPositionsResults: map[string]struct {
-					Response *vtctldatapb.ShardReplicationPositionsResponse
-					Error    error
-				}{
-					"otherks/-": {
-						Response: &vtctldatapb.ShardReplicationPositionsResponse{},
-					},
-				},
 				GetVSchemaResults: map[string]struct {
 					Response *vtctldatapb.GetVSchemaResponse
 					Error    error
@@ -3025,6 +3017,14 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 								},
 							},
 						}},
+				},
+				ShardReplicationPositionsResults: map[string]struct {
+					Response *vtctldatapb.ShardReplicationPositionsResponse
+					Error    error
+				}{
+					"otherks/-": {
+						Response: &vtctldatapb.ShardReplicationPositionsResponse{},
+					},
 				},
 			},
 			Tablets: []*vtadminpb.Tablet{

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -16,6 +16,11 @@
                     "value": "\"zone1-0000000100\": nil,"
                 },
                 {
+                    "field": "EmergencyReparentShardResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.EmergencyReparentShardResponse\nError error}",
+                    "value": "\"test/-\": {\nResponse: &vtctldatapb.EmergencyReparentShardResponse{},\n},"
+                },
+                {
                     "field": "FindAllShardsInKeyspaceResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.FindAllShardsInKeyspaceResponse\nError error}",
                     "value": "\"test\": {\nResponse: &vtctldatapb.FindAllShardsInKeyspaceResponse{\nShards: map[string]*vtctldatapb.Shard{\n\"-\": {\nKeyspace: \"test\",\nName: \"-\",\nShard: &topodatapb.Shard{},\n},\n},\n},\n},"
@@ -324,6 +329,39 @@
                     "include_error_var": true,
                     "assertions": [
                         "assert.Error(t, err, $$)",
+                        "assert.Nil(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "authorized actor",
+                    "actor": {"name": "allowed"},
+                    "include_error_var": true,
+                    "is_permitted": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "EmergencyFailoverShard",
+            "rules": [
+                {
+                    "resource": "Shard",
+                    "actions": ["emergency_failover_shard"],
+                    "subjects": ["user:allowed"],
+                    "clusters": ["*"]
+                }
+            ],
+            "request": "&vtadminpb.EmergencyFailoverShardRequest{\nClusterId: \"test\",\nOptions: &vtctldatapb.EmergencyReparentShardRequest{\nKeyspace: \"test\",\nShard: \"-\",\n},\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "other"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
                         "assert.Nil(t, resp, $$)"
                     ]
                 },

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -119,6 +119,11 @@
                     "field": "ValidateKeyspaceResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.ValidateKeyspaceResponse\nError error\n}",
                     "value": "\"test\": {\nResponse: &vtctldatapb.ValidateKeyspaceResponse{},\n},"
+                },
+                {
+                    "field": "ValidateSchemaKeyspaceResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.ValidateSchemaKeyspaceResponse\nError error\n}",
+                    "value": "\"test\": {\nResponse: &vtctldatapb.ValidateSchemaKeyspaceResponse{},\n},"
                 }
             ],
             "db_tablet_list": [
@@ -1511,6 +1516,39 @@
                 }
             ],
             "request": "&vtadminpb.ValidateKeyspaceRequest{\nClusterId: \"test\",\nKeyspace: \"test\",\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "other"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.Nil(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "authorized actor",
+                    "actor": {"name": "allowed"},
+                    "include_error_var": true,
+                    "is_permitted": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "ValidateSchemaKeyspace",
+            "rules": [
+                {
+                    "resource": "Keyspace",
+                    "actions": ["put"],
+                    "subjects": ["user:allowed"],
+                    "clusters": ["*"]
+                }
+            ],
+            "request": "&vtadminpb.ValidateSchemaKeyspaceRequest{\nClusterId: \"test\",\nKeyspace: \"test\",\n}",
             "cases": [
                 {
                     "name": "unauthorized actor",

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -56,11 +56,6 @@
                     "value": "\"zone1\": {\nResponse: &vtctldatapb.GetSrvVSchemaResponse{\nSrvVSchema: &vschemapb.SrvVSchema{},\n},\n},"
                 },
                 {
-                    "field": "ShardReplicationPositionsResults",
-                    "type": "map[string]struct{\nResponse *vtctldatapb.ShardReplicationPositionsResponse\nError error}",
-                    "value": "\"test/-\": {\nResponse: &vtctldatapb.ShardReplicationPositionsResponse{},\n},"
-                },
-                {
                     "field": "GetVSchemaResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.GetVSchemaResponse\nError error}",
                     "value": "\"test\": {\nResponse: &vtctldatapb.GetVSchemaResponse{\nVSchema: &vschemapb.Keyspace{},\n},\n},"
@@ -99,6 +94,11 @@
                     "field": "SetWritableResults",
                     "type": "map[string]error",
                     "value": "\"zone1-0000000100\": nil,"
+                },
+                {
+                    "field": "ShardReplicationPositionsResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.ShardReplicationPositionsResponse\nError error}",
+                    "value": "\"test/-\": {\nResponse: &vtctldatapb.ShardReplicationPositionsResponse{},\n},"
                 },
                 {
                     "field": "StartReplicationResults",
@@ -174,11 +174,6 @@
                     "value": "\"other1\": {\nResponse: &vtctldatapb.GetSrvVSchemaResponse{\nSrvVSchema: &vschemapb.SrvVSchema{},\n},\n},"
                 },
                 {
-                    "field": "ShardReplicationPositionsResults",
-                    "type": "map[string]struct{\nResponse *vtctldatapb.ShardReplicationPositionsResponse\nError error}",
-                    "value": "\"otherks/-\": {\nResponse: &vtctldatapb.ShardReplicationPositionsResponse{},\n},"
-                },
-                {
                     "field": "GetVSchemaResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.GetVSchemaResponse\nError error}",
                     "value": "\"otherks\": {\nResponse: &vtctldatapb.GetVSchemaResponse{\nVSchema: &vschemapb.Keyspace{},\n},\n},"
@@ -187,6 +182,11 @@
                     "field": "GetWorkflowsResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.GetWorkflowsResponse\nError error}",
                     "value": "\"otherks\": {\nResponse: &vtctldatapb.GetWorkflowsResponse{\nWorkflows: []*vtctldatapb.Workflow{\n{\nName: \"otherks_workflow\",\n},\n},\n}},"
+                },
+                {
+                    "field": "ShardReplicationPositionsResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.ShardReplicationPositionsResponse\nError error}",
+                    "value": "\"otherks/-\": {\nResponse: &vtctldatapb.ShardReplicationPositionsResponse{},\n},"
                 }
             ],
             "db_tablet_list": [

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -124,6 +124,11 @@
                     "field": "ValidateSchemaKeyspaceResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.ValidateSchemaKeyspaceResponse\nError error\n}",
                     "value": "\"test\": {\nResponse: &vtctldatapb.ValidateSchemaKeyspaceResponse{},\n},"
+                },
+                {
+                    "field": "ValidateVersionKeyspaceResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.ValidateVersionKeyspaceResponse\nError error\n}",
+                    "value": "\"test\": {\nResponse: &vtctldatapb.ValidateVersionKeyspaceResponse{},\n},"
                 }
             ],
             "db_tablet_list": [
@@ -1549,6 +1554,39 @@
                 }
             ],
             "request": "&vtadminpb.ValidateSchemaKeyspaceRequest{\nClusterId: \"test\",\nKeyspace: \"test\",\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "other"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.Nil(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "authorized actor",
+                    "actor": {"name": "allowed"},
+                    "include_error_var": true,
+                    "is_permitted": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "ValidateVersionKeyspace",
+            "rules": [
+                {
+                    "resource": "Keyspace",
+                    "actions": ["put"],
+                    "subjects": ["user:allowed"],
+                    "clusters": ["*"]
+                }
+            ],
+            "request": "&vtadminpb.ValidateVersionKeyspaceRequest{\nClusterId: \"test\",\nKeyspace: \"test\",\n}",
             "cases": [
                 {
                     "name": "unauthorized actor",

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -114,6 +114,11 @@
                     "field": "TabletExternallyReparentedResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.TabletExternallyReparentedResponse\nError error\n}",
                     "value": "\"zone1-0000000100\": {\nResponse: &vtctldatapb.TabletExternallyReparentedResponse{},\n},"
+                },
+                {
+                    "field": "ValidateKeyspaceResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.ValidateKeyspaceResponse\nError error\n}",
+                    "value": "\"test\": {\nResponse: &vtctldatapb.ValidateKeyspaceResponse{},\n},"
                 }
             ],
             "db_tablet_list": [
@@ -1480,6 +1485,39 @@
                     "include_error_var": true,
                     "assertions": [
                         "assert.Error(t, err, $$)",
+                        "assert.Nil(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "authorized actor",
+                    "actor": {"name": "allowed"},
+                    "include_error_var": true,
+                    "is_permitted": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "ValidateKeyspace",
+            "rules": [
+                {
+                    "resource": "Keyspace",
+                    "actions": ["put"],
+                    "subjects": ["user:allowed"],
+                    "clusters": ["*"]
+                }
+            ],
+            "request": "&vtadminpb.ValidateKeyspaceRequest{\nClusterId: \"test\",\nKeyspace: \"test\",\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "other"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
                         "assert.Nil(t, resp, $$)"
                     ]
                 },

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -76,6 +76,11 @@
                     "value": "\"zone1-0000000100\": nil,"
                 },
                 {
+                    "field": "PlannedReparentShardResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.PlannedReparentShardResponse\nError error}",
+                    "value": "\"test/-\": {\nResponse: &vtctldatapb.PlannedReparentShardResponse{},\n},"
+                },
+                {
                     "field": "RefreshStateResults",
                     "type": "map[string]error",
                     "value": "\"zone1-0000000100\": nil,"
@@ -1178,6 +1183,39 @@
                     "include_error_var": true,
                     "assertions": [
                         "assert.Error(t, err, $$)",
+                        "assert.Nil(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "authorized actor",
+                    "actor": {"name": "allowed"},
+                    "include_error_var": true,
+                    "is_permitted": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "PlannedFailoverShard",
+            "rules": [
+                {
+                    "resource": "Shard",
+                    "actions": ["planned_failover_shard"],
+                    "subjects": ["user:allowed"],
+                    "clusters": ["*"]
+                }
+            ],
+            "request": "&vtadminpb.PlannedFailoverShardRequest{\nClusterId: \"test\",\nOptions: &vtctldatapb.PlannedReparentShardRequest{\nKeyspace: \"test\",\nShard: \"-\",\n},\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "other"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
                         "assert.Nil(t, resp, $$)"
                     ]
                 },

--- a/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
+++ b/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
@@ -135,6 +135,10 @@ type VtctldClient struct {
 		Response *vtctldatapb.ValidateSchemaKeyspaceResponse
 		Error    error
 	}
+	ValidateVersionKeyspaceResults map[string]struct {
+		Response *vtctldatapb.ValidateVersionKeyspaceResponse
+		Error    error
+	}
 }
 
 // Compile-time type assertion to make sure we haven't overriden a method
@@ -650,6 +654,20 @@ func (fake *VtctldClient) ValidateSchemaKeyspace(ctx context.Context, req *vtctl
 
 	key := req.Keyspace
 	if result, ok := fake.ValidateSchemaKeyspaceResults[key]; ok {
+		return result.Response, result.Error
+	}
+
+	return nil, fmt.Errorf("%w: no result set for %s", assert.AnError, key)
+}
+
+// ValidateVersionKeyspace is part of the vtctldclient.VtctldClient interface.
+func (fake *VtctldClient) ValidateVersionKeyspace(ctx context.Context, req *vtctldatapb.ValidateVersionKeyspaceRequest, opts ...grpc.CallOption) (*vtctldatapb.ValidateVersionKeyspaceResponse, error) {
+	if fake.ValidateVersionKeyspaceResults == nil {
+		return nil, fmt.Errorf("%w: ValidateVersionKeyspaceResults not set on fake vtctldclient", assert.AnError)
+	}
+
+	key := req.Keyspace
+	if result, ok := fake.ValidateVersionKeyspaceResults[key]; ok {
 		return result.Response, result.Error
 	}
 

--- a/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
+++ b/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
@@ -127,6 +127,10 @@ type VtctldClient struct {
 		Response *vtctldatapb.TabletExternallyReparentedResponse
 		Error    error
 	}
+	ValidateKeyspaceResults map[string]struct {
+		Response *vtctldatapb.ValidateKeyspaceResponse
+		Error    error
+	}
 }
 
 // Compile-time type assertion to make sure we haven't overriden a method
@@ -614,6 +618,20 @@ func (fake *VtctldClient) TabletExternallyReparented(ctx context.Context, req *v
 
 	key := topoproto.TabletAliasString(req.Tablet)
 	if result, ok := fake.TabletExternallyReparentedResults[key]; ok {
+		return result.Response, result.Error
+	}
+
+	return nil, fmt.Errorf("%w: no result set for %s", assert.AnError, key)
+}
+
+// ValidateKeyspace is part of the vtctldclient.VtctldClient interface.
+func (fake *VtctldClient) ValidateKeyspace(ctx context.Context, req *vtctldatapb.ValidateKeyspaceRequest, opts ...grpc.CallOption) (*vtctldatapb.ValidateKeyspaceResponse, error) {
+	if fake.ValidateKeyspaceResults == nil {
+		return nil, fmt.Errorf("%w: ValidateKeyspaceResults not set on fake vtctldclient", assert.AnError)
+	}
+
+	key := req.Keyspace
+	if result, ok := fake.ValidateKeyspaceResults[key]; ok {
 		return result.Response, result.Error
 	}
 

--- a/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
+++ b/go/vt/vtadmin/vtctldclient/fakevtctldclient/vtctldclient.go
@@ -131,6 +131,10 @@ type VtctldClient struct {
 		Response *vtctldatapb.ValidateKeyspaceResponse
 		Error    error
 	}
+	ValidateSchemaKeyspaceResults map[string]struct {
+		Response *vtctldatapb.ValidateSchemaKeyspaceResponse
+		Error    error
+	}
 }
 
 // Compile-time type assertion to make sure we haven't overriden a method
@@ -632,6 +636,20 @@ func (fake *VtctldClient) ValidateKeyspace(ctx context.Context, req *vtctldatapb
 
 	key := req.Keyspace
 	if result, ok := fake.ValidateKeyspaceResults[key]; ok {
+		return result.Response, result.Error
+	}
+
+	return nil, fmt.Errorf("%w: no result set for %s", assert.AnError, key)
+}
+
+// ValidateSchemaKeyspace is part of the vtctldclient.VtctldClient interface.
+func (fake *VtctldClient) ValidateSchemaKeyspace(ctx context.Context, req *vtctldatapb.ValidateSchemaKeyspaceRequest, opts ...grpc.CallOption) (*vtctldatapb.ValidateSchemaKeyspaceResponse, error) {
+	if fake.ValidateSchemaKeyspaceResults == nil {
+		return nil, fmt.Errorf("%w: ValidateSchemaKeyspaceResults not set on fake vtctldclient", assert.AnError)
+	}
+
+	key := req.Keyspace
+	if result, ok := fake.ValidateSchemaKeyspaceResults[key]; ok {
 		return result.Response, result.Error
 	}
 

--- a/web/vtadmin/package-lock.json
+++ b/web/vtadmin/package-lock.json
@@ -18181,6 +18181,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/serve-handler/node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/serve-handler/node_modules/path-to-regexp": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
@@ -34236,6 +34248,15 @@
           "dev": true,
           "requires": {
             "mime-db": "~1.33.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "path-to-regexp": {


### PR DESCRIPTION
## Description

Everything except `(Find|Get)Schema`, `GetSchemas`, and `VTExplain` (which are coming next).

## Related Issue(s)

#10397 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
