### PR TITLE
[vtadmin] Add schema-related authz tests

### DIFF
--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -34,6 +34,7 @@ import (
 	"vitess.io/vitess/go/vt/vtadmin/testutil"
 	"vitess.io/vitess/go/vt/vtadmin/vtctldclient/fakevtctldclient"
 
+	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
 	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -2340,6 +2341,98 @@ func TestRefreshTabletReplicationSource(t *testing.T) {
 	})
 }
 
+func TestReloadSchemas(t *testing.T) {
+	t.Parallel()
+
+	opts := vtadmin.Options{
+		RBAC: &rbac.Config{
+			Rules: []*struct {
+				Resource string
+				Actions  []string
+				Subjects []string
+				Clusters []string
+			}{
+				{
+					Resource: "Schema",
+					Actions:  []string{"reload"},
+					Subjects: []string{"user:allowed-all"},
+					Clusters: []string{"*"},
+				},
+				{
+					Resource: "Schema",
+					Actions:  []string{"reload"},
+					Subjects: []string{"user:allowed-other"},
+					Clusters: []string{"other"},
+				},
+			},
+		},
+	}
+	err := opts.RBAC.Reify()
+	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
+
+	api := vtadmin.NewAPI(testClusters(t), opts)
+	t.Cleanup(func() {
+		if err := api.Close(); err != nil {
+			t.Logf("api did not close cleanly: %s", err.Error())
+		}
+	})
+
+	t.Run("unauthorized actor", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "unauthorized"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, err := api.ReloadSchemas(ctx, &vtadminpb.ReloadSchemasRequest{
+			Keyspaces: []string{
+				"test",
+				"otherks",
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, resp.KeyspaceResults, "actor %+v should not be permitted to ReloadSchemas", actor)
+	})
+
+	t.Run("partial access", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "allowed-other"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, _ := api.ReloadSchemas(ctx, &vtadminpb.ReloadSchemasRequest{
+			Keyspaces: []string{
+				"test",
+				"otherks",
+			},
+		})
+		assert.NotEmpty(t, resp.KeyspaceResults, "actor %+v should be permitted to ReloadSchemas", actor)
+	})
+
+	t.Run("full access", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "allowed-all"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, _ := api.ReloadSchemas(ctx, &vtadminpb.ReloadSchemasRequest{
+			Keyspaces: []string{
+				"test",
+				"otherks",
+			},
+		})
+		assert.NotEmpty(t, resp.KeyspaceResults, "actor %+v should be permitted to ReloadSchemas", actor)
+	})
+}
+
 func TestRunHealthCheck(t *testing.T) {
 	t.Parallel()
 
@@ -3192,6 +3285,15 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 				RefreshStateResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
+				ReloadSchemaKeyspaceResults: map[string]struct {
+					Response *vtctldatapb.ReloadSchemaKeyspaceResponse
+					Error    error
+				}{
+					"test": {
+						Response: &vtctldatapb.ReloadSchemaKeyspaceResponse{
+							Events: []*logutilpb.Event{{}, {}, {}}},
+					},
+				},
 				ReparentTabletResults: map[string]struct {
 					Response *vtctldatapb.ReparentTabletResponse
 					Error    error
@@ -3390,6 +3492,15 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 				}{
 					"otherks/-": {
 						Response: &vtctldatapb.ShardReplicationPositionsResponse{},
+					},
+				},
+				ReloadSchemaKeyspaceResults: map[string]struct {
+					Response *vtctldatapb.ReloadSchemaKeyspaceResponse
+					Error    error
+				}{
+					"otherks": {
+						Response: &vtctldatapb.ReloadSchemaKeyspaceResponse{
+							Events: []*logutilpb.Event{{}}},
 					},
 				},
 			},

--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -2912,7 +2912,10 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 							Cell: "zone1",
 							Uid:  100,
 						},
+						Keyspace: "test",
+						Type:     topodatapb.TabletType_REPLICA,
 					},
+					State: vtadminpb.Tablet_SERVING,
 				},
 			},
 			Config: &cluster.Config{
@@ -3035,7 +3038,10 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 							Cell: "other1",
 							Uid:  100,
 						},
+						Keyspace: "",
+						Type:     topodatapb.TabletType_UNKNOWN,
 					},
+					State: vtadminpb.Tablet_UNKNOWN,
 				},
 			},
 			Config: &cluster.Config{

--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -472,6 +472,91 @@ func TestEmergencyFailoverShard(t *testing.T) {
 	})
 }
 
+func TestFindSchema(t *testing.T) {
+	t.Parallel()
+
+	opts := vtadmin.Options{
+		RBAC: &rbac.Config{
+			Rules: []*struct {
+				Resource string
+				Actions  []string
+				Subjects []string
+				Clusters []string
+			}{
+				{
+					Resource: "Schema",
+					Actions:  []string{"get"},
+					Subjects: []string{"user:allowed-all"},
+					Clusters: []string{"*"},
+				},
+				{
+					Resource: "Schema",
+					Actions:  []string{"get"},
+					Subjects: []string{"user:allowed-other"},
+					Clusters: []string{"other"},
+				},
+			},
+		},
+	}
+	err := opts.RBAC.Reify()
+	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
+
+	api := vtadmin.NewAPI(testClusters(t), opts)
+	t.Cleanup(func() {
+		if err := api.Close(); err != nil {
+			t.Logf("api did not close cleanly: %s", err.Error())
+		}
+	})
+
+	t.Run("unauthorized actor", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "unauthorized"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, err := api.FindSchema(ctx, &vtadminpb.FindSchemaRequest{
+			Table: "t1",
+		})
+		assert.Error(t, err)
+		assert.Nil(t, resp, "actor %+v should not be permitted to FindSchema", actor)
+	})
+
+	t.Run("partial access", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "allowed-other"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, _ := api.FindSchema(ctx, &vtadminpb.FindSchemaRequest{
+			Table: "t1",
+		})
+		assert.NotEmpty(t, resp, "actor %+v should be permitted to FindSchema", actor)
+	})
+
+	t.Run("full access", func(t *testing.T) {
+		t.Parallel()
+		actor := &rbac.Actor{Name: "allowed-all"}
+
+		ctx := context.Background()
+		if actor != nil {
+			ctx = rbac.NewContext(ctx, actor)
+		}
+
+		resp, err := api.FindSchema(ctx, &vtadminpb.FindSchemaRequest{
+			Table: "t1",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple schemas found")
+		assert.Nil(t, resp)
+	})
+}
+
 func TestGetBackups(t *testing.T) {
 	t.Parallel()
 

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -414,6 +414,56 @@
             ]
         },
         {
+            "method": "FindSchema",
+            "rules": [
+                {
+                    "resource": "Schema",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-all"],
+                    "clusters": ["*"]
+                },
+                {
+                    "resource": "Schema",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-other"],
+                    "clusters": ["other"]
+                }
+            ],
+            "request": "&vtadminpb.FindSchemaRequest{\nTable: \"t1\",\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "unauthorized"},
+                    "is_permitted": false,
+                    "include_error_var": true,
+                    "assertions": [
+                        "assert.Error(t, err)",
+                        "assert.Nil(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "partial access",
+                    "actor": {"name": "allowed-other"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "full access",
+                    "comment": "because t1 exists in two clusters, and 'allowed-all' has access to both, FindSchema is ambiguous",
+                    "actor": {"name": "allowed-all"},
+                    "is_permitted": true,
+                    "include_error_var": true,
+                    "assertions": [
+                        "assert.Error(t, err)",
+                        "assert.Contains(t, err.Error(), \"multiple schemas found\")",
+                        "assert.Nil(t, resp)"
+                    ]         
+                }
+            ]
+        },
+        {
             "method": "GetBackups",
             "rules": [
                 {

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -134,8 +134,11 @@
             "db_tablet_list": [
                 {
                     "tablet": {
-                        "alias": {"cell": "zone1", "uid": 100}
-                    }
+                        "alias": {"cell": "zone1", "uid": 100},
+                        "type": 2,
+                        "keyspace": "test"
+                    },
+                    "state": 1
                 }
             ]
         },

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -206,8 +206,10 @@
             "db_tablet_list": [
                 {
                     "tablet": {
-                        "alias": {"cell": "other1", "uid": 100}
-                    }
+                        "alias": {"cell": "other1", "uid": 100},
+                        "keyspace": "otherks"
+                    },
+                    "state": 1
                 }
             ]
         }
@@ -764,6 +766,64 @@
                     "assertions": [
                         "require.NoError(t, err)",
                         "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "GetSchemas",
+            "rules": [
+                {
+                    "resource": "Schema",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-all"],
+                    "clusters": ["*"]
+                },
+                {
+                    "resource": "Schema",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed-other"],
+                    "clusters": ["other"]
+                }
+            ],
+            "request": "&vtadminpb.GetSchemasRequest{}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "unauthorized"},
+                    "is_permitted": false,
+                    "include_error_var": true,
+                    "assertions": [
+                        "assert.NoError(t, err)",
+                        "assert.Empty(t, resp.Schemas, $$)"
+                    ]
+                },
+                {
+                    "name": "partial access",
+                    "actor": {"name": "allowed-other"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.Schemas, $$)",
+                        "schemaMap := map[string][]string{}",
+                        "for _, schema := range resp.Schemas {",
+                        "if _, ok := schemaMap[schema.Cluster.Id]; !ok {\n schemaMap[schema.Cluster.Id] = []string{}\n}",
+                        "schemaMap[schema.Cluster.Id] = append(schemaMap[schema.Cluster.Id], schema.Keyspace)",
+                        "}",
+                        "assert.Equal(t, schemaMap, map[string][]string{\"other\": {\"otherks\"}}, $$)"
+                    ]
+                },
+                {
+                    "name": "full access",
+                    "actor": {"name": "allowed-all"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.Schemas, $$)",
+                        "schemaMap := map[string][]string{}",
+                        "for _, schema := range resp.Schemas {",
+                        "if _, ok := schemaMap[schema.Cluster.Id]; !ok {\n schemaMap[schema.Cluster.Id] = []string{}\n}",
+                        "schemaMap[schema.Cluster.Id] = append(schemaMap[schema.Cluster.Id], schema.Keyspace)",
+                        "}",
+                        "assert.Equal(t, schemaMap, map[string][]string{\"test\": {\"test\"}, \"other\": {\"otherks\"}}, $$)"
                     ]
                 }
             ]

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -736,6 +736,39 @@
             ]
         },
         {
+            "method": "GetSchema",
+            "rules": [
+                {
+                    "resource": "Schema",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed"],
+                    "clusters": ["*"]
+                }
+            ],
+            "request": "&vtadminpb.GetSchemaRequest{\nClusterId: \"test\",\nKeyspace: \"test\",\nTable: \"t1\",\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "other"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.Nil(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "authorized actor",
+                    "actor": {"name": "allowed"},
+                    "include_error_var": true,
+                    "is_permitted": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
             "method": "GetShardReplicationPositions",
             "rules": [
                 {

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -23,7 +23,7 @@
                 {
                     "field": "FindAllShardsInKeyspaceResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.FindAllShardsInKeyspaceResponse\nError error}",
-                    "value": "\"test\": {\nResponse: &vtctldatapb.FindAllShardsInKeyspaceResponse{\nShards: map[string]*vtctldatapb.Shard{\n\"-\": {\nKeyspace: \"test\",\nName: \"-\",\nShard: &topodatapb.Shard{},\n},\n},\n},\n},"
+                    "value": "\"test\": {\nResponse: &vtctldatapb.FindAllShardsInKeyspaceResponse{\nShards: map[string]*vtctldatapb.Shard{\n\"-\": {\nKeyspace: \"test\",\nName: \"-\",\nShard: &topodatapb.Shard{\nKeyRange: &topodatapb.KeyRange{},\n},\n},\n},\n},\n},"
                 },
                 {
                     "field": "GetBackupsResults",
@@ -51,9 +51,15 @@
                     "value": "Keyspaces: []*vtctldatapb.Keyspace{\n{\nName: \"test\",\nKeyspace: &topodatapb.Keyspace{},\n},\n},"
                 },
                 {
+                    "field": "GetSchemaResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.GetSchemaResponse\nError error}",
+                    "value": "\"zone1-0000000100\": {\nResponse: &vtctldatapb.GetSchemaResponse{\nSchema: &tabletmanagerdatapb.SchemaDefinition{\nTableDefinitions: []*tabletmanagerdatapb.TableDefinition{\n{Name: \"t1\", Schema: \"create table t1 (id int(11) not null primary key);\",},\n{Name: \"t2\"},\n},\n},\n},\n},"
+                },
+                {
                     "field": "GetSrvVSchemaResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.GetSrvVSchemaResponse\nError error}",
-                    "value": "\"zone1\": {\nResponse: &vtctldatapb.GetSrvVSchemaResponse{\nSrvVSchema: &vschemapb.SrvVSchema{},\n},\n},"
+                    "value": "\"zone1\": {\nResponse: &vtctldatapb.GetSrvVSchemaResponse{\nSrvVSchema: &vschemapb.SrvVSchema{\nKeyspaces: map[string]*vschemapb.Keyspace{\n\"test\": {\nSharded: true,\nVindexes: map[string]*vschemapb.Vindex{\n\"id\": {\nType: \"hash\",\n},\n},\nTables: map[string]*vschemapb.Table{\n\"t1\": {\nColumnVindexes: []*vschemapb.ColumnVindex{\n{\nName: \"id\",\nColumn: \"id\",\n},\n},\n},\n},\n},\n},\n},\n},\n},",
+                    "comment": "this structure exists primarily to support the VTExplain test cases; for GetSrvVSchema(s) itself, an empty but non-nil map is sufficient"
                 },
                 {
                     "field": "GetVSchemaResults",
@@ -170,6 +176,11 @@
                     "field": "GetKeyspacesResults",
                     "type": "&struct{\nKeyspaces []*vtctldatapb.Keyspace\nError error}",
                     "value": "Keyspaces: []*vtctldatapb.Keyspace{\n{\nName: \"otherks\",\nKeyspace: &topodatapb.Keyspace{},\n},\n},"
+                },
+                {
+                    "field": "GetSchemaResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.GetSchemaResponse\nError error}",
+                    "value": "\"other1-0000000100\": {\nResponse: &vtctldatapb.GetSchemaResponse{\nSchema: &tabletmanagerdatapb.SchemaDefinition{\nTableDefinitions: []*tabletmanagerdatapb.TableDefinition{\n{Name: \"t1\"},\n},\n},\n},\n},"
                 },
                 {
                     "field": "GetSrvVSchemaResults",
@@ -1498,6 +1509,39 @@
                     "include_error_var": true,
                     "assertions": [
                         "assert.Error(t, err, $$)",
+                        "assert.Nil(t, resp, $$)"
+                    ]
+                },
+                {
+                    "name": "authorized actor",
+                    "actor": {"name": "allowed"},
+                    "include_error_var": true,
+                    "is_permitted": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "VTExplain",
+            "rules": [
+                {
+                    "resource": "VTExplain",
+                    "actions": ["get"],
+                    "subjects": ["user:allowed"],
+                    "clusters": ["*"]
+                }
+            ],
+            "request": "&vtadminpb.VTExplainRequest{\nCluster: \"test\",\nKeyspace: \"test\",\nSql: \"select id from t1;\",}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "other"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
                         "assert.Nil(t, resp, $$)"
                     ]
                 },

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -87,6 +87,11 @@
                     "value": "\"zone1-0000000100\": nil,"
                 },
                 {
+                    "field": "ReloadSchemaKeyspaceResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.ReloadSchemaKeyspaceResponse\nError error\n}",
+                    "value": "\"test\": {\nResponse: &vtctldatapb.ReloadSchemaKeyspaceResponse{\nEvents: []*logutilpb.Event{{}, {}, {}}},\n},"
+                },
+                {
                     "field": "ReparentTabletResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.ReparentTabletResponse\nError error\n}",
                     "value": "\"zone1-0000000100\": {\nResponse: &vtctldatapb.ReparentTabletResponse{},\n},"
@@ -201,6 +206,11 @@
                     "field": "ShardReplicationPositionsResults",
                     "type": "map[string]struct{\nResponse *vtctldatapb.ShardReplicationPositionsResponse\nError error}",
                     "value": "\"otherks/-\": {\nResponse: &vtctldatapb.ShardReplicationPositionsResponse{},\n},"
+                },
+                {
+                    "field": "ReloadSchemaKeyspaceResults",
+                    "type": "map[string]struct{\nResponse *vtctldatapb.ReloadSchemaKeyspaceResponse\nError error\n}",
+                    "value": "\"otherks\": {\nResponse: &vtctldatapb.ReloadSchemaKeyspaceResponse{\nEvents: []*logutilpb.Event{{}}},\n},"
                 }
             ],
             "db_tablet_list": [
@@ -1465,6 +1475,51 @@
                     "assertions": [
                         "require.NoError(t, err)",
                         "assert.NotNil(t, resp, $$)"
+                    ]
+                }
+            ]
+        },
+        {
+            "method": "ReloadSchemas",
+            "rules": [
+                {
+                    "resource": "Schema",
+                    "actions": ["reload"],
+                    "subjects": ["user:allowed-all"],
+                    "clusters": ["*"]
+                },
+                {
+                    "resource": "Schema",
+                    "actions": ["reload"],
+                    "subjects": ["user:allowed-other"],
+                    "clusters": ["other"]
+                }
+            ],
+            "request": "&vtadminpb.ReloadSchemasRequest{\nKeyspaces: []string{\n\"test\",\n\"otherks\",\n},\n}",
+            "cases": [
+                {
+                    "name": "unauthorized actor",
+                    "actor": {"name": "unauthorized"},
+                    "include_error_var": true,
+                    "assertions": [
+                        "require.NoError(t, err)",
+                        "assert.Empty(t, resp.KeyspaceResults, $$)"
+                    ]
+                },
+                {
+                    "name": "partial access",
+                    "actor": {"name": "allowed-other"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.KeyspaceResults, $$)"
+                    ]
+                },
+                {
+                    "name": "full access",
+                    "actor": {"name": "allowed-all"},
+                    "is_permitted": true,
+                    "assertions": [
+                        "assert.NotEmpty(t, resp.KeyspaceResults, $$)"
                     ]
                 }
             ]

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -143,7 +143,10 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 							Cell: "{{ .Tablet.Alias.Cell }}",
 							Uid: {{ .Tablet.Alias.Uid }},
 						},
+						Keyspace: "{{ .Tablet.Keyspace }}",
+						Type: topodatapb.TabletType_{{ .Tablet.Type }},
 					},
+					State: vtadminpb.Tablet_{{ .State }},
 				},
 				{{- end }}
 			},

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -53,6 +53,7 @@ import (
 	"vitess.io/vitess/go/vt/vtadmin/vtctldclient/fakevtctldclient"
 
 	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -52,6 +52,7 @@ import (
 	"vitess.io/vitess/go/vt/vtadmin/testutil"
 	"vitess.io/vitess/go/vt/vtadmin/vtctldclient/fakevtctldclient"
 
+	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
 	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"


### PR DESCRIPTION
## Description

This is stacked on top of #10481 and should be merged after that PR (plus a rebase, and re-codegen).

This is the last of the authz tests to add:

```
$ diff -q <(cat ./proto/vtadmin.proto | grep 'rpc' | awk '{print $2}' | awk -F '(' '{print $1}' | sort) <(cat ./go/vt/vtadmin/testutil/authztestgen/config.json | jq -r '.tests[].method' | sort)
$ echo $?
0
```

## Related Issue(s)

#10397 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
