### PR TITLE
Fix missing case in fuzzer (68 -> 69)

### DIFF
--- a/go/test/fuzzing/vtctl_fuzzer.go
+++ b/go/test/fuzzing/vtctl_fuzzer.go
@@ -177,7 +177,7 @@ func Fuzz(data []byte) int {
 		to := i + chunkSize //upper
 
 		// Index of command in getCommandType():
-		commandIndex := int(commandPart[command]) % 68
+		commandIndex := int(commandPart[command]) % 69
 		vtCommand := getCommandType(commandIndex)
 		commandSlice := []string{vtCommand}
 		args := strings.Split(string(restOfArray[from:to]), " ")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

In `/go/test/fuzzing/vtctl_fuzzer.go`, the function `getCommandType`  contains 69 cases ([0, 68]). However, the fuzzer always miss the case 68 since it mods to 68. I fixed it to 69.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

None.
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

None.
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
