### PR TITLE
Fix upgrade-downgrade build on `release-13.0`

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.11
+        go-version: 1.18.3
 
     - name: Set up python
       uses: actions/setup-python@v2

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -75,6 +75,9 @@ jobs:
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
+    - name: Checkout to commit's code
+      uses: actions/checkout@v2
+
     - name: Get base dependencies
       run: |
         sudo DEBIAN_FRONTEND="noninteractive" apt-get update

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.11
+        go-version: 1.18.3
 
     - name: Set up python
       uses: actions/setup-python@v2

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -69,6 +69,9 @@ jobs:
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
+    - name: Checkout to commit's code
+      uses: actions/checkout@v2
+
     - name: Get base dependencies
       run: |
         sudo DEBIAN_FRONTEND="noninteractive" apt-get update

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.11
+        go-version: 1.18.3
 
     - name: Set up python
       uses: actions/setup-python@v2

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -69,6 +69,9 @@ jobs:
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
+    - name: Checkout to commit's code
+      uses: actions/checkout@v2
+
     - name: Get base dependencies
       run: |
         sudo DEBIAN_FRONTEND="noninteractive" apt-get update

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.11
+        go-version: 1.18.3
 
     - name: Set up python
       uses: actions/setup-python@v2

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -69,6 +69,9 @@ jobs:
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
+    - name: Checkout to commit's code
+      uses: actions/checkout@v2
+
     - name: Get base dependencies
       run: |
         sudo DEBIAN_FRONTEND="noninteractive" apt-get update

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.11
+        go-version: 1.18.3
 
     - name: Set up python
       uses: actions/setup-python@v2


### PR DESCRIPTION
## Description

This Pull Request changes the Go version used in the upgrade downgrade tests. It was set to `go1.17.11`, with this change it will use `go1.18.3` which is compatible with any release of Vitess.

While fixing this problem, I have realized that upgrade downgrade tests on `v13` are testing the current commit and the latest version of vitess, which is in this case: `release-14.0` ; instead it should use the "previous" release: `release-12.0`. I will open a follow-up issue.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
