### PR TITLE
feat: don't stop if compilation errors are happening on the generated files

### DIFF
--- a/go/tools/asthelpergen/asthelpergen.go
+++ b/go/tools/asthelpergen/asthelpergen.go
@@ -27,8 +27,6 @@ import (
 
 	"vitess.io/vitess/go/tools/goimports"
 
-	"vitess.io/vitess/go/tools/common"
-
 	"github.com/dave/jennifer/jen"
 	"golang.org/x/tools/go/packages"
 )
@@ -198,6 +196,13 @@ func VerifyFilesOnDisk(result map[string]*jen.File) (errors []error) {
 	return errors
 }
 
+var acceptableBuildErrorsOn = map[string]any{
+	"ast_equals.go":  nil,
+	"ast_clone.go":   nil,
+	"ast_rewrite.go": nil,
+	"ast_visit.go":   nil,
+}
+
 // GenerateASTHelpers loads the input code, constructs the necessary generators,
 // and generates the rewriter and clone methods for the AST
 func GenerateASTHelpers(packagePatterns []string, rootIface, exceptCloneType string) (map[string]*jen.File, error) {
@@ -205,10 +210,15 @@ func GenerateASTHelpers(packagePatterns []string, rootIface, exceptCloneType str
 		Mode: packages.NeedName | packages.NeedTypes | packages.NeedTypesSizes | packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports | packages.NeedModule,
 	}, packagePatterns...)
 
-	if err != nil || common.PkgFailed(loaded) {
+	if err != nil {
 		log.Fatal("error loading package")
 		return nil, err
 	}
+
+	checkErrors(loaded, func(fileName string) bool {
+		_, ok := acceptableBuildErrorsOn[fileName]
+		return ok
+	})
 
 	scopes := make(map[string]*types.Scope)
 	for _, pkg := range loaded {
@@ -320,10 +330,23 @@ func printableTypeName(t types.Type) string {
 	case *types.Named:
 		return t.Obj().Name()
 	case *types.Basic:
-		return strings.Title(t.Name()) //nolint
+		return strings.Title(t.Name()) // nolint
 	case *types.Interface:
 		return t.String()
 	default:
 		panic(fmt.Sprintf("unknown type %T %v", t, t))
+	}
+}
+
+func checkErrors(loaded []*packages.Package, canSkipErrorOn func(fileName string) bool) {
+	for _, l := range loaded {
+		for _, e := range l.Errors {
+			idx := strings.Index(e.Pos, ":")
+			filePath := e.Pos[:idx]
+			_, fileName := path.Split(filePath)
+			if !canSkipErrorOn(fileName) {
+				log.Fatalf("error loading package %s", e.Error())
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Description
Changes so `make codegen` doesn't stop because of compilation errors on the files with static methods (`ast_rewrite.go`, `ast_visit.go`, `ast_equals.go` and `ast_clone.go`). Since these files will be overwritten anyway, if all the compilation errors are on these, we'll just ignore the error.

Unfortunately, this does not work for the `ast_format_fast` generator. It produces methods that are interface implementations, and errors here are more difficult to ignore.

## Related Issue(s)

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
