### PR TITLE
Rework how the generation of the release notes and the changelog

### DIFF
--- a/doc/releasenotes/15_0_0_changelog.md
+++ b/doc/releasenotes/15_0_0_changelog.md
@@ -1,0 +1,35 @@
+# Changelog of Vitess v15.0.0
+
+### Bug fixes 
+#### Query Serving
+ * fix: scalar aggregation engine primitive #10465
+ * fix: aggregation empty row on join with grouping and aggregations #10480
+### Documentation 
+#### VTAdmin
+ * [vtadmin] Document known issue with node versions 17+ #10483
+### Enhancement 
+#### Query Serving
+ * fix: change planner_version to planner-version everywhere #10453
+ * Add support for alter table rename column #10469
+ * schemadiff: `ColumnRenameStrategy` in DiffHints #10472
+ * Add parsing support for performance schema functions #10478
+ * schemadiff: TableRenameStrategy in DiffHints #10479
+ * OnlineDDL executor: adding log entries #10482
+### Internal Cleanup 
+#### General
+ * Remove v2 resharding fields #10409 
+#### VTAdmin
+ * [vtadmin] Rename ERS/PRS pools+flags properly #10460 
+#### web UI
+ * Remove sharding_column_name and sharding_column_type from vtctld2 #10459
+### Testing 
+#### VTAdmin
+ * [vtadmin] authz tests - tablet actions #10457
+ * [vtadmin] Add authz tests for remaining non-schema related actions #10481
+ * [vtadmin] Add schema-related authz tests #10486
+
+
+The release includes 21 commits (excluding merges)
+
+Thanks to all our contributors: @GuptaManan100, @K-Kumar-01, @ajm188, @arvind-murty, @dbussink, @frouioui, @harshit-gangal, @notfelineit, @rohit-nayak-ps, @rsajwani, @shlomi-noach, @systay
+

--- a/doc/releasenotes/15_0_0_release_notes.md
+++ b/doc/releasenotes/15_0_0_release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v15.0.0
+The entire changelog for this release can be found [here](https:/github.com/vitessio/vitess/blob/main/doc/releasenotes/15_0_0_changelog.md).
+
+The release includes 21 commits (excluding merges)
+
+Thanks to all our contributors: @GuptaManan100, @K-Kumar-01, @ajm188, @arvind-murty, @dbussink, @frouioui, @harshit-gangal, @notfelineit, @rohit-nayak-ps, @rsajwani, @shlomi-noach, @systay
+

--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -21,10 +21,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -70,26 +70,23 @@ type (
 	}
 
 	releaseNote struct {
-		Version       string
-		Announcement  string
-		KnownIssues   string
-		AddDetails    string
-		ChangeLog     string
-		ChangeMetrics string
+		Version, VersionUnderscore                        string
+		Announcement                                      string
+		KnownIssues                                       string
+		AddDetails                                        string
+		PathToChangeLogFileOnGH, ChangeLog, ChangeMetrics string
 	}
 )
 
 const (
+	releaseNotesPath       = `doc/releasenotes/`
+	releaseNotesPathGitHub = `https://github.com/vitessio/vitess/blob/main/` + releaseNotesPath
+
 	markdownTemplate = `# Release of Vitess {{.Version}}
 
 {{- if or .Announcement .AddDetails }}
 ## Announcement
 {{ .Announcement }}
-{{- end }}
-
-{{- if .AddDetails }}
-> TODO: please detail these pull requests.
-{{ .AddDetails }}
 {{- end }}
 
 {{- if and (or .Announcement .AddDetails) (or .KnownIssues .ChangeLog) }}
@@ -99,17 +96,20 @@ const (
 {{- if .KnownIssues }}
 ## Known Issues
 {{ .KnownIssues }}
-
-{{- if .ChangeLog }}
-------------
-{{- end }}
 {{- end }}
 
 {{- if .ChangeLog }}
-## Changelog
-{{ .ChangeLog }}
+The entire changelog for this release can be found [here]({{ .PathToChangeLogFileOnGH }}).
+{{- end }}
+
+{{- if .ChangeLog }}
 {{ .ChangeMetrics }}
 {{- end }}
+`
+
+	markdownTemplateChangelog = `# Changelog of Vitess {{.Version}}
+{{ .ChangeLog }}
+{{ .ChangeMetrics }}
 `
 
 	markdownTemplatePR = `
@@ -145,18 +145,32 @@ func (l labels) needsToList() bool {
 	return false
 }
 
-func (l labels) needsDetails() bool {
-	for _, label := range l {
-		if label.Name == "release notes (needs details)" {
-			return true
+func (rn *releaseNote) generate(rnFile, changelogFile *os.File) error {
+	var err error
+	// Generate the release notes
+	rn.PathToChangeLogFileOnGH = fmt.Sprintf(releaseNotesPathGitHub+"%s_changelog.md", rn.VersionUnderscore)
+	if rnFile == nil {
+		rnFile, err = os.OpenFile(fmt.Sprintf(path.Join(releaseNotesPath, "%s_release_notes.md"), rn.VersionUnderscore), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+		if err != nil {
+			return err
 		}
 	}
-	return false
-}
 
-func (rn *releaseNote) generate(writeTo io.Writer) error {
 	t := template.Must(template.New("release_notes").Parse(markdownTemplate))
-	err := t.ExecuteTemplate(writeTo, "release_notes", rn)
+	err = t.ExecuteTemplate(rnFile, "release_notes", rn)
+	if err != nil {
+		return err
+	}
+
+	// Generate the changelog
+	if changelogFile == nil {
+		changelogFile, err = os.OpenFile(fmt.Sprintf(path.Join(releaseNotesPath, "%s_changelog.md"), rn.VersionUnderscore), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+		if err != nil {
+			return err
+		}
+	}
+	t = template.Must(template.New("release_notes_changelog").Parse(markdownTemplateChangelog))
+	err = t.ExecuteTemplate(changelogFile, "release_notes_changelog", rn)
 	if err != nil {
 		return err
 	}
@@ -283,7 +297,7 @@ type req struct {
 	key  string
 }
 
-func loadAllPRs(prs, authorCommits []string) ([]prInfo, []prInfo, []string, error) {
+func loadAllPRs(prs, authorCommits []string) ([]prInfo, []string, error) {
 	errChan := make(chan error)
 	wgDone := make(chan bool)
 	prChan := make(chan req, len(prs)+len(authorCommits))
@@ -296,7 +310,7 @@ func loadAllPRs(prs, authorCommits []string) ([]prInfo, []prInfo, []string, erro
 	}
 	close(prChan)
 
-	var prInfos, prNeedsDetails []prInfo
+	var prInfos []prInfo
 	var authors []string
 	fmt.Printf("Found %d merged PRs. Loading PR info", len(prs))
 	wg := sync.WaitGroup{}
@@ -324,9 +338,7 @@ func loadAllPRs(prs, authorCommits []string) ([]prInfo, []prInfo, []string, erro
 	addPR := func(in prInfo) {
 		mu.Lock()
 		defer mu.Unlock()
-		if in.Labels.needsDetails() {
-			prNeedsDetails = append(prNeedsDetails, in)
-		} else if in.Labels.needsToList() {
+		if in.Labels.needsToList() {
 			prInfos = append(prInfos, in)
 		}
 	}
@@ -380,7 +392,7 @@ func loadAllPRs(prs, authorCommits []string) ([]prInfo, []prInfo, []string, erro
 
 	sort.Strings(authors)
 
-	return prInfos, prNeedsDetails, authors, err
+	return prInfos, authors, err
 }
 
 func groupPRs(prInfos []prInfo) prsByType {
@@ -453,14 +465,6 @@ func releaseSummary(summaryFile string) (string, error) {
 	return string(contentSummary), nil
 }
 
-func getOutput(fileout string) (*os.File, error) {
-	if fileout == "" {
-		return os.Stdout, nil
-	}
-
-	return os.OpenFile(fileout, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
-}
-
 func getStringForPullRequestInfos(prPerType prsByType) (string, error) {
 	data := createSortedPrTypeSlice(prPerType)
 
@@ -501,11 +505,19 @@ func main() {
 	to := flag.String("to", "HEAD", "to sha/tag/branch")
 	versionName := flag.String("version", "", "name of the version (has to be the following format: v11.0.0)")
 	summaryFile := flag.String("summary", "", "readme file on which there is a summary of the release")
-	fileout := flag.String("file", "", "file on which to write release notes, stdout if empty")
 	flag.Parse()
 
+	// The -version flag must be of a valid format.
+	rx := regexp.MustCompile("v([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+	// There should be 4 sub-matches, input: "v14.0.0", output: ["v14.0.0", "14", "0", "0"].
+	versionMatch := rx.FindStringSubmatch(*versionName)
+	if len(versionMatch) != 4 {
+		log.Fatal("The -version flag must be set using a valid format. Format: 'vX.X.X'.")
+	}
+
 	releaseNotes := releaseNote{
-		Version: *versionName,
+		Version:           *versionName,
+		VersionUnderscore: fmt.Sprintf("%s_%s_%s", versionMatch[1], versionMatch[2], versionMatch[3]), // v14.0.0 -> 14_0_0, this is used to format filenames.
 	}
 
 	// summary of the release
@@ -518,32 +530,26 @@ func main() {
 	}
 
 	// known issues
-	if *versionName != "" {
-		knownIssues, err := loadKnownIssues(*versionName)
-		if err != nil {
-			log.Fatal(err)
-		}
-		knownIssuesStr, err := getStringForKnownIssues(knownIssues)
-		if err != nil {
-			log.Fatal(err)
-		}
-		releaseNotes.KnownIssues = knownIssuesStr
+	knownIssues, err := loadKnownIssues(*versionName)
+	if err != nil {
+		log.Fatal(err)
 	}
+	knownIssuesStr, err := getStringForKnownIssues(knownIssues)
+	if err != nil {
+		log.Fatal(err)
+	}
+	releaseNotes.KnownIssues = knownIssuesStr
 
 	// changelog with pull requests
 	prs, authorCommits, commits, err := loadMergedPRs(*from, *to)
 	if err != nil {
 		log.Fatal(err)
 	}
-	prInfos, prNeedsDetails, authors, err := loadAllPRs(prs, authorCommits)
+	prInfos, authors, err := loadAllPRs(prs, authorCommits)
 	if err != nil {
 		log.Fatal(err)
 	}
 	releaseNotes.ChangeLog, err = groupAndStringifyPullRequest(prInfos)
-	if err != nil {
-		log.Fatal(err)
-	}
-	releaseNotes.AddDetails, err = groupAndStringifyPullRequest(prNeedsDetails)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -557,12 +563,7 @@ Thanks to all our contributors: @%s
 `, commits, strings.Join(authors, ", @"))
 	}
 
-	out, err := getOutput(*fileout)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer out.Close()
-	if err := releaseNotes.generate(out); err != nil {
+	if err := releaseNotes.generate(nil, nil); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Description

This Pull Request changes how the release notes are generated. They are now divided into two files:
  - A changelog, that lists every Pull Request (regardless of the `release notes` label).
  - And the actual release notes file that contains the summary, the known issues, and a link to the changelog file.

> Reviewers: I have left the `15_0_0_*.md` files so you can have a preview, I intend to remove them before merging the Pull Request. 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
