### PR TITLE
[vtadmin] Add authzdocsgen to generate some website docs

### DIFF
--- a/go/vt/vtadmin/testutil/authztestgen/functions.go
+++ b/go/vt/vtadmin/testutil/authztestgen/functions.go
@@ -17,10 +17,29 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"vitess.io/vitess/go/vt/vtadmin/rbac"
 )
+
+func formatDocRow(m *DocMethod) string {
+	var buf strings.Builder
+	buf.WriteString("| `")
+	buf.WriteString(m.Name)
+	buf.WriteString("` | ")
+
+	for i, r := range m.Rules {
+		fmt.Fprintf(&buf, "`(%s, %s)`", r.Action, r.Resource)
+		if i != len(m.Rules)-1 {
+			buf.WriteString(", ")
+		}
+	}
+
+	buf.WriteString(" |")
+
+	return buf.String()
+}
 
 func getActor(actor *rbac.Actor) string {
 	var buf strings.Builder

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -167,8 +167,7 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 }
 `
 
-const _doct = `
-{{ range .Methods }}
-| {{ backtickEscape .Name }} | {{ range .Rules }}{{ end }} |
-{{ end }}
+const _doct = `{{ range .Methods -}}
+{{ formatDocRow . }}
+{{ end -}}
 `

--- a/go/vt/vtadmin/testutil/authztestgen/template.go
+++ b/go/vt/vtadmin/testutil/authztestgen/template.go
@@ -166,3 +166,9 @@ func testClusters(t testing.TB) []*cluster.Cluster {
 	return testutil.BuildClusters(t, configs...)
 }
 `
+
+const _doct = `
+{{ range .Methods }}
+| {{ backtickEscape .Name }} | {{ range .Rules }}{{ end }} |
+{{ end }}
+`


### PR DESCRIPTION

## Description

This extends the `authztestgen` code to include a template to also generate the markdown table of RBAC rules on the website, used in https://github.com/vitessio/website/pull/1018.

### NOTES

Explicitly calling these out (happy to hear disagreement on either point!):
- I don't think we should bother backporting this PR.
- I think this is one of the very few cases we actually want release-notes-none, but happy to hear disagreement!

## Related Issue(s)

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
