### PR TITLE
Add back unary single column expression check

### DIFF
--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -440,7 +440,7 @@ func translateConvertCharset(charset string, binary bool, lookup TranslationLook
 	return collationID, nil
 }
 
-func translateConvertExpr(expr sqlparser.Expr, type_ *sqlparser.ConvertType, lookup TranslationLookup) (Expr, error) {
+func translateConvertExpr(expr sqlparser.Expr, convertType *sqlparser.ConvertType, lookup TranslationLookup) (Expr, error) {
 	var (
 		convert ConvertExpr
 		err     error
@@ -451,17 +451,17 @@ func translateConvertExpr(expr sqlparser.Expr, type_ *sqlparser.ConvertType, loo
 		return nil, err
 	}
 
-	convert.Length, convert.HasLength, err = translateIntegral(type_.Length, lookup)
+	convert.Length, convert.HasLength, err = translateIntegral(convertType.Length, lookup)
 	if err != nil {
 		return nil, err
 	}
 
-	convert.Scale, convert.HasScale, err = translateIntegral(type_.Scale, lookup)
+	convert.Scale, convert.HasScale, err = translateIntegral(convertType.Scale, lookup)
 	if err != nil {
 		return nil, err
 	}
 
-	convert.Type = strings.ToUpper(type_.Type)
+	convert.Type = strings.ToUpper(convertType.Type)
 	switch convert.Type {
 	case "DECIMAL":
 		if convert.Length < convert.Scale {
@@ -483,7 +483,7 @@ func translateConvertExpr(expr sqlparser.Expr, type_ *sqlparser.ConvertType, loo
 	case "NCHAR":
 		convert.Collation = collations.CollationUtf8ID
 	case "CHAR":
-		convert.Collation, err = translateConvertCharset(type_.Charset.Name, type_.Charset.Binary, lookup)
+		convert.Collation, err = translateConvertCharset(convertType.Charset.Name, convertType.Charset.Binary, lookup)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/planbuilder/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/horizon_planning.go
@@ -732,7 +732,8 @@ func wrapAndPushExpr(ctx *plancontext.PlanningContext, expr sqlparser.Expr, weig
 			expr = unary.Expr
 		case *sqlparser.ConvertExpr:
 			expr = unary.Expr
-		default:
+		}
+		if !sqlparser.IsColName(expr) {
 			return 0, 0, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: in scatter query: complex order by expression: %s", sqlparser.String(expr))
 		}
 	}


### PR DESCRIPTION
This was accidentally removed in https://github.com/vitessio/vitess/pull/10512 but it shouldn't have
been.

It also updates the usage of a `type_` variable which the linters on older releases that use Go 1.17 will complain about (but the linter was disabled for Go 1.18). 

## Related Issue(s)

#10512

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required