### PR TITLE
Backport to release-14: Remove logging in GetDurabilityPolicy #10516

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -476,6 +476,7 @@ func (s *VtctldServer) ChangeTabletType(ctx context.Context, req *vtctldatapb.Ch
 	if err != nil {
 		return nil, err
 	}
+	log.Infof("Getting a new durability policy for %v", durabilityName)
 	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
 	if err != nil {
 		return nil, err
@@ -1750,6 +1751,7 @@ func (s *VtctldServer) InitShardPrimaryLocked(
 	if err != nil {
 		return err
 	}
+	log.Infof("Getting a new durability policy for %v", durabilityName)
 	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
 	if err != nil {
 		return err
@@ -2324,6 +2326,7 @@ func (s *VtctldServer) ReparentTablet(ctx context.Context, req *vtctldatapb.Repa
 	if err != nil {
 		return nil, err
 	}
+	log.Infof("Getting a new durability policy for %v", durabilityName)
 	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
 	if err != nil {
 		return nil, err
@@ -3035,6 +3038,7 @@ func (s *VtctldServer) StartReplication(ctx context.Context, req *vtctldatapb.St
 	if err != nil {
 		return nil, err
 	}
+	log.Infof("Getting a new durability policy for %v", durabilityName)
 	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
 	if err != nil {
 		return nil, err
@@ -3133,6 +3137,7 @@ func (s *VtctldServer) TabletExternallyReparented(ctx context.Context, req *vtct
 	if err != nil {
 		return nil, err
 	}
+	log.Infof("Getting a new durability policy for %v", durabilityName)
 	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtctl/reparentutil/durability.go
+++ b/go/vt/vtctl/reparentutil/durability.go
@@ -79,7 +79,6 @@ func GetDurabilityPolicy(name string) (Durabler, error) {
 	if !found {
 		return nil, fmt.Errorf("durability policy %v not found", name)
 	}
-	log.Infof("Getting a new durability policy for %v", name)
 	return newDurabilityCreationFunc(), nil
 }
 

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -167,6 +167,7 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		return err
 	}
 
+	erp.logger.Infof("Getting a new durability policy for %v", keyspaceDurability)
 	opts.durability, err = GetDurabilityPolicy(keyspaceDurability)
 	if err != nil {
 		return err

--- a/go/vt/vtctl/reparentutil/planned_reparenter.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter.go
@@ -514,6 +514,7 @@ func (pr *PlannedReparenter) reparentShardLocked(
 		return err
 	}
 
+	pr.logger.Infof("Getting a new durability policy for %v", keyspaceDurability)
 	opts.durability, err = GetDurabilityPolicy(keyspaceDurability)
 	if err != nil {
 		return err

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -188,6 +188,7 @@ func SetReplicationSource(ctx context.Context, ts *topo.Server, tmc tmclient.Tab
 	if err != nil {
 		return err
 	}
+	log.Infof("Getting a new durability policy for %v", durabilityName)
 	durability, err := GetDurabilityPolicy(durabilityName)
 	if err != nil {
 		return err

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -137,6 +137,7 @@ func (wr *Wrangler) TabletExternallyReparented(ctx context.Context, newPrimaryAl
 		if err != nil {
 			return err
 		}
+		log.Infof("Getting a new durability policy for %v", durabilityName)
 		durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
 		if err != nil {
 			return err


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR is the backport for #10516 which removes a log statement that was being overtly noisy.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
