### PR TITLE
Fix panic in VTOrc

### DIFF
--- a/go/vt/orchestrator/config/config.go
+++ b/go/vt/orchestrator/config/config.go
@@ -388,8 +388,8 @@ func newConfiguration() *Configuration {
 		WebMessage:                                  "",
 		MaxConcurrentReplicaOperations:              5,
 		InstanceDBExecContextTimeoutSeconds:         30,
-		LockShardTimeoutSeconds:                     1,
-		WaitReplicasTimeoutSeconds:                  1,
+		LockShardTimeoutSeconds:                     30,
+		WaitReplicasTimeoutSeconds:                  30,
 	}
 }
 

--- a/go/vt/orchestrator/logic/topology_recovery.go
+++ b/go/vt/orchestrator/logic/topology_recovery.go
@@ -704,7 +704,7 @@ func recoverDeadPrimary(ctx context.Context, analysisEntry inst.ReplicationAnaly
 
 	// We should refresh the tablet information again to update our information.
 	RefreshTablets(true /* forceRefresh */)
-	if ev.NewPrimary != nil {
+	if ev != nil && ev.NewPrimary != nil {
 		promotedReplica, _, _ = inst.ReadInstance(&inst.InstanceKey{
 			Hostname: ev.NewPrimary.MysqlHostname,
 			Port:     int(ev.NewPrimary.MysqlPort),
@@ -1681,7 +1681,7 @@ func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey
 	// For example, if we do not refresh the tablets forcefully and the new primary is found in the cache then its source key is not updated and this spawns off
 	// PrimaryHasPrimary analysis which runs ERS
 	RefreshTablets(true /* forceRefresh */)
-	if ev.NewPrimary != nil {
+	if ev != nil && ev.NewPrimary != nil {
 		promotedReplica, _, _ = inst.ReadInstance(&inst.InstanceKey{
 			Hostname: ev.NewPrimary.MysqlHostname,
 			Port:     int(ev.NewPrimary.MysqlPort),
@@ -1775,7 +1775,7 @@ func electNewPrimary(ctx context.Context, analysisEntry inst.ReplicationAnalysis
 	// For example, if we do not refresh the tablets forcefully and the new primary is found in the cache then its source key is not updated and this spawns off
 	// PrimaryHasPrimary analysis which runs ERS
 	RefreshTablets(true /* forceRefresh */)
-	if ev.NewPrimary != nil {
+	if ev != nil && ev.NewPrimary != nil {
 		promotedReplica, _, _ = inst.ReadInstance(&inst.InstanceKey{
 			Hostname: ev.NewPrimary.MysqlHostname,
 			Port:     int(ev.NewPrimary.MysqlPort),


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
A panic was seen in VTOrc with the following log - 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0xec5205]

goroutine 1444 [running]:
vitess.io/vitess/go/vt/orchestrator/logic.electNewPrimary({_, _}, {{{0xc00134cd70, 0xc}, 0xcea}, {{0xc00134ce80, 0xc}, 0xcea}, 0x2, {0x0, ...}, ...}, ...)
	vitess.io/vitess/go/vt/orchestrator/logic/topology_recovery.go:1778 +0x485
vitess.io/vitess/go/vt/orchestrator/logic.executeCheckAndRecoverFunction({{{0xc00134cd70, 0xc}, 0xcea}, {{0xc00134ce80, 0xc}, 0xcea}, 0x2, {0x0, 0x0, 0x0}, ...}, ...)
	vitess.io/vitess/go/vt/orchestrator/logic/topology_recovery.go:1395 +0xbbe
vitess.io/vitess/go/vt/orchestrator/logic.CheckAndRecover.func1()
	vitess.io/vitess/go/vt/orchestrator/logic/topology_recovery.go:1483 +0x5f
created by vitess.io/vitess/go/vt/orchestrator/logic.CheckAndRecover
	vitess.io/vitess/go/vt/orchestrator/logic/topology_recovery.go:1482 +0x470
```

On investigation it was found to occur because the `*events.Reparent` field returned was nil and the code does not check if the field is nil.

This PR fixes this panic by checking if `ev` is nil before using its fields.

This PR also increases the timeout of the default values of `LockShardTimeoutSeconds` and `WaitReplicasTimeoutSeconds` to 30 seconds each.
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
