### PR TITLE
Make etcd based tests more deterministic and surface errors

### DIFF
--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -57,6 +57,9 @@ func (topo *TopoProcess) Setup(topoFlavor string, cluster *LocalProcessCluster) 
 	case "consul":
 		return topo.SetupConsul(cluster)
 	default:
+		// We still rely on the etcd v2 API for things like mkdir
+		// If this ENV var is not set then tests will fail with etcd 3.x
+		os.Setenv("ETCDCTL_API", "2")
 		return topo.SetupEtcd()
 	}
 }

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -57,8 +57,9 @@ func (topo *TopoProcess) Setup(topoFlavor string, cluster *LocalProcessCluster) 
 	case "consul":
 		return topo.SetupConsul(cluster)
 	default:
-		// We still rely on the etcd v2 API for things like mkdir
-		// If this ENV var is not set then tests will fail with etcd 3.x
+		// We still rely on the etcd v2 API for things like mkdir.
+		// If this ENV var is not set then some tests may fail with etcd 3.4+
+		// where the v2 API is disabled by default in both the client and server.
 		os.Setenv("ETCDCTL_API", "2")
 		return topo.SetupEtcd()
 	}

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -310,10 +310,12 @@ func NewVitessCluster(t *testing.T, name string, cellNames []string, clusterConf
 
 	require.NotNil(t, topo)
 	require.Nil(t, topo.Setup("etcd2", nil))
-	topo.ManageTopoDir("mkdir", "/vitess/global")
+	err := topo.ManageTopoDir("mkdir", "/vitess/global")
+	require.NoError(t, err)
 	vc.Topo = topo
 	for _, cellName := range cellNames {
-		topo.ManageTopoDir("mkdir", "/vitess/"+cellName)
+		err := topo.ManageTopoDir("mkdir", "/vitess/"+cellName)
+		require.NoError(t, err)
 	}
 
 	vtctld := cluster.VtctldProcessInstance(vc.ClusterConfig.vtctldPort, vc.ClusterConfig.vtctldGrpcPort,


### PR DESCRIPTION
## Description

We were relying on an ENV variable being set — `ETCDCTL_API=2` — when running tests locally with [etcd 3.4+ where the v2 api is disabled by default](https://etcd.io/docs/v3.4/upgrades/upgrade_3_4/#make-etcd---enable-v2false-default).

And we were swallowing errors when creating the initial topo data. This led to confusing test failures later on when e.g.
creating the keyspace:
```
E0615 13:58:10.394159   48632 vtctl_process.go:66] CreateKeyspace returned err: exit status 255, output: E0615 13:58:10.276250   48641 vtctl.go:170] action failed: CreateKeyspace GetKnownCells failed: node doesn't exist: /vitess/global/cells/
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were updated
-   [x] Documentation is not required