### PR TITLE
[13.0] Take into account `github.ref` when doing upgrade-downgrade tests

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -24,14 +24,14 @@ jobs:
         with:
           label: Skip Upgrade Downgrade
 
-  get_latest_release:
+  get_previous_release:
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
     name: Get latest release
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
     outputs:
-      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
+      previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
     steps:
       - name: Check out to HEAD
@@ -40,20 +40,20 @@ jobs:
           fetch-depth: 0
 
       - name: Set output with latest release branch
-        id: output-latest-release-branch
+        id: output-previous-release-ref
         run: |
-          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
-          echo $latest_release_branch
-          echo "::set-output name=latest_release_branch::${latest_release_branch}"
+          previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $previous_release_ref
+          echo "::set-output name=previous_release_ref::${previous_release_ref}"
 
   upgrade_downgrade_test_e2e:
     timeout-minutes: 60
-    if: always() && (needs.get_latest_release.result == 'success')
+    if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-18.04
     needs:
       - get_upgrade_downgrade_label
-      - get_latest_release
+      - get_previous_release
 
     steps:
     - name: Set up Go
@@ -91,10 +91,10 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     # Checkout to the last release of Vitess
-    - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+    - name: Check out other version's code (${{ needs.get_previous_release.outputs.previous_release }})
       uses: actions/checkout@v2
       with:
-        ref: ${{ needs.get_latest_release.outputs.latest_release }}
+        ref: ${{ needs.get_previous_release.outputs.previous_release }}
 
     - name: Get dependencies for the last release
       run: |

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -24,14 +24,14 @@ jobs:
         with:
           label: Skip Upgrade Downgrade
 
-  get_latest_release:
+  get_previous_release:
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
     name: Get latest release
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
     outputs:
-      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
+      previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
     steps:
       - name: Check out to HEAD
@@ -40,21 +40,21 @@ jobs:
           fetch-depth: 0
 
       - name: Set output with latest release branch
-        id: output-latest-release-branch
+        id: output-previous-release-ref
         run: |
-          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
-          echo $latest_release_branch
-          echo "::set-output name=latest_release_branch::${latest_release_branch}"
+          previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $previous_release_ref
+          echo "::set-output name=previous_release_ref::${previous_release_ref}"
 
   # This job usually execute in ± 20 minutes
   upgrade_downgrade_test_manual:
     timeout-minutes: 40
-    if: always() && (needs.get_latest_release.result == 'success')
+    if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test Backup Manual
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
-      - get_latest_release
+      - get_previous_release
 
     steps:
     - name: Set up Go
@@ -111,10 +111,10 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     # Checkout to the last release of Vitess
-    - name: Checkout to the other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+    - name: Checkout to the other version's code (${{ needs.get_previous_release.outputs.previous_release }})
       uses: actions/checkout@v2
       with:
-        ref: ${{ needs.get_latest_release.outputs.latest_release }}
+        ref: ${{ needs.get_previous_release.outputs.previous_release }}
 
     - name: Get dependencies for the last release
       run: |

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -26,14 +26,14 @@ jobs:
         with:
           label: Skip Upgrade Downgrade
 
-  get_latest_release:
+  get_previous_release:
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
     name: Get latest release
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
     outputs:
-      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
+      previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
     steps:
       - name: Check out to HEAD
@@ -42,19 +42,19 @@ jobs:
           fetch-depth: 0
 
       - name: Set output with latest release branch
-        id: output-latest-release-branch
+        id: output-previous-release-ref
         run: |
-          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
-          echo $latest_release_branch
-          echo "::set-output name=latest_release_branch::${latest_release_branch}"
+          previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $previous_release_ref
+          echo "::set-output name=previous_release_ref::${previous_release_ref}"
 
   upgrade_downgrade_test:
-    if: always() && (needs.get_latest_release.result == 'success')
+    if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
-      - get_latest_release
+      - get_previous_release
 
     steps:
     - name: Set up Go
@@ -105,10 +105,10 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     # Checkout to the last release of Vitess
-    - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+    - name: Check out other version's code (${{ needs.get_previous_release.outputs.previous_release }})
       uses: actions/checkout@v2
       with:
-        ref: ${{ needs.get_latest_release.outputs.latest_release }}
+        ref: ${{ needs.get_previous_release.outputs.previous_release }}
 
     - name: Get dependencies for the last release
       run: |

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -26,14 +26,14 @@ jobs:
         with:
           label: Skip Upgrade Downgrade
 
-  get_latest_release:
+  get_previous_release:
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
     name: Get latest release
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
     outputs:
-      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
+      previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
     steps:
       - name: Check out to HEAD
@@ -42,19 +42,19 @@ jobs:
           fetch-depth: 0
 
       - name: Set output with latest release branch
-        id: output-latest-release-branch
+        id: output-previous-release-ref
         run: |
-          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
-          echo $latest_release_branch
-          echo "::set-output name=latest_release_branch::${latest_release_branch}"
+          previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $previous_release_ref
+          echo "::set-output name=previous_release_ref::${previous_release_ref}"
 
   upgrade_downgrade_test:
-    if: always() && (needs.get_latest_release.result == 'success')
+    if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
-      - get_latest_release
+      - get_previous_release
 
     steps:
     - name: Set up Go
@@ -105,10 +105,10 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     # Checkout to the last release of Vitess
-    - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+    - name: Check out other version's code (${{ needs.get_previous_release.outputs.previous_release }})
       uses: actions/checkout@v2
       with:
-        ref: ${{ needs.get_latest_release.outputs.latest_release }}
+        ref: ${{ needs.get_previous_release.outputs.previous_release }}
 
     - name: Get dependencies for the last release
       run: |

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -26,14 +26,14 @@ jobs:
         with:
           label: Skip Upgrade Downgrade
 
-  get_latest_release:
+  get_previous_release:
     if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
     name: Get latest release
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
     outputs:
-      latest_release: ${{ steps.output-latest-release-branch.outputs.latest_release_branch }}
+      previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
     steps:
       - name: Check out to HEAD
@@ -42,19 +42,19 @@ jobs:
           fetch-depth: 0
 
       - name: Set output with latest release branch
-        id: output-latest-release-branch
+        id: output-previous-release-ref
         run: |
-          latest_release_branch=$(./tools/get_latest_release.sh ${{github.base_ref}})
-          echo $latest_release_branch
-          echo "::set-output name=latest_release_branch::${latest_release_branch}"
+          previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $previous_release_ref
+          echo "::set-output name=previous_release_ref::${previous_release_ref}"
 
   upgrade_downgrade_test:
-    if: always() && (needs.get_latest_release.result == 'success')
+    if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:
       - get_upgrade_downgrade_label
-      - get_latest_release
+      - get_previous_release
 
     steps:
     - name: Set up Go
@@ -105,10 +105,10 @@ jobs:
         sudo apt-get install percona-xtrabackup-24
 
     # Checkout to the last release of Vitess
-    - name: Check out other version's code (${{ needs.get_latest_release.outputs.latest_release }})
+    - name: Check out other version's code (${{ needs.get_previous_release.outputs.previous_release }})
       uses: actions/checkout@v2
       with:
-        ref: ${{ needs.get_latest_release.outputs.latest_release }}
+        ref: ${{ needs.get_previous_release.outputs.previous_release }}
 
     - name: Get dependencies for the last release
       run: |

--- a/tools/get_previous_release.sh
+++ b/tools/get_previous_release.sh
@@ -23,6 +23,9 @@
 target_release=""
 
 base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*.0$')
+if [ "$base_release_branch" == "" ]; then
+  base_release_branch=$(echo "$2" | grep -E 'release-[0-9]*.0$')
+fi
 if [ "$base_release_branch" != "" ]; then
   major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
   target_major_release=$((major_release-1))


### PR DESCRIPTION
## Description

This is a backport of #10504 on `release-13.0`.

## Related Issue(s)

- fixes https://github.com/vitessio/vitess/pull/10503

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
