### PR TITLE
[vtadmin/tests] Serialize Schema test cases to avoid cache backfill races

### DIFF
--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -510,7 +510,6 @@ func TestFindSchema(t *testing.T) {
 	})
 
 	t.Run("unauthorized actor", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "unauthorized"}
 
 		ctx := context.Background()
@@ -526,7 +525,6 @@ func TestFindSchema(t *testing.T) {
 	})
 
 	t.Run("partial access", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "allowed-other"}
 
 		ctx := context.Background()
@@ -541,7 +539,6 @@ func TestFindSchema(t *testing.T) {
 	})
 
 	t.Run("full access", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "allowed-all"}
 
 		ctx := context.Background()
@@ -1139,7 +1136,6 @@ func TestGetSchema(t *testing.T) {
 	})
 
 	t.Run("unauthorized actor", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "other"}
 
 		ctx := context.Background()
@@ -1157,7 +1153,6 @@ func TestGetSchema(t *testing.T) {
 	})
 
 	t.Run("authorized actor", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "allowed"}
 
 		ctx := context.Background()
@@ -1212,7 +1207,6 @@ func TestGetSchemas(t *testing.T) {
 	})
 
 	t.Run("unauthorized actor", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "unauthorized"}
 
 		ctx := context.Background()
@@ -1226,7 +1220,6 @@ func TestGetSchemas(t *testing.T) {
 	})
 
 	t.Run("partial access", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "allowed-other"}
 
 		ctx := context.Background()
@@ -1247,7 +1240,6 @@ func TestGetSchemas(t *testing.T) {
 	})
 
 	t.Run("full access", func(t *testing.T) {
-		t.Parallel()
 		actor := &rbac.Actor{Name: "allowed-all"}
 
 		ctx := context.Background()

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -440,6 +440,7 @@
                 }
             ],
             "request": "&vtadminpb.FindSchemaRequest{\nTable: \"t1\",\n}",
+            "serialize_cases": true,
             "cases": [
                 {
                     "name": "unauthorized actor",
@@ -808,6 +809,7 @@
                 }
             ],
             "request": "&vtadminpb.GetSchemaRequest{\nClusterId: \"test\",\nKeyspace: \"test\",\nTable: \"t1\",\n}",
+            "serialize_cases": true,
             "cases": [
                 {
                     "name": "unauthorized actor",
@@ -847,6 +849,7 @@
                 }
             ],
             "request": "&vtadminpb.GetSchemasRequest{}",
+            "serialize_cases": true,
             "cases": [
                 {
                     "name": "unauthorized actor",


### PR DESCRIPTION
## Description

What it says on the tin.

Before, `go test -race -run '.*Schema.*' -count=10 ./go/vt/vtadmin/` failed reliably locally, and passes reliably (N=3, to be fair) now.

## Related Issue(s)

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
