### PR TITLE
Fixing flaky vtctld2 web test

### DIFF
--- a/go/test/endtoend/vtctldweb/vtctld_web_test.go
+++ b/go/test/endtoend/vtctldweb/vtctld_web_test.go
@@ -19,6 +19,7 @@ package vtctldweb
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,6 +133,7 @@ func TestCreateKs(t *testing.T) {
 	dismiss, err := dialog.FindElement(selenium.ByID, "vt-dismiss")
 	require.Nil(t, err)
 	click(t, dismiss)
+	time.Sleep(5 * time.Microsecond)
 
 	ksNames := getDashboardKeyspaces(t)
 	assert.ElementsMatch(t, []string{"test_keyspace", "test_keyspace2", "test_keyspace3"}, ksNames)


### PR DESCRIPTION
Signed-off-by: notfelineit <notfelineit@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
The selenium test for `TestCreateKs` is always flaky. After hunting around the web, my hunch is that _sometimes_ the DOM has not updated before the test executes `getDashboardKeyspaces`. To address randomness in DOM rendering, I've added an explicit wait for the DOM to refresh and render the new keyspace HTML objects. While that seems weird, at the end of the day there is some randomness in DOM rendering (from the network, machine, etc.).

I think this is the issue because while the test only tests creating 1 new keyspace `test-keyspace-3`, the failing tests show that none of the keyspaces show up (which doesn't make any sense):
```
I0610 00:59:44.459026   13243 vschema_manager.go:102] Received vschema update
    vtctld_web_test.go:137: 
        	Error Trace:	vtctld_web_test.go:137
        	Error:      	elements differ
        	            	extra elements in list A:
        	            	([]interface {}) (len=3) {
        	            	 (string) (len=13) "test_keyspace",
        	            	 (string) (len=14) "test_keyspace2",
        	            	 (string) (len=14) "test_keyspace3"
        	            	}
        	            	listA:
        	            	([]string) (len=3) {
        	            	 (string) (len=13) "test_keyspace",
        	            	 (string) (len=14) "test_keyspace2",
        	            	 (string) (len=14) "test_keyspace3"
        	            	}
        	            	listB:
        	            	([]string) <nil>
        	Test:       	TestCreateKs
```
That makes me think none of the HTML objects have loaded yet, hence a DOM rendering issue.

## Related Issue(s)
N/A

## Checklist

-   [X] "Backport me!" label has been added if this change should be backported **No**
-   [X] Tests were added or are not required **This modifies a test**
-   [x] Documentation was added or is not required **Not required**

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
