### PR TITLE
[14.0] fix: scalar aggregation engine primitive

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -33,7 +33,7 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	deleteAll := func() {
 		_, _ = utils.ExecAllowError(t, mcmp.VtConn, "set workload = oltp")
 
-		tables := []string{"aggr_test", "t3", "t7_xxhash", "aggr_test_dates", "t7_xxhash_idx"}
+		tables := []string{"aggr_test", "t3", "t7_xxhash", "aggr_test_dates", "t7_xxhash_idx", "t1", "t2"}
 		for _, table := range tables {
 			_, _ = mcmp.ExecAndIgnore("delete from " + table)
 		}
@@ -337,6 +337,21 @@ func TestAggOnTopOfLimit(t *testing.T) {
 			mcmp.AssertMatches(" select /*vt+ PLANNER=gen4 */ count(val2), sum(val2) from (select id, val2 from aggr_test where val2 is null limit 2) as x", "[[INT64(0) NULL]]")
 			mcmp.AssertMatches(" select /*vt+ PLANNER=gen4 */ val1, count(*), sum(id) from (select id, val1 from aggr_test where val2 < 4 order by val1 limit 2) as x group by val1", `[[NULL INT64(1) DECIMAL(7)] [VARCHAR("a") INT64(1) DECIMAL(2)]]`)
 			mcmp.AssertMatchesNoOrder(" select /*vt+ PLANNER=gen4 */ val1, count(val2), sum(val2) from (select val1, val2 from aggr_test limit 8) as x group by val1", `[[NULL INT64(1) DECIMAL(2)] [VARCHAR("a") INT64(2) DECIMAL(7)] [VARCHAR("b") INT64(1) DECIMAL(1)] [VARCHAR("c") INT64(2) DECIMAL(7)]]`)
+		})
+	}
+}
+
+func TestEmptyTableAggr(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	for _, workload := range []string{"oltp", "olap"} {
+		t.Run(workload, func(t *testing.T) {
+			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = %s", workload))
+			mcmp.AssertMatches(" select /*vt+ PLANNER=gen4 */ count(*) from t1 inner join t2 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
+			mcmp.AssertMatches(" select /*vt+ PLANNER=gen4 */ count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo'", "[[INT64(0)]]")
+			mcmp.AssertMatches(" select /*vt+ PLANNER=gen4 */ t1.`name`, count(*) from t2 inner join t1 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
+			mcmp.AssertMatches(" select /*vt+ PLANNER=gen4 */ t1.`name`, count(*) from t1 inner join t2 on (t1.t1_id = t2.id) where t1.value = 'foo' group by t1.`name`", "[]")
 		})
 	}
 }

--- a/go/test/endtoend/vtgate/queries/aggregation/schema.sql
+++ b/go/test/endtoend/vtgate/queries/aggregation/schema.sql
@@ -54,3 +54,18 @@ create table t7_xxhash_idx
     keyspace_id varbinary(50),
     primary key (phone, keyspace_id)
 ) Engine = InnoDB;
+
+CREATE TABLE t1 (
+    t1_id bigint unsigned NOT NULL,
+    `name` varchar(20) NOT NULL,
+    `value` varchar(50),
+    shardKey bigint,
+    UNIQUE KEY `t1id_name` (t1_id, `name`),
+    KEY `IDX_TA_ValueName` (`value`(20), `name`(10))
+) ENGINE InnoDB;
+
+CREATE TABLE t2 (
+    id bigint NOT NULL,
+    shardKey bigint,
+    PRIMARY KEY (id)
+) ENGINE InnoDB;

--- a/go/test/endtoend/vtgate/queries/aggregation/vschema.json
+++ b/go/test/endtoend/vtgate/queries/aggregation/vschema.json
@@ -107,6 +107,22 @@
           "name": "unicode_loose_xxhash"
         }
       ]
+    },
+    "t1": {
+      "column_vindexes": [
+        {
+          "column": "shardKey",
+          "name": "hash"
+        }
+      ]
+    },
+    "t2": {
+      "column_vindexes": [
+        {
+          "column": "shardKey",
+          "name": "hash"
+        }
+      ]
     }
   }
 }

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -108,6 +108,10 @@ type AggregateParams struct {
 	Alias    string `json:",omitempty"`
 	Expr     sqlparser.Expr
 	Original *sqlparser.AliasedExpr
+
+	// This is based on the function passed in the select expression and
+	// not what we use to aggregate at the engine primitive level.
+	OrigOpcode AggregateOpcode
 }
 
 func (ap *AggregateParams) isDistinct() bool {
@@ -127,10 +131,14 @@ func (ap *AggregateParams) String() string {
 		collation := collations.Local().LookupByID(ap.CollationID)
 		keyCol += " COLLATE " + collation.Name()
 	}
-	if ap.Alias != "" {
-		return fmt.Sprintf("%s(%s) AS %s", ap.Opcode.String(), keyCol, ap.Alias)
+	dispOrigOp := ""
+	if ap.OrigOpcode != AggregateUnassigned && ap.OrigOpcode != ap.Opcode {
+		dispOrigOp = "_" + ap.OrigOpcode.String()
 	}
-	return fmt.Sprintf("%s(%s)", ap.Opcode.String(), keyCol)
+	if ap.Alias != "" {
+		return fmt.Sprintf("%s%s(%s) AS %s", ap.Opcode.String(), dispOrigOp, keyCol, ap.Alias)
+	}
+	return fmt.Sprintf("%s%s(%s)", ap.Opcode.String(), dispOrigOp, keyCol)
 }
 
 // AggregateOpcode is the aggregation Opcode.
@@ -138,7 +146,8 @@ type AggregateOpcode int
 
 // These constants list the possible aggregate opcodes.
 const (
-	AggregateCount = AggregateOpcode(iota)
+	AggregateUnassigned = AggregateOpcode(iota)
+	AggregateCount
 	AggregateSum
 	AggregateMin
 	AggregateMax

--- a/go/vt/vtgate/engine/projection_test.go
+++ b/go/vt/vtgate/engine/projection_test.go
@@ -69,3 +69,38 @@ func TestMultiply(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "[[UINT64(6)] [UINT64(0)] [UINT64(2)]]", fmt.Sprintf("%v", qr.Rows))
 }
+
+func TestEmptyInput(t *testing.T) {
+	expr := &sqlparser.BinaryExpr{
+		Operator: sqlparser.MultOp,
+		Left:     &sqlparser.Offset{V: 0},
+		Right:    &sqlparser.Offset{V: 1},
+	}
+	evalExpr, err := evalengine.Translate(expr, nil)
+	require.NoError(t, err)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "uint64|uint64"))},
+	}
+	proj := &Projection{
+		Cols:       []string{"count(*)"},
+		Exprs:      []evalengine.Expr{evalExpr},
+		Input:      fp,
+		noTxNeeded: noTxNeeded{},
+	}
+	qr, err := proj.TryExecute(&noopVCursor{}, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", fmt.Sprintf("%v", qr.Rows))
+
+	//fp = &fakePrimitive{
+	//	results: []*sqltypes.Result{sqltypes.MakeTestResult(
+	//		sqltypes.MakeTestFields("a|b", "uint64|uint64"),
+	//		"3|2",
+	//		"1|0",
+	//		"1|2",
+	//	)},
+	//}
+	//proj.Input = fp
+	//qr, err = wrapStreamExecute(proj, newNoopVCursor(context.Background()), nil, true)
+	//require.NoError(t, err)
+	//assert.Equal(t, "[[UINT64(6)] [UINT64(0)] [UINT64(2)]]", fmt.Sprintf("%v", qr.Rows))
+}

--- a/go/vt/vtgate/engine/scalar_aggregation.go
+++ b/go/vt/vtgate/engine/scalar_aggregation.go
@@ -167,6 +167,20 @@ func (sa *ScalarAggregate) TryStreamExecute(vcursor VCursor, bindVars map[string
 		return err
 	}
 
+	if current == nil {
+		// When doing aggregation without grouping keys, we need to produce a single row containing zero-value for the
+		// different aggregation functions
+		current, err = sa.createEmptyRow()
+		if err != nil {
+			return err
+		}
+	} else {
+		current, err = convertFinal(current, sa.Aggregates)
+		if err != nil {
+			return err
+		}
+	}
+
 	return cb(&sqltypes.Result{Rows: [][]sqltypes.Value{current}})
 }
 
@@ -174,7 +188,11 @@ func (sa *ScalarAggregate) TryStreamExecute(vcursor VCursor, bindVars map[string
 func (sa *ScalarAggregate) createEmptyRow() ([]sqltypes.Value, error) {
 	out := make([]sqltypes.Value, len(sa.Aggregates))
 	for i, aggr := range sa.Aggregates {
-		value, err := createEmptyValueFor(aggr.Opcode)
+		op := aggr.Opcode
+		if aggr.OrigOpcode != AggregateUnassigned {
+			op = aggr.OrigOpcode
+		}
+		value, err := createEmptyValueFor(op)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/engine/scalar_aggregation_test.go
+++ b/go/vt/vtgate/engine/scalar_aggregation_test.go
@@ -29,6 +29,7 @@ import (
 func TestEmptyRows(outer *testing.T) {
 	testCases := []struct {
 		opcode      AggregateOpcode
+		origOpcode  AggregateOpcode
 		expectedVal string
 		expectedTyp string
 	}{{
@@ -47,6 +48,11 @@ func TestEmptyRows(outer *testing.T) {
 		opcode:      AggregateSum,
 		expectedVal: "null",
 		expectedTyp: "int64",
+	}, {
+		opcode:      AggregateSum,
+		expectedVal: "0",
+		expectedTyp: "int64",
+		origOpcode:  AggregateCount,
 	}, {
 		opcode:      AggregateMax,
 		expectedVal: "null",
@@ -73,9 +79,10 @@ func TestEmptyRows(outer *testing.T) {
 			oa := &ScalarAggregate{
 				PreProcess: true,
 				Aggregates: []*AggregateParams{{
-					Opcode: test.opcode,
-					Col:    0,
-					Alias:  test.opcode.String(),
+					Opcode:     test.opcode,
+					Col:        0,
+					Alias:      test.opcode.String(),
+					OrigOpcode: test.origOpcode,
 				}},
 				Input: fp,
 			}

--- a/go/vt/vtgate/planbuilder/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/horizon_planning.go
@@ -421,11 +421,12 @@ func generateAggregateParams(aggrs []abstract.Aggr, aggrParamOffsets [][]offsets
 		}
 
 		aggrParams[idx] = &engine.AggregateParams{
-			Opcode:   opcode,
-			Col:      offset,
-			Alias:    aggr.Alias,
-			Expr:     aggr.Original.Expr,
-			Original: aggr.Original,
+			Opcode:     opcode,
+			Col:        offset,
+			Alias:      aggr.Alias,
+			Expr:       aggr.Original.Expr,
+			Original:   aggr.Original,
+			OrigOpcode: aggr.OpCode,
 		}
 	}
 	return aggrParams, nil

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -107,7 +107,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(0) AS count",
+    "Aggregates": "sum_count(0) AS count",
     "GroupBy": "1, 4, 3",
     "ResultColumns": 4,
     "Inputs": [
@@ -133,7 +133,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "GroupBy": "(1|4), 2 COLLATE latin1_swedish_ci, (3|5)",
     "ResultColumns": 4,
     "Inputs": [
@@ -161,7 +161,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(0) AS count",
+    "Aggregates": "sum_count(0) AS count",
     "GroupBy": "1",
     "Inputs": [
       {
@@ -185,7 +185,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "GroupBy": "1",
     "Inputs": [
       {
@@ -218,7 +218,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(0) AS count",
+        "Aggregates": "sum_count(0) AS count",
         "GroupBy": "1, 4, 3",
         "ResultColumns": 5,
         "Inputs": [
@@ -252,7 +252,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(0) AS k",
+        "Aggregates": "sum_count_star(0) AS k",
         "GroupBy": "(1|4), 2 COLLATE latin1_swedish_ci, (3|5)",
         "Inputs": [
           {
@@ -281,7 +281,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count",
+    "Aggregates": "sum_count(0) AS count",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -303,7 +303,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -596,7 +596,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count",
+    "Aggregates": "sum_count(1) AS count",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -620,7 +620,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(*)",
+    "Aggregates": "sum_count_star(1) AS count(*)",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -648,7 +648,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(*)",
+    "Aggregates": "sum_count_star(1) AS count(*)",
     "GroupBy": "0, (2|3)",
     "ResultColumns": 2,
     "Inputs": [
@@ -676,7 +676,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count",
+    "Aggregates": "sum_count(1) AS count",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -701,7 +701,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(*)",
+    "Aggregates": "sum_count_star(1) AS count(*)",
     "GroupBy": "(0|2)",
     "ResultColumns": 2,
     "Inputs": [
@@ -871,7 +871,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS count",
+        "Aggregates": "sum_count(0) AS count",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -901,7 +901,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -928,7 +928,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(1) AS count",
+    "Aggregates": "sum_count(1) AS count",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -950,7 +950,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "random(0) AS id, sum(1) AS count(*)",
+    "Aggregates": "random(0) AS id, sum_count_star(1) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -1048,7 +1048,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count",
+    "Aggregates": "sum_count(1) AS count",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -1072,7 +1072,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(distinct id)",
+    "Aggregates": "sum_count_distinct(1) AS count(distinct id)",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -1099,7 +1099,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "count_distinct(1) AS count(distinct col2)",
+    "Aggregates": "count_distinct_count(1) AS count(distinct col2)",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -1152,7 +1152,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "count_distinct(0) AS count(distinct col2)",
+    "Aggregates": "count_distinct_count(0) AS count(distinct col2)",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -1203,7 +1203,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "count_distinct(1) AS c2",
+    "Aggregates": "count_distinct_count(1) AS c2",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -1256,7 +1256,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum_distinct(1) AS sum(distinct col2)",
+    "Aggregates": "sum_distinct_sum(1) AS sum(distinct col2)",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -1367,7 +1367,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "count_distinct(1) AS k",
+        "Aggregates": "count_distinct_count(1) AS k",
         "GroupBy": "0",
         "Inputs": [
           {
@@ -1434,7 +1434,7 @@ Gen4 error: Can't group on 'count(*)'
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(2) AS count",
+    "Aggregates": "sum_count(2) AS count",
     "GroupBy": "1, 0",
     "Inputs": [
       {
@@ -1459,7 +1459,7 @@ Gen4 error: Can't group on 'count(*)'
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(2) AS count(*)",
+    "Aggregates": "sum_count_star(2) AS count(*)",
     "GroupBy": "(0|3), (1|4)",
     "ResultColumns": 3,
     "Inputs": [
@@ -1487,7 +1487,7 @@ Gen4 error: Can't group on 'count(*)'
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(2) AS count",
+    "Aggregates": "sum_count(2) AS count",
     "GroupBy": "1, 0",
     "Inputs": [
       {
@@ -1512,7 +1512,7 @@ Gen4 error: Can't group on 'count(*)'
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(2) AS count(*)",
+    "Aggregates": "sum_count_star(2) AS count(*)",
     "GroupBy": "(0|3), (1|4)",
     "ResultColumns": 3,
     "Inputs": [
@@ -1540,7 +1540,7 @@ Gen4 error: Can't group on 'count(*)'
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(2) AS count",
+    "Aggregates": "sum_count(2) AS count",
     "GroupBy": "1, 0",
     "Inputs": [
       {
@@ -1565,7 +1565,7 @@ Gen4 error: Can't group on 'count(*)'
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(2) AS count(*)",
+    "Aggregates": "sum_count_star(2) AS count(*)",
     "GroupBy": "(0|3), (1|4)",
     "ResultColumns": 3,
     "Inputs": [
@@ -1647,7 +1647,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count",
+    "Aggregates": "sum_count(0) AS count",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -1669,7 +1669,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -1694,7 +1694,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(4) AS count",
+    "Aggregates": "sum_count(4) AS count",
     "GroupBy": "0, 1, 2",
     "Inputs": [
       {
@@ -1719,7 +1719,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "random(3) AS d, sum(4) AS count(*)",
+    "Aggregates": "random(3) AS d, sum_count_star(4) AS count(*)",
     "GroupBy": "(0|5), (1|6), (2|7)",
     "ResultColumns": 5,
     "Inputs": [
@@ -1747,7 +1747,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(4) AS count",
+    "Aggregates": "sum_count(4) AS count",
     "GroupBy": "0, 1, 2",
     "Inputs": [
       {
@@ -1772,7 +1772,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "random(3) AS d, sum(4) AS count(*)",
+    "Aggregates": "random(3) AS d, sum_count_star(4) AS count(*)",
     "GroupBy": "(0|5), (1|6), (2|7)",
     "ResultColumns": 5,
     "Inputs": [
@@ -1800,7 +1800,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(4) AS count",
+    "Aggregates": "sum_count(4) AS count",
     "GroupBy": "0, 1, 2, 3",
     "Inputs": [
       {
@@ -1825,7 +1825,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(4) AS count(*)",
+    "Aggregates": "sum_count_star(4) AS count(*)",
     "GroupBy": "(3|8), (1|6), (0|5), (2|7)",
     "ResultColumns": 5,
     "Inputs": [
@@ -1853,7 +1853,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(4) AS count",
+    "Aggregates": "sum_count(4) AS count",
     "GroupBy": "2, 1, 0, 3",
     "Inputs": [
       {
@@ -1878,7 +1878,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(4) AS count(*)",
+    "Aggregates": "sum_count_star(4) AS count(*)",
     "GroupBy": "(3|8), (1|6), (0|5), (2|7)",
     "ResultColumns": 5,
     "Inputs": [
@@ -1906,7 +1906,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(3) AS count",
+    "Aggregates": "sum_count(3) AS count",
     "GroupBy": "2, 1, 0",
     "Inputs": [
       {
@@ -1931,7 +1931,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(3) AS count(*)",
+    "Aggregates": "sum_count_star(3) AS count(*)",
     "GroupBy": "(0|4), (2|6), (1|5)",
     "ResultColumns": 4,
     "Inputs": [
@@ -1968,7 +1968,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(1) AS count",
+        "Aggregates": "sum_count(1) AS count",
         "GroupBy": "0",
         "Inputs": [
           {
@@ -1998,7 +1998,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(1) AS count(*)",
+        "Aggregates": "sum_count_star(1) AS count(*)",
         "GroupBy": "0",
         "Inputs": [
           {
@@ -2091,7 +2091,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(1) AS count",
+        "Aggregates": "sum_count(1) AS count",
         "GroupBy": "0",
         "Inputs": [
           {
@@ -2123,7 +2123,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "random(0) AS a, sum(1) AS count(*)",
+        "Aggregates": "random(0) AS a, sum_count_star(1) AS count(*)",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2153,7 +2153,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(1) AS count",
+        "Aggregates": "sum_count(1) AS count",
         "GroupBy": "0, 0",
         "Inputs": [
           {
@@ -2186,7 +2186,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(1) AS count(*)",
+        "Aggregates": "sum_count_star(1) AS count(*)",
         "GroupBy": "(0|2)",
         "Inputs": [
           {
@@ -2255,7 +2255,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -2282,7 +2282,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(*)",
+    "Aggregates": "sum_count_star(1) AS count(*)",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -2363,7 +2363,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS count",
+        "Aggregates": "sum_count(0) AS count",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2387,7 +2387,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -2508,7 +2508,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(1) AS k",
+        "Aggregates": "sum_count_star(1) AS k",
         "GroupBy": "0",
         "Inputs": [
           {
@@ -2537,7 +2537,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count",
+    "Aggregates": "sum_count(1) AS count",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -2561,7 +2561,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS k",
+    "Aggregates": "sum_count_star(1) AS k",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -2607,7 +2607,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count",
+    "Aggregates": "sum_count(0) AS count",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -2629,7 +2629,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -2673,7 +2673,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count",
+    "Aggregates": "sum_count(1) AS count",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -2698,7 +2698,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(*)",
+    "Aggregates": "sum_count_star(1) AS count(*)",
     "GroupBy": "(0|2)",
     "ResultColumns": 2,
     "Inputs": [
@@ -2726,7 +2726,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count",
+    "Aggregates": "sum_count(1) AS count",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -2751,7 +2751,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(*)",
+    "Aggregates": "sum_count_star(1) AS count(*)",
     "GroupBy": "(0|2)",
     "ResultColumns": 2,
     "Inputs": [
@@ -2878,7 +2878,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2910,7 +2910,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2942,7 +2942,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -2974,7 +2974,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3006,7 +3006,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3038,7 +3038,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3070,7 +3070,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3102,7 +3102,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3134,7 +3134,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(1) AS a",
+        "Aggregates": "sum_count_star(1) AS a",
         "GroupBy": "0",
         "Inputs": [
           {
@@ -3175,7 +3175,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "sum(0) AS a",
+            "Aggregates": "sum_count_star(0) AS a",
             "GroupBy": "(1|2)",
             "Inputs": [
               {
@@ -3206,7 +3206,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "count_distinct(1) AS count(distinct textcol1)",
+    "Aggregates": "count_distinct_count(1) AS count(distinct textcol1)",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -3287,7 +3287,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "random(0) AS 1, sum(1) AS count(id)",
+            "Aggregates": "random(0) AS 1, sum_count(1) AS count(id)",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3321,7 +3321,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Projection",
@@ -3398,7 +3398,7 @@ Gen4 plan same as above
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "random(0) AS 1, sum(1) AS count(id)",
+            "Aggregates": "random(0) AS 1, sum_count(1) AS count(id)",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3428,7 +3428,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(*)",
+    "Aggregates": "sum_count_star(1) AS count(*)",
     "GroupBy": "(0|2)",
     "ResultColumns": 2,
     "Inputs": [
@@ -3486,7 +3486,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(user_extra.a)",
+    "Aggregates": "sum_count(1) AS count(user_extra.a)",
     "GroupBy": "(0|2)",
     "ResultColumns": 2,
     "Inputs": [
@@ -3544,7 +3544,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(0) AS count(u.textcol1), sum(1) AS count(ue.foo)",
+    "Aggregates": "sum_count(0) AS count(u.textcol1), sum_count(1) AS count(ue.foo)",
     "GroupBy": "(2|3)",
     "ResultColumns": 3,
     "Inputs": [
@@ -3633,7 +3633,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "min(1), sum_distinct(2) AS sum(distinct col3)",
+    "Aggregates": "min(1), sum_distinct_sum(2) AS sum(distinct col3)",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -3687,7 +3687,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Projection",
@@ -3740,7 +3740,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "count_distinct(1) AS count(distinct val1), sum(2) AS count",
+    "Aggregates": "count_distinct_count(1) AS count(distinct val1), sum_count(2) AS count",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -3765,7 +3765,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "count_distinct(1|4) AS count(distinct val1), sum(2) AS count(*)",
+    "Aggregates": "count_distinct(1|4) AS count(distinct val1), sum_count_star(2) AS count(*)",
     "GroupBy": "(0|3)",
     "ResultColumns": 3,
     "Inputs": [
@@ -3793,7 +3793,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count",
+    "Aggregates": "sum_count(1) AS count",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -3818,7 +3818,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(*)",
+    "Aggregates": "sum_count_star(1) AS count(*)",
     "GroupBy": "(0|2)",
     "ResultColumns": 2,
     "Inputs": [
@@ -3876,7 +3876,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "count_distinct(0|4) AS count(distinct tcol2), sum(2) AS count(*), sum_distinct(3|4) AS sum(distinct tcol2)",
+    "Aggregates": "count_distinct(0|4) AS count(distinct tcol2), sum_count_star(2) AS count(*), sum_distinct(3|4) AS sum(distinct tcol2)",
     "GroupBy": "(1|5)",
     "ResultColumns": 4,
     "Inputs": [
@@ -4163,7 +4163,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "sum(1) AS count(*)",
+            "Aggregates": "sum_count_star(1) AS count(*)",
             "GroupBy": "(0|2)",
             "Inputs": [
               {
@@ -4293,7 +4293,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "sum(1) AS count(*)",
+            "Aggregates": "sum_count_star(1) AS count(*)",
             "GroupBy": "(0|2)",
             "Inputs": [
               {
@@ -4334,7 +4334,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "sum(1) AS count(u.`name`)",
+            "Aggregates": "sum_count(1) AS count(u.`name`)",
             "GroupBy": "(0|2)",
             "Inputs": [
               {
@@ -4450,7 +4450,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "sum(1) AS count(*)",
+            "Aggregates": "sum_count_star(1) AS count(*)",
             "GroupBy": "(0|2)",
             "Inputs": [
               {
@@ -4540,7 +4540,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Scalar",
-                "Aggregates": "random(0) AS 1, sum(1) AS count(ue.col)",
+                "Aggregates": "random(0) AS 1, sum_count(1) AS count(ue.col)",
                 "Inputs": [
                   {
                     "OperatorType": "Route",
@@ -4644,7 +4644,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "random(0) AS id, random(1) AS id, sum(2) AS count(*)",
+    "Aggregates": "random(0) AS id, random(1) AS id, sum_count_star(2) AS count(*)",
     "ResultColumns": 3,
     "Inputs": [
       {
@@ -4671,7 +4671,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(1) AS count",
+    "Aggregates": "sum_count(1) AS count",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -4693,7 +4693,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "random(0) AS id, sum(1) AS count(*)",
+    "Aggregates": "random(0) AS id, sum_count_star(1) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -3698,7 +3698,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS count",
+        "Aggregates": "sum_count(0) AS count",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -3728,7 +3728,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -4623,7 +4623,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count",
+    "Aggregates": "sum_count(1) AS count",
     "GroupBy": "0",
     "Inputs": [
       {
@@ -4648,7 +4648,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(*)",
+    "Aggregates": "sum_count_star(1) AS count(*)",
     "GroupBy": "(0|2)",
     "ResultColumns": 2,
     "Inputs": [

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
@@ -13,7 +13,7 @@
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(2) AS count",
+        "Aggregates": "sum_count(2) AS count",
         "GroupBy": "0",
         "ResultColumns": 4,
         "Inputs": [
@@ -41,7 +41,7 @@
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "random(1) AS b, sum(2) AS count(*)",
+    "Aggregates": "random(1) AS b, sum_count_star(2) AS count(*)",
     "GroupBy": "(0|3)",
     "ResultColumns": 3,
     "Inputs": [
@@ -74,7 +74,7 @@
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(2) AS count",
+        "Aggregates": "sum_count(2) AS count",
         "GroupBy": "0",
         "Inputs": [
           {
@@ -107,7 +107,7 @@
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "random(1) AS b, sum(2) AS k",
+        "Aggregates": "random(1) AS b, sum_count_star(2) AS k",
         "GroupBy": "(0|3)",
         "Inputs": [
           {
@@ -141,7 +141,7 @@
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(2) AS count",
+        "Aggregates": "sum_count(2) AS count",
         "GroupBy": "0",
         "ResultColumns": 5,
         "Inputs": [
@@ -175,7 +175,7 @@
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "random(1) AS b, sum(2) AS k",
+        "Aggregates": "random(1) AS b, sum_count_star(2) AS k",
         "GroupBy": "(0|3)",
         "Inputs": [
           {
@@ -213,7 +213,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "sum(2) AS count",
+            "Aggregates": "sum_count(2) AS count",
             "GroupBy": "0",
             "Inputs": [
               {
@@ -252,7 +252,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "random(1) AS b, sum(2) AS k",
+            "Aggregates": "random(1) AS b, sum_count_star(2) AS k",
             "GroupBy": "(0|3)",
             "Inputs": [
               {
@@ -289,7 +289,7 @@
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(2) AS count",
+        "Aggregates": "sum_count(2) AS count",
         "GroupBy": "0",
         "ResultColumns": 4,
         "Inputs": [
@@ -323,7 +323,7 @@
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "random(1) AS b, sum(2) AS k",
+        "Aggregates": "random(1) AS b, sum_count_star(2) AS k",
         "GroupBy": "(0|3)",
         "Inputs": [
           {
@@ -359,7 +359,7 @@
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(1) AS count",
+        "Aggregates": "sum_count(1) AS count",
         "GroupBy": "2",
         "ResultColumns": 3,
         "Inputs": [
@@ -392,7 +392,7 @@
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(1) AS k",
+        "Aggregates": "sum_count_star(1) AS k",
         "GroupBy": "0 COLLATE latin1_swedish_ci",
         "Inputs": [
           {

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -1837,7 +1837,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count",
+    "Aggregates": "sum_count(0) AS count",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -1859,7 +1859,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(id), random(1) AS num",
+    "Aggregates": "sum_count(0) AS count(id), random(1) AS num",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -1890,7 +1890,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS count",
+        "Aggregates": "sum_count(0) AS count",
         "ResultColumns": 3,
         "Inputs": [
           {
@@ -1915,7 +1915,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(id), random(1) AS num",
+    "Aggregates": "sum_count(0) AS count(id), random(1) AS num",
     "ResultColumns": 2,
     "Inputs": [
       {
@@ -1942,7 +1942,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(0) AS count",
+    "Aggregates": "sum_count(0) AS count",
     "GroupBy": "1",
     "Inputs": [
       {
@@ -1967,7 +1967,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(0) AS count(id)",
+    "Aggregates": "sum_count(0) AS count(id)",
     "GroupBy": "(1|2)",
     "ResultColumns": 2,
     "Inputs": [
@@ -2000,7 +2000,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(0) AS count",
+        "Aggregates": "sum_count(0) AS count",
         "GroupBy": "1",
         "Inputs": [
           {
@@ -2033,7 +2033,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum(0) AS count(id)",
+        "Aggregates": "sum_count(0) AS count(id)",
         "GroupBy": "(1|2)",
         "Inputs": [
           {
@@ -2123,7 +2123,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS count(*), random(2) AS c1",
+    "Aggregates": "sum_count_star(1) AS count(*), random(2) AS c1",
     "GroupBy": "0",
     "ResultColumns": 2,
     "Inputs": [
@@ -2339,7 +2339,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS a",
+        "Aggregates": "sum_count_star(0) AS a",
         "Inputs": [
           {
             "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -83,7 +83,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count",
+    "Aggregates": "sum_count(0) AS count",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -106,7 +106,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -178,7 +178,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count",
+    "Aggregates": "sum_count(0) AS count",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -201,7 +201,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -227,7 +227,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count",
+    "Aggregates": "sum_count(0) AS count",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -250,7 +250,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Scalar",
-    "Aggregates": "sum(0) AS count(*)",
+    "Aggregates": "sum_count_star(0) AS count(*)",
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -1758,7 +1758,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS count",
+        "Aggregates": "sum_count(0) AS count",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1802,7 +1802,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS count(*)",
+        "Aggregates": "sum_count_star(0) AS count(*)",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1894,7 +1894,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS count",
+        "Aggregates": "sum_count(0) AS count",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -1940,7 +1940,7 @@ Gen4 plan same as above
       {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "sum(0) AS count(*)",
+        "Aggregates": "sum_count_star(0) AS count(*)",
         "Inputs": [
           {
             "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
@@ -131,7 +131,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "sum(1) AS order_count",
+    "Aggregates": "sum_count_star(1) AS order_count",
     "GroupBy": "(0|2)",
     "ResultColumns": 2,
     "Inputs": [
@@ -1061,7 +1061,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "sum(1) AS numwait",
+            "Aggregates": "sum_count_star(1) AS numwait",
             "GroupBy": "(0|2)",
             "Inputs": [
               {

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.txt
@@ -1270,7 +1270,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "sum(0) AS count",
+            "Aggregates": "sum_count(0) AS count",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1288,7 +1288,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "sum(0) AS count",
+            "Aggregates": "sum_count(0) AS count",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1323,7 +1323,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "sum(0) AS s",
+            "Aggregates": "sum_count_star(0) AS s",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1341,7 +1341,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "sum(0) AS s",
+            "Aggregates": "sum_count_star(0) AS s",
             "Inputs": [
               {
                 "OperatorType": "Route",


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Backport of PR #10465 

This PR fixes two bugs in scalar aggregation engine primitive
1. Scalar aggregation was returning wrong output for empty row on count aggregation
2. Scalar aggregation in streaming mode was not handling empty row and also final convert logic.

This was caused when we moved from using AggregateSum over AggregateCount as opcode for count(*). As the actual operation at the engine primitive level was sum of count, this caused a negative effect of returning `NULL` for empty row instead of `0`.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
