### PR TITLE
[vtadmin] fix flaky GetSchemas test cases

### DIFF
--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -75,8 +75,8 @@ func TestCreateKeyspace(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -94,8 +94,8 @@ func TestCreateKeyspace(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -144,8 +144,8 @@ func TestCreateShard(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -164,8 +164,8 @@ func TestCreateShard(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -215,8 +215,8 @@ func TestDeleteKeyspace(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -234,8 +234,8 @@ func TestDeleteKeyspace(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -284,8 +284,8 @@ func TestDeleteShards(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -308,8 +308,8 @@ func TestDeleteShards(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -363,8 +363,8 @@ func TestDeleteTablet(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -383,8 +383,8 @@ func TestDeleteTablet(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -434,8 +434,8 @@ func TestEmergencyFailoverShard(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -454,8 +454,8 @@ func TestEmergencyFailoverShard(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -502,16 +502,17 @@ func TestFindSchema(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts)
-	t.Cleanup(func() {
-		if err := api.Close(); err != nil {
-			t.Logf("api did not close cleanly: %s", err.Error())
-		}
-	})
-
 	t.Run("unauthorized actor", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "unauthorized"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -525,8 +526,16 @@ func TestFindSchema(t *testing.T) {
 	})
 
 	t.Run("partial access", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "allowed-other"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -539,8 +548,16 @@ func TestFindSchema(t *testing.T) {
 	})
 
 	t.Run("full access", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "allowed-all"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -593,8 +610,8 @@ func TestGetBackups(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "unauthorized"}
 
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -607,8 +624,8 @@ func TestGetBackups(t *testing.T) {
 
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-other"}
 
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -621,8 +638,8 @@ func TestGetBackups(t *testing.T) {
 
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-all"}
 
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -672,8 +689,8 @@ func TestGetCellInfos(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "unauthorized"}
 
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -688,8 +705,8 @@ func TestGetCellInfos(t *testing.T) {
 
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-other"}
 
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -704,8 +721,8 @@ func TestGetCellInfos(t *testing.T) {
 
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-all"}
 
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -757,8 +774,8 @@ func TestGetCellsAliases(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "unauthorized"}
 
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -771,8 +788,8 @@ func TestGetCellsAliases(t *testing.T) {
 
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-other"}
 
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -785,8 +802,8 @@ func TestGetCellsAliases(t *testing.T) {
 
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-all"}
 
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -830,8 +847,8 @@ func TestGetClusters(t *testing.T) {
 
 	t.Run("unauthenticated", func(t *testing.T) {
 		t.Parallel()
-		var actor *rbac.Actor
 
+		var actor *rbac.Actor
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -843,8 +860,8 @@ func TestGetClusters(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -856,8 +873,8 @@ func TestGetClusters(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -898,16 +915,17 @@ func TestGetGates(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts)
-	t.Cleanup(func() {
-		if err := api.Close(); err != nil {
-			t.Logf("api did not close cleanly: %s", err.Error())
-		}
-	})
-
 	t.Run("unauthorized actor", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "unauthorized"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -919,8 +937,16 @@ func TestGetGates(t *testing.T) {
 	})
 
 	t.Run("partial access", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "allowed-other"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -933,8 +959,16 @@ func TestGetGates(t *testing.T) {
 	})
 
 	t.Run("full access", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "allowed-all"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -979,8 +1013,8 @@ func TestGetKeyspace(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -996,8 +1030,8 @@ func TestGetKeyspace(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1050,8 +1084,8 @@ func TestGetKeyspaces(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "unauthorized"}
 
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1064,8 +1098,8 @@ func TestGetKeyspaces(t *testing.T) {
 
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-other"}
 
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1085,8 +1119,8 @@ func TestGetKeyspaces(t *testing.T) {
 
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-all"}
 
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1128,16 +1162,17 @@ func TestGetSchema(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts)
-	t.Cleanup(func() {
-		if err := api.Close(); err != nil {
-			t.Logf("api did not close cleanly: %s", err.Error())
-		}
-	})
-
 	t.Run("unauthorized actor", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "other"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1153,8 +1188,16 @@ func TestGetSchema(t *testing.T) {
 	})
 
 	t.Run("authorized actor", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "allowed"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1199,16 +1242,17 @@ func TestGetSchemas(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts)
-	t.Cleanup(func() {
-		if err := api.Close(); err != nil {
-			t.Logf("api did not close cleanly: %s", err.Error())
-		}
-	})
-
 	t.Run("unauthorized actor", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "unauthorized"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1220,8 +1264,16 @@ func TestGetSchemas(t *testing.T) {
 	})
 
 	t.Run("partial access", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "allowed-other"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1240,8 +1292,16 @@ func TestGetSchemas(t *testing.T) {
 	})
 
 	t.Run("full access", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "allowed-all"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1298,8 +1358,8 @@ func TestGetShardReplicationPositions(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "unauthorized"}
 
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1312,8 +1372,8 @@ func TestGetShardReplicationPositions(t *testing.T) {
 
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-other"}
 
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1333,8 +1393,8 @@ func TestGetShardReplicationPositions(t *testing.T) {
 
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-all"}
 
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1385,8 +1445,8 @@ func TestGetSrvVSchema(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1402,8 +1462,8 @@ func TestGetSrvVSchema(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1456,8 +1516,8 @@ func TestGetSrvVSchemas(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "unauthorized"}
 
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1470,8 +1530,8 @@ func TestGetSrvVSchemas(t *testing.T) {
 
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-other"}
 
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1491,8 +1551,8 @@ func TestGetSrvVSchemas(t *testing.T) {
 
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-all"}
 
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1543,8 +1603,8 @@ func TestGetTablet(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1562,8 +1622,8 @@ func TestGetTablet(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1618,8 +1678,8 @@ func TestGetTablets(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "unauthorized"}
 
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1632,8 +1692,8 @@ func TestGetTablets(t *testing.T) {
 
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-other"}
 
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1653,8 +1713,8 @@ func TestGetTablets(t *testing.T) {
 
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-all"}
 
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1705,8 +1765,8 @@ func TestGetVSchema(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1722,8 +1782,8 @@ func TestGetVSchema(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1776,8 +1836,8 @@ func TestGetVSchemas(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "unauthorized"}
 
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1790,8 +1850,8 @@ func TestGetVSchemas(t *testing.T) {
 
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-other"}
 
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1811,8 +1871,8 @@ func TestGetVSchemas(t *testing.T) {
 
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-all"}
 
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1860,16 +1920,17 @@ func TestGetVtctlds(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts)
-	t.Cleanup(func() {
-		if err := api.Close(); err != nil {
-			t.Logf("api did not close cleanly: %s", err.Error())
-		}
-	})
-
 	t.Run("unauthorized actor", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "unauthorized"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1881,8 +1942,16 @@ func TestGetVtctlds(t *testing.T) {
 	})
 
 	t.Run("partial access", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "allowed-other"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1895,8 +1964,16 @@ func TestGetVtctlds(t *testing.T) {
 	})
 
 	t.Run("full access", func(t *testing.T) {
-		actor := &rbac.Actor{Name: "allowed-all"}
+		t.Parallel()
 
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
+
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1941,8 +2018,8 @@ func TestGetWorkflow(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -1959,8 +2036,8 @@ func TestGetWorkflow(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2014,8 +2091,8 @@ func TestGetWorkflows(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "unauthorized"}
 
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2028,8 +2105,8 @@ func TestGetWorkflows(t *testing.T) {
 
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-other"}
 
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2042,8 +2119,8 @@ func TestGetWorkflows(t *testing.T) {
 
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-all"}
 
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2087,8 +2164,8 @@ func TestPingTablet(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2106,8 +2183,8 @@ func TestPingTablet(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2156,8 +2233,8 @@ func TestPlannedFailoverShard(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2176,8 +2253,8 @@ func TestPlannedFailoverShard(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2227,8 +2304,8 @@ func TestRefreshState(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2246,8 +2323,8 @@ func TestRefreshState(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2296,8 +2373,8 @@ func TestRefreshTabletReplicationSource(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2315,8 +2392,8 @@ func TestRefreshTabletReplicationSource(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2371,8 +2448,8 @@ func TestReloadSchemas(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "unauthorized"}
 
+		actor := &rbac.Actor{Name: "unauthorized"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2390,8 +2467,8 @@ func TestReloadSchemas(t *testing.T) {
 
 	t.Run("partial access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-other"}
 
+		actor := &rbac.Actor{Name: "allowed-other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2408,8 +2485,8 @@ func TestReloadSchemas(t *testing.T) {
 
 	t.Run("full access", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed-all"}
 
+		actor := &rbac.Actor{Name: "allowed-all"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2457,8 +2534,8 @@ func TestRunHealthCheck(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2476,8 +2553,8 @@ func TestRunHealthCheck(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2526,8 +2603,8 @@ func TestSetReadOnly(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2545,8 +2622,8 @@ func TestSetReadOnly(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2595,8 +2672,8 @@ func TestSetReadWrite(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2614,8 +2691,8 @@ func TestSetReadWrite(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2664,8 +2741,8 @@ func TestStartReplication(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2683,8 +2760,8 @@ func TestStartReplication(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2733,8 +2810,8 @@ func TestStopReplication(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2752,8 +2829,8 @@ func TestStopReplication(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2802,8 +2879,8 @@ func TestTabletExternallyPromoted(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2821,8 +2898,8 @@ func TestTabletExternallyPromoted(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2871,8 +2948,8 @@ func TestVTExplain(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2888,8 +2965,8 @@ func TestVTExplain(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2936,8 +3013,8 @@ func TestValidateKeyspace(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -2953,8 +3030,8 @@ func TestValidateKeyspace(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -3001,8 +3078,8 @@ func TestValidateSchemaKeyspace(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -3018,8 +3095,8 @@ func TestValidateSchemaKeyspace(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -3066,8 +3143,8 @@ func TestValidateVersionKeyspace(t *testing.T) {
 
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "other"}
 
+		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)
@@ -3083,8 +3160,8 @@ func TestValidateVersionKeyspace(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
-		actor := &rbac.Actor{Name: "allowed"}
 
+		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()
 		if actor != nil {
 			ctx = rbac.NewContext(ctx, actor)


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

use individual API instances for certain test cases to prevent cross-test pollution. i've left a loop running overnight and we're at ~1500 successful test runs

## Related Issue(s)

fixes #10549 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
