### PR TITLE
Documented the legacy healthcheck and tabletgateway and added summary to 14's summary

### DIFF
--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -1,3 +1,20 @@
+## Summary
+
+- [Gen4 is now the default planner](#gen4-is-now-the-default-planner)
+- [New query support](#new-query-support)
+- [Command-line syntax deprecations](#command-line-syntax-deprecations)
+- [New or removed command line flags and behavior](#new-or-removed-command-line-flags-and-behavior)
+- [Online DDL changes](#online-ddl-changes)
+- [Table lifecycle](#table-lifecycle)
+- [Tablet throttler](#tablet-throttler)
+- [New Syntax](#new-syntax)
+- [Heartbeat](#heartbeat)
+- [VDiff2](#vdiff2)
+- [Durability Policy](#durability-policy)
+- [Deprecation of Durability Configuration](#deprecation-of-durability-configuration)
+- [Advisory locking optimisations](#advisory-locking-optimisations)
+- [Drop the use of the legacy healthcheck in VTCtld](#drop-the-use-of-the-legacy-healthcheck-in-vtctld)
+
 ## Major Changes
 
 ### Gen4 is now the default planner
@@ -73,7 +90,7 @@ $ # the following will NOT work, because --topo_implementation is a top-level fl
 $ vtctl -- --topo_implementation etcd2 AddCellInfo --root "/vitess/global"
 ```
 
-### New command line flags and behavior
+### New or removed command line flags and behavior
 
 #### vttablet --heartbeat_on_demand_duration
 
@@ -94,6 +111,10 @@ The flag `--online_ddl_check_interval` is deprecated and will be removed in `v15
 #### Deprecation of --planner-version for vtexplain
 
 The flag `--planner-version` is deprecated and will be removed in `v15`. Instead, please use `--planer_version`.
+
+#### Removal of --gateway_implementation
+
+In previous releases, the `discoverygateway` was deprecated. In Vitess 14 it is now entirely removed, along with the VTGate flag that allowed us to select the tablet gateway.
 
 ### Online DDL changes
 
@@ -290,3 +311,6 @@ path is to upgrade vtctld, run `SetKeyspaceDurabilityPolicy` and then upgrade VT
 
 ### Advisory locking optimisations
 Work has gone into making the advisory locks (`get_lock()`, `release_lock()`, et al) release reserved connections faster and in more situations than before.
+
+### Drop the use of the legacy healthcheck in VTCtld
+In release `7.0.0`, a new healthcheck was developed and the old one was renamed legacy healthcheck. In Vitess 14, we have changed VTCtld to use the new healthcheck instead of the legacy.


### PR DESCRIPTION
## Description

This PR documents the changes made by https://github.com/vitessio/vitess/pull/9500 and https://github.com/vitessio/vitess/pull/10254 on the legacy healthcheck and tabletgateway.

Additionally, this PR includes a new section to the summary that summarizes the different sections of the document.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
