### PR TITLE
[14.0] Update and prepare the `v14.0.0` summary

### DIFF
--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -36,7 +36,7 @@ Support has been added for inserting new data from SELECT queries.
 Now you can insert data from a query into a table using a query like:
 
 ```sql
-insert into tbl select   
+insert into tbl (col) select id from users 
 ```
 
 #### UPDATE from SELECT

--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -253,9 +253,12 @@ VDiff bf9dfc5f-e5e6-11ec-823d-0aa62e50dd24 scheduled on target shards, use show 
 
 $ vtctlclient --server=localhost:15999 VDiff -- --v2 customer.commerce2customer show last
 
-VDiff Summary for customer.commerce2customer (bf9dfc5f-e5e6-11ec-823d-0aa62e50dd24)
-State: completed
-HasMismatch: false
+VDiff Summary for customer.commerce2customer (4c664dc2-eba9-11ec-9ef7-920702940ee0)
+State:        completed
+RowsCompared: 196
+HasMismatch:  false
+StartedAt:    2022-06-26 22:44:29
+CompletedAt:  2022-06-26 22:44:31
 
 Use "--format=json" for more detailed output.
 
@@ -264,15 +267,18 @@ $ vtctlclient --server=localhost:15999 VDiff -- --v2 --format=json customer.comm
 	"Workflow": "commerce2customer",
 	"Keyspace": "customer",
 	"State": "completed",
-	"UUID": "bf9dfc5f-e5e6-11ec-823d-0aa62e50dd24",
+	"UUID": "4c664dc2-eba9-11ec-9ef7-920702940ee0",
+	"RowsCompared": 196,
 	"HasMismatch": false,
-	"Shards": "0"
+	"Shards": "0",
+	"StartedAt": "2022-06-26 22:44:29",
+	"CompletedAt": "2022-06-26 22:44:31"
 }
 ```
 
 > Even before it's marked as production-ready (feature complete and tested widely in 1+ releases), it should be safe to use and is likely to provide much better results for very large tables.
 
-For additional details, please see the [RFC](https://github.com/vitessio/vitess/issues/10134) and the [README](https://github.com/vitessio/vitess/tree/main/go/vt/vttablet/tabletmanager/vdiff/README.md).
+For additional details please see the [RFC](https://github.com/vitessio/vitess/issues/10134), the [README](https://github.com/vitessio/vitess/blob/release-14.0/go/vt/vttablet/tabletmanager/vdiff/README.md), and the VDiff2 [documentation](https://vitess.io/docs/14.0/reference/vreplication/vdiff2/).
 
 ### Durability Policy
 

--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -83,7 +83,7 @@ Everything after the `AddCellInfo` is treated by `package flag` as a positional 
 So, at the top-level, `flag.Args()` returns `["AddCellInfo", "--root", "/vitess/global"]`.
 
 The library we are transitioning to is more flexible, allowing flags and positional arguments to be interwoven on the command-line.
-For the above example, this means that we would attempt to parse `--root` as a top-level flag for the `vtctl` binary.
+For the above example, this means that we would attempt to parse `--root` as a top-level flag for the `VTCtl` binary.
 This will cause the program to exit on error, because that flag is only defined on the `AddCellInfo` subcommand.
 
 In order to transition, a standalone double-dash (literally, `--`) will cause the new flag library to treat everything following that as a positional argument, and also works with the current flag parsing code we use.
@@ -278,10 +278,10 @@ For additional details, please see the [RFC](https://github.com/vitessio/vitess/
 
 #### Deprecation of durability_policy Flag
 The durability policy for a keyspace is now stored in the keyspace record in the topology server.
-The `durability_policy` flag used by vtctl, vtctld, and vtworker binaries has been deprecated and will be removed in a future release.
+The `durability_policy` flag used by VTCtl, VTCtld, and VTWorker binaries has been deprecated and will be removed in a future release.
 
 #### New and Augmented Commands
-The vtctld command `CreateKeyspace` has been augmented to take in an additional argument `--durability-policy` which will
+The VTCtld command `CreateKeyspace` has been augmented to take in an additional argument `--durability-policy` which will
 allow users to set the desired durability policy for a keyspace at creation time.
 
 For existing keyspaces, a new command `SetKeyspaceDurabilityPolicy` has been added, which allows users to change the
@@ -298,7 +298,7 @@ the topology server. This allows VTOrc to monitor and repair multiple keyspaces 
 **VTOrc will ignore keyspaces which have no durability policy specified in the keyspace record. This is to avoid clobbering an existing
 config from a previous release. So on upgrading to v14, users must run the command `SetKeyspaceDurabilityPolicy` specified above,
 to ensure that VTOrc continues to work as desired. The recommended upgrade
-path is to upgrade vtctld, run `SetKeyspaceDurabilityPolicy` and then upgrade VTOrc.**
+path is to upgrade VTCtld, run `SetKeyspaceDurabilityPolicy` and then upgrade VTOrc.**
 
 ### Advisory locking optimizations
 Work has gone into making the advisory locks (`get_lock()`, `release_lock()`, etc.) release reserved connections faster and in more situations than before.

--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -33,9 +33,18 @@ Vitess can now plan and execute most aggregation queries across multiple shards 
 
 #### INSERT from SELECT
 Support has been added for inserting new data from SELECT queries.
+Now you can insert data from a query into a table using a query like:
+
+```sql
+insert into tbl select   
+```
 
 #### UPDATE from SELECT
-Similarly, we have added support for UPDATE with scalar sub-queries.
+Similarly, we have added support for UPDATE with scalar sub-queries. This allows for queries where the updated value is fetched using a subquery, such as this example:
+
+```sql
+update tbl set foo = (select count(*) from otherTbl)
+```
 
 ### Command-line syntax deprecations
 
@@ -113,6 +122,13 @@ The flag `--online_ddl_check_interval` is deprecated and will be removed in `v15
 #### Removal of --gateway_implementation
 
 In previous releases, the `discoverygateway` was deprecated. In Vitess 14 it is now entirely removed, along with the VTGate flag that allowed us to choose a gateway.
+
+#### Deprecation of --planner_version
+
+The flag `--planner_version` is deprecated and will be removed in `v15`. 
+Some binaries used `--planner_version`, and some used `--planner-version`. 
+This has been made consistent - all binaries that allow you to configure the planner now take `--planner-version`.
+All uses of the underscore form have been deprecated and will be removed in `v15`. 
 
 ### Online DDL changes
 

--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -244,8 +244,8 @@ In a sense, it's a "cold engine" scenario, where the engine takes time to start 
 
 ### VDiff2
 
-We introduced a new version of VDiff -- currently marked as Experimental -- that executes the VDiff on tablets rather than in VTCtld.
-While this is experimental we encourage you to try it out and provide feedback! This input will be invaluable as we improve this feature on the march toward a production-ready version.
+We introduced a new version of VDiff -- currently marked as EXPERIMENTAL -- that executes the VDiff on vttablets rather than in vtctld.
+While this is experimental we encourage you to try it out and provide feedback! This input will be invaluable as we improve the feature on the march toward [a production-ready version](https://github.com/vitessio/vitess/issues/10494).
 You can try it out by adding the `--v2` flag to your VDiff command. Here's an example:
 ```
 $ vtctlclient --server=localhost:15999 VDiff -- --v2 customer.commerce2customer

--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -1,3 +1,20 @@
+## Summary
+
+- [Gen4 is now the default planner](#gen4-is-now-the-default-planner)
+- [New query support](#new-query-support)
+- [Command-line syntax deprecations](#command-line-syntax-deprecations)
+- [New command line flags and behavior](#new-command-line-flags-and-behavior)
+- [Online DDL changes](#online-ddl-changes)
+- [Table lifecycle](#table-lifecycle)
+- [Tablet throttler](#tablet-throttler)
+- [New Syntax](#new-syntax)
+- [Heartbeat](#heartbeat)
+- [VDiff2](#vdiff2)
+- [Durability Policy](#durability-policy)
+- [Deprecation of Durability Configuration](#deprecation-of-durability-configuration)
+- [Advisory locking optimisations](#advisory-locking-optimisations)
+- [Drop the use of the legacy healthcheck in VTCtld](#drop-the-use-of-the-legacy-healthcheck-in-vtctld)
+
 ## Major Changes
 
 ### Gen4 is now the default planner
@@ -95,6 +112,10 @@ The flag `--online_ddl_check_interval` is deprecated and will be removed in `v15
 
 The flag `--planner-version` is deprecated and will be removed in `v15`. Instead, please use `--planer_version`.
 
+#### Removal of --gateway_implementation
+
+In previous releases, the `discoverygateway` was deprecated. In Vitess 14 it is now entirely removed, along with the VTGate flag that allowed us to select the tablet gateway.
+
 ### Online DDL changes
 
 #### Online DDL is generally available
@@ -164,6 +185,30 @@ API endpoint `/throttler/throttle-app` now accepts a `ratio` query argument, a f
 - `0` means "do not throttle at all"
 - `1` means "always throttle"
 - any numbr in between is allowd. For example, `0.3` means "throttle in 0.3 probability", ie on a per request and based on a dice roll, there's a `30%` change a request is denied. Overall we can expect about `30%` of requests to be denied. Example: `/throttler/throttle-app?app=vreplication&ratio=0.25`
+
+API endpoint `/debug/vars` now exposes throttler metrics, such as number of hits and errors per app per check type. Example:
+
+```shell
+$ curl -s 'http://127.0.0.1:15100/debug/vars' | jq . | grep throttler
+  "throttler.aggregated.mysql.self": 133.19334,
+  "throttler.aggregated.mysql.shard": 132.997847,
+  "throttler.check.any.error": 1086,
+  "throttler.check.any.mysql.self.error": 542,
+  "throttler.check.any.mysql.self.total": 570,
+  "throttler.check.any.mysql.shard.error": 544,
+  "throttler.check.any.mysql.shard.total": 570,
+  "throttler.check.any.total": 1140,
+  "throttler.check.mysql.self.seconds_since_healthy": 132,
+  "throttler.check.mysql.shard.seconds_since_healthy": 132,
+  "throttler.check.vitess.error": 1086,
+  "throttler.check.vitess.mysql.self.error": 542,
+  "throttler.check.vitess.mysql.self.total": 570,
+  "throttler.check.vitess.mysql.shard.error": 544,
+  "throttler.check.vitess.mysql.shard.total": 570,
+  "throttler.check.vitess.total": 1140,
+  "throttler.probes.latency": 292982,
+  "throttler.probes.total": 1138
+```
 
 See new SQL syntax for controlling/viewing throttling, down below.
 
@@ -269,3 +314,6 @@ Work has gone into making the advisory locks (`get_lock()`, `release_lock()`, et
 
 ### Pre-Legacy Resharding is now deprecated
 A long time ago, the sharding column and type were specified at the keyspace level. This syntax is now deprecated and will be removed in v15.
+
+### Drop the use of the legacy healthcheck in VTCtld
+In release `7.0.0`, a new healthcheck was developed and the old one was renamed legacy healthcheck. In Vitess 14, we have changed VTCtld to use the new healthcheck instead of the legacy.

--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -279,8 +279,9 @@ If semi-sync is being used then durability policy should be set to `semi_sync` f
 The `Durability` configuration is deprecated and removed from VTOrc. Instead VTOrc will find the durability policy of the keyspace from
 the topology server. This allows VTOrc to monitor and repair multiple keyspaces which have different durability policies in use.
 
-**VTOrc will ignore keyspaces which have no durability policy specified in the keyspace record. So on upgrading to v14, users must run
-the command `SetKeyspaceDurabilityPolicy` specified above, to ensure VTOrc continues to work as desired. The recommended upgrade 
+**VTOrc will ignore keyspaces which have no durability policy specified in the keyspace record. This is to avoid clobbering an existing
+config from a previous release. So on upgrading to v14, users must run the command `SetKeyspaceDurabilityPolicy` specified above,
+to ensure that VTOrc continues to work as desired. The recommended upgrade
 path is to upgrade vtctld, run `SetKeyspaceDurabilityPolicy` and then upgrade VTOrc.**
 
 ### Advisory locking optimizations


### PR DESCRIPTION
## Description

This Pull Request updates the release-14 summary in preparation for the `v14` GA.

Includes:
- A backport of #10567.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
