### PR TITLE
Throttler stats: amendment

### DIFF
--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -186,30 +186,6 @@ API endpoint `/throttler/throttle-app` now accepts a `ratio` query argument, a f
 - `1` means "always throttle"
 - any numbr in between is allowd. For example, `0.3` means "throttle in 0.3 probability", ie on a per request and based on a dice roll, there's a `30%` change a request is denied. Overall we can expect about `30%` of requests to be denied. Example: `/throttler/throttle-app?app=vreplication&ratio=0.25`
 
-API endpoint `/debug/vars` now exposes throttler metrics, such as number of hits and errors per app per check type. Example:
-
-```shell
-$ curl -s 'http://127.0.0.1:15100/debug/vars' | jq . | grep throttler
-  "throttler.aggregated.mysql.self": 133.19334,
-  "throttler.aggregated.mysql.shard": 132.997847,
-  "throttler.check.any.error": 1086,
-  "throttler.check.any.mysql.self.error": 542,
-  "throttler.check.any.mysql.self.total": 570,
-  "throttler.check.any.mysql.shard.error": 544,
-  "throttler.check.any.mysql.shard.total": 570,
-  "throttler.check.any.total": 1140,
-  "throttler.check.mysql.self.seconds_since_healthy": 132,
-  "throttler.check.mysql.shard.seconds_since_healthy": 132,
-  "throttler.check.vitess.error": 1086,
-  "throttler.check.vitess.mysql.self.error": 542,
-  "throttler.check.vitess.mysql.self.total": 570,
-  "throttler.check.vitess.mysql.shard.error": 544,
-  "throttler.check.vitess.mysql.shard.total": 570,
-  "throttler.check.vitess.total": 1140,
-  "throttler.probes.latency": 292982,
-  "throttler.probes.total": 1138
-```
-
 See new SQL syntax for controlling/viewing throttling, down below.
 
 ### New Syntax

--- a/doc/releasenotes/15_0_0_summary.md
+++ b/doc/releasenotes/15_0_0_summary.md
@@ -13,23 +13,17 @@
 API endpoint `/debug/vars` now exposes throttler metrics, such as number of hits and errors per app per check type. Example:
 
 ```shell
-$ curl -s 'http://127.0.0.1:15100/debug/vars' | jq . | grep throttler
-  "throttler.aggregated.mysql.self": 133.19334,
-  "throttler.aggregated.mysql.shard": 132.997847,
-  "throttler.check.any.error": 1086,
-  "throttler.check.any.mysql.self.error": 542,
-  "throttler.check.any.mysql.self.total": 570,
-  "throttler.check.any.mysql.shard.error": 544,
-  "throttler.check.any.mysql.shard.total": 570,
-  "throttler.check.any.total": 1140,
-  "throttler.check.mysql.self.seconds_since_healthy": 132,
-  "throttler.check.mysql.shard.seconds_since_healthy": 132,
-  "throttler.check.vitess.error": 1086,
-  "throttler.check.vitess.mysql.self.error": 542,
-  "throttler.check.vitess.mysql.self.total": 570,
-  "throttler.check.vitess.mysql.shard.error": 544,
-  "throttler.check.vitess.mysql.shard.total": 570,
-  "throttler.check.vitess.total": 1140,
-  "throttler.probes.latency": 292982,
-  "throttler.probes.total": 1138
+$ curl -s http://127.0.0.1:15100/debug/vars | jq . | grep Throttler
+  "ThrottlerAggregatedMysqlSelf": 0.191718,
+  "ThrottlerAggregatedMysqlShard": 0.960054,
+  "ThrottlerCheckAnyError": 27,
+  "ThrottlerCheckAnyMysqlSelfError": 13,
+  "ThrottlerCheckAnyMysqlSelfTotal": 38,
+  "ThrottlerCheckAnyMysqlShardError": 14,
+  "ThrottlerCheckAnyMysqlShardTotal": 42,
+  "ThrottlerCheckAnyTotal": 80,
+  "ThrottlerCheckMysqlSelfSecondsSinceHealthy": 0,
+  "ThrottlerCheckMysqlShardSecondsSinceHealthy": 0,
+  "ThrottlerProbesLatency": 355523,
+  "ThrottlerProbesTotal": 74,
 ```

--- a/doc/releasenotes/15_0_0_summary.md
+++ b/doc/releasenotes/15_0_0_summary.md
@@ -5,3 +5,31 @@
 ### New command line flags and behavior
 
 ### Online DDL changes
+
+### Tablet throttler
+
+#### API changes
+
+API endpoint `/debug/vars` now exposes throttler metrics, such as number of hits and errors per app per check type. Example:
+
+```shell
+$ curl -s 'http://127.0.0.1:15100/debug/vars' | jq . | grep throttler
+  "throttler.aggregated.mysql.self": 133.19334,
+  "throttler.aggregated.mysql.shard": 132.997847,
+  "throttler.check.any.error": 1086,
+  "throttler.check.any.mysql.self.error": 542,
+  "throttler.check.any.mysql.self.total": 570,
+  "throttler.check.any.mysql.shard.error": 544,
+  "throttler.check.any.mysql.shard.total": 570,
+  "throttler.check.any.total": 1140,
+  "throttler.check.mysql.self.seconds_since_healthy": 132,
+  "throttler.check.mysql.shard.seconds_since_healthy": 132,
+  "throttler.check.vitess.error": 1086,
+  "throttler.check.vitess.mysql.self.error": 542,
+  "throttler.check.vitess.mysql.self.total": 570,
+  "throttler.check.vitess.mysql.shard.error": 544,
+  "throttler.check.vitess.mysql.shard.total": 570,
+  "throttler.check.vitess.total": 1140,
+  "throttler.probes.latency": 292982,
+  "throttler.probes.total": 1138
+```


### PR DESCRIPTION

## Description

Amendment to https://github.com/vitessio/vitess/pull/10443; https://github.com/vitessio/vitess/pull/10443 was created pre v14, but did not make it to v14. However, it was merged with v14 release notes.

This PR moves the PR's release notes out of v14 and into v15; it also reflects updates to the metrics format.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/10443

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

