### PR TITLE
Fixed the release notes CI check helper

### DIFF
--- a/.github/workflows/release_notes_label.yml
+++ b/.github/workflows/release_notes_label.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Print helper
         if: failure() && steps.required_label.outcome == 'failure'
         run: |
-          echo The "release notes (needs details)" label is set. The changes made in this Pull Request need to be documented in the release notes summary ('./doc/releasenotes/x_x_x_summary.md'). Once documented, the "release notes (needs details)" label can be removed.
+          echo The "release notes (needs details)" label is set. The changes made in this Pull Request need to be documented in the release notes summary \('./doc/releasenotes/15_0_0_summary.md'\). Once documented, the "release notes (needs details)" label can be removed.
 
       - name: Check type and component labels
         env:

--- a/.github/workflows/release_notes_label.yml
+++ b/.github/workflows/release_notes_label.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Print helper
         if: failure() && steps.required_label.outcome == 'failure'
         run: |
-          echo The "release notes (needs details)" label is set. The changes made in this Pull Request need to be documented in the release notes summary \('./doc/releasenotes/15_0_0_summary.md'\). Once documented, the "release notes (needs details)" label can be removed.
+          echo The "release notes (needs details)" label is set. The changes made in this Pull Request need to be documented in the release notes summary "('./doc/releasenotes/15_0_0_summary.md')". Once documented, the "release notes (needs details)" label can be removed.
+          exit 1
 
       - name: Check type and component labels
         env:


### PR DESCRIPTION
## Description

This PR fixes the improper quoting in the release notes label CI workflow which was causing it to fail.

Additionally, the helper shows the actual release summary filename.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
