### PR TITLE
Cherry pick of VStream API: Fix vtgate memory leaks when context gets cancelled

### DIFF
--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -489,6 +489,7 @@ func (vs *vstream) streamFromTablet(ctx context.Context, sgtid *binlogdatapb.Sha
 				}
 				if err != nil {
 					errCh <- err
+					return err
 				}
 				return nil
 			})
@@ -537,7 +538,7 @@ func (vs *vstream) streamFromTablet(ctx context.Context, sgtid *binlogdatapb.Sha
 						return err
 					}
 
-					if err := vs.sendAll(sgtid, eventss); err != nil {
+					if err := vs.sendAll(ctx, sgtid, eventss); err != nil {
 						return err
 					}
 					eventss = nil
@@ -556,7 +557,7 @@ func (vs *vstream) streamFromTablet(ctx context.Context, sgtid *binlogdatapb.Sha
 					if vs.stopOnReshard && journal.MigrationType == binlogdatapb.MigrationType_SHARDS {
 						sendevents = append(sendevents, event)
 						eventss = append(eventss, sendevents)
-						if err := vs.sendAll(sgtid, eventss); err != nil {
+						if err := vs.sendAll(ctx, sgtid, eventss); err != nil {
 							return err
 						}
 						eventss = nil
@@ -609,7 +610,7 @@ func (vs *vstream) streamFromTablet(ctx context.Context, sgtid *binlogdatapb.Sha
 }
 
 // sendAll sends a group of events together while holding the lock.
-func (vs *vstream) sendAll(sgtid *binlogdatapb.ShardGtid, eventss [][]*binlogdatapb.VEvent) error {
+func (vs *vstream) sendAll(ctx context.Context, sgtid *binlogdatapb.ShardGtid, eventss [][]*binlogdatapb.VEvent) error {
 	vs.mu.Lock()
 	defer vs.mu.Unlock()
 
@@ -660,7 +661,11 @@ func (vs *vstream) sendAll(sgtid *binlogdatapb.ShardGtid, eventss [][]*binlogdat
 				}
 			}
 		}
-		vs.eventCh <- events
+		select {
+		case <-ctx.Done():
+			return nil
+		case vs.eventCh <- events:
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

This PR fixes a couple of memory leaks in the VStream API which was causing vtgates to OOM.

* Check for cancelled context when events received from the source were being sent into a event channel for eventual streaming to the vstream api client.
* When a context is cancelled, in the vstream API we need to return an error in the health streamer callback. Otherwise it keeps streaming and leaking (goroutines and ) grpc request buffers.
 
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

