### PR TITLE
Removed the check label in upgrade downgrade tests

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -8,28 +8,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get_upgrade_downgrade_label:
-    timeout-minutes: 10
-    if: github.repository == 'vitessio/vitess'
-    name: Get the Upgrade Downgrade pull request label
-    runs-on: ubuntu-latest
-    outputs:
-      hasLabel: ${{ steps.check_label.outputs.hasLabel }}
-
-    steps:
-      - name: Check Label for PR
-        if: github.event_name == 'pull_request'
-        uses: Dreamcodeio/pr-has-label-action@master
-        id: check_label
-        with:
-          label: Skip Upgrade Downgrade
-
   get_previous_release:
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
+    if: always() && github.event_name != 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
-    needs:
-      - get_upgrade_downgrade_label
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -48,11 +30,10 @@ jobs:
 
   upgrade_downgrade_test_e2e:
     timeout-minutes: 60
-    if: always() && (needs.get_previous_release.result == 'success')
+    if: always() && needs.get_previous_release.result == 'success'
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-18.04
     needs:
-      - get_upgrade_downgrade_label
       - get_previous_release
 
     steps:

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name != 'pull_request'
+    if: always() && github.event_name == 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -32,7 +32,7 @@ jobs:
   upgrade_downgrade_test_manual:
     timeout-minutes: 40
     if: always() && (needs.get_previous_release.result == 'success')
-    name: Run Upgrade Downgrade Test Backup Manual
+    name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:
       - get_previous_release

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name != 'pull_request'
+    if: always() && github.event_name == 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -8,28 +8,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get_upgrade_downgrade_label:
-    timeout-minutes: 5
-    if: github.repository == 'vitessio/vitess'
-    name: Get the Upgrade Downgrade pull request label
-    runs-on: ubuntu-latest
-    outputs:
-      hasLabel: ${{ steps.check_label.outputs.hasLabel }}
-
-    steps:
-      - name: Check Label for PR
-        if: github.event_name == 'pull_request'
-        uses: Dreamcodeio/pr-has-label-action@master
-        id: check_label
-        with:
-          label: Skip Upgrade Downgrade
-
   get_previous_release:
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
+    if: always() && github.event_name != 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
-    needs:
-      - get_upgrade_downgrade_label
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -53,7 +35,6 @@ jobs:
     name: Run Upgrade Downgrade Test Backup Manual
     runs-on: ubuntu-latest
     needs:
-      - get_upgrade_downgrade_label
       - get_previous_release
 
     steps:
@@ -311,8 +292,7 @@ jobs:
         echo "select count(sku) from corder;" | mysql 2>&1| grep 6
 
     - name: Stop the Vitess cluster
-      if: steps.changes.outputs.end_to_end == 'true'
-      if: always()
+      if: always() && steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env ; cd examples/local
         ./401_teardown.sh || true

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -11,27 +11,10 @@ concurrency:
 # (vtgate, vttablet, etc) built on different versions.
 
 jobs:
-  get_upgrade_downgrade_label:
-    if: github.repository == 'vitessio/vitess'
-    name: Get the Upgrade Downgrade pull request label
-    runs-on: ubuntu-latest
-    outputs:
-      hasLabel: ${{ steps.check_label.outputs.hasLabel }}
-
-    steps:
-      - name: Check Label for PR
-        if: github.event_name == 'pull_request'
-        uses: Dreamcodeio/pr-has-label-action@master
-        id: check_label
-        with:
-          label: Skip Upgrade Downgrade
-
   get_previous_release:
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
+    if: always() && github.event_name != 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
-    needs:
-      - get_upgrade_downgrade_label
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name != 'pull_request'
+    if: always() && github.event_name == 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name != 'pull_request'
+    if: always() && github.event_name == 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -11,27 +11,10 @@ concurrency:
 # (vtgate, vttablet, etc) built on different versions.
 
 jobs:
-  get_upgrade_downgrade_label:
-    if: github.repository == 'vitessio/vitess'
-    name: Get the Upgrade Downgrade pull request label
-    runs-on: ubuntu-latest
-    outputs:
-      hasLabel: ${{ steps.check_label.outputs.hasLabel }}
-
-    steps:
-      - name: Check Label for PR
-        if: github.event_name == 'pull_request'
-        uses: Dreamcodeio/pr-has-label-action@master
-        id: check_label
-        with:
-          label: Skip Upgrade Downgrade
-
   get_previous_release:
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
+    if: always() && github.event_name != 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
-    needs:
-      - get_upgrade_downgrade_label
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -53,7 +36,6 @@ jobs:
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:
-      - get_upgrade_downgrade_label
       - get_previous_release
 
     steps:

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name != 'pull_request'
+    if: always() && github.event_name == 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -11,27 +11,10 @@ concurrency:
 # (vtctl, vttablet, etc) built on different versions.
 
 jobs:
-  get_upgrade_downgrade_label:
-    if: github.repository == 'vitessio/vitess'
-    name: Get the Upgrade Downgrade pull request label
-    runs-on: ubuntu-latest
-    outputs:
-      hasLabel: ${{ steps.check_label.outputs.hasLabel }}
-
-    steps:
-      - name: Check Label for PR
-        if: github.event_name == 'pull_request'
-        uses: Dreamcodeio/pr-has-label-action@master
-        id: check_label
-        with:
-          label: Skip Upgrade Downgrade
-
   get_previous_release:
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
+    if: always() && github.event_name != 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
-    needs:
-      - get_upgrade_downgrade_label
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -53,7 +36,6 @@ jobs:
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:
-      - get_upgrade_downgrade_label
       - get_previous_release
 
     steps:

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -11,23 +11,8 @@ concurrency:
 # (vtctl, vttablet, etc) built on different versions.
 
 jobs:
-  get_upgrade_downgrade_label:
-    if: github.repository == 'vitessio/vitess'
-    name: Get the Upgrade Downgrade pull request label
-    runs-on: ubuntu-latest
-    outputs:
-      hasLabel: ${{ steps.check_label.outputs.hasLabel }}
-
-    steps:
-      - name: Check Label for PR
-        if: github.event_name == 'pull_request'
-        uses: Dreamcodeio/pr-has-label-action@master
-        id: check_label
-        with:
-          label: Skip Upgrade Downgrade
-
   get_previous_release:
-    if: always() && (github.event_name != 'pull_request' || needs.get_upgrade_downgrade_label.outputs.hasLabel != 'true')
+    if: always() && github.event_name != 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
     needs:
@@ -53,7 +38,6 @@ jobs:
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:
-      - get_upgrade_downgrade_label
       - get_previous_release
 
     steps:

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name != 'pull_request'
+    if: always() && github.event_name == 'pull_request'
     name: Get latest release
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Description

This Pull Request removes the job that checks the `skip upgrade downgrade` label in the upgrade downgrade workflows.

## Related Issue(s)

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
