### PR TITLE
Backport: VDiff2: Support Resuming VDiffs

### DIFF
--- a/doc/releasenotes/14_0_0_summary.md
+++ b/doc/releasenotes/14_0_0_summary.md
@@ -218,9 +218,12 @@ VDiff bf9dfc5f-e5e6-11ec-823d-0aa62e50dd24 scheduled on target shards, use show 
 
 $ vtctlclient --server=localhost:15999 VDiff -- --v2 customer.commerce2customer show last
 
-VDiff Summary for customer.commerce2customer (bf9dfc5f-e5e6-11ec-823d-0aa62e50dd24)
-State: completed
-HasMismatch: false
+VDiff Summary for customer.commerce2customer (4c664dc2-eba9-11ec-9ef7-920702940ee0)
+State:        completed
+RowsCompared: 196
+HasMismatch:  false
+StartedAt:    2022-06-26 22:44:29
+CompletedAt:  2022-06-26 22:44:31
 
 Use "--format=json" for more detailed output.
 
@@ -229,15 +232,18 @@ $ vtctlclient --server=localhost:15999 VDiff -- --v2 --format=json customer.comm
 	"Workflow": "commerce2customer",
 	"Keyspace": "customer",
 	"State": "completed",
-	"UUID": "bf9dfc5f-e5e6-11ec-823d-0aa62e50dd24",
+	"UUID": "4c664dc2-eba9-11ec-9ef7-920702940ee0",
+	"RowsCompared": 196,
 	"HasMismatch": false,
-	"Shards": "0"
+	"Shards": "0",
+	"StartedAt": "2022-06-26 22:44:29",
+	"CompletedAt": "2022-06-26 22:44:31"
 }
 ```
 
 :information_source:  NOTE: even before it's marked as production-ready (feature complete and tested widely in 1+ releases), it should be safe to use and is likely to provide much better results for very large tables.
 
-For additional details, please see the [RFC](https://github.com/vitessio/vitess/issues/10134) and the [README](https://github.com/vitessio/vitess/tree/main/go/vt/vttablet/tabletmanager/vdiff/README.md).
+For additional details please see the [RFC](https://github.com/vitessio/vitess/issues/10134), the [README](https://github.com/vitessio/vitess/blob/release-14.0/go/vt/vttablet/tabletmanager/vdiff/README.md), and the VDiff2 [documentation](https://vitess.io/docs/14.0/reference/vreplication/vdiff2/).
 
 ### Durability Policy
 

--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -28,7 +28,7 @@ package vreplication
 //   2. Column and table names with special characters in them, namely a dash
 //   3. Identifiers using reserved words, as lead is a reserved word in MySQL 8.0+ (https://dev.mysql.com/doc/refman/8.0/en/keywords.html)
 // The internal table _vt_PURGE_4f9194b43b2011eb8a0104ed332e05c2_20221210194431 should be ignored by vreplication
-// The db_order_test table is used to ensure vreplication and vdiff1 work well with complex non-integer PKs, even across DB versions.
+// The db_order_test table is used to ensure vreplication and vdiff work well with complex non-integer PKs, even across DB versions.
 var (
 	initialProductSchema = `
 create table product(pid int, description varbinary(128), date1 datetime not null default '0000-00-00 00:00:00', date2 datetime not null default '2021-00-01 00:00:00', primary key(pid)) CHARSET=utf8mb4;

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -30,22 +30,28 @@ type testCase struct {
 	tables                        string
 	workflow                      string
 	tabletBaseID                  int
+	resume                        bool   // test resume functionality with this workflow
+	resumeInsert                  string // if testing resume, what new rows should be diff'd
+	testCLIErrors                 bool   // test CLI errors against this workflow
 }
 
 var testCases = []*testCase{
 	{
-		name:         "MoveTables unsharded to two shards",
-		workflow:     "p1c2",
-		typ:          "MoveTables",
-		sourceKs:     "product",
-		targetKs:     "customer",
-		sourceShards: "0",
-		targetShards: "-80,80-",
-		tabletBaseID: 200,
-		tables:       "customer,Lead,Lead-1",
+		name:          "MoveTables/unsharded to two shards",
+		workflow:      "p1c2",
+		typ:           "MoveTables",
+		sourceKs:      "product",
+		targetKs:      "customer",
+		sourceShards:  "0",
+		targetShards:  "-80,80-",
+		tabletBaseID:  200,
+		tables:        "customer,Lead,Lead-1",
+		resume:        true,
+		resumeInsert:  `insert into customer(cid, name, typ) values(12345678, 'Testy McTester', 'soho')`,
+		testCLIErrors: true, // test for errors in the simplest workflow
 	},
 	{
-		name:         "Reshard Split/Merge 2 to 3",
+		name:         "Reshard Merge/split 2 to 3",
 		workflow:     "c2c3",
 		typ:          "Reshard",
 		sourceKs:     "customer",
@@ -53,9 +59,11 @@ var testCases = []*testCase{
 		sourceShards: "-80,80-",
 		targetShards: "-40,40-a0,a0-",
 		tabletBaseID: 400,
+		resume:       true,
+		resumeInsert: `insert into customer(cid, name, typ) values(987654321, 'Testy McTester Jr.', 'enterprise'), (987654322, 'Testy McTester III', 'enterprise')`,
 	},
 	{
-		name:         "Reshard Merge 3 to 1",
+		name:         "Reshard/merge 3 to 1",
 		workflow:     "c3c1",
 		typ:          "Reshard",
 		sourceKs:     "customer",
@@ -73,6 +81,7 @@ func TestVDiff2(t *testing.T) {
 	sourceShards := []string{"0"}
 	targetKs := "customer"
 	targetShards := []string{"-80", "80-"}
+	// This forces us to use multiple vstream packets even with small test tables
 	extraVTTabletArgs = []string{"--vstream_packet_size=1"}
 
 	vc = NewVitessCluster(t, "TestVDiff2", []string{allCellNames}, mainClusterConfig)
@@ -86,7 +95,9 @@ func TestVDiff2(t *testing.T) {
 
 	vtgate = defaultCell.Vtgates[0]
 	require.NotNil(t, vtgate)
-	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", sourceKs, sourceShards[0]), 1)
+	for _, shard := range sourceShards {
+		require.NoError(t, vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", sourceKs, shard), 1))
+	}
 
 	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
 	defer vtgateConn.Close()
@@ -101,10 +112,9 @@ func TestVDiff2(t *testing.T) {
 
 	_, err := vc.AddKeyspace(t, cells, targetKs, strings.Join(targetShards, ","), customerVSchema, customerSchema, 0, 0, 200, targetKsOpts)
 	require.NoError(t, err)
-	err = vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", targetKs, targetShards[0]), 1)
-	require.NoError(t, err)
-	err = vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", targetKs, targetShards[1]), 1)
-	require.NoError(t, err)
+	for _, shard := range targetShards {
+		require.NoError(t, vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", targetKs, shard), 1))
+	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -118,6 +128,9 @@ func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, cells []*Cell) 
 	if tc.typ == "Reshard" {
 		tks := vc.Cells[cells[0].Name].Keyspaces[tc.targetKs]
 		require.NoError(t, vc.AddShards(t, cells, tks, tc.targetShards, 0, 0, tc.tabletBaseID))
+		for _, shard := range arrTargetShards {
+			require.NoError(t, vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", tc.targetKs, shard), 1))
+		}
 	}
 	ksWorkflow := fmt.Sprintf("%s.%s", tc.targetKs, tc.workflow)
 	var args []string
@@ -137,6 +150,30 @@ func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, cells []*Cell) 
 		catchup(t, tab, tc.workflow, tc.typ)
 	}
 	vdiff(t, tc.targetKs, tc.workflow, cells[0].Name, true, true, nil)
+
+	if tc.resume {
+		expectedRows := int64(0)
+		if tc.resumeInsert != "" {
+			res := execVtgateQuery(t, vtgateConn, tc.sourceKs, tc.resumeInsert)
+			expectedRows = int64(res.RowsAffected)
+		}
+		vdiff2Resume(t, tc.targetKs, tc.workflow, cells[0].Name, expectedRows)
+	}
+
+	// This is done here so that we have a valid workflow to test the commands against
+	if tc.testCLIErrors {
+		t.Run("Client error handling", func(t *testing.T) {
+			_, output := performVDiff2Action(t, ksWorkflow, allCellNames, "badcmd", "", true)
+			require.Contains(t, output, "usage:")
+			_, output = performVDiff2Action(t, ksWorkflow, allCellNames, "create", "invalid_uuid", true)
+			require.Contains(t, output, "please provide a valid UUID")
+			_, output = performVDiff2Action(t, ksWorkflow, allCellNames, "resume", "invalid_uuid", true)
+			require.Contains(t, output, "can only resume a specific vdiff, please provide a valid UUID")
+			uuid, _ := performVDiff2Action(t, ksWorkflow, allCellNames, "show", "last", false)
+			_, output = performVDiff2Action(t, ksWorkflow, allCellNames, "create", uuid, true)
+			require.Contains(t, output, "already exists")
+		})
+	}
 
 	err = vc.VtctlClient.ExecuteCommand(tc.typ, "--", "SwitchTraffic", ksWorkflow)
 	require.NoError(t, err)

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -69,7 +69,7 @@ const (
 	deleteOpenTxQuery = "delete from customer where name = 'openTxQuery'"
 
 	merchantKeyspace = "merchant-type"
-	maxWait          = 10 * time.Second
+	maxWait          = 60 * time.Second
 	BypassLagCheck   = true // temporary fix for flakiness seen only in CI when lag check is introduced
 )
 
@@ -490,12 +490,12 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 
 		customerTab1 := custKs.Shards["-80"].Tablets["zone1-200"].Vttablet
 		customerTab2 := custKs.Shards["80-"].Tablets["zone1-300"].Vttablet
+		productTab := vc.Cells[defaultCell.Name].Keyspaces["product"].Shards["0"].Tablets["zone1-100"].Vttablet
 
 		catchup(t, customerTab1, workflow, "MoveTables")
 		catchup(t, customerTab2, workflow, "MoveTables")
 
-		productTab := vc.Cells[defaultCell.Name].Keyspaces["product"].Shards["0"].Tablets["zone1-100"].Vttablet
-		query := "select * from customer"
+		query := "select cid from customer"
 		require.True(t, validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "product", query, query))
 		insertQuery1 := "insert into customer(cid, name) values(1001, 'tempCustomer1')"
 		matchInsertQuery1 := "insert into customer(cid, `name`) values (:vtg1, :vtg2)"
@@ -526,6 +526,9 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 		if withOpenTx && commit != nil {
 			commit(t)
 		}
+
+		catchup(t, productTab, workflow, "MoveTables")
+
 		vdiff1(t, "product.p2c_reverse", "")
 		if withOpenTx {
 			execVtgateQuery(t, vtgateConn, "", deleteOpenTxQuery)

--- a/go/vt/vtctl/vdiff2.go
+++ b/go/vt/vtctl/vdiff2.go
@@ -50,7 +50,7 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 
 	sourceCell := subFlags.String("source_cell", "", "The source cell to compare from; default is any available cell")
 	targetCell := subFlags.String("target_cell", "", "The target cell to compare with; default is any available cell")
-	tabletTypes := subFlags.String("tablet_types", "in_order:replica,primary", "Tablet types for source and target")
+	tabletTypes := subFlags.String("tablet_types", "in_order:RDONLY,REPLICA,PRIMARY", "Tablet types for source (PRIMARY is always used on target)")
 
 	debugQuery := subFlags.Bool("debug_query", false, "Adds a mysql query to the report that can be used for further debugging")
 	onlyPks := subFlags.Bool("only_pks", false, "When reporting missing rows, only show primary keys in the report.")
@@ -67,7 +67,7 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 	var action vdiff.VDiffAction
 	var actionArg string
 
-	usage := fmt.Errorf("usage: vdiff -- --v2 <keyspace>.<workflow> %s [%s|<uuid>]", strings.Join(*(*[]string)(unsafe.Pointer(&vdiff.Actions)), "|"), strings.Join(vdiff.ActionArgs, "|"))
+	usage := fmt.Errorf("usage: VDiff -- --v2 <keyspace>.<workflow> %s [%s|<UUID>]", strings.Join(*(*[]string)(unsafe.Pointer(&vdiff.Actions)), "|"), strings.Join(vdiff.ActionArgs, "|"))
 	switch subFlags.NArg() {
 	case 1: // for backward compatibility with vdiff1
 		action = vdiff.CreateAction
@@ -83,16 +83,15 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 		return usage
 	}
 	if action == "" {
-		return fmt.Errorf("invalid action %s", subFlags.Arg(1))
+		return fmt.Errorf("invalid action %s; %s", subFlags.Arg(1), usage)
 	}
 	keyspace, workflowName, err := splitKeyspaceWorkflow(subFlags.Arg(0))
 	if err != nil {
 		return err
 	}
-	log.Infof("VDiff2 action is %s, args %s", action, strings.Join(args, " "))
 
 	if *maxRows <= 0 {
-		return fmt.Errorf("maximum number of rows to compare needs to be greater than 0")
+		return fmt.Errorf("invalid --limit value (%d), maximum number of rows to compare needs to be greater than 0", *maxRows)
 	}
 
 	options := &tabletmanagerdatapb.VDiffOptions{
@@ -120,9 +119,13 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 	var vdiffUUID uuid.UUID
 	switch action {
 	case vdiff.CreateAction:
-		vdiffUUID, err = uuid.NewUUID()
+		if actionArg != "" {
+			vdiffUUID, err = uuid.Parse(actionArg)
+		} else {
+			vdiffUUID, err = uuid.NewUUID()
+		}
 		if err != nil {
-			return err
+			return fmt.Errorf("%v, please provide a valid UUID", err)
 		}
 	case vdiff.ShowAction:
 		switch actionArg {
@@ -130,11 +133,16 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 		default:
 			vdiffUUID, err = uuid.Parse(actionArg)
 			if err != nil {
-				return fmt.Errorf("can only show specific migration, provide valid uuid; view all with: vdiff -- --v2 show all")
+				return fmt.Errorf("can only show a specific vdiff, please provide a valid UUID; view all with: VDiff -- --v2 %s.%s show all", keyspace, workflowName)
 			}
 		}
+	case vdiff.ResumeAction:
+		vdiffUUID, err = uuid.Parse(actionArg)
+		if err != nil {
+			return fmt.Errorf("can only resume a specific vdiff, please provide a valid UUID; view all with: VDiff -- --v2 %s.%s show all", keyspace, workflowName)
+		}
 	default:
-		return fmt.Errorf("invalid command %s", action)
+		return fmt.Errorf("invalid action %s; %s", action, usage)
 	}
 	type ErrorResponse struct {
 		Error string
@@ -146,18 +154,18 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 	}
 
 	switch action {
-	case vdiff.CreateAction:
-		displayVDiff2CreateResponse(wr, *format, vdiffUUID.String())
+	case vdiff.CreateAction, vdiff.ResumeAction:
+		displayVDiff2ScheduledResponse(wr, *format, vdiffUUID.String(), action)
 	case vdiff.ShowAction:
 		if output == nil {
-			return fmt.Errorf("invalid response from show command")
+			// should not happen
+			return fmt.Errorf("invalid (empty) response from show command")
 		}
-		log.Infof("show action: %+v", output)
 		if err := displayVDiff2ShowResponse(wr, *format, keyspace, workflowName, actionArg, output); err != nil {
 			return err
 		}
 	default:
-		return fmt.Errorf("action %s not valid", action)
+		return fmt.Errorf("invalid action %s; %s", action, usage)
 	}
 	return nil
 }
@@ -167,29 +175,36 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 // summary aggregates/selects the current state of the vdiff from all shards
 
 type vdiffTableSummary struct {
-	TableName, State string
-	RowsCompared     int64
-	MatchingRows     int64
-	MismatchedRows   int64
-	ExtraRowsSource  int64
-	ExtraRowsTarget  int64
-	LastUpdated      string `json:"LastUpdated,omitempty"`
+	TableName       string
+	State           vdiff.VDiffState
+	RowsCompared    int64
+	MatchingRows    int64
+	MismatchedRows  int64
+	ExtraRowsSource int64
+	ExtraRowsTarget int64
+	LastUpdated     string `json:"LastUpdated,omitempty"`
 }
 type vdiffSummary struct {
-	Workflow, Keyspace, State string
-	UUID                      string
-	HasMismatch               bool
-	Shards                    string
-	LastUpdated               string                                 `json:"LastUpdated,omitempty"`
-	TableSummaryMap           map[string]vdiffTableSummary           `json:"TableSummary,omitempty"`
-	Reports                   map[string]map[string]vdiff.DiffReport `json:"Reports,omitempty"`
+	Workflow, Keyspace string
+	State              vdiff.VDiffState
+	UUID               string
+	RowsCompared       int64
+	HasMismatch        bool
+	Shards             string
+	StartedAt          string                                 `json:"StartedAt,omitempty"`
+	CompletedAt        string                                 `json:"CompletedAt,omitempty"`
+	TableSummaryMap    map[string]vdiffTableSummary           `json:"TableSummary,omitempty"`
+	Reports            map[string]map[string]vdiff.DiffReport `json:"Reports,omitempty"`
 }
 
 const (
 	summaryTextTemplate = `
 VDiff Summary for {{.Keyspace}}.{{.Workflow}} ({{.UUID}})
-State: {{.State}}
-HasMismatch: {{.HasMismatch}}
+State:        {{.State}}
+RowsCompared: {{.RowsCompared}}
+HasMismatch:  {{.HasMismatch}}
+StartedAt:    {{.StartedAt}}
+CompletedAt:  {{.CompletedAt}}
 {{ range $table := .TableSummaryMap}} 
 Table {{$table.TableName}}:
 	State:            {{$table.State}}
@@ -363,13 +378,16 @@ func displayVDiff2ShowSingleSummary(wr *wrangler.Wrangler, format, keyspace, wor
 }
 func buildVDiff2SingleSummary(wr *wrangler.Wrangler, keyspace, workflow, uuid string, output *wrangler.VDiffOutput) (*vdiffSummary, error) {
 	summary := &vdiffSummary{
-		Workflow:    workflow,
-		Keyspace:    keyspace,
-		UUID:        uuid,
-		State:       "",
-		HasMismatch: false,
-		Shards:      "",
-		Reports:     make(map[string]map[string]vdiff.DiffReport),
+		Workflow:     workflow,
+		Keyspace:     keyspace,
+		UUID:         uuid,
+		State:        vdiff.UnknownState,
+		RowsCompared: 0,
+		StartedAt:    "",
+		CompletedAt:  "",
+		HasMismatch:  false,
+		Shards:       "",
+		Reports:      make(map[string]map[string]vdiff.DiffReport),
 	}
 
 	var tableSummaryMap map[string]vdiffTableSummary
@@ -385,56 +403,90 @@ func buildVDiff2SingleSummary(wr *wrangler.Wrangler, keyspace, workflow, uuid st
 				reports = make(map[string]map[string]vdiff.DiffReport, 0)
 			}
 			for _, row := range qr.Named().Rows {
+				// Update the global VDiff summary based on the per shard level summary.
+				// Since these values will be the same for all subsequent rows we only use the first row.
 				if first {
 					first = false
-					summary.State, _ = row.ToString("vdiff_state")
-					summary.State = strings.ToLower(summary.State)
-				}
-				// If we had a mismatch on any table then the vdiff as a unit does too
-				if mm, _ := row.ToBool("has_mismatch"); mm {
-					summary.HasMismatch = true
-				}
-				table := row.AsString("table_name", "")
-				if _, ok := tableSummaryMap[table]; !ok {
-					tableSummaryMap[table] = vdiffTableSummary{
-						TableName: table,
+					// Our timestamps are strings in `2022-06-26 20:43:25` format so we sort them lexicographically.
+					// We should use the earliest started_at across all shards.
+					if sa := row.AsString("started_at", ""); summary.StartedAt == "" || sa < summary.StartedAt {
+						summary.StartedAt = sa
 					}
-
-				}
-				ts := tableSummaryMap[table]
-				state := strings.ToLower(row.AsString("table_state", ""))
-
-				switch state {
-				case "completed":
-					if ts.State == "" {
-						ts.State = state
+					// And we should use the latest completed_at across all shards.
+					if ca := row.AsString("completed_at", ""); summary.CompletedAt == "" || ca > summary.CompletedAt {
+						summary.CompletedAt = ca
 					}
-				case "error":
-					ts.State = state
-				default:
-					if ts.State != "error" {
-						ts.State = state
-					}
-				}
-				diffReport := row.AsString("report", "")
-				dr := vdiff.DiffReport{}
-				if diffReport != "" {
-					err := json.Unmarshal([]byte(diffReport), &dr)
-					if err != nil {
-						return nil, err
-					}
-					ts.RowsCompared += dr.ProcessedRows
-					ts.MismatchedRows += dr.MismatchedRows
-					ts.MatchingRows += dr.MatchingRows
-					ts.ExtraRowsTarget += dr.ExtraRowsTarget
-					ts.ExtraRowsSource += dr.ExtraRowsSource
-				}
-				if _, ok := reports[table]; !ok {
-					reports[table] = make(map[string]vdiff.DiffReport)
 				}
 
-				reports[table][shard] = dr
-				tableSummaryMap[table] = ts
+				{ // Global VDiff summary updates that take into account the per table details per shard
+					summary.RowsCompared += row.AsInt64("rows_compared", 0)
+
+					// If we had a mismatch on any table on any shard then the global VDiff summary does too
+					if mm, _ := row.ToBool("has_mismatch"); mm {
+						summary.HasMismatch = true
+					}
+				}
+
+				{ // Table summary information that must be accounted for across all shards
+					table := row.AsString("table_name", "")
+					// Create the global VDiff table summary object if it doesn't exist
+					if _, ok := tableSummaryMap[table]; !ok {
+						tableSummaryMap[table] = vdiffTableSummary{
+							TableName: table,
+							State:     vdiff.UnknownState,
+						}
+
+					}
+					ts := tableSummaryMap[table]
+					// This is the shard level VDiff table state
+					sts := vdiff.VDiffState(strings.ToLower(row.AsString("table_state", "")))
+
+					// The error state must be sticky, and we should not override any other
+					// known state with completed.
+					switch sts {
+					case vdiff.CompletedState:
+						if ts.State == vdiff.UnknownState {
+							ts.State = sts
+						}
+					case vdiff.ErrorState:
+						ts.State = sts
+					default:
+						if ts.State != vdiff.ErrorState {
+							ts.State = sts
+
+						}
+					}
+
+					diffReport := row.AsString("report", "")
+					dr := vdiff.DiffReport{}
+					if diffReport != "" {
+						err := json.Unmarshal([]byte(diffReport), &dr)
+						if err != nil {
+							return nil, err
+						}
+						ts.RowsCompared += dr.ProcessedRows
+						ts.MismatchedRows += dr.MismatchedRows
+						ts.MatchingRows += dr.MatchingRows
+						ts.ExtraRowsTarget += dr.ExtraRowsTarget
+						ts.ExtraRowsSource += dr.ExtraRowsSource
+					}
+					if _, ok := reports[table]; !ok {
+						reports[table] = make(map[string]vdiff.DiffReport)
+					}
+
+					reports[table][shard] = dr
+					tableSummaryMap[table] = ts
+
+					// The global VDiff summary needs to align with the table states across all
+					// shards. It should progress from pending->started->completed with error at any point
+					// being sticky. This largely mirrors the global table summary, with the exception
+					// being the started state, which should also be sticky; i.e. we shouldn't go from
+					// started->pending->started in the global VDiff summary state.
+					if summary.State != ts.State &&
+						(summary.State != vdiff.StartedState && ts.State != vdiff.PendingState) {
+						summary.State = ts.State
+					}
+				}
 			}
 		}
 	}
@@ -446,20 +498,29 @@ func buildVDiff2SingleSummary(wr *wrangler.Wrangler, keyspace, workflow, uuid st
 		summary.Reports = nil
 		summary.TableSummaryMap = nil
 	}
+	// If we haven't completed the global VDiff then be sure to reflect that with no CompletedAt value
+	if summary.State != vdiff.CompletedState {
+		summary.CompletedAt = ""
+	}
 	return summary, nil
 }
 
 //endregion
 
-func displayVDiff2CreateResponse(wr *wrangler.Wrangler, format string, uuid string) {
+func displayVDiff2ScheduledResponse(wr *wrangler.Wrangler, format string, uuid string, typ vdiff.VDiffAction) {
 	if format == "json" {
-		type CreateResponse struct {
+		type ScheduledResponse struct {
 			UUID string
 		}
-		resp := &CreateResponse{UUID: uuid}
+		resp := &ScheduledResponse{UUID: uuid}
 		jsonText, _ := json.MarshalIndent(resp, "", "\t")
 		wr.Logger().Printf(string(jsonText) + "\n")
 	} else {
-		wr.Logger().Printf("VDiff %s scheduled on target shards, use show to view progress\n", uuid)
+		addtlMsg := ""
+		if typ == vdiff.ResumeAction {
+			addtlMsg = "to resume "
+		}
+		msg := fmt.Sprintf("VDiff %s scheduled %son target shards, use show to view progress\n", uuid, addtlMsg)
+		wr.Logger().Printf(msg)
 	}
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/action.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action.go
@@ -37,12 +37,13 @@ type VDiffAction string //nolint
 const (
 	CreateAction  VDiffAction = "create"
 	ShowAction    VDiffAction = "show"
+	ResumeAction  VDiffAction = "resume"
 	AllActionArg              = "all"
 	LastActionArg             = "last"
 )
 
 var (
-	Actions    = []VDiffAction{CreateAction, ShowAction}
+	Actions    = []VDiffAction{CreateAction, ShowAction, ResumeAction}
 	ActionArgs = []string{AllActionArg, LastActionArg}
 )
 
@@ -63,8 +64,22 @@ func (vde *Engine) PerformVDiffAction(ctx context.Context, req *tabletmanagerdat
 
 	action := VDiffAction(strings.ToLower(req.Command))
 	switch action {
-	case CreateAction:
-		// todo check if vdiff row already exists
+	case CreateAction, ResumeAction:
+		query := fmt.Sprintf(sqlGetVDiffID, encodeString(req.VdiffUuid))
+		if qr, err = withDDL.Exec(context.Background(), query, dbClient.ExecuteFetch, dbClient.ExecuteFetch); err != nil {
+			return nil, err
+		}
+		recordFound := len(qr.Rows) == 1
+		if recordFound && action == CreateAction {
+			return nil, fmt.Errorf("vdiff with UUID %s already exists", req.VdiffUuid)
+		} else if action == ResumeAction {
+			if !recordFound {
+				return nil, fmt.Errorf("vdiff with UUID %s not found", req.VdiffUuid)
+			}
+			if resp.Id, err = qr.Named().Row().ToInt64("id"); err != nil {
+				return nil, fmt.Errorf("vdiff found with invalid id: %w", err)
+			}
+		}
 		options, err = vde.fixupOptions(options)
 		if err != nil {
 			return nil, err
@@ -73,16 +88,26 @@ func (vde *Engine) PerformVDiffAction(ctx context.Context, req *tabletmanagerdat
 		if err != nil {
 			return nil, err
 		}
-		query := fmt.Sprintf(sqlNewVDiff,
-			encodeString(req.Keyspace), encodeString(req.Workflow), "pending", encodeString(string(optionsJSON)),
-			vde.thisTablet.Shard, topoproto.TabletDbName(vde.thisTablet), req.VdiffUuid)
-		if qr, err = withDDL.Exec(context.Background(), query, dbClient.ExecuteFetch, dbClient.ExecuteFetch); err != nil {
-			return nil, err
+		if action == CreateAction {
+			query := fmt.Sprintf(sqlNewVDiff,
+				encodeString(req.Keyspace), encodeString(req.Workflow), "pending", encodeString(string(optionsJSON)),
+				vde.thisTablet.Shard, topoproto.TabletDbName(vde.thisTablet), req.VdiffUuid)
+			if qr, err = withDDL.Exec(context.Background(), query, dbClient.ExecuteFetch, dbClient.ExecuteFetch); err != nil {
+				return nil, err
+			}
+			if qr.InsertID == 0 {
+				return nil, fmt.Errorf("unable to create vdiff record (%w); statement: %s", err, query)
+			}
+			resp.Id = int64(qr.InsertID)
+		} else {
+			query := fmt.Sprintf(sqlResumeVDiff, encodeString(string(optionsJSON)), encodeString(req.VdiffUuid))
+			if qr, err = withDDL.Exec(context.Background(), query, dbClient.ExecuteFetch, dbClient.ExecuteFetch); err != nil {
+				return nil, err
+			}
+			if qr.RowsAffected == 0 {
+				return nil, fmt.Errorf("unable to update vdiff record (%w); statement: %s", err, query)
+			}
 		}
-		if qr.InsertID == 0 {
-			return nil, fmt.Errorf("unable to insert")
-		}
-		resp.Id = int64(qr.InsertID)
 		resp.VdiffUuid = req.VdiffUuid
 		qr, err := vde.getVDiffByID(ctx, resp.Id)
 		if err != nil {
@@ -115,7 +140,7 @@ func (vde *Engine) PerformVDiffAction(ctx context.Context, req *tabletmanagerdat
 			}
 			switch len(qr.Rows) {
 			case 0:
-				return nil, fmt.Errorf("no VDiff found for keyspace %s and workflow %s: %s", req.Keyspace, req.Workflow, query)
+				return nil, fmt.Errorf("no vdiff found for keyspace %s and workflow %s: %s", req.Keyspace, req.Workflow, query)
 			case 1:
 				row := qr.Named().Row()
 				vdiffID, _ := row["id"].ToInt64()
@@ -125,7 +150,7 @@ func (vde *Engine) PerformVDiffAction(ctx context.Context, req *tabletmanagerdat
 					return nil, err
 				}
 			default:
-				return nil, fmt.Errorf("error: too many VDiffs found (%d) for keyspace %s and workflow %s", len(qr.Rows), req.Keyspace, req.Workflow)
+				return nil, fmt.Errorf("too many vdiffs found (%d) for keyspace %s and workflow %s", len(qr.Rows), req.Keyspace, req.Workflow)
 			}
 		}
 		switch req.SubCommand {

--- a/go/vt/vttablet/tabletmanager/vdiff/report.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/report.go
@@ -50,14 +50,14 @@ type DiffReport struct {
 
 // DiffMismatch is a sample of row diffs between source and target.
 type DiffMismatch struct {
-	Source *RowDiff `json:"source_diff,omitempty"`
-	Target *RowDiff `json:"target_diff,omitempty"`
+	Source *RowDiff `json:"Source,omitempty"`
+	Target *RowDiff `json:"Target,omitempty"`
 }
 
 // RowDiff is a row that didn't match as part of the comparison.
 type RowDiff struct {
 	Row   map[string]string `json:"Row,omitempty"`
-	Query string            `json:"-"`
+	Query string            `json:"Query,omitempty"`
 }
 
 func (td *tableDiffer) genRowDiff(queryStmt string, row []sqltypes.Value, debug, onlyPks bool) (*RowDiff, error) {

--- a/go/vt/vttablet/tabletmanager/vdiff/schema.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/schema.go
@@ -22,7 +22,18 @@ var withDDL *withddl.WithDDL
 
 func init() {
 	var ddls []string
+	// Initial VDiff related schema
 	ddls = append(ddls, sqlCreateSidecarDB, sqlCreateVDiffTable, sqlCreateVDiffTableTable, sqlCreateVDiffLogTable)
+	// Changes to VDiff related schema over time
+	ddls = append(ddls,
+		"ALTER TABLE _vt.vdiff MODIFY COLUMN id bigint AUTO_INCREMENT",
+		"ALTER TABLE _vt.vdiff CHANGE started_timestamp started_at timestamp NULL DEFAULT NULL",
+		"ALTER TABLE _vt.vdiff CHANGE completed_timestamp completed_at timestamp NULL DEFAULT NULL",
+		"ALTER TABLE _vt.vdiff MODIFY COLUMN state varbinary(64)",
+		"ALTER TABLE _vt.vdiff_table MODIFY COLUMN table_name varbinary(128)",
+		"ALTER TABLE _vt.vdiff_table MODIFY COLUMN state varbinary(64)",
+		"ALTER TABLE _vt.vdiff_table MODIFY COLUMN lastpk varbinary(2000)",
+	)
 	withDDL = withddl.New(ddls)
 }
 
@@ -64,26 +75,33 @@ const (
 		message text NOT NULL,
 		primary key (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
 
-	sqlNewVDiff                       = "insert into _vt.vdiff(keyspace, workflow, state, options, shard, db_name, vdiff_uuid) values(%s, %s, '%s', %s, '%s', '%s', '%s')"
+	sqlNewVDiff    = "insert into _vt.vdiff(keyspace, workflow, state, options, shard, db_name, vdiff_uuid) values(%s, %s, '%s', %s, '%s', '%s', '%s')"
+	sqlResumeVDiff = `update _vt.vdiff as vd, _vt.vdiff_table as vdt set vd.started_at = NULL, vd.completed_at = NULL, vd.state = 'pending',
+						vd.options = %s, vdt.state = 'pending', vdt.rows_compared = 0 where vd.vdiff_uuid = %s and vd.id = vdt.vdiff_id`
 	sqlGetVDiffByKeyspaceWorkflowUUID = "select * from _vt.vdiff where keyspace = %s and workflow = %s and vdiff_uuid = %s"
 	sqlGetMostRecentVDiff             = "select * from _vt.vdiff where keyspace = %s and workflow = %s order by id desc limit 1"
 	sqlGetVDiffByID                   = "select * from _vt.vdiff where id = %d"
-	sqlVDiffSummary                   = `select vt.vdiff_id, v.state as vdiff_state, vt.table_name, 
-										v.vdiff_uuid as 'uuid',
-										vt.state as table_state, vt.table_rows, 
-										vt.rows_compared, 
-										IF(vt.mismatch = 1, 1, 0) as has_mismatch, vt.report
-										from _vt.vdiff v, _vt.vdiff_table vt 
-										where v.id = vt.vdiff_id and v.id = %d`
-	sqlUpdateVDiffState     = "update _vt.vdiff set state = %s where id = %d"
+	sqlVDiffSummary                   = `select vd.state as vdiff_state, vdt.table_name as table_name,
+										vd.vdiff_uuid as 'uuid', vdt.state as table_state, vdt.table_rows as table_rows,
+										vd.started_at as started_at, vdt.rows_compared as rows_compared, vd.completed_at as completed_at,
+										IF(vdt.mismatch = 1, 1, 0) as has_mismatch, vdt.report as report
+										from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
+										where vdt.vdiff_id = %d`
+	// sqlUpdateVDiffState has a penultimate placeholder for any additional columns you want to update, e.g. `, foo = 1`
+	sqlUpdateVDiffState     = "update _vt.vdiff set state = %s %s where id = %d"
 	sqlGetVReplicationEntry = "select * from _vt.vreplication %s"
 	sqlGetPendingVDiffs     = "select * from _vt.vdiff where state = 'pending'"
+	sqlGetVDiffID           = "select id as id from _vt.vdiff where vdiff_uuid = %s"
 	sqlGetAllVDiffs         = "select * from _vt.vdiff order by id desc"
 
-	sqlNewVDiffTable       = "insert into _vt.vdiff_table(vdiff_id, table_name, state, table_rows) values(%d, %s, 'pending', %d)"
-	sqlUpdateRowsCompared  = "update _vt.vdiff_table set rows_compared = %d where vdiff_id = %d and table_name = %s"
-	sqlUpdateTableState    = "update _vt.vdiff_table set state = %s, report = %s where vdiff_id = %d and table_name = %s"
-	sqlUpdateTableMismatch = "update _vt.vdiff_table set mismatch = true where vdiff_id = %d and table_name = %s"
+	sqlNewVDiffTable = "insert into _vt.vdiff_table(vdiff_id, table_name, state, table_rows) values(%d, %s, 'pending', %d)"
+	sqlGetVDiffTable = `select vdt.lastpk as lastpk from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
+						where vdt.vdiff_id = %d and vdt.table_name = %s`
+	sqlUpdateTableRows       = "update _vt.vdiff_table set table_rows = %d where vdiff_id = %d and table_name = %s"
+	sqlUpdateTableProgress   = "update _vt.vdiff_table set rows_compared = %d, lastpk = %s where vdiff_id = %d and table_name = %s"
+	sqlUpdateTableNoProgress = "update _vt.vdiff_table set rows_compared = %d where vdiff_id = %d and table_name = %s"
+	sqlUpdateTableState      = "update _vt.vdiff_table set state = %s, report = %s where vdiff_id = %d and table_name = %s"
+	sqlUpdateTableMismatch   = "update _vt.vdiff_table set mismatch = true where vdiff_id = %d and table_name = %s"
 
-	sqlGetIncompleteTables = "select * from _vt.vdiff_table where vdiff_id = %d and state != 'completed'"
+	sqlGetIncompleteTables = "select table_name as table_name from _vt.vdiff_table where vdiff_id = %d and state != 'completed'"
 )

--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -67,6 +66,7 @@ type tableDiffer struct {
 	// sourceQuery is computed from the associated query for this table in the vreplication workflow's Rule Filter
 	sourceQuery string
 	table       *tabletmanagerdatapb.TableDefinition
+	lastPK      *querypb.QueryResult
 }
 
 func newTableDiffer(wd *workflowDiffer, table *tabletmanagerdatapb.TableDefinition, sourceQuery string) *tableDiffer {
@@ -89,7 +89,7 @@ func (td *tableDiffer) initialize(ctx context.Context) error {
 	log.Infof("Locking target keyspace %s", targetKeyspace)
 	ctx, unlock, lockErr := td.wd.ct.ts.LockKeyspace(ctx, targetKeyspace, "vdiff")
 	if lockErr != nil {
-		log.Errorf("LockKeyspace failed: %w", lockErr)
+		log.Errorf("LockKeyspace failed: %v", lockErr)
 		return lockErr
 	}
 
@@ -97,7 +97,7 @@ func (td *tableDiffer) initialize(ctx context.Context) error {
 	defer func() {
 		unlock(&err)
 		if err != nil {
-			log.Errorf("UnlockKeyspace %s failed: %w", targetKeyspace, lockErr)
+			log.Errorf("UnlockKeyspace %s failed: %v", targetKeyspace, lockErr)
 		}
 	}()
 
@@ -106,7 +106,7 @@ func (td *tableDiffer) initialize(ctx context.Context) error {
 	}
 	defer func() {
 		if err := td.restartTargetVReplicationStreams(ctx); err != nil {
-			log.Errorf("error restarting target streams: %w", err)
+			log.Errorf("error restarting target streams: %v", err)
 		}
 	}()
 
@@ -237,7 +237,7 @@ func pickTablet(ctx context.Context, ts *topo.Server, cell, keyspace, shard, tab
 func (td *tableDiffer) syncSourceStreams(ctx context.Context) error {
 	// source can be replica, wait for them to at least reach max gtid of all target streams
 	ct := td.wd.ct
-	waitCtx, cancel := context.WithTimeout(ctx, time.Duration(ct.options.CoreOptions.TimeoutSeconds)*time.Second)
+	waitCtx, cancel := context.WithTimeout(ctx, time.Duration(ct.options.CoreOptions.TimeoutSeconds*int64(time.Second)))
 	defer cancel()
 
 	if err := td.forEachSource(func(source *migrationSource) error {
@@ -254,7 +254,7 @@ func (td *tableDiffer) syncSourceStreams(ctx context.Context) error {
 
 func (td *tableDiffer) syncTargetStreams(ctx context.Context) error {
 	ct := td.wd.ct
-	waitCtx, cancel := context.WithTimeout(ctx, time.Duration(ct.options.CoreOptions.TimeoutSeconds)*time.Second)
+	waitCtx, cancel := context.WithTimeout(ctx, time.Duration(ct.options.CoreOptions.TimeoutSeconds*int64(time.Second)))
 	defer cancel()
 
 	if err := td.forEachSource(func(source *migrationSource) error {
@@ -278,10 +278,10 @@ func (td *tableDiffer) startTargetDataStream(ctx context.Context) error {
 	ct := td.wd.ct
 	gtidch := make(chan string, 1)
 	ct.targetShardStreamer.result = make(chan *sqltypes.Result, 1)
-	go td.streamOneShard(ctx, ct.targetShardStreamer, td.tablePlan.targetQuery, gtidch)
+	go td.streamOneShard(ctx, ct.targetShardStreamer, td.tablePlan.targetQuery, td.lastPK, gtidch)
 	gtid, ok := <-gtidch
 	if !ok {
-		log.Infof("streaming error: %w", ct.targetShardStreamer.err)
+		log.Infof("streaming error: %v", ct.targetShardStreamer.err)
 		return ct.targetShardStreamer.err
 	}
 	ct.targetShardStreamer.snapshotPosition = gtid
@@ -292,7 +292,7 @@ func (td *tableDiffer) startSourceDataStreams(ctx context.Context) error {
 	if err := td.forEachSource(func(source *migrationSource) error {
 		gtidch := make(chan string, 1)
 		source.result = make(chan *sqltypes.Result, 1)
-		go td.streamOneShard(ctx, source.shardStreamer, td.tablePlan.sourceQuery, gtidch)
+		go td.streamOneShard(ctx, source.shardStreamer, td.tablePlan.sourceQuery, td.lastPK, gtidch)
 
 		gtid, ok := <-gtidch
 		if !ok {
@@ -314,7 +314,7 @@ func (td *tableDiffer) restartTargetVReplicationStreams(ctx context.Context) err
 	return err
 }
 
-func (td *tableDiffer) streamOneShard(ctx context.Context, participant *shardStreamer, query string, gtidch chan string) {
+func (td *tableDiffer) streamOneShard(ctx context.Context, participant *shardStreamer, query string, lastPK *querypb.QueryResult, gtidch chan string) {
 	log.Infof("streamOneShard Start %s", participant.tablet.Alias.String())
 	defer func() {
 		log.Infof("streamOneShard End %s", participant.tablet.Alias.String())
@@ -334,7 +334,7 @@ func (td *tableDiffer) streamOneShard(ctx context.Context, participant *shardStr
 			TabletType: participant.tablet.Type,
 		}
 		var fields []*querypb.Field
-		return conn.VStreamRows(ctx, target, query, nil, func(vsrRaw *binlogdatapb.VStreamRowsResponse) error {
+		return conn.VStreamRows(ctx, target, query, lastPK, func(vsrRaw *binlogdatapb.VStreamRowsResponse) error {
 			// We clone (deep copy) the VStreamRowsResponse -- which contains a vstream packet with N rows and
 			// their corresponding GTID position/snapshot along with the LastPK in the row set -- so that we
 			// can safely process it while the next VStreamRowsResponse message is getting prepared by the
@@ -408,20 +408,22 @@ func (td *tableDiffer) diff(ctx context.Context, rowsToCompare *int64, debug, on
 	sourceExecutor := newPrimitiveExecutor(ctx, td.sourcePrimitive, "source")
 	targetExecutor := newPrimitiveExecutor(ctx, td.targetPrimitive, "target")
 	dr := &DiffReport{TableName: td.table.Name}
-	var sourceRow, targetRow []sqltypes.Value
+	var sourceRow, lastProcessedRow, targetRow []sqltypes.Value
 	var err error
 	advanceSource := true
 	advanceTarget := true
 	mismatch := false
 
-	for {
-		// TODO: store the progress in the _vt vdiff tables so that it can be exposed via the CLI interface
-		if dr.ProcessedRows%1e7 == 0 { // log progress every 10 million rows
-			log.Infof("VDiff progress:: table %s: %d rows", td.table.Name, dr.ProcessedRows)
-			if err := td.updateRowsCompared(dbClient, dr.ProcessedRows); err != nil {
-				return nil, err
-			}
+	// Save our progress when we finish the run
+	defer func() {
+		if err := td.updateTableProgress(dbClient, dr.ProcessedRows, lastProcessedRow); err != nil {
+			log.Errorf("Failed to update vdiff progress on %s table: %v", td.table.Name, err)
 		}
+	}()
+
+	for {
+		lastProcessedRow = sourceRow
+
 		if !mismatch && dr.MismatchedRows > 0 {
 			mismatch = true
 			log.Infof("Flagging mismatch for %s: %+v", td.table.Name, dr)
@@ -542,6 +544,15 @@ func (td *tableDiffer) diff(ctx context.Context, rowsToCompare *int64, debug, on
 		default:
 			dr.MatchingRows++
 		}
+
+		// Update progress every 10,000 rows as we go along. This will allow us to provide
+		// approximate progress information but without too much overhead for when it's not
+		// needed or even desired.
+		if dr.ProcessedRows%1e4 == 0 {
+			if err := td.updateTableProgress(dbClient, dr.ProcessedRows, sourceRow); err != nil {
+				return nil, err
+			}
+		}
 	}
 }
 
@@ -571,16 +582,31 @@ func (td *tableDiffer) compare(sourceRow, targetRow []sqltypes.Value, cols []com
 	return 0, nil
 }
 
-func (td *tableDiffer) updateRowsCompared(dbClient binlogplayer.DBClient, numRows int64) error {
-	query := fmt.Sprintf(sqlUpdateRowsCompared, numRows, td.wd.ct.id, encodeString(td.table.Name))
+func (td *tableDiffer) updateTableProgress(dbClient binlogplayer.DBClient, numRows int64, lastRow []sqltypes.Value) error {
+	var lastPK []byte
+	var err error
+	var query string
+	if lastRow != nil {
+		lastPK, err = td.lastPKFromRow(lastRow)
+		if err != nil {
+			return err
+		}
+		query = fmt.Sprintf(sqlUpdateTableProgress, numRows, encodeString(string(lastPK)), td.wd.ct.id, encodeString(td.table.Name))
+	} else if numRows != 0 {
+		// This should never happen
+		return fmt.Errorf("invalid vdiff state detected, %d row(s) were processed but the row data is missing", numRows)
+	} else {
+		// We didn't process any rows this time around so reflect that and keep any
+		// lastpk from a previous run. This is only relevant for RESUMEd vdiffs.
+		query = fmt.Sprintf(sqlUpdateTableNoProgress, numRows, td.wd.ct.id, encodeString(td.table.Name))
+	}
 	if _, err := dbClient.ExecuteFetch(query, 1); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (td *tableDiffer) updateTableState(ctx context.Context, dbClient binlogplayer.DBClient, tableName, state string, dr *DiffReport) error {
-	state = strings.ToLower(state)
+func (td *tableDiffer) updateTableState(ctx context.Context, dbClient binlogplayer.DBClient, tableName string, state VDiffState, dr *DiffReport) error {
 	reportJSON := "{}"
 	if dr != nil {
 		reportJSONBytes, err := json.Marshal(dr)
@@ -589,7 +615,7 @@ func (td *tableDiffer) updateTableState(ctx context.Context, dbClient binlogplay
 		}
 		reportJSON = string(reportJSONBytes)
 	}
-	query := fmt.Sprintf(sqlUpdateTableState, encodeString(state), encodeString(reportJSON), td.wd.ct.id, encodeString(tableName))
+	query := fmt.Sprintf(sqlUpdateTableState, encodeString(string(state)), encodeString(reportJSON), td.wd.ct.id, encodeString(tableName))
 	if _, err := withDDL.Exec(ctx, query, dbClient.ExecuteFetch, dbClient.ExecuteFetch); err != nil {
 		return err
 	}
@@ -604,4 +630,19 @@ func updateTableMismatch(dbClient binlogplayer.DBClient, vdiffID int64, table st
 		return err
 	}
 	return nil
+}
+
+func (td *tableDiffer) lastPKFromRow(row []sqltypes.Value) ([]byte, error) {
+	pkColCnt := len(td.tablePlan.pkCols)
+	pkFields := make([]*querypb.Field, pkColCnt)
+	pkVals := make([]sqltypes.Value, pkColCnt)
+	for i, colIndex := range td.tablePlan.pkCols {
+		pkFields[i] = td.tablePlan.table.Fields[colIndex]
+		pkVals[i] = row[colIndex]
+	}
+	buf, err := prototext.Marshal(&querypb.QueryResult{
+		Fields: pkFields,
+		Rows:   []*querypb.Row{sqltypes.RowToProto3(pkVals)},
+	})
+	return buf, err
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/utils.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/utils.go
@@ -73,7 +73,7 @@ func insertVDiffLog(ctx context.Context, dbClient binlogplayer.DBClient, vdiffID
 	query := "insert into _vt.vdiff_log(vdiff_id, message) values (%d, %s)"
 	query = fmt.Sprintf(query, vdiffID, encodeString(message))
 	if _, err := withDDL.Exec(ctx, query, dbClient.ExecuteFetch, dbClient.ExecuteFetch); err != nil {
-		log.Error("Error inserting into _vt.vdiff_log: %w", err)
+		log.Error("Error inserting into _vt.vdiff_log: %v", err)
 	}
 }
 

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"strings"
 
+	"google.golang.org/protobuf/encoding/prototext"
+
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 
 	"vitess.io/vitess/go/vt/schema"
@@ -29,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtctl/schematools"
@@ -93,15 +96,15 @@ func (wd *workflowDiffer) reconcileExtraRows(dr *DiffReport, maxExtraRowsToCompa
 
 func (wd *workflowDiffer) diffTable(ctx context.Context, dbClient binlogplayer.DBClient, td *tableDiffer) error {
 	tableName := td.table.Name
-	log.Infof("starting differ on table %s", tableName)
-	if err := td.updateTableState(ctx, dbClient, tableName, "started", nil); err != nil {
+	log.Infof("Starting differ on table %s", tableName)
+	if err := td.updateTableState(ctx, dbClient, tableName, StartedState, nil); err != nil {
 		return err
 	}
 	if err := td.initialize(ctx); err != nil {
 		return err
 	}
 	log.Infof("initialize done")
-	dr, err := td.diff(ctx, &wd.opts.CoreOptions.MaxRows, false, false, wd.opts.CoreOptions.MaxExtraRowsToCompare)
+	dr, err := td.diff(ctx, &wd.opts.CoreOptions.MaxRows, wd.opts.ReportOptions.DebugQuery, false, wd.opts.CoreOptions.MaxExtraRowsToCompare)
 	if err != nil {
 		log.Errorf("td.diff error %s", err.Error())
 		return err
@@ -118,21 +121,21 @@ func (wd *workflowDiffer) diffTable(ctx context.Context, dbClient binlogplayer.D
 	}
 
 	log.Infof("td.diff after reconciliation for %s, with dr %+v", tableName, dr)
-	if err := td.updateTableState(ctx, dbClient, tableName, "completed", dr); err != nil {
+	if err := td.updateTableState(ctx, dbClient, tableName, CompletedState, dr); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (wd *workflowDiffer) getTotalRowsEstimate(dbClient binlogplayer.DBClient) error {
-	query := "select db_name from _vt.vreplication where workflow = %s limit 1"
+	query := "select db_name as db_name from _vt.vreplication where workflow = %s limit 1"
 	query = fmt.Sprintf(query, encodeString(wd.ct.workflow))
 	qr, err := dbClient.ExecuteFetch(query, 1)
 	if err != nil {
 		return err
 	}
 	dbName, _ := qr.Named().Row().ToString("db_name")
-	query = "select table_name, table_rows from information_schema.tables where table_schema = %s"
+	query = "select table_name as table_name, table_rows as table_rows from information_schema.tables where table_schema = %s"
 	query = fmt.Sprintf(query, encodeString(dbName))
 	qr, err = dbClient.ExecuteFetch(query, -1)
 	if err != nil {
@@ -141,10 +144,7 @@ func (wd *workflowDiffer) getTotalRowsEstimate(dbClient binlogplayer.DBClient) e
 	for _, row := range qr.Named().Rows {
 		tableName, _ := row.ToString("table_name")
 		tableRows, _ := row.ToInt64("table_rows")
-		_, ok := wd.tableSizes[tableName]
-		if ok {
-			wd.tableSizes[tableName] = tableRows
-		}
+		wd.tableSizes[tableName] = tableRows
 	}
 	return nil
 }
@@ -161,7 +161,7 @@ func (wd *workflowDiffer) diff(ctx context.Context) error {
 	if err != nil {
 		return vterrors.Wrap(err, "GetSchema")
 	}
-	if err = wd.buildPlan(filter, schm); err != nil {
+	if err = wd.buildPlan(dbClient, filter, schm); err != nil {
 		return vterrors.Wrap(err, "buildPlan")
 	}
 	if err := wd.getTotalRowsEstimate(dbClient); err != nil {
@@ -172,15 +172,25 @@ func (wd *workflowDiffer) diff(ctx context.Context) error {
 		if !ok {
 			tableRows = 0
 		}
-		query := fmt.Sprintf(sqlNewVDiffTable, wd.ct.id, encodeString(td.table.Name), tableRows)
+		var query string
+		query = fmt.Sprintf(sqlGetVDiffTable, wd.ct.id, encodeString(td.table.Name))
+		qr, err := withDDL.Exec(ctx, query, dbClient.ExecuteFetch, dbClient.ExecuteFetch)
+		if err != nil {
+			return err
+		}
+		if len(qr.Rows) == 0 {
+			query = fmt.Sprintf(sqlNewVDiffTable, wd.ct.id, encodeString(td.table.Name), tableRows)
+		} else {
+			// Update the table rows estimate when resuming
+			query = fmt.Sprintf(sqlUpdateTableRows, tableRows, wd.ct.id, encodeString(td.table.Name))
+		}
 		if _, err := withDDL.Exec(ctx, query, dbClient.ExecuteFetch, dbClient.ExecuteFetch); err != nil {
 			return err
 		}
-	}
-	for _, td := range wd.tableDiffers {
+
 		log.Infof("starting table %s", td.table.Name)
 		if err := wd.diffTable(ctx, dbClient, td); err != nil {
-			if err := td.updateTableState(ctx, dbClient, td.table.Name, "error", nil); err != nil {
+			if err := td.updateTableState(ctx, dbClient, td.table.Name, ErrorState, nil); err != nil {
 				return err
 			}
 			insertVDiffLog(ctx, dbClient, wd.ct.id, fmt.Sprintf("Table %s Error: %s", td.table.Name, err))
@@ -201,14 +211,14 @@ func (wd *workflowDiffer) markIfCompleted(ctx context.Context, dbClient binlogpl
 		return err
 	}
 	if len(qr.Rows) == 0 {
-		if err := wd.ct.updateState(dbClient, "completed"); err != nil {
+		if err := wd.ct.updateState(dbClient, CompletedState); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (wd *workflowDiffer) buildPlan(filter *binlogdatapb.Filter, schm *tabletmanagerdatapb.SchemaDefinition) error {
+func (wd *workflowDiffer) buildPlan(dbClient binlogplayer.DBClient, filter *binlogdatapb.Filter, schm *tabletmanagerdatapb.SchemaDefinition) error {
 	var specifiedTables []string
 	optTables := strings.TrimSpace(wd.opts.CoreOptions.Tables)
 	if optTables != "" {
@@ -243,6 +253,11 @@ func (wd *workflowDiffer) buildPlan(filter *binlogdatapb.Filter, schm *tabletman
 		}
 
 		td := newTableDiffer(wd, table, sourceQuery)
+		lastpkpb, err := wd.getTableLastPK(dbClient, table.Name)
+		if err != nil {
+			return err
+		}
+		td.lastPK = lastpkpb
 		wd.tableDiffers[table.Name] = td
 		if _, err := td.buildTablePlan(); err != nil {
 			return err
@@ -252,4 +267,27 @@ func (wd *workflowDiffer) buildPlan(filter *binlogdatapb.Filter, schm *tabletman
 		return fmt.Errorf("no tables found to diff, %s:%s", optTables, specifiedTables)
 	}
 	return nil
+}
+
+// getTableLastPK gets the lastPK protobuf message for a given vdiff table
+func (wd *workflowDiffer) getTableLastPK(dbClient binlogplayer.DBClient, tableName string) (*querypb.QueryResult, error) {
+	query := fmt.Sprintf(sqlGetVDiffTable, wd.ct.id, encodeString(tableName))
+	qr, err := dbClient.ExecuteFetch(query, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(qr.Rows) == 1 {
+		var lastpk []byte
+		if lastpk, err = qr.Named().Row().ToBytes("lastpk"); err != nil {
+			return nil, err
+		}
+		if len(lastpk) != 0 {
+			var lastpkpb querypb.QueryResult
+			if err := prototext.Unmarshal(lastpk, &lastpkpb); err != nil {
+				return nil, err
+			}
+			return &lastpkpb, nil
+		}
+	}
+	return nil, nil
 }

--- a/go/vt/wrangler/vdiff2.go
+++ b/go/vt/wrangler/vdiff2.go
@@ -68,10 +68,9 @@ func (wr *Wrangler) VDiff2(ctx context.Context, keyspace, workflowName string, c
 		return err
 	})
 	if output.Err != nil {
-		log.Errorf("Error in command %s: %w", command, output.Err)
-		return nil, err
+		log.Errorf("Error in command %s: %v", command, output.Err)
+		return nil, output.Err
 	}
-	log.Infof("Output for %s is %+v", command, output)
 
 	return output, nil
 }


### PR DESCRIPTION
## Description

This is a backport of https://github.com/vitessio/vitess/pull/10497. While the primary intention of that work was to add a new feature — namely `Resume` — in the process of implementing that it became clear that [the existing VDiff2 work in 14.0](https://github.com/vitessio/vitess/pull/10382) could easily produce incorrect results and was not easy to validate or debug. There were also a number of other smaller/minor bugs that were fixed in that work. All of this made it very challenging for early adopters to try it out, get value, and provide meaningful feedback (which was the entire reason to get the experimental version into 14.0 in the first place). Because of this, combined with the fact that VDiff2 is experimental and has isolated code, we are backporting this work for 14.0 GA (normally new feature work would only go into main).

## Related Issue(s)

- Cherry-pick from: https://github.com/vitessio/vitess/pull/10497

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added
-   [x] Documentation: https://github.com/vitessio/website/pull/1060