### PR TITLE
fix: Allow gen4 to handle variables on authoritative tables

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2012,3 +2012,7 @@ func convertStringToInt(integer string) int {
 	val, _ := strconv.Atoi(integer)
 	return val
 }
+
+func (node *ColName) IsVariable() bool {
+	return node.Name.AtCount() != NoAt
+}

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -3472,3 +3472,23 @@ Gen4 plan same as above
     ]
   }
 }
+
+# Getting variable value from an authoritative table should work just fine
+# V3 still fails. Fixed in v15
+"select @@foo from authoritative"
+"symbol @@foo not found in table or subquery"
+{
+  "QueryType": "SELECT",
+  "Original": "select @@foo from authoritative",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select @@foo from authoritative where 1 != 1",
+    "Query": "select @@foo from authoritative",
+    "Table": "authoritative"
+  }
+}

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -91,6 +91,9 @@ func (b *binder) up(cursor *sqlparser.Cursor) error {
 			node.Using = nil
 		}
 	case *sqlparser.ColName:
+		if node.IsVariable() {
+			break
+		}
 		currentScope := b.scoper.currentScope()
 		deps, err := b.resolveColumn(node, currentScope, false)
 		if err != nil {


### PR DESCRIPTION
## Description
In V15, this has been fixes in a [different way](https://github.com/vitessio/vitess/pull/10547) but for the backported fix, we want to change as little as possible.

This change allows Gen4 to handle these queries, even if V3 still fails.

## Related Issue(s)

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
