### PR TITLE
Add stale PRs action

### DIFF
--- a/.github/workflows/close_stale_pull_requests.yml
+++ b/.github/workflows/close_stale_pull_requests.yml
@@ -1,0 +1,26 @@
+name: close_stale_pull_requests
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close_stale_pull_requests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-stale: 30
+          # Do not handle issues at all. We only want to handle PRs.
+          days-before-issue-stale: -1
+
+          stale-pr-message: "This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment, or this will be closed in 7 days."
+          close-pr-message: "This PR was closed because it has been stale for 7 days with no activity."
+
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # (TODO:ajm188) - remove these after testing/validating the workflow.
+          debug-only: true
+          enable-statistics: true


### PR DESCRIPTION
## Description

This adds a new workflow using https://github.com/actions/stale to close stale PRs after a period of time.

It currently is scheduled on a cron to run at 1am UTC, but obviously we can change that. I've also left it in debug-only (so it won't actually close anything) and with stats on, so we can see what it's doing before turning it on For Real. The other thing is I _believe_ we'll need to manually create the `Stale` label, so I'll do that once we're happy and ready to merge this.

I'm not 100% sure how to test this without merging and then manually triggering the workflow, but if you have sweet gh-actions debugging tips I'd love to hear them!

The other _other_ thing is there's currently no way to tag the PR author, but there is an [open issue for that feature](https://github.com/actions/stale/issues/714)

## Related Issue(s)

#10565 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

Before-merge:
- [ ] create Stale label

After-merge:
- [ ] trigger manually to verify
- [ ] wait a few days and check debug logs after nightly runs
- [ ] follow-up PR to turn off stats and `debug-only`
