### PR TITLE
Implement VDiff2 Delete Action

### DIFF
--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -175,6 +175,15 @@ func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, cells []*Cell) 
 		})
 	}
 
+	// test show verbose and delete
+	_, output := performVDiff2Action(t, ksWorkflow, allCellNames, "show", "last", false, "--verbose")
+	// only present with --verbose
+	require.Contains(t, output, `"TableSummary":`)
+	_, output = performVDiff2Action(t, ksWorkflow, allCellNames, "delete", "all", false)
+	require.Contains(t, output, `"Status": "completed"`)
+	_, output = performVDiff2Action(t, ksWorkflow, allCellNames, "show", "all", false)
+	require.Equal(t, "[]\n", output)
+
 	err = vc.VtctlClient.ExecuteCommand(tc.typ, "--", "SwitchTraffic", ksWorkflow)
 	require.NoError(t, err)
 	err = vc.VtctlClient.ExecuteCommand(tc.typ, "--", "Complete", ksWorkflow)

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -215,7 +215,7 @@ func testDelete(t *testing.T, ksWorkflow, cells string) {
 
 func testNoOrphanedData(t *testing.T, keyspace, workflow string, shards []string) {
 	t.Run("No orphaned data", func(t *testing.T) {
-		query := fmt.Sprintf("select vd.id as vdiff_id, vdt.vdiff_id as vdiff_table_id from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id) where vd.keyspace = %s and vd.workflow = %s",
+		query := fmt.Sprintf("select vd.id as vdiff_id, vdt.vdiff_id as vdiff_table_id, vdl.vdiff_id as vdiff_log_id from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id) inner join _vt.vdiff_log as vdl on (vd.id = vdl.vdiff_id) where vd.keyspace = %s and vd.workflow = %s",
 			encodeString(keyspace), encodeString(workflow))
 		for _, shard := range shards {
 			res, err := vc.getPrimaryTablet(t, keyspace, shard).QueryTablet(query, keyspace, false)

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -190,6 +190,8 @@ func testCLIErrors(t *testing.T, ksWorkflow, cells string) {
 		require.Contains(t, output, "please provide a valid UUID")
 		_, output = performVDiff2Action(t, ksWorkflow, cells, "resume", "invalid_uuid", true)
 		require.Contains(t, output, "can only resume a specific vdiff, please provide a valid UUID")
+		_, output = performVDiff2Action(t, ksWorkflow, cells, "delete", "invalid_uuid", true)
+		require.Contains(t, output, "can only delete a specific vdiff, please provide a valid UUID")
 		uuid, _ := performVDiff2Action(t, ksWorkflow, cells, "show", "last", false)
 		_, output = performVDiff2Action(t, ksWorkflow, cells, "create", uuid, true)
 		require.Contains(t, output, "already exists")
@@ -199,9 +201,11 @@ func testCLIErrors(t *testing.T, ksWorkflow, cells string) {
 func testDelete(t *testing.T, ksWorkflow, cells string) {
 	t.Run("Delete", func(t *testing.T) {
 		// test show verbose too as a side effect
-		_, output := performVDiff2Action(t, ksWorkflow, cells, "show", "last", false, "--verbose")
+		uuid, output := performVDiff2Action(t, ksWorkflow, cells, "show", "last", false, "--verbose")
 		// only present with --verbose
 		require.Contains(t, output, `"TableSummary":`)
+		_, output = performVDiff2Action(t, ksWorkflow, cells, "delete", uuid, false)
+		require.Contains(t, output, `"Status": "completed"`)
 		_, output = performVDiff2Action(t, ksWorkflow, cells, "delete", "all", false)
 		require.Contains(t, output, `"Status": "completed"`)
 		_, output = performVDiff2Action(t, ksWorkflow, cells, "show", "all", false)

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/wrangler"
 )
@@ -204,4 +205,10 @@ func getVDiffInfo(jsonStr string) *vdiffInfo {
 	info.HasMismatch, _ = jsonparser.GetBoolean(json, "HasMismatch")
 
 	return &info
+}
+
+func encodeString(in string) string {
+	var buf strings.Builder
+	sqltypes.NewVarChar(in).EncodeSQL(&buf)
+	return buf.String()
 }

--- a/go/vt/vtctl/vdiff2.go
+++ b/go/vt/vtctl/vdiff2.go
@@ -54,12 +54,15 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 
 	debugQuery := subFlags.Bool("debug_query", false, "Adds a mysql query to the report that can be used for further debugging")
 	onlyPks := subFlags.Bool("only_pks", false, "When reporting missing rows, only show primary keys in the report.")
-	format := subFlags.String("format", "", "Format of report") // "json" or ""
+	var format string
+	subFlags.StringVar(&format, "format", "text", "Format of report") // "json" or "text"
+	format = strings.ToLower(format)
 	maxExtraRowsToCompare := subFlags.Int64("max_extra_rows_to_compare", 1000, "If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation.")
 
 	resumable := subFlags.Bool("resumable", false, "Should this vdiff retry in case of recoverable errors, not yet implemented")
 	checksum := subFlags.Bool("checksum", false, "Use row-level checksums to compare, not yet implemented")
 	samplePct := subFlags.Int64("sample_pct", 100, "How many rows to sample, not yet implemented")
+	verbose := subFlags.Bool("verbose", false, "Show full vdiff output in summaries (only applicable when using JSON format)")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -112,7 +115,7 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 		ReportOptions: &tabletmanagerdatapb.VDiffReportOptions{
 			OnlyPKS:    *onlyPks,
 			DebugQuery: *debugQuery,
-			Format:     *format,
+			Format:     format,
 		},
 	}
 
@@ -141,6 +144,15 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 		if err != nil {
 			return fmt.Errorf("can only resume a specific vdiff, please provide a valid UUID; view all with: VDiff -- --v2 %s.%s show all", keyspace, workflowName)
 		}
+	case vdiff.DeleteAction:
+		switch actionArg {
+		case vdiff.AllActionArg:
+		default:
+			vdiffUUID, err = uuid.Parse(actionArg)
+			if err != nil {
+				return fmt.Errorf("can only delete a specific vdiff, please provide a valid UUID; view all with: VDiff -- --v2 %s.%s show all", keyspace, workflowName)
+			}
+		}
 	default:
 		return fmt.Errorf("invalid action %s; %s", action, usage)
 	}
@@ -155,15 +167,17 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 
 	switch action {
 	case vdiff.CreateAction, vdiff.ResumeAction:
-		displayVDiff2ScheduledResponse(wr, *format, vdiffUUID.String(), action)
+		displayVDiff2ScheduledResponse(wr, format, vdiffUUID.String(), action)
 	case vdiff.ShowAction:
 		if output == nil {
 			// should not happen
 			return fmt.Errorf("invalid (empty) response from show command")
 		}
-		if err := displayVDiff2ShowResponse(wr, *format, keyspace, workflowName, actionArg, output); err != nil {
+		if err := displayVDiff2ShowResponse(wr, format, keyspace, workflowName, actionArg, output, *verbose); err != nil {
 			return err
 		}
+	case vdiff.DeleteAction:
+		displayVDiff2ActionStatusResponse(wr, format, action, vdiff.CompletedState)
 	default:
 		return fmt.Errorf("invalid action %s; %s", action, usage)
 	}
@@ -264,7 +278,7 @@ func displayListings(listings []*VDiffListing) string {
 	return str
 }
 
-func displayVDiff2ShowResponse(wr *wrangler.Wrangler, format, keyspace, workflowName, actionArg string, output *wrangler.VDiffOutput) error {
+func displayVDiff2ShowResponse(wr *wrangler.Wrangler, format, keyspace, workflowName, actionArg string, output *wrangler.VDiffOutput, verbose bool) error {
 	var vdiffUUID uuid.UUID
 	var err error
 	switch actionArg {
@@ -294,7 +308,7 @@ func displayVDiff2ShowResponse(wr *wrangler.Wrangler, format, keyspace, workflow
 		if len(output.Responses) == 0 {
 			return fmt.Errorf("no response received for vdiff show of %s.%s(%s)", keyspace, workflowName, vdiffUUID.String())
 		}
-		return displayVDiff2ShowSingleSummary(wr, format, keyspace, workflowName, vdiffUUID.String(), output)
+		return displayVDiff2ShowSingleSummary(wr, format, keyspace, workflowName, vdiffUUID.String(), output, verbose)
 	}
 }
 
@@ -342,9 +356,9 @@ func buildVDiff2Recent(output *wrangler.VDiffOutput) ([]*VDiffListing, error) {
 	return listings, nil
 }
 
-func displayVDiff2ShowSingleSummary(wr *wrangler.Wrangler, format, keyspace, workflowName, uuid string, output *wrangler.VDiffOutput) error {
+func displayVDiff2ShowSingleSummary(wr *wrangler.Wrangler, format, keyspace, workflowName, uuid string, output *wrangler.VDiffOutput, verbose bool) error {
 	str := ""
-	summary, err := buildVDiff2SingleSummary(wr, keyspace, workflowName, uuid, output)
+	summary, err := buildVDiff2SingleSummary(wr, keyspace, workflowName, uuid, output, verbose)
 	if err != nil {
 		return err
 	}
@@ -376,7 +390,7 @@ func displayVDiff2ShowSingleSummary(wr *wrangler.Wrangler, format, keyspace, wor
 	wr.Logger().Printf(str + "\n")
 	return nil
 }
-func buildVDiff2SingleSummary(wr *wrangler.Wrangler, keyspace, workflow, uuid string, output *wrangler.VDiffOutput) (*vdiffSummary, error) {
+func buildVDiff2SingleSummary(wr *wrangler.Wrangler, keyspace, workflow, uuid string, output *wrangler.VDiffOutput, verbose bool) (*vdiffSummary, error) {
 	summary := &vdiffSummary{
 		Workflow:     workflow,
 		Keyspace:     keyspace,
@@ -494,7 +508,7 @@ func buildVDiff2SingleSummary(wr *wrangler.Wrangler, keyspace, workflow, uuid st
 	summary.Shards = strings.Join(shards, ",")
 	summary.TableSummaryMap = tableSummaryMap
 	summary.Reports = reports
-	if !summary.HasMismatch {
+	if !summary.HasMismatch && !verbose {
 		summary.Reports = nil
 		summary.TableSummaryMap = nil
 	}
@@ -521,6 +535,21 @@ func displayVDiff2ScheduledResponse(wr *wrangler.Wrangler, format string, uuid s
 			addtlMsg = "to resume "
 		}
 		msg := fmt.Sprintf("VDiff %s scheduled %son target shards, use show to view progress\n", uuid, addtlMsg)
+		wr.Logger().Printf(msg)
+	}
+}
+
+func displayVDiff2ActionStatusResponse(wr *wrangler.Wrangler, format string, action vdiff.VDiffAction, status vdiff.VDiffState) {
+	if format == "json" {
+		type ActionStatusResponse struct {
+			Action vdiff.VDiffAction
+			Status vdiff.VDiffState
+		}
+		resp := &ActionStatusResponse{Action: action, Status: status}
+		jsonText, _ := json.MarshalIndent(resp, "", "\t")
+		wr.Logger().Printf(string(jsonText) + "\n")
+	} else {
+		msg := fmt.Sprintf("VDiff %s is %s on target shards\n", action, status)
 		wr.Logger().Printf(msg)
 	}
 }

--- a/go/vt/vtctl/vdiff2.go
+++ b/go/vt/vtctl/vdiff2.go
@@ -56,17 +56,18 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 	onlyPks := subFlags.Bool("only_pks", false, "When reporting missing rows, only show primary keys in the report.")
 	var format string
 	subFlags.StringVar(&format, "format", "text", "Format of report") // "json" or "text"
-	format = strings.ToLower(format)
 	maxExtraRowsToCompare := subFlags.Int64("max_extra_rows_to_compare", 1000, "If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation.")
 
 	resumable := subFlags.Bool("resumable", false, "Should this vdiff retry in case of recoverable errors, not yet implemented")
 	checksum := subFlags.Bool("checksum", false, "Use row-level checksums to compare, not yet implemented")
 	samplePct := subFlags.Int64("sample_pct", 100, "How many rows to sample, not yet implemented")
-	verbose := subFlags.Bool("verbose", false, "Show full vdiff output in summaries (only applicable when using JSON format)")
+	verbose := subFlags.Bool("verbose", false, "Show verbose vdiff output in summaries")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
+	format = strings.ToLower(format)
+
 	var action vdiff.VDiffAction
 	var actionArg string
 

--- a/go/vt/vtctl/vdiff2.go
+++ b/go/vt/vtctl/vdiff2.go
@@ -550,7 +550,7 @@ func displayVDiff2ActionStatusResponse(wr *wrangler.Wrangler, format string, act
 		jsonText, _ := json.MarshalIndent(resp, "", "\t")
 		wr.Logger().Printf(string(jsonText) + "\n")
 	} else {
-		msg := fmt.Sprintf("VDiff %s is %s on target shards\n", action, status)
+		msg := fmt.Sprintf("VDiff %s status is %s on target shards\n", action, status)
 		wr.Logger().Printf(msg)
 	}
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/schema.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/schema.go
@@ -81,12 +81,17 @@ const (
 	sqlGetVDiffByKeyspaceWorkflowUUID = "select * from _vt.vdiff where keyspace = %s and workflow = %s and vdiff_uuid = %s"
 	sqlGetMostRecentVDiff             = "select * from _vt.vdiff where keyspace = %s and workflow = %s order by id desc limit 1"
 	sqlGetVDiffByID                   = "select * from _vt.vdiff where id = %d"
-	sqlVDiffSummary                   = `select vd.state as vdiff_state, vdt.table_name as table_name,
-										vd.vdiff_uuid as 'uuid', vdt.state as table_state, vdt.table_rows as table_rows,
-										vd.started_at as started_at, vdt.rows_compared as rows_compared, vd.completed_at as completed_at,
-										IF(vdt.mismatch = 1, 1, 0) as has_mismatch, vdt.report as report
-										from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
-										where vdt.vdiff_id = %d`
+	// sqlDeleteVDiffs has a placeholder for any query predicates -- deleting all VDiffs by default
+	sqlDeleteVDiffs = `delete from vd, vdt using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id) where
+						vd.keyspace = %s and vd.workflow = %s`
+	sqlDeleteVDiffByUUID = `delete from vd, vdt using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
+							and vd.keyspace = %s and vd.workflow = %s and vd.vdiff_uuid = %s`
+	sqlVDiffSummary = `select vd.state as vdiff_state, vdt.table_name as table_name,
+						vd.vdiff_uuid as 'uuid', vdt.state as table_state, vdt.table_rows as table_rows,
+						vd.started_at as started_at, vdt.rows_compared as rows_compared, vd.completed_at as completed_at,
+						IF(vdt.mismatch = 1, 1, 0) as has_mismatch, vdt.report as report
+						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
+						where vdt.vdiff_id = %d`
 	// sqlUpdateVDiffState has a penultimate placeholder for any additional columns you want to update, e.g. `, foo = 1`
 	sqlUpdateVDiffState     = "update _vt.vdiff set state = %s %s where id = %d"
 	sqlGetVReplicationEntry = "select * from _vt.vreplication %s"

--- a/go/vt/vttablet/tabletmanager/vdiff/schema.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/schema.go
@@ -81,9 +81,8 @@ const (
 	sqlGetVDiffByKeyspaceWorkflowUUID = "select * from _vt.vdiff where keyspace = %s and workflow = %s and vdiff_uuid = %s"
 	sqlGetMostRecentVDiff             = "select * from _vt.vdiff where keyspace = %s and workflow = %s order by id desc limit 1"
 	sqlGetVDiffByID                   = "select * from _vt.vdiff where id = %d"
-	// sqlDeleteVDiffs has a placeholder for any query predicates -- deleting all VDiffs by default
-	sqlDeleteVDiffs = `delete from vd, vdt using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id) where
-						vd.keyspace = %s and vd.workflow = %s`
+	sqlDeleteVDiffs                   = `delete from vd, vdt using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id) where
+										vd.keyspace = %s and vd.workflow = %s`
 	sqlDeleteVDiffByUUID = `delete from vd, vdt using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
 							and vd.keyspace = %s and vd.workflow = %s and vd.vdiff_uuid = %s`
 	sqlVDiffSummary = `select vd.state as vdiff_state, vdt.table_name as table_name,

--- a/go/vt/vttablet/tabletmanager/vdiff/schema.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/schema.go
@@ -81,8 +81,9 @@ const (
 	sqlGetVDiffByKeyspaceWorkflowUUID = "select * from _vt.vdiff where keyspace = %s and workflow = %s and vdiff_uuid = %s"
 	sqlGetMostRecentVDiff             = "select * from _vt.vdiff where keyspace = %s and workflow = %s order by id desc limit 1"
 	sqlGetVDiffByID                   = "select * from _vt.vdiff where id = %d"
-	sqlDeleteVDiffs                   = `delete from vd, vdt using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id) where
-										vd.keyspace = %s and vd.workflow = %s`
+	sqlDeleteVDiffs                   = `delete from vd, vdt, vdl using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
+										inner join _vt.vdiff_log as vdl on (vd.id = vdl.vdiff_id)
+										where vd.keyspace = %s and vd.workflow = %s`
 	sqlDeleteVDiffByUUID = `delete from vd, vdt using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
 							and vd.keyspace = %s and vd.workflow = %s and vd.vdiff_uuid = %s`
 	sqlVDiffSummary = `select vd.state as vdiff_state, vdt.table_name as table_name,

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1586,9 +1586,9 @@ func (ts *trafficSwitcher) dropSourceReverseVReplicationStreams(ctx context.Cont
 		if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet, query); err != nil {
 			return err
 		}
-		query = fmt.Sprintf(sqlDeleteVDiffs, encodeString(source.GetPrimary().Keyspace), encodeString(ts.WorkflowName()))
+		query = fmt.Sprintf(sqlDeleteVDiffs, encodeString(source.GetPrimary().Keyspace), encodeString(workflow.ReverseWorkflowName(ts.WorkflowName())))
 		if _, err := ts.wr.tmc.ExecuteFetchAsDba(ctx, source.GetPrimary().Tablet, false, []byte(query), -1, false, false); err != nil {
-			ts.Logger().Infof("Error deleting vdiff data for %s.%s workflow: %v", source.GetPrimary().Keyspace, ts.WorkflowName(), err)
+			ts.Logger().Infof("Error deleting vdiff data for %s.%s workflow: %v", source.GetPrimary().Keyspace, workflow.ReverseWorkflowName(ts.WorkflowName()), err)
 		}
 		return nil
 	})

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -55,6 +55,10 @@ const (
 	errorNoStreams = "no streams found in keyspace %s for: %s"
 	// use pt-osc's naming convention, this format also ensures vstreamer ignores such tables
 	renameTableTemplate = "_%.59s_old" // limit table name to 64 characters
+
+	sqlDeleteWorkflow = "delete from _vt.vreplication where db_name = %s and workflow = %s"
+	sqlDeleteVDiffs   = `delete from vd, vdt using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on
+						(vd.id = vdt.vdiff_id) where vd.keyspace = %s and vd.workflow = %s`
 )
 
 // accessType specifies the type of access for a shard (allow/disallow writes).
@@ -1237,9 +1241,15 @@ func (ts *trafficSwitcher) getReverseVReplicationUpdateQuery(targetCell string, 
 
 func (ts *trafficSwitcher) deleteReverseVReplication(ctx context.Context) error {
 	return ts.ForAllSources(func(source *workflow.MigrationSource) error {
-		query := fmt.Sprintf("delete from _vt.vreplication where db_name=%s and workflow=%s", encodeString(source.GetPrimary().DbName()), encodeString(ts.reverseWorkflow))
-		_, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet, query)
-		return err
+		query := fmt.Sprintf(sqlDeleteWorkflow, encodeString(source.GetPrimary().DbName()), encodeString(ts.reverseWorkflow))
+		if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet, query); err != nil {
+			return err
+		}
+		query = fmt.Sprintf(sqlDeleteVDiffs, encodeString(source.GetPrimary().Keyspace), encodeString(ts.reverseWorkflow))
+		if _, err := ts.wr.tmc.ExecuteFetchAsDba(ctx, source.GetPrimary().Tablet, false, []byte(query), -1, false, false); err != nil {
+			ts.Logger().Infof("Error deleting vdiff data for %s.%s workflow: %v", source.GetPrimary().Keyspace, ts.reverseWorkflow, err)
+		}
+		return nil
 	})
 }
 
@@ -1556,20 +1566,31 @@ func (ts *trafficSwitcher) freezeTargetVReplication(ctx context.Context) error {
 
 func (ts *trafficSwitcher) dropTargetVReplicationStreams(ctx context.Context) error {
 	return ts.ForAllTargets(func(target *workflow.MigrationTarget) error {
-		ts.Logger().Infof("Deleting target streams for workflow %s db_name %s", ts.WorkflowName(), target.GetPrimary().DbName())
-		query := fmt.Sprintf("delete from _vt.vreplication where db_name=%s and workflow=%s", encodeString(target.GetPrimary().DbName()), encodeString(ts.WorkflowName()))
-		_, err := ts.TabletManagerClient().VReplicationExec(ctx, target.GetPrimary().Tablet, query)
-		return err
+		ts.Logger().Infof("Deleting target streams and related data for workflow %s db_name %s", ts.WorkflowName(), target.GetPrimary().DbName())
+		query := fmt.Sprintf(sqlDeleteWorkflow, encodeString(target.GetPrimary().DbName()), encodeString(ts.WorkflowName()))
+		if _, err := ts.TabletManagerClient().VReplicationExec(ctx, target.GetPrimary().Tablet, query); err != nil {
+			return err
+		}
+		query = fmt.Sprintf(sqlDeleteVDiffs, encodeString(target.GetPrimary().Keyspace), encodeString(ts.WorkflowName()))
+		if _, err := ts.wr.tmc.ExecuteFetchAsDba(ctx, target.GetPrimary().Tablet, false, []byte(query), -1, false, false); err != nil {
+			ts.Logger().Infof("Error deleting vdiff data for %s.%s workflow: %v", target.GetPrimary().Keyspace, ts.WorkflowName(), err)
+		}
+		return nil
 	})
 }
 
 func (ts *trafficSwitcher) dropSourceReverseVReplicationStreams(ctx context.Context) error {
 	return ts.ForAllSources(func(source *workflow.MigrationSource) error {
-		ts.Logger().Infof("Deleting reverse streams for workflow %s db_name %s", ts.WorkflowName(), source.GetPrimary().DbName())
-		query := fmt.Sprintf("delete from _vt.vreplication where db_name=%s and workflow=%s",
-			encodeString(source.GetPrimary().DbName()), encodeString(workflow.ReverseWorkflowName(ts.WorkflowName())))
-		_, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet, query)
-		return err
+		ts.Logger().Infof("Deleting reverse streams and related data for workflow %s db_name %s", ts.WorkflowName(), source.GetPrimary().DbName())
+		query := fmt.Sprintf(sqlDeleteWorkflow, encodeString(source.GetPrimary().DbName()), encodeString(workflow.ReverseWorkflowName(ts.WorkflowName())))
+		if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet, query); err != nil {
+			return err
+		}
+		query = fmt.Sprintf(sqlDeleteVDiffs, encodeString(source.GetPrimary().Keyspace), encodeString(ts.WorkflowName()))
+		if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet, query); err != nil {
+			ts.Logger().Infof("Error deleting vdiff data for %s.%s workflow: %v", source.GetPrimary().Keyspace, ts.WorkflowName(), err)
+		}
+		return nil
 	})
 }
 

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1587,7 +1587,7 @@ func (ts *trafficSwitcher) dropSourceReverseVReplicationStreams(ctx context.Cont
 			return err
 		}
 		query = fmt.Sprintf(sqlDeleteVDiffs, encodeString(source.GetPrimary().Keyspace), encodeString(ts.WorkflowName()))
-		if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet, query); err != nil {
+		if _, err := ts.wr.tmc.ExecuteFetchAsDba(ctx, source.GetPrimary().Tablet, false, []byte(query), -1, false, false); err != nil {
 			ts.Logger().Infof("Error deleting vdiff data for %s.%s workflow: %v", source.GetPrimary().Keyspace, ts.WorkflowName(), err)
 		}
 		return nil

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -57,8 +57,9 @@ const (
 	renameTableTemplate = "_%.59s_old" // limit table name to 64 characters
 
 	sqlDeleteWorkflow = "delete from _vt.vreplication where db_name = %s and workflow = %s"
-	sqlDeleteVDiffs   = `delete from vd, vdt using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on
-						(vd.id = vdt.vdiff_id) where vd.keyspace = %s and vd.workflow = %s`
+	sqlDeleteVDiffs   = `delete from vd, vdt, vdl using _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
+						inner join _vt.vdiff_log as vdl on (vd.id = vdl.vdiff_id)
+						where vd.keyspace = %s and vd.workflow = %s`
 )
 
 // accessType specifies the type of access for a shard (allow/disallow writes).

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -45,9 +45,9 @@ import (
 )
 
 const (
-	vexecTableQualifier    = "_vt"
-	vreplicationTableName  = "vreplication"
-	sqlVReplicationlDelete = "delete from _vt.vreplication"
+	vexecTableQualifier   = "_vt"
+	vreplicationTableName = "vreplication"
+	sqlVReplicationDelete = "delete from _vt.vreplication"
 )
 
 // vexec is the construct by which we run a query against backend shards. vexec is created by user-facing
@@ -215,7 +215,7 @@ func (vx *vexec) exec() (map[*topo.TabletInfo]*querypb.QueryResult, error) {
 			} else {
 				// If we deleted a workflow then let's make a best effort attempt to clean
 				// up any related data.
-				if vx.query == sqlVReplicationlDelete {
+				if vx.query == sqlVReplicationDelete {
 					query := fmt.Sprintf(sqlDeleteVDiffs, encodeString(primary.Keyspace), encodeString(vx.workflow))
 					if _, err := vx.wr.tmc.ExecuteFetchAsDba(ctx, primary.Tablet, false, []byte(query), -1, false, false); err != nil {
 						vx.wr.Logger().Infof("Error deleting vdiff data for %s.%s workflow: %v", primary.Keyspace, vx.workflow, err)
@@ -324,7 +324,7 @@ func (wr *Wrangler) getWorkflowActionQuery(action string) (string, error) {
 	case "start":
 		query = fmt.Sprintf(updateSQL, encodeString("Running"))
 	case "delete":
-		query = sqlVReplicationlDelete
+		query = sqlVReplicationDelete
 	default:
 		return "", fmt.Errorf("invalid action found: %s", action)
 	}

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -47,6 +47,7 @@ import (
 const (
 	vexecTableQualifier   = "_vt"
 	vreplicationTableName = "vreplication"
+	sqlVReplDelete        = "delete from _vt.vreplication"
 )
 
 // vexec is the construct by which we run a query against backend shards. vexec is created by user-facing
@@ -158,7 +159,7 @@ func (wr *Wrangler) VExec(ctx context.Context, workflow, keyspace, query string,
 	return retResults, err
 }
 
-// runVexec is th emain function that runs a dry or wet execution of 'query` on backend shards.
+// runVexec is the main function that runs a dry or wet execution of 'query' on backend shards.
 func (wr *Wrangler) runVexec(ctx context.Context, workflow, keyspace, query string, dryRun bool) (map[*topo.TabletInfo]*querypb.QueryResult, error) {
 	vx := newVExec(ctx, workflow, keyspace, query, wr)
 
@@ -212,6 +213,14 @@ func (vx *vexec) exec() (map[*topo.TabletInfo]*querypb.QueryResult, error) {
 			if err != nil {
 				allErrors.RecordError(err)
 			} else {
+				// If we deleted a workflow then let's make a best effort attempt to clean
+				// up any related data.
+				if strings.HasPrefix(vx.query, sqlVReplDelete) {
+					query := fmt.Sprintf(sqlDeleteVDiffs, encodeString(primary.Keyspace), encodeString(vx.workflow))
+					if _, err := vx.wr.tmc.ExecuteFetchAsDba(ctx, primary.Tablet, false, []byte(query), -1, false, false); err != nil {
+						vx.wr.Logger().Infof("Error deleting vdiff data for %s.%s workflow: %v", primary.Keyspace, vx.workflow, err)
+					}
+				}
 				mu.Lock()
 				results[primary] = qr
 				mu.Unlock()
@@ -315,7 +324,7 @@ func (wr *Wrangler) getWorkflowActionQuery(action string) (string, error) {
 	case "start":
 		query = fmt.Sprintf(updateSQL, encodeString("Running"))
 	case "delete":
-		query = "delete from _vt.vreplication"
+		query = sqlVReplDelete
 	default:
 		return "", fmt.Errorf("invalid action found: %s", action)
 	}

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -45,9 +45,9 @@ import (
 )
 
 const (
-	vexecTableQualifier   = "_vt"
-	vreplicationTableName = "vreplication"
-	sqlVReplDelete        = "delete from _vt.vreplication"
+	vexecTableQualifier    = "_vt"
+	vreplicationTableName  = "vreplication"
+	sqlVReplicationlDelete = "delete from _vt.vreplication"
 )
 
 // vexec is the construct by which we run a query against backend shards. vexec is created by user-facing
@@ -215,7 +215,7 @@ func (vx *vexec) exec() (map[*topo.TabletInfo]*querypb.QueryResult, error) {
 			} else {
 				// If we deleted a workflow then let's make a best effort attempt to clean
 				// up any related data.
-				if strings.HasPrefix(vx.query, sqlVReplDelete) {
+				if vx.query == sqlVReplicationlDelete {
 					query := fmt.Sprintf(sqlDeleteVDiffs, encodeString(primary.Keyspace), encodeString(vx.workflow))
 					if _, err := vx.wr.tmc.ExecuteFetchAsDba(ctx, primary.Tablet, false, []byte(query), -1, false, false); err != nil {
 						vx.wr.Logger().Infof("Error deleting vdiff data for %s.%s workflow: %v", primary.Keyspace, vx.workflow, err)
@@ -324,7 +324,7 @@ func (wr *Wrangler) getWorkflowActionQuery(action string) (string, error) {
 	case "start":
 		query = fmt.Sprintf(updateSQL, encodeString("Running"))
 	case "delete":
-		query = sqlVReplDelete
+		query = sqlVReplicationlDelete
 	default:
 		return "", fmt.Errorf("invalid action found: %s", action)
 	}


### PR DESCRIPTION
## Description

The primary thing that this PR does is add the `VDiff -- --v2 <keyspace>.<workflow> delete {all,<UUID>}` VDiff command action. 

Secondly, it purges any VDiff records for a workflow when that workflow is deleted via:
- &lt;workflow&gt; complete
- &lt;workflow&gt; cancel
- &lt;workflow&gt; delete

Lastly, it also adds a `--verbose` flag for `VDiff show` output.


## Related Issue(s)
 - Fixes: https://github.com/vitessio/vitess/issues/10609

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added
-   [x] Documentation: https://github.com/vitessio/website/pull/1079