### PR TITLE
unit test: fix mysql tests to run on MacOS

### DIFF
--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -36,7 +37,7 @@ import (
 )
 
 // assertSQLError makes sure we get the right error.
-func assertSQLError(t *testing.T, err error, code int, sqlState string, subtext string, query string) {
+func assertSQLError(t *testing.T, err error, code int, sqlState string, subtext string, query string, pattern string) {
 	t.Helper()
 
 	require.Error(t, err, "was expecting SQLError %v / %v / %v but got no error.", code, sqlState, subtext)
@@ -44,7 +45,11 @@ func assertSQLError(t *testing.T, err error, code int, sqlState string, subtext 
 	require.True(t, ok, "was expecting SQLError %v / %v / %v but got: %v", code, sqlState, subtext, err)
 	require.Equal(t, code, serr.Num, "was expecting SQLError %v / %v / %v but got code %v", code, sqlState, subtext, serr.Num)
 	require.Equal(t, sqlState, serr.State, "was expecting SQLError %v / %v / %v but got state %v", code, sqlState, subtext, serr.State)
-	require.True(t, subtext == "" || strings.Contains(serr.Message, subtext), "was expecting SQLError %v / %v / %v but got message %v", code, sqlState, subtext, serr.Message)
+	if pattern != "" {
+		require.Regexp(t, regexp.MustCompile(pattern), serr.Message)
+	} else {
+		require.True(t, subtext == "" || strings.Contains(serr.Message, subtext), "was expecting SQLError %v / %v / %v but got message %v", code, sqlState, subtext, serr.Message)
+	}
 	require.Equal(t, query, serr.Query, "was expecting SQLError %v / %v / %v with Query '%v' but got query '%v'", code, sqlState, subtext, query, serr.Query)
 }
 
@@ -105,14 +110,14 @@ func TestConnectTimeout(t *testing.T) {
 	}()
 	ctx = context.Background()
 	_, err = Connect(ctx, params)
-	assertSQLError(t, err, CRServerLost, SSUnknownSQLState, "initial packet read failed", "")
+	assertSQLError(t, err, CRServerLost, SSUnknownSQLState, "initial packet read failed", "", "")
 
 	// Now close the listener. Connect should fail right away,
 	// check the error.
 	listener.Close()
 	wg.Wait()
 	_, err = Connect(ctx, params)
-	assertSQLError(t, err, CRConnHostError, SSUnknownSQLState, "connection refused", "")
+	assertSQLError(t, err, CRConnHostError, SSUnknownSQLState, "connection refused", "", "")
 
 	// Tests a connection where Dial to a unix socket fails
 	// properly returns the right error. To simulate exactly the
@@ -125,7 +130,8 @@ func TestConnectTimeout(t *testing.T) {
 	ctx = context.Background()
 	_, err = Connect(ctx, params)
 	os.Remove(name)
-	assertSQLError(t, err, CRConnectionError, SSUnknownSQLState, "connection refused", "")
+	t.Log(err)
+	assertSQLError(t, err, CRConnectionError, SSUnknownSQLState, "connection refused", "", "net\\.Dial\\(([a-z0-9A-Z\\/]*)\\) to local server failed:")
 }
 
 // TestTLSClientDisabled creates a Server with TLS support, then connects
@@ -386,7 +392,7 @@ func TestTLSClientVerifyCA(t *testing.T) {
 
 	fmt.Printf("Error: %s", err)
 
-	assert.Contains(t, err.Error(), "certificate signed by unknown authority")
+	assert.Contains(t, err.Error(), "cannot send HandshakeResponse41: x509:")
 
 	// Now setup proper CA that is valid to verify
 	params.SslCa = path.Join(root, "ca-cert.pem")
@@ -469,7 +475,7 @@ func TestTLSClientVerifyIdentity(t *testing.T) {
 
 	fmt.Printf("Error: %s", err)
 
-	assert.Contains(t, err.Error(), "certificate signed by unknown authority")
+	assert.Contains(t, err.Error(), "cannot send HandshakeResponse41: x509:")
 
 	// Now setup proper CA that is valid to verify
 	params.SslCa = path.Join(root, "ca-cert.pem")

--- a/go/mysql/server_flaky_test.go
+++ b/go/mysql/server_flaky_test.go
@@ -784,7 +784,7 @@ func TestDialogServer(t *testing.T) {
 	}
 	sql := "select rows"
 	output, ok := runMysql(t, params, sql)
-	if strings.Contains(output, "No such file or directory") {
+	if strings.Contains(output, "No such file or directory") || strings.Contains(output, "Authentication plugin 'dialog' cannot be loaded") {
 		t.Logf("skipping dialog plugin tests, as the dialog plugin cannot be loaded: %v", err)
 		return
 	}


### PR DESCRIPTION
## Description
Several unit tests in `go/mysql` fail on Mac because of slightly different error messages.
Fix them by either using a regex or checking for the common part of the error message.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
