### PR TITLE
Online DDL: increase stale migration timeout

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -113,7 +113,7 @@ var maxConstraintNameLength = 64
 
 const (
 	maxPasswordLength                        = 32 // MySQL's *replication* password may not exceed 32 characters
-	staleMigrationMinutes                    = 10
+	staleMigrationMinutes                    = 120
 	progressPctStarted               float64 = 0
 	progressPctFull                  float64 = 100.0
 	etaSecondsUnknown                        = -1

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -113,7 +113,7 @@ var maxConstraintNameLength = 64
 
 const (
 	maxPasswordLength                        = 32 // MySQL's *replication* password may not exceed 32 characters
-	staleMigrationMinutes                    = 120
+	staleMigrationMinutes                    = 180
 	progressPctStarted               float64 = 0
 	progressPctFull                  float64 = 100.0
 	etaSecondsUnknown                        = -1


### PR DESCRIPTION

## Description

A very simple change, increasing stale migration timeout from `10min` to `180min`  (`3h`).

Stale migration timeout is when Online DDL sees no liveness indication on a migration for a period of time. In such case, it cancels the migration, forcibly terminating it.

Normally, a 10minute timeout is a reasonable value. However, we are seeing some scenarios where this may be insufficient, relating to how VReplication reports (or does not report) liveness. Until VReplication's behavior is reviewed, this simple increase should do well to avoid terminating some migrations prematurely. Downside of this change, is that migrations that really go rogue, will take 3h to terminate clean up.
Thankfully, rogue migrations are a rare thing, and so aforementioned downside is also rare.

## Related Issue(s)

#6926 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
