### PR TITLE
Use the old planner version flag in v14 upgrade-downgrade tests

### DIFF
--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -87,7 +87,15 @@ func (vtgate *VtgateProcess) Setup() (err error) {
 		"--mysql_auth_server_impl", vtgate.MySQLAuthServerImpl,
 	}
 	if vtgate.PlannerVersion > 0 {
-		args = append(args, "--planner-version", vtgate.PlannerVersion.String())
+		v, err := GetMajorVersion("vtgate")
+		if err != nil {
+			return err
+		}
+		plannerFlag := "--planner-version"
+		if v < 14 {
+			plannerFlag = "--planner_version"
+		}
+		args = append(args, plannerFlag, vtgate.PlannerVersion.String())
 	}
 	if vtgate.SysVarSetEnabled {
 		args = append(args, "--enable_system_settings")

--- a/go/test/endtoend/vtgate/schematracker/unauthorized/unauthorized_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unauthorized/unauthorized_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/test/endtoend/utils"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
@@ -88,6 +90,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestSchemaTrackingError(t *testing.T) {
+	utils.SkipIfBinaryIsBelowVersion(t, 14, "vtgate")
+
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -95,7 +99,7 @@ func TestSchemaTrackingError(t *testing.T) {
 
 	logDir := clusterInstance.VtgateProcess.LogDir
 
-	timeout := time.After(5 * time.Minute)
+	timeout := time.After(1 * time.Minute)
 	var present bool
 	for {
 		select {
@@ -104,9 +108,7 @@ func TestSchemaTrackingError(t *testing.T) {
 		case <-time.After(1 * time.Second):
 			// check info logs
 			all, err := os.ReadFile(path.Join(logDir, "vtgate.WARNING"))
-			if err != nil {
-				continue
-			}
+			require.NoError(t, err)
 			if strings.Contains(string(all), "Table ACL might be enabled, --schema_change_signal_user needs to be passed to VTGate for schema tracking to work. Check 'schema tracking' docs on vitess.io") {
 				present = true
 			}

--- a/go/test/endtoend/vtgate/schematracker/unauthorized/unauthorized_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unauthorized/unauthorized_test.go
@@ -95,7 +95,7 @@ func TestSchemaTrackingError(t *testing.T) {
 
 	logDir := clusterInstance.VtgateProcess.LogDir
 
-	timeout := time.After(1 * time.Minute)
+	timeout := time.After(5 * time.Minute)
 	var present bool
 	for {
 		select {
@@ -104,7 +104,9 @@ func TestSchemaTrackingError(t *testing.T) {
 		case <-time.After(1 * time.Second):
 			// check info logs
 			all, err := os.ReadFile(path.Join(logDir, "vtgate.WARNING"))
-			require.NoError(t, err)
+			if err != nil {
+				continue
+			}
 			if strings.Contains(string(all), "Table ACL might be enabled, --schema_change_signal_user needs to be passed to VTGate for schema tracking to work. Check 'schema tracking' docs on vitess.io") {
 				present = true
 			}


### PR DESCRIPTION
## Description

This PR updates the flag used in the end-to-end tests for the planner version. If the binary `vtgate` is below version `14` (which is the case during upgrade downgrade tests on `release-14.0`, we use vtgate `13` at some point), the flag `--planner-version`  is unknown and leads to the test failing to start, and ultimately, timeout.

We do not need to backport or forward port this as this issue is only happening in `release-14.0`. For the issue to be reproduced, we need to run the end-to-end tests that live on `v14.x` with a vtgate built using `<= v13.x` code.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
