### PR TITLE
Enable stale PR closer

### DIFF
--- a/.github/workflows/close_stale_pull_requests.yml
+++ b/.github/workflows/close_stale_pull_requests.yml
@@ -18,11 +18,8 @@ jobs:
           # Do not handle issues at all. We only want to handle PRs.
           days-before-issue-stale: -1
 
-          stale-pr-message: "This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment, or this will be closed in 7 days."
+          stale-pr-message: "This PR is being marked as stale because it has been open for 30 days with no activity. Please remove the stale label or add a comment, or it will be closed in 7 days."
           close-pr-message: "This PR was closed because it has been stale for 7 days with no activity."
 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          # (TODO:ajm188) - remove these after testing/validating the workflow.
-          debug-only: true
-          enable-statistics: true


### PR DESCRIPTION


## Description

After a [successful test run](https://github.com/vitessio/vitess/runs/7101353212?check_suite_focus=true) yesterday, we're ready to turn off debug-only. I've also updated the wording of the "your PR is now stale" message.

If we find we need to bump the operation limit, we can follow up with that later!

## Related Issue(s)

- closes #10565 
- #10603 and #10610 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

- [ ] Post to #developers in OSS slack to let them know this is now A Thing
