### PR TITLE
Refactor VTAdmin local example script to pass the cluster information as a file.

### DIFF
--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -19,7 +19,7 @@ vtadmin \
   --alsologtostderr \
   --rbac \
   --rbac-config="./vtadmin/rbac.yaml" \
-  --cluster "id=local,name=local,discovery=staticfile,discovery-staticfile-path=./vtadmin/discovery.json,tablet-fqdn-tmpl={{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
+  --cluster-config="./vtadmin/cluster-config.yaml" \
   > "${log_dir}/vtadmin-api.out" 2>&1 &
 
 vtadmin_api_pid=$!

--- a/examples/local/vtadmin/cluster-config.yaml
+++ b/examples/local/vtadmin/cluster-config.yaml
@@ -1,0 +1,6 @@
+clusters:
+  local:
+    name: local
+    discovery: staticfile
+    discovery-staticfile-path: ./vtadmin/discovery.json
+    tablet-fqdn-tmpl: "{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}"


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

The VTAdmin start-up script in the local example currently passes the cluster configuration as a comma-separated list of values, but VTAdmin has a flag to allow to pass the same information in a yaml file. Since the yaml file is the recommended way of providing this information, we should be using that in our local example too.
This PR addresses this issue.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
