### PR TITLE
Use many more valid test cases

### DIFF
--- a/go/vt/sqlparser/testdata/select_cases.txt
+++ b/go/vt/sqlparser/testdata/select_cases.txt
@@ -23,10 +23,10 @@ OUTPUT
 select t1.`name`, t2.`name`, t2.id from t1 left join t2 on t1.id = t2.owner
 END
 INPUT
-select from ((t1 natural join t2), (t3 natural join t4)) natural join t5;
+select * from ((t1 natural join t2), (t3 natural join t4)) natural join t5;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from ((t1 natural join t2), (t3 natural join t4)) natural join t5
 END
 INPUT
 select ref_mag from t1 where match ref_mag against ('+test' in boolean mode);
@@ -47,10 +47,10 @@ OUTPUT
 select a1, a2, b, max(c) from t1 where c < 'a0' or c > 'b1' group by a1, a2, b
 END
 INPUT
-select from t1 left join t2 on venue_id = entity_id where match(name) against('aberdeen' in boolean mode) and dt = '2003-05-23 19:30:00';
+select * from t1 left join t2 on venue_id = entity_id where match(name) against('aberdeen' in boolean mode) and dt = '2003-05-23 19:30:00';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on venue_id = entity_id where match(`name`) against ('aberdeen' in boolean mode) and dt = '2003-05-23 19:30:00'
 END
 INPUT
 select t1.name, t2.name, t2.id from t1 left join t2 on (t1.id = t2.owner) where t2.id is null;
@@ -89,10 +89,10 @@ OUTPUT
 select a1, max(c) from t2 where a1 >= 'c' or a1 < 'b' group by a1, a2, b
 END
 INPUT
-select from t1 order by b;
+select * from t1 order by b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 order by b asc
 END
 INPUT
 select lpad('hello', 4294967296, '1');
@@ -101,10 +101,10 @@ OUTPUT
 select lpad('hello', 4294967296, '1') from dual
 END
 INPUT
-select from v3 order by a;
+select * from v3 order by a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v3 order by a asc
 END
 INPUT
 select ROUTINE_NAME, ROUTINE_DEFINITION from information_schema.ROUTINES WHERE ROUTINE_SCHEMA='test' ORDER BY ROUTINE_NAME;
@@ -143,10 +143,10 @@ OUTPUT
 select inet_aton('') from dual
 END
 INPUT
-select from t1 where word like 'AE';
+select * from t1 where word like 'AE';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word like 'AE'
 END
 INPUT
 select yearweek('1987-01-01',1),yearweek('1987-01-01');
@@ -185,10 +185,10 @@ OUTPUT
 select s1 from t1 group by 1 having 1 = 0
 END
 INPUT
-select from performance_schema.session_status where variable_name like 'COMPRESSION%' order by 1;
+select * from performance_schema.session_status where variable_name like 'COMPRESSION%' order by 1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from performance_schema.session_status where variable_name like 'COMPRESSION%' order by 1 asc
 END
 INPUT
 select (min(a4)+max(a4))/2 from t1;
@@ -197,10 +197,10 @@ OUTPUT
 select (min(a4) + max(a4)) / 2 from t1
 END
 INPUT
-select from mysqltest1.t11;
+select * from mysqltest1.t11;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysqltest1.t11
 END
 INPUT
 select c1 from t1 where c2='ZZZZ';
@@ -209,16 +209,16 @@ OUTPUT
 select c1 from t1 where c2 = 'ZZZZ'
 END
 INPUT
-select from t1 natural join (t3 cross join t4);
+select * from t1 natural join (t3 cross join t4);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural join (t3 join t4)
 END
 INPUT
-select from t3 natural right join t2 natural right join t1;
+select * from t3 natural right join t2 natural right join t1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 natural right join t2 natural right join t1
 END
 INPUT
 select "hep";
@@ -227,10 +227,10 @@ OUTPUT
 select 'hep' from dual
 END
 INPUT
-select from t1 where match a against ("+aaa* +bbb1*" in boolean mode);
+select * from t1 where match a against ("+aaa* +bbb1*" in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a) against ('+aaa* +bbb1*' in boolean mode)
 END
 INPUT
 select locate('lo','hello',18446744073709551615);
@@ -263,10 +263,10 @@ OUTPUT
 select t1.*, t2.*, t3.a from t1 left join t2 on t3.a = t2.a left join t1 as t3 on t1.a = t3.a
 END
 INPUT
-select from v2 where renamed=1 group by renamed;
+select * from v2 where renamed=1 group by renamed;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v2 where renamed = 1 group by renamed
 END
 INPUT
 select get_format(TIMESTAMP, 'eur') as a;
@@ -317,10 +317,10 @@ OUTPUT
 select field(null, 'a', null), field(null, 0, null) + 0, field(null, 0.0, null) + 0.0, field(null, 0.0e1, null) + 0.0e1 from dual
 END
 INPUT
-select from t2 order by id;
+select * from t2 order by id;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 order by id asc
 END
 INPUT
 select "strawberry","blueberry","potato";
@@ -347,10 +347,10 @@ ERROR
 syntax error at position 9
 END
 INPUT
-select from t1 where a like '%ESKA%';
+select * from t1 where a like '%ESKA%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '%ESKA%'
 END
 INPUT
 select 1;
@@ -419,10 +419,10 @@ OUTPUT
 select insert('aa', 100, 1, 'b'), insert('aa', 1, 3, 'b') from dual
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('+(support collections) +foobar*' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('+(support collections) +foobar*' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('+(support collections) +foobar*' in boolean mode)
 END
 INPUT
 select sum(if(num is null,0.00,num)) from t1;
@@ -449,10 +449,10 @@ OUTPUT
 select std(s1 / s2) from bug22555 where i = 1 group by i
 END
 INPUT
-select from INFORMATION_SCHEMA.TABLE_PRIVILEGES WHERE table_schema NOT IN ('sys','mysql');
+select * from INFORMATION_SCHEMA.TABLE_PRIVILEGES WHERE table_schema NOT IN ('sys','mysql');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from INFORMATION_SCHEMA.TABLE_PRIVILEGES where table_schema not in ('sys', 'mysql')
 END
 INPUT
 select count(*) from t1 group by s1 having s1 is null;
@@ -473,16 +473,16 @@ OUTPUT
 select group_concat(c1 order by c1 asc) from t1 group by c1 collate utf8_slovak_ci
 END
 INPUT
-select from t1 where match(s) against('par*' in boolean mode);
+select * from t1 where match(s) against('par*' in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(s) against ('par*' in boolean mode)
 END
 INPUT
-select from t1 where a = 'b' and a != 'b';
+select * from t1 where a = 'b' and a != 'b';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 'b' and a != 'b'
 END
 INPUT
 select left('aaa','1');
@@ -491,10 +491,10 @@ OUTPUT
 select left('aaa', '1') from dual
 END
 INPUT
-select from v_bug5719;
+select * from v_bug5719;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v_bug5719
 END
 INPUT
 select -9223372036854775808 -1 as result;
@@ -557,10 +557,10 @@ OUTPUT
 select substring_index('the king of thethethe.the hill', 'the', -1) from dual
 END
 INPUT
-select from (t1 natural join t2) join (t3 natural join t4) on a = y;
+select * from (t1 natural join t2) join (t3 natural join t4) on a = y;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 natural join t2) join (t3 natural join t4) on a = y
 END
 INPUT
 select strcmp(_koi8r'a', _latin1'A');
@@ -629,16 +629,16 @@ OUTPUT
 select hex(soundex(_utf32 0x000000BF000000C0)) from dual
 END
 INPUT
-select from t1 where 'cH' = s1 and s1 <> 'ch';
+select * from t1 where 'cH' = s1 and s1 <> 'ch';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where 'cH' = s1 and s1 != 'ch'
 END
 INPUT
-select from ((t1 natural join t2) natural join t3) natural join t4;
+select * from ((t1 natural join t2) natural join t3) natural join t4;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from ((t1 natural join t2) natural join t3) natural join t4
 END
 INPUT
 select hex(substr(_utf16 0x00e400e5D800DC00,3));
@@ -713,10 +713,10 @@ OUTPUT
 select substr(null, null, null), mid(null, null, null) from dual
 END
 INPUT
-select from t1 where a=if(b<10,_ucs2 0x00C0,_ucs2 0x0062);
+select * from t1 where a=if(b<10,_ucs2 0x00C0,_ucs2 0x0062);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = if(b < 10, _ucs2 0x00C0, _ucs2 0x0062)
 END
 INPUT
 select substring('hello', 1, -4294967295);
@@ -773,16 +773,16 @@ OUTPUT
 select _latin2 '1' = 1 from dual
 END
 INPUT
-select from t1 where word= 0xe4 or word=CAST(0xe4 as CHAR);
+select * from t1 where word= 0xe4 or word=CAST(0xe4 as CHAR);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word = 0xe4 or word = cast(0xe4 as CHAR)
 END
 INPUT
-select from t1 left join t2 on t1.a=t2.a having not (t2.a <=> t1.a);
+select * from t1 left join t2 on t1.a=t2.a having not (t2.a <=> t1.a);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on t1.a = t2.a having not t2.a <=> t1.a
 END
 INPUT
 select format(pi(), NULL);
@@ -827,10 +827,10 @@ OUTPUT
 select field(0, null, 1, 0), field('', null, 'bar', ''), field(0.0, null, 1.0, 0.0) from dual
 END
 INPUT
-select from information_schema.table_privileges where table_schema NOT IN ('sys','mysql');
+select * from information_schema.table_privileges where table_schema NOT IN ('sys','mysql');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.table_privileges where table_schema not in ('sys', 'mysql')
 END
 INPUT
 select t1.a, t1.b,t2.a, t2.b from t1 left join t2 on t1.a=t2.a where t1.b=1 and t2.b=1 or t2.a is NULL;
@@ -839,10 +839,10 @@ OUTPUT
 select t1.a, t1.b, t2.a, t2.b from t1 left join t2 on t1.a = t2.a where t1.b = 1 and t2.b = 1 or t2.a is null
 END
 INPUT
-select from tm;
+select * from tm;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from tm
 END
 INPUT
 select fld3 FROM t2 where (fld3 like "C%" and fld3 = "Chantilly");
@@ -863,10 +863,10 @@ OUTPUT
 select ST_astext(ST_intersection(ST_GeomFromText('polygon((0 0, 1 0, 0 1, 0 0))'), ST_GeomFromText('polygon((0 0, 1 1, 0 2, 0 0))'))) from dual
 END
 INPUT
-select from t1 left join t2 on m_id = id where match(d, e, f) against ('+aword +bword' in boolean mode);
+select * from t1 left join t2 on m_id = id where match(d, e, f) against ('+aword +bword' in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on m_id = id where match(d, e, f) against ('+aword +bword' in boolean mode)
 END
 INPUT
 select a2 from ((t1 natural join t2) join t3 on b=c1) natural join t4;
@@ -905,10 +905,10 @@ OUTPUT
 select timestampdiff(month, '2004-09-11', '2004-09-11') from dual
 END
 INPUT
-select from t3 join (t2 outr2 join t2 outr join t1) on (outr.pk = t3.pk) and (t1.col_int_key = t3.pk) and isnull(t1.col_date_key) and (outr2.pk <> t3.pk);
+select * from t3 join (t2 outr2 join t2 outr join t1) on (outr.pk = t3.pk) and (t1.col_int_key = t3.pk) and isnull(t1.col_date_key) and (outr2.pk <> t3.pk);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 join (t2 as outr2 join t2 as outr join t1) on outr.pk = t3.pk and t1.col_int_key = t3.pk and isnull(t1.col_date_key) and outr2.pk != t3.pk
 END
 INPUT
 select a.CONSTRAINT_SCHEMA, b.TABLE_NAME, CONSTRAINT_TYPE, b.CONSTRAINT_NAME, UNIQUE_CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_NAME, MATCH_OPTION, UPDATE_RULE, DELETE_RULE, b.REFERENCED_TABLE_NAME from information_schema.TABLE_CONSTRAINTS a, information_schema.REFERENTIAL_CONSTRAINTS b where a.CONSTRAINT_SCHEMA COLLATE UTF8_GENERAL_CI = 'test' and a.CONSTRAINT_SCHEMA COLLATE UTF8_GENERAL_CI = b.CONSTRAINT_SCHEMA and a.CONSTRAINT_NAME = b.CONSTRAINT_NAME;
@@ -917,10 +917,10 @@ OUTPUT
 select a.CONSTRAINT_SCHEMA, b.TABLE_NAME, CONSTRAINT_TYPE, b.CONSTRAINT_NAME, UNIQUE_CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_NAME, MATCH_OPTION, UPDATE_RULE, DELETE_RULE, b.REFERENCED_TABLE_NAME from information_schema.TABLE_CONSTRAINTS as a, information_schema.REFERENTIAL_CONSTRAINTS as b where a.CONSTRAINT_SCHEMA collate UTF8_GENERAL_CI = 'test' and a.CONSTRAINT_SCHEMA collate UTF8_GENERAL_CI = b.CONSTRAINT_SCHEMA and a.CONSTRAINT_NAME = b.CONSTRAINT_NAME
 END
 INPUT
-select from t2 order by a,b;
+select * from t2 order by a,b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 order by a asc, b asc
 END
 INPUT
 select _latin1'B' between _latin1'a' and _latin1'c' collate latin1_bin;
@@ -959,16 +959,16 @@ OUTPUT
 select 0 | -1, 0 ^ -1, 0 & -1 from dual
 END
 INPUT
-select from words;
+select * from words;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from words
 END
 INPUT
-select from t1, t2 where t1.value64=17156792991891826145 and t2.value64=t1.value64;
+select * from t1, t2 where t1.value64=17156792991891826145 and t2.value64=t1.value64;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2 where t1.value64 = 17156792991891826145 and t2.value64 = t1.value64
 END
 INPUT
 select cast(s1 as decimal(7,2)) from t1;
@@ -1025,10 +1025,10 @@ OUTPUT
 select grp, group_concat(distinct c order by c asc) from t1 group by grp
 END
 INPUT
-select from t1 where xxx regexp('is a test of some long text to ');
+select * from t1 where xxx regexp('is a test of some long text to ');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where xxx regexp 'is a test of some long text to '
 END
 INPUT
 select repeat('hello', 18446744073709551615);
@@ -1049,10 +1049,10 @@ OUTPUT
 select a as like_lll from t1 where a like 'lll%'
 END
 INPUT
-select from t1 where upper(b)='BBB';
+select * from t1 where upper(b)='BBB';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where upper(b) = 'BBB'
 END
 INPUT
 select table_name, index_type from information_schema.statistics where table_schema = 'test' and table_name like 't%' order by table_name;
@@ -1073,10 +1073,10 @@ OUTPUT
 select right('hello', null), right(null, 1), right(null, null) from dual
 END
 INPUT
-select from `information_schema`.`REFERENTIAL_CONSTRAINTS` where `CONSTRAINT_SCHEMA` = NULL;
+select * from `information_schema`.`REFERENTIAL_CONSTRAINTS` where `CONSTRAINT_SCHEMA` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.REFERENTIAL_CONSTRAINTS where CONSTRAINT_SCHEMA = null
 END
 INPUT
 select truncate(52.64,1),truncate(52.64,2),truncate(52.64,-1),truncate(52.64,-2), truncate(-52.64,1),truncate(-52.64,-1);
@@ -1103,10 +1103,10 @@ OUTPUT
 select count(a) from t1 where a >= 10
 END
 INPUT
-select from information_schema.USER_PRIVILEGES where grantee like '%mysqltest_1%';
+select * from information_schema.USER_PRIVILEGES where grantee like '%mysqltest_1%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.USER_PRIVILEGES where grantee like '%mysqltest_1%'
 END
 INPUT
 select text1, length(text1) from t1 where text1='teststring' or text1 >= 'teststring	';
@@ -1127,10 +1127,10 @@ OUTPUT
 select makedate(1997, 0) from dual
 END
 INPUT
-select from mysqltest.mysqltest;
+select * from mysqltest.mysqltest;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysqltest.mysqltest
 END
 INPUT
 select c, substring_index(lcase(c), @q:=',', -1) as res from t1;
@@ -1193,10 +1193,10 @@ OUTPUT
 select concat(a, if(b > 10, _utf8mb4 0x78, _utf8mb4 0x79)) from t1
 END
 INPUT
-select from t1 where match a against ("+aaa* +bbb*" in boolean mode);
+select * from t1 where match a against ("+aaa* +bbb*" in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a) against ('+aaa* +bbb*' in boolean mode)
 END
 INPUT
 select @keyword3_id:= 10203;
@@ -1205,10 +1205,10 @@ ERROR
 syntax error at position 21 near ':'
 END
 INPUT
-select from t3 where x = 1 and y < 5 order by y desc;
+select * from t3 where x = 1 and y < 5 order by y desc;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 where x = 1 and y < 5 order by y desc
 END
 INPUT
 select a1, max(a2) from t1 group by a1;
@@ -1253,10 +1253,10 @@ OUTPUT
 select distinct t1.a from t1, t2 order by t2.a asc
 END
 INPUT
-select from t1 where not(not(not(a > 10)));
+select * from t1 where not(not(not(a > 10)));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not not not a > 10
 END
 INPUT
 select 'Glazgo' sounds like 'Liverpool';
@@ -1313,10 +1313,10 @@ OUTPUT
 select value, description, count(bug_id) from t2 left join t1 on t2.program = t1.product and t2.value = t1.component where program = 'AAAAA' group by value having count(bug_id) in (0, 2)
 END
 INPUT
-select from t1 where s1 < 'K' and s1 = 'Y';
+select * from t1 where s1 < 'K' and s1 = 'Y';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where s1 < 'K' and s1 = 'Y'
 END
 INPUT
 select DATE_ADD(20071108, INTERVAL 1 DAY);
@@ -1373,10 +1373,10 @@ OUTPUT
 select bit_and(col), bit_or(col) from t1
 END
 INPUT
-select from sakila.film_text where match(title,description) against("SCISSORHANDS");
+select * from sakila.film_text where match(title,description) against("SCISSORHANDS");
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from sakila.film_text where match(title, description) against ('SCISSORHANDS')
 END
 INPUT
 select time_format(19980131131415,'%H|%I|%k|%l|%i|%p|%r|%S|%T');
@@ -1421,10 +1421,10 @@ OUTPUT
 select a from t1 where left(a + 0, 6) = left(20040106, 6)
 END
 INPUT
-select from t1 where a like concat("abc","%");
+select * from t1 where a like concat("abc","%");
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like concat('abc', '%')
 END
 INPUT
 select a1,a2,b,min(c),max(c) from t2 where (a1 = 'b' or a1 = 'd' or a1 = 'a' or a1 = 'c') and (a2 > 'a') group by a1,a2,b;
@@ -1493,10 +1493,10 @@ OUTPUT
 select ST_asbinary(g) from t1
 END
 INPUT
-select from t1 join t2 using(`t1_id`) where match (t1.name, t2.name) against('xxfoo' in boolean mode);
+select * from t1 join t2 using(`t1_id`) where match (t1.name, t2.name) against('xxfoo' in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 join t2 using (t1_id) where match(t1.`name`, t2.`name`) against ('xxfoo' in boolean mode)
 END
 INPUT
 select sql_big_result distinct t1.a from t1,t2;
@@ -1505,10 +1505,10 @@ ERROR
 syntax error at position 31 near 'distinct'
 END
 INPUT
-select from t1 where a = 'b' and a = 'b';
+select * from t1 where a = 'b' and a = 'b';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 'b' and a = 'b'
 END
 INPUT
 select (select d from t2 where d > a), t1.* from t1;
@@ -1553,16 +1553,16 @@ OUTPUT
 select coercibility(weight_string('test')) from dual
 END
 INPUT
-select from (t1 natural join t2) natural join (t3 natural join t4);
+select * from (t1 natural join t2) natural join (t3 natural join t4);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 natural join t2) natural join (t3 natural join t4)
 END
 INPUT
-select from t2 where MATCH inhalt AGAINST (t2.inhalt);
+select * from t2 where MATCH inhalt AGAINST (t2.inhalt);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 where match(inhalt) against (t2.inhalt)
 END
 INPUT
 select a from t1 order by rand(10);
@@ -1571,10 +1571,10 @@ OUTPUT
 select a from t1 order by rand(10)
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST("+search +(support vector)" IN BOOLEAN MODE);
+select * from t1 where MATCH(a,b) AGAINST("+search +(support vector)" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('+search +(support vector)' in boolean mode)
 END
 INPUT
 select cast(NULL as decimal(6)) as t1;
@@ -1667,10 +1667,10 @@ OUTPUT
 select distinct a1, a1 from t1
 END
 INPUT
-select from t1 where not(a >= 10);
+select * from t1 where not(a >= 10);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not a >= 10
 END
 INPUT
 select hex(soundex(_utf8 0xD091D092D093));
@@ -1679,10 +1679,10 @@ OUTPUT
 select hex(soundex(_utf8 0xD091D092D093)) from dual
 END
 INPUT
-select from t1 where btn like "ff%";
+select * from t1 where btn like "ff%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where btn like 'ff%'
 END
 INPUT
 select 1<=>0,0<=>NULL,NULL<=>0;
@@ -1733,10 +1733,10 @@ OUTPUT
 select max(id) from t1
 END
 INPUT
-select from v1a natural join v2a;
+select * from v1a natural join v2a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1a natural join v2a
 END
 INPUT
 select 1 as a from t1 union all select 1 from dual limit 1;
@@ -1745,22 +1745,22 @@ OUTPUT
 select 1 as a from t1 union all select 1 from dual limit 1
 END
 INPUT
-select from t1 where a > _latin1 'B' collate latin1_bin;
+select * from t1 where a > _latin1 'B' collate latin1_bin;
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from (select 1 union select 1) aaa;
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a > _latin1 'B' collate latin1_bin
 END
 INPUT
-select from information_schema.STATISTICS where TABLE_SCHEMA = "mysqltest" order by table_name, index_name;
+select * from (select 1 union select 1) aaa;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select 1 from dual union select 1 from dual) as aaa
+END
+INPUT
+select * from information_schema.STATISTICS where TABLE_SCHEMA = "mysqltest" order by table_name, index_name;
+END
+OUTPUT
+select * from information_schema.STATISTICS where TABLE_SCHEMA = 'mysqltest' order by table_name asc, index_name asc
 END
 INPUT
 select convert(char(0xff,0x8f) using utf8mb4);
@@ -1793,10 +1793,10 @@ OUTPUT
 select round(1e1, 2147483648), truncate(1e1, 2147483648) from dual
 END
 INPUT
-select from information_schema.character_sets order by 1 limit 3;
+select * from information_schema.character_sets order by 1 limit 3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.character_sets order by 1 asc limit 3
 END
 INPUT
 select get_lock('bug27638', 101);
@@ -1811,16 +1811,16 @@ OUTPUT
 select 2 or 3 from dual
 END
 INPUT
-select from t1 where word=binary 0xDF;
+select * from t1 where word=binary 0xDF;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word = convert(0xDF, binary)
 END
 INPUT
-select from ( select from t1 union select from t1) a,(select from t1 union select from t1) b;
+select * from ( select * from t1 union select * from t1) a,(select * from t1 union select * from t1) b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select * from t1 union select * from t1) as a, (select * from t1 union select * from t1) as b
 END
 INPUT
 select find_in_set(binary 'a',binary 'A,B,C');
@@ -1841,10 +1841,10 @@ OUTPUT
 select 2 in (3, 2, 5, 9, 5, 1), 'monty' in ('david', 'monty', 'allan'), 1.2 in (1.4, 1.2, 1.0) from dual
 END
 INPUT
-select from bug20691 order by x asc;
+select * from bug20691 order by x asc;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from bug20691 order by x asc
 END
 INPUT
 select i, count(*), std(e1/e2) from bug22555 group by i order by i;
@@ -1895,10 +1895,10 @@ OUTPUT
 select a, max(b), case max(b) when 4 then 4 when 43 then 43 else 0 end from t1 group by a
 END
 INPUT
-select from t4 where c1 < f1();
+select * from t4 where c1 < f1();
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t4 where c1 < f1()
 END
 INPUT
 select concat("$",format(2500,2));
@@ -1943,10 +1943,10 @@ OUTPUT
 select c1, min(c2) as c2 from t1 group by c1 order by c2 asc
 END
 INPUT
-select from mysqldump_dba.v1;
+select * from mysqldump_dba.v1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysqldump_dba.v1
 END
 INPUT
 select SUBSTR('abcdefg',-3,2) FROM DUAL;
@@ -1979,10 +1979,10 @@ OUTPUT
 select c as c_a from t1 where c = 'б'
 END
 INPUT
-select from v3a;
+select * from v3a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v3a
 END
 INPUT
 select ltrim("a"),rtrim("a"),trim(BOTH "" from "a"),trim(BOTH " " from "a");
@@ -2237,10 +2237,10 @@ OUTPUT
 select strcmp(_koi8r 'a' collate koi8r_general_ci, _koi8r 'A') from dual
 END
 INPUT
-select from v1 group by id limit 0;
+select * from v1 group by id limit 0;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1 group by id limit 0
 END
 INPUT
 select char(2557 using utf8mb4);
@@ -2279,10 +2279,10 @@ OUTPUT
 select @@global.optimizer_switch from dual
 END
 INPUT
-select from t5;
+select * from t5;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t5
 END
 INPUT
 select date_sub("1998-01-01 00:00:00.000001",INTERVAL "1:1.000002" MINUTE_MICROSECOND);
@@ -2351,10 +2351,10 @@ OUTPUT
 select group_concat(c1 order by convert(c1, binary) asc separator '') from t1 group by c1 collate utf16_slovenian_ci
 END
 INPUT
-select from t2 where MATCH ticket AGAINST ('foobar');
+select * from t2 where MATCH ticket AGAINST ('foobar');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 where match(ticket) against ('foobar')
 END
 INPUT
 select date_sub("1998-01-01 00:00:00",INTERVAL "1 1" YEAR_MONTH);
@@ -2381,16 +2381,16 @@ OUTPUT
 select ST_astext(geom), ST_area(geom), ST_area(ST_buffer(geom, 2)) from t1
 END
 INPUT
-select from t1,t2 right join t3 on (t2.i=t3.i) order by t1.i,t2.i,t3.i;
+select * from t1,t2 right join t3 on (t2.i=t3.i) order by t1.i,t2.i,t3.i;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2 right join t3 on t2.i = t3.i order by t1.i asc, t2.i asc, t3.i asc
 END
 INPUT
-select FROM t3 where fld3='bonfire';
+select * from t3 where fld3='bonfire';
 END
-ERROR
-syntax error at position 12 near 'FROM'
+OUTPUT
+select * from t3 where fld3 = 'bonfire'
 END
 INPUT
 select count(*) from t1 where id2 = 10;
@@ -2411,10 +2411,10 @@ OUTPUT
 select TRIGGER_NAME from information_schema.`triggers` where trigger_schema = 'test'
 END
 INPUT
-select from v1 where id=1 group by id;
+select * from v1 where id=1 group by id;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1 where id = 1 group by id
 END
 INPUT
 select t2.isbn,city,t1.libname,count(t1.libname) as a from t3 left join t1 on t3.libname=t1.libname left join t2 on t3.isbn=t2.isbn group by city,t1.libname;
@@ -2423,10 +2423,10 @@ OUTPUT
 select t2.isbn, city, t1.libname, count(t1.libname) as a from t3 left join t1 on t3.libname = t1.libname left join t2 on t3.isbn = t2.isbn group by city, t1.libname
 END
 INPUT
-select from information_schema.partitions where table_schema="test" and table_name="t3";
+select * from information_schema.partitions where table_schema="test" and table_name="t3";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`partitions` where table_schema = 'test' and table_name = 't3'
 END
 INPUT
 select id from t2;
@@ -2501,10 +2501,10 @@ ERROR
 syntax error at position 26 near 'like'
 END
 INPUT
-select from t1 left join t2 on t1.a = t2.a order by t1.b;
+select * from t1 left join t2 on t1.a = t2.a order by t1.b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on t1.a = t2.a order by t1.b asc
 END
 INPUT
 select date,format,concat(TIME(str_to_date(date, format))) as time2 from t1;
@@ -2519,10 +2519,10 @@ OUTPUT
 select cast(cast('1.2' as decimal(3, 2)) as signed) from dual
 END
 INPUT
-select from t1 where a = 7 or not(a < 15 and a > 5);
+select * from t1 where a = 7 or not(a < 15 and a > 5);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 7 or not (a < 15 and a > 5)
 END
 INPUT
 select concat('',left(right(concat('what ',concat('is ','happening')),9),4),'',substring('monty',5,1));
@@ -2549,10 +2549,10 @@ OUTPUT
 select count(*) from t1 group by col2 having col1 = 10
 END
 INPUT
-select from t1 where match a against ("+aaa* +ccc*" in boolean mode);
+select * from t1 where match a against ("+aaa* +ccc*" in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a) against ('+aaa* +ccc*' in boolean mode)
 END
 INPUT
 select max_data_length into @changed_max_data_length from information_schema.tables where table_name='t1';
@@ -2591,10 +2591,10 @@ OUTPUT
 select _utf8 0xD0B0D0B1D0B2 like concat(_utf8 '%', _utf8 0xD0B1, _utf8 '%') from dual
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("indexes");
+select * from t1 where MATCH(a,b) AGAINST ("indexes");
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('indexes')
 END
 INPUT
 select collation(lpad(_latin2'a',4,_latin2'b')), coercibility(lpad(_latin2'a',4,_latin2'b'));
@@ -2627,10 +2627,10 @@ OUTPUT
 select timestampadd(SQL_TSI_SECOND, 1, `date`) from t1
 END
 INPUT
-select from (select 1 as a) b left join (select 2 as a) c using(a);
+select * from (select 1 as a) b left join (select 2 as a) c using(a);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select 1 as a from dual) as b left join (select 2 as a from dual) as c using (a)
 END
 INPUT
 select s1 as after_delete_bin from t1 where s1 like 'ペテ%';
@@ -2741,16 +2741,16 @@ OUTPUT
 select group_concat(c1 order by c1 asc) from t1 group by c1 collate utf8_vietnamese_ci
 END
 INPUT
-select from information_schema.partitions where table_schema="test" and table_name="t1";
+select * from information_schema.partitions where table_schema="test" and table_name="t1";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`partitions` where table_schema = 'test' and table_name = 't1'
 END
 INPUT
-select from t1 join (t2, t3) using (b);
+select * from t1 join (t2, t3) using (b);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 join (t2, t3) using (b)
 END
 INPUT
 select group_concat(null) from t1;
@@ -2765,16 +2765,16 @@ OUTPUT
 select hex(weight_string(_utf16 0xD800DC01 collate utf16_unicode_ci)) from dual
 END
 INPUT
-select from t4 where a+0 > 90;
+select * from t4 where a+0 > 90;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t4 where a + 0 > 90
 END
 INPUT
-select from t1 where st_a=1 and swt1a=1 and swt2a=1 and st_b=1 and swt1b=1 and swt2b=1 limit 5;
+select * from t1 where st_a=1 and swt1a=1 and swt2a=1 and st_b=1 and swt1b=1 and swt2b=1 limit 5;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where st_a = 1 and swt1a = 1 and swt2a = 1 and st_b = 1 and swt1b = 1 and swt2b = 1 limit 5
 END
 INPUT
 select a from t1 where right(a+0,6) in ( right(20040106123400,6) );
@@ -2813,10 +2813,10 @@ OUTPUT
 select date_sub('1998-01-01 00:00:00', interval 1 SECOND) from dual
 END
 INPUT
-select from t6 order by a,b;
+select * from t6 order by a,b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t6 order by a asc, b asc
 END
 INPUT
 select hex(weight_string(s1)) from t1 order by s1;
@@ -2855,10 +2855,10 @@ OUTPUT
 select ST_Contains(ST_GeomFromText('POLYGON((0 0,5 0,5 5,0 5,0 0))'), ST_GeomFromText('LINESTRING(1 2,5 5)')) as result from dual
 END
 INPUT
-select from t1 where a like '%PESA%';
+select * from t1 where a like '%PESA%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '%PESA%'
 END
 INPUT
 select a1,a2,b from t1 where (a2 >= 'b') and (b = 'a') group by a1,a2,b;
@@ -2903,10 +2903,10 @@ OUTPUT
 select timestampdiff(QUARTER, '2002-05-01', '2001-01-01') as a from dual
 END
 INPUT
-select from information_schema.TABLE_CONSTRAINTS where TABLE_NAME= "vo";
+select * from information_schema.TABLE_CONSTRAINTS where TABLE_NAME= "vo";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.TABLE_CONSTRAINTS where TABLE_NAME = 'vo'
 END
 INPUT
 select distinct a1 from t1 where a2 = 'b';
@@ -2987,10 +2987,10 @@ OUTPUT
 select Fld1, max(Fld2) from t1 group by Fld1 having avg(Fld2) is not null
 END
 INPUT
-select from t1 where tt like '%AA%';
+select * from t1 where tt like '%AA%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where tt like '%AA%'
 END
 INPUT
 select concat(a, if(b>10, 'x' 'æ', 'y' 'ß')) from t1;
@@ -2999,10 +2999,10 @@ OUTPUT
 select concat(a, if(b > 10, 'x' as `æ`, 'y' as `ß`)) from t1
 END
 INPUT
-select from (t1 natural join t2) natural join (t3 join (t4 natural join t5) on (b < z));
+select * from (t1 natural join t2) natural join (t3 join (t4 natural join t5) on (b < z));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 natural join t2) natural join (t3 join (t4 natural join t5) on b < z)
 END
 INPUT
 select a.* from (select 214748364 as v_small) a;
@@ -3017,16 +3017,16 @@ OUTPUT
 select a as uci1 from t1 where a like 'さしすせそかきくけこあいうえお%'
 END
 INPUT
-select from t2 right join t1 on t2.a=t1.a;
+select * from t2 right join t1 on t2.a=t1.a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 right join t1 on t2.a = t1.a
 END
 INPUT
-select from information_schema.views where table_name='v1' or table_name='v2';
+select * from information_schema.views where table_name='v1' or table_name='v2';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.views where table_name = 'v1' or table_name = 'v2'
 END
 INPUT
 select count(*) from t3 where id3;
@@ -3083,16 +3083,16 @@ OUTPUT
 select `sql_big_result` as score, count(*) from t1 group by score order by score desc
 END
 INPUT
-select from information_schema.TABLE_CONSTRAINTS where TABLE_SCHEMA= "test" order by constraint_name;
+select * from information_schema.TABLE_CONSTRAINTS where TABLE_SCHEMA= "test" order by constraint_name;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.TABLE_CONSTRAINTS where TABLE_SCHEMA = 'test' order by constraint_name asc
 END
 INPUT
-select from `information_schema`.`VIEWS` where `TABLE_NAME` = NULL;
+select * from `information_schema`.`VIEWS` where `TABLE_NAME` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.VIEWS where TABLE_NAME = null
 END
 INPUT
 select locate(_utf8 0xD091, _utf8 0xD0B0D0B1D0B2);
@@ -3107,10 +3107,10 @@ OUTPUT
 select group_concat(distinct a, c order by a desc, c desc) from t1
 END
 INPUT
-select from t1 natural join (t2 join t4 on b + 1 = y);
+select * from t1 natural join (t2 join t4 on b + 1 = y);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural join (t2 join t4 on b + 1 = y)
 END
 INPUT
 select _utf8mb4 0xD0B0D0B1D0B2 like concat(_utf8mb4'%',_utf8mb4 0xD0B1,_utf8mb4 '%');
@@ -3185,10 +3185,10 @@ OUTPUT
 select a from t1 where a = 'http://www.foo.com/' order by abs(timediff(ts, 0)) asc
 END
 INPUT
-select from t1, t2 where t1.start >= t2.ctime1 and t1.start <= t2.ctime2;
+select * from t1, t2 where t1.start >= t2.ctime1 and t1.start <= t2.ctime2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2 where t1.`start` >= t2.ctime1 and t1.`start` <= t2.ctime2
 END
 INPUT
 select substring_index('the king of the the hill','the',3);
@@ -3221,10 +3221,10 @@ OUTPUT
 select substr('hello', 1, 18446744073709551616) from dual
 END
 INPUT
-select from t1 where bob is null and cip=1;
+select * from t1 where bob is null and cip=1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where bob is null and cip = 1
 END
 INPUT
 select a.f1 as a, b.f1 as b, a.f1 > b.f1 as gt, a.f1 < b.f1 as lt, a.f1<=>b.f1 as eq from t1 a, t1 b;
@@ -3233,10 +3233,10 @@ OUTPUT
 select a.f1 as a, b.f1 as b, a.f1 > b.f1 as gt, a.f1 < b.f1 as lt, a.f1 <=> b.f1 as eq from t1 as a, t1 as b
 END
 INPUT
-select from t1 where a like "%abcd%";
+select * from t1 where a like "%abcd%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '%abcd%'
 END
 INPUT
 select fld3,companynr FROM t2 where companynr = 58 order by fld3;
@@ -3269,10 +3269,10 @@ OUTPUT
 select insert('hello', -1, 1, 'hi') from dual
 END
 INPUT
-select from t1 join (t2 join t4 on b + 1 = y) on t1.c = t4.c;
+select * from t1 join (t2 join t4 on b + 1 = y) on t1.c = t4.c;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 join (t2 join t4 on b + 1 = y) on t1.c = t4.c
 END
 INPUT
 select f3 from t1 where timestamp(f3) between cast("2006-1-1 12:1:1" as datetime) and cast("2006-1-1 12:1:2" as datetime);
@@ -3293,10 +3293,10 @@ OUTPUT
 select hex(soundex(_utf32 0x000004100000041100000412)) from dual
 END
 INPUT
-select from t1 where 'K' > s1 and s1 = 'Y';
+select * from t1 where 'K' > s1 and s1 = 'Y';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where 'K' > s1 and s1 = 'Y'
 END
 INPUT
 select timediff(cast('2004-12-30 12:00:00' as time), '12:00:00');
@@ -3341,10 +3341,10 @@ OUTPUT
 select 'xyz' as `name` from dual union select 'abc' as `name` from dual order by `name` desc
 END
 INPUT
-select from t1 where text1 like 'teststring_%';
+select * from t1 where text1 like 'teststring_%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where text1 like 'teststring_%'
 END
 INPUT
 select week("2000-01-01",1) as '2000', week("2001-01-01",1) as '2001', week("2002-01-01",1) as '2002',week("2003-01-01",1) as '2003', week("2004-01-01",1) as '2004', week("2005-01-01",1) as '2005', week("2006-01-01",1) as '2006';
@@ -3371,10 +3371,10 @@ OUTPUT
 select 0 <=> 0.0, 0.0 <=> 0E0, 0E0 <=> '0', 10.0 <=> 1E1, 10 <=> 10.0, 10 <=> 1E1 from dual
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ("+call* +coll*" IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ("+call* +coll*" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('+call* +coll*' in boolean mode)
 END
 INPUT
 select count(*) from t1 where id1;
@@ -3407,10 +3407,10 @@ OUTPUT
 select 'st_Intersects' from dual
 END
 INPUT
-select from table_24562;
+select * from table_24562;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from table_24562
 END
 INPUT
 select grp,group_concat(distinct c order by c separator ",") from t1 group by grp;
@@ -3521,10 +3521,10 @@ OUTPUT
 select substr('hello', -1, 1) from dual
 END
 INPUT
-select from information_schema.user_privileges where grantee like '%user%' and grantee not like '%session%' order by grantee;
+select * from information_schema.user_privileges where grantee like '%user%' and grantee not like '%session%' order by grantee;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.user_privileges where grantee like '%user%' and grantee not like '%session%' order by grantee asc
 END
 INPUT
 select hex(substr(_utf32 0x000000e4000000e500000068,-3));
@@ -3563,10 +3563,10 @@ OUTPUT
 select round(1.5, -4294967296), round(1.5, 4294967296) from dual
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("indexes collections" WITH QUERY EXPANSION);
+select * from t1 where MATCH(a,b) AGAINST ("indexes collections" WITH QUERY EXPANSION);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('indexes collections' with query expansion)
 END
 INPUT
 select a1,a2,b,min(c),max(c) from t1 where (b = 'b') group by a1,a2;
@@ -3647,10 +3647,10 @@ OUTPUT
 select FIELD(_latin2 'b', 'A', 'B') from dual
 END
 INPUT
-select from t1 where name='patnom' and author='patauteur' and category=0;
+select * from t1 where name='patnom' and author='patauteur' and category=0;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where `name` = 'patnom' and author = 'patauteur' and category = 0
 END
 INPUT
 select std(s1/s2) from bug22555 where i=1;
@@ -3713,10 +3713,10 @@ OUTPUT
 select mod(12.0, null) as `NULL` from dual
 END
 INPUT
-select from v1c join v2a on v1c.b = v2a.c;
+select * from v1c join v2a on v1c.b = v2a.c;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1c join v2a on v1c.b = v2a.c
 END
 INPUT
 select count(*) from t1 where match a against ('aaaxxx' in boolean mode);
@@ -3731,10 +3731,10 @@ OUTPUT
 select date_add('1997-12-31 23:59:59.000002', interval '10000 99:99:99.999999' DAY_MICROSECOND) from dual
 END
 INPUT
-select from t5 where a < 3;
+select * from t5 where a < 3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t5 where a < 3
 END
 INPUT
 select count(*) from t1 where a = 100;
@@ -3767,10 +3767,10 @@ OUTPUT
 select max(t2.a2), max(t1.a1) from t1, t2
 END
 INPUT
-select from `information_schema`.`VIEWS` where `TABLE_SCHEMA` = NULL;
+select * from `information_schema`.`VIEWS` where `TABLE_SCHEMA` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.VIEWS where TABLE_SCHEMA = null
 END
 INPUT
 select 1 like 2 xor 2 like 1;
@@ -3779,10 +3779,10 @@ OUTPUT
 select 1 like 2 xor 2 like 1 from dual
 END
 INPUT
-select from bug15205_2;
+select * from bug15205_2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from bug15205_2
 END
 INPUT
 select count(*) from t where id>=8894754949779693574 and id <=17790886498483827171;
@@ -3821,10 +3821,10 @@ OUTPUT
 select @@warning_count from dual
 END
 INPUT
-select 2 as a from (select from t1) b;
+select 2 as a from (select * from t1) b;
 END
-ERROR
-syntax error at position 32 near 'from'
+OUTPUT
+select 2 as a from (select * from t1) as b
 END
 INPUT
 select benchmark(100, (select avg(func_26093_a(a)) from table_26093));
@@ -3923,10 +3923,10 @@ OUTPUT
 select row_number() over (), value, description, count(bug_id) from t2 left join t1 on t2.program = t1.product and t2.value = t1.component where program = 'AAAAA' group by value having count(bug_id) in (0, 2)
 END
 INPUT
-select from t1 where lower(a)='aaa';
+select * from t1 where lower(a)='aaa';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where lower(a) = 'aaa'
 END
 INPUT
 select a1,min(c),max(c) from t2 where a1 >= 'b' group by a1,a2,b;
@@ -3941,10 +3941,10 @@ OUTPUT
 select table_name, column_name from information_schema.`COLUMNS` where table_schema like 'test%' order by table_name asc, column_name asc
 END
 INPUT
-select from v0;
+select * from v0;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v0
 END
 INPUT
 select ST_astext(st_symdifference(ST_GeomFromText('multipoint(2 2, 3 3)'), st_intersection(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)'))));
@@ -3977,10 +3977,10 @@ OUTPUT
 select timestampdiff(month, '2003-02-28', '2005-02-28') from dual
 END
 INPUT
-select t1.a,t3.a from t1,(select from t2 where b='c') as t3 where t1.a = t3.a;
+select t1.a,t3.a from t1,(select * from t2 where b='c') as t3 where t1.a = t3.a;
 END
-ERROR
-syntax error at position 38 near 'from'
+OUTPUT
+select t1.a, t3.a from t1, (select * from t2 where b = 'c') as t3 where t1.a = t3.a
 END
 INPUT
 select ST_astext(Polygon(LineString(Point(0, 0), Point(30, 0), Point(30, 30), Point(1, 0), Point(0, 0))));
@@ -3995,10 +3995,10 @@ OUTPUT
 select host, `user` from mysql.`user` where `User` = 'myuser'
 END
 INPUT
-select from t5 natural right join (t4 natural right join ((t2 natural right join t1) natural right join t3));
+select * from t5 natural right join (t4 natural right join ((t2 natural right join t1) natural right join t3));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t5 natural right join (t4 natural right join ((t2 natural right join t1) natural right join t3))
 END
 INPUT
 select count(distinct concat(c1, repeat('xx', 250))) as cc from t2 order by 1;
@@ -4067,10 +4067,10 @@ OUTPUT
 select collation(char(130)), coercibility(hex(130)) from dual
 END
 INPUT
-select from_unixtime(2147483647);
+select * from_unixtime(2147483647);
 END
-OUTPUT
-select from_unixtime(2147483647) from dual
+ERROR
+syntax error at position 23 near 'from_unixtime'
 END
 INPUT
 select release_lock('mysqltest_lock');
@@ -4205,10 +4205,10 @@ OUTPUT
 select password_lifetime from mysql.`user` where `user` = 'wl7131'
 END
 INPUT
-select from myUC;
+select * from myUC;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from myUC
 END
 INPUT
 select id >= 0 and id <= 5 as grp,count(*) from t1 group by grp;
@@ -4223,16 +4223,16 @@ OUTPUT
 select 'y' = '~' from dual
 END
 INPUT
-select from t1 where i between 2 and 4 and v in ('def','3r4f','lmn');
+select * from t1 where i between 2 and 4 and v in ('def','3r4f','lmn');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where i between 2 and 4 and v in ('def', '3r4f', 'lmn')
 END
 INPUT
-select from t1 where c1='b';
+select * from t1 where c1='b';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where c1 = 'b'
 END
 INPUT
 select datediff("1997-11-30 23:59:59.000001","1997-12-31");
@@ -4265,10 +4265,10 @@ OUTPUT
 select date_add(`date`, interval '1:1' DAY_HOUR) from t1
 END
 INPUT
-select from v1a join v1b on t1.b = t2.b;
+select * from v1a join v1b on t1.b = t2.b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1a join v1b on t1.b = t2.b
 END
 INPUT
 select date_sub("1998-01-01 00:00:00",INTERVAL "1 1:1:1" DAY_SECOND);
@@ -4283,10 +4283,10 @@ OUTPUT
 select cast(rtrim(ltrim(' 20.06 ')) as decimal(19, 2)) from dual
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('"xt indexes"' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('"xt indexes"' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('\"xt indexes\"' in boolean mode)
 END
 INPUT
 select max(value) from t1 AS m LEFT JOIN t2 AS c1 ON m.c1id = c1.id AND c1.active = 'Yes' LEFT JOIN t3 AS c2 ON m.c2id = c2.id AND c2.active = 'Yes' WHERE m.pid=1 AND (c1.id IS NOT NULL OR c2.id IS NOT NULL);
@@ -4295,16 +4295,16 @@ OUTPUT
 select max(value) from t1 as m left join t2 as c1 on m.c1id = c1.id and c1.active = 'Yes' left join t3 as c2 on m.c2id = c2.id and c2.active = 'Yes' where m.pid = 1 and (c1.id is not null or c2.id is not null)
 END
 INPUT
-select from t1 where a in (select a from t11) order by 1, 2, 3 limit 1;
+select * from t1 where a in (select a from t11) order by 1, 2, 3 limit 1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a in (select a from t11) order by 1 asc, 2 asc, 3 asc limit 1
 END
 INPUT
-select from t1 where a='807780' and b='477' and c='165';
+select * from t1 where a='807780' and b='477' and c='165';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = '807780' and b = '477' and c = '165'
 END
 INPUT
 select timestampdiff(month,'1999-09-11','2001-9-11');
@@ -4331,10 +4331,10 @@ OUTPUT
 select a1, a2, b, min(c), max(c) from t2 where c > 'f123' group by a1, a2, b
 END
 INPUT
-select from t1_base;
+select * from t1_base;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1_base
 END
 INPUT
 select @iv;
@@ -4343,10 +4343,10 @@ OUTPUT
 select @iv from dual
 END
 INPUT
-select from t1 where str is null;
+select * from t1 where str is null;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where str is null
 END
 INPUT
 select _koi8r 0xFF regexp _koi8r '[[:upper:]]' COLLATE koi8r_bin;
@@ -4355,16 +4355,16 @@ OUTPUT
 select _koi8r 0xFF regexp _koi8r '[[:upper:]]' collate koi8r_bin from dual
 END
 INPUT
-select from t1 left join t2 on (t1.i=t2.i) left join t3 on (t2.i=t3.i);
+select * from t1 left join t2 on (t1.i=t2.i) left join t3 on (t2.i=t3.i);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on t1.i = t2.i left join t3 on t2.i = t3.i
 END
 INPUT
-select from mysqltest1.t22;
+select * from mysqltest1.t22;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysqltest1.t22
 END
 INPUT
 select round(999999999999999999, -18);
@@ -4379,10 +4379,10 @@ OUTPUT
 select locate(_utf8mb4 0xD0B1, _utf8mb4 0xD0B0D0B1D0B2) from dual
 END
 INPUT
-select from t1 where str="foo";
+select * from t1 where str="foo";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where str = 'foo'
 END
 INPUT
 select date_add(datetime, INTERVAL 1 SECOND) from t1;
@@ -4439,10 +4439,10 @@ OUTPUT
 select a1, a2, b, min(c), max(c) from t2 where a1 >= 'c' or a2 < 'b' group by a1, a2, b
 END
 INPUT
-select from t1 where id <=>id;
+select * from t1 where id <=>id;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where id <=> id
 END
 INPUT
 select hex(cast(9007199254740993 as decimal(30,0)));
@@ -4475,10 +4475,10 @@ OUTPUT
 select collation(group_concat(a, _koi8r 'test')) from t1
 END
 INPUT
-select from t1 where match title against ('test' in boolean mode);
+select * from t1 where match title against ('test' in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(title) against ('test' in boolean mode)
 END
 INPUT
 select a1,a2,b,min(c) from t2 where (a2 = 'a') and b is NULL group by a1;
@@ -4505,10 +4505,10 @@ OUTPUT
 select grp, group_concat(a order by a asc, d + c - ascii(c) - a asc) from t1 group by grp
 END
 INPUT
-select from t1 union select from t2 order by 1, 2;
+select * from t1 union select * from t2 order by 1, 2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 union select * from t2 order by 1 asc, 2 asc
 END
 INPUT
 select CAST(1-2 AS UNSIGNED);
@@ -4661,10 +4661,10 @@ OUTPUT
 select min(a) from t1i
 END
 INPUT
-select from t1 where t1="ABCD";
+select * from t1 where t1="ABCD";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where t1 = 'ABCD'
 END
 INPUT
 select 1e18 cast('1.2' as decimal(3,2));
@@ -4727,16 +4727,16 @@ OUTPUT
 select max(t1.a1), max(t2.a2) from t1, t2
 END
 INPUT
-select from (select 2 from DUAL) b;
+select * from (select 2 from DUAL) b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select 2 from dual) as b
 END
 INPUT
-select from t1 where field = '2006-11-06';
+select * from t1 where field = '2006-11-06';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where field = '2006-11-06'
 END
 INPUT
 select _latin1'B' COLLATE latin1_general_ci in (_latin1'a',_latin1'b' COLLATE latin1_bin);
@@ -4763,10 +4763,10 @@ OUTPUT
 select date_add('1998-01-30', interval 1 month) from dual
 END
 INPUT
-select from t12;
+select * from t12;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t12
 END
 INPUT
 select row('A' COLLATE latin1_general_ci,'b','c') = row('a' COLLATE latin1_bin,'b','c');
@@ -4835,7 +4835,7 @@ ERROR
 syntax error at position 28
 END
 INPUT
-select count(distinct x.id_aams) into not_installed from (select from (select t1.id_aams, t2.* from t1 left join t2 on t2.code_id = vlt_code_id and t1.id_aams = t2.id_game where t1.id_aams = 1715000360 order by t2.id desc ) as g group by g.id_aams having g.id is null ) as x;
+select count(distinct x.id_aams) into not_installed from (select * from (select t1.id_aams, t2.* from t1 left join t2 on t2.code_id = vlt_code_id and t1.id_aams = t2.id_game where t1.id_aams = 1715000360 order by t2.id desc ) as g group by g.id_aams having g.id is null ) as x;
 END
 ERROR
 syntax error at position 52 near 'not_installed'
@@ -4847,10 +4847,10 @@ OUTPUT
 select '... and something more ...' from dual
 END
 INPUT
-select from v1;
+select * from v1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1
 END
 INPUT
 select f1(), f2();
@@ -4901,10 +4901,10 @@ ERROR
 syntax error at position 139 near 'test_bug16407'
 END
 INPUT
-select from t1 where bigint_col='17666000000000000000';
+select * from t1 where bigint_col='17666000000000000000';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where bigint_col = '17666000000000000000'
 END
 INPUT
 select date_add(date,INTERVAL 1 DAY) from t1;
@@ -4913,10 +4913,10 @@ OUTPUT
 select date_add(`date`, interval 1 DAY) from t1
 END
 INPUT
-select from t1 where word between binary 0xDF and binary 0xDF;
+select * from t1 where word between binary 0xDF and binary 0xDF;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word between convert(0xDF, binary) and convert(0xDF, binary)
 END
 INPUT
 select left('hello', -4294967297);
@@ -4979,10 +4979,10 @@ OUTPUT
 select group_concat(c1 order by convert(c1, binary) asc separator '') from t1 group by c1 collate utf32_icelandic_ci
 END
 INPUT
-select from t1 where a = 0;
+select * from t1 where a = 0;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 0
 END
 INPUT
 select _latin1'B' in (_latin1'a',_latin1'b');
@@ -4991,10 +4991,10 @@ OUTPUT
 select _latin1 'B' in (_latin1 'a', _latin1 'b') from dual
 END
 INPUT
-select from t1 where word2=binary 0xDF;
+select * from t1 where word2=binary 0xDF;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word2 = convert(0xDF, binary)
 END
 INPUT
 select min(a2) from t1 group by a1;
@@ -5045,16 +5045,16 @@ OUTPUT
 select st_crosses(st_intersection(ST_GeomFromText('point(1 1)'), ST_GeomFromText('multipoint(2 2, 3 3)')), st_intersection(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)'))) from dual
 END
 INPUT
-select from v1c;
+select * from v1c;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1c
 END
 INPUT
-select from t4 order by a,b;
+select * from t4 order by a,b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t4 order by a asc, b asc
 END
 INPUT
 select a1,a2,b,min(c),max(c) from t2 where a1 >= 'b' group by a1,a2,b;
@@ -5075,10 +5075,10 @@ OUTPUT
 select strcmp(_koi8r 'a' collate koi8r_general_ci, _koi8r 'A' collate koi8r_bin) from dual
 END
 INPUT
-select from t1 union distinct select from t2;
+select * from t1 union distinct select * from t2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 union select * from t2
 END
 INPUT
 select hex(soundex(_ucs2 0x00BF00C0));
@@ -5093,10 +5093,10 @@ OUTPUT
 select insert('hello', -4294967297, 1, 'hi') from dual
 END
 INPUT
-select from (t3 cross join t4) natural join t1;
+select * from (t3 cross join t4) natural join t1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t3 join t4) natural join t1
 END
 INPUT
 select format(cast(-2 as unsigned), 2), format(18446744073709551614, 2), format(-2, 2);
@@ -5147,10 +5147,10 @@ OUTPUT
 select trim(trailing 'foo' from 'foo') from dual
 END
 INPUT
-select from (t1 natural join t2) natural left join (t3 natural join t4);
+select * from (t1 natural join t2) natural left join (t3 natural join t4);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 natural join t2) natural left join (t3 natural join t4)
 END
 INPUT
 select max_data_length into @orig_max_data_length from information_schema.tables where table_name='t1';
@@ -5171,22 +5171,22 @@ OUTPUT
 select collation(conv(130, 16, 10)), coercibility(conv(130, 16, 10)) from dual
 END
 INPUT
-select from mysqldump_dbb.v1;
+select * from mysqldump_dbb.v1;
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from t1 where match a against ("+(+aaa* +bbb1*)" in boolean mode);
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysqldump_dbb.v1
 END
 INPUT
-select from t1 where isnull(to_days(mydate));
+select * from t1 where match a against ("+(+aaa* +bbb1*)" in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a) against ('+(+aaa* +bbb1*)' in boolean mode)
+END
+INPUT
+select * from t1 where isnull(to_days(mydate));
+END
+OUTPUT
+select * from t1 where isnull(to_days(mydate))
 END
 INPUT
 select count(distinct i) from v1;
@@ -5225,10 +5225,10 @@ OUTPUT
 select t1.col1 from t1 where t1.col2 in (select t2.col2 from t2 group by t2.col1, t2.col2 having t1.col1 <= 10)
 END
 INPUT
-select from t1 where match a against('ab c' in boolean mode);
+select * from t1 where match a against('ab c' in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a) against ('ab c' in boolean mode)
 END
 INPUT
 select @ujis2 = CONVERT(@utf82 USING ujis);
@@ -5351,10 +5351,10 @@ OUTPUT
 select `sql_big_result` as spid, sum(userid) from t1 group by spid order by spid desc
 END
 INPUT
-select from t1 where f1='test' and (f2= md5("test") or f2= md5("TEST"));
+select * from t1 where f1='test' and (f2= md5("test") or f2= md5("TEST"));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where f1 = 'test' and (f2 = md5('test') or f2 = md5('TEST'))
 END
 INPUT
 select count(*) from t1 /bin /boot /cdrom /dev /etc /home /lib /lib32 /lib64 /libx32 /lost+found /media /mnt /opt /proc /root /run /sbin /snap /srv /swapfile /sys /tmp /usr /var must be 0 */;
@@ -5381,10 +5381,10 @@ OUTPUT
 select hex(convert(0xFF using utf8)) from dual
 END
 INPUT
-select from t1, t3 where t1.start between t3.ctime1 and t3.ctime2;
+select * from t1, t3 where t1.start between t3.ctime1 and t3.ctime2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t3 where t1.`start` between t3.ctime1 and t3.ctime2
 END
 INPUT
 select substring_index('the king of the.the hill','the',-2);
@@ -5423,10 +5423,10 @@ OUTPUT
 select s1 from t1 where s1 in (select version from information_schema.`tables`) union select version from information_schema.`tables`
 END
 INPUT
-select from t1 where a='a';
+select * from t1 where a='a';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 'a'
 END
 INPUT
 select concat(_latin1'a',_latin2'a');
@@ -5483,10 +5483,10 @@ OUTPUT
 select week('2000-01-01', 0) as `2000`, week('2001-01-01', 0) as `2001`, week('2002-01-01', 0) as `2002`, week('2003-01-01', 0) as `2003`, week('2004-01-01', 0) as `2004`, week('2005-01-01', 0) as `2005`, week('2006-01-01', 0) as `2006` from dual
 END
 INPUT
-select from (t1 natural join t2), (t3 natural join t4);
+select * from (t1 natural join t2), (t3 natural join t4);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 natural join t2), (t3 natural join t4)
 END
 INPUT
 select count(*) from t3 where id3 > 95;
@@ -5501,10 +5501,10 @@ OUTPUT
 select st_intersects(st_union(ST_GeomFromText('point(1 1)'), ST_GeomFromText('multipoint(2 2, 3 3)')), st_intersection(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)'))) from dual
 END
 INPUT
-select from t1 where id=000000000001;
+select * from t1 where id=000000000001;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where id = 000000000001
 END
 INPUT
 select a,count(b), sum(b), avg(b), std(b), min(b), max(b), bit_and(b), bit_or(b) from t1 group by a;
@@ -5519,10 +5519,10 @@ OUTPUT
 select a1, a2, b, min(c), max(c) from t2 where c < 'a0' or c > 'b1' group by a1, a2, b
 END
 INPUT
-select from t1 natural left join t2 where (t2.i is not null)=0;
+select * from t1 natural left join t2 where (t2.i is not null)=0;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural left join t2 where t2.i is not null = 0
 END
 INPUT
 select 5 between 0 and 10 between 0 and 1,(5 between 0 and 10) between 0 and 1;
@@ -5531,10 +5531,10 @@ OUTPUT
 select 5 between 0 and (10 between 0 and 1), 5 between 0 and 10 between 0 and 1 from dual
 END
 INPUT
-select from (t1 join t2 on t1.b=t2.b) natural join (t3 natural join t4);
+select * from (t1 join t2 on t1.b=t2.b) natural join (t3 natural join t4);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 join t2 on t1.b = t2.b) natural join (t3 natural join t4)
 END
 INPUT
 select round(999999999.0, -9);
@@ -5567,10 +5567,10 @@ OUTPUT
 select index_name from information_schema.statistics where table_schema = 'test' order by index_name asc
 END
 INPUT
-select (select from (select from (select t1.a from t2) as dt limit 1) dt2) from t1;
+select (select * from (select * from (select t1.a from t2) as dt limit 1) dt2) from t1;
 END
-ERROR
-syntax error at position 20 near 'from'
+OUTPUT
+select (select * from (select * from (select t1.a from t2) as dt limit 1) as dt2) from t1
 END
 INPUT
 select substring_index('the king of the the hill',' the ',-2);
@@ -5591,10 +5591,10 @@ OUTPUT
 select distinct a1, a2, b from t1
 END
 INPUT
-select from t1 where city = 'Durban';
+select * from t1 where city = 'Durban';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where city = 'Durban'
 END
 INPUT
 select CAST(0xb3 as signed);
@@ -5621,10 +5621,10 @@ OUTPUT
 select SUBSTRING_INDEX(_latin1 'abcdabcdabcd', _latin2 'd', 2) from dual
 END
 INPUT
-select from t1 where tt like 'AA%';
+select * from t1 where tt like 'AA%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where tt like 'AA%'
 END
 INPUT
 select repeat('hello', -4294967295);
@@ -5633,10 +5633,10 @@ OUTPUT
 select repeat('hello', -4294967295) from dual
 END
 INPUT
-select from (t3 natural join t4) natural join (t1 join t2 on t1.b=t2.b);
+select * from (t3 natural join t4) natural join (t1 join t2 on t1.b=t2.b);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t3 natural join t4) natural join (t1 join t2 on t1.b = t2.b)
 END
 INPUT
 select hex(c1) as h, c1 from t1 order by c1, h;
@@ -5651,16 +5651,16 @@ OUTPUT
 select s1 * 0 from t1 group by s1 having s1 = 0
 END
 INPUT
-select from t1 where not((a < 5 and a < 10) and (not(a > 16) or a > 17));
+select * from t1 where not((a < 5 and a < 10) and (not(a > 16) or a > 17));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not (a < 5 and a < 10 and (not a > 16 or a > 17))
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('"text search" "now support"' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('"text search" "now support"' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('\"text search\" \"now support\"' in boolean mode)
 END
 INPUT
 select insert('hello', 1, -18446744073709551616, 'hi');
@@ -5717,10 +5717,10 @@ OUTPUT
 select extract(month from '0000-00-00'), extract(month from d), extract(month from dt), extract(month from t), extract(month from c) from t1
 END
 INPUT
-select from t3 where a < 10;
+select * from t3 where a < 10;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 where a < 10
 END
 INPUT
 select 1, ST_Within(ST_GeomFromText('POLYGON((1 1,20 10,10 30, 1 1))'), ST_GeomFromText('POLYGON((0 0,30 5,10 40, 0 0))'));
@@ -5759,10 +5759,10 @@ OUTPUT
 select yearweek('1981-12-31', 1), yearweek('1982-01-01', 1), yearweek('1982-12-31', 1), yearweek('1983-01-01', 1) from dual
 END
 INPUT
-select from t5 order by b,a limit 3,3;
+select * from t5 order by b,a limit 3,3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t5 order by b asc, a asc limit 3, 3
 END
 INPUT
 select mod(12, 0.0) as 'NULL';
@@ -5795,10 +5795,10 @@ OUTPUT
 select timediff('1997-12-31 23:59:59.000001', '1997-12-30 01:01:01.000002') from dual
 END
 INPUT
-select from t1 where NULL or not(a < 15 and a > 5);
+select * from t1 where NULL or not(a < 15 and a > 5);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where null or not (a < 15 and a > 5)
 END
 INPUT
 select ST_GeomFromText("POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))") into @a;
@@ -5819,10 +5819,10 @@ OUTPUT
 select t1.*, t2.* from t1 natural join t2
 END
 INPUT
-select from INFORMATION_SCHEMA.COLUMN_PRIVILEGES WHERE table_schema != 'sys';
+select * from INFORMATION_SCHEMA.COLUMN_PRIVILEGES WHERE table_schema != 'sys';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from INFORMATION_SCHEMA.COLUMN_PRIVILEGES where table_schema != 'sys'
 END
 INPUT
 select aes_decrypt(aes_encrypt('abc','1'),'1');
@@ -5897,10 +5897,10 @@ OUTPUT
 select unhex(hex('foobar')), hex(unhex('1234567890ABCDEF')), unhex('345678'), unhex(null) from dual
 END
 INPUT
-select from performance_schema.global_variables where variable_name='init_connect';
+select * from performance_schema.global_variables where variable_name='init_connect';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from performance_schema.global_variables where variable_name = 'init_connect'
 END
 INPUT
 select t1.a from MYSQLTEST.T1;
@@ -5957,10 +5957,10 @@ OUTPUT
 select interval 1 DAY + '1997-12-31' from dual
 END
 INPUT
-select from t1 where t1 like "a_%";
+select * from t1 where t1 like "a_%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where t1 like 'a_%'
 END
 INPUT
 select cast(1-pow(2,63) as signed) as qq;
@@ -6029,16 +6029,16 @@ OUTPUT
 select ifnull(A = 1, 'N') as A, ifnull(B = 1, 'N') as B, ifnull(not A = 1, 'N') as nA, ifnull(not B = 1, 'N') as nB, ifnull(A = 1 and B = 1, 'N') as AB, ifnull(not (A = 1 and B = 1), 'N') as `n(AB)`, ifnull(not A = 1 or not B = 1, 'N') as nAonB, ifnull(A = 1 or B = 1, 'N') as AoB, ifnull(not (A = 1 or B = 1), 'N') as `n(AoB)`, ifnull(not A = 1 and not B = 1, 'N') as nAnB from t1
 END
 INPUT
-select from (select polygon(t1.a) as p from t1 order by t1.a) d;
+select * from (select polygon(t1.a) as p from t1 order by t1.a) d;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select polygon(t1.a) as p from t1 order by t1.a asc) as d
 END
 INPUT
-select from t1 where a = 'b';
+select * from t1 where a = 'b';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 'b'
 END
 INPUT
 select hex(@utf83);
@@ -6095,10 +6095,10 @@ OUTPUT
 select benchmark((select 10 from dual), pi()) from dual
 END
 INPUT
-select from t6 natural join ((t1 natural join t2), (t3 natural join t4));
+select * from t6 natural join ((t1 natural join t2), (t3 natural join t4));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t6 natural join ((t1 natural join t2), (t3 natural join t4))
 END
 INPUT
 select ST_astext(g) from t1 where ST_Contains(ST_GeomFromText('POLYGON((5 1, 7 1, 7 7, 5 7, 3 3, 5 3, 5 1))'), g);
@@ -6119,10 +6119,10 @@ ERROR
 syntax error at position 132 near 'bug27638'
 END
 INPUT
-select from_unixtime(-1);
+select * from_unixtime(-1);
 END
-OUTPUT
-select from_unixtime(-1) from dual
+ERROR
+syntax error at position 23 near 'from_unixtime'
 END
 INPUT
 select hex(conv(convert('123' using utf16), -10, 16));
@@ -6191,10 +6191,10 @@ OUTPUT
 select (with recursive dt as (select t1.a as a from dual union select a + 1 from dt where a < 10) select dt1.a from dt as dt1 where dt1.a = t1.a) as subq from t1
 END
 INPUT
-select from t5 natural join ((t1 natural join t2), (t3 natural join t4));
+select * from t5 natural join ((t1 natural join t2), (t3 natural join t4));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t5 natural join ((t1 natural join t2), (t3 natural join t4))
 END
 INPUT
 select count(*) FROM t4;
@@ -6203,10 +6203,10 @@ OUTPUT
 select count(*) from t4
 END
 INPUT
-select from (t4 natural right join t3) natural right join (t2 natural right join t1);
+select * from (t4 natural right join t3) natural right join (t2 natural right join t1);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t4 natural right join t3) natural right join (t2 natural right join t1)
 END
 INPUT
 select a1,a2,b,min(c),max(c) from t1 where a1 = 'z' or a1 = 'b' or a1 = 'd' group by a1,a2,b;
@@ -6311,10 +6311,10 @@ OUTPUT
 select ST_astext(ST_convexhull(ST_PolyFromWKB(ST_AsWKB(Polygon(LineString(Point(0, 0), Point(30, 0), Point(30, 30), Point(1, 0), Point(0, 0))))))) from dual
 END
 INPUT
-select from t1 where i between 2 and 4 and v in ('def','3r4f','abc');
+select * from t1 where i between 2 and 4 and v in ('def','3r4f','abc');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where i between 2 and 4 and v in ('def', '3r4f', 'abc')
 END
 INPUT
 select a,c,sum(a) from t1 group by a;
@@ -6329,10 +6329,10 @@ OUTPUT
 select t1.*, t2.* from t1 left join t2 on t1.a = t2.a where t2.id = 3
 END
 INPUT
-select from information_schema.key_column_usage where TABLE_SCHEMA= "test" order by constraint_name;
+select * from information_schema.key_column_usage where TABLE_SCHEMA= "test" order by constraint_name;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.key_column_usage where TABLE_SCHEMA = 'test' order by constraint_name asc
 END
 INPUT
 select ST_Length(ST_MLineFromWKB(0x0000000005000000020000000002000000035FB317E5EF3AB327E3A4B378469B67320000000000000000C0240000000000003FF05FD8ADAB9F560000000000000000000000000200000003000000000000000000000000000000000000000000000000BFF08B439581062540240000000000004341C37937E08000)) as length;
@@ -6359,10 +6359,10 @@ OUTPUT
 select 12 % 2 as `0` from dual
 END
 INPUT
-select from t1 where match (a) against ('aaaa');
+select * from t1 where match (a) against ('aaaa');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a) against ('aaaa')
 END
 INPUT
 select date_sub("1998-01-01 00:00:00",INTERVAL "1:1" DAY_HOUR);
@@ -6383,10 +6383,10 @@ OUTPUT
 select date_add(`date`, interval '1:1:1' HOUR_SECOND) from t1
 END
 INPUT
-select from t1 where a <> _latin1 'B' collate latin1_bin;
+select * from t1 where a <> _latin1 'B' collate latin1_bin;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a != _latin1 'B' collate latin1_bin
 END
 INPUT
 select b from t1 where binary b like '';
@@ -6395,10 +6395,10 @@ OUTPUT
 select b from t1 where convert(b, binary) like ''
 END
 INPUT
-select from t1 where str='str';
+select * from t1 where str='str';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where str = 'str'
 END
 INPUT
 select '?' like '|%', '?' like '|%' ESCAPE '|', '%' like '|%', '%' like '|%' ESCAPE '|', '%' like '%';
@@ -6419,10 +6419,10 @@ OUTPUT
 select t1.*, t2.* from t1 left join t2 on t1.n = t2.n and t1.m = t2.m where t1.n = 1
 END
 INPUT
-select from t1 where ((a between 5 and 15) and (not(a like 10)));
+select * from t1 where ((a between 5 and 15) and (not(a like 10)));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a between 5 and 15 and not a like 10
 END
 INPUT
 select t1.a, dt.a from t1, lateral (select t2.a as a from t2 having t1.a) dt;
@@ -6485,10 +6485,10 @@ OUTPUT
 select date_format(f1, '%m') as d1, date_format(f1, '%M') as d2 from t1 order by date_format(f1, '%M') asc
 END
 INPUT
-select from t1 where st_a=1 and swt1a=1 and swt2a=1 and st_b=1 and swt1b=1 limit 5;
+select * from t1 where st_a=1 and swt1a=1 and swt2a=1 and st_b=1 and swt1b=1 limit 5;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where st_a = 1 and swt1a = 1 and swt2a = 1 and st_b = 1 and swt1b = 1 limit 5
 END
 INPUT
 select a,b from t1 order by a,b;
@@ -6509,10 +6509,10 @@ OUTPUT
 select host, db, `user`, table_name from mysql.tables_priv where `user` like 'mysqltest_%' order by host asc, db asc, `user` asc, table_name asc
 END
 INPUT
-select from t1 where a=18446744073709551615;
+select * from t1 where a=18446744073709551615;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 18446744073709551615
 END
 INPUT
 select cast(18446744073709551615 as signed);
@@ -6569,10 +6569,10 @@ OUTPUT
 select repeat('hello', 18446744073709551617) from dual
 END
 INPUT
-select from t2 order by a;
+select * from t2 order by a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 order by a asc
 END
 INPUT
 select a2, min(c), max(c) from t1 group by a1,a2,b;
@@ -6653,10 +6653,10 @@ OUTPUT
 select group_concat(c1 order by convert(c1, binary) asc separator '') from t1 group by c1 collate utf32_spanish_ci
 END
 INPUT
-select from t1,t1 as t2;
+select * from t1,t1 as t2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t1 as t2
 END
 INPUT
 select 'zвася' rlike '[[:<:]]вася[[:>:]]';
@@ -6749,10 +6749,10 @@ OUTPUT
 select a from t1 where a like 'abcdefgh�'
 END
 INPUT
-select from t1 where a=b and b=0x01;
+select * from t1 where a=b and b=0x01;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = b and b = 0x01
 END
 INPUT
 select substring_index('aaaaaaaaa1','aa',-3);
@@ -6767,22 +6767,22 @@ OUTPUT
 select if(u = 1, convert(st, binary), st) as s from t1 order by s asc
 END
 INPUT
-select from t1 where match a against ("(+aaa* +bbb1*)" in boolean mode);
+select * from t1 where match a against ("(+aaa* +bbb1*)" in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from t1 where MATCH(a,b) AGAINST("+search -(support vector)" IN BOOLEAN MODE);
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a) against ('(+aaa* +bbb1*)' in boolean mode)
 END
 INPUT
-select from t1 where match b against ('+aaaaaa bbbbbb' in boolean mode);
+select * from t1 where MATCH(a,b) AGAINST("+search -(support vector)" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('+search -(support vector)' in boolean mode)
+END
+INPUT
+select * from t1 where match b against ('+aaaaaa bbbbbb' in boolean mode);
+END
+OUTPUT
+select * from t1 where match(b) against ('+aaaaaa bbbbbb' in boolean mode)
 END
 INPUT
 select substring_index("1abcd;
@@ -6815,10 +6815,10 @@ OUTPUT
 select monthname(`date`) from t1 join t2 on t1.id = t2.id order by t1.id asc
 END
 INPUT
-select from t1 where CAST(field as DATE) < '2006-11-06 04:08:36.0';
+select * from t1 where CAST(field as DATE) < '2006-11-06 04:08:36.0';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where cast(field as DATE) < '2006-11-06 04:08:36.0'
 END
 INPUT
 select interval(55,10,20,30,40,50,60,70,80,90,100),interval(3,1,1+1,1+1+1+1),field("IBM","NCA","ICL","SUN","IBM","DIGITAL"),field("A","B","C"),elt(2,"ONE","TWO","THREE"),interval(0,1,2,3,4),elt(1,1,2,3)|0,elt(1,1.1,1.2,1.3)+0;
@@ -6959,10 +6959,10 @@ OUTPUT
 select t1.col1 from t1 where t1.col2 in (select t2.col2 from t2 group by t2.col1, t2.col2 having t2.col1 <= 10)
 END
 INPUT
-select from t1 where a like "%�%";
+select * from t1 where a like "%�%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '%�%'
 END
 INPUT
 select coercibility(weight_string('test' collate latin1_swedish_ci));
@@ -6995,10 +6995,10 @@ OUTPUT
 select _koi8r 'a' = _latin1 'A' from dual
 END
 INPUT
-select from t1 where not(a != 1);
+select * from t1 where not(a != 1);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not a != 1
 END
 INPUT
 select fld3 FROM t2 order by fld3 desc limit 5,5;
@@ -7013,10 +7013,10 @@ OUTPUT
 select hex(char(0xFF using utf8mb4)) from dual
 END
 INPUT
-select from `information_schema`.`TABLE_CONSTRAINTS` where `TABLE_SCHEMA` = NULL;
+select * from `information_schema`.`TABLE_CONSTRAINTS` where `TABLE_SCHEMA` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.TABLE_CONSTRAINTS where TABLE_SCHEMA = null
 END
 INPUT
 select current_user();
@@ -7055,10 +7055,10 @@ OUTPUT
 select aes_decrypt('a', null) from dual
 END
 INPUT
-select from t2 left join t1 on t1.fooID = t2.fooID and t1.fooID = 30;
+select * from t2 left join t1 on t1.fooID = t2.fooID and t1.fooID = 30;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 left join t1 on t1.fooID = t2.fooID and t1.fooID = 30
 END
 INPUT
 select FIELD('b','A' COLLATE latin1_bin,'B');
@@ -7097,10 +7097,10 @@ OUTPUT
 select a, b, c from t3 force index (a) where a = 1 order by a desc, b desc, c desc
 END
 INPUT
-select from t1 where a > 736494;
+select * from t1 where a > 736494;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a > 736494
 END
 INPUT
 select _latin1'B' in (_latin2'a',_latin1'b');
@@ -7115,10 +7115,10 @@ OUTPUT
 select friedrich from (select 1 as otto from dual) as t1
 END
 INPUT
-select from information_schema.tables where table_catalog = NULL;
+select * from information_schema.tables where table_catalog = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`tables` where table_catalog = null
 END
 INPUT
 select aes_decrypt(aes_encrypt('abc','1'),1);
@@ -7229,10 +7229,10 @@ OUTPUT
 select count(distinct t) from t1
 END
 INPUT
-select from t3 right join t2 on (t3.i=t2.i);
+select * from t3 right join t2 on (t3.i=t2.i);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 right join t2 on t3.i = t2.i
 END
 INPUT
 select trace from information_schema.optimizer_trace;
@@ -7259,10 +7259,10 @@ OUTPUT
 select a1, a2, b, min(c), max(c) from t1 where c < 'a0' or c > 'b1' group by a1, a2, b
 END
 INPUT
-select from v3 where renamed=1 group by renamed;
+select * from v3 where renamed=1 group by renamed;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v3 where renamed = 1 group by renamed
 END
 INPUT
 select a2 from ((t1 join t2 using (a1)) join t3 on b=c1) join t4 using (c2);
@@ -7367,10 +7367,10 @@ OUTPUT
 select grp, group_concat(d order by a asc) from t1 group by grp
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST("support -collections" IN BOOLEAN MODE);
+select * from t1 where MATCH(a,b) AGAINST("support -collections" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('support -collections' in boolean mode)
 END
 INPUT
 select benchmark(-1, 1);
@@ -7379,10 +7379,10 @@ OUTPUT
 select benchmark(-1, 1) from dual
 END
 INPUT
-select from t1 where a=version();
+select * from t1 where a=version();
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = version()
 END
 INPUT
 select max(a) from t1i;
@@ -7421,10 +7421,10 @@ OUTPUT
 select COLUMN_NAME, COLUMN_TYPE, CHARACTER_MAXIMUM_LENGTH, CHARACTER_OCTET_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE from information_schema.`columns` where table_name = 't1'
 END
 INPUT
-select from `information_schema`.`key_column_usage` where `TABLE_SCHEMA` = NULL;
+select * from `information_schema`.`key_column_usage` where `TABLE_SCHEMA` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.key_column_usage where TABLE_SCHEMA = null
 END
 INPUT
 select ST_AsText(f2),ST_AsText(f3) from t1;
@@ -7445,10 +7445,10 @@ OUTPUT
 select t2.fld3 from t2 where fld3 like 'honeysuckle_'
 END
 INPUT
-select from t1 where upper(a)='AAA';
+select * from t1 where upper(a)='AAA';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where upper(a) = 'AAA'
 END
 INPUT
 select cast("A" as binary) = "a", cast(BINARY "a" as CHAR) = "A";
@@ -7457,10 +7457,10 @@ OUTPUT
 select cast('A' as binary) = 'a', cast(convert('a', BINARY) as CHAR) = 'A' from dual
 END
 INPUT
-select from `information_schema`.`TRIGGERS` where `EVENT_OBJECT_SCHEMA` = NULL;
+select * from `information_schema`.`TRIGGERS` where `EVENT_OBJECT_SCHEMA` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`TRIGGERS` where EVENT_OBJECT_SCHEMA = null
 END
 INPUT
 select cast(min(ff) as decimal(5,2)) from t2;
@@ -7469,10 +7469,10 @@ OUTPUT
 select cast(min(ff) as decimal(5, 2)) from t2
 END
 INPUT
-select from information_schema.views where TABLE_SCHEMA != 'sys' and TABLE_NAME rlike "v[0-4]{1}$" order by table_name;
+select * from information_schema.views where TABLE_SCHEMA != 'sys' and TABLE_NAME rlike "v[0-4]{1}$" order by table_name;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.views where TABLE_SCHEMA != 'sys' and TABLE_NAME regexp 'v[0-4]{1}$' order by table_name asc
 END
 INPUT
 select group_concat(distinct a) from t1;
@@ -7529,16 +7529,16 @@ OUTPUT
 select table_schema, table_name, column_name from information_schema.`columns` where table_schema not in ('performance_schema', 'sys', 'mysql') and data_type = 'longtext' order by table_name asc, column_name asc
 END
 INPUT
-select from t1 ignore key (key1) where text1='teststring' or text1 like 'teststring_%' ORDER BY text1;
+select * from t1 ignore key (key1) where text1='teststring' or text1 like 'teststring_%' ORDER BY text1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 ignore index (key1) where text1 = 'teststring' or text1 like 'teststring_%' order by text1 asc
 END
 INPUT
-select from t1 where a not between 1 and 2 and b not between 3 and 4;
+select * from t1 where a not between 1 and 2 and b not between 3 and 4;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a not between 1 and 2 and b not between 3 and 4
 END
 INPUT
 select max(7) from t2m join t1m;
@@ -7655,10 +7655,10 @@ OUTPUT
 select 1.1 + '1.2' from dual
 END
 INPUT
-select from_days(to_days("960101")),to_days(960201)-to_days("19960101"),to_days(date_add(curdate(), interval 1 day))-to_days(curdate()),weekday("1997-11-29");
+select * from_days(to_days("960101")),to_days(960201)-to_days("19960101"),to_days(date_add(curdate(), interval 1 day))-to_days(curdate()),weekday("1997-11-29");
 END
-OUTPUT
-select from_days(to_days('960101')), to_days(960201) - to_days('19960101'), to_days(date_add(curdate(), interval 1 day)) - to_days(curdate()), weekday('1997-11-29') from dual
+ERROR
+syntax error at position 19 near 'from_days'
 END
 INPUT
 select c c1 from t1 where c='1';
@@ -7715,10 +7715,10 @@ OUTPUT
 select mysqltest1.f1() from dual
 END
 INPUT
-select from (select from t1 where t1.a=(select a from t2 where t2.a=t1.a)) a;
+select * from (select * from t1 where t1.a=(select a from t2 where t2.a=t1.a)) a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select * from t1 where t1.a = (select a from t2 where t2.a = t1.a)) as a
 END
 INPUT
 select st_disjoint(st_intersection(ST_GeomFromText('point(1 1)'), ST_GeomFromText('multipoint(2 2, 3 3)')), st_intersection(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)')));
@@ -7829,10 +7829,10 @@ OUTPUT
 select std(s1 / s2) from bug22555 where i = 3
 END
 INPUT
-select from t1 where btn like "q%";
+select * from t1 where btn like "q%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where btn like 'q%'
 END
 INPUT
 select timestampdiff(month,'2004-09-11','2006-09-11');
@@ -7967,10 +7967,10 @@ OUTPUT
 select insert(_utf32 0x000000610000006200000063, 1, 2, _utf32 0x000000640000006500000066) from dual
 END
 INPUT
-select from t1 where tt like '%Aa%';
+select * from t1 where tt like '%Aa%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where tt like '%Aa%'
 END
 INPUT
 select distinct c1, c2 from t1 order by c2;
@@ -8009,10 +8009,10 @@ OUTPUT
 select a1, a2, b, max(c) from t2 where c > 'b1' or c <= 'g1' group by a1, a2, b
 END
 INPUT
-select from mysqldump_myDB.u1;
+select * from mysqldump_myDB.u1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysqldump_myDB.u1
 END
 INPUT
 select t1.id,t2.id from t2 left join t1 on t1.id>=74 and t1.id<=0 where t2.id=75 and t1.id is null;
@@ -8045,10 +8045,10 @@ OUTPUT
 select One, Two, sum(Four) from t1 group by One, Two
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('"text i"' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('"text i"' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('\"text i\"' in boolean mode)
 END
 INPUT
 select column_name,data_type,CHARACTER_OCTET_LENGTH, CHARACTER_MAXIMUM_LENGTH from information_schema.columns where table_name='t1' order by column_name;
@@ -8099,10 +8099,10 @@ OUTPUT
 select count(*) from t2 where id2
 END
 INPUT
-select from t1 where match(s) against('para' in boolean mode);
+select * from t1 where match(s) against('para' in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(s) against ('para' in boolean mode)
 END
 INPUT
 select -(-9223372036854775808), -(-(-9223372036854775808));
@@ -8111,16 +8111,16 @@ OUTPUT
 select - -9223372036854775808, - - -9223372036854775808 from dual
 END
 INPUT
-select from t1_mrg;
+select * from t1_mrg;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1_mrg
 END
 INPUT
-select from t1 where a >= '1';
+select * from t1 where a >= '1';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a >= '1'
 END
 INPUT
 select concat(b,'.') from t1;
@@ -8135,16 +8135,16 @@ OUTPUT
 select mod(12, null) as `NULL` from dual
 END
 INPUT
-select from (select from t1,t2) foo;
+select * from (select * from t1,t2) foo;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select * from t1, t2) as foo
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('"support now"' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('"support now"' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('\"support now\"' in boolean mode)
 END
 INPUT
 select hex(inet_aton('127.1.1'));
@@ -8177,10 +8177,10 @@ OUTPUT
 select constraint_name from information_schema.table_constraints where table_schema = 'test' order by constraint_name asc
 END
 INPUT
-select from information_schema.partitions where table_schema="test";
+select * from information_schema.partitions where table_schema="test";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`partitions` where table_schema = 'test'
 END
 INPUT
 select max(a2) from t1 where a2 >= 1;
@@ -8189,16 +8189,16 @@ OUTPUT
 select max(a2) from t1 where a2 >= 1
 END
 INPUT
-select from t6 order by b,a limit 6,3;
+select * from t6 order by b,a limit 6,3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t6 order by b asc, a asc limit 6, 3
 END
 INPUT
-select from t1 where a like "te_t";
+select * from t1 where a like "te_t";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like 'te_t'
 END
 INPUT
 select match(t1.texte,t1.sujet,t1.motsclefs) against('droit' IN BOOLEAN MODE) from t1 left join t2 on t2.id=t1.id;
@@ -8285,10 +8285,10 @@ ERROR
 syntax error at position 19 near ':'
 END
 INPUT
-select from t5 order by a,b;
+select * from t5 order by a,b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t5 order by a asc, b asc
 END
 INPUT
 select 1, max(a) from t1i where a=99;
@@ -8333,10 +8333,10 @@ OUTPUT
 select insert('hello', 1, -18446744073709551617, 'hi') from dual
 END
 INPUT
-select from t1 union all select from t2;
+select * from t1 union all select * from t2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 union all select * from t2
 END
 INPUT
 select 'a' regexp 'A' collate latin1_general_ci;
@@ -8423,16 +8423,16 @@ OUTPUT
 select week(19981231, 2), week(19981231, 3), week(20000101, 2), week(20000101, 3) from dual
 END
 INPUT
-select t2.* from ((select from t1) as A inner join t2 on A.ID = t2.FID);
+select t2.* from ((select * from t1) as A inner join t2 on A.ID = t2.FID);
 END
-ERROR
-syntax error at position 31 near 'from'
+OUTPUT
+select t2.* from ((select * from t1) as A join t2 on A.ID = t2.FID)
 END
 INPUT
-select from information_schema.COLUMNS where table_name="t1" and column_name= "a" order by table_name;
+select * from information_schema.COLUMNS where table_name="t1" and column_name= "a" order by table_name;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`COLUMNS` where table_name = 't1' and column_name = 'a' order by table_name asc
 END
 INPUT
 select rpad('hello', 4294967295, '1');
@@ -8453,10 +8453,10 @@ OUTPUT
 select case when 1 = 0 then 'true' else 'false' end from dual
 END
 INPUT
-select from t1 where match b against ('full*' in boolean mode);
+select * from t1 where match b against ('full*' in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(b) against ('full*' in boolean mode)
 END
 INPUT
 select locate(_utf8 0xD0B1, _utf8 0xD0B0D091D0B2);
@@ -8471,10 +8471,10 @@ OUTPUT
 select 18446744073709551615, 18446744073709551615 div 1, 18446744073709551615 div 2 from dual
 END
 INPUT
-select from t2 where match name against ('*a*b*c*d*e*f*' in boolean mode);
+select * from t2 where match name against ('*a*b*c*d*e*f*' in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 where match(`name`) against ('*a*b*c*d*e*f*' in boolean mode)
 END
 INPUT
 select hex(c) from t1;
@@ -8597,10 +8597,10 @@ OUTPUT
 select weight_string(null) from dual
 END
 INPUT
-select from information_schema.TABLE_CONSTRAINTS where TABLE_SCHEMA= "test" order by TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME;
+select * from information_schema.TABLE_CONSTRAINTS where TABLE_SCHEMA= "test" order by TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.TABLE_CONSTRAINTS where TABLE_SCHEMA = 'test' order by TABLE_SCHEMA asc, TABLE_NAME asc, CONSTRAINT_NAME asc
 END
 INPUT
 select distinct least(1,count(distinct a)) from t1 group by a;
@@ -8645,22 +8645,22 @@ OUTPUT
 select 'a' regexp 'A' collate latin1_bin from dual
 END
 INPUT
-select from information_schema.views where table_schema != 'sys' order by table_name;
+select * from information_schema.views where table_schema != 'sys' order by table_name;
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from t2 left outer join t1 using (n);
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.views where table_schema != 'sys' order by table_name asc
 END
 INPUT
-select from t1, t2 where t1.value64= 9223372036854775807 and t2.value64=t1.value64;
+select * from t2 left outer join t1 using (n);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 left join t1 using (n)
+END
+INPUT
+select * from t1, t2 where t1.value64= 9223372036854775807 and t2.value64=t1.value64;
+END
+OUTPUT
+select * from t1, t2 where t1.value64 = 9223372036854775807 and t2.value64 = t1.value64
 END
 INPUT
 select makedate(1997,1);
@@ -8741,10 +8741,10 @@ OUTPUT
 select sum(a), count(*) from t1 group by a
 END
 INPUT
-select from t1;
+select * from t1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1
 END
 INPUT
 select makedate(03,1);
@@ -8789,10 +8789,10 @@ OUTPUT
 select a as x from t1 having x = 3
 END
 INPUT
-select from t1 where x != 0;
+select * from t1 where x != 0;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where x != 0
 END
 INPUT
 select locate('lo','hello',-4294967297);
@@ -8801,22 +8801,22 @@ OUTPUT
 select locate('lo', 'hello', -4294967297) from dual
 END
 INPUT
-select from t1 where firstname='John' and firstname like binary 'john';
+select * from t1 where firstname='John' and firstname like binary 'john';
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select (with cte as (select t1.a) select from cte) from t1;
-END
-ERROR
-syntax error at position 46 near 'from'
+OUTPUT
+select * from t1 where firstname = 'John' and firstname like convert('john', binary)
 END
 INPUT
-select from v1d;
+select (with cte as (select t1.a) select * from cte) from t1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select (with cte as (select t1.a from dual) select * from cte) from t1
+END
+INPUT
+select * from v1d;
+END
+OUTPUT
+select * from v1d
 END
 INPUT
 select count(*) from t1, t2 where t1.p = t2.i;
@@ -8831,10 +8831,10 @@ OUTPUT
 select isnull(date(null)), isnull(cast(null as DATE)) from dual
 END
 INPUT
-select from t1 ignore index (primary) where tt like 'Aa%';
+select * from t1 ignore index (primary) where tt like 'Aa%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 ignore index (`primary`) where tt like 'Aa%'
 END
 INPUT
 select hex(weight_string(_utf8mb4 0xF0908080 /bin /boot /cdrom /dev /etc /home /lib /lib32 /lib64 /libx32 /lost+found /media /mnt /opt /proc /root /run /sbin /snap /srv /swapfile /sys /tmp /usr /var U+10000 node_modules/ collate utf8mb4_unicode_ci));
@@ -8843,10 +8843,10 @@ ERROR
 syntax error at position 201 near 'U'
 END
 INPUT
-select from t1 natural left join t2 natural left join t3;
+select * from t1 natural left join t2 natural left join t3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural left join t2 natural left join t3
 END
 INPUT
 select collation(group_concat(a separator ',')) from t1;
@@ -8861,10 +8861,10 @@ OUTPUT
 select 'hepp' from dual
 END
 INPUT
-select from t1 where word like 'ae';
+select * from t1 where word like 'ae';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word like 'ae'
 END
 INPUT
 select strcmp(date_format(utc_timestamp(),"%T"), utc_time())=0;
@@ -8891,10 +8891,10 @@ OUTPUT
 select date_add('1000-01-01 00:00:00', interval '1.02' day_microsecond) from dual
 END
 INPUT
-select from (select b from t1) as t1, (select b from t2) as t2 order by 1, 2;
+select * from (select b from t1) as t1, (select b from t2) as t2 order by 1, 2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select b from t1) as t1, (select b from t2) as t2 order by 1 asc, 2 asc
 END
 INPUT
 select "Test delimiter : from command line" as "_";
@@ -8915,10 +8915,10 @@ OUTPUT
 select cast('1a' as signed) from dual
 END
 INPUT
-select from t1 where a in ('4828532208463511553');
+select * from t1 where a in ('4828532208463511553');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a in ('4828532208463511553')
 END
 INPUT
 select column_name from information_schema.columns where table_schema='test' order by column_name;
@@ -8993,10 +8993,10 @@ OUTPUT
 select *, uncompress(a), uncompress(a) is null from t1
 END
 INPUT
-select from bug15205;
+select * from bug15205;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from bug15205
 END
 INPUT
 select case 1/0 when "a" then "true" END;
@@ -9017,10 +9017,10 @@ OUTPUT
 select collation(a), collation(b), collation(convert('ccc', binary)) from t1 limit 1
 END
 INPUT
-select from t1 where a like "%U%";
+select * from t1 where a like "%U%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '%U%'
 END
 INPUT
 select count(*) from t where id between 8894754949779693574 and 17790886498483827171;
@@ -9053,10 +9053,10 @@ ERROR
 syntax error at position 24 near 'test');'
 END
 INPUT
-select from t1 where a like '%PES%';
+select * from t1 where a like '%PES%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '%PES%'
 END
 INPUT
 select ifnull(c1,'�'), ifnull(null,c1) from t1;
@@ -9167,10 +9167,10 @@ OUTPUT
 select case 1 when 1 then 'one' when 2 then 'two' else 'more' end from dual
 END
 INPUT
-select from (t1 join t2 using (b)) join (t3 join t4 using (c)) using (c);
+select * from (t1 join t2 using (b)) join (t3 join t4 using (c)) using (c);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 join t2 using (b)) join (t3 join t4 using (c)) using (c)
 END
 INPUT
 select min(7) from t1i;
@@ -9185,10 +9185,10 @@ OUTPUT
 select locate(_utf8 0xD0B1, _utf8 0xD0B0D0B1D0B2) from dual
 END
 INPUT
-select from t1 where b like 'foob%';
+select * from t1 where b like 'foob%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where b like 'foob%'
 END
 INPUT
 select convert(_latin1'G�nter Andr�' using utf8mb4) like CONVERT(_latin1'G�NTER%' USING utf8mb4);
@@ -9239,10 +9239,10 @@ OUTPUT
 select mod(12.0, 0) as `NULL` from dual
 END
 INPUT
-select from t1 where str <> default(str);
+select * from t1 where str <> default(str);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where str != default(str)
 END
 INPUT
 select count(*) from INFORMATION_SCHEMA.TABLES where TABLE_SCHEMA='mysql' AND TABLE_NAME='nonexisting';
@@ -9329,10 +9329,10 @@ OUTPUT
 select host, db, `user`, table_name from mysql.tables_priv where `user` = 'mysqltest_1' order by host asc, db asc, `user` asc, table_name asc
 END
 INPUT
-select from v1a join (t3 natural join t4) on a = y;
+select * from v1a join (t3 natural join t4) on a = y;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1a join (t3 natural join t4) on a = y
 END
 INPUT
 select a1,a2,b,max(c),min(c) from t1 group by a1,a2,b;
@@ -9341,10 +9341,10 @@ OUTPUT
 select a1, a2, b, max(c), min(c) from t1 group by a1, a2, b
 END
 INPUT
-select from information_schema.column_privileges where grantee like '%user%' order by grantee;
+select * from information_schema.column_privileges where grantee like '%user%' order by grantee;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.column_privileges where grantee like '%user%' order by grantee asc
 END
 INPUT
 select distinct s,t from t1;
@@ -9353,10 +9353,10 @@ OUTPUT
 select distinct s, t from t1
 END
 INPUT
-select from (select from t1 union all select from t1 limit 2) a;
+select * from (select * from t1 union all select * from t1 limit 2) a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select * from t1 union all select * from t1 limit 2) as a
 END
 INPUT
 select CAST(0x8fffffffffffffff as signed);
@@ -9431,10 +9431,10 @@ OUTPUT
 select s1 * 0 as s1 from t1 group by s1 having s1 != 0
 END
 INPUT
-select from (t3 natural join t4) natural right join (t1 natural join t2) where b + 1 = y or b + 10 = y group by b,c,a,y having min(b) < max(y) order by a, y;
+select * from (t3 natural join t4) natural right join (t1 natural join t2) where b + 1 = y or b + 10 = y group by b,c,a,y having min(b) < max(y) order by a, y;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t3 natural join t4) natural right join (t1 natural join t2) where b + 1 = y or b + 10 = y group by b, c, a, y having min(b) < max(y) order by a asc, y asc
 END
 INPUT
 select st_distance_sphere(st_geomfromtext('point(-120 45)'), st_geomfromtext('point(30.24 68.37)'));
@@ -9461,10 +9461,10 @@ OUTPUT
 select t1.*, t2.* from t1 left join t2 using (a)
 END
 INPUT
-select from t1, t2 where t1.value64=17156792991891826145 and t2.value64=17156792991891826145;
+select * from t1, t2 where t1.value64=17156792991891826145 and t2.value64=17156792991891826145;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2 where t1.value64 = 17156792991891826145 and t2.value64 = 17156792991891826145
 END
 INPUT
 select t from t1 where t='tttt';
@@ -9473,10 +9473,10 @@ OUTPUT
 select t from t1 where t = 'tttt'
 END
 INPUT
-select from t3 where x = 1 and y < 5 order by y;
+select * from t3 where x = 1 and y < 5 order by y;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 where x = 1 and y < 5 order by y asc
 END
 INPUT
 select rpad(741653838,17,'0'),lpad(741653838,17,'0');
@@ -9503,10 +9503,10 @@ OUTPUT
 select convert(_koi8r '�' using utf8mb4) < convert(_koi8r '�' using utf8mb4) from dual
 END
 INPUT
-select from t4;
+select * from t4;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t4
 END
 INPUT
 select ST_DISTANCE(ST_GeomFromText('polygon((0 0, 3 6, 6 3, 0 0))'), ST_GeomFromText('polygon((2 2, 3 4, 4 3, 2 2))'));
@@ -9521,10 +9521,10 @@ OUTPUT
 select (with recursive dt as (select t1.a as a from dual union select a + 1 from dt where a < 10) select concat(count(*), ' - ', avg(dt.a)) from dt) as subq from t1
 END
 INPUT
-select from t1 natural left join (t4 natural join t5) where t5.z is not NULL;
+select * from t1 natural left join (t4 natural join t5) where t5.z is not NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural left join (t4 natural join t5) where t5.z is not null
 END
 INPUT
 select distinct a1,a2,b from t2 where (a2 >= 'b') and (b = 'a');
@@ -9545,10 +9545,10 @@ OUTPUT
 select c as c_a from t1 where c = 'Ã±'
 END
 INPUT
-select from t1 where text1='teststring' or text1 >= 'teststring	';
+select * from t1 where text1='teststring' or text1 >= 'teststring	';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where text1 = 'teststring' or text1 >= 'teststring\t'
 END
 INPUT
 select mbrwithin(ST_GeomFromText("point(2 4)"), ST_GeomFromText("linestring(2 0, 2 4)"));
@@ -9617,10 +9617,10 @@ OUTPUT
 select unix_timestamp('1970-01-01 03:00:01') from dual
 END
 INPUT
-select from v;
+select * from v;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v
 END
 INPUT
 select hex(soundex(_utf16 0x00BF00C0));
@@ -9653,10 +9653,10 @@ OUTPUT
 select count(*) from t1 where facility is not null
 END
 INPUT
-select from (t1, t2) join (t3, t4) on (a < y and t2.b < t3.c);
+select * from (t1, t2) join (t3, t4) on (a < y and t2.b < t3.c);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1, t2) join (t3, t4) on a < y and t2.b < t3.c
 END
 INPUT
 select name from t1 where name between '�' and '�';
@@ -9665,10 +9665,10 @@ OUTPUT
 select `name` from t1 where `name` between '�' and '�'
 END
 INPUT
-select from t1 where i = 1;
+select * from t1 where i = 1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where i = 1
 END
 INPUT
 select POSITION(_latin1'B' IN _latin1'abcd');
@@ -9677,10 +9677,10 @@ OUTPUT
 select locate(_latin1 'B', _latin1 'abcd') from dual
 END
 INPUT
-select from t1 where MATCH b AGAINST ("sear*" IN BOOLEAN MODE);
+select * from t1 where MATCH b AGAINST ("sear*" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(b) against ('sear*' in boolean mode)
 END
 INPUT
 select b from v1 vq1, lateral (select count(*) from v1 vq2 having vq1.b = 3) dt;
@@ -9689,10 +9689,10 @@ OUTPUT
 select b from v1 as vq1, lateral (select count(*) from v1 as vq2 having vq1.b = 3) as dt
 END
 INPUT
-select from t1 where not a between 2 and 3;
+select * from t1 where not a between 2 and 3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not a between 2 and 3
 END
 INPUT
 select hex(char(0x010203 using ucs2));
@@ -9707,10 +9707,10 @@ OUTPUT
 select ST_astext(st_difference(st_intersection(ST_GeomFromText('point(1 1)'), ST_GeomFromText('multipoint(2 2, 3 3)')), st_difference(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)')))) from dual
 END
 INPUT
-select from information_schema.user_privileges where grantee like "'mysqltest_8'%";
+select * from information_schema.user_privileges where grantee like "'mysqltest_8'%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.user_privileges where grantee like '\'mysqltest_8\'%'
 END
 INPUT
 select a.ROUTINE_NAME from information_schema.ROUTINES a, information_schema.SCHEMATA b where a.ROUTINE_SCHEMA = b.SCHEMA_NAME AND b.SCHEMA_NAME='test' ORDER BY a.ROUTINE_NAME;
@@ -9737,10 +9737,10 @@ OUTPUT
 select count(*) from t2 where id2 > 90
 END
 INPUT
-select from non_qualif;
+select * from non_qualif;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from non_qualif
 END
 INPUT
 select _koi8r'a' COLLATE koi8r_general_ci LIKE _koi8r'A' COLLATE koi8r_bin;
@@ -9749,10 +9749,10 @@ OUTPUT
 select _koi8r 'a' collate koi8r_general_ci like _koi8r 'A' collate koi8r_bin from dual
 END
 INPUT
-select from renamed_general_log;
+select * from renamed_general_log;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from renamed_general_log
 END
 INPUT
 select 1, 1.0, -1, "hello", NULL;
@@ -9767,10 +9767,10 @@ OUTPUT
 select min(a3) from t1 where 2 = a2
 END
 INPUT
-select from t1 where not(a is not null);
+select * from t1 where not(a is not null);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not a is not null
 END
 INPUT
 select format(pi(), (select 3 from dual));
@@ -9791,10 +9791,10 @@ OUTPUT
 select count(*) as count_col1 from t1 group by col1 having col1 = 10
 END
 INPUT
-select from `information_schema`.`STATISTICS` where `TABLE_SCHEMA` = NULL;
+select * from `information_schema`.`STATISTICS` where `TABLE_SCHEMA` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.STATISTICS where TABLE_SCHEMA = null
 END
 INPUT
 select table_name, auto_increment from information_schema.tables where table_schema = 'test' and table_name in ('t1', 't2');
@@ -9803,10 +9803,10 @@ OUTPUT
 select table_name, `auto_increment` from information_schema.`tables` where table_schema = 'test' and table_name in ('t1', 't2')
 END
 INPUT
-select from t1 where uncompress(a) is null;
+select * from t1 where uncompress(a) is null;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where uncompress(a) is null
 END
 INPUT
 select row('A','b','c') = row('a','b','c');
@@ -9827,10 +9827,10 @@ OUTPUT
 select repeat('hello', -4294967296) from dual
 END
 INPUT
-select '^^: The above should be ~= 8 + cost(select from t1). Value less than 8 is an error' Z;
+select '^^: The above should be ~= 8 + cost(select * from t1). Value less than 8 is an error' Z;
 END
 OUTPUT
-select '^^: The above should be ~= 8 + cost(select from t1). Value less than 8 is an error' as Z from dual
+select '^^: The above should be ~= 8 + cost(select * from t1). Value less than 8 is an error' as Z from dual
 END
 INPUT
 select truncate(cast(-2 as unsigned), 1), truncate(18446744073709551614, 1), truncate(-2, 1);
@@ -9845,10 +9845,10 @@ OUTPUT
 select insert('hello', -4294967296, 1, 'hi') from dual
 END
 INPUT
-select from t1 natural join t2 natural join t3 natural join t4;
+select * from t1 natural join t2 natural join t3 natural join t4;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural join t2 natural join t3 natural join t4
 END
 INPUT
 select a1,a2,b, max(c) from t2 where a1 < 'd' group by a1,a2,b;
@@ -9857,10 +9857,10 @@ OUTPUT
 select a1, a2, b, max(c) from t2 where a1 < 'd' group by a1, a2, b
 END
 INPUT
-select from t2;
+select * from t2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2
 END
 INPUT
 select truncate(4, cast(-2 as unsigned)), truncate(4, 18446744073709551614), truncate(4, -2);
@@ -9875,10 +9875,10 @@ OUTPUT
 select timestampdiff(year, '2004-02-29', '2005-02-28') from dual
 END
 INPUT
-select from t1 where tt like 'Aa%';
+select * from t1 where tt like 'Aa%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where tt like 'Aa%'
 END
 INPUT
 select _koi8r'a' COLLATE koi8r_general_ci LIKE _koi8r'A';
@@ -9911,16 +9911,16 @@ OUTPUT
 select t1.*, t2.* from t1, t1 as t2 where t1.A = t2.B order by convert(t1.a, binary) asc, t2.a asc
 END
 INPUT
-select from information_schema.parameters where specific_schema='test';
+select * from information_schema.parameters where specific_schema='test';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.parameters where specific_schema = 'test'
 END
 INPUT
-select from t1 where firstname='john' and firstname like binary 'john';
+select * from t1 where firstname='john' and firstname like binary 'john';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where firstname = 'john' and firstname like convert('john', binary)
 END
 INPUT
 select 2 between null and 1,2 between 3 AND NULL,NULL between 1 and 2,2 between NULL and 3, 2 between 1 AND null;
@@ -9935,10 +9935,10 @@ OUTPUT
 select text1, length(text1) from t1 order by convert(text1, binary) asc
 END
 INPUT
-select from t2 having MATCH inhalt AGAINST ('foobar');
+select * from t2 having MATCH inhalt AGAINST ('foobar');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 having match(inhalt) against ('foobar')
 END
 INPUT
 select 0, ST_Within(ST_GeomFromText('LINESTRING(15 15, 50 50, 60 60)'), ST_GeomFromText('POLYGON((10 10,30 20,20 40, 10 10))'));
@@ -10001,10 +10001,10 @@ OUTPUT
 select concat(a, if(b < 10, _ucs2 0x0061, _ucs2 0x0062)) from t1
 END
 INPUT
-select from t1 order by name;
+select * from t1 order by name;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 order by `name` asc
 END
 INPUT
 select group_concat(c1 order by binary c1 separator '') from t1 group by c1 collate utf32_croatian_ci;
@@ -10079,10 +10079,10 @@ OUTPUT
 select space(-4294967297) from dual
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("indexes" IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION);
+select * from t1 where MATCH(a,b) AGAINST ("indexes" IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('indexes' in natural language mode with query expansion)
 END
 INPUT
 select hex(substr(_ucs2 0x00e400e50068,-2));
@@ -10115,10 +10115,10 @@ ERROR
 syntax error at position 16
 END
 INPUT
-select from t1 where soundex(a) = soundex('Test');
+select * from t1 where soundex(a) = soundex('Test');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where soundex(a) = soundex('Test')
 END
 INPUT
 select count(*) from t1 where c like 'a%';
@@ -10139,10 +10139,10 @@ OUTPUT
 select min(`name`), min(concat('*', `name`, '*')), max(`name`), max(concat('*', `name`, '*')) from t1
 END
 INPUT
-select from t1 where CAST(field as DATETIME) < '2006-11-06 04:08:36.0';
+select * from t1 where CAST(field as DATETIME) < '2006-11-06 04:08:36.0';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where cast(field as DATETIME) < '2006-11-06 04:08:36.0'
 END
 INPUT
 select hex(char(2557));
@@ -10151,10 +10151,10 @@ OUTPUT
 select hex(char(2557)) from dual
 END
 INPUT
-select from t5 order by c1;
+select * from t5 order by c1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t5 order by c1 asc
 END
 INPUT
 select sha1(name) from bug20536;
@@ -10205,16 +10205,16 @@ OUTPUT
 select distinct a from t1 order by rand(10)
 END
 INPUT
-select from words2;
+select * from words2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from words2
 END
 INPUT
-select from (t3 join (t4 natural join t5) on (b < z)) natural join (t1 natural join t2);
+select * from (t3 join (t4 natural join t5) on (b < z)) natural join (t1 natural join t2);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t3 join (t4 natural join t5) on b < z) natural join (t1 natural join t2)
 END
 INPUT
 select right(_utf8mb4 0xD0B0D0B2D0B2,1);
@@ -10229,10 +10229,10 @@ OUTPUT
 select hex(weight_string('aa' as binary(3))) from dual
 END
 INPUT
-select from information_schema.table_privileges;
+select * from information_schema.table_privileges;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.table_privileges
 END
 INPUT
 select min(a), min(case when 1=1 then a else NULL end), min(case when 1!=1 then NULL else a end) from t1 where b=3 group by b;
@@ -10259,10 +10259,10 @@ OUTPUT
 select dayname('1962-03-03'), dayname('1962-03-03') + 0 from dual
 END
 INPUT
-select from t1 left join t2 on (venue_id = entity_id and match(name) against('aberdeen' in boolean mode)) where dt = '2003-05-23 19:30:00';
+select * from t1 left join t2 on (venue_id = entity_id and match(name) against('aberdeen' in boolean mode)) where dt = '2003-05-23 19:30:00';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on venue_id = entity_id and match(`name`) against ('aberdeen' in boolean mode) where dt = '2003-05-23 19:30:00'
 END
 INPUT
 select locate('HE','hello',2);
@@ -10301,22 +10301,22 @@ OUTPUT
 select unix_timestamp(@a) from dual
 END
 INPUT
-select from information_schema.column_privileges;
+select * from information_schema.column_privileges;
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from t1 where x=1;
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.column_privileges
 END
 INPUT
-select from t3 where a = 10;
+select * from t1 where x=1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where x = 1
+END
+INPUT
+select * from t3 where a = 10;
+END
+OUTPUT
+select * from t3 where a = 10
 END
 INPUT
 select ifnull(a,'') from t1;
@@ -10349,10 +10349,10 @@ OUTPUT
 select event_name from performance_schema.events_stages_history_long where thread_id = @con1_thread_id and event_name like '%Opening %tables' or event_name like '%Locking system tables' or event_name like '%System lock'
 END
 INPUT
-select from t1 where a = 736494;
+select * from t1 where a = 736494;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 736494
 END
 INPUT
 select @@collation_connection;
@@ -10379,10 +10379,10 @@ OUTPUT
 select concat(a, if(b > 10, 'x' as x, 'y' as y)) from t1
 END
 INPUT
-select from `information_schema`.`COLUMNS` where `TABLE_NAME` = NULL;
+select * from `information_schema`.`COLUMNS` where `TABLE_NAME` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`COLUMNS` where TABLE_NAME = null
 END
 INPUT
 select f1 from t1 where cast("2006-1-1" as date) between f1 and cast('zzz' as date);
@@ -10391,16 +10391,16 @@ OUTPUT
 select f1 from t1 where cast('2006-1-1' as date) between f1 and cast('zzz' as date)
 END
 INPUT
-select from t1 where a=1;
+select * from t1 where a=1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 1
 END
 INPUT
-select from t1, (select from t3) as t where t.a =5 order by 1, 2;
+select * from t1, (select * from t3) as t where t.a =5 order by 1, 2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, (select * from t3) as t where t.a = 5 order by 1 asc, 2 asc
 END
 INPUT
 select count(*) from t1 where match a against ('aaax*' in boolean mode);
@@ -10415,10 +10415,10 @@ OUTPUT
 select extract(day_second from '225 10:11:12') from dual
 END
 INPUT
-select from t1 where c2 = 3;
+select * from t1 where c2 = 3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where c2 = 3
 END
 INPUT
 select distinct a from t1 order by a desc;
@@ -10481,16 +10481,16 @@ OUTPUT
 select concat('-', a, '-', b, '-') from t1 where b = 'hello'
 END
 INPUT
-select from t1 union select from t2 order by 1 limit 1;
+select * from t1 union select * from t2 order by 1 limit 1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 union select * from t2 order by 1 asc limit 1
 END
 INPUT
-select from t1 join t2 using (a1) join t3 on b=c1 join t4 using (c2);
+select * from t1 join t2 using (a1) join t3 on b=c1 join t4 using (c2);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 join t2 using (a1) join t3 on b = c1 join t4 using (c2)
 END
 INPUT
 select hex(left(c,1)) from t1 group by c;
@@ -10505,10 +10505,10 @@ OUTPUT
 select substring_index(null, 'the', 3) from dual
 END
 INPUT
-select from t1 where s1 = 'cH' and s1 <> 'ch';
+select * from t1 where s1 = 'cH' and s1 <> 'ch';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where s1 = 'cH' and s1 != 'ch'
 END
 INPUT
 select find_in_set("abc","abc"),find_in_set("ab","abc"),find_in_set("abcd","abc");
@@ -10559,10 +10559,10 @@ OUTPUT
 select table_name, data_type, column_type from information_schema.`columns` where column_name = 'numeric_precision' and table_schema = 'information_schema'
 END
 INPUT
-select from `information_schema`.`TABLE_CONSTRAINTS` where `TABLE_NAME` = NULL;
+select * from `information_schema`.`TABLE_CONSTRAINTS` where `TABLE_NAME` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.TABLE_CONSTRAINTS where TABLE_NAME = null
 END
 INPUT
 select md5(name) from bug20536;
@@ -10601,10 +10601,10 @@ OUTPUT
 select 1 = _latin2 '1' from dual
 END
 INPUT
-select from information_schema.collations order by id limit 1;
+select * from information_schema.collations order by id limit 1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.collations order by id asc limit 1
 END
 INPUT
 select min(f2),max(f2) from t1;
@@ -10643,10 +10643,10 @@ OUTPUT
 select `sql_big_result` as c, count(t) from t1 group by c order by c asc limit 10
 END
 INPUT
-select from t3 where b in (select a from t1);
+select * from t3 where b in (select a from t1);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 where b in (select a from t1)
 END
 INPUT
 select right('hello', -4294967295);
@@ -10697,10 +10697,10 @@ OUTPUT
 select strcmp('�', 'o�'), strcmp('�', 'u�'), strcmp('�', 'oeb') from dual
 END
 INPUT
-select from information_schema.schema_privileges where grantee like "'mysqltest_8'%";
+select * from information_schema.schema_privileges where grantee like "'mysqltest_8'%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.schema_privileges where grantee like '\'mysqltest_8\'%'
 END
 INPUT
 select t1.name, t2.name, t2.id from t2 right join t1 on (t1.id = t2.owner) where t2.id is null;
@@ -10739,28 +10739,28 @@ OUTPUT
 select `name`, avg(value1), std(value1), variance(value1) from t1, t2 where t1.id = t2.id group by t1.id
 END
 INPUT
-select from tm_base_temp;
+select * from tm_base_temp;
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from t1 natural left join t2 where (t2.i is not null) is not null;
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from tm_base_temp
 END
 INPUT
-select from mysql.db where user=@user123;
+select * from t1 natural left join t2 where (t2.i is not null) is not null;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural left join t2 where (t2.i is not null) is not null
 END
 INPUT
-select from t1 :;
+select * from mysql.db where user=@user123;
+END
+OUTPUT
+select * from mysql.db where `user` = @user123
+END
+INPUT
+select * from t1 :;
 END
 ERROR
-syntax error at position 12 near 'from'
+syntax error at position 19 near ':'
 END
 INPUT
 select AES_ENCRYPT(@ENCSTR, @KEYS, @IV)=AES_ENCRYPT(@ENCSTR, @KEYS, @IV1);
@@ -10865,16 +10865,16 @@ OUTPUT
 select date_add(`time`, interval 1 SECOND) from t1
 END
 INPUT
-select from v3;
+select * from v3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v3
 END
 INPUT
-select from t1 natural join t2 where t1.b > t2.b;
+select * from t1 natural join t2 where t1.b > t2.b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural join t2 where t1.b > t2.b
 END
 INPUT
 select sum(num) from t1;
@@ -10889,10 +10889,10 @@ OUTPUT
 select a1, a2, b, min(c) from t2 where (a1 > 'a' or a1 < '9') and (a2 >= 'b' and a2 < 'z') and b = 'a' and (c = 'j121' or c > 'k121' and c < 'm122' or c > 'o122' or c < 'h112' or c = 'c111') group by a1, a2, b
 END
 INPUT
-select from t1 where a > 5 xor a < 10;
+select * from t1 where a > 5 xor a < 10;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a > 5 xor a < 10
 END
 INPUT
 select column_name, privileges from columns where table_name='user' and column_name like '%o%' order by column_name;
@@ -10931,10 +10931,10 @@ OUTPUT
 select t1.id1 from t1 join (t3 left join v1 on t3.id3 = v1.id3)
 END
 INPUT
-select from t1 where find_in_set('-1', a);
+select * from t1 where find_in_set('-1', a);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where find_in_set('-1', a)
 END
 INPUT
 select _koi8r'a' LIKE _koi8r'A';
@@ -10943,10 +10943,10 @@ OUTPUT
 select _koi8r 'a' like _koi8r 'A' from dual
 END
 INPUT
-select from (select from t1 union select from t1) a;
+select * from (select * from t1 union select * from t1) a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select * from t1 union select * from t1) as a
 END
 INPUT
 select count(distinct n1,s) from t1;
@@ -10991,10 +10991,10 @@ OUTPUT
 select id, avg(value1), std(value1), variance(value1) from t1 group by id
 END
 INPUT
-select from t1 where 'd' < s1 and s1 = 'CH';
+select * from t1 where 'd' < s1 and s1 = 'CH';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where 'd' < s1 and s1 = 'CH'
 END
 INPUT
 select a,b,cast(a as char character set cp1251),cast(b as binary) from t1;
@@ -11015,16 +11015,16 @@ OUTPUT
 select text1, length(text1) from t1 order by text1 asc
 END
 INPUT
-select from t1 limit 9999999999;
+select * from t1 limit 9999999999;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 limit 9999999999
 END
 INPUT
-select from t3 natural right join t2;
+select * from t3 natural right join t2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 natural right join t2
 END
 INPUT
 select word, word=cast(0xdf AS CHAR) as t from t1 having t > 0;
@@ -11087,10 +11087,10 @@ OUTPUT
 select table_name, index_type from information_schema.statistics where table_schema = 'test' and table_name = 'tm' and index_name = 'w' order by table_name asc
 END
 INPUT
-select from t3 order by b,a limit 3;
+select * from t3 order by b,a limit 3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 order by b asc, a asc limit 3
 END
 INPUT
 select distinct vs from t1;
@@ -11111,10 +11111,10 @@ ERROR
 syntax error at position 43 near 'with'
 END
 INPUT
-select from t1,t2 left join t3 on (t2.i=t3.i) order by t1.i,t2.i,t3.i;
+select * from t1,t2 left join t3 on (t2.i=t3.i) order by t1.i,t2.i,t3.i;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2 left join t3 on t2.i = t3.i order by t1.i asc, t2.i asc, t3.i asc
 END
 INPUT
 select release_lock('test_bug16407');
@@ -11141,10 +11141,10 @@ OUTPUT
 select a1, a2, b, min(c) from t1 where a1 > 'a' and a2 > 'a' and b = 'c' group by a1, a2, b
 END
 INPUT
-select from t1 order by func1(a);
+select * from t1 order by func1(a);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 order by func1(a) asc
 END
 INPUT
 select repeat('hello', 4294967297);
@@ -11153,10 +11153,10 @@ OUTPUT
 select repeat('hello', 4294967297) from dual
 END
 INPUT
-select from information_schema.triggers where trigger_schema in ('mysql', 'information_schema', 'test', 'mysqltest') order by trigger_name;
+select * from information_schema.triggers where trigger_schema in ('mysql', 'information_schema', 'test', 'mysqltest') order by trigger_name;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`triggers` where trigger_schema in ('mysql', 'information_schema', 'test', 'mysqltest') order by trigger_name asc
 END
 INPUT
 select substring_index('aaaaaaaaa1','a',-1);
@@ -11207,10 +11207,10 @@ OUTPUT
 select st_overlaps(st_intersection(ST_GeomFromText('point(1 1)'), ST_GeomFromText('multipoint(2 2, 3 3)')), st_intersection(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)'))) from dual
 END
 INPUT
-select from (t4 natural join t5) natural join t1 where t4.y > 7;
+select * from (t4 natural join t5) natural join t1 where t4.y > 7;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t4 natural join t5) natural join t1 where t4.y > 7
 END
 INPUT
 select hex(@a);
@@ -11225,10 +11225,10 @@ OUTPUT
 select space(-1) from dual
 END
 INPUT
-select from v1b join v2a on v1b.b = v2a.c;
+select * from v1b join v2a on v1b.b = v2a.c;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1b join v2a on v1b.b = v2a.c
 END
 INPUT
 select space(4294967295);
@@ -11249,10 +11249,10 @@ OUTPUT
 select strcmp('�', 'af'), strcmp('a', '�'), strcmp('��', 'aeq'), strcmp('��', 'aeaeq') from dual
 END
 INPUT
-select from t1 where a=user();
+select * from t1 where a=user();
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = user()
 END
 INPUT
 select get_format(DATETIME, 'eur') as a;
@@ -11285,10 +11285,10 @@ OUTPUT
 select log10(100), log10(18), log10(-4), log10(0), log10(null) from dual
 END
 INPUT
-select from t1 order by 1,2;
+select * from t1 order by 1,2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 order by 1 asc, 2 asc
 END
 INPUT
 select lpad(f1, 12, "-o-/") from t2;
@@ -11297,10 +11297,10 @@ OUTPUT
 select lpad(f1, 12, '-o-/') from t2
 END
 INPUT
-select from t1 where t1.a in (select a from t2) order by 1, 2;
+select * from t1 where t1.a in (select a from t2) order by 1, 2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where t1.a in (select a from t2) order by 1 asc, 2 asc
 END
 INPUT
 select locate('lo','hello',-4294967295);
@@ -11309,10 +11309,10 @@ OUTPUT
 select locate('lo', 'hello', -4294967295) from dual
 END
 INPUT
-select from t1 order by id;
+select * from t1 order by id;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 order by id asc
 END
 INPUT
 select round(sum(a)), count(*) from t1 group by a;
@@ -11351,10 +11351,10 @@ OUTPUT
 select strcmp(concat(utc_date(), ' ', utc_time()), utc_timestamp()) = 0 from dual
 END
 INPUT
-select from t1 where match b against ('+aaaaaa @bbbbbb' in boolean mode);
+select * from t1 where match b against ('+aaaaaa @bbbbbb' in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(b) against ('+aaaaaa @bbbbbb' in boolean mode)
 END
 INPUT
 select hex(col1) from t1;
@@ -11423,10 +11423,10 @@ OUTPUT
 select group_concat(c1 order by convert(c1, binary) asc separator '') from t1 group by c1 collate utf16_lithuanian_ci
 END
 INPUT
-select from t1 where id <=> value or value<=>id;
+select * from t1 where id <=> value or value<=>id;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where id <=> value or value <=> id
 END
 INPUT
 select a1,a2,b, max(c) from t1 where (c > 'f123') group by a1,a2,b;
@@ -11453,10 +11453,10 @@ OUTPUT
 select t1.a as str, length(t1.a) as str_length, t2.a as pos, t2.a + 10 as length, insert(t1.a, t2.a, t2.a + 10, '1234567') as `insert` from t1, t2
 END
 INPUT
-select from mysql.slow_log;
+select * from mysql.slow_log;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysql.slow_log
 END
 INPUT
 select substring('hello', -2, 1);
@@ -11525,10 +11525,10 @@ OUTPUT
 select TABLE_NAME from information_schema.`tables` where table_schema = 'test' order by TABLE_NAME asc
 END
 INPUT
-select from ((t3 natural join (t1 natural join t2)) natural join t4) natural join t5;
+select * from ((t3 natural join (t1 natural join t2)) natural join t4) natural join t5;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from ((t3 natural join (t1 natural join t2)) natural join t4) natural join t5
 END
 INPUT
 select t1.* from t t0 cross join t t1 join t t2 on 100=(select count(*) from t t3 left join t t4 on t4.a>t3.a-t0.a);
@@ -11543,10 +11543,10 @@ OUTPUT
 select d from (select a as d, 2 * a as two from t) as dt
 END
 INPUT
-select from t1 union distinct select from t2 union all select from t3;
+select * from t1 union distinct select * from t2 union all select * from t3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 union select * from t2 union all select * from t3
 END
 INPUT
 select "CASE" as "LOWER";
@@ -11597,10 +11597,10 @@ OUTPUT
 select date_add('1997-12-31 23:59:59', interval '1:1:1' HOUR_SECOND) from dual
 END
 INPUT
-select from v2a;
+select * from v2a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v2a
 END
 INPUT
 select repeat('hello', -18446744073709551617);
@@ -11621,10 +11621,10 @@ OUTPUT
 select 1.0 <=> 0.0, 0.0 <=> null, null <=> 0.0 from dual
 END
 INPUT
-select from t1 where a like '2004-03-11 12:00:21';
+select * from t1 where a like '2004-03-11 12:00:21';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '2004-03-11 12:00:21'
 END
 INPUT
 select _koi8r'a' COLLATE koi8r_general_ci = _koi8r'A';
@@ -11639,10 +11639,10 @@ OUTPUT
 select _koi8r 'a' like _koi8r 'A' collate koi8r_bin from dual
 END
 INPUT
-select from t1 where str is not null order by id;
+select * from t1 where str is not null order by id;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where str is not null order by id asc
 END
 INPUT
 select b + interval a day from t1;
@@ -11753,16 +11753,16 @@ OUTPUT
 select export_set(9, 'Y', 'N', '-', 5), export_set(9, 'Y', 'N'), export_set(9, 'Y', 'N', '') from dual
 END
 INPUT
-select from t1 where a like '%PESKA%';
+select * from t1 where a like '%PESKA%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '%PESKA%'
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST("+search" IN BOOLEAN MODE);
+select * from t1 where MATCH(a,b) AGAINST("+search" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('+search' in boolean mode)
 END
 INPUT
 select repeat('hello', 18446744073709551616);
@@ -11795,10 +11795,10 @@ OUTPUT
 select distinct t1_outer.a from t1 as t1_outer order by (select max(t1_outer.b + t1_inner.b) from t1 as t1_inner) asc
 END
 INPUT
-select from slow_log;
+select * from slow_log;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from slow_log
 END
 INPUT
 select table_name, index_type from information_schema.statistics where table_schema = 'test' and table_name like 't%' and index_name = 'p' order by table_name;
@@ -11837,10 +11837,10 @@ OUTPUT
 select insert('hello', 18446744073709551617, 18446744073709551617, 'hi') from dual
 END
 INPUT
-select from t1 where a is null;
+select * from t1 where a is null;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a is null
 END
 INPUT
 select collation(soundex(_latin2'ab')), coercibility(soundex(_latin2'ab'));
@@ -11879,16 +11879,16 @@ OUTPUT
 select a1, a2, b, min(c), max(c) from t1 where c < 'a0' group by a1, a2, b
 END
 INPUT
-select from t1 where not(a < 15 and a > 5);
+select * from t1 where not(a < 15 and a > 5);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not (a < 15 and a > 5)
 END
 INPUT
-select from t1 where a=_koi8r'����';
+select * from t1 where a=_koi8r'����';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = _koi8r '����'
 END
 INPUT
 select text1, length(text1) from t1 where text1='teststring' or text1 like 'teststring_%';
@@ -11939,10 +11939,10 @@ OUTPUT
 select inet_aton('122.226.') from dual
 END
 INPUT
-select from v1 where id=1000 group by id;
+select * from v1 where id=1000 group by id;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1 where id = 1000 group by id
 END
 INPUT
 select 1 from t1 order by 2;
@@ -11975,10 +11975,10 @@ OUTPUT
 select concat(a, '.') from t1 where a = 'aaa'
 END
 INPUT
-select from t1 where a = 2 or not(a < 5 or a > 15);
+select * from t1 where a = 2 or not(a < 5 or a > 15);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 2 or not (a < 5 or a > 15)
 END
 INPUT
 select 'e'='`';
@@ -12059,10 +12059,10 @@ OUTPUT
 select if(0, 'ERROR', 'this'), if(1, 'is', 'ERROR'), if(null, 'ERROR', 'a'), if(1, 2, 3) | 0, if(1, 2.0, 3.0) + 0 from dual
 END
 INPUT
-select from t1 where a=if(b>10,_ucs2 0x0061,_ucs2 0x0062);
+select * from t1 where a=if(b>10,_ucs2 0x0061,_ucs2 0x0062);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = if(b > 10, _ucs2 0x0061, _ucs2 0x0062)
 END
 INPUT
 select ST_Crosses(ST_GeomFromText('MULTIPOINT(1 0,15 0,10 10)'),ST_GeomFromText('MULTILINESTRING((15 0,20 0,20 20,15 0))')) as result;
@@ -12119,10 +12119,10 @@ ERROR
 syntax error at position 47 near 'as'
 END
 INPUT
-select from t1,t2 natural right join t3 order by t1.i,t2.i,t3.i;
+select * from t1,t2 natural right join t3 order by t1.i,t2.i,t3.i;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2 natural right join t3 order by t1.i asc, t2.i asc, t3.i asc
 END
 INPUT
 select count(*) from t1 where match a against ('000000');
@@ -12167,10 +12167,10 @@ OUTPUT
 select t1.*, a, t1.* from t1
 END
 INPUT
-select from ((t1 natural join t2), (t3 natural join t4)) natural join t6;
+select * from ((t1 natural join t2), (t3 natural join t4)) natural join t6;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from ((t1 natural join t2), (t3 natural join t4)) natural join t6
 END
 INPUT
 select date_add("2001-01-01 23:59:59",INTERVAL -2000 YEAR);
@@ -12209,10 +12209,10 @@ OUTPUT
 select hex(a) from t1
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('"text search" +"now support"' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('"text search" +"now support"' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('\"text search\" +\"now support\"' in boolean mode)
 END
 INPUT
 select trigger_name from information_schema.triggers where event_object_table='t1';
@@ -12263,10 +12263,10 @@ OUTPUT
 select extract(day from '1999-01-02') from dual
 END
 INPUT
-select from t1, t2;
+select * from t1, t2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2
 END
 INPUT
 select hex(_utf16 0x44);
@@ -12299,16 +12299,16 @@ OUTPUT
 select round(std(s1 / s2), 17) from bug22555
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST("support collections" IN BOOLEAN MODE);
+select * from t1 where MATCH(a,b) AGAINST("support collections" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('support collections' in boolean mode)
 END
 INPUT
-select distinct t_00.a1 from t1 t_00 where exists ( select from t2 where a1 = t_00.a1 );
+select distinct t_00.a1 from t1 t_00 where exists ( select * from t2 where a1 = t_00.a1 );
 END
-ERROR
-syntax error at position 64 near 'from'
+OUTPUT
+select distinct t_00.a1 from t1 as t_00 where exists (select * from t2 where a1 = t_00.a1)
 END
 INPUT
 select locate('LO','hello' collate utf8mb4_bin,2);
@@ -12329,10 +12329,10 @@ OUTPUT
 select substring_index('aaaaaaaaa1', 'aa', 3) from dual
 END
 INPUT
-select from information_schema.views where table_schema != 'sys' order by table_schema, table_name;
+select * from information_schema.views where table_schema != 'sys' order by table_schema, table_name;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.views where table_schema != 'sys' order by table_schema asc, table_name asc
 END
 INPUT
 select straight_join from t1,t2 force index (primary) where t1.a=t2.a;
@@ -12347,16 +12347,16 @@ OUTPUT
 select group_concat(c1 order by convert(c1, binary) asc separator '') from t1 group by c1 collate utf16_esperanto_ci
 END
 INPUT
-select from t1,t2,t3 where t1.a=t2.a AND t2.b=t3.a and t1.b=t3.b order by t1.a,t1.b;
+select * from t1,t2,t3 where t1.a=t2.a AND t2.b=t3.a and t1.b=t3.b order by t1.a,t1.b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2, t3 where t1.a = t2.a and t2.b = t3.a and t1.b = t3.b order by t1.a asc, t1.b asc
 END
 INPUT
-select from t1 where btn like " %";
+select * from t1 where btn like " %";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where btn like ' %'
 END
 INPUT
 select hex(substr(_utf16 0x00e400e50068,1));
@@ -12455,10 +12455,10 @@ OUTPUT
 select locate('a', 'b', 2), locate('', 'a', 1) from dual
 END
 INPUT
-select from t3 right join t2 on (t3.i=t2.i) right join t1 on (t2.i=t1.i);
+select * from t3 right join t2 on (t3.i=t2.i) right join t1 on (t2.i=t1.i);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 right join t2 on t3.i = t2.i right join t1 on t2.i = t1.i
 END
 INPUT
 select db, table_name, table_priv from mysql.tables_priv where user='mysqluser10' and host='localhost';
@@ -12527,10 +12527,10 @@ OUTPUT
 select rpad('abcd', 7, 'ab'), lpad('abcd', 7, 'ab') from dual
 END
 INPUT
-select from t1 where soundex(a) = soundex('TEST');
+select * from t1 where soundex(a) = soundex('TEST');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where soundex(a) = soundex('TEST')
 END
 INPUT
 select hex(soundex(_utf8mb4 0xE99885E8A788E99A8FE697B6E69BB4E696B0E79A84E696B0E997BB));
@@ -12575,10 +12575,10 @@ OUTPUT
 select count(*) from information_schema.ROUTINES where routine_schema = 'test'
 END
 INPUT
-select from ((t3 join (t1 join t2 on c > a) on t3.b < t2.a) join t4 on y > t1.c) join t5 on z = t1.b + 3;
+select * from ((t3 join (t1 join t2 on c > a) on t3.b < t2.a) join t4 on y > t1.c) join t5 on z = t1.b + 3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from ((t3 join (t1 join t2 on c > a) on t3.b < t2.a) join t4 on y > t1.c) join t5 on z = t1.b + 3
 END
 INPUT
 select cast(_latin1'test' as char character set latin2);
@@ -12683,10 +12683,10 @@ OUTPUT
 select strcmp(localtime(), concat(current_date(), ' ', current_time())) from dual
 END
 INPUT
-select from t1 a, t1 b group by a.s1 having s1 is null;
+select * from t1 a, t1 b group by a.s1 having s1 is null;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 as a, t1 as b group by a.s1 having s1 is null
 END
 INPUT
 select benchmark(10, pi());
@@ -12755,10 +12755,10 @@ OUTPUT
 select locate('LO', 'hello' collate ujis_bin, 2) from dual
 END
 INPUT
-select from t1 where f1='test' and (f2= sha("TEST") or f2= sha("test"));
+select * from t1 where f1='test' and (f2= sha("TEST") or f2= sha("test"));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where f1 = 'test' and (f2 = sha('TEST') or f2 = sha('test'))
 END
 INPUT
 select hex(substr(_utf16 0x00e400e50068,3));
@@ -12803,10 +12803,10 @@ OUTPUT
 select table_name, column_name, `privileges` from information_schema.`columns` where table_schema = 'mysqltest' and table_name = 'v1' order by table_name asc, column_name asc
 END
 INPUT
-select from t1 order by a,b;
+select * from t1 order by a,b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 order by a asc, b asc
 END
 INPUT
 select date_add("1997-12-31 23:59:59",INTERVAL -100000 DAY);
@@ -12863,10 +12863,10 @@ OUTPUT
 select _latin1 'B' in (_latin1 'a', _latin1 'b' collate latin1_bin) from dual
 END
 INPUT
-select from t1 where a is null and b=2;
+select * from t1 where a is null and b=2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a is null and b = 2
 END
 INPUT
 select a, left(a,1) as b from t1 group by a;
@@ -12881,10 +12881,10 @@ OUTPUT
 select @@`keycache2.key_buffer_size` from dual
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("indexes collections");
+select * from t1 where MATCH(a,b) AGAINST ("indexes collections");
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('indexes collections')
 END
 INPUT
 select _latin2'B' between _latin1'a' and _latin1'b';
@@ -12917,10 +12917,10 @@ OUTPUT
 select collation(cast('a' as char(2))), collation(cast('a' as char(2) binary)) from dual
 END
 INPUT
-select from v1d join v2a on v1d.a = v2a.c;
+select * from v1d join v2a on v1d.a = v2a.c;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1d join v2a on v1d.a = v2a.c
 END
 INPUT
 select t2.isbn,city,t1.libname,count(distinct t1.libname) as a from t3 left join t1 on t3.libname=t1.libname left join t2 on t3.isbn=t2.isbn group by city having count(distinct concat(t1.libname,'a')) > 1;
@@ -12953,10 +12953,10 @@ OUTPUT
 select c1, c2, c3, c4, hex(c5) from t1
 END
 INPUT
-select from t2 where MATCH inhalt AGAINST (NULL);
+select * from t2 where MATCH inhalt AGAINST (NULL);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 where match(inhalt) against (null)
 END
 INPUT
 select table_name from information_schema.tables where table_schema = 'test' and table_name not in (select table_name from information_schema.columns where table_schema = 'test' and column_name = 'f3') order by table_name;
@@ -12977,10 +12977,10 @@ OUTPUT
 select group_concat(b) from t1 group by a
 END
 INPUT
-select from (select from t1 where t1.a=(select t2.a from t2 where t2.a=t1.a) union select t1.a, t1.b from t1) a;
+select * from (select * from t1 where t1.a=(select t2.a from t2 where t2.a=t1.a) union select t1.a, t1.b from t1) a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select * from t1 where t1.a = (select t2.a from t2 where t2.a = t1.a) union select t1.a, t1.b from t1) as a
 END
 INPUT
 select @@character_set_client;
@@ -12989,10 +12989,10 @@ OUTPUT
 select @@character_set_client from dual
 END
 INPUT
-select from t1 limit 0;
+select * from t1 limit 0;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 limit 0
 END
 INPUT
 select uncompressed_length(compress(@test_compress_string))=length(@test_compress_string);
@@ -13001,10 +13001,10 @@ OUTPUT
 select uncompressed_length(compress(@test_compress_string)) = length(@test_compress_string) from dual
 END
 INPUT
-select from t1 natural join (t4 natural join t5) where t4.y > 7;
+select * from t1 natural join (t4 natural join t5) where t4.y > 7;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural join (t4 natural join t5) where t4.y > 7
 END
 INPUT
 select a1,a2,b,max(c) from t2 where (a2 = 'a') and b is NULL group by a1;
@@ -13019,10 +13019,10 @@ OUTPUT
 select round(999999999, -9) from dual
 END
 INPUT
-select from_unixtime(unix_timestamp("1994-03-02 10:11:12")),from_unixtime(unix_timestamp("1994-03-02 10:11:12"),"%Y-%m-%d %h:%i:%s"),from_unixtime(unix_timestamp("1994-03-02 10:11:12"))+0;
+select * from_unixtime(unix_timestamp("1994-03-02 10:11:12")),from_unixtime(unix_timestamp("1994-03-02 10:11:12"),"%Y-%m-%d %h:%i:%s"),from_unixtime(unix_timestamp("1994-03-02 10:11:12"))+0;
 END
-OUTPUT
-select from_unixtime(unix_timestamp('1994-03-02 10:11:12')), from_unixtime(unix_timestamp('1994-03-02 10:11:12'), '%Y-%m-%d %h:%i:%s'), from_unixtime(unix_timestamp('1994-03-02 10:11:12')) + 0 from dual
+ERROR
+syntax error at position 23 near 'from_unixtime'
 END
 INPUT
 select event_schema, event_name, sql_mode from information_schema.events order by event_schema, event_name;
@@ -13079,10 +13079,10 @@ OUTPUT
 select collation(trim(leading _latin2 ' ' from _latin2 'a')), coercibility(trim(leading _latin2 'a' from _latin2 'a')) from dual
 END
 INPUT
-select from t1 AS m LEFT JOIN t2 AS c1 ON m.c1id = c1.id AND c1.active = 'Yes' LEFT JOIN t3 AS c2 ON m.c2id = c2.id AND c2.active = 'Yes' WHERE m.pid=1 AND (c1.id IS NOT NULL OR c2.id IS NOT NULL);
+select * from t1 AS m LEFT JOIN t2 AS c1 ON m.c1id = c1.id AND c1.active = 'Yes' LEFT JOIN t3 AS c2 ON m.c2id = c2.id AND c2.active = 'Yes' WHERE m.pid=1 AND (c1.id IS NOT NULL OR c2.id IS NOT NULL);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 as m left join t2 as c1 on m.c1id = c1.id and c1.active = 'Yes' left join t3 as c2 on m.c2id = c2.id and c2.active = 'Yes' where m.pid = 1 and (c1.id is not null or c2.id is not null)
 END
 INPUT
 select id, stddev_pop(value1), var_pop(value1), stddev_samp(value1), var_samp(value1) from t1 group by id;
@@ -13103,10 +13103,10 @@ OUTPUT
 select c, table_name from v1 join information_schema.`TABLES` as v2 on v1.c = v2.table_name where v1.c regexp 't[1-5]{1}$' order by c asc
 END
 INPUT
-select from t1 natural join t2 where t1.b > 0;
+select * from t1 natural join t2 where t1.b > 0;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural join t2 where t1.b > 0
 END
 INPUT
 select 0x00b25278956e0044683dfc180cd886aeff2f5bc3fc18 like '%-122%';
@@ -13145,10 +13145,10 @@ OUTPUT
 select ST_geomfromtext(col9, col89) as a from t1
 END
 INPUT
-select from t4 order by b,a limit 3;
+select * from t4 order by b,a limit 3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t4 order by b asc, a asc limit 3
 END
 INPUT
 select @@key_buffer_size;
@@ -13157,16 +13157,16 @@ OUTPUT
 select @@key_buffer_size from dual
 END
 INPUT
-select from t1 where not(a < 5 or a > 15);
+select * from t1 where not(a < 5 or a > 15);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not (a < 5 or a > 15)
 END
 INPUT
-select from t1 where not(NULL and a > 5);
+select * from t1 where not(NULL and a > 5);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not (null and a > 5)
 END
 INPUT
 select period FROM t1;
@@ -13175,16 +13175,16 @@ OUTPUT
 select period from t1
 END
 INPUT
-select from `information_schema`.`PARTITIONS` where `TABLE_NAME` = NULL;
+select * from `information_schema`.`PARTITIONS` where `TABLE_NAME` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`PARTITIONS` where TABLE_NAME = null
 END
 INPUT
-select from (t1 cross join t2) join (t3 cross join t4) on (a < y and t2.b < t3.c);
+select * from (t1 cross join t2) join (t3 cross join t4) on (a < y and t2.b < t3.c);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 join t2) join (t3 join t4) on a < y and t2.b < t3.c
 END
 INPUT
 select t2.fld3 FROM t2 where fld3 LIKE 'honeysuckl_';
@@ -13199,10 +13199,10 @@ OUTPUT
 select mbrtouches(ST_GeomFromText('point(2 4)'), ST_GeomFromText('polygon((2 2, 6 2, 6 6, 2 6, 2 2))')) from dual
 END
 INPUT
-select from t1, t2 where t1.start between t2.ctime1 and t2.ctime2;
+select * from t1, t2 where t1.start between t2.ctime1 and t2.ctime2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2 where t1.`start` between t2.ctime1 and t2.ctime2
 END
 INPUT
 select a, MAX(b), ELT(MAX(b), 'a', 'b', 'c', 'd', 'e', 'f') from t1 group by a;
@@ -13235,10 +13235,10 @@ OUTPUT
 select 0x003c8793403032 like '%-112%' from dual
 END
 INPUT
-select from t3;
+select * from t3;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3
 END
 INPUT
 select concat(a,ifnull(min(date_format(now(), '%Y-%m-%d')),' ull')) from t1;
@@ -13253,10 +13253,10 @@ OUTPUT
 select conv(1, 10, 16), conv((1 << 2) - 1, 10, 16), conv((1 << 10) - 2, 10, 16), conv((1 << 16) - 3, 10, 16), conv((1 << 25) - 4, 10, 16), conv((1 << 31) - 5, 10, 16), conv((1 << 36) - 6, 10, 16), conv((1 << 47) - 7, 10, 16), conv((1 << 48) - 8, 10, 16), conv((1 << 55) - 9, 10, 16), conv((1 << 56) - 10, 10, 16), conv((1 << 63) - 11, 10, 16) from dual
 END
 INPUT
-select from t1 where f1='test' and (f2= md5("TEST") or f2= md5("test"));
+select * from t1 where f1='test' and (f2= md5("TEST") or f2= md5("test"));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where f1 = 'test' and (f2 = md5('TEST') or f2 = md5('test'))
 END
 INPUT
 select hex(char(0x01020304 using ucs2));
@@ -13277,10 +13277,10 @@ OUTPUT
 select locate('lo', 'hello', -4294967296) from dual
 END
 INPUT
-select from events_test.events_smode_test order by ev_name, a;
+select * from events_test.events_smode_test order by ev_name, a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from events_test.events_smode_test order by ev_name asc, a asc
 END
 INPUT
 select insert(_utf16 0x006100620063,10,2,_utf16 0x006400650066);
@@ -13319,10 +13319,10 @@ OUTPUT
 select max(t1.a3), min(t2.a2) from t1, t2 where t1.a2 = 2 and t1.a3 < 'MIN' and t2.a3 = 'CA'
 END
 INPUT
-select from information_schema.schema_privileges order by grantee;
+select * from information_schema.schema_privileges order by grantee;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.schema_privileges order by grantee asc
 END
 INPUT
 select @@autocommit;
@@ -13469,10 +13469,10 @@ OUTPUT
 select date_format('2004-01-01', '%W (%a), %e %M (%b) %Y') from dual
 END
 INPUT
-select from t1 where bigint_col=17666000000000000000;
+select * from t1 where bigint_col=17666000000000000000;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where bigint_col = 17666000000000000000
 END
 INPUT
 select v,count(c) from t1 group by v order by v limit 10;
@@ -13493,10 +13493,10 @@ OUTPUT
 select date_sub('1998-01-02', interval 31 DAY) from dual
 END
 INPUT
-select from db where user = 'mysqltest_1';
+select * from db where user = 'mysqltest_1';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from db where `user` = 'mysqltest_1'
 END
 INPUT
 select time_format(19980131000000,'%H|%I|%k|%l|%i|%p|%r|%S|%T');
@@ -13541,16 +13541,16 @@ OUTPUT
 select left(_utf8 0xD0B0D0B1D0B2, 1) from dual
 END
 INPUT
-select from information_schema.SCHEMA_PRIVILEGES where grantee like '%mysqltest_1%';
+select * from information_schema.SCHEMA_PRIVILEGES where grantee like '%mysqltest_1%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.SCHEMA_PRIVILEGES where grantee like '%mysqltest_1%'
 END
 INPUT
-select from имя_таблицы_в_кодировке_утф8_длиной_больше_чем_48;
+select * from имя_таблицы_в_кодировке_утф8_длиной_больше_чем_48;
 END
 ERROR
-syntax error at position 12 near 'from'
+syntax error at position 16 near 'Ð'
 END
 INPUT
 select i, count(*) from bug22555 group by i;
@@ -13661,16 +13661,16 @@ OUTPUT
 select `AUTO_INCREMENT` from information_schema.`tables` where table_name = 't1'
 END
 INPUT
-select from mysql.slow_log where sql_text NOT LIKE '%slow_log%';
+select * from mysql.slow_log where sql_text NOT LIKE '%slow_log%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysql.slow_log where sql_text not like '%slow_log%'
 END
 INPUT
-select from t3 order by a,b;
+select * from t3 order by a,b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 order by a asc, b asc
 END
 INPUT
 select SUBSTR('abcdefg',3,2);
@@ -13739,10 +13739,10 @@ OUTPUT
 select date_add('1000-01-01 00:00:00', interval '1.03:02:01.05' day_microsecond) from dual
 END
 INPUT
-select from t1 where a=database();
+select * from t1 where a=database();
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = database()
 END
 INPUT
 select ST_Crosses(ST_GeomFromText('MULTIPOINT(1 0,15 0,10 10)'),ST_GeomFromText('LINESTRING(15 0,20 0,10 10,20 20)')) as result;
@@ -13925,16 +13925,16 @@ OUTPUT
 select a from t1 where left(a + 0, 6) in (left(20040106, 6))
 END
 INPUT
-select from t1, t2, t3 where t3.a=t1.a and t2.a=t1.b;
+select * from t1, t2, t3 where t3.a=t1.a and t2.a=t1.b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2, t3 where t3.a = t1.a and t2.a = t1.b
 END
 INPUT
-select from t1 as x1, (select from t1) as x2;
+select * from t1 as x1, (select * from t1) as x2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 as x1, (select * from t1) as x2
 END
 INPUT
 select hex(soundex(_utf16 0x041004110412));
@@ -13967,10 +13967,10 @@ OUTPUT
 select hex(weight_string(_utf16 0xD800DC00 collate utf16_unicode_ci)) from dual
 END
 INPUT
-select from information_schema.tables where table_name = NULL;
+select * from information_schema.tables where table_name = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`tables` where table_name = null
 END
 INPUT
 select max(7) from t1i;
@@ -14039,10 +14039,10 @@ OUTPUT
 select a1, a2, b, min(c), max(c) from t2 where c > 'b111' and c <= 'g112' group by a1, a2, b
 END
 INPUT
-select from t1 where a in (869751,736494,226312,802616);
+select * from t1 where a in (869751,736494,226312,802616);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a in (869751, 736494, 226312, 802616)
 END
 INPUT
 select table_name, index_type from information_schema.statistics where table_schema = 'test' and table_name ='tm' order by table_name;
@@ -14141,10 +14141,10 @@ OUTPUT
 select hex(ujis), hex(ucs2), hex(ujis2), `name` from t1
 END
 INPUT
-select from t1 LEFT JOIN t1 t2 ON (t1.id=t2.pid) AND t2.rep_del IS NULL;
+select * from t1 LEFT JOIN t1 t2 ON (t1.id=t2.pid) AND t2.rep_del IS NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t1 as t2 on t1.id = t2.pid and t2.rep_del is null
 END
 INPUT
 select benchmark(5+5, pi());
@@ -14153,10 +14153,10 @@ OUTPUT
 select benchmark(5 + 5, pi()) from dual
 END
 INPUT
-select from t2 left join t1 ignore index(primary) on t1.fooID = t2.fooID and t1.fooID = 30;
+select * from t2 left join t1 ignore index(primary) on t1.fooID = t2.fooID and t1.fooID = 30;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 left join t1 ignore index (`primary`) on t1.fooID = t2.fooID and t1.fooID = 30
 END
 INPUT
 select locate('lo','hello',4294967296);
@@ -14183,10 +14183,10 @@ OUTPUT
 select _latin1 'B' collate latin1_bin in (_latin1 'a', _latin1 'b') from dual
 END
 INPUT
-select from t1 where field = '2006-11-06 04:08:36.0';
+select * from t1 where field = '2006-11-06 04:08:36.0';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where field = '2006-11-06 04:08:36.0'
 END
 INPUT
 select t2.fld3 FROM t2 where fld3 LIKE 'honeysuckle%';
@@ -14225,10 +14225,10 @@ OUTPUT
 select _latin1 0xFF regexp _latin1 '[[:upper:]]' collate latin1_bin from dual
 END
 INPUT
-select from ((t1 natural join t2) cross join (t3 natural join t4)) natural join t5;
+select * from ((t1 natural join t2) cross join (t3 natural join t4)) natural join t5;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from ((t1 natural join t2) join (t3 natural join t4)) natural join t5
 END
 INPUT
 select dayofmonth("0000-00-00"),dayofmonth(d),dayofmonth(dt),dayofmonth(t),dayofmonth(c) from t1;
@@ -14303,10 +14303,10 @@ OUTPUT
 select _koi8r 'a' collate koi8r_bin = _koi8r 'A' collate koi8r_general_ci from dual
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("indexes" IN NATURAL LANGUAGE MODE);
+select * from t1 where MATCH(a,b) AGAINST ("indexes" IN NATURAL LANGUAGE MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('indexes' in natural language mode)
 END
 INPUT
 select @my_uuid_date - @my_uuid_synthetic;
@@ -14333,10 +14333,10 @@ OUTPUT
 select 1 and 0 or 2, 2 or 1 and 0 from dual
 END
 INPUT
-select from t1 where a like '%PESA %';
+select * from t1 where a like '%PESA %';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '%PESA %'
 END
 INPUT
 select length(data) from t1;
@@ -14393,10 +14393,10 @@ OUTPUT
 select if(1, c1, '�'), if(0, c1, '�') from t1
 END
 INPUT
-select from v2b;
+select * from v2b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v2b
 END
 INPUT
 select "123456789012345678901234567890.123456789012345678901234567890" div 1 as x;
@@ -14483,10 +14483,10 @@ OUTPUT
 select a1 from t1 where a2 = 'b' group by a1
 END
 INPUT
-select from (select a as d, 2*a as two from t) dt;
+select * from (select a as d, 2*a as two from t) dt;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select a as d, 2 * a as two from t) as dt
 END
 INPUT
 select concat(a1,min(c)),b,max(c) from t1 where a1 < 'd' group by a1,a2,b;
@@ -14501,16 +14501,16 @@ OUTPUT
 select _latin1 'B' between _latin1 'a' and _latin1 'c' from dual
 END
 INPUT
-select from t_bug25347;
+select * from t_bug25347;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t_bug25347
 END
 INPUT
-select from information_schema.SCHEMATA where schema_name > 'm' ORDER BY SCHEMA_NAME;
+select * from information_schema.SCHEMATA where schema_name > 'm' ORDER BY SCHEMA_NAME;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.SCHEMATA where schema_name > 'm' order by SCHEMA_NAME asc
 END
 INPUT
 select cast(ltrim(' 20.06 ') as decimal(19,2));
@@ -14621,10 +14621,10 @@ OUTPUT
 select insert('hello', -18446744073709551617, -18446744073709551617, 'hi') from dual
 END
 INPUT
-select from t1 where word=CAST(0xDF as CHAR);
+select * from t1 where word=CAST(0xDF as CHAR);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word = cast(0xDF as CHAR)
 END
 INPUT
 select datediff("1997-12-31 23:59:59.000001","1997-12-30");
@@ -14747,10 +14747,10 @@ ERROR
 syntax error at position 19 near ':'
 END
 INPUT
-select from t1 where MATCH a,b AGAINST('"space model' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST('"space model' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('\"space model' in boolean mode)
 END
 INPUT
 select @ujis4 = CONVERT(@utf84 USING ujis);
@@ -14759,16 +14759,16 @@ OUTPUT
 select @ujis4 = convert(@utf84 using ujis) from dual
 END
 INPUT
-select (select from (select t1.a) cte) from t1;
+select (select * from (select t1.a) cte) from t1;
 END
-ERROR
-syntax error at position 20 near 'from'
+OUTPUT
+select (select * from (select t1.a from dual) as cte) from t1
 END
 INPUT
-select from t11;
+select * from t11;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t11
 END
 INPUT
 select count(a) as b from t1 where a=0 having b > 0;
@@ -14873,10 +14873,10 @@ OUTPUT
 select repeat('hello', 4294967296) from dual
 END
 INPUT
-select from t1 where not(a is null);
+select * from t1 where not(a is null);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not a is null
 END
 INPUT
 select table_name, index_type from information_schema.statistics where table_schema = 'test' and table_name = 'tm' and index_name = 'l' order by table_name;
@@ -14903,10 +14903,10 @@ OUTPUT
 select a, concat(b, '.') from t1
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('"text search" -"now support"' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('"text search" -"now support"' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('\"text search\" -\"now support\"' in boolean mode)
 END
 INPUT
 select _rowid,t1._rowid,skey,sval from t1;
@@ -14933,10 +14933,10 @@ OUTPUT
 select -9223372036854775808 from dual
 END
 INPUT
-select from information_schema.COLUMN_PRIVILEGES where grantee like '%mysqltest_1%';
+select * from information_schema.COLUMN_PRIVILEGES where grantee like '%mysqltest_1%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.COLUMN_PRIVILEGES where grantee like '%mysqltest_1%'
 END
 INPUT
 select a from t1 order by a;
@@ -14957,10 +14957,10 @@ OUTPUT
 select strcmp('s�', '�a'), strcmp('a�', '�x') from dual
 END
 INPUT
-select from_unixtime(0);
+select * from_unixtime(0);
 END
-OUTPUT
-select from_unixtime(0) from dual
+ERROR
+syntax error at position 23 near 'from_unixtime'
 END
 INPUT
 select group_concat(c1 order by binary c1 separator '') from t1 group by c1 collate utf32_unicode_ci;
@@ -14981,10 +14981,10 @@ OUTPUT
 select a1, a2, b, min(c), max(c) from t1 where a1 >= 'c' or a2 < 'b' group by a1, a2, b
 END
 INPUT
-select from float_test;
+select * from float_test;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from float_test
 END
 INPUT
 select sum(a) + 200 as the_sum, @Oporto as the_town from t1 where a > 1 group by b having avg(a) > 2;
@@ -15047,10 +15047,10 @@ OUTPUT
 select a1, a2, b from t2 where a1 > 'a' and a2 > 'a' and b = 'c' group by a1, a2, b
 END
 INPUT
-select from general_log;
+select * from general_log;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from general_log
 END
 INPUT
 select @@keycache2.key_cache_block_size;
@@ -15071,10 +15071,10 @@ OUTPUT
 select null = null, null != null, IFNULL(null, 1.1) + 0, IFNULL(null, 1) | 0 from dual
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST("sear*" IN BOOLEAN MODE);
+select * from t1 where MATCH(a,b) AGAINST("sear*" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('sear*' in boolean mode)
 END
 INPUT
 select count(*) from t1 where id IS NOT NULL;
@@ -15095,10 +15095,10 @@ OUTPUT
 select date_add(null, interval 100000 SECOND) from dual
 END
 INPUT
-select from information_schema.tables where table_schema = NULL;
+select * from information_schema.tables where table_schema = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`tables` where table_schema = null
 END
 INPUT
 select @@keycache1.key_cache_block_size;
@@ -15161,16 +15161,16 @@ OUTPUT
 select unix_timestamp('1969-12-30 01:00:00') from dual
 END
 INPUT
-select from t1 where xxx regexp('is a test of some long text to se');
+select * from t1 where xxx regexp('is a test of some long text to se');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where xxx regexp 'is a test of some long text to se'
 END
 INPUT
-select from t1 where not((a < 5 or a < 10) and (not(a > 16) or a > 17));
+select * from t1 where not((a < 5 or a < 10) and (not(a > 16) or a > 17));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not ((a < 5 or a < 10) and (not a > 16 or a > 17))
 END
 INPUT
 select 1,11,101,1001,10001,100001,1000001,10000001,100000001,1000000001,10000000001,100000000001,1000000000001,10000000000001,100000000000001,1000000000000001,10000000000000001,100000000000000001,1000000000000000001,10000000000000000001;
@@ -15197,10 +15197,10 @@ OUTPUT
 select count(*) > 3 from t1 group by a order by b asc
 END
 INPUT
-select from t1 group by f2;
+select * from t1 group by f2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 group by f2
 END
 INPUT
 select make_set(3,c1,'�'), make_set(3,'�',c1) from t1;
@@ -15221,10 +15221,10 @@ OUTPUT
 select t1.a, t2.b from t1, t2 where t1.a = t2.a group by t1.a, t2.b
 END
 INPUT
-select from t1 where a = 2 or not(a < 10);
+select * from t1 where a = 2 or not(a < 10);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 2 or not a < 10
 END
 INPUT
 select grp,group_concat(c order by grp desc) from t1 group by grp order by grp;
@@ -15245,10 +15245,10 @@ OUTPUT
 select (select t2.* from t2) from t1
 END
 INPUT
-select from t1 left outer join t2 using (f2) left outer join t3 using (f3);
+select * from t1 left outer join t2 using (f2) left outer join t3 using (f3);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 using (f2) left join t3 using (f3)
 END
 INPUT
 select concat_ws(c1,'�','�'), concat_ws('�',c1,'�') from t1;
@@ -15263,22 +15263,22 @@ OUTPUT
 select c as c3 from t1 where c = '3'
 END
 INPUT
-select from t1 where MATCH a AGAINST ("search" IN BOOLEAN MODE);
+select * from t1 where MATCH a AGAINST ("search" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from t1 where concat(A,C,B,D) = 'AAAA2003-03-011051';
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a) against ('search' in boolean mode)
 END
 INPUT
-select from m1;
+select * from t1 where concat(A,C,B,D) = 'AAAA2003-03-011051';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where concat(A, C, B, D) = 'AAAA2003-03-011051'
+END
+INPUT
+select * from m1;
+END
+OUTPUT
+select * from m1
 END
 INPUT
 select hex(weight_string('a' as char(1)));
@@ -15323,16 +15323,16 @@ OUTPUT
 select unix_timestamp('2038-01-19 07:14:07') from dual
 END
 INPUT
-select from (t3 natural join t4) natural right join (t1 natural join t2);
+select * from (t3 natural join t4) natural right join (t1 natural join t2);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t3 natural join t4) natural right join (t1 natural join t2)
 END
 INPUT
-select from t1 group by f1, f2;
+select * from t1 group by f1, f2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 group by f1, f2
 END
 INPUT
 select quote(name) from bug20536;
@@ -15449,10 +15449,10 @@ ERROR
 syntax error at position 21 near ';'
 END
 INPUT
-select from t3 order by a desc;
+select * from t3 order by a desc;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 order by a desc
 END
 INPUT
 select st_astext(st_difference(ST_GeometryFromText('geometrycollection(polygon((0 0, 1 0, 1 1, 0 1, 0 0)))'), ST_GeometryFromText('geometrycollection(polygon((1 0, 2 0, 2 1, 1 1, 1 0)))')));
@@ -15479,10 +15479,10 @@ OUTPUT
 select count(distinct case when id <= 64 then id end) from tb
 END
 INPUT
-select from t1 where xxx regexp('is a test of some long text to');
+select * from t1 where xxx regexp('is a test of some long text to');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where xxx regexp 'is a test of some long text to'
 END
 INPUT
 select b from t1 group by binary b like '';
@@ -15821,10 +15821,10 @@ OUTPUT
 select rpad('abcd', 1, 'ab'), lpad('abcd', 1, 'ab') from dual
 END
 INPUT
-select A.* from (t1 inner join (select from t2) as A on t1.ID = A.FID);
+select A.* from (t1 inner join (select * from t2) as A on t1.ID = A.FID);
 END
-ERROR
-syntax error at position 44 near 'from'
+OUTPUT
+select A.* from (t1 join (select * from t2) as A on t1.ID = A.FID)
 END
 INPUT
 select b.id, group_concat(b.name) from t1 a, t1 b group by b.id;
@@ -15899,10 +15899,10 @@ OUTPUT
 select t2.col2 from t2 group by t2.col1, t2.col2 having t1.col1 <= 10
 END
 INPUT
-select from t1 where a like "test%";
+select * from t1 where a like "test%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like 'test%'
 END
 INPUT
 select 1+2/*hello*/+3;
@@ -16037,10 +16037,10 @@ ERROR
 syntax error at position 39 near 'thread_id'
 END
 INPUT
-select from information_schema.CHARACTER_SETS where CHARACTER_SET_NAME like 'latin1%' order by character_set_name;
+select * from information_schema.CHARACTER_SETS where CHARACTER_SET_NAME like 'latin1%' order by character_set_name;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.CHARACTER_SETS where CHARACTER_SET_NAME like 'latin1%' order by character_set_name asc
 END
 INPUT
 select "Test 'go' command g" as "_";
@@ -16061,10 +16061,10 @@ OUTPUT
 select ST_astext(st_union(st_intersection(multipoint(point(-1, -1)), point(1, -1)), st_difference(multipoint(point(-1, 1)), point(-1, -1)))) from dual
 END
 INPUT
-select from t1, lateral (with qn as (select t1.a) select (select max(a) from qn)) as dt;
+select * from t1, lateral (with qn as (select t1.a) select (select max(a) from qn)) as dt;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, lateral (with qn as (select t1.a from dual) select (select max(a) from qn) from dual) as dt
 END
 INPUT
 select referenced_table_schema, referenced_table_name from information_schema.key_column_usage where constraint_schema = 'db-1' and table_schema != 'PERFORMANCE_SCHEMA' order by referenced_table_schema, referenced_table_name;
@@ -16163,10 +16163,10 @@ OUTPUT
 select distinct a from t1
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST("+support +collections" IN BOOLEAN MODE);
+select * from t1 where MATCH(a,b) AGAINST("+support +collections" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('+support +collections' in boolean mode)
 END
 INPUT
 select hex(substr(_utf32 0x000000e4000000e500000068,2));
@@ -16187,10 +16187,10 @@ OUTPUT
 select format(atan2(pi(), 0), 6) from dual
 END
 INPUT
-select from t1 natural left join t2;
+select * from t1 natural left join t2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural left join t2
 END
 INPUT
 select MYSQLTEST.T1.* from MYSQLTEST.T1;
@@ -16217,10 +16217,10 @@ OUTPUT
 select t1a.a, t1b.a from t1 as t1a, t1 as t1b where t1a.a = t1b.a order by convert(t1a.a, binary) asc, convert(t1b.a, binary) asc
 END
 INPUT
-select from information_schema.partitions where table_schema="test" and table_name="t4";
+select * from information_schema.partitions where table_schema="test" and table_name="t4";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`partitions` where table_schema = 'test' and table_name = 't4'
 END
 INPUT
 select hex(group_concat(a)) from t1;
@@ -16241,10 +16241,10 @@ OUTPUT
 select hex(char(0x01 using ucs2)) from dual
 END
 INPUT
-select from information_schema.columns where table_schema = NULL;
+select * from information_schema.columns where table_schema = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`columns` where table_schema = null
 END
 INPUT
 select distinct n1,n2 from t1;
@@ -16265,10 +16265,10 @@ OUTPUT
 select unix_timestamp(from_unixtime(2147483648)) from dual
 END
 INPUT
-select from t2,t3 where MATCH (t2.inhalt,t3.inhalt) AGAINST ('foobar');
+select * from t2,t3 where MATCH (t2.inhalt,t3.inhalt) AGAINST ('foobar');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2, t3 where match(t2.inhalt, t3.inhalt) against ('foobar')
 END
 INPUT
 select weekofyear("1997-11-30 23:59:59.000001");
@@ -16289,10 +16289,10 @@ OUTPUT
 select group_concat(c1 order by convert(c1, binary) asc separator '') from t1 group by c1 collate utf16_hungarian_ci
 END
 INPUT
-select from t1 where a like "%ss%";
+select * from t1 where a like "%ss%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '%ss%'
 END
 INPUT
 select hex(_utf8mb4 X'616263FF');
@@ -16385,10 +16385,10 @@ OUTPUT
 select insert('hello', 1, -4294967296, 'hi') from dual
 END
 INPUT
-select from t1, t2 where t2.a=t1.a and t2.b + 1;
+select * from t1, t2 where t2.a=t1.a and t2.b + 1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2 where t2.a = t1.a and t2.b + 1
 END
 INPUT
 select cast(min(df) as signed) from t1;
@@ -16403,10 +16403,10 @@ OUTPUT
 select _koi8r 'a' like _latin1 'A' from dual
 END
 INPUT
-select from information_schema.schemata where schema_name = NULL;
+select * from information_schema.schemata where schema_name = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.schemata where schema_name = null
 END
 INPUT
 select rpad('a',4,'1'),rpad('a',4,'12'),rpad('abcd',3,'12'), rpad(11, 10 , 22), rpad("ab", 10, 22);
@@ -16451,10 +16451,10 @@ OUTPUT
 select 1, ST_touches(t.geom, p.geom) from tbl_polygon as t, tbl_polygon as p where t.id = 'POLY1' and p.id = 'POLY2'
 END
 INPUT
-select from (select from t1 natural join t2) as t12 natural join (select from t3 natural join t4) as t34;
+select * from (select * from t1 natural join t2) as t12 natural join (select * from t3 natural join t4) as t34;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select * from t1 natural join t2) as t12 natural join (select * from t3 natural join t4) as t34
 END
 INPUT
 select event_name, event_definition, interval_value, interval_field from information_schema.events order by event_name;
@@ -16505,16 +16505,16 @@ OUTPUT
 select column_default from information_schema.`columns` where table_name = 't1'
 END
 INPUT
-select from t1 where a like "abc%";
+select * from t1 where a like "abc%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like 'abc%'
 END
 INPUT
-select from (select from t1 union distinct select from t2 union all select from t3) X;
+select * from (select * from t1 union distinct select * from t2 union all select * from t3) X;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select * from t1 union select * from t2 union all select * from t3) as X
 END
 INPUT
 select @test_compress_string:='string for test compress function aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ';
@@ -16553,16 +16553,16 @@ OUTPUT
 select right('hello', -4294967296) from dual
 END
 INPUT
-select from information_schema.key_column_usage where TABLE_NAME= "vo";
+select * from information_schema.key_column_usage where TABLE_NAME= "vo";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.key_column_usage where TABLE_NAME = 'vo'
 END
 INPUT
-select from t1 where a='a' order by binary a;
+select * from t1 where a='a' order by binary a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 'a' order by convert(a, binary) asc
 END
 INPUT
 select @@global.concurrent_insert;
@@ -16571,10 +16571,10 @@ OUTPUT
 select @@global.concurrent_insert from dual
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("only");
+select * from t1 where MATCH(a,b) AGAINST ("only");
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('only')
 END
 INPUT
 select null % 0 as 'NULL';
@@ -16595,10 +16595,10 @@ OUTPUT
 select a1, max(c) from t1 where a1 in ('a', 'b', 'd') group by a1, a2, b
 END
 INPUT
-select from (select from t1 natural join t2) as t12 natural left join (select from t3 natural join t4) as t34;
+select * from (select * from t1 natural join t2) as t12 natural left join (select * from t3 natural join t4) as t34;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select * from t1 natural join t2) as t12 natural left join (select * from t3 natural join t4) as t34
 END
 INPUT
 select ST_astext(st_union(ST_GeomFromText('multipoint(2 2, 3 3)'), st_intersection(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)'))));
@@ -16607,10 +16607,10 @@ OUTPUT
 select ST_astext(st_union(ST_GeomFromText('multipoint(2 2, 3 3)'), st_intersection(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)')))) from dual
 END
 INPUT
-select from t3_trans;
+select * from t3_trans;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3_trans
 END
 INPUT
 select t1.a from t1 as t1 left join t1 as t2 using (a) left join t1 as t3 using (a) left join t1 as t4 using (a) left join t1 as t5 using (a) left join t1 as t6 using (a) left join t1 as t7 using (a) left join t1 as t8 using (a) left join t1 as t9 using (a) left join t1 as t10 using (a) left join t1 as t11 using (a) left join t1 as t12 using (a) left join t1 as t13 using (a) left join t1 as t14 using (a) left join t1 as t15 using (a) left join t1 as t16 using (a) left join t1 as t17 using (a) left join t1 as t18 using (a) left join t1 as t19 using (a) left join t1 as t20 using (a) left join t1 as t21 using (a) left join t1 as t22 using (a) left join t1 as t23 using (a) left join t1 as t24 using (a) left join t1 as t25 using (a) left join t1 as t26 using (a) left join t1 as t27 using (a) left join t1 as t28 using (a) left join t1 as t29 using (a) left join t1 as t30 using (a) left join t1 as t31 using (a) left join t1 as t32 using (a) left join t1 as t33 using (a) left join t1 as t34 using (a) left join t1 as t35 using (a) left join t1 as t36 using (a) left join t1 as t37 using (a) left join t1 as t38 using (a) left join t1 as t39 using (a) left join t1 as t40 using (a) left join t1 as t41 using (a) left join t1 as t42 using (a) left join t1 as t43 using (a) left join t1 as t44 using (a) left join t1 as t45 using (a) left join t1 as t46 using (a) left join t1 as t47 using (a) left join t1 as t48 using (a) left join t1 as t49 using (a) left join t1 as t50 using (a) left join t1 as t51 using (a) left join t1 as t52 using (a) left join t1 as t53 using (a) left join t1 as t54 using (a) left join t1 as t55 using (a) left join t1 as t56 using (a) left join t1 as t57 using (a) left join t1 as t58 using (a) left join t1 as t59 using (a) left join t1 as t60 using (a) left join t1 as t61 using (a) left join t1 as t62 using (a) left join t1 as t63 using (a) left join t1 as t64 using (a) left join t1 as t65 using (a);
@@ -16697,10 +16697,10 @@ OUTPUT
 select a, t > 0, c, i from t1
 END
 INPUT
-select from t1 left join t2 on t1.b = t2.b order by t1.a;
+select * from t1 left join t2 on t1.b = t2.b order by t1.a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on t1.b = t2.b order by t1.a asc
 END
 INPUT
 select locate('HE','hello');
@@ -16757,10 +16757,10 @@ OUTPUT
 select count(*) from t1 where a is null
 END
 INPUT
-select from bug20691 order by i asc;
+select * from bug20691 order by i asc;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from bug20691 order by i asc
 END
 INPUT
 select insert('hello', 4294967295, 1, 'hi');
@@ -16775,16 +16775,16 @@ OUTPUT
 select 'The cost of accessing t1 (dont care if it changes' as `^` from dual
 END
 INPUT
-select from t1 natural left join t2 where (i is not null)=0;
+select * from t1 natural left join t2 where (i is not null)=0;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural left join t2 where i is not null = 0
 END
 INPUT
-select from t2 /bin /boot /cdrom /dev /etc /home /lib /lib32 /lib64 /libx32 /lost+found /media /mnt /opt /proc /root /run /sbin /snap /srv /swapfile /sys /tmp /usr /var must be (3,1), (4,4) */;
+select * from t2 /bin /boot /cdrom /dev /etc /home /lib /lib32 /lib64 /libx32 /lost+found /media /mnt /opt /proc /root /run /sbin /snap /srv /swapfile /sys /tmp /usr /var must be (3,1), (4,4) */;
 END
 ERROR
-syntax error at position 12 near 'from'
+syntax error at position 19
 END
 INPUT
 select count(distinct n1), count(distinct n2) from t1;
@@ -16877,10 +16877,10 @@ OUTPUT
 select 5 from t1
 END
 INPUT
-select from t1 where not(not(not(a < 5) and not(a > 10)));
+select * from t1 where not(not(not(a < 5) and not(a > 10)));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not not (not a < 5 and not a > 10)
 END
 INPUT
 select min(f3),max(f3) from t1;
@@ -17009,10 +17009,10 @@ OUTPUT
 select hex(weight_string(_utf16 0xD800DC01)) from dual
 END
 INPUT
-select from (select *,substring(b,1),substring(b,-1),substring(b,-2),substring(b,-3),substring(b,-4),substring(b,-5) from t1) t;
+select * from (select *,substring(b,1),substring(b,-1),substring(b,-2),substring(b,-3),substring(b,-4),substring(b,-5) from t1) t;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select *, substr(b, 1), substr(b, -1), substr(b, -2), substr(b, -3), substr(b, -4), substr(b, -5) from t1) as t
 END
 INPUT
 select st_overlaps(st_intersection(ST_GeomFromText('point(1 1)'), ST_GeomFromText('multipoint(2 2, 3 3)')), st_union(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)')));
@@ -17117,10 +17117,10 @@ OUTPUT
 select t1.*, t2.* from t1 join t2 on t1.a = t2.a
 END
 INPUT
-select from T1;
+select * from T1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from T1
 END
 INPUT
 select st_a, swt1a, st_b, swt1b from t1 where st_a=1 and swt1a=1 and st_b=1 and swt1b=1 and swt1b=1 limit 5;
@@ -17141,10 +17141,10 @@ OUTPUT
 select count(*) from t1 left join t2 on t1.id = t2.owner
 END
 INPUT
-select tt.field100 from t1 join (select from t1) tt where t1.field100=tt.field100 limit 1;
+select tt.field100 from t1 join (select * from t1) tt where t1.field100=tt.field100 limit 1;
 END
-ERROR
-syntax error at position 45 near 'from'
+OUTPUT
+select tt.field100 from t1 join (select * from t1) as tt where t1.field100 = tt.field100 limit 1
 END
 INPUT
 select cast(repeat('1',20) as signed);
@@ -17201,10 +17201,10 @@ OUTPUT
 select `date`, `format`, TIME(str_to_date(`date`, `format`)) as `time` from t1
 END
 INPUT
-select from v4;
+select * from v4;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v4
 END
 INPUT
 select table_name from information_schema.views where table_schema='test' order by table_name;
@@ -17237,10 +17237,10 @@ OUTPUT
 select distinct t3.a, e from t3, t1 order by t3.b asc
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST("support +collections" IN BOOLEAN MODE);
+select * from t1 where MATCH(a,b) AGAINST("support +collections" IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('support +collections' in boolean mode)
 END
 INPUT
 select @ujis1 = CONVERT(@utf81 USING ujis);
@@ -17279,10 +17279,10 @@ OUTPUT
 select count(*) from t2
 END
 INPUT
-select from (t1 natural join t2) natural left join (t3 natural join t4) where b + 1 = y or b + 10 = y group by b,c,a,y having min(b) < max(y) order by a, y;
+select * from (t1 natural join t2) natural left join (t3 natural join t4) where b + 1 = y or b + 10 = y group by b,c,a,y having min(b) < max(y) order by a, y;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 natural join t2) natural left join (t3 natural join t4) where b + 1 = y or b + 10 = y group by b, c, a, y having min(b) < max(y) order by a asc, y asc
 END
 INPUT
 select cast(min(ifl) as decimal(5,2)) from t3;
@@ -17333,10 +17333,10 @@ OUTPUT
 select group_concat(c order by (select c from t2 where t2.a = t1.a limit 1) asc) as grp from t1
 END
 INPUT
-select from t1 where text1='teststring' or text1 > 'teststring	';
+select * from t1 where text1='teststring' or text1 > 'teststring	';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where text1 = 'teststring' or text1 > 'teststring\t'
 END
 INPUT
 select var_samp(o) as 'null', var_pop(o) as '0' from bug22555;
@@ -17387,10 +17387,10 @@ OUTPUT
 select str_to_date('2003-04-05 g', '%Y-%m-%d') as f1, str_to_date('2003-04-05 10:11:12.101010234567', '%Y-%m-%d %H:%i:%S.%f') as f2 from dual
 END
 INPUT
-select from t1 where 1 xor 1;
+select * from t1 where 1 xor 1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where 1 xor 1
 END
 INPUT
 select d, two from v;
@@ -17513,10 +17513,10 @@ OUTPUT
 select QN.a from (select 1 as a from dual) as QN
 END
 INPUT
-select from t1 natural join t2 where t1.c > t2.a;
+select * from t1 natural join t2 where t1.c > t2.a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural join t2 where t1.c > t2.a
 END
 INPUT
 select length(last_day("1997-12-1"));
@@ -17693,10 +17693,10 @@ OUTPUT
 select get_lock('bug27638', 1) from dual
 END
 INPUT
-select from t1 where str like 'aa%';
+select * from t1 where str like 'aa%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where str like 'aa%'
 END
 INPUT
 select t1.name, t2.name, t2.id, t2.owner, t3.id from t1 left join t2 on (t1.id = t2.owner) right join t1 as t3 on t3.id=t2.owner;
@@ -17735,10 +17735,10 @@ OUTPUT
 select locate('lo', 'hello', 18446744073709551616) from dual
 END
 INPUT
-select from t1 natural left join t2 where (i is not null) is not null;
+select * from t1 natural left join t2 where (i is not null) is not null;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural left join t2 where (i is not null) is not null
 END
 INPUT
 select date_sub("1998-01-01 00:00:00",INTERVAL "1:1" MINUTE_SECOND);
@@ -17765,10 +17765,10 @@ OUTPUT
 select t1.*, t2.* from t1 natural left join t2
 END
 INPUT
-select from t1 ignore index (primary) where tt like 'AA%';
+select * from t1 ignore index (primary) where tt like 'AA%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 ignore index (`primary`) where tt like 'AA%'
 END
 INPUT
 select substring_index('aaaaaaaaa1','aa',-2);
@@ -17795,10 +17795,10 @@ OUTPUT
 select count(*) from t1 where a = 'aaaxxx'
 END
 INPUT
-select from mysqldump_myDB.v1;
+select * from mysqldump_myDB.v1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysqldump_myDB.v1
 END
 INPUT
 select Aaa.col1 from t1Aa as AaA;
@@ -17813,10 +17813,10 @@ OUTPUT
 select date_sub('50-01-01 00:00:01', interval 2 SECOND) from dual
 END
 INPUT
-select from `information_schema`.`REFERENTIAL_CONSTRAINTS` where `TABLE_NAME` = NULL;
+select * from `information_schema`.`REFERENTIAL_CONSTRAINTS` where `TABLE_NAME` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.REFERENTIAL_CONSTRAINTS where TABLE_NAME = null
 END
 INPUT
 select (1.175494351E-37 div 1.7976931348623157E+308);
@@ -17843,10 +17843,10 @@ OUTPUT
 select var_samp(e) as `null`, var_pop(e) as `null` from bug22555
 END
 INPUT
-select from (select 1) as a;
+select * from (select 1) as a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select 1 from dual) as a
 END
 INPUT
 select hex(char(0x41 using ucs2));
@@ -17945,10 +17945,10 @@ OUTPUT
 select true, false, null from dual
 END
 INPUT
-select from t1 where a=4;
+select * from t1 where a=4;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 4
 END
 INPUT
 select ST_ASTEXT(ST_UNION(ST_GEOMFROMTEXT('GEOMETRYCOLLECTION(MULTILINESTRING((0 -14,13 -8),(-5 -3,8 7),(-6 18,17 -11,-12 19,19 5),(16 11,9 -5),(17 -5,5 10),(-4 17,6 4),(-12 15,17 13,-18 11,15 10),(7 0,2 -16,-18 13,-6 4),(-17 -6,-6 -7,1 4,-18 0)),GEOMETRYCOLLECTION(MULTIPOINT(0 14,-9 -11),MULTILINESTRING((-11 -2,17 -14),(18 -12,18 -8),(-13 -16,9 16,9 -10,-7 20),(-14 -5,10 -9,4 1,17 -8),(-9 -4,-2 -12,9 -13,-5 4),(15 17,13 20))),MULTIPOINT(16 1,-9 -17,-16 6,-17 3),POINT(-18 13))'), ST_GEOMFROMTEXT('GEOMETRYCOLLECTION(POINT(7 0),MULTILINESTRING((-13 -18,-16 0),(17 11,-1 11,-18 -19,-4 -18),(-8 -8,-15 -13,3 -18,6 8)),LINESTRING(5 16,0 -9,-6 4,-15 17),MULTIPOINT(-9 -5,5 15,12 -11,12 11))'))) as result;
@@ -17981,10 +17981,10 @@ OUTPUT
 select locate(_latin1 'B' collate latin1_bin, _latin1 'abcd') from dual
 END
 INPUT
-select from v2;
+select * from v2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v2
 END
 INPUT
 select group_concat(distinct a, c order by a) from t1;
@@ -17999,10 +17999,10 @@ OUTPUT
 select !0, not 0 = 1, !(0 = 0), 1 and 1, 1 and 0, 0 or 1, 1 or null, 1 = 1 or 1 = 1 and 1 = 0 from dual
 END
 INPUT
-select from t1 left join t2 on (t1.i=t2.i);
+select * from t1 left join t2 on (t1.i=t2.i);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on t1.i = t2.i
 END
 INPUT
 select C.a, c.a from t1 c, t2 C;
@@ -18089,10 +18089,10 @@ OUTPUT
 select group_concat(c1 order by c1 asc) from t1 group by c1 collate utf8_unicode_520_ci
 END
 INPUT
-select from t3 join (t1 join t2 using (a1)) on b=c1 join t4 using (c2);
+select * from t3 join (t1 join t2 using (a1)) on b=c1 join t4 using (c2);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 join (t1 join t2 using (a1)) on b = c1 join t4 using (c2)
 END
 INPUT
 select extract(HOUR_MICROSECOND FROM "1999-01-02 10:11:12.000123");
@@ -18131,10 +18131,10 @@ OUTPUT
 select c as cy from t1 where c = 'y'
 END
 INPUT
-select from t1 where xxx REGEXP '^this is some text: to test - out.reg exp [[(][0-9]+[/][0-9]+[])][ ]*$';
+select * from t1 where xxx REGEXP '^this is some text: to test - out.reg exp [[(][0-9]+[/][0-9]+[])][ ]*$';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where xxx regexp '^this is some text: to test - out.reg exp [[(][0-9]+[/][0-9]+[])][ ]*$'
 END
 INPUT
 select collation(repeat(_latin2'a',10)), coercibility(repeat(_latin2'a',10));
@@ -18161,10 +18161,10 @@ OUTPUT
 select a as like_a from t1 where a like 'a%'
 END
 INPUT
-select from t1 where a = '4828532208463511553';
+select * from t1 where a = '4828532208463511553';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = '4828532208463511553'
 END
 INPUT
 select char_length('abcd'), octet_length('abcd');
@@ -18305,10 +18305,10 @@ OUTPUT
 select host, db, `user`, table_name, column_name from mysql.columns_priv where `user` like 'mysqltest_%' order by host asc, db asc, `user` asc, table_name asc, column_name asc
 END
 INPUT
-select from renamed_slow_log;
+select * from renamed_slow_log;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from renamed_slow_log
 END
 INPUT
 select 2 or 3;
@@ -18317,10 +18317,10 @@ OUTPUT
 select 2 or 3 from dual
 END
 INPUT
-select from t1 where a not between 1 and 2;
+select * from t1 where a not between 1 and 2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a not between 1 and 2
 END
 INPUT
 select pow(cast(-2 as unsigned), 5), pow(18446744073709551614, 5), pow(-2, 5);
@@ -18365,10 +18365,10 @@ OUTPUT
 select t2.b, ifnull(t2.b, 'this is null') from t1 as t2 left join t1 as t3 on t2.b = t3.a
 END
 INPUT
-select from (select @arg00) aaa;
+select * from (select @arg00) aaa;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select @arg00 from dual) as aaa
 END
 INPUT
 select concat("*",name,"*") from t2 order by 1;
@@ -18497,10 +18497,10 @@ ERROR
 syntax error at position 9
 END
 INPUT
-select from t3 order by 1,2;
+select * from t3 order by 1,2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 order by 1 asc, 2 asc
 END
 INPUT
 select rpad('hello', -18446744073709551616, '1');
@@ -18521,10 +18521,10 @@ OUTPUT
 select min(col002) from t1 union select col002 from t1
 END
 INPUT
-select from t1,t1 as t2 where t1.x=t2.y;
+select * from t1,t1 as t2 where t1.x=t2.y;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t1 as t2 where t1.x = t2.y
 END
 INPUT
 select date,format,cast(str_to_date(date, format) as datetime) as datetime from t1;
@@ -18539,10 +18539,10 @@ OUTPUT
 select rpad('hello', -18446744073709551615, '1') from dual
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('"now support"' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('"now support"' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('\"now support\"' in boolean mode)
 END
 INPUT
 select date_add("1997-12-31 23:59:59",INTERVAL "10000:99:99" HOUR_SECOND);
@@ -18581,16 +18581,16 @@ OUTPUT
 select round(cast(-2 as unsigned), 1), round(18446744073709551614, 1), round(-2, 1) from dual
 END
 INPUT
-select from t3 where a > 10 and a < 20;
+select * from t3 where a > 10 and a < 20;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 where a > 10 and a < 20
 END
 INPUT
-select from t1 where a like "%a%";
+select * from t1 where a like "%a%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '%a%'
 END
 INPUT
 select a1,a2,b,min(c),max(c) from t1 where a1 >= 'b' group by a1,a2,b;
@@ -18689,10 +18689,10 @@ OUTPUT
 select t1.*, t2.* from t1 left join t2 on t1.b = t2.b where coercibility(t2.a) = 5 order by t1.a asc, t2.a asc
 END
 INPUT
-select from (t4 natural join t5) natural right join t1 where t4.y > 7;
+select * from (t4 natural join t5) natural right join t1 where t4.y > 7;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t4 natural join t5) natural right join t1 where t4.y > 7
 END
 INPUT
 select (ST_asWKT(ST_geomfromwkb((0x000000000140240000000000004024000000000000))));
@@ -18731,16 +18731,16 @@ OUTPUT
 select t1.f1, t.* from t1, t1 as t group by 1
 END
 INPUT
-select from t1 where not(a < 10);
+select * from t1 where not(a < 10);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not a < 10
 END
 INPUT
-select from t1 where firstname='john' and firstname like binary 'John';
+select * from t1 where firstname='john' and firstname like binary 'John';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where firstname = 'john' and firstname like convert('John', binary)
 END
 INPUT
 select charset(charset(_utf8'a')), charset(collation(_utf8'a'));
@@ -18749,10 +18749,10 @@ OUTPUT
 select charset(charset(_utf8 'a')), charset(collation(_utf8 'a')) from dual
 END
 INPUT
-select from `information_schema`.`key_column_usage` where `TABLE_NAME` = NULL;
+select * from `information_schema`.`key_column_usage` where `TABLE_NAME` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.key_column_usage where TABLE_NAME = null
 END
 INPUT
 select user() like "%@%";
@@ -18773,10 +18773,10 @@ OUTPUT
 select log2(-1) from dual
 END
 INPUT
-select from t1 c, t2 C;
+select * from t1 c, t2 C;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 as c, t2 as C
 END
 INPUT
 select charset(database());
@@ -18785,10 +18785,10 @@ OUTPUT
 select charset(database()) from dual
 END
 INPUT
-select from t1 left join t2 on b1 = a1 left join t3 on c1 = a1 and b1 is null;
+select * from t1 left join t2 on b1 = a1 left join t3 on c1 = a1 and b1 is null;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on b1 = a1 left join t3 on c1 = a1 and b1 is null
 END
 INPUT
 select round(18446744073709551614, -1), truncate(18446744073709551614, -1);
@@ -18893,10 +18893,10 @@ OUTPUT
 select MBRwithin(b, b) is null, MBRcontains(b, b) is null, MBRoverlaps(b, b) is null, MBRequals(b, b) is null, MBRdisjoint(b, b) is null, ST_touches(b, b) is null, MBRintersects(b, b) is null, ST_crosses(b, b) is null from t1
 END
 INPUT
-select from mysqltest.t1;
+select * from mysqltest.t1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysqltest.t1
 END
 INPUT
 select grp,group_concat(a order by d+c-ascii(c),a) from t1 group by grp;
@@ -18905,10 +18905,10 @@ OUTPUT
 select grp, group_concat(a order by d + c - ascii(c) asc, a asc) from t1 group by grp
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("collections") UNION ALL select from t1 where MATCH(a,b) AGAINST ("indexes");
+select * from t1 where MATCH(a,b) AGAINST ("collections") UNION ALL select * from t1 where MATCH(a,b) AGAINST ("indexes");
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('collections') union all select * from t1 where match(a, b) against ('indexes')
 END
 INPUT
 select 0, ST_Within(ST_GeomFromText('POLYGON((0 0,20 10,10 30, 0 0))'), ST_GeomFromText('POLYGON((10 10,30 20,20 40, 10 10))'));
@@ -18947,10 +18947,10 @@ OUTPUT
 select i from t1 where b = repeat(_utf8 'b', 310)
 END
 INPUT
-select from t1 where not(not(a));
+select * from t1 where not(not(a));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not not a
 END
 INPUT
 select bar from t1 having instr(group_concat(bar order by concat(bar,bar) desc), "test2,test1") > 0;
@@ -19019,10 +19019,10 @@ OUTPUT
 select '1997-12-31 23:59:59' + interval 1 SECOND from dual
 END
 INPUT
-select from t2 where b="world";
+select * from t2 where b="world";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 where b = 'world'
 END
 INPUT
 select count(*) from mysql.host;
@@ -19109,10 +19109,10 @@ ERROR
 syntax error at position 107 near '/*+ no_semijoin() node_modules/ a from cte);'
 END
 INPUT
-select from v1a;
+select * from v1a;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1a
 END
 INPUT
 select @@optimizer_switch;
@@ -19181,10 +19181,10 @@ OUTPUT
 select 3 from dual
 END
 INPUT
-select from (select group_concat('c') from DUAL) t;
+select * from (select group_concat('c') from DUAL) t;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select group_concat('c') from dual) as t
 END
 INPUT
 select NAME_CONST('_id',1234) as id;
@@ -19211,10 +19211,10 @@ OUTPUT
 select 12 % 0 <=> null as `1` from dual
 END
 INPUT
-select from t1 where a=if(b<10,_ucs2 0x0061,_ucs2 0x0062);
+select * from t1 where a=if(b<10,_ucs2 0x0061,_ucs2 0x0062);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = if(b < 10, _ucs2 0x0061, _ucs2 0x0062)
 END
 INPUT
 select ST_astext(st_symdifference(ST_GeomFromText('multipoint(2 2, 3 3)'), ST_GeomFromText('multipoint(2 2, 3 3)')));
@@ -19241,16 +19241,16 @@ OUTPUT
 select column_name from information_schema.`columns` where table_name = 't1' order by column_name asc
 END
 INPUT
-select from t1 where t1="ABC";
+select * from t1 where t1="ABC";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where t1 = 'ABC'
 END
 INPUT
-select from v3b;
+select * from v3b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v3b
 END
 INPUT
 select group_concat(distinct s1 order by s2) from t1 where s2 < 4;
@@ -19271,16 +19271,16 @@ OUTPUT
 select space(-4294967295) from dual
 END
 INPUT
-select from t3 where a=1 order by b limit 2;
+select * from t3 where a=1 order by b limit 2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 where a = 1 order by b asc limit 2
 END
 INPUT
-select from (select group_concat(a) from t1) t2;
+select * from (select group_concat(a) from t1) t2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select group_concat(a) from t1) as t2
 END
 INPUT
 select left('hello', -18446744073709551617);
@@ -19289,10 +19289,10 @@ OUTPUT
 select left('hello', -18446744073709551617) from dual
 END
 INPUT
-select from t1 where match(d, e) against ('+aword +bword' in boolean mode);
+select * from t1 where match(d, e) against ('+aword +bword' in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(d, e) against ('+aword +bword' in boolean mode)
 END
 INPUT
 select right('hello', 4294967295);
@@ -19343,10 +19343,10 @@ OUTPUT
 select rpad(i, 7, ' ') as t from t1
 END
 INPUT
-select from t1 where not(a <= 10);
+select * from t1 where not(a <= 10);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not a <= 10
 END
 INPUT
 select LAST_DAY('2007-12-06 08:59:19.05') - INTERVAL 1 SECOND;
@@ -19361,10 +19361,10 @@ OUTPUT
 select t1.*, t2.*, t3.a from t1 left join t2 on t3.a = t2.a left join t1 as t3 on t2.a = t3.a
 END
 INPUT
-select from t1 order by text1;
+select * from t1 order by text1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 order by text1 asc
 END
 INPUT
 select a as bin2 from t1 where a like 'あいうえおかきくけこさしすせそ';
@@ -19385,16 +19385,16 @@ OUTPUT
 select 7 from dual
 END
 INPUT
-select from information_schema.table_names;
+select * from information_schema.table_names;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.table_names
 END
 INPUT
-select from information_schema.COLLATIONS where COLLATION_NAME like 'latin1%' order by collation_name;
+select * from information_schema.COLLATIONS where COLLATION_NAME like 'latin1%' order by collation_name;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.COLLATIONS where COLLATION_NAME like 'latin1%' order by collation_name asc
 END
 INPUT
 select 'a ' = 'a	', 'a ' < 'a	', 'a ' > 'a	';
@@ -19403,10 +19403,10 @@ OUTPUT
 select 'a ' = 'a\t', 'a ' < 'a\t', 'a ' > 'a\t' from dual
 END
 INPUT
-select from t1 where b=1;
+select * from t1 where b=1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where b = 1
 END
 INPUT
 select group_concat(c1 order by binary c1 separator '') from t1 group by c1 collate utf16_vietnamese_ci;
@@ -19433,10 +19433,10 @@ OUTPUT
 select t1.*, t2.* from t1 left join t2 on t1.b = t2.b where collation(t2.a) = _utf8 'binary' order by t1.a asc, t2.a asc
 END
 INPUT
-select from t1 where i = 2;
+select * from t1 where i = 2;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where i = 2
 END
 INPUT
 select count(*) from t1 group by branch having branch<>'mumbai' order by id desc,branch desc limit 100;
@@ -19499,10 +19499,10 @@ OUTPUT
 select timestampdiff(SQL_TSI_DAY, '1986-02-01', '1986-03-01') as a1, timestampdiff(SQL_TSI_DAY, '1900-02-01', '1900-03-01') as a2, timestampdiff(SQL_TSI_DAY, '1996-02-01', '1996-03-01') as a3, timestampdiff(SQL_TSI_DAY, '2000-02-01', '2000-03-01') as a4 from dual
 END
 INPUT
-select from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COLLATION_NAME like 'latin1%' ORDER BY COLLATION_NAME;
+select * from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COLLATION_NAME like 'latin1%' ORDER BY COLLATION_NAME;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COLLATION_NAME like 'latin1%' order by COLLATION_NAME asc
 END
 INPUT
 select find_in_set('1','3,1,');
@@ -19583,10 +19583,10 @@ OUTPUT
 select t2.fld3, companynr from t2 where companynr = 57 + 1 order by fld3 asc
 END
 INPUT
-select from general_log where argument like '%general_log%';
+select * from general_log where argument like '%general_log%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from general_log where argument like '%general_log%'
 END
 INPUT
 select db, routine_name, routine_type, proc_priv from mysql.procs_priv where user='mysqluser10' and host='localhost';
@@ -19745,10 +19745,10 @@ OUTPUT
 select 0x0000000001020003F03F40408484040ADDE40 like 0x256F3B38312A7725 from dual
 END
 INPUT
-select from performance_schema.global_variables where variable_name like 'event_scheduler';
+select * from performance_schema.global_variables where variable_name like 'event_scheduler';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from performance_schema.global_variables where variable_name like 'event_scheduler'
 END
 INPUT
 select hex(s1) from t1 where s1 = 0xfffd;
@@ -19757,10 +19757,10 @@ OUTPUT
 select hex(s1) from t1 where s1 = 0xfffd
 END
 INPUT
-select from `information_schema`.`STATISTICS` where `TABLE_NAME` = NULL;
+select * from `information_schema`.`STATISTICS` where `TABLE_NAME` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.STATISTICS where TABLE_NAME = null
 END
 INPUT
 select t1.i,t2.i,t3.i from t2 natural right join t3,t1 order by t1.i,t2.i,t3.i;
@@ -19781,10 +19781,10 @@ OUTPUT
 select truncate(1.5, -2147483649), truncate(1.5, 2147483648) from dual
 END
 INPUT
-select from t1 where not(NULL and a);
+select * from t1 where not(NULL and a);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not (null and a)
 END
 INPUT
 select distinct a1,a2,b from t1 where (a1 > 'a') and (a2 > 'a') and (b = 'c');
@@ -19805,10 +19805,10 @@ OUTPUT
 select locate('he', 'hello', 2) from dual
 END
 INPUT
-select from `information_schema`.`TRIGGERS` where `EVENT_OBJECT_TABLE` = NULL;
+select * from `information_schema`.`TRIGGERS` where `EVENT_OBJECT_TABLE` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`TRIGGERS` where EVENT_OBJECT_TABLE = null
 END
 INPUT
 select ST_Overlaps(ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'), ST_GeomFromText('POLYGON((10 10, 10 4, 4 4, 4 10, 10 10))'));
@@ -19877,22 +19877,22 @@ OUTPUT
 select table_name, index_type from information_schema.statistics where table_schema = 'test' and table_name like 't%' and index_name = 'k' order by table_name asc
 END
 INPUT
-select from t1 order by a;
+select * from t1 order by a;
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from t1 where a like "ABC%";
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 order by a asc
 END
 INPUT
-select from t2_base;
+select * from t1 where a like "ABC%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like 'ABC%'
+END
+INPUT
+select * from t2_base;
+END
+OUTPUT
+select * from t2_base
 END
 INPUT
 select f1 from t1 where f2 <> '0000-00-00 00:00:00' order by f1;
@@ -19907,10 +19907,10 @@ OUTPUT
 select timediff('2008-09-29 20:10:10', '2008-09-30 20:10:10') < time('00:00:00') from dual
 END
 INPUT
-select from mysql.general_log;
+select * from mysql.general_log;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysql.general_log
 END
 INPUT
 select repeat('hello', -1);
@@ -19937,10 +19937,10 @@ OUTPUT
 select extract(day_hour from '1999-01-02 10:11:12') from dual
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('+(+(support collections)) +foobar*' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('+(+(support collections)) +foobar*' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('+(+(support collections)) +foobar*' in boolean mode)
 END
 INPUT
 select a1,max(c),min(c) from t2 where (a2 = 'a') and (b = 'b') group by a1;
@@ -20003,10 +20003,10 @@ OUTPUT
 select `SQL_BIG_RESULT` as a, count(b), sum(b), avg(b), std(b), min(b), max(b), bit_and(b), bit_or(b), bit_xor(b) from t1 group by a
 END
 INPUT
-select from (t2 join t4 on b + 1 = y) join t1 on t1.c = t4.c;
+select * from (t2 join t4 on b + 1 = y) join t1 on t1.c = t4.c;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t2 join t4 on b + 1 = y) join t1 on t1.c = t4.c
 END
 INPUT
 select concat('|',a,'|'), concat('|',b,'|') from t1;
@@ -20021,10 +20021,10 @@ OUTPUT
 select cast(null as BINARY) from dual
 END
 INPUT
-select from v_bug25347;
+select * from v_bug25347;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v_bug25347
 END
 INPUT
 select round(999999999999999999.0, -18);
@@ -20093,10 +20093,10 @@ OUTPUT
 select charset(version()) from dual
 END
 INPUT
-select from t1 where xxx regexp('is a test of some long text to s');
+select * from t1 where xxx regexp('is a test of some long text to s');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where xxx regexp 'is a test of some long text to s'
 END
 INPUT
 select char(53647 using utf8mb4);
@@ -20117,10 +20117,10 @@ OUTPUT
 select rpad('hello', -4294967297, '1') from dual
 END
 INPUT
-select t2.* from (select from t1) as A inner join t2 on A.ID = t2.FID;
+select t2.* from (select * from t1) as A inner join t2 on A.ID = t2.FID;
 END
-ERROR
-syntax error at position 30 near 'from'
+OUTPUT
+select t2.* from (select * from t1) as A join t2 on A.ID = t2.FID
 END
 INPUT
 select col1 as count_col1,col2 from t1 as tmp1 group by col1,col2 having col1 = 10;
@@ -20135,16 +20135,16 @@ OUTPUT
 select col_t1, sum(col1) from t1 group by col_t1 having col_t1 > 10 and exists (select sum(t2.col1) from t2 group by t2.col2 having t2.col2 > 'b')
 END
 INPUT
-select from t1,t2 natural left join t3 order by t1.i,t2.i,t3.i;
+select * from t1,t2 natural left join t3 order by t1.i,t2.i,t3.i;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2 natural left join t3 order by t1.i asc, t2.i asc, t3.i asc
 END
 INPUT
-select from (t1 natural join t2) join (t3 natural join t4) on t1.b = t3.b;
+select * from (t1 natural join t2) join (t3 natural join t4) on t1.b = t3.b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 natural join t2) join (t3 natural join t4) on t1.b = t3.b
 END
 INPUT
 select group_concat(t1.b,t2.c) from t1 inner join t2 using(a) group by a;
@@ -20165,10 +20165,10 @@ OUTPUT
 select uncompress(a) from t1
 END
 INPUT
-select from t1 where word between CAST(0xDF AS CHAR) and CAST(0xDF AS CHAR);
+select * from t1 where word between CAST(0xDF AS CHAR) and CAST(0xDF AS CHAR);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word between cast(0xDF as CHAR) and cast(0xDF as CHAR)
 END
 INPUT
 select group_concat(c1 order by binary c1 separator '') from t1 group by c1 collate utf16_unicode_ci;
@@ -20243,10 +20243,10 @@ OUTPUT
 select b from t1 having convert(b, binary) like ''
 END
 INPUT
-select from t5 natural join ((t1 natural join t2) cross join (t3 natural join t4));
+select * from t5 natural join ((t1 natural join t2) cross join (t3 natural join t4));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t5 natural join ((t1 natural join t2) join (t3 natural join t4))
 END
 INPUT
 select 1/*!2*/;
@@ -20285,10 +20285,10 @@ OUTPUT
 select count(*) from t1 where v like 'a%'
 END
 INPUT
-select from_unixtime(2147483648);
+select * from_unixtime(2147483648);
 END
-OUTPUT
-select from_unixtime(2147483648) from dual
+ERROR
+syntax error at position 23 near 'from_unixtime'
 END
 INPUT
 select month("0000-00-00"),month(d),month(dt),month(t),month(c) from t1;
@@ -20303,10 +20303,10 @@ OUTPUT
 select substr(f1, 4, 1), substr(f1, -4, 1) from t2
 END
 INPUT
-select FROM t1;
+select * from t1;
 END
-ERROR
-syntax error at position 12 near 'FROM'
+OUTPUT
+select * from t1
 END
 INPUT
 select case a when 1 then "one" when 2 then "two" else "nothing" end as fcase, count(*) from t1 group by fcase;
@@ -20363,10 +20363,10 @@ OUTPUT
 select cast(5 as unsigned) - 6.0 from dual
 END
 INPUT
-select from t1 where a like "�%";
+select * from t1 where a like "�%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like '�%'
 END
 INPUT
 select sql_big_result t2.id, avg(rating) from t2 group by t2.id;
@@ -20417,22 +20417,22 @@ OUTPUT
 select min(7) from dual
 END
 INPUT
-select from (t1 natural left join t2) natural left join (t3 natural left join t4);
+select * from (t1 natural left join t2) natural left join (t3 natural left join t4);
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select count(distinct x.id_aams) from (select from (select t1.id_aams, t2.* from t1 left join t2 on t2.code_id='G0000000012' and t1.id_aams=t2.id_game where t1.id_aams=1715000360 order by t2.id desc ) as g group by g.id_aams having g.id is null ) as x;
-END
-ERROR
-syntax error at position 51 near 'from'
+OUTPUT
+select * from (t1 natural left join t2) natural left join (t3 natural left join t4)
 END
 INPUT
-select from t1 natural join (t2 natural join (t3 natural join t4));
+select count(distinct x.id_aams) from (select * from (select t1.id_aams, t2.* from t1 left join t2 on t2.code_id='G0000000012' and t1.id_aams=t2.id_game where t1.id_aams=1715000360 order by t2.id desc ) as g group by g.id_aams having g.id is null ) as x;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select count(distinct x.id_aams) from (select * from (select t1.id_aams, t2.* from t1 left join t2 on t2.code_id = 'G0000000012' and t1.id_aams = t2.id_game where t1.id_aams = 1715000360 order by t2.id desc) as g group by g.id_aams having g.id is null) as x
+END
+INPUT
+select * from t1 natural join (t2 natural join (t3 natural join t4));
+END
+OUTPUT
+select * from t1 natural join (t2 natural join (t3 natural join t4))
 END
 INPUT
 select c c2 from t1 where c='2';
@@ -20441,28 +20441,28 @@ OUTPUT
 select c as c2 from t1 where c = '2'
 END
 INPUT
-select from t1 where not(a > 10);
+select * from t1 where not(a > 10);
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from t1 where word like CAST(0xDF as CHAR);
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not a > 10
 END
 INPUT
-select from information_schema.schema_privileges where grantee like '%user%' and table_schema !='performance_schema' order by grantee;
+select * from t1 where word like CAST(0xDF as CHAR);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word like cast(0xDF as CHAR)
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("indexes" WITH QUERY EXPANSION);
+select * from information_schema.schema_privileges where grantee like '%user%' and table_schema !='performance_schema' order by grantee;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.schema_privileges where grantee like '%user%' and table_schema != 'performance_schema' order by grantee asc
+END
+INPUT
+select * from t1 where MATCH(a,b) AGAINST ("indexes" WITH QUERY EXPANSION);
+END
+OUTPUT
+select * from t1 where match(a, b) against ('indexes' with query expansion)
 END
 INPUT
 select timediff('2008-09-29 20:10:10','2008-09-30 20:10:10'),time('00:00:00');
@@ -20471,10 +20471,10 @@ OUTPUT
 select timediff('2008-09-29 20:10:10', '2008-09-30 20:10:10'), time('00:00:00') from dual
 END
 INPUT
-select from information_schema.TABLE_PRIVILEGES where grantee like '%mysqltest_1%';
+select * from information_schema.TABLE_PRIVILEGES where grantee like '%mysqltest_1%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.TABLE_PRIVILEGES where grantee like '%mysqltest_1%'
 END
 INPUT
 select max(a3) from t1 where a3 = 'MIN' and a2 = 2;
@@ -20501,10 +20501,10 @@ OUTPUT
 select distinct 1 from t1, t3 where t1.a = t3.a
 END
 INPUT
-select from t1 where a=b;
+select * from t1 where a=b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = b
 END
 INPUT
 select strcmp("a",NULL),(1<NULL)+0.0,NULL regexp "a",null like "a%","a%" like null;
@@ -20561,10 +20561,10 @@ OUTPUT
 select sum(a) from t1 where a > 10
 END
 INPUT
-select from information_schema.partitions where table_schema="test" and table_name="t2";
+select * from information_schema.partitions where table_schema="test" and table_name="t2";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`partitions` where table_schema = 'test' and table_name = 't2'
 END
 INPUT
 select a b, b c from t1 as t2;
@@ -20573,10 +20573,10 @@ OUTPUT
 select a as b, b as c from t1 as t2
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("collections");
+select * from t1 where MATCH(a,b) AGAINST ("collections");
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('collections')
 END
 INPUT
 select (CASE "two" when "one" then "1" WHEN "two" then "2" END) | 0;
@@ -20597,16 +20597,16 @@ OUTPUT
 select a1, a2, b, max(c) from t1 where a1 = 'z' or a1 = 'b' or a1 = 'd' group by a1, a2, b
 END
 INPUT
-select from t1, t2 where t1.value64= 9223372036854775807 and t2.value64=9223372036854775807;
+select * from t1, t2 where t1.value64= 9223372036854775807 and t2.value64=9223372036854775807;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1, t2 where t1.value64 = 9223372036854775807 and t2.value64 = 9223372036854775807
 END
 INPUT
-select from t1 where firstname='john' and firstname = binary 'john';
+select * from t1 where firstname='john' and firstname = binary 'john';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where firstname = 'john' and firstname = convert('john', binary)
 END
 INPUT
 select str_to_date("2003-01-02 10:11:12.0012", "%Y-%m-%d %H:%i:%S.%f");
@@ -20633,10 +20633,10 @@ OUTPUT
 select group_concat(distinct f1) from t1
 END
 INPUT
-select from information_schema.column_privileges order by grantee;
+select * from information_schema.column_privileges order by grantee;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.column_privileges order by grantee asc
 END
 INPUT
 select NULL AND 0, 0 and NULL;
@@ -20675,10 +20675,10 @@ OUTPUT
 select a1, min(a2), max(a2) from t1 group by a1
 END
 INPUT
-select from t1 where firstname='john' and binary 'john' = firstname;
+select * from t1 where firstname='john' and binary 'john' = firstname;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where firstname = 'john' and convert('john', binary) = firstname
 END
 INPUT
 select -(9223372036854775808);
@@ -20699,10 +20699,10 @@ OUTPUT
 select distinct b from t2 where a2 >= 'b' and b = 'a' group by a1, a2, b
 END
 INPUT
-select from information_schema.user_privileges order by grantee;
+select * from information_schema.user_privileges order by grantee;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.user_privileges order by grantee asc
 END
 INPUT
 select t1.*,t2.* from t1 JOIN t2 where t1.a=t2.a;
@@ -20795,10 +20795,10 @@ OUTPUT
 select makedate(9999, 366) from dual
 END
 INPUT
-select from information_schema.engines WHERE ENGINE="MyISAM";
+select * from information_schema.engines WHERE ENGINE="MyISAM";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`engines` where `ENGINE` = 'MyISAM'
 END
 INPUT
 select cast(concat('184467440','73709551615') as unsigned);
@@ -20861,10 +20861,10 @@ OUTPUT
 select lpad('hello', 18446744073709551617, '1') from dual
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('+collections -supp* -foobar*' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('+collections -supp* -foobar*' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('+collections -supp* -foobar*' in boolean mode)
 END
 INPUT
 select date_sub("0200-01-01 00:00:01",INTERVAL 1 SECOND);
@@ -20903,10 +20903,10 @@ ERROR
 syntax error at position 32 near 'Test default delimiter;'
 END
 INPUT
-select from t1 where match a against ("te*" in boolean mode)+0;
+select * from t1 where match a against ("te*" in boolean mode)+0;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a) against ('te*' in boolean mode) + 0
 END
 INPUT
 select sql_buffer_result max(f1)+1 from t1;
@@ -21047,16 +21047,16 @@ OUTPUT
 select substr('hello', 1, -4294967296) from dual
 END
 INPUT
-select from t1 where word2=CAST(0xDF as CHAR);
+select * from t1 where word2=CAST(0xDF as CHAR);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word2 = cast(0xDF as CHAR)
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("collections" WITH QUERY EXPANSION);
+select * from t1 where MATCH(a,b) AGAINST ("collections" WITH QUERY EXPANSION);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('collections' with query expansion)
 END
 INPUT
 select user,db from information_schema.processlist;
@@ -21077,10 +21077,10 @@ OUTPUT
 select i, count(*), variance(s1 / s2) from bug22555 group by i order by i asc
 END
 INPUT
-select from mysqltest_db1.t_column_priv_only;
+select * from mysqltest_db1.t_column_priv_only;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from mysqltest_db1.t_column_priv_only
 END
 INPUT
 select maketime(10,11,12);
@@ -21197,10 +21197,10 @@ OUTPUT
 select distinct a2, a1, a2, a1 from t1
 END
 INPUT
-select from information_schema.KEY_COLUMN_USAGE where TABLE_SCHEMA= "test" order by TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, COLUMN_NAME;
+select * from information_schema.KEY_COLUMN_USAGE where TABLE_SCHEMA= "test" order by TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, COLUMN_NAME;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.KEY_COLUMN_USAGE where TABLE_SCHEMA = 'test' order by TABLE_SCHEMA asc, TABLE_NAME asc, CONSTRAINT_NAME asc, COLUMN_NAME asc
 END
 INPUT
 select left('hello', -4294967295);
@@ -21233,10 +21233,10 @@ OUTPUT
 select min(t1.a5), max(t2.a3) from t1, t2
 END
 INPUT
-select from t1 where match a against ("+aaa10 +(bbb*)" in boolean mode);
+select * from t1 where match a against ("+aaa10 +(bbb*)" in boolean mode);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a) against ('+aaa10 +(bbb*)' in boolean mode)
 END
 INPUT
 select 10.0+cast('a' as decimal);
@@ -21245,10 +21245,10 @@ OUTPUT
 select 10.0 + cast('a' as decimal) from dual
 END
 INPUT
-select from t1 where f1='test' and (f2= sha("test") or f2= sha("TEST"));
+select * from t1 where f1='test' and (f2= sha("test") or f2= sha("TEST"));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where f1 = 'test' and (f2 = sha('test') or f2 = sha('TEST'))
 END
 INPUT
 select FIND_IN_SET(_latin1'B',_latin1'a,b,c,d');
@@ -21281,10 +21281,10 @@ OUTPUT
 select sec_to_time(time_to_sec('-838:59:59')) from dual
 END
 INPUT
-select from t1 where not(a = 10);
+select * from t1 where not(a = 10);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not a = 10
 END
 INPUT
 select TABLE_NAME,COLUMN_NAME,DATA_TYPE,DATETIME_PRECISION from information_schema.columns where TABLE_SCHEMA='mysqltest' order by table_name, column_name;
@@ -21341,10 +21341,10 @@ OUTPUT
 select point(b, b) is null, linestring(b) is null, polygon(b) is null, multipoint(b) is null, multilinestring(b) is null, multipolygon(b) is null, geometrycollection(b) is null from t1
 END
 INPUT
-select from information_schema.table_privileges where grantee like '%user%' and table_schema !='mysql' order by grantee;
+select * from information_schema.table_privileges where grantee like '%user%' and table_schema !='mysql' order by grantee;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.table_privileges where grantee like '%user%' and table_schema != 'mysql' order by grantee asc
 END
 INPUT
 select lpad('hello', -18446744073709551617, '1');
@@ -21353,10 +21353,10 @@ OUTPUT
 select lpad('hello', -18446744073709551617, '1') from dual
 END
 INPUT
-select from t1 into outfile 'tmp1.txt' character set binary;
+select * from t1 into outfile 'tmp1.txt' character set binary;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 into outfile 'tmp1.txt' character set binary
 END
 INPUT
 select t1.* from t t0 cross join (t t1 join t t2 on 100=(select count(*) from t t3 left join t t4 on t4.a>t3.a-t0.a));
@@ -21383,10 +21383,10 @@ OUTPUT
 select distinct id, IFNULL(dsc, '-') from t1
 END
 INPUT
-select from t1 left join t2 on (venue_id = entity_id and match(name) against('aberdeen')) where dt = '2003-05-23 19:30:00';
+select * from t1 left join t2 on (venue_id = entity_id and match(name) against('aberdeen')) where dt = '2003-05-23 19:30:00';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on venue_id = entity_id and match(`name`) against ('aberdeen') where dt = '2003-05-23 19:30:00'
 END
 INPUT
 select col1,count(col1),sum(col1),avg(col1) from t1 group by col1;
@@ -21395,10 +21395,10 @@ OUTPUT
 select col1, count(col1), sum(col1), avg(col1) from t1 group by col1
 END
 INPUT
-select from t1 where a=_latin1'����';
+select * from t1 where a=_latin1'����';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = _latin1 '����'
 END
 INPUT
 select conv("18383815659218730760",10,10) + 0;
@@ -21455,10 +21455,10 @@ OUTPUT
 select count(*) from t1 where match(a) against ('aaa*' in boolean mode)
 END
 INPUT
-select from t1 where field < '2006-11-06 04:08:36.0';
+select * from t1 where field < '2006-11-06 04:08:36.0';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where field < '2006-11-06 04:08:36.0'
 END
 INPUT
 select 'A' like 'a' collate sjis_bin;
@@ -21479,22 +21479,22 @@ OUTPUT
 select case 1 / 0 when 'a' then 'true' else 'false' end from dual
 END
 INPUT
-select from t1 where soundex(a) = soundex('test');
+select * from t1 where soundex(a) = soundex('test');
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from t1 where word='ae';
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where soundex(a) = soundex('test')
 END
 INPUT
-select from t1 where a=lpad('xxx',10,' ');
+select * from t1 where word='ae';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word = 'ae'
+END
+INPUT
+select * from t1 where a=lpad('xxx',10,' ');
+END
+OUTPUT
+select * from t1 where a = lpad('xxx', 10, ' ')
 END
 INPUT
 select group_concat(c1 order by c1) from t1 group by c1 collate utf8_croatian_ci;
@@ -21551,10 +21551,10 @@ OUTPUT
 select charset(null), collation(null), coercibility(null) from dual
 END
 INPUT
-select from t2 where MATCH inhalt AGAINST ('foobar');
+select * from t2 where MATCH inhalt AGAINST ('foobar');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 where match(inhalt) against ('foobar')
 END
 INPUT
 select st_within(st_union(ST_GeomFromText('point(1 1)'), ST_GeomFromText('multipoint(2 2, 3 3)')), st_intersection(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)')));
@@ -21575,10 +21575,10 @@ OUTPUT
 select release_lock('test_lock2') from dual
 END
 INPUT
-select from information_schema.table_privileges order by grantee;
+select * from information_schema.table_privileges order by grantee;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.table_privileges order by grantee asc
 END
 INPUT
 select distinct char(a) from t1;
@@ -21593,10 +21593,10 @@ OUTPUT
 select group_concat(distinct a, c) from t1
 END
 INPUT
-select from t1 where a=869751 or a=736494;
+select * from t1 where a=869751 or a=736494;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = 869751 or a = 736494
 END
 INPUT
 select min(name),min(concat("*",name,"*")),max(name),max(concat("*",name,"*")) from t2;
@@ -21701,10 +21701,10 @@ OUTPUT
 select a from t1 group by b
 END
 INPUT
-select from t2 natural join t1;
+select * from t2 natural join t1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 natural join t1
 END
 INPUT
 select a, left(a,1) as b from t1;
@@ -21731,10 +21731,10 @@ OUTPUT
 select i, count(*), std(s1 / s2) from bug22555 group by i order by i asc
 END
 INPUT
-select from v1 group by id limit 1;
+select * from v1 group by id limit 1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1 group by id limit 1
 END
 INPUT
 select concat('monty',' was here ','again'),length('hello'),char(ascii('h')),ord('h');
@@ -21755,10 +21755,10 @@ OUTPUT
 select s1 as before_delete_bin from t1 where s1 like 'ペテ%'
 END
 INPUT
-select from t1 where MATCH(a,b) AGAINST ("indexes" IN BOOLEAN MODE WITH QUERY EXPANSION);
+select * from t1 where MATCH(a,b) AGAINST ("indexes" IN BOOLEAN MODE WITH QUERY EXPANSION);
 END
 ERROR
-syntax error at position 12 near 'from'
+syntax error at position 74 near 'WITH'
 END
 INPUT
 select 1 from (select 1 from test.t1) a;
@@ -21767,10 +21767,10 @@ OUTPUT
 select 1 from (select 1 from test.t1) as a
 END
 INPUT
-select from (t1 join t2 using (b)) natural join (t3 join t4 using (c));
+select * from (t1 join t2 using (b)) natural join (t3 join t4 using (c));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (t1 join t2 using (b)) natural join (t3 join t4 using (c))
 END
 INPUT
 select hex(char(1 using utf8));
@@ -21797,10 +21797,10 @@ OUTPUT
 select timestampdiff(month, '2005-09-11', '2003-09-11') from dual
 END
 INPUT
-select from sakila.film_text where film_id = 984;
+select * from sakila.film_text where film_id = 984;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from sakila.film_text where film_id = 984
 END
 INPUT
 select cast(pow(2,63) as signed) as pp;
@@ -21815,10 +21815,10 @@ OUTPUT
 select concat(2, 3) from dual
 END
 INPUT
-select from t1 where text1='teststring' or text1 like 'teststring_%';
+select * from t1 where text1='teststring' or text1 like 'teststring_%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where text1 = 'teststring' or text1 like 'teststring_%'
 END
 INPUT
 select date_format('1998-12-31','%x-%v'),date_format('1999-01-01','%x-%v');
@@ -21851,10 +21851,10 @@ OUTPUT
 select round(1.1e1, 4294967295), truncate(1.1e1, 4294967295) from dual
 END
 INPUT
-select from t1 where i = 3|||| show status like 'Slow_queries'|||| drop table t1|||| delimiter;
+select * from t1 where i = 3|||| show status like 'Slow_queries'|||| drop table t1|||| delimiter;
 END
 ERROR
-syntax error at position 12 near 'from'
+syntax error at position 33
 END
 INPUT
 select count(*) from t1 where match a against ('aaaxxx aaayyy aaazzz');
@@ -21899,10 +21899,10 @@ OUTPUT
 select date_format('1997-01-02', concat('%M %W %D ', '%Y %y %m %d %h %i %s %w')) from dual
 END
 INPUT
-select from t1 where a=concat(_koi8r'����');
+select * from t1 where a=concat(_koi8r'����');
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = concat(_koi8r '����')
 END
 INPUT
 select id, sum(qty) as sqty from t1 group by id having sqty>2 and count(qty)>1;
@@ -22121,10 +22121,10 @@ OUTPUT
 select min(a3) from t1 where a2 = 2 and a3 >= 'CHI' and a3 < 'SEA'
 END
 INPUT
-select from t1 where lower(b)='bbb';
+select * from t1 where lower(b)='bbb';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where lower(b) = 'bbb'
 END
 INPUT
 select a1,a2,b,min(c),max(c) from t1 where (a1 >= 'c' or a2 < 'b') and (c > 'b111') group by a1,a2,b;
@@ -22139,16 +22139,16 @@ OUTPUT
 select case 1 / 0 when 'a' then 'true' end + 0.0 from dual
 END
 INPUT
-select from t1 where a like 'c%';
+select * from t1 where a like 'c%';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like 'c%'
 END
 INPUT
-select from t1 where MATCH a,b AGAINST ('"Now sUPPort"' IN BOOLEAN MODE);
+select * from t1 where MATCH a,b AGAINST ('"Now sUPPort"' IN BOOLEAN MODE);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where match(a, b) against ('\"Now sUPPort\"' in boolean mode)
 END
 INPUT
 select sum(all a),count(all a),avg(all a),std(all a),variance(all a),bit_or(all a),bit_and(all a),min(all a),max(all a),min(all c),max(all c) from t1;
@@ -22217,10 +22217,10 @@ OUTPUT
 select max(b) from t1 where a = 2
 END
 INPUT
-select from t1 where length(s1)=1 and s1='oe';
+select * from t1 where length(s1)=1 and s1='oe';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where length(s1) = 1 and s1 = 'oe'
 END
 INPUT
 select c,table_name from v1 left join information_schema.TABLES v2 on (v1.c=v2.table_name) where v1.c rlike "t[1-5]{1}$" order by c;
@@ -22325,10 +22325,10 @@ OUTPUT
 select ST_astext(st_difference(ST_GeomFromText('multipoint(2 2, 3 3)'), st_intersection(ST_GeomFromText('point(0 0)'), ST_GeomFromText('point(1 1)')))) from dual
 END
 INPUT
-select from v1b;
+select * from v1b;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from v1b
 END
 INPUT
 select command_type, argument from mysql.general_log where thread_id = @thread_id;
@@ -22337,10 +22337,10 @@ OUTPUT
 select command_type, argument from mysql.general_log where thread_id = @thread_id
 END
 INPUT
-select from t1 where a like binary "%�%";
+select * from t1 where a like binary "%�%";
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a like convert('%�%', binary)
 END
 INPUT
 select a1,a2,b,min(c),max(c) from t1 where (c > 'b111') and (c <= 'g112') group by a1,a2,b;
@@ -22385,10 +22385,10 @@ OUTPUT
 select cast(concat('184467440', '73709551615') as signed) from dual
 END
 INPUT
-select from t3 left join (t2 outr2 join t2 outr join t1) on (outr.pk = t3.pk) and (t1.col_int_key = t3.pk) and isnull(t1.col_date_key) and (outr2.pk <> t3.pk);
+select * from t3 left join (t2 outr2 join t2 outr join t1) on (outr.pk = t3.pk) and (t1.col_int_key = t3.pk) and isnull(t1.col_date_key) and (outr2.pk <> t3.pk);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t3 left join (t2 as outr2 join t2 as outr join t1) on outr.pk = t3.pk and t1.col_int_key = t3.pk and isnull(t1.col_date_key) and outr2.pk != t3.pk
 END
 INPUT
 select group_concat(c1 order by c1) from t1 group by c1 collate utf8_roman_ci;
@@ -22493,16 +22493,16 @@ OUTPUT
 select date_add(`date`, interval 1 SECOND) from t1
 END
 INPUT
-select from t1 order by i1;
+select * from t1 order by i1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 order by i1 asc
 END
 INPUT
-select from t5 /bin /boot /cdrom /dev /etc /home /lib /lib32 /lib64 /libx32 /lost+found /media /mnt /opt /proc /root /run /sbin /snap /srv /swapfile /sys /tmp /usr /var must be (1),(1) */;
+select * from t5 /bin /boot /cdrom /dev /etc /home /lib /lib32 /lib64 /libx32 /lost+found /media /mnt /opt /proc /root /run /sbin /snap /srv /swapfile /sys /tmp /usr /var must be (1),(1) */;
 END
 ERROR
-syntax error at position 12 near 'from'
+syntax error at position 19
 END
 INPUT
 select concat("-",a,"-",b,"-") from t1 ignore index (a) where a="hello ";
@@ -22529,10 +22529,10 @@ OUTPUT
 select f1(1) from dual
 END
 INPUT
-select from t1 where a > 5 and not(a > 10);
+select * from t1 where a > 5 and not(a > 10);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a > 5 and not a > 10
 END
 INPUT
 select _ujis 0xa1a2a1a3 like concat(_ujis'%',_ujis 0xa2a1, _ujis'%');
@@ -22583,10 +22583,10 @@ OUTPUT
 select cast('18446744073709551615' as unsigned) from dual
 END
 INPUT
-select from t1 where s1 > 'd' and s1 = 'CH';
+select * from t1 where s1 > 'd' and s1 = 'CH';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where s1 > 'd' and s1 = 'CH'
 END
 INPUT
 select benchmark(100, (select avg(a) from table_26093));
@@ -22607,10 +22607,10 @@ ERROR
 syntax error at position 61 near 'save_expire_logs_days'
 END
 INPUT
-select from t1 where a=if(b<10,_ucs2 0x0062,_ucs2 0x00C0);
+select * from t1 where a=if(b<10,_ucs2 0x0062,_ucs2 0x00C0);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where a = if(b < 10, _ucs2 0x0062, _ucs2 0x00C0)
 END
 INPUT
 select distinct left(name,1) as name from t1;
@@ -22631,10 +22631,10 @@ OUTPUT
 select ctime, hour(ctime) from t1
 END
 INPUT
-select from t1 order by (oct(a));
+select * from t1 order by (oct(a));
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 order by oct(a) asc
 END
 INPUT
 select hex(char(0x010203 using utf32));
@@ -22733,10 +22733,10 @@ OUTPUT
 select repeat('hello', 4294967295) from dual
 END
 INPUT
-select from t1 where word like binary 0xDF;
+select * from t1 where word like binary 0xDF;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where word like convert(0xDF, binary)
 END
 INPUT
 select count(*), min(7), max(7) from t2m, t1i;
@@ -22745,10 +22745,10 @@ OUTPUT
 select count(*), min(7), max(7) from t2m, t1i
 END
 INPUT
-select from t1 left join t2 on t1.a=t2.a where not (t2.a <=> t1.a);
+select * from t1 left join t2 on t1.a=t2.a where not (t2.a <=> t1.a);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on t1.a = t2.a where not t2.a <=> t1.a
 END
 INPUT
 select 'aa' like 'a%';
@@ -22817,10 +22817,10 @@ OUTPUT
 select domain from t1 where concat('@', trim(leading '.' from concat('.', domain))) = '@test.de'
 END
 INPUT
-select from t1 natural left join (t4 natural join t5) where t4.y > 7;
+select * from t1 natural left join (t4 natural join t5) where t4.y > 7;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 natural left join (t4 natural join t5) where t4.y > 7
 END
 INPUT
 select release_lock("test_lock2_1");
@@ -22829,28 +22829,28 @@ OUTPUT
 select release_lock('test_lock2_1') from dual
 END
 INPUT
-select from t1 where misc > 5 and bool is null;
+select * from t1 where misc > 5 and bool is null;
 END
-ERROR
-syntax error at position 12 near 'from'
-END
-INPUT
-select from (select from t3 natural join t4) as t34 natural right join (select from t1 natural join t2) as t12;
-END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where misc > 5 and `bool` is null
 END
 INPUT
-select from t7 where concat(s1 collate latin1_general_ci,s1 collate latin1_swedish_ci) = 'AA';
+select * from (select * from t3 natural join t4) as t34 natural right join (select * from t1 natural join t2) as t12;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from (select * from t3 natural join t4) as t34 natural right join (select * from t1 natural join t2) as t12
 END
 INPUT
-select from (select from t1 union all select from t1) a;
+select * from t7 where concat(s1 collate latin1_general_ci,s1 collate latin1_swedish_ci) = 'AA';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t7 where concat(s1 collate latin1_general_ci, s1 collate latin1_swedish_ci) = 'AA'
+END
+INPUT
+select * from (select * from t1 union all select * from t1) a;
+END
+OUTPUT
+select * from (select * from t1 union all select * from t1) as a
 END
 INPUT
 select coalesce('�',c1), coalesce(null,c1) from t1;
@@ -22901,10 +22901,10 @@ OUTPUT
 select count(*) from t1
 END
 INPUT
-select FROM t4 where fld3='bonfire';
+select * from t4 where fld3='bonfire';
 END
-ERROR
-syntax error at position 12 near 'FROM'
+OUTPUT
+select * from t4 where fld3 = 'bonfire'
 END
 INPUT
 select ST_AsText(a) from t1 where MBRContains(ST_GeomFromText('Polygon((0 0, 0 2, 2 2, 2 0, 0 0))'), a) and MBRContains(ST_GeomFromText('Polygon((0 0, 0 7, 7 7, 7 0, 0 0))'), a);
@@ -22937,10 +22937,10 @@ OUTPUT
 select date_add('1997-12-31 23:59:59', interval 100000 MONTH) from dual
 END
 INPUT
-select from t2 order by name;
+select * from t2 order by name;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t2 order by `name` asc
 END
 INPUT
 select RANDOM_BYTES(0);
@@ -22979,10 +22979,10 @@ OUTPUT
 select 5 from dual
 END
 INPUT
-select from t1 where not(NULL or a);
+select * from t1 where not(NULL or a);
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where not (null or a)
 END
 INPUT
 select log(-2,1);
@@ -23009,16 +23009,16 @@ OUTPUT
 select substring_index('the king of the the hill', ' the ', -1) from dual
 END
 INPUT
-select from t6;
+select * from t6;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t6
 END
 INPUT
-select from t1 where city = 'Durban ';
+select * from t1 where city = 'Durban ';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where city = 'Durban '
 END
 INPUT
 select max(t1.a1) from t1, t2;
@@ -23057,10 +23057,10 @@ OUTPUT
 select substr('hello', -4294967295, 1) from dual
 END
 INPUT
-select from t1 where value <=> value;
+select * from t1 where value <=> value;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 where value <=> value
 END
 INPUT
 select f3 from t1 where f3 between cast("2006-1-1 12:1:1" as datetime) and cast("2006-1-1 12:1:2" as datetime);
@@ -23069,10 +23069,10 @@ OUTPUT
 select f3 from t1 where f3 between cast('2006-1-1 12:1:1' as datetime) and cast('2006-1-1 12:1:2' as datetime)
 END
 INPUT
-select from t1 left join t2 on venue_id = entity_id where match(name) against('aberdeen') and dt = '2003-05-23 19:30:00';
+select * from t1 left join t2 on venue_id = entity_id where match(name) against('aberdeen') and dt = '2003-05-23 19:30:00';
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 left join t2 on venue_id = entity_id where match(`name`) against ('aberdeen') and dt = '2003-05-23 19:30:00'
 END
 INPUT
 select concat('|', text1, '|') from t1 where text1='teststring ';
@@ -23087,16 +23087,16 @@ OUTPUT
 select Host, Db, `User`, Table_name, Column_name, Column_priv from mysql.columns_priv
 END
 INPUT
-select from t1 group by f1;
+select * from t1 group by f1;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from t1 group by f1
 END
 INPUT
-select tt.* from (select from t1) as tt order by 1, 2;
+select tt.* from (select * from t1) as tt order by 1, 2;
 END
-ERROR
-syntax error at position 30 near 'from'
+OUTPUT
+select tt.* from (select * from t1) as tt order by 1 asc, 2 asc
 END
 INPUT
 select @@key_cache_block_size;
@@ -23105,10 +23105,10 @@ OUTPUT
 select @@key_cache_block_size from dual
 END
 INPUT
-select from `information_schema`.`PARTITIONS` where `TABLE_SCHEMA` = NULL;
+select * from `information_schema`.`PARTITIONS` where `TABLE_SCHEMA` = NULL;
 END
-ERROR
-syntax error at position 12 near 'from'
+OUTPUT
+select * from information_schema.`PARTITIONS` where TABLE_SCHEMA = null
 END
 INPUT
 select space(18446744073709551615);


### PR DESCRIPTION
There are over 500 test cases in `select_cases.txt` that are all invalid because it uses `select from`. This is more likely a mistake, since the queries are valid if this is changed to `select * from`.

Moving this exercises more valid queries and improves test coverage. Having 500+ cases that all test the exact same parse error isn't useful so I think this change is a net improvement.

## Related Issue(s)

Found as part of work on #10203 & #8604

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
