### PR TITLE
test: for unit tests set TMPDIR=/tmp_XXXXXX on mac

### DIFF
--- a/tools/unit_test_runner.sh
+++ b/tools/unit_test_runner.sh
@@ -36,6 +36,20 @@ if [[ -z $VT_GO_PARALLEL && -n $VT_GO_PARALLEL_VALUE ]]; then
   VT_GO_PARALLEL="-p $VT_GO_PARALLEL_VALUE"
 fi
 
+# Mac makes long temp directories for os.TempDir(). MySQL can't connect to
+# sockets in those directories. Tell Golang to use /tmp/vttest_XXXXXX instead.
+kernel="$(uname -s)"
+case "$kernel" in
+  darwin|Darwin)
+    TMPDIR=${TMPDIR:-}
+    if [ -z "$TMPDIR" ]; then
+      TMPDIR="$(mktemp -d /tmp/vttest_XXXXXX)"
+      export TMPDIR
+    fi
+    echo "Using temporary directory for tests: $TMPDIR"
+    ;;
+esac
+
 # All Go packages with test files.
 # Output per line: <full Go package name> <all _test.go files in the package>*
 packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/... | sort)


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->
## Description

Some tests use `t.TempDir` ([docs](https://pkg.go.dev/testing#B.TempDir)) to create temp dirs for storing per-test
files, such as MySQL configuration files and logs.

On Mac OS, this can generate long directory names, such as
`/var/folders/96/k7gzd7q10zdb749vr02q7sjh0000gn/T/tmp.yqDFqOY3`. If during
a test a mysqld socket is put in a long directory like that, mysql
client won't be able to connect to it, and the test will fail.

This commit modifies `tools/unit_test_runner.sh` so that on Mac OS, as
long as TMPDIR isn't already set, it will export
`TMPDIR=/tmp/vttest_XXXXX` (where `XXXXXX` is dynamically replaced with
random characters). Golang uses that as a base for further temporary
files and directories.

## Related Issue(s)

Fixes #10649

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->