### PR TITLE
Fix VTOrc Discovery to also retry discovering tablets which aren't present in database_instance table

### DIFF
--- a/go/test/endtoend/vtorc/general/vtorc_test.go
+++ b/go/test/endtoend/vtorc/general/vtorc_test.go
@@ -426,9 +426,9 @@ func TestMultipleDurabilities(t *testing.T) {
 	assert.NotNil(t, primary, "should have elected a primary")
 }
 
-// TestDurabilityPolicySetLate tests that VTOrc works even if the durability policy of the keyspace is
+// TestDurabilityPolicySetLater tests that VTOrc works even if the durability policy of the keyspace is
 // set after VTOrc has been started.
-func TestDurabilityPolicySetLate(t *testing.T) {
+func TestDurabilityPolicySetLater(t *testing.T) {
 	// stop any vtorc instance running due to a previous test.
 	utils.StopVtorcs(t, clusterInfo)
 	newCluster := utils.SetupNewClusterSemiSync(t)
@@ -436,7 +436,7 @@ func TestDurabilityPolicySetLate(t *testing.T) {
 	shard0 := &keyspace.Shards[0]
 	// Before starting VTOrc we explicity want to set the durability policy of the keyspace to an empty string
 	func() {
-		ctx, unlock, lockErr := newCluster.Ts.LockKeyspace(context.Background(), keyspace.Name, "TestDurabilityPolicySetLate")
+		ctx, unlock, lockErr := newCluster.Ts.LockKeyspace(context.Background(), keyspace.Name, "TestDurabilityPolicySetLater")
 		require.NoError(t, lockErr)
 		defer unlock(&lockErr)
 		ki, err := newCluster.Ts.GetKeyspace(ctx, keyspace.Name)

--- a/go/test/endtoend/vtorc/general/vtorc_test.go
+++ b/go/test/endtoend/vtorc/general/vtorc_test.go
@@ -17,18 +17,17 @@ limitations under the License.
 package general
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
-
-	"vitess.io/vitess/go/vt/log"
-
-	"vitess.io/vitess/go/test/endtoend/vtorc/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/vtorc/utils"
+	"vitess.io/vitess/go/vt/log"
 )
 
 // Cases to test:
@@ -425,4 +424,52 @@ func TestMultipleDurabilities(t *testing.T) {
 	// find primary from topo
 	primary := utils.ShardPrimaryTablet(t, clusterInfo, keyspaceSemiSync, shardSemiSync)
 	assert.NotNil(t, primary, "should have elected a primary")
+}
+
+// TestDurabilityPolicySetLate tests that VTOrc works even if the durability policy of the keyspace is
+// set after VTOrc has been started.
+func TestDurabilityPolicySetLate(t *testing.T) {
+	// stop any vtorc instance running due to a previous test.
+	utils.StopVtorcs(t, clusterInfo)
+	newCluster := utils.SetupNewClusterSemiSync(t)
+	keyspace := &newCluster.ClusterInstance.Keyspaces[0]
+	shard0 := &keyspace.Shards[0]
+	// Before starting VTOrc we explicity want to set the durability policy of the keyspace to an empty string
+	func() {
+		ctx, unlock, lockErr := newCluster.Ts.LockKeyspace(context.Background(), keyspace.Name, "TestDurabilityPolicySetLate")
+		require.NoError(t, lockErr)
+		defer unlock(&lockErr)
+		ki, err := newCluster.Ts.GetKeyspace(ctx, keyspace.Name)
+		require.NoError(t, err)
+		ki.DurabilityPolicy = ""
+		err = newCluster.Ts.UpdateKeyspace(ctx, ki)
+		require.NoError(t, err)
+	}()
+
+	// Verify that the durability policy is indeed empty
+	ki, err := newCluster.Ts.GetKeyspace(context.Background(), keyspace.Name)
+	require.NoError(t, err)
+	require.Empty(t, ki.DurabilityPolicy)
+
+	// Now start the vtorc instances
+	utils.StartVtorcs(t, newCluster, nil, cluster.VtorcConfiguration{
+		PreventCrossDataCenterPrimaryFailover: true,
+	}, 1)
+	defer func() {
+		utils.StopVtorcs(t, newCluster)
+		newCluster.ClusterInstance.Teardown()
+	}()
+
+	// Wait for some time to be sure that VTOrc has started.
+	// TODO(GuptaManan100): Once we have a debug page for VTOrc, use that instead
+	time.Sleep(30 * time.Second)
+
+	// Now set the correct durability policy
+	out, err := newCluster.VtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspace.Name, "--durability-policy=semi_sync")
+	require.NoError(t, err, out)
+
+	// VTOrc should promote a new primary after seeing the durability policy change
+	primary := utils.ShardPrimaryTablet(t, newCluster, keyspace, shard0)
+	assert.NotNil(t, primary, "should have elected a primary")
+	utils.CheckReplication(t, newCluster, primary, shard0.Vttablets, 10*time.Second)
 }

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -805,9 +805,12 @@ func SetupNewClusterSemiSync(t *testing.T) *VtOrcClusterInfo {
 	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
 	require.NoError(t, err, out)
 
+	// create topo server connection
+	ts, err := topo.OpenServer(*clusterInstance.TopoFlavorString(), clusterInstance.VtctlProcess.TopoGlobalAddress, clusterInstance.VtctlProcess.TopoGlobalRoot)
+	require.NoError(t, err)
 	clusterInfo := &VtOrcClusterInfo{
 		ClusterInstance:     clusterInstance,
-		Ts:                  nil,
+		Ts:                  ts,
 		CellInfos:           nil,
 		lastUsedValue:       100,
 		VtctldClientProcess: vtctldClientProcess,

--- a/go/vt/orchestrator/inst/instance_dao.go
+++ b/go/vt/orchestrator/inst/instance_dao.go
@@ -2103,24 +2103,37 @@ func ReadAllMinimalInstances() ([]MinimalInstance, error) {
 }
 
 // ReadOutdatedInstanceKeys reads and returns keys for all instances that are not up to date (i.e.
-// pre-configured time has passed since they were last checked)
-// But we also check for the case where an attempt at instance checking has been made, that hasn't
+// pre-configured time has passed since they were last checked) or the ones whose tablet information was read
+// but not the mysql information. This could happen if the durability policy of the keyspace wasn't
+// available at the time it was discovered. This would lead to not having the record of the tablet in the
+// database_instance table.
+// We also check for the case where an attempt at instance checking has been made, that hasn't
 // resulted in an actual check! This can happen when TCP/IP connections are hung, in which case the "check"
 // never returns. In such case we multiply interval by a factor, so as not to open too many connections on
 // the instance.
 func ReadOutdatedInstanceKeys() ([]InstanceKey, error) {
 	res := []InstanceKey{}
 	query := `
-		select
+		SELECT
 			hostname, port
-		from
+		FROM
 			database_instance
-		where
-			case
-				when last_attempted_check <= last_checked
-				then last_checked < now() - interval ? second
-				else last_checked < now() - interval ? second
-			end
+		WHERE
+			CASE
+				WHEN last_attempted_check <= last_checked
+				THEN last_checked < now() - interval ? second
+				ELSE last_checked < now() - interval ? second
+			END
+		UNION
+		SELECT
+			vitess_tablet.hostname, vitess_tablet.port
+		FROM
+			vitess_tablet LEFT JOIN database_instance ON (
+			vitess_tablet.hostname = database_instance.hostname
+			AND vitess_tablet.port = database_instance.port
+		)
+		WHERE
+			database_instance.hostname IS NULL
 			`
 	args := sqlutils.Args(config.Config.InstancePollSeconds, 2*config.Config.InstancePollSeconds)
 


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds and end to end reproducing the linked issue wherein if the durability policy is set after VTOrc startup, VTOrc cannot pick up the changes and does not discover the vttablets at all, even after a lot of time elapses.

The problem was found in the loop where we refresh the MySQL information for vttablets. There we were only looking for tablets that were outdated i.e. their last valid check was older than the configured time.
In case the durability policy doesn't exist when the tablets are first discovered, we do not read the MySQL information and exit out early, leading to the tablet not being present in the `database_instance` table at all.
Therefore, the fix entails also checking for these tablets as well in the refresh code. The way to find these tablets is to find the ones that are present in the `vitess_tablet` table but not in the `database_instance` table. This operation is equivalent to an anti-join between the two tables, which can be written in MySQL as a left outer join with a predicate for only selecting rows that didn't have a matching counterpart in the `database_instance` table.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #10650

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
