### PR TITLE
Experiment: rowstreamer to select @@global.gtid_executed as part of sendQuery

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -229,6 +229,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 	var sqlbuffer bytes2.Buffer
 
 	err = vc.vr.sourceVStreamer.VStreamRows(ctx, initialPlan.SendRule.Filter, lastpkpb, func(rows *binlogdatapb.VStreamRowsResponse) error {
+		fmt.Printf("======== ZZZ2 got rows.gtid: %v\n", rows.Gtid)
 		for {
 			select {
 			case <-rowsCopiedTicker.C:
@@ -257,6 +258,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 			if len(rows.Fields) == 0 {
 				return fmt.Errorf("expecting field event first, got: %v", rows)
 			}
+			fmt.Printf("======== ZZZ2 calling fastForward with gtid: %v\n", rows.Gtid)
 			if err := vc.fastForward(ctx, copyState, rows.Gtid); err != nil {
 				return err
 			}
@@ -349,7 +351,9 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 
 func (vc *vcopier) fastForward(ctx context.Context, copyState map[string]*sqltypes.Result, gtid string) error {
 	defer vc.vr.stats.PhaseTimings.Record("fastforward", time.Now())
+	fmt.Printf("======== ZZZ3  fastForward gtid: %v\n", gtid)
 	pos, err := mysql.DecodePosition(gtid)
+	fmt.Printf("======== ZZZ4 fastForward pos: %v, err: %v\n", pos, err)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -313,6 +313,7 @@ func (rs *rowStreamer) streamQuery(conn *snapshotConn, send func(*binlogdatapb.V
 		charsets[i] = collations.ID(fld.Charset)
 	}
 
+	var gtidReadFromRow bool
 	var reportGTIDOnce sync.Once
 	reportGTID := func() error {
 		var err error
@@ -371,12 +372,13 @@ func (rs *rowStreamer) streamQuery(conn *snapshotConn, send func(*binlogdatapb.V
 		if mysqlrow == nil {
 			break
 		}
-		if gtid == "" {
+		if !gtidReadFromRow {
 			gtid = mysqlrow[len(mysqlrow)-1].ToString()
 			log.Infof("======== ZZZ got gtid from row: %v\n", gtid)
 			if err := reportGTID(); err != nil {
 				return err
 			}
+			gtidReadFromRow = true
 		}
 		// truncate the row -- remove @@gtid_executed
 		// mysqlrow = mysqlrow[0 : len(mysqlrow)-1]

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -241,6 +241,7 @@ func (rs *rowStreamer) buildSelect() (string, error) {
 		}
 		prefix = ", "
 	}
+	buf.Myprintf(", @@global.gtid_executed as _vt_rowstreamer_gtid_executed")
 	buf.Myprintf(" from %v", sqlparser.NewIdentifierCS(rs.plan.Table.Name))
 	if len(rs.lastpk) != 0 {
 		if len(rs.lastpk) != len(rs.pkColumns) {

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -48,7 +48,7 @@ func snapshotConnect(ctx context.Context, cp dbconfigs.Connector) (*snapshotConn
 // It returns the gtid of the time when the snapshot was taken.
 func (conn *snapshotConn) streamWithSnapshot(ctx context.Context, table, query string) (gtid string, err error) {
 	// gtid, err = conn.startSnapshot(ctx, table)
-	gtid, err = conn.startSnapshotWithoutGTID(ctx)
+	gtid, err = conn.startSnapshotWithoutLock(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -102,7 +102,7 @@ func (conn *snapshotConn) startSnapshot(ctx context.Context, table string) (gtid
 }
 
 // snapshot performs the snapshotting.
-func (conn *snapshotConn) startSnapshotWithoutGTID(ctx context.Context) (gtid string, err error) {
+func (conn *snapshotConn) startSnapshotWithoutLock(ctx context.Context) (gtid string, err error) {
 	// Starting a transaction now will allow us to start the read later,
 	// which will happen after we release the lock on the table.
 	if _, err := conn.ExecuteFetch("set transaction isolation level repeatable read", 1, false); err != nil {
@@ -114,7 +114,11 @@ func (conn *snapshotConn) startSnapshotWithoutGTID(ctx context.Context) (gtid st
 	if _, err := conn.ExecuteFetch("set @@session.time_zone = '+00:00'", 1, false); err != nil {
 		return "", err
 	}
-	return "", nil
+	mpos, err := conn.PrimaryPosition()
+	if err != nil {
+		return "", err
+	}
+	return mysql.EncodePosition(mpos), nil
 }
 
 // Close rollsback any open transactions and closes the connection.

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -47,8 +47,8 @@ func snapshotConnect(ctx context.Context, cp dbconfigs.Connector) (*snapshotConn
 // startSnapshot starts a streaming query with a snapshot view of the specified table.
 // It returns the gtid of the time when the snapshot was taken.
 func (conn *snapshotConn) streamWithSnapshot(ctx context.Context, table, query string) (gtid string, err error) {
-	gtid, err = conn.startSnapshot(ctx, table)
-	// gtid, err = conn.startSnapshotWithoutGTID(ctx)
+	// gtid, err = conn.startSnapshot(ctx, table)
+	gtid, err = conn.startSnapshotWithoutGTID(ctx)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## EXPERIMENTAL

## Description

This is an experiment to see whether we can get a transactional consistent `@@gtid_executed`. It's a different approach to #9991. In this experiment, we modify `sendQuery` to select an extra column, which is `@@global.gtid_executed`. Previous experiments show that the value is consistent/fixed within the transaction; what we want to validate here is that it is consistent with the transaction itself, ie that it represents the GTID value consistent with the data the transaction sees.

## Related Issue(s)


## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
