### PR TITLE
Use TMC RPCs in VTOrc

### DIFF
--- a/go/vt/orchestrator/logic/tablet_discovery.go
+++ b/go/vt/orchestrator/logic/tablet_discovery.go
@@ -43,6 +43,7 @@ import (
 
 var (
 	ts                *topo.Server
+	tmc               tmclient.TabletManagerClient
 	clustersToWatch   = flag.String("clusters_to_watch", "", "Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: \"ks1,ks2/-80\"")
 	shutdownWaitTime  = flag.Duration("shutdown_wait_time", 30*time.Second, "maximum time to wait for vtorc to release all the locks that it is holding before shutting down on SIGTERM")
 	shardsLockCounter int32
@@ -55,6 +56,7 @@ func OpenTabletDiscovery() <-chan time.Time {
 	ts = topo.Open()
 	// TODO(sougou): remove ts and push some functions into inst.
 	inst.TopoServ = ts
+	tmc = tmclient.NewTabletManagerClient()
 	// Clear existing cache and perform a new refresh.
 	if _, err := db.ExecOrchestrator("delete from vitess_tablet"); err != nil {
 		log.Errore(err)
@@ -285,55 +287,23 @@ func TabletRefresh(instanceKey inst.InstanceKey) (*topodatapb.Tablet, error) {
 	return ti.Tablet, nil
 }
 
-// TabletDemotePrimary requests the primary tablet to stop accepting transactions.
-func TabletDemotePrimary(instanceKey inst.InstanceKey) error {
-	return tabletDemotePrimary(instanceKey, true)
+// tabletUndoDemotePrimary calls the said RPC for the given tablet.
+func tabletUndoDemotePrimary(ctx context.Context, tablet *topodatapb.Tablet, semiSync bool) error {
+	return tmc.UndoDemotePrimary(ctx, tablet, semiSync)
 }
 
-// TabletUndoDemotePrimary requests the primary tablet to undo the demote.
-func TabletUndoDemotePrimary(instanceKey inst.InstanceKey) error {
-	return tabletDemotePrimary(instanceKey, false)
-}
-
-func tabletDemotePrimary(instanceKey inst.InstanceKey, forward bool) error {
-	if instanceKey.Hostname == "" {
-		return errors.New("can't demote/undo primary: instance is unspecified")
-	}
-	tablet, err := inst.ReadTablet(instanceKey)
-	if err != nil {
-		return err
-	}
-	durability, err := inst.GetDurabilityPolicy(tablet)
-	if err != nil {
-		return err
-	}
-	tmc := tmclient.NewTabletManagerClient()
-	// TODO(sougou): this should be controllable because we may want
-	// to give a longer timeout for a graceful takeover.
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	if forward {
-		_, err = tmc.DemotePrimary(ctx, tablet)
-	} else {
-		err = tmc.UndoDemotePrimary(ctx, tablet, inst.SemiSyncAckers(durability, instanceKey) > 0)
-	}
-	return err
-}
-
-// SetReadOnly calls the said RPC for the given tablet
-func SetReadOnly(ctx context.Context, tablet *topodatapb.Tablet) error {
-	tmc := tmclient.NewTabletManagerClient()
+// setReadOnly calls the said RPC for the given tablet
+func setReadOnly(ctx context.Context, tablet *topodatapb.Tablet) error {
 	return tmc.SetReadOnly(ctx, tablet)
 }
 
-// SetReplicationSource calls the said RPC with the parameters provided
-func SetReplicationSource(ctx context.Context, replica *topodatapb.Tablet, primary *topodatapb.Tablet, semiSync bool) error {
-	tmc := tmclient.NewTabletManagerClient()
+// setReplicationSource calls the said RPC with the parameters provided
+func setReplicationSource(ctx context.Context, replica *topodatapb.Tablet, primary *topodatapb.Tablet, semiSync bool) error {
 	return tmc.SetReplicationSource(ctx, replica, primary.Alias, 0, "", true, semiSync)
 }
 
-// ShardPrimary finds the primary of the given keyspace-shard by reading the topo server
-func ShardPrimary(ctx context.Context, keyspace string, shard string) (primary *topodatapb.Tablet, err error) {
+// shardPrimary finds the primary of the given keyspace-shard by reading the topo server
+func shardPrimary(ctx context.Context, keyspace string, shard string) (primary *topodatapb.Tablet, err error) {
 	si, err := ts.GetShard(ctx, keyspace, shard)
 	if err != nil {
 		return nil, err

--- a/go/vt/orchestrator/logic/topology_recovery.go
+++ b/go/vt/orchestrator/logic/topology_recovery.go
@@ -1775,18 +1775,6 @@ func fixPrimary(ctx context.Context, analysisEntry inst.ReplicationAnalysis, can
 	defer func() {
 		resolveRecovery(topologyRecovery, nil)
 	}()
-	durability, err := inst.GetDurabilityPolicy(analysisEntry.AnalyzedInstanceKey)
-	if err != nil {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("can't read durability policy - %v.", err))
-		return false, topologyRecovery, err
-	}
-	// TODO(sougou): this code pattern has reached DRY limits. Reuse.
-	count := inst.SemiSyncAckers(durability, analysisEntry.AnalyzedInstanceKey)
-	err = inst.SetSemiSyncPrimary(&analysisEntry.AnalyzedInstanceKey, count > 0)
-	//AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- fixPrimary: applying semi-sync %v: success=%t", count > 0, (err == nil)))
-	if err != nil {
-		return false, topologyRecovery, err
-	}
 
 	if err := TabletUndoDemotePrimary(analysisEntry.AnalyzedInstanceKey); err != nil {
 		return false, topologyRecovery, err


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR changes the last remaining recovery function of VTOrc `fixReplica` to also use TabletManagerClient RPCs instead of running operations on the MySQL instance directly. 
In `fixReplica`, there are multiple things that need to be fixed - 
- The correct primary source should be set
- Replication should be started
- Correct semi-sync settings should be set
- The tablet should be read-only

The first 3 things are accomplished by `SetReplicationSource` RPC and the last by `SetReadOnly` RPC. Functionally, there is no difference from the user standpoint, but internally, now VTOrc talks to MySQL through the vttablet. 

As part of the PR, I also clean up the `fixPrimary` function. The code to set semi-sync directly on the MySQL instance was redundant since the following RPC already accomplished it. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #6612 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
