### PR TITLE
Inject shard name in commit-phase multi-shard errors

### DIFF
--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -99,7 +99,7 @@ func NewTabletGateway(ctx context.Context, hc discovery.HealthCheck, serv srvtop
 		statusAggregators: make(map[string]*TabletStatusAggregator),
 	}
 	gw.setupBuffering(ctx)
-	gw.QueryService = queryservice.Wrap(nil, gw.withRetry)
+	gw.QueryService = queryservice.Wrap(queryservice.Wrap(nil, gw.withRetry), gw.withShardError)
 	return gw
 }
 
@@ -160,7 +160,8 @@ func (gw *TabletGateway) setupBuffering(ctx context.Context) {
 
 // QueryServiceByAlias satisfies the Gateway interface
 func (gw *TabletGateway) QueryServiceByAlias(alias *topodatapb.TabletAlias, target *querypb.Target) (queryservice.QueryService, error) {
-	return gw.hc.TabletConnection(alias, target)
+	qs, err := gw.hc.TabletConnection(alias, target)
+	return queryservice.Wrap(qs, gw.withShardError), NewShardError(err, target)
 }
 
 // RegisterStats registers the stats to export the lag since the last refresh
@@ -334,6 +335,13 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 		}
 		break
 	}
+	return err
+}
+
+// withShardError adds shard information to errors returned from the inner QueryService.
+func (gw *TabletGateway) withShardError(ctx context.Context, target *querypb.Target, conn queryservice.QueryService,
+	_ string, _ bool, inner func(ctx context.Context, target *querypb.Target, conn queryservice.QueryService) (bool, error)) error {
+	_, err := inner(ctx, target, conn)
 	return NewShardError(err, target)
 }
 

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -99,7 +99,7 @@ func NewTabletGateway(ctx context.Context, hc discovery.HealthCheck, serv srvtop
 		statusAggregators: make(map[string]*TabletStatusAggregator),
 	}
 	gw.setupBuffering(ctx)
-	gw.QueryService = queryservice.Wrap(queryservice.Wrap(nil, gw.withRetry), gw.withShardError)
+	gw.QueryService = queryservice.Wrap(nil, gw.withRetry)
 	return gw
 }
 
@@ -228,6 +228,9 @@ func (gw *TabletGateway) CacheStatus() TabletCacheStatusList {
 // the middle of a transaction. While returning the error check if it maybe a result of
 // a resharding event, and set the re-resolve bit and let the upper layers
 // re-resolve and retry.
+//
+// withRetry also adds shard information to errors returned from the inner QueryService, so
+// withShardError should not be combined with withRetry.
 func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, _ queryservice.QueryService,
 	_ string, inTransaction bool, inner func(ctx context.Context, target *querypb.Target, conn queryservice.QueryService) (bool, error)) error {
 	// for transactions, we connect to a specific tablet instead of letting gateway choose one
@@ -335,7 +338,7 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 		}
 		break
 	}
-	return err
+	return NewShardError(err, target)
 }
 
 // withShardError adds shard information to errors returned from the inner QueryService.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

In MULTI transactional mode, errors can occur at different phases:

 1. When the transaction is started (e.g. with `BEGIN`).
 2. Inside the transaction.
 3. When the transaction is committed (e.g. with `COMMIT`).

Error messages generated within-transaction include the shard name,
e.g.:

> ERROR 1317 (70100): target: keyspace2.c0-.primary: vttablet: ...

However, messages generated in the commit phase do not:

> ERROR 1317 (70100): vttablet: rpc error: code = Canceled desc...

This commit injects shard name into commit-phase errors.

## Related Issue(s)

#10692 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->