### PR TITLE
Fix full status test to work with both MySQL versions and de-flake it

### DIFF
--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -154,7 +154,7 @@ func TestFullStatus(t *testing.T) {
 	assert.Equal(t, "ON", primaryStatus.GtidMode)
 	assert.True(t, primaryStatus.LogReplicaUpdates)
 	assert.True(t, primaryStatus.LogBinEnabled)
-	assert.Contains(t, primaryStatus.Version, "5.7")
+	assert.Regexp(t, `[58]\.[07].*`, primaryStatus.Version)
 	assert.NotEmpty(t, primaryStatus.VersionComment)
 
 	// Check that full status gives the correct result for a replica tablet
@@ -174,7 +174,7 @@ func TestFullStatus(t *testing.T) {
 	assert.Empty(t, replicaStatus.ReplicationStatus.LastIoError)
 	assert.Empty(t, replicaStatus.ReplicationStatus.LastSqlError)
 	assert.Equal(t, replicaStatus.ReplicationStatus.SourceUuid, primaryStatus.ServerUuid)
-	assert.EqualValues(t, 0, replicaStatus.ReplicationStatus.ReplicationLagSeconds)
+	assert.LessOrEqual(t, int(replicaStatus.ReplicationStatus.ReplicationLagSeconds), 1)
 	assert.False(t, replicaStatus.ReplicationStatus.ReplicationLagUnknown)
 	assert.EqualValues(t, 0, replicaStatus.ReplicationStatus.SqlDelay)
 	assert.False(t, replicaStatus.ReplicationStatus.SslAllowed)
@@ -199,7 +199,7 @@ func TestFullStatus(t *testing.T) {
 	assert.Equal(t, "ON", replicaStatus.GtidMode)
 	assert.True(t, replicaStatus.LogReplicaUpdates)
 	assert.True(t, replicaStatus.LogBinEnabled)
-	assert.Contains(t, replicaStatus.Version, "5.7")
+	assert.Regexp(t, `[58]\.[07].*`, replicaStatus.Version)
 	assert.NotEmpty(t, replicaStatus.VersionComment)
 }
 


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR is the equivalent of the commit https://github.com/vitessio/vitess/pull/10665/commits/b4b3848c7ef6f5a2f6c75c7dc886dfff7a58d428 on main. It changes the test `TestFullStatus` to run with MySQL 8.0 too and also reduces  the flakiness of the test

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
