### PR TITLE
vtgate e2e unsharded TestFloatValueDefault: expect different value for mysql80 

### DIFF
--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -44,6 +44,20 @@ func AssertMatches(t testing.TB, conn *mysql.Conn, query, expected string) {
 	}
 }
 
+// AssertMatchesOneOf ensures the given query produces one of the expected results.
+// useful when a test can give different results depending on mysql flavor
+func AssertMatchesOneOf(t testing.TB, conn *mysql.Conn, query string, expectedValues ...string) {
+	t.Helper()
+	qr := Exec(t, conn, query)
+	got := fmt.Sprintf("%v", qr.Rows)
+	for _, expected := range expectedValues {
+		if cmp.Equal(expected, got) {
+			return
+		}
+	}
+	t.Errorf("Query: %s (-want +got):\n%+v\nGot:%s", query, expectedValues, got)
+}
+
 // AssertMatchesCompareMySQL executes the given query on both Vitess and MySQL and make sure
 // they have the same result set. The result set of Vitess is then matched with the given expectation.
 func AssertMatchesCompareMySQL(t *testing.T, vtConn, mysqlConn *mysql.Conn, query, expected string) {

--- a/go/test/endtoend/vtgate/unsharded/main_test.go
+++ b/go/test/endtoend/vtgate/unsharded/main_test.go
@@ -460,7 +460,12 @@ func TestFloatValueDefault(t *testing.T) {
 
 	utils.Exec(t, conn, `create table test_float_default (pos_f float default 2.1, neg_f float default -2.1);`)
 	defer utils.Exec(t, conn, `drop table test_float_default`)
-	utils.AssertMatches(t, conn, "select table_name, column_name, column_default from information_schema.columns where table_name = 'test_float_default'", `[[VARCHAR("test_float_default") VARCHAR("pos_f") TEXT("2.1")] [VARCHAR("test_float_default") VARCHAR("neg_f") TEXT("-2.1")]]`)
+
+	want57 := `[[VARCHAR("test_float_default") VARCHAR("pos_f") TEXT("2.1")] [VARCHAR("test_float_default") VARCHAR("neg_f") TEXT("-2.1")]]`
+	want80 := `[[VARBINARY("test_float_default") VARCHAR("pos_f") BLOB("2.1")] [VARBINARY("test_float_default") VARCHAR("neg_f") BLOB("-2.1")]]`
+
+	query := "select table_name, column_name, column_default from information_schema.columns where table_name = 'test_float_default'"
+	utils.AssertMatchesOneOf(t, conn, query, want57, want80)
 }
 
 // TestRowCountExceeded tests the error message received when a query exceeds the row count specified


### PR DESCRIPTION
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
