### PR TITLE
Allow apply SCATTER_ERRORS_AS_WARNINGS to inserts

### DIFF
--- a/go/vt/vtgate/engine/errors.go
+++ b/go/vt/vtgate/engine/errors.go
@@ -1,0 +1,89 @@
+package engine
+
+import (
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/stats"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+type ErrorMode int
+
+const (
+	ErrorModeAggregate = ErrorMode(iota)
+	ErrorModeAsWarningsIfResultElseAggregate
+	ErrorModeAsWarnings
+)
+
+type errorContext struct {
+	errs      []error
+	numShards int
+	session   SessionActions
+}
+
+var (
+	partialSuccessScatterQueries = stats.NewCounter("PartialSuccessScatterQueries", "Count of partially successful scatter queries")
+)
+
+func (em ErrorMode) CanRecordWarnings() bool {
+	return em != ErrorModeAggregate
+}
+
+func errorFuncAggregate(c *errorContext) error {
+	if len(c.errs) == 0 {
+		return nil
+	}
+
+	return vterrors.Aggregate(c.errs)
+}
+
+func errorFuncAsWarnings(c *errorContext) error {
+	for _, err := range c.errs {
+		serr := mysql.NewSQLErrorFromError(err).(*mysql.SQLError)
+		c.session.RecordWarning(
+			&querypb.QueryWarning{Code: uint32(serr.Num), Message: err.Error()},
+		)
+	}
+
+	if len(c.errs) < c.numShards {
+		partialSuccessScatterQueries.Add(1)
+	}
+
+	return nil
+}
+
+func errorFuncAsWarningsIfResultElseAggregate(c *errorContext) error {
+	if len(c.errs) < c.numShards {
+		return errorFuncAsWarnings(c)
+	}
+
+	return errorFuncAggregate(c)
+}
+
+func filterOutNilErrors(errs []error) []error {
+	var errors []error
+	for _, err := range errs {
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+	return errors
+}
+
+func newErrorContext(errs []error, numShards int, session SessionActions) *errorContext {
+	return &errorContext{
+		errs:      filterOutNilErrors(errs),
+		numShards: numShards,
+		session:   session,
+	}
+}
+
+func (ec *errorContext) apply(mode ErrorMode) error {
+	switch mode {
+	case ErrorModeAsWarnings:
+		return errorFuncAsWarnings(ec)
+	case ErrorModeAsWarningsIfResultElseAggregate:
+		return errorFuncAsWarningsIfResultElseAggregate(ec)
+	}
+	return errorFuncAggregate(ec)
+}

--- a/go/vt/vtgate/planbuilder/comment_directives.go
+++ b/go/vt/vtgate/planbuilder/comment_directives.go
@@ -1,0 +1,27 @@
+package planbuilder
+
+import (
+	"strconv"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+)
+
+// queryTimeout returns DirectiveQueryTimeout value if set, otherwise returns 0.
+func queryTimeout(d sqlparser.CommentDirectives) int {
+	if val, ok := d[sqlparser.DirectiveQueryTimeout]; ok {
+		if intVal, err := strconv.Atoi(val); err == nil {
+			return intVal
+		}
+	}
+	return 0
+}
+
+// scatterErrorsAsWarnings returns an engine ErrorMode based on the contents of the ScatterErrorsAsWarnings comment directive.
+func scatterErrorsAsWarnings(d sqlparser.CommentDirectives) engine.ErrorMode {
+	if d.IsSet(sqlparser.DirectiveScatterErrorsAsWarnings) {
+		return engine.ErrorModeAsWarningsIfResultElseAggregate
+	}
+
+	return engine.ErrorModeAggregate
+}

--- a/go/vt/vtgate/planbuilder/gen4_planner.go
+++ b/go/vt/vtgate/planbuilder/gen4_planner.go
@@ -440,14 +440,14 @@ func pushCommentDirectivesOnPlan(plan logicalPlan, stmt sqlparser.Statement) (lo
 		directives = make(sqlparser.CommentDirectives)
 	}
 
-	scatterAsWarns := directives.IsSet(sqlparser.DirectiveScatterErrorsAsWarnings)
+	errorMode := scatterErrorsAsWarnings(directives)
 	queryTimeout := queryTimeout(directives)
 
-	if scatterAsWarns || queryTimeout > 0 {
+	if errorMode.CanRecordWarnings() || queryTimeout > 0 {
 		_, _ = visit(plan, func(logicalPlan logicalPlan) (bool, logicalPlan, error) {
 			switch plan := logicalPlan.(type) {
 			case *routeGen4:
-				plan.eroute.ScatterErrorsAsWarnings = scatterAsWarns
+				plan.eroute.ErrorMode = errorMode
 				plan.eroute.QueryTimeout = queryTimeout
 			}
 			return true, logicalPlan, nil

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -298,6 +298,7 @@ func applyCommentDirectives(ins *sqlparser.Insert, eins *engine.Insert) {
 	if directives.IsSet(sqlparser.DirectiveMultiShardAutocommit) {
 		eins.MultiShardAutocommit = true
 	}
+	eins.ErrorMode = scatterErrorsAsWarnings(directives)
 	eins.QueryTimeout = queryTimeout(directives)
 }
 

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -17,8 +17,6 @@ limitations under the License.
 package planbuilder
 
 import (
-	"strconv"
-
 	"vitess.io/vitess/go/mysql/collations"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -847,14 +845,4 @@ func (rb *route) exprIsValue(expr sqlparser.Expr) bool {
 		return node.Metadata.(*column).Origin() != rb
 	}
 	return sqlparser.IsValue(expr)
-}
-
-// queryTimeout returns DirectiveQueryTimeout value if set, otherwise returns 0.
-func queryTimeout(d sqlparser.CommentDirectives) int {
-	if val, ok := d[sqlparser.DirectiveQueryTimeout]; ok {
-		if intVal, err := strconv.Atoi(val); err == nil {
-			return intVal
-		}
-	}
-	return 0
 }

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -206,9 +206,7 @@ func (pb *primitiveBuilder) processSelect(sel *sqlparser.Select, reservedVars *s
 		if rb.eroute.TargetDestination != nil {
 			return errors.New("unsupported: SELECT with a target destination")
 		}
-		if directives.IsSet(sqlparser.DirectiveScatterErrorsAsWarnings) {
-			rb.eroute.ScatterErrorsAsWarnings = true
-		}
+		rb.eroute.ErrorMode = scatterErrorsAsWarnings(directives)
 	}
 
 	// Set the outer symtab after processing of FROM clause.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

By default errors from scatter queries are aggregated into a single
error. Clients may override this behavior for some queries, but not others,
with the `/*vt+ SCATTER_ERRORS_AS_WARNINGS */` comment directive.
It does not work with inserts prior to this commit.

This commit:

 - Enables the use of `SCATTER_ERRORS_AS_WARNINGS` for inserts.
 - Refactors existing usage so that `SCATTER_ERRORS_AS_WARNINGS`
   is applied with shared code.

## Related Issue(s)

#10692 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
