### PR TITLE
added vindex interface breaking change to summary notes

### DIFF
--- a/doc/releasenotes/15_0_0_summary.md
+++ b/doc/releasenotes/15_0_0_summary.md
@@ -14,7 +14,7 @@ Map(ctx context.Context, vcursor VCursor, .... ) ....
 ```
 
 This only impacts the users who have added their own vindex implementation. 
-They would be required to change their implementation with these new interface method expectation.
+They would be required to change their implementation with these new interface method expectations.
 
 ### Command-line syntax deprecations
 

--- a/doc/releasenotes/15_0_0_summary.md
+++ b/doc/releasenotes/15_0_0_summary.md
@@ -13,7 +13,7 @@ Map(vcursor VCursor, .... ) ....
 Map(ctx context.Context, vcursor VCursor, .... ) ....
 ```
 
-This only impact the users who have added their own vindex implementation. 
+This only impacts the users who have added their own vindex implementation. 
 They would be required to change their implementation with these new interface method expectation.
 
 ### Command-line syntax deprecations

--- a/doc/releasenotes/15_0_0_summary.md
+++ b/doc/releasenotes/15_0_0_summary.md
@@ -1,5 +1,21 @@
 ## Major Changes
 
+### Breaking Change
+
+#### Vindex Implementation
+
+All the vindex interface methods are changed by adding context.Context as the input parameter.
+
+E.g:
+```go
+Map(vcursor VCursor, .... ) .... 
+	To
+Map(ctx context.Context, vcursor VCursor, .... ) ....
+```
+
+This only impact the users who have added their own vindex implementation. 
+They would be required to change their implementation with these new interface method expectation.
+
 ### Command-line syntax deprecations
 
 #### vttablet startup flag deletions


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

As part of this PR https://github.com/vitessio/vitess/pull/10632 the vindex interface methods were modified to add context to the method parameters.
This PR documents those breaking change in the summary release notes.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/pull/10632

## Checklist

-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
