### PR TITLE
[14.0] set parameter on vtgate than on vttablet

### DIFF
--- a/go/test/endtoend/vtgate/reservedconn/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/main_test.go
@@ -118,13 +118,13 @@ func TestMain(m *testing.M) {
 			SchemaSQL: sqlSchema,
 			VSchema:   vSchema,
 		}
-		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-transaction-timeout", "5", "--mysql_server_version", "5.7.0"}
+		clusterInstance.VtTabletExtraArgs = []string{"--queryserver-config-transaction-timeout", "5"}
 		if err := clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 1, false); err != nil {
 			return 1
 		}
 
 		// Start vtgate
-		clusterInstance.VtGateExtraArgs = []string{"--lock_heartbeat_time", "2s", "--enable_system_settings=true"}
+		clusterInstance.VtGateExtraArgs = []string{"--lock_heartbeat_time", "2s", "--mysql_server_version", "5.7.0"}
 		if err := clusterInstance.StartVtgate(); err != nil {
 			return 1
 		}

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -39,45 +39,46 @@ func TestSetSysVarSingle(t *testing.T) {
 		Port: clusterInstance.VtgateMySQLPort,
 	}
 	type queriesWithExpectations struct {
-		name, expr, expected string
+		name, expr string
+		expected   []string
 	}
 
 	queries := []queriesWithExpectations{{
 		name:     "default_storage_engine", // ignored
 		expr:     "INNODB",
-		expected: `[[VARCHAR("InnoDB")]]`,
+		expected: []string{`[[VARCHAR("InnoDB")]]`},
 	}, {
 		name:     "character_set_client", // check and ignored
 		expr:     "utf8mb4",
-		expected: `[[VARCHAR("utf8mb4")]]`,
+		expected: []string{`[[VARCHAR("utf8mb4")]]`, `[[VARCHAR("utf8")]]`},
 	}, {
 		name:     "character_set_client", // ignored so will keep the actual value
 		expr:     "@charvar",
-		expected: `[[VARCHAR("utf8mb4")]]`,
+		expected: []string{`[[VARCHAR("utf8mb4")]]`, `[[VARCHAR("utf8")]]`},
 	}, {
 		name:     "sql_mode", // use reserved conn
 		expr:     "''",
-		expected: `[[VARCHAR("")]]`,
+		expected: []string{`[[VARCHAR("")]]`},
 	}, {
 		name:     "sql_mode", // use reserved conn
 		expr:     `concat(@@sql_mode,"NO_ZERO_DATE")`,
-		expected: `[[VARCHAR("NO_ZERO_DATE")]]`,
+		expected: []string{`[[VARCHAR("NO_ZERO_DATE")]]`},
 	}, {
 		name:     "sql_mode", // use reserved conn
 		expr:     "@@sql_mode",
-		expected: `[[VARCHAR("NO_ZERO_DATE")]]`,
+		expected: []string{`[[VARCHAR("NO_ZERO_DATE")]]`},
 	}, {
 		name:     "SQL_SAFE_UPDATES", // use reserved conn
 		expr:     "1",
-		expected: "[[INT64(1)]]",
+		expected: []string{"[[INT64(1)]]"},
 	}, {
 		name:     "sql_auto_is_null", // ignored so will keep the actual value
 		expr:     "on",
-		expected: `[[INT64(0)]]`,
+		expected: []string{`[[INT64(0)]]`},
 	}, {
 		name:     "sql_notes", // use reserved conn
 		expr:     "off",
-		expected: "[[INT64(0)]]",
+		expected: []string{"[[INT64(0)]]"},
 	}}
 
 	conn, err := mysql.Connect(ctx, &vtParams)
@@ -88,7 +89,7 @@ func TestSetSysVarSingle(t *testing.T) {
 		query := fmt.Sprintf("set %s = %s", q.name, q.expr)
 		t.Run(fmt.Sprintf("%d-%s", i, query), func(t *testing.T) {
 			utils.Exec(t, conn, query)
-			utils.AssertMatches(t, conn, fmt.Sprintf("select @@%s", q.name), q.expected)
+			utils.AssertMatchesOneOf(t, conn, fmt.Sprintf("select @@%s", q.name), q.expected...)
 		})
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Backport of https://github.com/vitessio/vitess/pull/10698

This PR fixes the e2e test setup for reserved connection where the parameter to be set on vtgate was set on vttablet. This fixes that.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
