### PR TITLE
Tweak make targets MacOS M1 xc to Linux arches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,31 @@
 MAKEFLAGS = -s
 GIT_STATUS := $(shell git status --porcelain)
 
-export GOBIN=$(PWD)/bin
+ifndef GOARCH
+export GOARCH=$(go env GOARCH)
+endif
+
+# This is where Go installs binaries when you run `go install`. By default this
+# is $GOPATH/bin. It is better to try to avoid setting this globally, because
+# Go will complain if you try to cross-install while this is set.
+#
+# GOBIN=
+
+ifndef GOOS
+export GOOS=$(go env GOOS)
+endif
+
+# GOPATH is the root of the Golang installation. `bin` is nested under here. In
+# development environments, this is usually $HOME/go. In production and Docker
+# environments, this is usually /go.
+ifndef GOPATH
+export GOPATH=$(go env GOROOT)
+endif
+
+# This governs where Vitess binaries are installed during `make install` and
+# `make cross-install`. Typically for production builds we set this to /vt.
+# PREFIX=
+
 export REWRITER=go/vt/sqlparser/rewriter.go
 
 # Disabled parallel processing of target prerequisites to avoid that integration tests are racing each other (e.g. for ports) and may fail.
@@ -37,9 +61,13 @@ ifdef VT_EXTRA_BUILD_FLAGS
 export EXTRA_BUILD_FLAGS := $(VT_EXTRA_BUILD_FLAGS)
 endif
 
+# This should be the root of the vitess Git directory.
 ifndef VTROOT
 export VTROOT=${PWD}
 endif
+
+# This is where Go will install binaries in response to `go build`.
+export VTROOTBIN=${VTROOT}/bin
 
 # We now have CGO code in the build which throws warnings with newer gcc builds.
 # See: https://github.com/mattn/go-sqlite3/issues/803
@@ -57,8 +85,11 @@ ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
 	bash ./build.env
-	go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
-	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=../../../bin/vttablet)
+	go build -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) \
+		-ldflags "$(shell tools/build_version_flags.sh)"  \
+		-o ${VTROOTBIN} ./go/...
+
+	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=${VTROOTBIN}/vttablet)
 
 # build the vitess binaries statically
 build:
@@ -66,12 +97,21 @@ ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
 	bash ./build.env
-	# build all the binaries by default with CGO disabled
-	CGO_ENABLED=0 go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
+	# build all the binaries by default with CGO disabled.
+	# Binaries will be placed in ${VTROOTBIN}.
+	CGO_ENABLED=0 go build \
+		    -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) \
+		    -ldflags "$(shell tools/build_version_flags.sh)" \
+		    -o ${VTROOTBIN} ./go/...
+
 	# embed local resources in the vttablet executable
-	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=../../../bin/vttablet)
+	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=${VTROOT}/bin/vttablet)
+
 	# build vtorc with CGO, because it depends on sqlite
-	CGO_ENABLED=1 go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/cmd/vtorc/...
+	CGO_ENABLED=1 go build \
+		    -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) \
+		    -ldflags "$(shell tools/build_version_flags.sh)" \
+		    -o ${VTROOTBIN} ./go/cmd/vtorc/...
 
 # cross-build can be used to cross-compile Vitess client binaries
 # Outside of select client binaries (namely vtctlclient & vtexplain), cross-compiled Vitess Binaries are not recommended for production deployments
@@ -81,17 +121,33 @@ ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
 	bash ./build.env
-	# In order to cross-compile, go install requires GOBIN to be unset
-	export GOBIN=""
-	# For the specified GOOS + GOARCH, build all the binaries by default with CGO disabled
-	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
-	# unset GOOS and embed local resources in the vttablet executable
-	if [ -d /go/bin ]; then
-		# Probably in the bootstrap container
-		(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice --verbose append --exec=/go/bin/${GOOS}_${GOARCH}/vttablet)
-	else
-		(cd go/cmd/vttablet && unset GOOS && unset GOARCH && go run github.com/GeertJohan/go.rice/rice --verbose append --exec=$${HOME}/go/bin/${GOOS}_${GOARCH}/vttablet)
+
+	# For the specified GOOS + GOARCH, build all the binaries by default
+	# with CGO disabled. Binaries will be placed in
+	# ${VTROOTBIN}/${GOOS}_${GOARG}.
+	mkdir -p ${VTROOTBIN}/${GOOS}_${GOARCH}
+	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build         \
+		    -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) \
+		    -ldflags "$(shell tools/build_version_flags.sh)" \
+		    -o ${VTROOTBIN}/${GOOS}_${GOARCH} ./go/...
+
+	@if [ ! -x "${VTROOTBIN}/${GOOS}_${GOARCH}/vttablet" ]; then \
+		echo "Missing vttablet at: ${VTROOTBIN}/${GOOS}_${GOARCH}." && exit; \
 	fi
+
+	# Either ${GOPATH}/rice is already present, and we assume it is
+	# compiled to the architecture of this machine, or it's not present, in
+	# which case we need to download, compile and run it. We want to make
+	# sure we compile it in the current machine's architecture, otherwise
+	# we won't be able to run it.
+	@if [ -x "${GOPATH}/rice" ]; then \
+		echo "Applying ricebox to vttablet with already-present rice."; \
+		(cd ${VTROOT}/go/cmd/vttablet && ${GOPATH}/rice --verbose append --exec=${VTROOTBIN}/${GOOS}_${GOARCH}/vttablet); \
+	else \
+		echo "Applying ricebox to vttablet with download-and-compile rice."; \
+		(cd ${VTROOT}/go/cmd/vttablet && unset GOOS && unset GOARCH && go run github.com/GeertJohan/go.rice/rice --verbose append --exec=${VTROOTBIN}/${GOOS}_${GOARCH}/vttablet); \
+	fi
+
 	# Cross-compiling w/ cgo isn't trivial and we don't need vtorc, so we can skip building it
 
 debug:
@@ -99,7 +155,11 @@ ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
 	bash ./build.env
-	go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" -gcflags -'N -l' ./go/...
+	go build -trimpath \
+		$(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) \
+		-ldflags "$(shell tools/build_version_flags.sh)"  \
+		-gcflags -'N -l' \
+		-o ${VTROOTBIN} ./go/...
 
 # install copies the files needed to run Vitess into the given directory tree.
 # This target is optimized for docker images. It only installs the files needed for running vitess in docker
@@ -107,14 +167,14 @@ endif
 install: build
 	# binaries
 	mkdir -p "$${PREFIX}/bin"
-	cp "$${VTROOT}/bin/"{mysqlctl,mysqlctld,vtorc,vtadmin,vtctld,vtctlclient,vtctldclient,vtgate,vttablet,vtbackup} "$${PREFIX}/bin/"
+	cp "$${VTROOTBIN}/"{mysqlctl,mysqlctld,vtorc,vtadmin,vtctld,vtctlclient,vtctldclient,vtgate,vttablet,vtbackup} "$${PREFIX}/bin/"
 
 # Will only work inside the docker bootstrap for now
 cross-install: cross-build
 	# binaries
 	mkdir -p "$${PREFIX}/bin"
 	# Still no vtorc for cross-compile
-	cp "/go/bin/${GOOS}_${GOARCH}/"{mysqlctl,mysqlctld,vtadmin,vtctld,vtctlclient,vtctldclient,vtgate,vttablet,vtbackup} "$${PREFIX}/bin/"
+	cp "${VTROOTBIN}/${GOOS}_${GOARCH}/"{mysqlctl,mysqlctld,vtadmin,vtctld,vtctlclient,vtctldclient,vtgate,vttablet,vtbackup} "$${PREFIX}/bin/"
 
 # Install local install the binaries needed to run vitess locally
 # Usage: make install-local PREFIX=/path/to/install/root
@@ -224,9 +284,9 @@ java_test:
 	VTROOT=${PWD} mvn -f java/pom.xml -B clean verify
 
 install_protoc-gen-go:
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@$(shell go list -m -f '{{ .Version }}' google.golang.org/protobuf)
-	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0 # the GRPC compiler its own pinned version
-	go install github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@$(shell go list -m -f '{{ .Version }}' github.com/planetscale/vtprotobuf)
+	GOBIN=$(VTROOTBIN) go install google.golang.org/protobuf/cmd/protoc-gen-go@$(shell go list -m -f '{{ .Version }}' google.golang.org/protobuf)
+	GOBIN=$(VTROOTBIN) go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0 # the GRPC compiler its own pinned version
+	GOBIN=$(VTROOTBIN) go install github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@$(shell go list -m -f '{{ .Version }}' github.com/planetscale/vtprotobuf)
 
 PROTO_SRCS = $(wildcard proto/*.proto)
 PROTO_SRC_NAMES = $(basename $(notdir $(PROTO_SRCS)))
@@ -240,9 +300,9 @@ endif
 
 $(PROTO_GO_OUTS): minimaltools install_protoc-gen-go proto/*.proto
 	$(VTROOT)/bin/protoc \
-		--go_out=. --plugin protoc-gen-go="${GOBIN}/protoc-gen-go" \
-		--go-grpc_out=. --plugin protoc-gen-go-grpc="${GOBIN}/protoc-gen-go-grpc" \
-		--go-vtproto_out=. --plugin protoc-gen-go-vtproto="${GOBIN}/protoc-gen-go-vtproto" \
+		--go_out=. --plugin protoc-gen-go="${VTROOTBIN}/protoc-gen-go" \
+		--go-grpc_out=. --plugin protoc-gen-go-grpc="${VTROOTBIN}/protoc-gen-go-grpc" \
+		--go-vtproto_out=. --plugin protoc-gen-go-vtproto="${VTROOTBIN}/protoc-gen-go-vtproto" \
 		--go-vtproto_opt=features=marshal+unmarshal+size+pool \
 		--go-vtproto_opt=pool=vitess.io/vitess/go/vt/proto/query.Row \
 		--go-vtproto_opt=pool=vitess.io/vitess/go/vt/proto/binlogdata.VStreamRowsResponse \
@@ -367,10 +427,10 @@ install_k8s-code-generator: tools/tools.go go.mod
 	go install k8s.io/code-generator/cmd/lister-gen
 	go install k8s.io/code-generator/cmd/informer-gen
 
-DEEPCOPY_GEN=$(GOBIN)/deepcopy-gen
-CLIENT_GEN=$(GOBIN)/client-gen
-LISTER_GEN=$(GOBIN)/lister-gen
-INFORMER_GEN=$(GOBIN)/informer-gen
+DEEPCOPY_GEN=$(VTROOTBIN)/deepcopy-gen
+CLIENT_GEN=$(VTROOTBIN)/client-gen
+LISTER_GEN=$(VTROOTBIN)/lister-gen
+INFORMER_GEN=$(VTROOTBIN)/informer-gen
 
 GEN_BASE_DIR ?= vitess.io/vitess/go/vt/topo/k8stopo
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

The cross-build and cross-compile make targets are meant to let you
compile from host architecture (e.g. Mac M1) to target architectures
(e.g. Linux AMD64). They don't currently work for Mac M1 to other
targets.

There are a couple problems:

 - Some syntactical errors in the Makefile targets.
 - Golang doesn't like it when you use GOBIN in cross-architecture
   installs.

This commit makes cross builds work on Mac, while preserving existing
usage (used in a build step of docker/lite/Docker.ubi8.arm64.mysql80):

 - Fixes syntactical errors in conditional statement in make target.
 - Replaces GOBIN usage with VTROOTBIN during build steps, preserving
   GOBIN usage in install steps.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #10704 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
