### PR TITLE
[mysqlctl] Rewrite CLI to cobra

### DIFF
--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -21,76 +21,146 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"time"
 
-	"github.com/spf13/pflag"
+	"github.com/spf13/cobra"
 
-	"vitess.io/vitess/go/cmd"
+	"vitess.io/vitess/go/cmd/vtctldclient/cli"
 	"vitess.io/vitess/go/exit"
-	"vitess.io/vitess/go/flagutil"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/dbconfigs"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
-
-	// Include deprecation warnings for soon-to-be-unsupported flag invocations.
-	_flag "vitess.io/vitess/go/internal/flag"
 )
 
+// Global flag variables for all commands.
 var (
-	port        = flag.Int("port", 6612, "vttablet port")
-	mysqlPort   = flag.Int("mysql_port", 3306, "mysql port")
-	tabletUID   = flag.Uint("tablet_uid", 41983, "tablet uid")
-	mysqlSocket = flag.String("mysql_socket", "", "path to the mysql socket")
-
-	// Reason for nolint : Being used in line 246 (tabletAddr = netutil.JoinHostPort("localhost", int32(*port))
-	tabletAddr string //nolint
+	port        int32
+	mysqlPort   int32
+	tabletUID   uint32
+	mysqlSocket string
+	tabletAddr  string // set in Mysqlctl.PersistentPreRun
 )
 
-func initConfigCmd(subFlags *flag.FlagSet, args []string) error {
-	subFlags.Parse(args)
+// Commands for the mysqlctl binary.
+var (
+	// Mysqlctl is the root command for the mysqlctl binary.
+	Mysqlctl = &cobra.Command{
+		Use:   "mysqlctl [global flags] <command> [command flags]",
+		Short: "Controls a local mysqld process and my.cnf config.",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			tmp := os.Args
+			os.Args = os.Args[0:1]
+			flag.Parse()
+			os.Args = tmp
+
+			tabletAddr = netutil.JoinHostPort("localhost", port)
+		},
+	}
+
+	Init = &cobra.Command{
+		Use:                   "init [--wait_time=5m] [--init_db_sql_file=<path>]",
+		Short:                 "Initializes the directory structure and starts mysqld.",
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE:                  commandInit,
+	}
+	InitConfig = &cobra.Command{
+		Use:                   "init_config",
+		Short:                 "Initializes the directory structure and creates a my.cnf, but does not start mysqld.",
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE:                  commandInitConfig,
+	}
+	ReinitConfig = &cobra.Command{
+		Use:                   "reinit_config",
+		Short:                 "Reinitializes my.cnf file with a new server_id.",
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE:                  commandReinitConfig,
+	}
+	Shutdown = &cobra.Command{
+		Use:                   "shutdown [--wait_time=5m]",
+		Short:                 "Shuts down mysqld. This does not remove any files.",
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE:                  commandShutdown,
+	}
+	Start = &cobra.Command{
+		Use:                   "start [--wait_time=5m] [--mysqld_args <arg1,arg2,...>]",
+		Short:                 "Starts mysqld on an already 'init'-ed directory.",
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE:                  commandStart,
+	}
+	Teardown = &cobra.Command{
+		Use:                   "teardown [--wait_time=5m] [--force]",
+		Short:                 "Shuts down mysqld and removes the directory.",
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		RunE:                  commandTeardown,
+	}
+
+	Position = &cobra.Command{
+		Use:                   "position <operation> <pos1> <pos2 | gtid>",
+		Short:                 "Compute operations on replication positions. Valid operations are 'equal', 'at_least', and 'append'.",
+		Args:                  cobra.ExactArgs(3),
+		DisableFlagsInUseLine: true,
+		RunE:                  commandPosition,
+	}
+)
+
+func commandInitConfig(cmd *cobra.Command, args []string) error {
+	cli.FinishedParsing(cmd)
 
 	// Generate my.cnf from scratch and use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(uint32(*tabletUID), *mysqlSocket, int32(*mysqlPort))
+	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(tabletUID, mysqlSocket, mysqlPort)
 	if err != nil {
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}
 	defer mysqld.Close()
+
 	if err := mysqld.InitConfig(cnf); err != nil {
 		return fmt.Errorf("failed to init mysql config: %v", err)
 	}
+
 	return nil
 }
 
-func initCmd(subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for startup")
-	initDBSQLFile := subFlags.String("init_db_sql_file", "", "path to .sql file to run after mysql_install_db")
-	subFlags.Parse(args)
+var commandInitOptions = struct {
+	WaitTime      time.Duration
+	InitDbSQLFile string
+}{
+	WaitTime: 5 * time.Minute,
+}
+
+func commandInit(cmd *cobra.Command, args []string) error {
+	cli.FinishedParsing(cmd)
 
 	// Generate my.cnf from scratch and use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(uint32(*tabletUID), *mysqlSocket, int32(*mysqlPort))
+	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(tabletUID, mysqlSocket, mysqlPort)
 	if err != nil {
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}
 	defer mysqld.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), *waitTime)
+	ctx, cancel := context.WithTimeout(context.Background(), commandInitOptions.WaitTime)
 	defer cancel()
-	if err := mysqld.Init(ctx, cnf, *initDBSQLFile); err != nil {
-		return fmt.Errorf("failed init mysql: %v", err)
+
+	if err := mysqld.Init(ctx, cnf, commandInitOptions.InitDbSQLFile); err != nil {
+		return fmt.Errorf("failed to init mysql: %v", err)
 	}
+
 	return nil
 }
 
-func reinitConfigCmd(subFlags *flag.FlagSet, args []string) error {
-	subFlags.Parse(args)
+func commandReinitConfig(cmd *cobra.Command, args []string) error {
+	cli.FinishedParsing(cmd)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(*tabletUID))
+	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(tabletUID)
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
@@ -99,179 +169,168 @@ func reinitConfigCmd(subFlags *flag.FlagSet, args []string) error {
 	if err := mysqld.ReinitConfig(context.TODO(), cnf); err != nil {
 		return fmt.Errorf("failed to reinit mysql config: %v", err)
 	}
+
 	return nil
 }
 
-func shutdownCmd(subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for shutdown")
-	subFlags.Parse(args)
+var commandShutdownOptions = struct {
+	WaitTime time.Duration
+}{
+	WaitTime: 5 * time.Minute,
+}
+
+func commandShutdown(cmd *cobra.Command, args []string) error {
+	cli.FinishedParsing(cmd)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(*tabletUID))
+	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(tabletUID)
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
 	defer mysqld.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), *waitTime)
+	ctx, cancel := context.WithTimeout(context.Background(), commandShutdownOptions.WaitTime)
 	defer cancel()
+
 	if err := mysqld.Shutdown(ctx, cnf, true); err != nil {
-		return fmt.Errorf("failed shutdown mysql: %v", err)
+		return fmt.Errorf("failed to shutdown mysql: %v", err)
 	}
+
 	return nil
 }
 
-func startCmd(subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for startup")
-	var mysqldArgs flagutil.StringListValue
-	subFlags.Var(&mysqldArgs, "mysqld_args", "List of comma-separated flags to pass additionally to mysqld")
-	subFlags.Parse(args)
+var commandStartOptions = struct {
+	WaitTime   time.Duration
+	MySQLdArgs []string
+}{
+	WaitTime: 5 * time.Minute,
+}
+
+func commandStart(cmd *cobra.Command, args []string) error {
+	cli.FinishedParsing(cmd)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(*tabletUID))
+	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(tabletUID)
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
 	defer mysqld.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), *waitTime)
+	ctx, cancel := context.WithTimeout(context.Background(), commandStartOptions.WaitTime)
 	defer cancel()
-	if err := mysqld.Start(ctx, cnf, mysqldArgs...); err != nil {
-		return fmt.Errorf("failed start mysql: %v", err)
+
+	if err := mysqld.Start(ctx, cnf, commandStartOptions.MySQLdArgs...); err != nil {
+		return fmt.Errorf("failed to start mysql: %v", err)
 	}
+
 	return nil
 }
 
-func teardownCmd(subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for shutdown")
-	force := subFlags.Bool("force", false, "will remove the root directory even if mysqld shutdown fails")
-	subFlags.Parse(args)
+var commandTeardownOptions = struct {
+	WaitTime time.Duration
+	Force    bool
+}{
+	WaitTime: 5 * time.Minute,
+}
+
+func commandTeardown(cmd *cobra.Command, args []string) error {
+	cli.FinishedParsing(cmd)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(*tabletUID))
+	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(tabletUID)
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
 	defer mysqld.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), *waitTime)
+	ctx, cancel := context.WithTimeout(context.Background(), commandTeardownOptions.WaitTime)
 	defer cancel()
-	if err := mysqld.Teardown(ctx, cnf, *force); err != nil {
-		return fmt.Errorf("failed teardown mysql (forced? %v): %v", *force, err)
+
+	if err := mysqld.Teardown(ctx, cnf, commandTeardownOptions.Force); err != nil {
+		return fmt.Errorf("failed to teardown mysql (force=%v): %v", commandTeardownOptions.Force, err)
 	}
+
 	return nil
 }
 
-func positionCmd(subFlags *flag.FlagSet, args []string) error {
-	subFlags.Parse(args)
-	if len(args) < 3 {
-		return fmt.Errorf("not enough arguments for position operation")
-	}
-
-	pos1, err := mysql.DecodePosition(args[1])
+func commandPosition(cmd *cobra.Command, args []string) error {
+	pos1, err := mysql.DecodePosition(cmd.Flags().Arg(1))
 	if err != nil {
 		return err
 	}
 
-	switch args[0] {
+	var resultFn func() any
+
+	switch op := cmd.Flags().Arg(0); op {
 	case "equal":
-		pos2, err := mysql.DecodePosition(args[2])
+		pos2, err := mysql.DecodePosition(cmd.Flags().Arg(2))
 		if err != nil {
 			return err
 		}
-		fmt.Println(pos1.Equal(pos2))
+
+		cli.FinishedParsing(cmd)
+
+		resultFn = func() any { return pos1.Equal(pos2) }
 	case "at_least":
-		pos2, err := mysql.DecodePosition(args[2])
+		pos2, err := mysql.DecodePosition(cmd.Flags().Arg(2))
 		if err != nil {
 			return err
 		}
-		fmt.Println(pos1.AtLeast(pos2))
+
+		cli.FinishedParsing(cmd)
+
+		resultFn = func() any { return pos1.AtLeast(pos2) }
 	case "append":
-		gtid, err := mysql.DecodeGTID(args[2])
+		gtid, err := mysql.DecodeGTID(cmd.Flags().Arg(2))
 		if err != nil {
 			return err
 		}
-		fmt.Println(mysql.AppendGTID(pos1, gtid))
+
+		cli.FinishedParsing(cmd)
+
+		resultFn = func() any { return mysql.AppendGTID(pos1, gtid) }
+	default:
+		return fmt.Errorf("unsupported operation: %v; valid operations are 'equal', 'at_least', and 'append'", op)
 	}
 
+	fmt.Fprintf(cmd.OutOrStdout(), "%v\n", resultFn())
+
 	return nil
-}
-
-type command struct {
-	name   string
-	method func(*flag.FlagSet, []string) error
-	params string
-	help   string
-}
-
-var commands = []command{
-	{"init", initCmd, "[--wait_time=5m] [--init_db_sql_file=]",
-		"Initializes the directory structure and starts mysqld"},
-	{"init_config", initConfigCmd, "",
-		"Initializes the directory structure, creates my.cnf file, but does not start mysqld"},
-	{"reinit_config", reinitConfigCmd, "",
-		"Reinitializes my.cnf file with new server_id"},
-	{"teardown", teardownCmd, "[--wait_time=5m] [--force]",
-		"Shuts mysqld down, and removes the directory"},
-	{"start", startCmd, "[--wait_time=5m]",
-		"Starts mysqld on an already 'init'-ed directory"},
-	{"shutdown", shutdownCmd, "[--wait_time=5m]",
-		"Shuts down mysqld, does not remove any file"},
-
-	{"position", positionCmd,
-		"<operation> <pos1> <pos2 | gtid>",
-		"Compute operations on replication positions"},
 }
 
 func main() {
 	defer exit.Recover()
 	defer logutil.Flush()
 
-	_flag.SetUsage(flag.CommandLine, _flag.UsageOptions{
-		Preface: func(w io.Writer) {
-			fmt.Fprintf(w, "Usage: %s [global parameters] command [command parameters]\n", os.Args[0])
-			fmt.Fprintf(w, "\nThe global optional parameters are:\n")
-		},
-		Epilogue: func(w io.Writer) {
-			fmt.Fprintf(w, "\nThe commands are listed below. Use '%s <command> -h' for more help.\n\n", os.Args[0])
-			for _, cmd := range commands {
-				fmt.Fprintf(w, "  %s", cmd.name)
-				if cmd.params != "" {
-					fmt.Fprintf(w, " %s", cmd.params)
-				}
-				fmt.Fprintf(w, "\n")
-			}
-			fmt.Fprintf(w, "\n")
-		},
-	})
+	Mysqlctl.PersistentFlags().Int32Var(&port, "port", 6612, "vttablet port")
+	Mysqlctl.PersistentFlags().Int32Var(&mysqlPort, "mysql_port", 3306, "mysql port")
+	Mysqlctl.PersistentFlags().Uint32Var(&tabletUID, "tablet_uid", 41983, "tablet uid")
+	Mysqlctl.PersistentFlags().StringVar(&mysqlSocket, "mysql_socket", "", "path to the mysql socket")
 
-	if cmd.IsRunningAsRoot() {
-		fmt.Fprintln(os.Stderr, "mysqlctl cannot be ran as root. Please run as a different user")
+	dbconfigs.RegisterFlags(dbconfigs.Dba)
+	Mysqlctl.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+
+	Init.Flags().DurationVar(&commandInitOptions.WaitTime, "wait_time", 5*time.Minute, "Time to wait for startup.")
+	Init.Flags().StringVar(&commandInitOptions.InitDbSQLFile, "init_db_sql_file", "", "Path to .sql file to run after `mysql_install_db` completes.")
+	Mysqlctl.AddCommand(Init)
+
+	Mysqlctl.AddCommand(InitConfig)
+	Mysqlctl.AddCommand(ReinitConfig)
+
+	Shutdown.Flags().DurationVar(&commandShutdownOptions.WaitTime, "wait_time", 5*time.Minute, "Time to wait for shutdown.")
+	Mysqlctl.AddCommand(Shutdown)
+
+	Start.Flags().DurationVar(&commandStartOptions.WaitTime, "wait_time", 5*time.Minute, "Time to wait for startup.")
+	Start.Flags().StringSliceVar(&commandStartOptions.MySQLdArgs, "mysqld_args", nil, "List of comma-separated flags to additionally pass to mysqld.")
+	Mysqlctl.AddCommand(Start)
+
+	Teardown.Flags().DurationVar(&commandTeardownOptions.WaitTime, "wait_time", 5*time.Minute, "Time to wait for shutdown.")
+	Teardown.Flags().BoolVarP(&commandTeardownOptions.Force, "force", "f", false, "Remove the root directory even if mysqld shutdown fails.")
+	Mysqlctl.AddCommand(Teardown)
+
+	Mysqlctl.AddCommand(Position)
+
+	if err := Mysqlctl.Execute(); err != nil {
 		exit.Return(1)
 	}
-	dbconfigs.RegisterFlags(dbconfigs.Dba)
-	_flag.Parse(pflag.NewFlagSet("mysqlctl", pflag.ExitOnError))
-
-	tabletAddr = netutil.JoinHostPort("localhost", int32(*port))
-
-	action := _flag.Arg(0)
-	for _, cmd := range commands {
-		if cmd.name == action {
-			subFlags := flag.NewFlagSet(action, flag.ExitOnError)
-			_flag.SetUsage(subFlags, _flag.UsageOptions{
-				Preface: func(w io.Writer) {
-					fmt.Fprintf(w, "Usage: %s %s %s\n\n", os.Args[0], cmd.name, cmd.params)
-					fmt.Fprintf(w, "%s\n\n", cmd.help)
-				},
-			})
-
-			if err := cmd.method(subFlags, _flag.Args()[1:]); err != nil {
-				log.Error(err)
-				exit.Return(1)
-			}
-			return
-		}
-	}
-	log.Errorf("invalid action: %v", action)
-	exit.Return(1)
 }

--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/cmd/vtctldclient/cli"
 	"vitess.io/vitess/go/exit"
@@ -33,6 +34,7 @@ import (
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 // Global flag variables for all commands.
@@ -308,7 +310,14 @@ func main() {
 	Mysqlctl.PersistentFlags().StringVar(&mysqlSocket, "mysql_socket", "", "path to the mysql socket")
 
 	dbconfigs.RegisterFlags(dbconfigs.Dba)
-	Mysqlctl.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+
+	servenv.OnParseFor("mysqlctl", func(fs *pflag.FlagSet) {
+		Mysqlctl.PersistentFlags().AddFlagSet(fs)
+	})
+	tmp := os.Args
+	os.Args = os.Args[0:1]
+	servenv.ParseFlags("mysqlctl")
+	os.Args = tmp
 
 	Init.Flags().DurationVar(&commandInitOptions.WaitTime, "wait_time", 5*time.Minute, "Time to wait for startup.")
 	Init.Flags().StringVar(&commandInitOptions.InitDbSQLFile, "init_db_sql_file", "", "Path to .sql file to run after `mysql_install_db` completes.")

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -122,8 +122,9 @@ ssl_key={{.Dir}}/server-001-key.pem
 
 		tmpProcess.Args = append(tmpProcess.Args, "init",
 			"--init_db_sql_file", mysqlctl.InitDBFile)
+	} else {
+		tmpProcess.Args = append(tmpProcess.Args, "start")
 	}
-	tmpProcess.Args = append(tmpProcess.Args, "start")
 	log.Infof("Starting mysqlctl with command: %v", tmpProcess.Args)
 	return tmpProcess, tmpProcess.Start()
 }

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -52,7 +52,7 @@ func (mysqlctl *MysqlctlProcess) InitDb() (err error) {
 	args := []string{"--log_dir", mysqlctl.LogDirectory,
 		"--tablet_uid", fmt.Sprintf("%d", mysqlctl.TabletUID),
 		"--mysql_port", fmt.Sprintf("%d", mysqlctl.MySQLPort),
-		"init", "--",
+		"init",
 		"--init_db_sql_file", mysqlctl.InitDBFile}
 	if *isCoverage {
 		args = append([]string{"--test.coverprofile=" + getCoveragePath("mysql-initdb.out"), "--test.v"}, args...)
@@ -120,7 +120,7 @@ ssl_key={{.Dir}}/server-001-key.pem
 			tmpProcess.Env = append(tmpProcess.Env, "VTDATAROOT="+os.Getenv("VTDATAROOT"))
 		}
 
-		tmpProcess.Args = append(tmpProcess.Args, "init", "--",
+		tmpProcess.Args = append(tmpProcess.Args, "init",
 			"--init_db_sql_file", mysqlctl.InitDBFile)
 	}
 	tmpProcess.Args = append(tmpProcess.Args, "start")

--- a/go/vt/vttest/mysqlctl.go
+++ b/go/vt/vttest/mysqlctl.go
@@ -64,7 +64,7 @@ func (ctl *Mysqlctl) Setup() error {
 		"--alsologtostderr",
 		"--tablet_uid", fmt.Sprintf("%d", ctl.UID),
 		"--mysql_port", fmt.Sprintf("%d", ctl.Port),
-		"init", "--",
+		"init",
 		"--init_db_sql_file", ctl.InitFile,
 	)
 


### PR DESCRIPTION


## Description

This expands on the work in #10619, rewriting the `mysqlctl` command with all its subcommands to use `spf13/cobra`.

### Testing

Starting the local example initial cluster, which invokes `mysqlctl` 

## Related Issue(s)

TK

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
