### PR TITLE
ApplySchema: renew keyspace lock while iterating SQLs

### DIFF
--- a/go/timer/rate_limiter.go
+++ b/go/timer/rate_limiter.go
@@ -46,6 +46,7 @@ func NewRateLimiter(d time.Duration) *RateLimiter {
 			select {
 			case <-ctx.Done():
 				ticker.Stop()
+				return
 			case <-ticker.C:
 				atomic.StoreInt64(&r.tickerValue, r.tickerValue+1)
 			}

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -36,10 +36,6 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 )
 
-var (
-	lockRenewTimeout = 10 * time.Second // has to be a fraction of Topo's defaultLockTimeout (30sec at this time)
-)
-
 // TabletExecutor applies schema changes to all tablets.
 type TabletExecutor struct {
 	migrationContext     string
@@ -363,7 +359,7 @@ func (exec *TabletExecutor) Execute(ctx context.Context, sqls []string) *Execute
 	}
 	providedUUID := ""
 
-	rl := timer.NewRateLimiter(lockRenewTimeout)
+	rl := timer.NewRateLimiter(*topo.RemoteOperationTimeout / 4)
 	defer rl.Stop()
 
 	syncOperationExecuted := false

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -368,8 +368,8 @@ func (exec *TabletExecutor) Execute(ctx context.Context, sqls []string) *Execute
 
 	syncOperationExecuted := false
 	for index, sql := range sqls {
+		// Attempt to renew lease:
 		if err := rl.Do(func() error { return topo.CheckKeyspaceLockedAndRenew(ctx, exec.keyspace) }); err != nil {
-			// This renews the lock lease
 			execResult.ExecutorErr = vterrors.Wrapf(err, "CheckKeyspaceLocked in ApplySchemaKeyspace %v", exec.keyspace).Error()
 			return &execResult
 		}

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -414,7 +414,7 @@ func (exec *TabletExecutor) Execute(ctx context.Context, sqls []string) *Execute
 					result.Shard,
 					result.Position,
 					concurrency,
-					false, /* includePrimary */
+					true, /* includePrimary */
 				)
 			}(result)
 		}

--- a/go/vt/topo/locks.go
+++ b/go/vt/topo/locks.go
@@ -196,16 +196,12 @@ func CheckKeyspaceLocked(ctx context.Context, keyspace string) error {
 	defer i.mu.Unlock()
 
 	// find the individual entry
-	_, ok = i.info[keyspace]
+	entry, ok := i.info[keyspace]
 	if !ok {
 		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "keyspace %v is not locked (no lockInfo in map)", keyspace)
 	}
-
-	// TODO(alainjobart): check the lock server implementation
-	// still holds the lock. Will need to look at the lockInfo struct.
-
-	// and we're good for now.
-	return nil
+	// try renewing lease:
+	return entry.lockDescriptor.Check(ctx)
 }
 
 // lockKeyspace will lock the keyspace in the topology server.


### PR DESCRIPTION
## Description

Followup to #10719. Before applying DDLs, `TabletExecutor` acquires a _keyspace_ lock. It then iterates all SQLs, applies them, and finally releases the lock.

When there's a large number of SQLs, the iteration can take a lon gtime. #10719 already reduces that time. However, applying SQLs can still take longer than the lock timeout. What we've seen happening was that SQLs were applied, but when it came to unlocking the keyspace, the lock was expired and the unlock operation failed.

In this PR we renew the lock on each SQL iteration. This is a naive implementation and perhaps too aggressive. We could later refine this to renew once per X seconds, for example. **UPDATE:** now calls are rate limited.

With this change, the lock will not expire on reasonable DDLs. Specifically, Online DDLs are very quick and are never expected to run long. Large `direct` `ALTER`s may still exceed lock timeout. This PR does not attempt to solve that scenario.

We have not changes the tests here. We've changes internal implementation of `CheckKeyspaceLocked()` and a re expecting to see all tests passing. In case of a problem, we will restore original behavior of this function, and create a new function which we will then use in `TabletExecutor`. **U{DATE**: refactored into a new function.

## Related Issue(s)

#6926 
#10719 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

cc @dbussink 