### PR TITLE
RateLimiter: exit goroutine at Stop()

### DIFF
--- a/go/timer/rate_limiter.go
+++ b/go/timer/rate_limiter.go
@@ -46,6 +46,7 @@ func NewRateLimiter(d time.Duration) *RateLimiter {
 			select {
 			case <-ctx.Done():
 				ticker.Stop()
+				return
 			case <-ticker.C:
 				atomic.StoreInt64(&r.tickerValue, r.tickerValue+1)
 			}


### PR DESCRIPTION

## Description

`RateLimiter` was leaking `goroutine` that never got destroyed. The fix is here.

## Related Issue(s)

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

