### PR TITLE
Flakes: Refactor OnlineDDL e2e tests

### DIFF
--- a/go/test/endtoend/onlineddl/ghost/onlineddl_ghost_test.go
+++ b/go/test/endtoend/onlineddl/ghost/onlineddl_ghost_test.go
@@ -224,7 +224,7 @@ func TestSchemaChange(t *testing.T) {
 	})
 	t.Run("successful online alter, vtgate", func(t *testing.T) {
 		uuid := testOnlineDDLStatement(t, alterTableSuccessfulStatement, "gh-ost", "vtgate", "ghost_col", "")
-		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
+		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusComplete)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)
 

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -852,14 +852,14 @@ func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy str
 	}
 	if strategySetting.IsPostponeCompletion() {
 		// We expect it to be running by default
-		if expectStatuses == nil || len(expectStatuses) == 0 {
+		if len(expectStatuses) == 0 {
 			expectStatuses = []schema.OnlineDDLStatus{schema.OnlineDDLStatusRunning}
 		}
 	}
 	if expectError == "" {
 		if waitFor == "migration" {
 			// Unless otherwise specified, the migration should be completed
-			if expectStatuses == nil || len(expectStatuses) == 0 {
+			if len(expectStatuses) == 0 {
 				expectStatuses = []schema.OnlineDDLStatus{schema.OnlineDDLStatusComplete}
 			}
 			status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, expectStatuses...)

--- a/go/test/endtoend/onlineddl/vtgate_util.go
+++ b/go/test/endtoend/onlineddl/vtgate_util.go
@@ -316,6 +316,7 @@ func WaitForThrottledTimestamp(t *testing.T, vtParams *mysql.ConnParams, uuid st
 		}
 		time.Sleep(1 * time.Second)
 	}
-	require.Fail(t, fmt.Sprintf("failed to get a last_throttled_timestamp value before timeout of %v", timeout))
+	require.Fail(t, fmt.Sprintf("failed to get a last_throttled_timestamp value for migration %s before hitting the timeout of %v",
+		uuid, timeout))
 	return
 }

--- a/test/config.json
+++ b/test/config.json
@@ -261,7 +261,7 @@
 		},
 		"onlineddl_vrepl": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/vrepl"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/vrepl", "-timeout", "20m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "onlineddl_vrepl",


### PR DESCRIPTION
## Description

Review of the test code and logic, attempting to make it more intuitive, explicit, and correct — followed by generalizing the new code initially used in the vrepl tests across the many other test suites/workflows: singleton, ghost, revert, scheduler, etc.

These were realatively minor changes that, I think, were largely needed due to the addition of more and more features over time and shoehorning their testing into the existing framework (copy-pasta and the usual). It's a natural process that happens regularly, hopefully this helps to tighten things back up a bit.

When combined with https://github.com/vitessio/vitess/pull/10757 we should be in really good shape.

## Related Issue(s)

  - https://github.com/vitessio/vitess/pull/10757

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required