### PR TITLE
Add the linter for exporting a loop variable through a pointer reference

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     # Extras
     - gofmt
     - goimports
+    - exportloopref
 
     # revive is a replacement for golint, but we do not run it in CI for now.
     # This is only enabled as a post-commit hook


### PR DESCRIPTION
Doing this is almost always a bug anyway so we should lint for this to avoid problems.

This would have caught the bug that was plaguing us in https://github.com/vitessio/vitess/pull/10739 as it's easy to overlook this type of issue. So we'd rather prefer the linter catches it for next time.

## Related Issue(s)

Adding because of the issue found in https://github.com/vitessio/vitess/pull/10739

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required