### PR TITLE
Be explicit about capturing the pointer

### DIFF
--- a/go/mysql/collations/tools/makecolldata/contractions.go
+++ b/go/mysql/collations/tools/makecolldata/contractions.go
@@ -52,7 +52,10 @@ func (wa *weightarray) print(g *codegen.Generator) {
 func printContraction1(g *codegen.Generator, wa *weightarray, incont []uca.Contraction, depth int) {
 	trie := make(map[rune][]uca.Contraction)
 	var leaf *uca.Contraction
-	for _, cont := range incont {
+	for i := range incont {
+		// Ensure local variable since we grab a pointer later
+		// potentially.
+		cont := incont[i]
 		if depth < len(cont.Path) {
 			r := cont.Path[depth]
 			trie[r] = append(trie[r], cont)

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -145,7 +145,7 @@ func (cached *DML) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(96)
+		size += int64(112)
 	}
 	// field Query string
 	size += hack.RuntimeAllocSize(int64(len(cached.Query)))
@@ -153,9 +153,12 @@ func (cached *DML) CachedSize(alloc bool) int64 {
 	if cc, ok := cached.KsidVindex.(cachedObject); ok {
 		size += cc.CachedSize(true)
 	}
-	// field Table *vitess.io/vitess/go/vt/vtgate/vindexes.Table
-	for _, table := range cached.Table {
-		size += table.CachedSize(true)
+	// field Table []*vitess.io/vitess/go/vt/vtgate/vindexes.Table
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.Table)) * int64(8))
+		for _, elem := range cached.Table {
+			size += elem.CachedSize(true)
+		}
 	}
 	// field OwnedVindexQuery string
 	size += hack.RuntimeAllocSize(int64(len(cached.OwnedVindexQuery)))


### PR DESCRIPTION
The logic here was accidentally correct since we always in practice grab the pointer only on the last iteration, so it works.

But the loop pointer linter catches this as an issue which is a good thing. Let's make it explicit how we capture this variable so there's no confusion and the linter also is happy about it.

## Related Issue(s)

This is the only other case the new linter alerts on in the codebase it looks apart from the bug fix that is in progress in https://github.com/vitessio/vitess/pull/10739

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
