### PR TITLE
Online DDL: issue a ReloadSchema at the completion of any migration

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -614,6 +614,7 @@ func (e *Executor) executeDirectly(ctx context.Context, onlineDDL *schema.Online
 	if err != nil {
 		return false, err
 	}
+	defer e.reloadSchema(ctx)
 	_ = e.onSchemaMigrationStatus(ctx, onlineDDL.UUID, schema.OnlineDDLStatusComplete, false, progressPctFull, etaSecondsNow, rowsCopiedUnknown, emptyHint)
 
 	return acceptableErrorCodeFound, nil
@@ -1439,6 +1440,7 @@ exit $exit_code
 			return err
 		}
 		// Migration successful!
+		defer e.reloadSchema(ctx)
 		successfulMigrations.Add(1)
 		log.Infof("+ OK")
 		return nil
@@ -1663,6 +1665,7 @@ export MYSQL_PWD
 			return err
 		}
 		// Migration successful!
+		defer e.reloadSchema(ctx)
 		successfulMigrations.Add(1)
 		log.Infof("+ OK")
 		return nil


### PR DESCRIPTION
## Description

As we look to reduce the footprint of `ApplySchema`, we removed excessive calls to `ReloadSchema` (see linked PRs follwing). We also noted that any `ReloadSchema` for Online DDL operations is irrelevant in `ApplySchema` because the actual schema change runs asynchronously, and almost certainly _after_ `ApplySchema` completes.

In this PR we make sure to call `ReloadSchema` at the end of any successful schema change. Up till now, this was only true for `vitess` `ALTER` migrations. Not it applies to `CREATE`, `DROP`, `gh-ost`, `pt-osc` migrations, including "fast" migrations and View migrations.

In the future we wish to further reduce the footprint by only reloading a single table, instead of the entire schema.

No tests are changed. We expect all existing tests to pass.

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/10739
- https://github.com/vitessio/vitess/pull/10719
- https://github.com/vitessio/vitess/pull/10727 
- #6926 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
