### PR TITLE
Add drop_foreign_keys to v2 MoveTables command

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2181,6 +2181,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	keepRoutingRules := subFlags.Bool("keep_routing_rules", false, "Do not remove the routing rules for the source keyspace.  --keep_routing_rules is only supported for Complete and Cancel.")
 	autoStart := subFlags.Bool("auto_start", true, "If false, streams will start in the Stopped state and will need to be explicitly started")
 	stopAfterCopy := subFlags.Bool("stop_after_copy", false, "Streams will be stopped once the copy phase is completed")
+	dropForeignKeys := subFlags.Bool("drop_foreign_keys", false, "If true, tables in the target keyspace will be created without foreign keys.")
 	maxReplicationLagAllowed := subFlags.Duration("max_replication_lag_allowed", defaultMaxReplicationLagAllowed, "Allow traffic to be switched only if vreplication lag is below this (in seconds)")
 
 	// MoveTables and Migrate params
@@ -2317,6 +2318,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 			vrwp.Timeout = *timeout
 			vrwp.ExternalCluster = externalClusterName
 			vrwp.SourceTimeZone = *sourceTimeZone
+			vrwp.DropForeignKeys = *dropForeignKeys
 		case wrangler.ReshardWorkflow:
 			if *sourceShards == "" || *targetShards == "" {
 				return fmt.Errorf("source and target shards are not specified")

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -57,11 +57,12 @@ type VReplicationWorkflowParams struct {
 	SourceKeyspace, Tables  string
 	AllTables, RenameTables bool
 	SourceTimeZone          string
+	DropForeignKeys         bool
 
 	// Reshard specific
-	SourceShards, TargetShards                []string
-	SkipSchemaCopy                            bool
-	AutoStart, StopAfterCopy, DropConstraints bool
+	SourceShards, TargetShards []string
+	SkipSchemaCopy             bool
+	AutoStart, StopAfterCopy   bool
 
 	// Migrate specific
 	ExternalCluster string
@@ -408,8 +409,7 @@ func (vrw *VReplicationWorkflow) initMoveTables() error {
 	log.Infof("In VReplicationWorkflow.initMoveTables() for %+v", vrw)
 	return vrw.wr.MoveTables(vrw.ctx, vrw.params.Workflow, vrw.params.SourceKeyspace, vrw.params.TargetKeyspace,
 		vrw.params.Tables, vrw.params.Cells, vrw.params.TabletTypes, vrw.params.AllTables, vrw.params.ExcludeTables,
-		vrw.params.AutoStart, vrw.params.StopAfterCopy, vrw.params.ExternalCluster, vrw.params.DropConstraints,
-		vrw.params.SourceTimeZone)
+		vrw.params.AutoStart, vrw.params.StopAfterCopy, vrw.params.ExternalCluster, vrw.params.DropForeignKeys, vrw.params.SourceTimeZone)
 }
 
 func (vrw *VReplicationWorkflow) initReshard() error {


### PR DESCRIPTION
## Description

This change was missed in https://github.com/vitessio/vitess/pull/9904 so it doesn't work for v2 right now.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/9904 which missed this change

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

This also will need to be backported to 14 then which is missing this bit as well. 