### PR TITLE
Prefix column names with tables names in Gen4

### DIFF
--- a/go/vt/vtexplain/testdata/multi-output/comments-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/comments-output.txt
@@ -17,25 +17,25 @@ select /* ; */ 1 from user
 ----------------------------------------------------------------------
 select 1 from user where x=';'
 
-1 ks_sharded/-40: select 1 from `user` where x = ';' limit 10001
-1 ks_sharded/40-80: select 1 from `user` where x = ';' limit 10001
-1 ks_sharded/80-c0: select 1 from `user` where x = ';' limit 10001
-1 ks_sharded/c0-: select 1 from `user` where x = ';' limit 10001
+1 ks_sharded/-40: select 1 from `user` where `user`.x = ';' limit 10001
+1 ks_sharded/40-80: select 1 from `user` where `user`.x = ';' limit 10001
+1 ks_sharded/80-c0: select 1 from `user` where `user`.x = ';' limit 10001
+1 ks_sharded/c0-: select 1 from `user` where `user`.x = ';' limit 10001
 
 ----------------------------------------------------------------------
 select 1 from user where x='/* hello */'
 
-1 ks_sharded/-40: select 1 from `user` where x = '/* hello */' limit 10001
-1 ks_sharded/40-80: select 1 from `user` where x = '/* hello */' limit 10001
-1 ks_sharded/80-c0: select 1 from `user` where x = '/* hello */' limit 10001
-1 ks_sharded/c0-: select 1 from `user` where x = '/* hello */' limit 10001
+1 ks_sharded/-40: select 1 from `user` where `user`.x = '/* hello */' limit 10001
+1 ks_sharded/40-80: select 1 from `user` where `user`.x = '/* hello */' limit 10001
+1 ks_sharded/80-c0: select 1 from `user` where `user`.x = '/* hello */' limit 10001
+1 ks_sharded/c0-: select 1 from `user` where `user`.x = '/* hello */' limit 10001
 
 ----------------------------------------------------------------------
 select 1 from user where x='/* ; */'
 
-1 ks_sharded/-40: select 1 from `user` where x = '/* ; */' limit 10001
-1 ks_sharded/40-80: select 1 from `user` where x = '/* ; */' limit 10001
-1 ks_sharded/80-c0: select 1 from `user` where x = '/* ; */' limit 10001
-1 ks_sharded/c0-: select 1 from `user` where x = '/* ; */' limit 10001
+1 ks_sharded/-40: select 1 from `user` where `user`.x = '/* ; */' limit 10001
+1 ks_sharded/40-80: select 1 from `user` where `user`.x = '/* ; */' limit 10001
+1 ks_sharded/80-c0: select 1 from `user` where `user`.x = '/* ; */' limit 10001
+1 ks_sharded/c0-: select 1 from `user` where `user`.x = '/* ; */' limit 10001
 
 ----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/multi-output/deletesharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/deletesharded-output.txt
@@ -27,7 +27,7 @@ delete from user where id=1
 delete from user where name='billy'
 
 1 ks_sharded/c0-: begin
-1 ks_sharded/c0-: select `name`, user_id from name_user_map where `name` in ('billy') limit 10001 for update
+1 ks_sharded/c0-: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('billy') limit 10001 for update
 2 ks_sharded/-40: begin
 2 ks_sharded/-40: select id, `name` from `user` where `name` = 'billy' limit 10001 for update
 3 ks_sharded/40-80: begin

--- a/go/vt/vtexplain/testdata/multi-output/gen4-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/gen4-output.txt
@@ -1,25 +1,25 @@
 ----------------------------------------------------------------------
 select * from user_region where regionId = 4611686018427387904 and userId = 100 /* exact shard */
 
-1 ks_sharded/40-80: select * from user_region where regionId = 4611686018427387904 and userId = 100 limit 10001 /* exact shard */
+1 ks_sharded/40-80: select * from user_region where user_region.regionId = 4611686018427387904 and user_region.userId = 100 limit 10001 /* exact shard */
 
 ----------------------------------------------------------------------
 select * from user_region where regionId = 4611686018427387904 /* subshard */
 
-1 ks_sharded/40-80: select * from user_region where regionId = 4611686018427387904 limit 10001 /* subshard */
+1 ks_sharded/40-80: select * from user_region where user_region.regionId = 4611686018427387904 limit 10001 /* subshard */
 
 ----------------------------------------------------------------------
 select * from user_region where regionId in (4611686018427387903, 4611686018427387904) /* subshard */
 
-1 ks_sharded/-40: select * from user_region where regionId in (4611686018427387903) limit 10001 /* subshard */
-1 ks_sharded/40-80: select * from user_region where regionId in (4611686018427387904) limit 10001 /* subshard */
+1 ks_sharded/-40: select * from user_region where user_region.regionId in (4611686018427387903) limit 10001 /* subshard */
+1 ks_sharded/40-80: select * from user_region where user_region.regionId in (4611686018427387904) limit 10001 /* subshard */
 
 ----------------------------------------------------------------------
 select * from user_region where userId = 100 /* scatter, needs prefix columns for subshard routing */
 
-1 ks_sharded/-40: select * from user_region where userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
-1 ks_sharded/40-80: select * from user_region where userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
-1 ks_sharded/80-c0: select * from user_region where userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
-1 ks_sharded/c0-: select * from user_region where userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
+1 ks_sharded/-40: select * from user_region where user_region.userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
+1 ks_sharded/40-80: select * from user_region where user_region.userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
+1 ks_sharded/80-c0: select * from user_region where user_region.userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
+1 ks_sharded/c0-: select * from user_region where user_region.userId = 100 limit 10001 /* scatter, needs prefix columns for subshard routing */
 
 ----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/multi-output/insertsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/insertsharded-output.txt
@@ -23,7 +23,7 @@ insert ignore into user (id, name) values(2, 'bob')
 
 1 ks_sharded/c0-: begin
 1 ks_sharded/c0-: insert ignore into name_user_map(`name`, user_id) values ('bob', 2)
-2 ks_sharded/c0-: select `name` from name_user_map where `name` = 'bob' and user_id = 2 limit 10001
+2 ks_sharded/c0-: select name_user_map.`name` as ```name``` from name_user_map where name_user_map.`name` = 'bob' and name_user_map.user_id = 2 limit 10001
 3 ks_sharded/-40: begin
 3 ks_sharded/-40: insert ignore into `user`(id, `name`) values (2, 'bob')
 4 ks_sharded/c0-: commit
@@ -34,7 +34,7 @@ insert ignore into user (id, name, nickname) values(2, 'bob', 'bob')
 
 1 ks_sharded/c0-: begin
 1 ks_sharded/c0-: insert ignore into name_user_map(`name`, user_id) values ('bob', 2)
-2 ks_sharded/c0-: select `name` from name_user_map where `name` = 'bob' and user_id = 2 limit 10001
+2 ks_sharded/c0-: select name_user_map.`name` as ```name``` from name_user_map where name_user_map.`name` = 'bob' and name_user_map.user_id = 2 limit 10001
 3 ks_sharded/-40: begin
 3 ks_sharded/-40: insert ignore into `user`(id, `name`, nickname) values (2, 'bob', 'bob')
 4 ks_sharded/c0-: commit
@@ -45,7 +45,7 @@ insert into user (id, name, nickname) values(2, 'bob', 'bobby') on duplicate key
 
 1 ks_sharded/c0-: begin
 1 ks_sharded/c0-: insert ignore into name_user_map(`name`, user_id) values ('bob', 2)
-2 ks_sharded/c0-: select `name` from name_user_map where `name` = 'bob' and user_id = 2 limit 10001
+2 ks_sharded/c0-: select name_user_map.`name` as ```name``` from name_user_map where name_user_map.`name` = 'bob' and name_user_map.user_id = 2 limit 10001
 3 ks_sharded/-40: begin
 3 ks_sharded/-40: insert into `user`(id, `name`, nickname) values (2, 'bob', 'bobby') on duplicate key update nickname = 'bobby'
 4 ks_sharded/c0-: commit
@@ -56,7 +56,7 @@ insert into user (id, name, nickname, address) values(2, 'bob', 'bobby', '123 ma
 
 1 ks_sharded/c0-: begin
 1 ks_sharded/c0-: insert ignore into name_user_map(`name`, user_id) values ('bob', 2)
-2 ks_sharded/c0-: select `name` from name_user_map where `name` = 'bob' and user_id = 2 limit 10001
+2 ks_sharded/c0-: select name_user_map.`name` as ```name``` from name_user_map where name_user_map.`name` = 'bob' and name_user_map.user_id = 2 limit 10001
 3 ks_sharded/-40: begin
 3 ks_sharded/-40: insert into `user`(id, `name`, nickname, address) values (2, 'bob', 'bobby', '123 main st') on duplicate key update nickname = values(nickname), address = values(address)
 4 ks_sharded/c0-: commit
@@ -77,9 +77,9 @@ insert into member (lkp, more_id, id) values ("a", 1, 1), ("b", 1, 3), ("c", 1, 
 
 1 ks_sharded/40-80: insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ ignore into lkp_idx(lkp, id) values ('b', 3), ('c', 1)
 1 ks_sharded/c0-: insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ ignore into lkp_idx(lkp, id) values ('a', 1)
-2 ks_sharded/c0-: select lkp from lkp_idx where lkp = 'a' and id = 1 limit 10001
-3 ks_sharded/40-80: select lkp from lkp_idx where lkp = 'b' and id = 3 limit 10001
-4 ks_sharded/40-80: select lkp from lkp_idx where lkp = 'c' and id = 1 limit 10001
+2 ks_sharded/c0-: select lkp_idx.lkp as lkp from lkp_idx where lkp_idx.lkp = 'a' and lkp_idx.id = 1 limit 10001
+3 ks_sharded/40-80: select lkp_idx.lkp as lkp from lkp_idx where lkp_idx.lkp = 'b' and lkp_idx.id = 3 limit 10001
+4 ks_sharded/40-80: select lkp_idx.lkp as lkp from lkp_idx where lkp_idx.lkp = 'c' and lkp_idx.id = 1 limit 10001
 5 ks_sharded/-40: begin
 5 ks_sharded/-40: savepoint x1
 5 ks_sharded/-40: insert into `member`(lkp, more_id, id) values ('a', 1, 1), ('c', 1, 1) on duplicate key update more_id = 2

--- a/go/vt/vtexplain/testdata/multi-output/options-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/options-output.txt
@@ -1,17 +1,17 @@
 ----------------------------------------------------------------------
 select * from user where email='null@void.com'
 
-1 ks_sharded/-40: select * from `user` where email = 'null@void.com' limit 10001
-1 ks_sharded/40-80: select * from `user` where email = 'null@void.com' limit 10001
-1 ks_sharded/80-c0: select * from `user` where email = 'null@void.com' limit 10001
-1 ks_sharded/c0-: select * from `user` where email = 'null@void.com' limit 10001
+1 ks_sharded/-40: select * from `user` where `user`.email = 'null@void.com' limit 10001
+1 ks_sharded/40-80: select * from `user` where `user`.email = 'null@void.com' limit 10001
+1 ks_sharded/80-c0: select * from `user` where `user`.email = 'null@void.com' limit 10001
+1 ks_sharded/c0-: select * from `user` where `user`.email = 'null@void.com' limit 10001
 
 ----------------------------------------------------------------------
 select * from user where id in (1,2,3,4,5,6,7,8)
 
-1 ks_sharded/-40: select * from `user` where id in (1, 2) limit 10001
-1 ks_sharded/40-80: select * from `user` where id in (3, 5) limit 10001
-1 ks_sharded/c0-: select * from `user` where id in (4, 6, 7, 8) limit 10001
+1 ks_sharded/-40: select * from `user` where `user`.id in (1, 2) limit 10001
+1 ks_sharded/40-80: select * from `user` where `user`.id in (3, 5) limit 10001
+1 ks_sharded/c0-: select * from `user` where `user`.id in (4, 6, 7, 8) limit 10001
 
 ----------------------------------------------------------------------
 insert into user (id, name) values (2, 'bob')

--- a/go/vt/vtexplain/testdata/multi-output/select-sharded-8-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/select-sharded-8-output.txt
@@ -13,6 +13,6 @@ select * from user
 ----------------------------------------------------------------------
 select * from user where id in (1, 2)
 
-1 ks_sharded/-20: select * from `user` where id in (1, 2) limit 10001
+1 ks_sharded/-20: select * from `user` where `user`.id in (1, 2) limit 10001
 
 ----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -9,29 +9,29 @@ select * from user /* scatter */
 ----------------------------------------------------------------------
 select * from user where id = 1 /* equal unique */
 
-1 ks_sharded/-40: select * from `user` where id = 1 limit 10001 /* equal unique */
+1 ks_sharded/-40: select * from `user` where `user`.id = 1 limit 10001 /* equal unique */
 
 ----------------------------------------------------------------------
 select * from user where id > 100 /* scatter range */
 
-1 ks_sharded/-40: select * from `user` where id > 100 limit 10001 /* scatter range */
-1 ks_sharded/40-80: select * from `user` where id > 100 limit 10001 /* scatter range */
-1 ks_sharded/80-c0: select * from `user` where id > 100 limit 10001 /* scatter range */
-1 ks_sharded/c0-: select * from `user` where id > 100 limit 10001 /* scatter range */
+1 ks_sharded/-40: select * from `user` where `user`.id > 100 limit 10001 /* scatter range */
+1 ks_sharded/40-80: select * from `user` where `user`.id > 100 limit 10001 /* scatter range */
+1 ks_sharded/80-c0: select * from `user` where `user`.id > 100 limit 10001 /* scatter range */
+1 ks_sharded/c0-: select * from `user` where `user`.id > 100 limit 10001 /* scatter range */
 
 ----------------------------------------------------------------------
 select * from user where name = 'bob' /* vindex lookup */
 
-1 ks_sharded/c0-: select `name`, user_id from name_user_map where `name` in ('bob') limit 10001 /* vindex lookup */
-2 ks_sharded/-40: select * from `user` where `name` = 'bob' limit 10001 /* vindex lookup */
+1 ks_sharded/c0-: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('bob') limit 10001 /* vindex lookup */
+2 ks_sharded/-40: select * from `user` where `user`.`name` = 'bob' limit 10001 /* vindex lookup */
 
 ----------------------------------------------------------------------
 select * from user where name = 'bob' or nickname = 'bob' /* vindex lookup */
 
-1 ks_sharded/-40: select * from `user` where `name` = 'bob' or nickname = 'bob' limit 10001 /* vindex lookup */
-1 ks_sharded/40-80: select * from `user` where `name` = 'bob' or nickname = 'bob' limit 10001 /* vindex lookup */
-1 ks_sharded/80-c0: select * from `user` where `name` = 'bob' or nickname = 'bob' limit 10001 /* vindex lookup */
-1 ks_sharded/c0-: select * from `user` where `name` = 'bob' or nickname = 'bob' limit 10001 /* vindex lookup */
+1 ks_sharded/-40: select * from `user` where `user`.`name` = 'bob' or `user`.nickname = 'bob' limit 10001 /* vindex lookup */
+1 ks_sharded/40-80: select * from `user` where `user`.`name` = 'bob' or `user`.nickname = 'bob' limit 10001 /* vindex lookup */
+1 ks_sharded/80-c0: select * from `user` where `user`.`name` = 'bob' or `user`.nickname = 'bob' limit 10001 /* vindex lookup */
+1 ks_sharded/c0-: select * from `user` where `user`.`name` = 'bob' or `user`.nickname = 'bob' limit 10001 /* vindex lookup */
 
 ----------------------------------------------------------------------
 select u.id, u.name, u.nickname, n.info from user u join name_info n on u.name = n.name /* join on varchar */
@@ -54,39 +54,39 @@ select m.id, m.song, e.extra from music m join music_extra e on m.id = e.id wher
 ----------------------------------------------------------------------
 select count(*) from user where id = 1 /* point aggregate */
 
-1 ks_sharded/-40: select count(*) from `user` where id = 1 limit 10001 /* point aggregate */
+1 ks_sharded/-40: select count(*) from `user` where `user`.id = 1 limit 10001 /* point aggregate */
 
 ----------------------------------------------------------------------
 select count(*) from user where name in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') /* scatter aggregate */
 
-1 ks_sharded/c0-: select `name`, user_id from name_user_map where `name` in ('a') limit 10001 /* scatter aggregate */
-2 ks_sharded/40-80: select `name`, user_id from name_user_map where `name` in ('b') limit 10001 /* scatter aggregate */
-3 ks_sharded/40-80: select `name`, user_id from name_user_map where `name` in ('c') limit 10001 /* scatter aggregate */
-4 ks_sharded/c0-: select `name`, user_id from name_user_map where `name` in ('d') limit 10001 /* scatter aggregate */
-5 ks_sharded/80-c0: select `name`, user_id from name_user_map where `name` in ('e') limit 10001 /* scatter aggregate */
-6 ks_sharded/-40: select `name`, user_id from name_user_map where `name` in ('f') limit 10001 /* scatter aggregate */
-7 ks_sharded/-40: select `name`, user_id from name_user_map where `name` in ('g') limit 10001 /* scatter aggregate */
-8 ks_sharded/40-80: select `name`, user_id from name_user_map where `name` in ('h') limit 10001 /* scatter aggregate */
-9 ks_sharded/-40: select `name`, user_id from name_user_map where `name` in ('i') limit 10001 /* scatter aggregate */
-10 ks_sharded/-40: select `name`, user_id from name_user_map where `name` in ('j') limit 10001 /* scatter aggregate */
-11 ks_sharded/-40: select count(*) from `user` where `name` in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') limit 10001 /* scatter aggregate */
+1 ks_sharded/c0-: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('a') limit 10001 /* scatter aggregate */
+2 ks_sharded/40-80: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('b') limit 10001 /* scatter aggregate */
+3 ks_sharded/40-80: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('c') limit 10001 /* scatter aggregate */
+4 ks_sharded/c0-: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('d') limit 10001 /* scatter aggregate */
+5 ks_sharded/80-c0: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('e') limit 10001 /* scatter aggregate */
+6 ks_sharded/-40: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('f') limit 10001 /* scatter aggregate */
+7 ks_sharded/-40: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('g') limit 10001 /* scatter aggregate */
+8 ks_sharded/40-80: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('h') limit 10001 /* scatter aggregate */
+9 ks_sharded/-40: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('i') limit 10001 /* scatter aggregate */
+10 ks_sharded/-40: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('j') limit 10001 /* scatter aggregate */
+11 ks_sharded/-40: select count(*) from `user` where `user`.`name` in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') limit 10001 /* scatter aggregate */
 
 ----------------------------------------------------------------------
 select count(*) from customer where email in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') /* scatter aggregate with batching */
 
-1 ks_sharded/-40: select email, user_id from email_customer_map where email in ('f', 'g', 'i', 'j') limit 10001 /* scatter aggregate with batching */
-1 ks_sharded/40-80: select email, user_id from email_customer_map where email in ('b', 'c', 'h') limit 10001 /* scatter aggregate with batching */
-1 ks_sharded/80-c0: select email, user_id from email_customer_map where email in ('e') limit 10001 /* scatter aggregate with batching */
-1 ks_sharded/c0-: select email, user_id from email_customer_map where email in ('a', 'd') limit 10001 /* scatter aggregate with batching */
-2 ks_sharded/-40: select count(*) from customer where email in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') limit 10001 /* scatter aggregate with batching */
+1 ks_sharded/-40: select email_customer_map.email as email, email_customer_map.user_id as user_id from email_customer_map where email_customer_map.email in ('f', 'g', 'i', 'j') limit 10001 /* scatter aggregate with batching */
+1 ks_sharded/40-80: select email_customer_map.email as email, email_customer_map.user_id as user_id from email_customer_map where email_customer_map.email in ('b', 'c', 'h') limit 10001 /* scatter aggregate with batching */
+1 ks_sharded/80-c0: select email_customer_map.email as email, email_customer_map.user_id as user_id from email_customer_map where email_customer_map.email in ('e') limit 10001 /* scatter aggregate with batching */
+1 ks_sharded/c0-: select email_customer_map.email as email, email_customer_map.user_id as user_id from email_customer_map where email_customer_map.email in ('a', 'd') limit 10001 /* scatter aggregate with batching */
+2 ks_sharded/-40: select count(*) from customer where customer.email in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') limit 10001 /* scatter aggregate with batching */
 
 ----------------------------------------------------------------------
 select name, count(*) from user group by name /* scatter aggregate */
 
-1 ks_sharded/-40: select `name`, count(*) from `user` group by `name` limit 10001 /* scatter aggregate */
-1 ks_sharded/40-80: select `name`, count(*) from `user` group by `name` limit 10001 /* scatter aggregate */
-1 ks_sharded/80-c0: select `name`, count(*) from `user` group by `name` limit 10001 /* scatter aggregate */
-1 ks_sharded/c0-: select `name`, count(*) from `user` group by `name` limit 10001 /* scatter aggregate */
+1 ks_sharded/-40: select `user`.`name` as ```name```, count(*) from `user` group by `user`.`name` limit 10001 /* scatter aggregate */
+1 ks_sharded/40-80: select `user`.`name` as ```name```, count(*) from `user` group by `user`.`name` limit 10001 /* scatter aggregate */
+1 ks_sharded/80-c0: select `user`.`name` as ```name```, count(*) from `user` group by `user`.`name` limit 10001 /* scatter aggregate */
+1 ks_sharded/c0-: select `user`.`name` as ```name```, count(*) from `user` group by `user`.`name` limit 10001 /* scatter aggregate */
 
 ----------------------------------------------------------------------
 select 1, "hello", 3.14, null from user limit 10 /* select constant sql values */
@@ -107,86 +107,86 @@ select * from (select id from user) s /* scatter paren select */
 ----------------------------------------------------------------------
 select name from user where id = (select id from t1) /* non-correlated subquery as value */
 
-1 ks_unsharded/-: select id from t1 limit 10001 /* non-correlated subquery as value */
-2 ks_sharded/-40: select `name` from `user` where id = 1 limit 10001 /* non-correlated subquery as value */
+1 ks_unsharded/-: select t1.id as id from t1 limit 10001 /* non-correlated subquery as value */
+2 ks_sharded/-40: select `user`.`name` as ```name``` from `user` where `user`.id = 1 limit 10001 /* non-correlated subquery as value */
 
 ----------------------------------------------------------------------
 select name from user where id in (select id from t1) /* non-correlated subquery in IN clause */
 
-1 ks_unsharded/-: select id from t1 limit 10001 /* non-correlated subquery in IN clause */
-2 ks_sharded/-40: select `name` from `user` where 1 = 1 and id in (1) limit 10001 /* non-correlated subquery in IN clause */
+1 ks_unsharded/-: select t1.id as id from t1 limit 10001 /* non-correlated subquery in IN clause */
+2 ks_sharded/-40: select `user`.`name` as ```name``` from `user` where 1 = 1 and `user`.id in (1) limit 10001 /* non-correlated subquery in IN clause */
 
 ----------------------------------------------------------------------
 select name from user where id not in (select id from t1) /* non-correlated subquery in NOT IN clause */
 
-1 ks_unsharded/-: select id from t1 limit 10001 /* non-correlated subquery in NOT IN clause */
-2 ks_sharded/-40: select `name` from `user` where 1 = 0 or id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
-2 ks_sharded/40-80: select `name` from `user` where 1 = 0 or id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
-2 ks_sharded/80-c0: select `name` from `user` where 1 = 0 or id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
-2 ks_sharded/c0-: select `name` from `user` where 1 = 0 or id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
+1 ks_unsharded/-: select t1.id as id from t1 limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/-40: select `user`.`name` as ```name``` from `user` where 1 = 0 or `user`.id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/40-80: select `user`.`name` as ```name``` from `user` where 1 = 0 or `user`.id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/80-c0: select `user`.`name` as ```name``` from `user` where 1 = 0 or `user`.id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/c0-: select `user`.`name` as ```name``` from `user` where 1 = 0 or `user`.id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
 
 ----------------------------------------------------------------------
 select name from user where exists (select id from t1) /* non-correlated subquery as EXISTS */
 
 1 ks_unsharded/-: select 1 from t1 limit 1 /* non-correlated subquery as EXISTS */
-2 ks_sharded/-40: select `name` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */
-2 ks_sharded/40-80: select `name` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */
-2 ks_sharded/80-c0: select `name` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */
-2 ks_sharded/c0-: select `name` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */
+2 ks_sharded/-40: select `user`.`name` as ```name``` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */
+2 ks_sharded/40-80: select `user`.`name` as ```name``` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */
+2 ks_sharded/80-c0: select `user`.`name` as ```name``` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */
+2 ks_sharded/c0-: select `user`.`name` as ```name``` from `user` where 1 limit 10001 /* non-correlated subquery as EXISTS */
 
 ----------------------------------------------------------------------
 select * from name_info order by info /* select * and order by varchar column */
 
-1 ks_sharded/-40: select `name`, info, weight_string(info) from name_info order by info asc limit 10001 /* select * and order by varchar column */
-1 ks_sharded/40-80: select `name`, info, weight_string(info) from name_info order by info asc limit 10001 /* select * and order by varchar column */
-1 ks_sharded/80-c0: select `name`, info, weight_string(info) from name_info order by info asc limit 10001 /* select * and order by varchar column */
-1 ks_sharded/c0-: select `name`, info, weight_string(info) from name_info order by info asc limit 10001 /* select * and order by varchar column */
+1 ks_sharded/-40: select name_info.`name` as ```name```, name_info.info as info, weight_string(name_info.info) from name_info order by name_info.info asc limit 10001 /* select * and order by varchar column */
+1 ks_sharded/40-80: select name_info.`name` as ```name```, name_info.info as info, weight_string(name_info.info) from name_info order by name_info.info asc limit 10001 /* select * and order by varchar column */
+1 ks_sharded/80-c0: select name_info.`name` as ```name```, name_info.info as info, weight_string(name_info.info) from name_info order by name_info.info asc limit 10001 /* select * and order by varchar column */
+1 ks_sharded/c0-: select name_info.`name` as ```name```, name_info.info as info, weight_string(name_info.info) from name_info order by name_info.info asc limit 10001 /* select * and order by varchar column */
 
 ----------------------------------------------------------------------
 select distinct(name) from user where id = 1 /* select distinct */
 
-1 ks_sharded/-40: select distinct `name` from `user` where id = 1 limit 10001 /* select distinct */
+1 ks_sharded/-40: select distinct `user`.`name` as ```name``` from `user` where `user`.id = 1 limit 10001 /* select distinct */
 
 ----------------------------------------------------------------------
 select distinct name from user where id = 1 /* select distinct */
 
-1 ks_sharded/-40: select distinct `name` from `user` where id = 1 limit 10001 /* select distinct */
+1 ks_sharded/-40: select distinct `user`.`name` as ```name``` from `user` where `user`.id = 1 limit 10001 /* select distinct */
 
 ----------------------------------------------------------------------
 select id, substring(name, 1, -1) from user where id = 123 /* select substring */
 
-1 ks_sharded/-40: select id, substr(`name`, 1, -1) from `user` where id = 123 limit 10001 /* select substring */
+1 ks_sharded/-40: select `user`.id as id, substr(`user`.`name`, 1, -1) as `substr(``name``, :vtg1, -:vtg1)` from `user` where `user`.id = 123 limit 10001 /* select substring */
 
 ----------------------------------------------------------------------
 select id, substring_index(name, '123456', -1) from user where id = 123 /* select substring_index */
 
-1 ks_sharded/-40: select id, substring_index(`name`, '123456', -1) from `user` where id = 123 limit 10001 /* select substring_index */
+1 ks_sharded/-40: select `user`.id as id, substring_index(`user`.`name`, '123456', -1) as `substring_index(``name``, :vtg1, -:vtg2)` from `user` where `user`.id = 123 limit 10001 /* select substring_index */
 
 ----------------------------------------------------------------------
 select id, case when name = 'alice' then 'ALICE' when name = 'bob' then 'BOB' end as name from user where id = 1 /* select case */
 
-1 ks_sharded/-40: select id, case when `name` = 'alice' then 'ALICE' when `name` = 'bob' then 'BOB' end as `name` from `user` where id = 1 limit 10001 /* select case */
+1 ks_sharded/-40: select `user`.id as id, case when `name` = 'alice' then 'ALICE' when `name` = 'bob' then 'BOB' end as `name` from `user` where `user`.id = 1 limit 10001 /* select case */
 
 ----------------------------------------------------------------------
 select id, case when name = 'alice' then 'ALICE' when name = 'bob' then 'BOB' else 'OTHER' end as name from user where id = 1 /* select case */
 
-1 ks_sharded/-40: select id, case when `name` = 'alice' then 'ALICE' when `name` = 'bob' then 'BOB' else 'OTHER' end as `name` from `user` where id = 1 limit 10001 /* select case */
+1 ks_sharded/-40: select `user`.id as id, case when `name` = 'alice' then 'ALICE' when `name` = 'bob' then 'BOB' else 'OTHER' end as `name` from `user` where `user`.id = 1 limit 10001 /* select case */
 
 ----------------------------------------------------------------------
 select id, case when substr(name, 1, 5) = 'alice' then 'ALICE' when name = 'bob' then 'BOB' else 'OTHER' end as name from user where id = 1 /* select case */
 
-1 ks_sharded/-40: select id, case when substr(`name`, 1, 5) = 'alice' then 'ALICE' when `name` = 'bob' then 'BOB' else 'OTHER' end as `name` from `user` where id = 1 limit 10001 /* select case */
+1 ks_sharded/-40: select `user`.id as id, case when substr(`name`, 1, 5) = 'alice' then 'ALICE' when `name` = 'bob' then 'BOB' else 'OTHER' end as `name` from `user` where `user`.id = 1 limit 10001 /* select case */
 
 ----------------------------------------------------------------------
 select id, 'abc' as test from user where id = 1 union all select id, 'def' as test from user where id = 1 union all select id, 'ghi' as test from user where id = 1 /* union all */
 
-1 ks_sharded/-40: select id, 'abc' as test from `user` where id = 1 union all select id, 'def' as test from `user` where id = 1 union all select id, 'ghi' as test from `user` where id = 1 limit 10001 /* union all */
+1 ks_sharded/-40: select `user`.id as id, 'abc' as test from `user` where `user`.id = 1 union all select `user`.id as id, 'def' as test from `user` where `user`.id = 1 union all select `user`.id as id, 'ghi' as test from `user` where `user`.id = 1 limit 10001 /* union all */
 
 ----------------------------------------------------------------------
 select id from user where not id in (select col from music where music.user_id = 42) and id in (select col from music where music.user_id = 411)
 
-1 ks_sharded/40-80: select col from music where music.user_id = 411 limit 10001
-2 ks_sharded/40-80: select col from music where music.user_id = 42 limit 10001
+1 ks_sharded/40-80: select music.col as col from music where music.user_id = 411 limit 10001
+2 ks_sharded/40-80: select music.col as col from music where music.user_id = 42 limit 10001
 
 ----------------------------------------------------------------------
 SELECT user.id, user.name, name_info.info FROM user INNER JOIN music ON (user.id = music.user_id) LEFT OUTER JOIN name_info ON (user.name = name_info.name)

--- a/go/vt/vtexplain/testdata/multi-output/uneven-keyspace-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/uneven-keyspace-output.txt
@@ -10,7 +10,7 @@ select * from user
 ----------------------------------------------------------------------
 select * from user where id in (10, 17, 42, 100000)
 
-1 ks_sharded/-80: select * from `user` where id in (10, 17, 42) limit 10001
-1 ks_sharded/80-90: select * from `user` where id in (100000) limit 10001
+1 ks_sharded/-80: select * from `user` where `user`.id in (10, 17, 42) limit 10001
+1 ks_sharded/80-90: select * from `user` where `user`.id in (100000) limit 10001
 
 ----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/multi-output/updatesharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/updatesharded-output.txt
@@ -2,16 +2,16 @@
 update user set nickname='alice' where id=1
 
 1 ks_sharded/-40: begin
-1 ks_sharded/-40: update `user` set nickname = 'alice' where id = 1 limit 10001
+1 ks_sharded/-40: update `user` set `user`.nickname = 'alice' where `user`.id = 1 limit 10001
 1 ks_sharded/-40: commit
 
 ----------------------------------------------------------------------
 update user set nickname='alice' where name='alice'
 
 1 ks_sharded/40-80: begin
-1 ks_sharded/40-80: select `name`, user_id from name_user_map where `name` in ('alice') limit 10001 for update
+1 ks_sharded/40-80: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('alice') limit 10001 for update
 2 ks_sharded/-40: begin
-2 ks_sharded/-40: update `user` set nickname = 'alice' where `name` = 'alice' limit 10001
+2 ks_sharded/-40: update `user` set `user`.nickname = 'alice' where `user`.`name` = 'alice' limit 10001
 3 ks_sharded/40-80: commit
 4 ks_sharded/-40: commit
 
@@ -19,19 +19,19 @@ update user set nickname='alice' where name='alice'
 update user set pet='fido' where id=1
 
 1 ks_sharded/-40: begin
-1 ks_sharded/-40: update `user` set pet = 'fido' where id = 1 limit 10001
+1 ks_sharded/-40: update `user` set `user`.pet = 'fido' where `user`.id = 1 limit 10001
 1 ks_sharded/-40: commit
 
 ----------------------------------------------------------------------
 update user set name='alicia' where id=1
 
 1 ks_sharded/-40: begin
-1 ks_sharded/-40: select id, `name`, `name` = 'alicia' from `user` where id = 1 limit 10001 for update
+1 ks_sharded/-40: select id, `name`, `user`.`name` = 'alicia' from `user` where `user`.id = 1 limit 10001 for update
 2 ks_sharded/40-80: begin
 2 ks_sharded/40-80: delete from name_user_map where `name` = 'name_val_2' and user_id = 1 limit 10001
 3 ks_sharded/c0-: begin
 3 ks_sharded/c0-: insert into name_user_map(`name`, user_id) values ('alicia', 1)
-4 ks_sharded/-40: update `user` set `name` = 'alicia' where id = 1 limit 10001
+4 ks_sharded/-40: update `user` set `user`.`name` = 'alicia' where `user`.id = 1 limit 10001
 5 ks_sharded/-40: commit
 6 ks_sharded/40-80: commit
 7 ks_sharded/c0-: commit
@@ -40,13 +40,13 @@ update user set name='alicia' where id=1
 update user set name='alicia' where name='alice'
 
 1 ks_sharded/40-80: begin
-1 ks_sharded/40-80: select `name`, user_id from name_user_map where `name` in ('alice') limit 10001 for update
+1 ks_sharded/40-80: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('alice') limit 10001 for update
 2 ks_sharded/-40: begin
-2 ks_sharded/-40: select id, `name`, `name` = 'alicia' from `user` where `name` = 'alice' limit 10001 for update
+2 ks_sharded/-40: select id, `name`, `user`.`name` = 'alicia' from `user` where `user`.`name` = 'alice' limit 10001 for update
 3 ks_sharded/40-80: delete from name_user_map where `name` = 'name_val_2' and user_id = 1 limit 10001
 4 ks_sharded/c0-: begin
 4 ks_sharded/c0-: insert into name_user_map(`name`, user_id) values ('alicia', 1)
-5 ks_sharded/-40: update `user` set `name` = 'alicia' where `name` = 'alice' limit 10001
+5 ks_sharded/-40: update `user` set `user`.`name` = 'alicia' where `user`.`name` = 'alice' limit 10001
 6 ks_sharded/40-80: commit
 7 ks_sharded/-40: commit
 8 ks_sharded/c0-: commit
@@ -55,25 +55,25 @@ update user set name='alicia' where name='alice'
 update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set info='apa' where name != 'hog'
 
 1 ks_sharded/-40: begin
-1 ks_sharded/-40: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set info = 'apa' where `name` != 'hog' limit 10001
+1 ks_sharded/-40: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set name_info.info = 'apa' where name_info.`name` != 'hog' limit 10001
 1 ks_sharded/-40: commit
 1 ks_sharded/40-80: begin
-1 ks_sharded/40-80: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set info = 'apa' where `name` != 'hog' limit 10001
+1 ks_sharded/40-80: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set name_info.info = 'apa' where name_info.`name` != 'hog' limit 10001
 1 ks_sharded/40-80: commit
 1 ks_sharded/80-c0: begin
-1 ks_sharded/80-c0: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set info = 'apa' where `name` != 'hog' limit 10001
+1 ks_sharded/80-c0: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set name_info.info = 'apa' where name_info.`name` != 'hog' limit 10001
 1 ks_sharded/80-c0: commit
 1 ks_sharded/c0-: begin
-1 ks_sharded/c0-: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set info = 'apa' where `name` != 'hog' limit 10001
+1 ks_sharded/c0-: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set name_info.info = 'apa' where name_info.`name` != 'hog' limit 10001
 1 ks_sharded/c0-: commit
 
 ----------------------------------------------------------------------
 update user set pet='rover' where name='alice'
 
 1 ks_sharded/40-80: begin
-1 ks_sharded/40-80: select `name`, user_id from name_user_map where `name` in ('alice') limit 10001 for update
+1 ks_sharded/40-80: select name_user_map.`name` as ```name```, name_user_map.user_id as user_id from name_user_map where name_user_map.`name` in ('alice') limit 10001 for update
 2 ks_sharded/-40: begin
-2 ks_sharded/-40: update `user` set pet = 'rover' where `name` = 'alice' limit 10001
+2 ks_sharded/-40: update `user` set `user`.pet = 'rover' where `user`.`name` = 'alice' limit 10001
 3 ks_sharded/40-80: commit
 4 ks_sharded/-40: commit
 
@@ -85,12 +85,12 @@ begin
 update user set nickname='alice' where id=1
 
 1 ks_sharded/-40: begin
-1 ks_sharded/-40: update `user` set nickname = 'alice' where id = 1 limit 10001
+1 ks_sharded/-40: update `user` set `user`.nickname = 'alice' where `user`.id = 1 limit 10001
 
 ----------------------------------------------------------------------
 update user set nickname='bob' where id=1
 
-2 ks_sharded/-40: update `user` set nickname = 'bob' where id = 1 limit 10001
+2 ks_sharded/-40: update `user` set `user`.nickname = 'bob' where `user`.id = 1 limit 10001
 
 ----------------------------------------------------------------------
 commit
@@ -105,13 +105,13 @@ begin
 update user set nickname='alice' where id=1
 
 1 ks_sharded/-40: begin
-1 ks_sharded/-40: update `user` set nickname = 'alice' where id = 1 limit 10001
+1 ks_sharded/-40: update `user` set `user`.nickname = 'alice' where `user`.id = 1 limit 10001
 
 ----------------------------------------------------------------------
 update user set nickname='bob' where id=3
 
 2 ks_sharded/40-80: begin
-2 ks_sharded/40-80: update `user` set nickname = 'bob' where id = 3 limit 10001
+2 ks_sharded/40-80: update `user` set `user`.nickname = 'bob' where `user`.id = 3 limit 10001
 
 ----------------------------------------------------------------------
 commit
@@ -128,10 +128,10 @@ update user set nickname='alice' where id in (1,4)
 
 1 ks_sharded/-40: begin
 1 ks_sharded/-40: savepoint x1
-1 ks_sharded/-40: update `user` set nickname = 'alice' where id in (1, 4) limit 10001
+1 ks_sharded/-40: update `user` set `user`.nickname = 'alice' where `user`.id in (1, 4) limit 10001
 1 ks_sharded/c0-: begin
 1 ks_sharded/c0-: savepoint x1
-1 ks_sharded/c0-: update `user` set nickname = 'alice' where id in (1, 4) limit 10001
+1 ks_sharded/c0-: update `user` set `user`.nickname = 'alice' where `user`.id in (1, 4) limit 10001
 
 ----------------------------------------------------------------------
 commit

--- a/go/vt/vtexplain/vtexplain_test.go
+++ b/go/vt/vtexplain/vtexplain_test.go
@@ -261,7 +261,7 @@ func TestJSONOutput(t *testing.T) {
     "ks_sharded/-40": {
         "MysqlQueries": [
             {
-                "SQL": "select 1 from ` + "`user`" + ` where id = 1 limit 10001",
+                "SQL": "select 1 from ` + "`user`" + ` where ` + "`user`" + `.id = 1 limit 10001",
                 "Time": 1
             }
         ],
@@ -271,7 +271,7 @@ func TestJSONOutput(t *testing.T) {
                     "#maxLimit": "10001",
                     "vtg1": "1"
                 },
-                "SQL": "select :vtg1 from ` + "`user`" + ` where id = :vtg1",
+                "SQL": "select :vtg1 from ` + "`user`" + ` where ` + "`user`" + `.id = :vtg1",
                 "Time": 1
             }
         ]

--- a/go/vt/vtgate/planbuilder/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/horizon_planning.go
@@ -977,8 +977,10 @@ func (hp *horizonPlanning) addDistinct(ctx *plancontext.PlanningContext, plan lo
 			// If we have an alias, we need to use the alias and not the original expression
 			// to make sure dependencies work correctly,
 			// we simply copy the dependencies of the original expression here
+			// We also make sure to copy the expression type.
 			inner = sqlparser.NewColName(aliasExpr.As.String())
 			ctx.SemTable.CopyDependencies(aliasExpr.Expr, inner)
+			ctx.SemTable.CopyExprType(aliasExpr.Expr, inner)
 		}
 		grpParam := &engine.GroupByParams{KeyCol: index, WeightStringCol: -1, CollationID: ctx.SemTable.CollationForExpr(inner), Expr: inner}
 		_, wOffset, err := wrapAndPushExpr(ctx, aliasExpr.Expr, aliasExpr.Expr, plan)

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -67,8 +67,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select count(*), col from `user` where 1 != 1",
-    "Query": "select count(*), col from `user` where id = 1",
+    "FieldQuery": "select count(*), `user`.col as col from `user` where 1 != 1",
+    "Query": "select count(*), `user`.col as col from `user` where `user`.id = 1",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -107,8 +107,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select fun(1), col from `user` where 1 != 1",
-    "Query": "select fun(1), col from `user`",
+    "FieldQuery": "select fun(1), `user`.col as col from `user` where 1 != 1",
+    "Query": "select fun(1), `user`.col as col from `user`",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -143,8 +143,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col1, id from `user` where 1 != 1",
-    "Query": "select distinct col1, id from `user`",
+    "FieldQuery": "select `user`.col1 as col1, `user`.id as id from `user` where 1 != 1",
+    "Query": "select distinct `user`.col1 as col1, `user`.id as id from `user`",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -179,8 +179,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col1, id from `user` where 1 != 1 group by col1",
-    "Query": "select distinct col1, id from `user` group by col1",
+    "FieldQuery": "select `user`.col1 as col1, `user`.id as id from `user` where 1 != 1 group by `user`.col1",
+    "Query": "select distinct `user`.col1 as col1, `user`.id as id from `user` group by `user`.col1",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -233,9 +233,9 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select count(*), a, textcol1, b, weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, weight_string(a), textcol1, b, weight_string(b)",
+        "FieldQuery": "select count(*), `user`.a as a, `user`.textcol1 as textcol1, `user`.b as b, weight_string(`user`.a), weight_string(`user`.b) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a), `user`.textcol1, `user`.b, weight_string(`user`.b)",
         "OrderBy": "(1|4) ASC, 2 ASC COLLATE latin1_swedish_ci, (3|5) ASC",
-        "Query": "select count(*), a, textcol1, b, weight_string(a), weight_string(b) from `user` group by a, weight_string(a), textcol1, b, weight_string(b) order by a asc, textcol1 asc, b asc",
+        "Query": "select count(*), `user`.a as a, `user`.textcol1 as textcol1, `user`.b as b, weight_string(`user`.a), weight_string(`user`.b) from `user` group by `user`.a, weight_string(`user`.a), `user`.textcol1, `user`.b, weight_string(`user`.b) order by `user`.a asc, `user`.textcol1 asc, `user`.b asc",
         "Table": "`user`"
       }
     ]
@@ -287,9 +287,9 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select count(*), intcol from `user` where 1 != 1 group by intcol",
+        "FieldQuery": "select count(*), `user`.intcol as intcol from `user` where 1 != 1 group by `user`.intcol",
         "OrderBy": "1 ASC",
-        "Query": "select count(*), intcol from `user` group by intcol order by intcol asc",
+        "Query": "select count(*), `user`.intcol as intcol from `user` group by `user`.intcol order by `user`.intcol asc",
         "Table": "`user`"
       }
     ]
@@ -357,9 +357,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select count(*) as k, a, textcol1, b, weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, weight_string(a), textcol1, b, weight_string(b)",
+            "FieldQuery": "select count(*) as k, `user`.a as a, `user`.textcol1 as textcol1, `user`.b as b, weight_string(`user`.a), weight_string(`user`.b) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a), `user`.textcol1, `user`.b, weight_string(`user`.b)",
             "OrderBy": "(1|4) ASC, 2 ASC COLLATE latin1_swedish_ci, (3|5) ASC",
-            "Query": "select count(*) as k, a, textcol1, b, weight_string(a), weight_string(b) from `user` group by a, weight_string(a), textcol1, b, weight_string(b) order by a asc, textcol1 asc, b asc",
+            "Query": "select count(*) as k, `user`.a as a, `user`.textcol1 as textcol1, `user`.b as b, weight_string(`user`.a), weight_string(`user`.b) from `user` group by `user`.a, weight_string(`user`.a), `user`.textcol1, `user`.b, weight_string(`user`.b) order by `user`.a asc, `user`.textcol1 asc, `user`.b asc",
             "Table": "`user`"
           }
         ]
@@ -460,8 +460,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select sum(col) from `user` where 1 != 1",
-        "Query": "select sum(col) from `user`",
+        "FieldQuery": "select sum(`user`.col) as `sum(col)` from `user` where 1 != 1",
+        "Query": "select sum(`user`.col) as `sum(col)` from `user`",
         "Table": "`user`"
       }
     ]
@@ -510,8 +510,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select min(col) from `user` where 1 != 1",
-        "Query": "select min(col) from `user`",
+        "FieldQuery": "select min(`user`.col) as `min(col)` from `user` where 1 != 1",
+        "Query": "select min(`user`.col) as `min(col)` from `user`",
         "Table": "`user`"
       }
     ]
@@ -560,8 +560,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select max(col) from `user` where 1 != 1",
-        "Query": "select max(col) from `user`",
+        "FieldQuery": "select max(`user`.col) as `max(col)` from `user` where 1 != 1",
+        "Query": "select max(`user`.col) as `max(col)` from `user`",
         "Table": "`user`"
       }
     ]
@@ -613,9 +613,9 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1",
+        "FieldQuery": "select `user`.col1 as col1, `user`.col2 as col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1 group by `user`.col1",
         "OrderBy": "(0|2) ASC, (1|3) ASC",
-        "Query": "select distinct col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1 order by col1 asc, col2 asc",
+        "Query": "select distinct `user`.col1 as col1, `user`.col2 as col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` group by `user`.col1 order by col1 asc, col2 asc",
         "Table": "`user`"
       }
     ]
@@ -727,8 +727,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id, count(*) from `user` where 1 != 1 group by id",
-    "Query": "select id, count(*) from `user` group by id",
+    "FieldQuery": "select `user`.id as id, count(*) from `user` where 1 != 1 group by `user`.id",
+    "Query": "select `user`.id as id, count(*) from `user` group by `user`.id",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -763,8 +763,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id, col, count(*) from `user` where 1 != 1 group by id, col",
-    "Query": "select id, col, count(*) from `user` group by id, col",
+    "FieldQuery": "select `user`.id as id, `user`.col as col, count(*) from `user` where 1 != 1 group by `user`.id, `user`.col",
+    "Query": "select `user`.id as id, `user`.col as col, count(*) from `user` group by `user`.id, `user`.col",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -814,9 +814,9 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col, count(*) from `user` where 1 != 1 group by col",
+        "FieldQuery": "select `user`.col as col, count(*) from `user` where 1 != 1 group by `user`.col",
         "OrderBy": "0 ASC",
-        "Query": "select col, count(*) from `user` group by col order by col asc",
+        "Query": "select `user`.col as col, count(*) from `user` group by `user`.col order by `user`.col asc",
         "Table": "`user`"
       }
     ]
@@ -846,9 +846,9 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col, count(*), baz, weight_string(baz) from `user` where 1 != 1 group by col, baz, weight_string(baz)",
+        "FieldQuery": "select `user`.col as col, count(*), `user`.baz, weight_string(`user`.baz) from `user` where 1 != 1 group by `user`.col, `user`.baz, weight_string(`user`.baz)",
         "OrderBy": "0 ASC, (2|3) ASC",
-        "Query": "select col, count(*), baz, weight_string(baz) from `user` group by col, baz, weight_string(baz) order by col asc, baz asc",
+        "Query": "select `user`.col as col, count(*), `user`.baz, weight_string(`user`.baz) from `user` group by `user`.col, `user`.baz, weight_string(`user`.baz) order by `user`.col asc, `user`.baz asc",
         "Table": "`user`"
       }
     ]
@@ -902,9 +902,9 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select `name`, count(*), weight_string(`name`) from `user` where 1 != 1 group by `name`, weight_string(`name`)",
+        "FieldQuery": "select `user`.`name` as ```name```, count(*), weight_string(`user`.`name`) from `user` where 1 != 1 group by `user`.`name`, weight_string(`user`.`name`)",
         "OrderBy": "(0|2) ASC",
-        "Query": "select `name`, count(*), weight_string(`name`) from `user` group by `name`, weight_string(`name`) order by `name` asc",
+        "Query": "select `user`.`name` as ```name```, count(*), weight_string(`user`.`name`) from `user` group by `user`.`name`, weight_string(`user`.`name`) order by `user`.`name` asc",
         "Table": "`user`"
       }
     ]
@@ -941,8 +941,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id, 1 + count(*) from `user` where 1 != 1 group by id",
-    "Query": "select id, 1 + count(*) from `user` group by id",
+    "FieldQuery": "select `user`.id as id, 1 + count(*) from `user` where 1 != 1 group by `user`.id",
+    "Query": "select `user`.id as id, 1 + count(*) from `user` group by `user`.id",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -977,8 +977,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id as val, 1 + count(*) from `user` where 1 != 1 group by val",
-    "Query": "select id as val, 1 + count(*) from `user` group by val",
+    "FieldQuery": "select `user`.id as val, 1 + count(*) from `user` where 1 != 1 group by val",
+    "Query": "select `user`.id as val, 1 + count(*) from `user` group by val",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -1013,8 +1013,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select val as id, 1 + count(*) from `user` where 1 != 1 group by `user`.id",
-    "Query": "select val as id, 1 + count(*) from `user` group by `user`.id",
+    "FieldQuery": "select `user`.val as id, 1 + count(*) from `user` where 1 != 1 group by `user`.id",
+    "Query": "select `user`.val as id, 1 + count(*) from `user` group by `user`.id",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -1072,8 +1072,8 @@ Gen4 error: unsupported: '*' expression in cross-shard query
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id, count(*) as c from `user` where 1 != 1 group by id",
-    "Query": "select id, count(*) as c from `user` where id = 1 group by id having c = 10",
+    "FieldQuery": "select `user`.id as id, count(*) as c from `user` where 1 != 1 group by `user`.id",
+    "Query": "select `user`.id as id, count(*) as c from `user` where `user`.id = 1 group by `user`.id having c = 10",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -1112,8 +1112,8 @@ Gen4 error: unsupported: '*' expression in cross-shard query
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id, count(*) as c from `user` where 1 != 1 group by id",
-    "Query": "select id, count(*) as c from `user` group by id having max(col) \u003e 10",
+    "FieldQuery": "select `user`.id as id, count(*) as c from `user` where 1 != 1 group by `user`.id",
+    "Query": "select `user`.id as id, count(*) as c from `user` group by `user`.id having max(`user`.col) \u003e 10",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -1226,8 +1226,8 @@ Gen4 error: unsupported: '*' expression in cross-shard query
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id, count(*) from `user` where 1 != 1",
-        "Query": "select id, count(*) from `user`",
+        "FieldQuery": "select `user`.id as id, count(*) from `user` where 1 != 1",
+        "Query": "select `user`.id as id, count(*) from `user`",
         "Table": "`user`"
       }
     ]
@@ -1277,9 +1277,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
         "OrderBy": "0 ASC",
-        "Query": "select distinct col from `user` order by col asc",
+        "Query": "select distinct `user`.col as col from `user` order by col asc",
         "Table": "`user`"
       }
     ]
@@ -1329,9 +1329,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1 group by col",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1 group by `user`.col",
         "OrderBy": "0 ASC",
-        "Query": "select col from `user` group by col order by col asc",
+        "Query": "select `user`.col as col from `user` group by `user`.col order by `user`.col asc",
         "Table": "`user`"
       }
     ]
@@ -1368,8 +1368,8 @@ Gen4 error: unsupported: '*' expression in cross-shard query
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id, count(distinct col) from `user` where 1 != 1 group by id",
-    "Query": "select id, count(distinct col) from `user` group by id",
+    "FieldQuery": "select `user`.id as id, count(distinct `user`.col) as `count(distinct col)` from `user` where 1 != 1 group by `user`.id",
+    "Query": "select `user`.id as id, count(distinct `user`.col) as `count(distinct col)` from `user` group by `user`.id",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -1419,9 +1419,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col, count(distinct id) from `user` where 1 != 1 group by col",
+        "FieldQuery": "select `user`.col as col, count(distinct `user`.id) as `count(distinct id)` from `user` where 1 != 1 group by `user`.col",
         "OrderBy": "0 ASC",
-        "Query": "select col, count(distinct id) from `user` group by col order by col asc",
+        "Query": "select `user`.col as col, count(distinct `user`.id) as `count(distinct id)` from `user` group by `user`.col order by `user`.col asc",
         "Table": "`user`"
       }
     ]
@@ -1475,9 +1475,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, weight_string(col1), col2, weight_string(col2)",
+        "FieldQuery": "select `user`.col1 as col1, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1 group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2)",
         "OrderBy": "(0|2) ASC, (1|3) ASC",
-        "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, weight_string(col1), col2, weight_string(col2) order by col1 asc, col2 asc",
+        "Query": "select `user`.col1 as col1, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2) order by `user`.col1 asc, `user`.col2 asc",
         "Table": "`user`"
       }
     ]
@@ -1529,9 +1529,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col2, weight_string(col2) from `user` where 1 != 1 group by col2, weight_string(col2)",
+        "FieldQuery": "select `user`.col2, weight_string(`user`.col2) from `user` where 1 != 1 group by `user`.col2, weight_string(`user`.col2)",
         "OrderBy": "(0|1) ASC",
-        "Query": "select col2, weight_string(col2) from `user` group by col2, weight_string(col2) order by col2 asc",
+        "Query": "select `user`.col2, weight_string(`user`.col2) from `user` group by `user`.col2, weight_string(`user`.col2) order by `user`.col2 asc",
         "Table": "`user`"
       }
     ]
@@ -1585,9 +1585,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, weight_string(col1), col2, weight_string(col2)",
+        "FieldQuery": "select `user`.col1 as col1, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1 group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2)",
         "OrderBy": "(0|2) ASC, (1|3) ASC",
-        "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, weight_string(col1), col2, weight_string(col2) order by col1 asc, col2 asc",
+        "Query": "select `user`.col1 as col1, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2) order by `user`.col1 asc, `user`.col2 asc",
         "Table": "`user`"
       }
     ]
@@ -1641,9 +1641,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, weight_string(col1), col2, weight_string(col2)",
+        "FieldQuery": "select `user`.col1 as col1, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1 group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2)",
         "OrderBy": "(0|2) ASC, (1|3) ASC",
-        "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, weight_string(col1), col2, weight_string(col2) order by col1 asc, col2 asc",
+        "Query": "select `user`.col1 as col1, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2) order by `user`.col1 asc, `user`.col2 asc",
         "Table": "`user`"
       }
     ]
@@ -1697,9 +1697,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, weight_string(col1), col2, weight_string(col2)",
+        "FieldQuery": "select `user`.col1 as col1, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1 group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2)",
         "OrderBy": "(0|2) ASC, (1|3) ASC",
-        "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, weight_string(col1), col2, weight_string(col2) order by col1 asc, col2 asc",
+        "Query": "select `user`.col1 as col1, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2) order by `user`.col1 asc, `user`.col2 asc",
         "Table": "`user`"
       }
     ]
@@ -1765,9 +1765,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, weight_string(col1), col2, weight_string(col2)",
+            "FieldQuery": "select `user`.col1 as col1, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1 group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2)",
             "OrderBy": "(0|2) ASC, (1|3) ASC",
-            "Query": "select col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, weight_string(col1), col2, weight_string(col2) order by col1 asc, col2 asc",
+            "Query": "select `user`.col1 as col1, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2) order by `user`.col1 asc, `user`.col2 asc",
             "Table": "`user`"
           }
         ]
@@ -1828,9 +1828,9 @@ Gen4 error: Can't group on 'count(*)'
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, b, count(*), weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, weight_string(a), b, weight_string(b)",
+        "FieldQuery": "select `user`.a as a, `user`.b as b, count(*), weight_string(`user`.a), weight_string(`user`.b) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b)",
         "OrderBy": "(0|3) ASC, (1|4) ASC",
-        "Query": "select a, b, count(*), weight_string(a), weight_string(b) from `user` group by a, weight_string(a), b, weight_string(b) order by a asc, b asc",
+        "Query": "select `user`.a as a, `user`.b as b, count(*), weight_string(`user`.a), weight_string(`user`.b) from `user` group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b) order by `user`.a asc, `user`.b asc",
         "Table": "`user`"
       }
     ]
@@ -1884,9 +1884,9 @@ Gen4 error: Can't group on 'count(*)'
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, b, count(*), weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, weight_string(a), b, weight_string(b)",
+        "FieldQuery": "select `user`.a as a, `user`.b as b, count(*), weight_string(`user`.a), weight_string(`user`.b) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b)",
         "OrderBy": "(0|3) ASC, (1|4) ASC",
-        "Query": "select a, b, count(*), weight_string(a), weight_string(b) from `user` group by a, weight_string(a), b, weight_string(b) order by a asc, b asc",
+        "Query": "select `user`.a as a, `user`.b as b, count(*), weight_string(`user`.a), weight_string(`user`.b) from `user` group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b) order by `user`.a asc, `user`.b asc",
         "Table": "`user`"
       }
     ]
@@ -1940,9 +1940,9 @@ Gen4 error: Can't group on 'count(*)'
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, b, count(*), weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, weight_string(a), b, weight_string(b)",
+        "FieldQuery": "select `user`.a as a, `user`.b as b, count(*), weight_string(`user`.a), weight_string(`user`.b) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b)",
         "OrderBy": "(0|3) ASC, (1|4) ASC",
-        "Query": "select a, b, count(*), weight_string(a), weight_string(b) from `user` group by a, weight_string(a), b, weight_string(b) order by a asc, b asc",
+        "Query": "select `user`.a as a, `user`.b as b, count(*), weight_string(`user`.a), weight_string(`user`.b) from `user` group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b) order by `user`.a asc, `user`.b asc",
         "Table": "`user`"
       }
     ]
@@ -1983,7 +1983,8 @@ Gen4 error: Can't group on 'count(*)'
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "GroupBy": "0",
+    "GroupBy": "(0|1)",
+    "ResultColumns": 1,
     "Inputs": [
       {
         "OperatorType": "Route",
@@ -1992,9 +1993,9 @@ Gen4 error: Can't group on 'count(*)'
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1 group by col",
-        "OrderBy": "0 ASC",
-        "Query": "select col from `user` group by col order by col asc",
+        "FieldQuery": "select `user`.col as col, weight_string(`user`.col) from `user` where 1 != 1 group by `user`.col, weight_string(`user`.col)",
+        "OrderBy": "(0|1) ASC",
+        "Query": "select `user`.col as col, weight_string(`user`.col) from `user` group by `user`.col, weight_string(`user`.col) order by `user`.col asc",
         "Table": "`user`"
       }
     ]
@@ -2103,9 +2104,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` where 1 != 1 group by a, weight_string(a), b, weight_string(b), c, weight_string(c)",
+        "FieldQuery": "select `user`.a as a, `user`.b as b, `user`.c as c, `user`.d as d, count(*), weight_string(`user`.a), weight_string(`user`.b), weight_string(`user`.c) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b), `user`.c, weight_string(`user`.c)",
         "OrderBy": "(0|5) ASC, (1|6) ASC, (2|7) ASC",
-        "Query": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` group by a, weight_string(a), b, weight_string(b), c, weight_string(c) order by a asc, b asc, c asc",
+        "Query": "select `user`.a as a, `user`.b as b, `user`.c as c, `user`.d as d, count(*), weight_string(`user`.a), weight_string(`user`.b), weight_string(`user`.c) from `user` group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b), `user`.c, weight_string(`user`.c) order by `user`.a asc, `user`.b asc, `user`.c asc",
         "Table": "`user`"
       }
     ]
@@ -2159,9 +2160,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` where 1 != 1 group by a, weight_string(a), b, weight_string(b), c, weight_string(c)",
+        "FieldQuery": "select `user`.a as a, `user`.b as b, `user`.c as c, `user`.d as d, count(*), weight_string(`user`.a), weight_string(`user`.b), weight_string(`user`.c) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b), `user`.c, weight_string(`user`.c)",
         "OrderBy": "(0|5) ASC, (1|6) ASC, (2|7) ASC",
-        "Query": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` group by a, weight_string(a), b, weight_string(b), c, weight_string(c) order by a asc, b asc, c asc",
+        "Query": "select `user`.a as a, `user`.b as b, `user`.c as c, `user`.d as d, count(*), weight_string(`user`.a), weight_string(`user`.b), weight_string(`user`.c) from `user` group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b), `user`.c, weight_string(`user`.c) order by `user`.a asc, `user`.b asc, `user`.c asc",
         "Table": "`user`"
       }
     ]
@@ -2215,9 +2216,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c), weight_string(d) from `user` where 1 != 1 group by a, weight_string(a), b, weight_string(b), c, weight_string(c), d, weight_string(d)",
+        "FieldQuery": "select `user`.a as a, `user`.b as b, `user`.c as c, `user`.d as d, count(*), weight_string(`user`.a), weight_string(`user`.b), weight_string(`user`.c), weight_string(`user`.d) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b), `user`.c, weight_string(`user`.c), `user`.d, weight_string(`user`.d)",
         "OrderBy": "(3|8) ASC, (1|6) ASC, (0|5) ASC, (2|7) ASC",
-        "Query": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c), weight_string(d) from `user` group by a, weight_string(a), b, weight_string(b), c, weight_string(c), d, weight_string(d) order by d asc, b asc, a asc, c asc",
+        "Query": "select `user`.a as a, `user`.b as b, `user`.c as c, `user`.d as d, count(*), weight_string(`user`.a), weight_string(`user`.b), weight_string(`user`.c), weight_string(`user`.d) from `user` group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b), `user`.c, weight_string(`user`.c), `user`.d, weight_string(`user`.d) order by `user`.d asc, `user`.b asc, `user`.a asc, `user`.c asc",
         "Table": "`user`"
       }
     ]
@@ -2271,9 +2272,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c), weight_string(d) from `user` where 1 != 1 group by a, weight_string(a), b, weight_string(b), c, weight_string(c), d, weight_string(d)",
+        "FieldQuery": "select `user`.a as a, `user`.b as b, `user`.c as c, `user`.d as d, count(*), weight_string(`user`.a), weight_string(`user`.b), weight_string(`user`.c), weight_string(`user`.d) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b), `user`.c, weight_string(`user`.c), `user`.d, weight_string(`user`.d)",
         "OrderBy": "(3|8) ASC, (1|6) ASC, (0|5) ASC, (2|7) ASC",
-        "Query": "select a, b, c, d, count(*), weight_string(a), weight_string(b), weight_string(c), weight_string(d) from `user` group by a, weight_string(a), b, weight_string(b), c, weight_string(c), d, weight_string(d) order by d asc, b asc, a asc, c asc",
+        "Query": "select `user`.a as a, `user`.b as b, `user`.c as c, `user`.d as d, count(*), weight_string(`user`.a), weight_string(`user`.b), weight_string(`user`.c), weight_string(`user`.d) from `user` group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b), `user`.c, weight_string(`user`.c), `user`.d, weight_string(`user`.d) order by `user`.d asc, `user`.b asc, `user`.a asc, `user`.c asc",
         "Table": "`user`"
       }
     ]
@@ -2327,9 +2328,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, b, c, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` where 1 != 1 group by a, weight_string(a), b, weight_string(b), c, weight_string(c)",
+        "FieldQuery": "select `user`.a as a, `user`.b as b, `user`.c as c, count(*), weight_string(`user`.a), weight_string(`user`.b), weight_string(`user`.c) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b), `user`.c, weight_string(`user`.c)",
         "OrderBy": "(0|4) DESC, (2|6) DESC, (1|5) ASC",
-        "Query": "select a, b, c, count(*), weight_string(a), weight_string(b), weight_string(c) from `user` group by a, weight_string(a), b, weight_string(b), c, weight_string(c) order by a desc, c desc, b asc",
+        "Query": "select `user`.a as a, `user`.b as b, `user`.c as c, count(*), weight_string(`user`.a), weight_string(`user`.b), weight_string(`user`.c) from `user` group by `user`.a, weight_string(`user`.a), `user`.b, weight_string(`user`.b), `user`.c, weight_string(`user`.c) order by `user`.a desc, `user`.c desc, `user`.b asc",
         "Table": "`user`"
       }
     ]
@@ -2396,9 +2397,9 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select col, count(*) from `user` where 1 != 1 group by col",
+            "FieldQuery": "select `user`.col as col, count(*) from `user` where 1 != 1 group by `user`.col",
             "OrderBy": "0 ASC",
-            "Query": "select col, count(*) from `user` group by col order by col asc limit :__upper_limit",
+            "Query": "select `user`.col as col, count(*) from `user` group by `user`.col order by `user`.col asc limit :__upper_limit",
             "Table": "`user`"
           }
         ]
@@ -2481,8 +2482,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": false
     },
-    "FieldQuery": "select id, count(*) from unsharded as route2 where 1 != 1 group by id",
-    "Query": "select id, count(*) from unsharded as route2 group by id",
+    "FieldQuery": "select route2.id as id, count(*) from unsharded as route2 where 1 != 1 group by route2.id",
+    "Query": "select route2.id as id, count(*) from unsharded as route2 group by route2.id",
     "Table": "unsharded"
   },
   "TablesUsed": [
@@ -2517,8 +2518,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from ref where 1 != 1",
-    "Query": "select col from ref order by col asc",
+    "FieldQuery": "select ref.col as col from ref where 1 != 1",
+    "Query": "select ref.col as col from ref order by ref.col asc",
     "Table": "ref"
   },
   "TablesUsed": [
@@ -2578,8 +2579,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select a, count(*) from `user` where 1 != 1",
-            "Query": "select a, count(*) from `user`",
+            "FieldQuery": "select `user`.a as a, count(*) from `user` where 1 != 1",
+            "Query": "select `user`.a as a, count(*) from `user`",
             "Table": "`user`"
           }
         ]
@@ -2645,9 +2646,9 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select a, count(*), weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)",
+            "FieldQuery": "select `user`.a as a, count(*), weight_string(`user`.a) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a)",
             "OrderBy": "(0|2) ASC",
-            "Query": "select a, count(*), weight_string(a) from `user` group by a, weight_string(a) order by a asc",
+            "Query": "select `user`.a as a, count(*), weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc",
             "Table": "`user`"
           }
         ]
@@ -2679,9 +2680,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id, 1.1 from `user` where 1 != 1 group by 1.1",
+        "FieldQuery": "select `user`.id as id, 1.1 from `user` where 1 != 1 group by 1.1",
         "OrderBy": "1 ASC",
-        "Query": "select id, 1.1 from `user` group by 1.1 order by 1.1 asc",
+        "Query": "select `user`.id as id, 1.1 from `user` group by 1.1 order by 1.1 asc",
         "Table": "`user`"
       }
     ]
@@ -2801,9 +2802,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col1, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, col2",
+        "FieldQuery": "select `user`.col1 as col1, `user`.col2 as col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1 group by `user`.col1, `user`.col2",
         "OrderBy": "(0|2) ASC, (1|3) ASC",
-        "Query": "select distinct col1, col2, weight_string(col1), weight_string(col2) from `user` group by col1, col2 order by col1 asc, col2 asc",
+        "Query": "select distinct `user`.col1 as col1, `user`.col2 as col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` group by `user`.col1, `user`.col2 order by col1 asc, col2 asc",
         "Table": "`user`"
       }
     ]
@@ -2931,7 +2932,7 @@ Gen4 plan same as above
 # Cannot have more than one aggr(distinct...
 "select count(distinct a), count(distinct b) from user"
 "unsupported: only one distinct aggregation allowed in a select: count(distinct b)"
-Gen4 plan same as above
+Gen4 error: unsupported: only one distinct aggregation allowed in a select: count(distinct `user`.b) as `count(distinct b)`
 
 # multiple distinct functions with grouping.
 "select col1, count(distinct col2), sum(distinct col2) from user group by col1"
@@ -2953,9 +2954,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col1, col2, col2, weight_string(col1), weight_string(col2) from `user` where 1 != 1 group by col1, weight_string(col1), col2, weight_string(col2)",
+        "FieldQuery": "select `user`.col1 as col1, `user`.col2, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1 group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2)",
         "OrderBy": "(0|3) ASC, (1|4) ASC",
-        "Query": "select col1, col2, col2, weight_string(col1), weight_string(col2) from `user` group by col1, weight_string(col1), col2, weight_string(col2) order by col1 asc, col2 asc",
+        "Query": "select `user`.col1 as col1, `user`.col2, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` group by `user`.col1, weight_string(`user`.col1), `user`.col2, weight_string(`user`.col2) order by `user`.col1 asc, `user`.col2 asc",
         "Table": "`user`"
       }
     ]
@@ -2989,9 +2990,9 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select col, count(*) as k from `user` where 1 != 1 group by col",
+            "FieldQuery": "select `user`.col as col, count(*) as k from `user` where 1 != 1 group by `user`.col",
             "OrderBy": "0 ASC",
-            "Query": "select col, count(*) as k from `user` group by col order by col asc",
+            "Query": "select `user`.col as col, count(*) as k from `user` group by `user`.col order by `user`.col asc",
             "Table": "`user`"
           }
         ]
@@ -3045,9 +3046,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col, count(*) as k from `user` where 1 != 1 group by col",
+        "FieldQuery": "select `user`.col as col, count(*) as k from `user` where 1 != 1 group by `user`.col",
         "OrderBy": "0 ASC",
-        "Query": "select col, count(*) as k from `user` group by col order by col asc",
+        "Query": "select `user`.col as col, count(*) as k from `user` group by `user`.col order by `user`.col asc",
         "Table": "`user`"
       }
     ]
@@ -3158,8 +3159,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1 group by id",
-    "Query": "select id from `user` group by id having count(id) = 10",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1 group by `user`.id",
+    "Query": "select `user`.id as id from `user` group by `user`.id having count(`user`.id) = 10",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -3211,9 +3212,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select lower(textcol1) as v, count(*), weight_string(lower(textcol1)) from `user` where 1 != 1 group by v, weight_string(lower(textcol1))",
+        "FieldQuery": "select lower(`user`.textcol1) as v, count(*), weight_string(lower(`user`.textcol1)) from `user` where 1 != 1 group by v, weight_string(lower(`user`.textcol1))",
         "OrderBy": "(0|2) ASC",
-        "Query": "select lower(textcol1) as v, count(*), weight_string(lower(textcol1)) from `user` group by v, weight_string(lower(textcol1)) order by v asc",
+        "Query": "select lower(`user`.textcol1) as v, count(*), weight_string(lower(`user`.textcol1)) from `user` group by v, weight_string(lower(`user`.textcol1)) order by v asc",
         "Table": "`user`"
       }
     ]
@@ -3267,9 +3268,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select char_length(texcol1) as a, count(*), weight_string(char_length(texcol1)) from `user` where 1 != 1 group by a, weight_string(char_length(texcol1))",
+        "FieldQuery": "select char_length(`user`.texcol1) as a, count(*), weight_string(char_length(`user`.texcol1)) from `user` where 1 != 1 group by a, weight_string(char_length(`user`.texcol1))",
         "OrderBy": "(0|2) ASC",
-        "Query": "select char_length(texcol1) as a, count(*), weight_string(char_length(texcol1)) from `user` group by a, weight_string(char_length(texcol1)) order by a asc",
+        "Query": "select char_length(`user`.texcol1) as a, count(*), weight_string(char_length(`user`.texcol1)) from `user` group by a, weight_string(char_length(`user`.texcol1)) order by a asc",
         "Table": "`user`"
       }
     ]
@@ -3318,9 +3319,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
+        "FieldQuery": "select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1",
         "OrderBy": "(0|1) ASC",
-        "Query": "select id, weight_string(id) from `user` order by id asc limit :__upper_limit",
+        "Query": "select `user`.id as id, weight_string(`user`.id) from `user` order by `user`.id asc limit :__upper_limit",
         "ResultColumns": 1,
         "Table": "`user`"
       }
@@ -3342,7 +3343,7 @@ Gen4 plan same as above
     "JoinVars": {
       "user_id": 0
     },
-    "ProjectedIndexes": "-2,-1",
+    "ProjectedIndexes": "-2,-3",
     "TableName": "`user`_user_extra",
     "Inputs": [
       {
@@ -3352,9 +3353,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select `user`.id, col, weight_string(id) from `user` where 1 != 1",
-        "OrderBy": "(0|2) ASC",
-        "Query": "select `user`.id, col, weight_string(id) from `user` order by id asc",
+        "FieldQuery": "select `user`.id, `user`.col as col, `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1",
+        "OrderBy": "(2|3) ASC",
+        "Query": "select `user`.id, `user`.col as col, `user`.id as id, weight_string(`user`.id) from `user` order by `user`.id asc",
         "Table": "`user`"
       },
       {
@@ -3683,9 +3684,9 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select col, count(*) as a from `user` where 1 != 1 group by col",
+            "FieldQuery": "select `user`.col as col, count(*) as a from `user` where 1 != 1 group by `user`.col",
             "OrderBy": "0 ASC",
-            "Query": "select col, count(*) as a from `user` group by col order by col asc",
+            "Query": "select `user`.col as col, count(*) as a from `user` group by `user`.col order by `user`.col asc",
             "Table": "`user`"
           }
         ]
@@ -3727,9 +3728,9 @@ Gen4 plan same as above
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select count(*) as a, val1, weight_string(val1) from `user` where 1 != 1 group by val1, weight_string(val1)",
+                "FieldQuery": "select count(*) as a, `user`.val1 as val1, weight_string(`user`.val1) from `user` where 1 != 1 group by `user`.val1, weight_string(`user`.val1)",
                 "OrderBy": "(1|2) ASC",
-                "Query": "select count(*) as a, val1, weight_string(val1) from `user` group by val1, weight_string(val1) order by val1 asc",
+                "Query": "select count(*) as a, `user`.val1 as val1, weight_string(`user`.val1) from `user` group by `user`.val1, weight_string(`user`.val1) order by `user`.val1 asc",
                 "Table": "`user`"
               }
             ]
@@ -3786,9 +3787,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col, textcol1 from `user` where 1 != 1 group by col, textcol1",
+        "FieldQuery": "select `user`.col as col, `user`.textcol1 from `user` where 1 != 1 group by `user`.col, `user`.textcol1",
         "OrderBy": "0 ASC, 1 ASC COLLATE latin1_swedish_ci",
-        "Query": "select col, textcol1 from `user` group by col, textcol1 order by col asc, textcol1 asc",
+        "Query": "select `user`.col as col, `user`.textcol1 from `user` group by `user`.col, `user`.textcol1 order by `user`.col asc, `user`.textcol1 asc",
         "Table": "`user`"
       }
     ]
@@ -3830,12 +3831,12 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Filter",
-        "Predicate": "OFFSET(1, 'count(id)') = 10",
+        "Predicate": "OFFSET(1, 'count(`user`.id)') = 10",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "random(0) AS 1, sum_count(1) AS count(id)",
+            "Aggregates": "random(0) AS 1, sum_count(1) AS count(`user`.id)",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3844,8 +3845,8 @@ Gen4 plan same as above
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select 1, count(id) from `user` where 1 != 1",
-                "Query": "select 1, count(id) from `user` where `name` = 'a'",
+                "FieldQuery": "select 1, count(`user`.id) from `user` where 1 != 1",
+                "Query": "select 1, count(`user`.id) from `user` where `user`.`name` = 'a'",
                 "Table": "`user`",
                 "Values": [
                   "VARCHAR(\"a\")"
@@ -3948,12 +3949,12 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Filter",
-        "Predicate": "OFFSET(1, 'count(id)') = 10",
+        "Predicate": "OFFSET(1, 'count(`user`.id)') = 10",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "random(0) AS 1, sum_count(1) AS count(id)",
+            "Aggregates": "random(0) AS 1, sum_count(1) AS count(`user`.id)",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3962,8 +3963,8 @@ Gen4 plan same as above
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select 1, count(id) from `user` where 1 != 1",
-                "Query": "select 1, count(id) from `user`",
+                "FieldQuery": "select 1, count(`user`.id) from `user` where 1 != 1",
+                "Query": "select 1, count(`user`.id) from `user`",
                 "Table": "`user`"
               }
             ]
@@ -4240,9 +4241,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col1, min(distinct id), col3, weight_string(col1), weight_string(col3) from `user` where 1 != 1 group by col1, weight_string(col1), col3, weight_string(col3)",
+        "FieldQuery": "select `user`.col1 as col1, min(distinct `user`.id) as `min(distinct id)`, `user`.col3, weight_string(`user`.col1), weight_string(`user`.col3) from `user` where 1 != 1 group by `user`.col1, weight_string(`user`.col1), `user`.col3, weight_string(`user`.col3)",
         "OrderBy": "(0|3) ASC, (2|4) ASC",
-        "Query": "select col1, min(distinct id), col3, weight_string(col1), weight_string(col3) from `user` group by col1, weight_string(col1), col3, weight_string(col3) order by col1 asc, col3 asc",
+        "Query": "select `user`.col1 as col1, min(distinct `user`.id) as `min(distinct id)`, `user`.col3, weight_string(`user`.col1), weight_string(`user`.col3) from `user` group by `user`.col1, weight_string(`user`.col1), `user`.col3, weight_string(`user`.col3) order by `user`.col1 asc, `user`.col3 asc",
         "Table": "`user`"
       }
     ]
@@ -4354,9 +4355,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select val2, val1, count(*), weight_string(val2), weight_string(val1) from `user` where 1 != 1 group by val2, weight_string(val2), val1, weight_string(val1)",
+        "FieldQuery": "select `user`.val2 as val2, `user`.val1, count(*), weight_string(`user`.val2), weight_string(`user`.val1) from `user` where 1 != 1 group by `user`.val2, weight_string(`user`.val2), `user`.val1, weight_string(`user`.val1)",
         "OrderBy": "(0|3) ASC, (1|4) ASC",
-        "Query": "select val2, val1, count(*), weight_string(val2), weight_string(val1) from `user` group by val2, weight_string(val2), val1, weight_string(val1) order by val2 asc, val1 asc",
+        "Query": "select `user`.val2 as val2, `user`.val1, count(*), weight_string(`user`.val2), weight_string(`user`.val1) from `user` group by `user`.val2, weight_string(`user`.val2), `user`.val1, weight_string(`user`.val1) order by `user`.val2 asc, `user`.val1 asc",
         "Table": "`user`"
       }
     ]
@@ -4410,9 +4411,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select ascii(val1) as a, count(*), weight_string(ascii(val1)) from `user` where 1 != 1 group by a, weight_string(ascii(val1))",
+        "FieldQuery": "select ascii(`user`.val1) as a, count(*), weight_string(ascii(`user`.val1)) from `user` where 1 != 1 group by a, weight_string(ascii(`user`.val1))",
         "OrderBy": "(0|2) ASC",
-        "Query": "select ascii(val1) as a, count(*), weight_string(ascii(val1)) from `user` group by a, weight_string(ascii(val1)) order by a asc",
+        "Query": "select ascii(`user`.val1) as a, count(*), weight_string(ascii(`user`.val1)) from `user` group by a, weight_string(ascii(`user`.val1)) order by a asc",
         "Table": "`user`"
       }
     ]
@@ -4442,9 +4443,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select tcol1, tcol2, tcol2, weight_string(tcol1), weight_string(tcol2) from `user` where 1 != 1 group by tcol1, weight_string(tcol1), tcol2, weight_string(tcol2)",
+        "FieldQuery": "select `user`.tcol1 as tcol1, `user`.tcol2, `user`.tcol2, weight_string(`user`.tcol1), weight_string(`user`.tcol2) from `user` where 1 != 1 group by `user`.tcol1, weight_string(`user`.tcol1), `user`.tcol2, weight_string(`user`.tcol2)",
         "OrderBy": "(0|3) ASC, (1|4) ASC",
-        "Query": "select tcol1, tcol2, tcol2, weight_string(tcol1), weight_string(tcol2) from `user` group by tcol1, weight_string(tcol1), tcol2, weight_string(tcol2) order by tcol1 asc, tcol2 asc",
+        "Query": "select `user`.tcol1 as tcol1, `user`.tcol2, `user`.tcol2, weight_string(`user`.tcol1), weight_string(`user`.tcol2) from `user` group by `user`.tcol1, weight_string(`user`.tcol1), `user`.tcol2, weight_string(`user`.tcol2) order by `user`.tcol1 asc, `user`.tcol2 asc",
         "Table": "`user`"
       }
     ]
@@ -4474,9 +4475,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select tcol2, tcol1, count(*), tcol2, weight_string(tcol2), weight_string(tcol1) from `user` where 1 != 1 group by tcol2, weight_string(tcol2), tcol1, weight_string(tcol1)",
+        "FieldQuery": "select `user`.tcol2, `user`.tcol1 as tcol1, count(*), `user`.tcol2, weight_string(`user`.tcol2), weight_string(`user`.tcol1) from `user` where 1 != 1 group by `user`.tcol2, weight_string(`user`.tcol2), `user`.tcol1, weight_string(`user`.tcol1)",
         "OrderBy": "(1|5) ASC, (0|4) ASC",
-        "Query": "select tcol2, tcol1, count(*), tcol2, weight_string(tcol2), weight_string(tcol1) from `user` group by tcol2, weight_string(tcol2), tcol1, weight_string(tcol1) order by tcol1 asc, tcol2 asc",
+        "Query": "select `user`.tcol2, `user`.tcol1 as tcol1, count(*), `user`.tcol2, weight_string(`user`.tcol2), weight_string(`user`.tcol1) from `user` group by `user`.tcol2, weight_string(`user`.tcol2), `user`.tcol1, weight_string(`user`.tcol1) order by `user`.tcol1 asc, `user`.tcol2 asc",
         "Table": "`user`"
       }
     ]
@@ -4675,8 +4676,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select group_concat(user_id order by `name` asc), id from `user` where 1 != 1 group by id",
-    "Query": "select group_concat(user_id order by `name` asc), id from `user` group by id",
+    "FieldQuery": "select group_concat(`user`.user_id order by `user`.`name` asc) as `group_concat(user_id order by ``name`` asc)`, `user`.id as id from `user` where 1 != 1 group by `user`.id",
+    "Query": "select group_concat(`user`.user_id order by `user`.`name` asc) as `group_concat(user_id order by ``name`` asc)`, `user`.id as id from `user` group by `user`.id",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -4721,7 +4722,7 @@ Gen4 plan same as above
 
 "select count(distinct user_id, name) from user"
 "unsupported: only one expression allowed inside aggregates: count(distinct user_id, `name`)"
-Gen4 error: aggregate functions take a single argument 'count(distinct user_id, `name`)'
+Gen4 error: aggregate functions take a single argument 'count(distinct `user`.user_id, `user`.`name`)'
 
 "select sum(col) from (select user.col as col, 32 from user join user_extra) t"
 "unsupported: cross-shard query with aggregates"
@@ -4809,9 +4810,9 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select foo, count(*), weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
+                "FieldQuery": "select `user`.foo as foo, count(*), weight_string(`user`.foo) from `user` where 1 != 1 group by `user`.foo, weight_string(`user`.foo)",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select foo, count(*), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc",
+                "Query": "select `user`.foo as foo, count(*), weight_string(`user`.foo) from `user` group by `user`.foo, weight_string(`user`.foo) order by `user`.foo asc",
                 "Table": "`user`"
               }
             ]
@@ -4841,7 +4842,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
     "Inputs": [
       {
         "OperatorType": "Filter",
-        "Predicate": "OFFSET(1, 'sum(foo)') + OFFSET(2, 'sum(bar)') = 42",
+        "Predicate": "OFFSET(1, 'sum(`user`.foo)') + OFFSET(2, 'sum(`user`.bar)') = 42",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -4856,9 +4857,9 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select foo, sum(foo), sum(bar), weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
+                "FieldQuery": "select `user`.foo as foo, sum(`user`.foo) as `sum(foo)`, sum(`user`.bar) as `sum(bar)`, weight_string(`user`.foo) from `user` where 1 != 1 group by `user`.foo, weight_string(`user`.foo)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select foo, sum(foo), sum(bar), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc",
+                "Query": "select `user`.foo as foo, sum(`user`.foo) as `sum(foo)`, sum(`user`.bar) as `sum(bar)`, weight_string(`user`.foo) from `user` group by `user`.foo, weight_string(`user`.foo) order by `user`.foo asc",
                 "Table": "`user`"
               }
             ]
@@ -4888,7 +4889,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
     "Inputs": [
       {
         "OperatorType": "Filter",
-        "Predicate": "fooSum + OFFSET(2, 'sum(bar)') = 42",
+        "Predicate": "fooSum + OFFSET(2, 'sum(`user`.bar)') = 42",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -4903,9 +4904,9 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select foo, sum(foo) as fooSum, sum(bar) as barSum, weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
+                "FieldQuery": "select `user`.foo as foo, sum(`user`.foo) as fooSum, sum(`user`.bar) as barSum, weight_string(`user`.foo) from `user` where 1 != 1 group by `user`.foo, weight_string(`user`.foo)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select foo, sum(foo) as fooSum, sum(bar) as barSum, weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc",
+                "Query": "select `user`.foo as foo, sum(`user`.foo) as fooSum, sum(`user`.bar) as barSum, weight_string(`user`.foo) from `user` group by `user`.foo, weight_string(`user`.foo) order by `user`.foo asc",
                 "Table": "`user`"
               }
             ]
@@ -4948,9 +4949,9 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select foo, count(*), weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
+                "FieldQuery": "select `user`.foo as foo, count(*), weight_string(`user`.foo) from `user` where 1 != 1 group by `user`.foo, weight_string(`user`.foo)",
                 "OrderBy": "(0|2) ASC",
-                "Query": "select foo, count(*), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc",
+                "Query": "select `user`.foo as foo, count(*), weight_string(`user`.foo) from `user` group by `user`.foo, weight_string(`user`.foo) order by `user`.foo asc",
                 "Table": "`user`"
               }
             ]
@@ -5322,9 +5323,9 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id, b as id, count(*), weight_string(b) from `user` where 1 != 1",
+        "FieldQuery": "select id, `user`.b as id, count(*), weight_string(`user`.b) from `user` where 1 != 1",
         "OrderBy": "(1|3) ASC",
-        "Query": "select id, b as id, count(*), weight_string(b) from `user` order by id asc",
+        "Query": "select id, `user`.b as id, count(*), weight_string(`user`.b) from `user` order by id asc",
         "Table": "`user`"
       }
     ]
@@ -5373,8 +5374,8 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id, count(*) from `user` where 1 != 1",
-        "Query": "select id, count(*) from `user`",
+        "FieldQuery": "select `user`.id as id, count(*) from `user` where 1 != 1",
+        "Query": "select `user`.id as id, count(*) from `user`",
         "Table": "`user`"
       }
     ]
@@ -5393,22 +5394,20 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
-    "Aggregates": "random(0) AS id",
-    "GroupBy": "(2|1)",
+    "GroupBy": "(0|1)",
     "ResultColumns": 1,
     "Inputs": [
       {
         "OperatorType": "Projection",
         "Expressions": [
-          "[COLUMN 2] * [COLUMN 3] as id",
-          "[COLUMN 1]",
-          "[COLUMN 0] as id"
+          "[COLUMN 0] as id",
+          "[COLUMN 1]"
         ],
         "Inputs": [
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:0,L:1,L:0,R:1",
+            "JoinColumnIndexes": "L:0,L:1",
             "TableName": "`user`_user_extra",
             "Inputs": [
               {
@@ -5418,9 +5417,9 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select `user`.id, weight_string(id) from `user` where 1 != 1 group by id, weight_string(id)",
+                "FieldQuery": "select `user`.id, weight_string(`user`.id) from `user` where 1 != 1 group by `user`.id, weight_string(`user`.id)",
                 "OrderBy": "(0|1) ASC",
-                "Query": "select `user`.id, weight_string(id) from `user` group by id, weight_string(id) order by id asc",
+                "Query": "select `user`.id, weight_string(`user`.id) from `user` group by `user`.id, weight_string(`user`.id) order by `user`.id asc",
                 "Table": "`user`"
               },
               {
@@ -5430,8 +5429,8 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select 1, count(*) from user_extra where 1 != 1 group by 1",
-                "Query": "select 1, count(*) from user_extra group by 1",
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra",
                 "Table": "user_extra"
               }
             ]
@@ -5597,3 +5596,51 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
   ]
 }
 Gen4 plan same as above
+
+# grouping on data from derived table
+"select val1, count(*)  from (select id, val1 from user where val2 \u003c 4 order by val1 limit 2) as x group by val1"
+"unsupported: cross-shard query with aggregates"
+{
+  "QueryType": "SELECT",
+  "Original": "select val1, count(*)  from (select id, val1 from user where val2 \u003c 4 order by val1 limit 2) as x group by val1",
+  "Instructions": {
+    "OperatorType": "Aggregate",
+    "Variant": "Ordered",
+    "Aggregates": "count_star(1) AS count(*)",
+    "GroupBy": "(0|2)",
+    "ResultColumns": 2,
+    "Inputs": [
+      {
+        "OperatorType": "Projection",
+        "Expressions": [
+          "[COLUMN 1] as val1",
+          "[COLUMN 0] as count(*)",
+          "[COLUMN 2]"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Limit",
+            "Count": "INT64(2)",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select id, val1, weight_string(val1) from `user` where 1 != 1",
+                "OrderBy": "(1|2) ASC, (1|2) ASC",
+                "Query": "select id, val1, weight_string(val1) from `user` where val2 \u003c 4 order by val1 asc, val1 asc limit :__upper_limit",
+                "Table": "`user`"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "TablesUsed": [
+    "user.user"
+  ]
+}

--- a/go/vt/vtgate/planbuilder/testdata/ddl_cases_no_default_keyspace.txt
+++ b/go/vt/vtgate/planbuilder/testdata/ddl_cases_no_default_keyspace.txt
@@ -138,7 +138,7 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "Query": "create view view_a as select user_id, col1, col2 from authoritative"
+    "Query": "create view view_a as select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2 from authoritative"
   },
   "TablesUsed": [
     "user.view_a"
@@ -437,7 +437,21 @@ Gen4 plan same as above
     "user.view_a"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DDL",
+  "Original": "create view user.view_a as select * from user where id = 0x04",
+  "Instructions": {
+    "OperatorType": "DDL",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "create view view_a as select * from `user` where `user`.id = 0x04"
+  },
+  "TablesUsed": [
+    "user.view_a"
+  ]
+}
 
 # create view with limit works if it can be dropped
 "create view user.view_a as select * from user where name ='abc' AND (id = 4) limit 5"
@@ -456,7 +470,21 @@ Gen4 plan same as above
     "user.view_a"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DDL",
+  "Original": "create view user.view_a as select * from user where name ='abc' AND (id = 4) limit 5",
+  "Instructions": {
+    "OperatorType": "DDL",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "create view view_a as select * from `user` where `user`.`name` = 'abc' and `user`.id = 4 limit 5"
+  },
+  "TablesUsed": [
+    "user.view_a"
+  ]
+}
 
 # create view with Multiple parenthesized expressions
 "create view user.view_a as select * from user where (id = 4) AND (name ='abc') limit 5"
@@ -475,7 +503,21 @@ Gen4 plan same as above
     "user.view_a"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DDL",
+  "Original": "create view user.view_a as select * from user where (id = 4) AND (name ='abc') limit 5",
+  "Instructions": {
+    "OperatorType": "DDL",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "create view view_a as select * from `user` where `user`.id = 4 and `user`.`name` = 'abc' limit 5"
+  },
+  "TablesUsed": [
+    "user.view_a"
+  ]
+}
 
 # create view with Multiple parenthesized expressions
 "create view user.view_a as select * from user where (id = 4 and name ='abc') limit 5"
@@ -494,7 +536,21 @@ Gen4 plan same as above
     "user.view_a"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DDL",
+  "Original": "create view user.view_a as select * from user where (id = 4 and name ='abc') limit 5",
+  "Instructions": {
+    "OperatorType": "DDL",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "create view view_a as select * from `user` where `user`.id = 4 and `user`.`name` = 'abc' limit 5"
+  },
+  "TablesUsed": [
+    "user.view_a"
+  ]
+}
 
 # create view with Column Aliasing with Table.Column
 "create view user.view_a as select user0_.col as col0_ from user user0_ where id = 1 order by user0_.col"
@@ -513,7 +569,21 @@ Gen4 plan same as above
     "user.view_a"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DDL",
+  "Original": "create view user.view_a as select user0_.col as col0_ from user user0_ where id = 1 order by user0_.col",
+  "Instructions": {
+    "OperatorType": "DDL",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "create view view_a as select user0_.col as col0_ from `user` as user0_ where user0_.id = 1 order by user0_.col asc"
+  },
+  "TablesUsed": [
+    "user.view_a"
+  ]
+}
 
 # create view with Column Aliasing with Column
 "create view user.view_a as select user0_.col as col0_ from user user0_ where id = 1 order by col0_ desc"
@@ -532,7 +602,21 @@ Gen4 plan same as above
     "user.view_a"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DDL",
+  "Original": "create view user.view_a as select user0_.col as col0_ from user user0_ where id = 1 order by col0_ desc",
+  "Instructions": {
+    "OperatorType": "DDL",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "create view view_a as select user0_.col as col0_ from `user` as user0_ where user0_.id = 1 order by col0_ desc"
+  },
+  "TablesUsed": [
+    "user.view_a"
+  ]
+}
 
 # create view with Booleans and parenthesis
 "create view user.view_a as select * from user where (id = 1) AND name = true"
@@ -551,7 +635,21 @@ Gen4 plan same as above
     "user.view_a"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DDL",
+  "Original": "create view user.view_a as select * from user where (id = 1) AND name = true",
+  "Instructions": {
+    "OperatorType": "DDL",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "create view view_a as select * from `user` where `user`.id = 1 and `user`.`name` = true"
+  },
+  "TablesUsed": [
+    "user.view_a"
+  ]
+}
 
 # create view with union with the same target shard
 "create view user.view_a as select * from music where user_id = 1 union select * from user where id = 1"
@@ -570,7 +668,21 @@ Gen4 plan same as above
     "user.view_a"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DDL",
+  "Original": "create view user.view_a as select * from music where user_id = 1 union select * from user where id = 1",
+  "Instructions": {
+    "OperatorType": "DDL",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "create view view_a as select * from music where music.user_id = 1 union select * from `user` where `user`.id = 1"
+  },
+  "TablesUsed": [
+    "user.view_a"
+  ]
+}
 
 # create view with testing SingleRow Projection
 "create view user.view_a as select 42 from user"
@@ -608,7 +720,21 @@ Gen4 plan same as above
     "user.view_a"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DDL",
+  "Original": "create view user.view_a as select sql_calc_found_rows * from music where user_id = 1",
+  "Instructions": {
+    "OperatorType": "DDL",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "create view view_a as select * from music where music.user_id = 1"
+  },
+  "TablesUsed": [
+    "user.view_a"
+  ]
+}
 
 # DDL
 "create index a on user(id)"

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -183,7 +183,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update `user` as route1 set a = 1 where id = 1",
+    "Query": "update `user` as route1 set route1.a = 1 where route1.id = 1",
     "Table": "user",
     "Values": [
       "INT64(1)"
@@ -297,7 +297,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update `user` set val = 1 where id = 1",
+    "Query": "update `user` set `user`.val = 1 where `user`.id = 1",
     "Table": "user",
     "Values": [
       "INT64(1)"
@@ -346,7 +346,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update `user` as user_alias set val = 1 where user_alias.id = 1",
+    "Query": "update `user` as user_alias set user_alias.val = 1 where user_alias.id = 1",
     "Table": "user",
     "Values": [
       "INT64(1)"
@@ -395,7 +395,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update `user` set val = 1 where id = 1",
+    "Query": "update `user` set `user`.val = 1 where `user`.id = 1",
     "Table": "user",
     "Values": [
       "INT64(1)"
@@ -444,7 +444,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update `user` set val = 1 where `name` = 'foo' and id = 1",
+    "Query": "update `user` set `user`.val = 1 where `user`.`name` = 'foo' and `user`.id = 1",
     "Table": "user",
     "Values": [
       "INT64(1)"
@@ -504,8 +504,8 @@ Gen4 plan same as above
     "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io' from user_metadata where user_id = 1 for update",
-    "Query": "update user_metadata set email = 'juan@vitess.io' where user_id = 1",
+    "OwnedVindexQuery": "select user_id, email, address, user_metadata.email = 'juan@vitess.io' from user_metadata where user_metadata.user_id = 1 for update",
+    "Query": "update user_metadata set user_metadata.email = 'juan@vitess.io' where user_metadata.user_id = 1",
     "Table": "user_metadata",
     "Values": [
       "INT64(1)"
@@ -572,8 +572,8 @@ Gen4 plan same as above
     "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io', address = '155 5th street' from user_metadata where user_id = 1 for update",
-    "Query": "update user_metadata set email = 'juan@vitess.io', address = '155 5th street' where user_id = 1",
+    "OwnedVindexQuery": "select user_id, email, address, user_metadata.email = 'juan@vitess.io', user_metadata.address = '155 5th street' from user_metadata where user_metadata.user_id = 1 for update",
+    "Query": "update user_metadata set user_metadata.email = 'juan@vitess.io', user_metadata.address = '155 5th street' where user_metadata.user_id = 1",
     "Table": "user_metadata",
     "Values": [
       "INT64(1)"
@@ -633,8 +633,8 @@ Gen4 plan same as above
     "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io' from user_metadata where user_id = 1 order by user_id asc limit 10 for update",
-    "Query": "update user_metadata set email = 'juan@vitess.io' where user_id = 1 order by user_id asc limit 10",
+    "OwnedVindexQuery": "select user_id, email, address, user_metadata.email = 'juan@vitess.io' from user_metadata where user_metadata.user_id = 1 order by user_metadata.user_id asc limit 10 for update",
+    "Query": "update user_metadata set user_metadata.email = 'juan@vitess.io' where user_metadata.user_id = 1 order by user_metadata.user_id asc limit 10",
     "Table": "user_metadata",
     "Values": [
       "INT64(1)"
@@ -694,8 +694,8 @@ Gen4 plan same as above
     "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select user_id, music_id = 1 from music_extra where user_id = 1 for update",
-    "Query": "update music_extra set music_id = 1 where user_id = 1",
+    "OwnedVindexQuery": "select user_id, music_extra.music_id = 1 from music_extra where music_extra.user_id = 1 for update",
+    "Query": "update music_extra set music_extra.music_id = 1 where music_extra.user_id = 1",
     "Table": "music_extra",
     "Values": [
       "INT64(1)"
@@ -744,7 +744,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update `user` set val = 1 where id = id2 and id = 1",
+    "Query": "update `user` set `user`.val = 1 where `user`.id = `user`.id2 and `user`.id = 1",
     "Table": "user",
     "Values": [
       "INT64(1)"
@@ -793,7 +793,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update `user` set val = 1 where id = 18446744073709551616 and id = 1",
+    "Query": "update `user` set `user`.val = 1 where `user`.id = 18446744073709551616 and `user`.id = 1",
     "Table": "user",
     "Values": [
       "INT64(1)"
@@ -996,7 +996,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update music set val = 1 where id = 1",
+    "Query": "update music set music.val = 1 where music.id = 1",
     "Table": "music",
     "Values": [
       "INT64(1)"
@@ -2394,8 +2394,8 @@ Gen4 plan same as above
     "KsidLength": 1,
     "KsidVindex": "kid_index",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select kid, column_a, column_b, column_c, column_b = 1 and column_c = 2 from multicolvin where kid = 1 for update",
-    "Query": "update multicolvin set column_b = 1, column_c = 2 where kid = 1",
+    "OwnedVindexQuery": "select kid, column_a, column_b, column_c, multicolvin.column_b = 1 and multicolvin.column_c = 2 from multicolvin where multicolvin.kid = 1 for update",
+    "Query": "update multicolvin set multicolvin.column_b = 1, multicolvin.column_c = 2 where multicolvin.kid = 1",
     "Table": "multicolvin",
     "Values": [
       "INT64(1)"
@@ -2457,8 +2457,8 @@ Gen4 plan same as above
     "KsidLength": 1,
     "KsidVindex": "kid_index",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select kid, column_a, column_b, column_c, column_a = 0, column_b = 1 and column_c = 2 from multicolvin where kid = 1 for update",
-    "Query": "update multicolvin set column_a = 0, column_b = 1, column_c = 2 where kid = 1",
+    "OwnedVindexQuery": "select kid, column_a, column_b, column_c, multicolvin.column_a = 0, multicolvin.column_b = 1 and multicolvin.column_c = 2 from multicolvin where multicolvin.kid = 1 for update",
+    "Query": "update multicolvin set multicolvin.column_a = 0, multicolvin.column_b = 1, multicolvin.column_c = 2 where multicolvin.kid = 1",
     "Table": "multicolvin",
     "Values": [
       "INT64(1)"
@@ -2491,7 +2491,25 @@ Gen4 plan same as above
     "user.user_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update user_extra set val = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update user_extra set user_extra.val = 1",
+    "Table": "user_extra"
+  },
+  "TablesUsed": [
+    "user.user_extra"
+  ]
+}
 
 # update with target destination
 "update `user[-]`.user_extra set val = 1"
@@ -2514,7 +2532,25 @@ Gen4 plan same as above
     "user.user_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update `user[-]`.user_extra set val = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "ByDestination",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update user_extra set user_extra.val = 1",
+    "Table": "user_extra"
+  },
+  "TablesUsed": [
+    "user.user_extra"
+  ]
+}
 
 # update with no primary vindex on where clause (scatter update)   - multi shard autocommit
 "update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */  user_extra set val = 1"
@@ -2537,7 +2573,25 @@ Gen4 plan same as above
     "user.user_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */  user_extra set val = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": true,
+    "Query": "update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ user_extra set user_extra.val = 1",
+    "Table": "user_extra"
+  },
+  "TablesUsed": [
+    "user.user_extra"
+  ]
+}
 
 # update with no primary vindex on where clause (scatter update)   - query timeout
 "update /*vt+ QUERY_TIMEOUT_MS=1 */  user_extra set val = 1"
@@ -2561,7 +2615,26 @@ Gen4 plan same as above
     "user.user_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update /*vt+ QUERY_TIMEOUT_MS=1 */  user_extra set val = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update /*vt+ QUERY_TIMEOUT_MS=1 */ user_extra set user_extra.val = 1",
+    "QueryTimeout": 1,
+    "Table": "user_extra"
+  },
+  "TablesUsed": [
+    "user.user_extra"
+  ]
+}
 
 # update with non-comparison expr
 "update user_extra set val = 1 where id between 1 and 2"
@@ -2584,7 +2657,25 @@ Gen4 plan same as above
     "user.user_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update user_extra set val = 1 where id between 1 and 2",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update user_extra set user_extra.val = 1 where user_extra.id between 1 and 2",
+    "Table": "user_extra"
+  },
+  "TablesUsed": [
+    "user.user_extra"
+  ]
+}
 
 # update with primary id through IN clause
 "update user_extra set val = 1 where user_id in (1, 2)"
@@ -2611,7 +2702,29 @@ Gen4 plan same as above
     "user.user_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update user_extra set val = 1 where user_id in (1, 2)",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update user_extra set user_extra.val = 1 where user_extra.user_id in (1, 2)",
+    "Table": "user_extra",
+    "Values": [
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "user_index"
+  },
+  "TablesUsed": [
+    "user.user_extra"
+  ]
+}
 
 # update with non-unique key
 "update user_extra set val = 1 where name = 'foo'"
@@ -2634,7 +2747,25 @@ Gen4 plan same as above
     "user.user_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update user_extra set val = 1 where name = 'foo'",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update user_extra set user_extra.val = 1 where user_extra.`name` = 'foo'",
+    "Table": "user_extra"
+  },
+  "TablesUsed": [
+    "user.user_extra"
+  ]
+}
 
 # update by lookup with IN clause
 "update user_extra set val = 1 where id in (1, 2)"
@@ -2657,7 +2788,25 @@ Gen4 plan same as above
     "user.user_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update user_extra set val = 1 where id in (1, 2)",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update user_extra set user_extra.val = 1 where user_extra.id in (1, 2)",
+    "Table": "user_extra"
+  },
+  "TablesUsed": [
+    "user.user_extra"
+  ]
+}
 
 # update with where clause with parens
 "update user_extra set val = 1 where (name = 'foo' or id = 1)"
@@ -2680,7 +2829,25 @@ Gen4 plan same as above
     "user.user_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update user_extra set val = 1 where (name = 'foo' or id = 1)",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update user_extra set user_extra.val = 1 where user_extra.`name` = 'foo' or user_extra.id = 1",
+    "Table": "user_extra"
+  },
+  "TablesUsed": [
+    "user.user_extra"
+  ]
+}
 
 # delete from with no where clause
 "delete from user_extra"
@@ -2962,8 +3129,8 @@ Gen4 plan same as above
     "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = null from `user` where id = 1 for update",
-    "Query": "update `user` set `name` = null where id = 1",
+    "OwnedVindexQuery": "select Id, `Name`, Costly, `user`.`name` = null from `user` where `user`.id = 1 for update",
+    "Query": "update `user` set `user`.`name` = null where `user`.id = 1",
     "Table": "user",
     "Values": [
       "INT64(1)"
@@ -3029,7 +3196,35 @@ Gen4 plan same as above
     "user.user"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update user set name = null where id in (1, 2, 3)",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "ChangedVindexValues": [
+      "name_user_map:3"
+    ],
+    "KsidLength": 1,
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select Id, `Name`, Costly, `user`.`name` = null from `user` where `user`.id in (1, 2, 3) for update",
+    "Query": "update `user` set `user`.`name` = null where `user`.id in (1, 2, 3)",
+    "Table": "user",
+    "Values": [
+      "(INT64(1), INT64(2), INT64(3))"
+    ],
+    "Vindex": "user_index"
+  },
+  "TablesUsed": [
+    "user.user"
+  ]
+}
 
 # update vindex value to null without a where clause
 "update user set name = null"
@@ -3058,7 +3253,31 @@ Gen4 plan same as above
     "user.user"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update user set name = null",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "ChangedVindexValues": [
+      "name_user_map:3"
+    ],
+    "KsidLength": 1,
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select Id, `Name`, Costly, `user`.`name` = null from `user` for update",
+    "Query": "update `user` set `user`.`name` = null",
+    "Table": "user"
+  },
+  "TablesUsed": [
+    "user.user"
+  ]
+}
 
 # update vindex value to null with complex where clause
 "update user set name = null where id + 1 = 2"
@@ -3087,7 +3306,31 @@ Gen4 plan same as above
     "user.user"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update user set name = null where id + 1 = 2",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "ChangedVindexValues": [
+      "name_user_map:3"
+    ],
+    "KsidLength": 1,
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select Id, `Name`, Costly, `user`.`name` = null from `user` where `user`.id + 1 = 2 for update",
+    "Query": "update `user` set `user`.`name` = null where `user`.id + 1 = 2",
+    "Table": "user"
+  },
+  "TablesUsed": [
+    "user.user"
+  ]
+}
 
 # delete from user by primary keyspace id with in clause
 "delete from user where id in (1, 2, 3)"
@@ -3222,7 +3465,25 @@ Gen4 plan same as above
     "user.user"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update user set val = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update `user` set `user`.val = 1",
+    "Table": "user"
+  },
+  "TablesUsed": [
+    "user.user"
+  ]
+}
 
 # scatter delete with owned lookup vindex
 "delete from user"
@@ -3298,8 +3559,8 @@ Gen4 plan same as above
     "KsidLength": 1,
     "KsidVindex": "kid_index",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select kid, column_a, column_b, column_c, column_c = 2 from multicolvin where kid = 1 for update",
-    "Query": "update multicolvin set column_c = 2 where kid = 1",
+    "OwnedVindexQuery": "select kid, column_a, column_b, column_c, multicolvin.column_c = 2 from multicolvin where multicolvin.kid = 1 for update",
+    "Query": "update multicolvin set multicolvin.column_c = 2 where multicolvin.kid = 1",
     "Table": "multicolvin",
     "Values": [
       "INT64(1)"
@@ -3359,8 +3620,8 @@ Gen4 plan same as above
     "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = _binary 'abc' from `user` where id = 1 for update",
-    "Query": "update `user` set `name` = _binary 'abc' where id = 1",
+    "OwnedVindexQuery": "select Id, `Name`, Costly, `user`.`name` = _binary 'abc' from `user` where `user`.id = 1 for update",
+    "Query": "update `user` set `user`.`name` = _binary 'abc' where `user`.id = 1",
     "Table": "user",
     "Values": [
       "INT64(1)"
@@ -3451,7 +3712,31 @@ Gen4 plan same as above
     "user.user"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update `user[-]`.user set name = 'myname'",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "ByDestination",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "ChangedVindexValues": [
+      "name_user_map:3"
+    ],
+    "KsidLength": 1,
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select Id, `Name`, Costly, `user[-]`.`user`.`name` = 'myname' from `user` for update",
+    "Query": "update `user` set `user`.`name` = 'myname'",
+    "Table": "user"
+  },
+  "TablesUsed": [
+    "user.user"
+  ]
+}
 
 # update with shard targeting without vindex
 "update `user[-]`.user_extra set val = 1"
@@ -3474,7 +3759,25 @@ Gen4 plan same as above
     "user.user_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update `user[-]`.user_extra set val = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "ByDestination",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update user_extra set user_extra.val = 1",
+    "Table": "user_extra"
+  },
+  "TablesUsed": [
+    "user.user_extra"
+  ]
+}
 
 # multi-table delete with single table
 "delete u.* from user u where u.id * u.col = u.foo"
@@ -3592,7 +3895,31 @@ Gen4 plan same as above
     "zlookup_unique.t1"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update zlookup_unique.t1 set c2 = 1 where c2 = 20",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "zlookup_unique",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "ChangedVindexValues": [
+      "lookup_t1:3"
+    ],
+    "KsidLength": 1,
+    "KsidVindex": "xxhash",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select c1, c2, c3, zlookup_unique.t1.c2 = 1 from t1 where zlookup_unique.t1.c2 = 20 for update",
+    "Query": "update t1 set t1.c2 = 1 where t1.c2 = 20",
+    "Table": "t1"
+  },
+  "TablesUsed": [
+    "zlookup_unique.t1"
+  ]
+}
 
 # Delete on backfilling and non-backfilling unique lookup vindexes should be a delete equal
 "delete from zlookup_unique.t1 where c2 = 10 and c3 = 20"
@@ -3672,8 +3999,8 @@ Gen4 plan same as above
     "KsidLength": 1,
     "KsidVindex": "xxhash",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select c1, c2, c3, c2 = 1 from t1 where c2 = 10 and c3 = 20 for update",
-    "Query": "update t1 set c2 = 1 where c2 = 10 and c3 = 20",
+    "OwnedVindexQuery": "select c1, c2, c3, zlookup_unique.t1.c2 = 1 from t1 where zlookup_unique.t1.c2 = 10 and zlookup_unique.t1.c3 = 20 for update",
+    "Query": "update t1 set t1.c2 = 1 where t1.c2 = 10 and t1.c3 = 20",
     "Table": "t1",
     "Values": [
       "INT64(20)"
@@ -3746,7 +4073,35 @@ Gen4 plan same as above
     "zlookup_unique.t1"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update zlookup_unique.t1 set c2 = 1 where c2 = 10 and c3 in (20, 21)",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "zlookup_unique",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "ChangedVindexValues": [
+      "lookup_t1:3"
+    ],
+    "KsidLength": 1,
+    "KsidVindex": "xxhash",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select c1, c2, c3, zlookup_unique.t1.c2 = 1 from t1 where zlookup_unique.t1.c2 = 10 and zlookup_unique.t1.c3 in (20, 21) for update",
+    "Query": "update t1 set t1.c2 = 1 where t1.c2 = 10 and t1.c3 in (20, 21)",
+    "Table": "t1",
+    "Values": [
+      "(INT64(20), INT64(21))"
+    ],
+    "Vindex": "lookup_t1_2"
+  },
+  "TablesUsed": [
+    "zlookup_unique.t1"
+  ]
+}
 
 #update with alias table
 "update user u set u.name = 'john' where u.col \u003e 20"
@@ -3841,7 +4196,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update multicol_tbl set x = 1 where cola = 1 and colb = 2",
+    "Query": "update multicol_tbl set multicol_tbl.x = 1 where multicol_tbl.cola = 1 and multicol_tbl.colb = 2",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(1)",
@@ -3892,7 +4247,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update multicol_tbl set x = 1 where colb = 2 and cola = 1",
+    "Query": "update multicol_tbl set multicol_tbl.x = 1 where multicol_tbl.colb = 2 and multicol_tbl.cola = 1",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(1)",
@@ -3931,7 +4286,30 @@ Gen4 plan same as above
     "user.multicol_tbl"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set x = 1 where colb IN (1,2) and cola = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update multicol_tbl set multicol_tbl.x = 1 where multicol_tbl.colb in (1, 2) and multicol_tbl.cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "multicolIdx"
+  },
+  "TablesUsed": [
+    "user.multicol_tbl"
+  ]
+}
 
 # update with a multicol vindex using an IN clause
 "update multicol_tbl set x = 1 where colb IN (1,2) and cola IN (3,4)"
@@ -3959,7 +4337,30 @@ Gen4 plan same as above
     "user.multicol_tbl"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set x = 1 where colb IN (1,2) and cola IN (3,4)",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update multicol_tbl set multicol_tbl.x = 1 where multicol_tbl.colb in (1, 2) and multicol_tbl.cola in (3, 4)",
+    "Table": "multicol_tbl",
+    "Values": [
+      "(INT64(3), INT64(4))",
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "multicolIdx"
+  },
+  "TablesUsed": [
+    "user.multicol_tbl"
+  ]
+}
 
 # delete with a multicol vindex
 "delete from multicol_tbl where cola = 1 and colb = 2"
@@ -4134,8 +4535,8 @@ Gen4 plan same as above
     "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select cola, colb, colc, `name`, colc = 1 from multicol_tbl where cola = 1 and colb = 2 for update",
-    "Query": "update multicol_tbl set colc = 1 where cola = 1 and colb = 2",
+    "OwnedVindexQuery": "select cola, colb, colc, `name`, multicol_tbl.colc = 1 from multicol_tbl where multicol_tbl.cola = 1 and multicol_tbl.colb = 2 for update",
+    "Query": "update multicol_tbl set multicol_tbl.colc = 1 where multicol_tbl.cola = 1 and multicol_tbl.colb = 2",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(1)",
@@ -4173,7 +4574,29 @@ Gen4 plan same as above
     "user.multicol_tbl"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set x = 42 where name = 'foo'",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update multicol_tbl set multicol_tbl.x = 42 where multicol_tbl.`name` = 'foo'",
+    "Table": "multicol_tbl",
+    "Values": [
+      "VARCHAR(\"foo\")"
+    ],
+    "Vindex": "name_muticoltbl_map"
+  },
+  "TablesUsed": [
+    "user.multicol_tbl"
+  ]
+}
 
 # update with routing using subsharding column
 "update multicol_tbl set x = 42 where cola = 1"
@@ -4212,7 +4635,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update multicol_tbl set x = 42 where cola = 1",
+    "Query": "update multicol_tbl set multicol_tbl.x = 42 where multicol_tbl.cola = 1",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(1)"
@@ -4272,8 +4695,8 @@ Gen4 plan same as above
     "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
-    "OwnedVindexQuery": "select cola, colb, colc, `name`, `name` = 'bar' from multicol_tbl where cola = 1 for update",
-    "Query": "update multicol_tbl set `name` = 'bar' where cola = 1",
+    "OwnedVindexQuery": "select cola, colb, colc, `name`, multicol_tbl.`name` = 'bar' from multicol_tbl where multicol_tbl.cola = 1 for update",
+    "Query": "update multicol_tbl set multicol_tbl.`name` = 'bar' where multicol_tbl.cola = 1",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(1)"
@@ -4316,7 +4739,35 @@ Gen4 plan same as above
     "user.multicol_tbl"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set name = 'bar' where cola in (1,2)",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "IN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "ChangedVindexValues": [
+      "name_muticoltbl_map:4"
+    ],
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name`, multicol_tbl.`name` = 'bar' from multicol_tbl where multicol_tbl.cola in (1, 2) for update",
+    "Query": "update multicol_tbl set multicol_tbl.`name` = 'bar' where multicol_tbl.cola in (1, 2)",
+    "Table": "multicol_tbl",
+    "Values": [
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "multicolIdx"
+  },
+  "TablesUsed": [
+    "user.multicol_tbl"
+  ]
+}
 
 # update with routing using subsharding column with in query as lower cost over lookup vindex
 "update multicol_tbl set x = 1 where name = 'foo' and cola = 2"
@@ -4355,7 +4806,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update multicol_tbl set x = 1 where `name` = 'foo' and cola = 2",
+    "Query": "update multicol_tbl set multicol_tbl.x = 1 where multicol_tbl.`name` = 'foo' and multicol_tbl.cola = 2",
     "Table": "multicol_tbl",
     "Values": [
       "VARCHAR(\"foo\")"
@@ -4638,8 +5089,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` for update",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` for update",
         "Table": "`user`"
       }
     ]
@@ -4712,8 +5163,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select null, id from `user` where 1 != 1",
-        "Query": "select null, id from `user` for update",
+        "FieldQuery": "select null, `user`.id as id from `user` where 1 != 1",
+        "Query": "select null, `user`.id as id from `user` for update",
         "Table": "`user`"
       }
     ]
@@ -4947,8 +5398,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col1, col2 from `user` where 1 != 1",
-        "Query": "select col1, col2 from `user` for update",
+        "FieldQuery": "select `user`.col1 as col1, `user`.col2 as col2 from `user` where 1 != 1",
+        "Query": "select `user`.col1 as col1, `user`.col2 as col2 from `user` for update",
         "Table": "`user`"
       }
     ]
@@ -5063,8 +5514,8 @@ Gen4 plan same as above
           "Name": "zlookup_unique",
           "Sharded": true
         },
-        "FieldQuery": "select col1, col2 from t1 where 1 != 1",
-        "Query": "select col1, col2 from t1 for update",
+        "FieldQuery": "select t1.col1 as col1, t1.col2 as col2 from t1 where 1 != 1",
+        "Query": "select t1.col1 as col1, t1.col2 as col2 from t1 for update",
         "Table": "t1"
       }
     ]
@@ -5269,8 +5720,8 @@ Gen4 plan same as above
           "Name": "zlookup_unique",
           "Sharded": true
         },
-        "FieldQuery": "select col from t1 where 1 != 1",
-        "Query": "select col from t1 for update",
+        "FieldQuery": "select t1.col as col from t1 where 1 != 1",
+        "Query": "select t1.col as col from t1 for update",
         "Table": "t1"
       }
     ]
@@ -5301,8 +5752,8 @@ Gen4 plan same as above
           "Name": "main",
           "Sharded": false
         },
-        "FieldQuery": "select id from unsharded where 1 != 1",
-        "Query": "select id from unsharded lock in share mode",
+        "FieldQuery": "select unsharded.id as id from unsharded where 1 != 1",
+        "Query": "select unsharded.id as id from unsharded lock in share mode",
         "Table": "unsharded"
       },
       {
@@ -5314,7 +5765,7 @@ Gen4 plan same as above
         },
         "TargetTabletType": "PRIMARY",
         "MultiShardAutocommit": false,
-        "Query": "update `user` set col = :__sq1",
+        "Query": "update `user` set `user`.col = :__sq1",
         "Table": "user"
       }
     ]
@@ -5345,8 +5796,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` lock in share mode",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` lock in share mode",
         "Table": "`user`"
       },
       {
@@ -5358,7 +5809,7 @@ Gen4 plan same as above
         },
         "TargetTabletType": "PRIMARY",
         "MultiShardAutocommit": false,
-        "Query": "update unsharded set col = :__sq1",
+        "Query": "update unsharded set unsharded.col = :__sq1",
         "Table": "unsharded"
       }
     ]
@@ -5409,8 +5860,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where `user`.id = :unsharded_id lock in share mode",
+            "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+            "Query": "select `user`.id as id from `user` where `user`.id = :unsharded_id lock in share mode",
             "Table": "`user`",
             "Values": [
               ":unsharded_id"
@@ -5428,7 +5879,7 @@ Gen4 plan same as above
         },
         "TargetTabletType": "PRIMARY",
         "MultiShardAutocommit": false,
-        "Query": "update unsharded set col = :__sq1",
+        "Query": "update unsharded set unsharded.col = :__sq1",
         "Table": "unsharded"
       }
     ]
@@ -5454,7 +5905,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update `user` set col = (select count(*) from user_extra where user_extra.user_id = 5) where id = 5",
+    "Query": "update `user` set `user`.col = (select count(*) from user_extra where user_extra.user_id = 5) where `user`.id = 5",
     "Table": "user",
     "Values": [
       "INT64(5)"
@@ -5482,7 +5933,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update `user` set col = (select count(*) from user_extra where user_extra.user_id = `user`.id) where id = 5",
+    "Query": "update `user` set `user`.col = (select count(*) from user_extra where user_extra.user_id = `user`.id) where `user`.id = 5",
     "Table": "user",
     "Values": [
       "INT64(5)"
@@ -5510,7 +5961,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update `user` set col = (select count(*) from user_extra where user_extra.user_id = `user`.id) where id \u003e 5",
+    "Query": "update `user` set `user`.col = (select count(*) from user_extra where user_extra.user_id = `user`.id) where `user`.id \u003e 5",
     "Table": "user"
   },
   "TablesUsed": [

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -25,8 +25,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user`",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user`",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -61,8 +61,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where someColumn = null",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.someColumn = null",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -97,8 +97,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where someColumn \u003c=\u003e null",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.someColumn \u003c=\u003e null",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -137,8 +137,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.id = 5",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.id = 5",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -177,8 +177,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.id = 5 + 5",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.id = 5 + 5",
     "Table": "`user`",
     "Values": [
       "INT64(10)"
@@ -221,8 +221,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where id = 5 and user_id = 4",
+    "FieldQuery": "select music.id as id from music where 1 != 1",
+    "Query": "select music.id as id from music where music.id = 5 and music.user_id = 4",
     "Table": "music",
     "Values": [
       "INT64(4)"
@@ -265,8 +265,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where costly = 'aa' and `name` = 'bb'",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.costly = 'aa' and `user`.`name` = 'bb'",
     "Table": "`user`",
     "Values": [
       "VARCHAR(\"bb\")"
@@ -309,8 +309,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where costly in ('aa', 'bb') and `name` in ::__vals",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.costly in ('aa', 'bb') and `user`.`name` in ::__vals",
     "Table": "`user`",
     "Values": [
       "(VARCHAR(\"aa\"), VARCHAR(\"bb\"))"
@@ -353,8 +353,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (`name`, col) in (('aa', 'bb'), ('cc', 'dd'))",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where (`user`.`name`, `user`.col) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
       "(VARCHAR(\"aa\"), VARCHAR(\"cc\"))"
@@ -397,8 +397,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (col, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where (`user`.col, `user`.`name`) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
       "(VARCHAR(\"bb\"), VARCHAR(\"dd\"))"
@@ -441,8 +441,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (costly, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where (`user`.costly, `user`.`name`) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
       "(VARCHAR(\"bb\"), VARCHAR(\"dd\"))"
@@ -485,8 +485,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (`name`, costly) in (('aa', 'bb'), ('cc', 'dd'))",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where (`user`.`name`, `user`.costly) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
       "(VARCHAR(\"aa\"), VARCHAR(\"cc\"))"
@@ -529,8 +529,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (col, costly) in (('aa', 'bb')) and (col, `name`) in (('cc', 'dd'))",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where (`user`.col, `user`.costly) in (('aa', 'bb')) and (`user`.col, `user`.`name`) in (('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
       "(VARCHAR(\"dd\"))"
@@ -573,8 +573,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (col, `name`) in (('aa', 'bb')) and id = 5",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where (`user`.col, `user`.`name`) in (('aa', 'bb')) and `user`.id = 5",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -617,8 +617,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (costly, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where (`user`.costly, `user`.`name`) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
       "(VARCHAR(\"bb\"), VARCHAR(\"dd\"))"
@@ -661,8 +661,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where ((col1, `name`), col2) in ((('aa', 'bb'), 'cc'), (('dd', 'ee'), 'ff'))",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where ((`user`.col1, `user`.`name`), `user`.col2) in ((('aa', 'bb'), 'cc'), (('dd', 'ee'), 'ff'))",
     "Table": "`user`",
     "Values": [
       "(VARCHAR(\"bb\"), VARCHAR(\"ee\"))"
@@ -705,8 +705,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (`name`, (col1, col2)) in (('aa', ('bb', 'cc')), ('dd', ('ee', 'ff')))",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where (`user`.`name`, (`user`.col1, `user`.col2)) in (('aa', ('bb', 'cc')), ('dd', ('ee', 'ff')))",
     "Table": "`user`",
     "Values": [
       "(VARCHAR(\"aa\"), VARCHAR(\"dd\"))"
@@ -745,8 +745,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where ((col1, `name`), col2) in (('aa', 'bb', 'cc'), (('dd', 'ee'), 'ff'))",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where ((`user`.col1, `user`.`name`), `user`.col2) in (('aa', 'bb', 'cc'), (('dd', 'ee'), 'ff'))",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -781,8 +781,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (col1, `name`) in (select * from music where music.user_id = `user`.id)",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where (`user`.col1, `user`.`name`) in (select * from music where music.user_id = `user`.id)",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -818,8 +818,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (col1, `name`) in (('aa', 1 + 1))",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where (`user`.col1, `user`.`name`) in (('aa', 1 + 1))",
     "Table": "`user`",
     "Values": [
       "(INT64(2))"
@@ -858,8 +858,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select Id from `user` where 1 != 1",
-    "Query": "select Id from `user` where 1 in ('aa', 'bb')",
+    "FieldQuery": "select `user`.Id as Id from `user` where 1 != 1",
+    "Query": "select `user`.Id as Id from `user` where 1 in ('aa', 'bb')",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -894,8 +894,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `name` in (col, 'bb')",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.`name` in (`user`.col, 'bb')",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -934,8 +934,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `name` = :a",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.`name` = :a",
     "Table": "`user`",
     "Values": [
       ":a"
@@ -978,8 +978,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `name` = 18446744073709551615",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.`name` = 18446744073709551615",
     "Table": "`user`",
     "Values": [
       "UINT64(18446744073709551615)"
@@ -1022,8 +1022,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `name` in ::__vals",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.`name` in ::__vals",
     "Table": "`user`",
     "Values": [
       ":list"
@@ -1540,8 +1540,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.col = 5 and `user`.id in ::__vals",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.col = 5 and `user`.id in ::__vals",
     "Table": "`user`",
     "Values": [
       "(INT64(1), INT64(2))"
@@ -1584,8 +1584,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.col = case `user`.col when 'foo' then true else false end and `user`.id in ::__vals",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.col = case `user`.col when 'foo' then true else false end and `user`.id in ::__vals",
     "Table": "`user`",
     "Values": [
       "(INT64(1), INT64(2))"
@@ -1628,8 +1628,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id or col as val from `user` where 1 != 1",
-    "Query": "select id or col as val from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa'",
+    "FieldQuery": "select `user`.id or `user`.col as val from `user` where 1 != 1",
+    "Query": "select `user`.id or `user`.col as val from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa'",
     "Table": "`user`",
     "Values": [
       "VARCHAR(\"aa\")"
@@ -1672,8 +1672,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.col = false and `user`.id in (1, 2) and `user`.`name` = 'aa'",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.col = false and `user`.id in (1, 2) and `user`.`name` = 'aa'",
     "Table": "`user`",
     "Values": [
       "VARCHAR(\"aa\")"
@@ -1716,8 +1716,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa' and `user`.id = 1",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa' and `user`.id = 1",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -1760,8 +1760,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.id = 1 and `user`.`name` = 'aa' and `user`.id in (1, 2) and `user`.col = 5",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.id = 1 and `user`.`name` = 'aa' and `user`.id in (1, 2) and `user`.col = 5",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -1800,8 +1800,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.id = 1 or `user`.`name` = 'aa' and `user`.id in (1, 2)",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.id = 1 or `user`.`name` = 'aa' and `user`.id in (1, 2)",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -1925,8 +1925,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` as route1 where 1 != 1",
-    "Query": "select col from `user` as route1 where id = 1",
+    "FieldQuery": "select route1.col as col from `user` as route1 where 1 != 1",
+    "Query": "select route1.col as col from `user` as route1 where route1.id = 1",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -2012,7 +2012,7 @@ Gen4 plan same as above
           "Sharded": true
         },
         "FieldQuery": "select u.m from `user` as u where 1 != 1",
-        "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col) and u.id in ::__vals",
+        "Query": "select u.m from `user` as u where u.id in (select `user`.m2 as m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col) and u.id in ::__vals",
         "Table": "`user`",
         "Values": [
           "(:user_extra_col, INT64(1))"
@@ -2101,7 +2101,7 @@ Gen4 plan same as above
           "Sharded": true
         },
         "FieldQuery": "select u.m from `user` as u where 1 != 1",
-        "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = u.id) and u.id in ::__vals",
+        "Query": "select u.m from `user` as u where u.id in (select `user`.m2 as m2 from `user` where `user`.id = u.id) and u.id in ::__vals",
         "Table": "`user`",
         "Values": [
           "(:user_extra_col, INT64(1))"
@@ -2184,7 +2184,7 @@ Gen4 plan same as above
           "Sharded": true
         },
         "FieldQuery": "select u.m from `user` as u where 1 != 1",
-        "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = 5) and u.id = 5",
+        "Query": "select u.m from `user` as u where u.id in (select `user`.m2 as m2 from `user` where `user`.id = 5) and u.id = 5",
         "Table": "`user`",
         "Values": [
           "INT64(5)"
@@ -2273,7 +2273,7 @@ Gen4 plan same as above
           "Sharded": true
         },
         "FieldQuery": "select u.m from `user` as u where 1 != 1",
-        "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col and `user`.id in (select m3 from user_extra where user_extra.user_id = `user`.id)) and u.id in ::__vals",
+        "Query": "select u.m from `user` as u where u.id in (select `user`.m2 as m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col and `user`.id in (select user_extra.m3 as m3 from user_extra where user_extra.user_id = `user`.id)) and u.id in ::__vals",
         "Table": "`user`",
         "Values": [
           "(:user_extra_col, INT64(1))"
@@ -2315,8 +2315,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.col in (select user_extra.col from user_extra where user_extra.user_id = `user`.id)",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.col in (select user_extra.col from user_extra where user_extra.user_id = `user`.id)",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -2356,8 +2356,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where id = 5 and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = 5)",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.id = 5 and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = 5)",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -2401,8 +2401,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where id = 'aa' and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = 'aa')",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.id = 'aa' and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = 'aa')",
     "Table": "`user`",
     "Values": [
       "VARCHAR(\"aa\")"
@@ -2446,8 +2446,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where id = :a and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = :a)",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.id = :a and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = :a)",
     "Table": "`user`",
     "Values": [
       ":a"
@@ -2492,8 +2492,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id2 from `user` as uu where 1 != 1",
-    "Query": "select id2 from `user` as uu where id in (select id from `user` where id = uu.id and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = uu.id))",
+    "FieldQuery": "select uu.id2 as id2 from `user` as uu where 1 != 1",
+    "Query": "select uu.id2 as id2 from `user` as uu where uu.id in (select `user`.id as id from `user` where `user`.id = uu.id and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = uu.id))",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -2563,8 +2563,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -2574,8 +2574,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where :__sq_has_values1 = 1 and `user`.id in ::__vals",
         "Table": "`user`",
         "Values": [
           ":__sq1"
@@ -2645,8 +2645,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -2656,8 +2656,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where :__sq_has_values1 = 0 or id not in ::__sq1",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where :__sq_has_values1 = 0 or `user`.id not in ::__sq1",
         "Table": "`user`"
       }
     ]
@@ -2745,8 +2745,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where :__sq_has_values1",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where :__sq_has_values1",
         "Table": "`user`"
       }
     ]
@@ -2816,8 +2816,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -2827,8 +2827,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where id = :__sq1",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where `user`.id = :__sq1",
         "Table": "`user`",
         "Values": [
           ":__sq1"
@@ -2931,8 +2931,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id3 from `user` where 1 != 1",
-            "Query": "select id3 from `user`",
+            "FieldQuery": "select `user`.id3 as id3 from `user` where 1 != 1",
+            "Query": "select `user`.id3 as id3 from `user`",
             "Table": "`user`"
           },
           {
@@ -2942,8 +2942,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id2 from `user` where 1 != 1",
-            "Query": "select id2 from `user` where :__sq_has_values2 = 1 and id2 in ::__sq2",
+            "FieldQuery": "select `user`.id2 as id2 from `user` where 1 != 1",
+            "Query": "select `user`.id2 as id2 from `user` where :__sq_has_values2 = 1 and `user`.id2 in ::__sq2",
             "Table": "`user`"
           }
         ]
@@ -2955,8 +2955,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id1 from `user` where 1 != 1",
-        "Query": "select id1 from `user` where id = :__sq1",
+        "FieldQuery": "select `user`.id1 as id1 from `user` where 1 != 1",
+        "Query": "select `user`.id1 as id1 from `user` where `user`.id = :__sq1",
         "Table": "`user`",
         "Values": [
           ":__sq1"
@@ -2997,8 +2997,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
-    "Query": "select col from `user` where id = (select id from `user` as route1 where route1.id = `user`.id)",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+    "Query": "select `user`.col as col from `user` where `user`.id = (select route1.id as id from `user` as route1 where route1.id = `user`.id)",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -3066,8 +3066,8 @@ Gen4 plan same as above
           "Name": "main",
           "Sharded": false
         },
-        "FieldQuery": "select id from unsharded as route2 where 1 != 1",
-        "Query": "select id from unsharded as route2",
+        "FieldQuery": "select route2.id as id from unsharded as route2 where 1 != 1",
+        "Query": "select route2.id as id from unsharded as route2",
         "Table": "unsharded"
       },
       {
@@ -3077,8 +3077,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user` where id = :__sq1",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user` where `user`.id = :__sq1",
         "Table": "`user`",
         "Values": [
           ":__sq1"
@@ -3165,8 +3165,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where database()",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where database()",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -3201,8 +3201,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where id = null",
+    "FieldQuery": "select music.id as id from music where 1 != 1",
+    "Query": "select music.id as id from music where music.id = null",
     "Table": "music"
   },
   "TablesUsed": [
@@ -3237,8 +3237,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where id is null",
+    "FieldQuery": "select music.id as id from music where 1 != 1",
+    "Query": "select music.id as id from music where music.id is null",
     "Table": "music"
   },
   "TablesUsed": [
@@ -3273,8 +3273,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where id is not null",
+    "FieldQuery": "select music.id as id from music where 1 != 1",
+    "Query": "select music.id as id from music where music.id is not null",
     "Table": "music"
   },
   "TablesUsed": [
@@ -3309,8 +3309,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where user_id = 4 and id = null",
+    "FieldQuery": "select music.id as id from music where 1 != 1",
+    "Query": "select music.id as id from music where music.user_id = 4 and music.id = null",
     "Table": "music"
   },
   "TablesUsed": [
@@ -3345,8 +3345,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where user_id = 4 and id in (null)",
+    "FieldQuery": "select music.id as id from music where 1 != 1",
+    "Query": "select music.id as id from music where music.user_id = 4 and music.id in (null)",
     "Table": "music"
   },
   "TablesUsed": [
@@ -3385,8 +3385,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where user_id = 4 and id in (null, 1, 2)",
+    "FieldQuery": "select music.id as id from music where 1 != 1",
+    "Query": "select music.id as id from music where music.user_id = 4 and music.id in (null, 1, 2)",
     "Table": "music",
     "Values": [
       "INT64(4)"
@@ -3425,8 +3425,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where user_id = 4 and id not in (null, 1, 2)",
+    "FieldQuery": "select music.id as id from music where 1 != 1",
+    "Query": "select music.id as id from music where music.user_id = 4 and music.id not in (null, 1, 2)",
     "Table": "music"
   },
   "TablesUsed": [
@@ -3461,8 +3461,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where id not in (null, 1, 2) and user_id = 4",
+    "FieldQuery": "select music.id as id from music where 1 != 1",
+    "Query": "select music.id as id from music where music.id not in (null, 1, 2) and music.user_id = 4",
     "Table": "music"
   },
   "TablesUsed": [
@@ -3597,8 +3597,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where (:__sq_has_values1 = 0 or id not in ::__sq1) and (:__sq_has_values2 = 1 and id in ::__vals)",
+            "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+            "Query": "select `user`.id as id from `user` where (:__sq_has_values1 = 0 or `user`.id not in ::__sq1) and (:__sq_has_values2 = 1 and `user`.id in ::__vals)",
             "Table": "`user`",
             "Values": [
               ":__sq2"
@@ -3646,8 +3646,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select c2 from cfc_vindex_col where 1 != 1",
-    "Query": "select c2 from cfc_vindex_col where c1 like 'A%'",
+    "FieldQuery": "select cfc_vindex_col.c2 as c2 from cfc_vindex_col where 1 != 1",
+    "Query": "select cfc_vindex_col.c2 as c2 from cfc_vindex_col where cfc_vindex_col.c1 like 'A%'",
     "Table": "cfc_vindex_col",
     "Values": [
       "VARCHAR(\"A%\")"
@@ -3689,8 +3689,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from samecolvin where 1 != 1",
-    "Query": "select col from samecolvin where col = :col",
+    "FieldQuery": "select samecolvin.col as col from samecolvin where 1 != 1",
+    "Query": "select samecolvin.col as col from samecolvin where samecolvin.col = :col",
     "Table": "samecolvin",
     "Values": [
       ":col"
@@ -3729,8 +3729,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.id \u003e 5",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.id \u003e 5",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -3835,8 +3835,8 @@ Gen4 plan same as above
           "Name": "main",
           "Sharded": false
         },
-        "FieldQuery": "select col from unsharded where 1 != 1",
-        "Query": "select col from unsharded where col = id",
+        "FieldQuery": "select unsharded.col as col from unsharded where 1 != 1",
+        "Query": "select unsharded.col as col from unsharded where unsharded.col = unsharded.id",
         "Table": "unsharded"
       },
       {
@@ -3846,8 +3846,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where :__sq_has_values1 = 1 and `user`.id in ::__vals",
         "Table": "`user`",
         "Values": [
           ":__sq1"
@@ -4255,8 +4255,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where id = 5 and id not in (select user_extra.col from user_extra where user_extra.user_id = 5) and (:__sq_has_values2 = 1 and id in ::__sq2)",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where `user`.id = 5 and `user`.id not in (select user_extra.col from user_extra where user_extra.user_id = 5) and (:__sq_has_values2 = 1 and `user`.id in ::__sq2)",
         "Table": "`user`",
         "Values": [
           "INT64(5)"
@@ -4350,8 +4350,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where id = 5 and (:__sq_has_values1 = 0 or id not in ::__sq1) and id in (select user_extra.col from user_extra where user_extra.user_id = 5)",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where `user`.id = 5 and (:__sq_has_values1 = 0 or `user`.id not in ::__sq1) and `user`.id in (select user_extra.col from user_extra where user_extra.user_id = 5)",
         "Table": "`user`",
         "Values": [
           "INT64(5)"
@@ -4430,8 +4430,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.id = `user`.col and `user`.col = 5",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.id = `user`.col and `user`.col = 5",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -4492,8 +4492,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user`, user_extra where 1 != 1",
-    "Query": "select id from `user`, user_extra where user_extra.col = user_extra.user_id and `user`.id = user_extra.col",
+    "FieldQuery": "select `user`.id as id from `user`, user_extra where 1 != 1",
+    "Query": "select `user`.id as id from `user`, user_extra where user_extra.col = user_extra.user_id and `user`.id = user_extra.col",
     "Table": "`user`, user_extra"
   },
   "TablesUsed": [
@@ -4571,8 +4571,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where `user`.id = :user_extra_col",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where `user`.id = :user_extra_col",
         "Table": "`user`",
         "Values": [
           ":user_extra_col"
@@ -4614,8 +4614,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
-    "Query": "select col from `user` where id = (select id from `user` as a where a.id = `user`.id)",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+    "Query": "select `user`.col as col from `user` where `user`.id = (select a.id as id from `user` as a where a.id = `user`.id)",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -4799,8 +4799,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id from music where 1 != 1",
-            "Query": "select id from music where col2 = 'a'",
+            "FieldQuery": "select music.id as id from music where 1 != 1",
+            "Query": "select music.id as id from music where music.col2 = 'a'",
             "Table": "music"
           },
           {
@@ -4857,7 +4857,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicolvin where 1 != 1",
-    "Query": "select * from multicolvin where column_b = 1",
+    "Query": "select * from multicolvin where multicolvin.column_b = 1",
     "Table": "multicolvin",
     "Values": [
       "INT64(1)"
@@ -4901,7 +4901,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicolvin where 1 != 1",
-    "Query": "select * from multicolvin where column_b = 1 and column_c = 2",
+    "Query": "select * from multicolvin where multicolvin.column_b = 1 and multicolvin.column_c = 2",
     "Table": "multicolvin",
     "Values": [
       "INT64(1)"
@@ -4945,7 +4945,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicolvin where 1 != 1",
-    "Query": "select * from multicolvin where column_b = 1 and column_c = 2 and column_a = 3",
+    "Query": "select * from multicolvin where multicolvin.column_b = 1 and multicolvin.column_c = 2 and multicolvin.column_a = 3",
     "Table": "multicolvin",
     "Values": [
       "INT64(1)"
@@ -4989,7 +4989,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicolvin where 1 != 1",
-    "Query": "select * from multicolvin where column_a = 3 and column_b = 1",
+    "Query": "select * from multicolvin where multicolvin.column_a = 3 and multicolvin.column_b = 1",
     "Table": "multicolvin",
     "Values": [
       "INT64(1)"
@@ -5029,7 +5029,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where cola = 1 and colb = 2",
+    "Query": "select * from multicol_tbl where multicol_tbl.cola = 1 and multicol_tbl.colb = 2",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(1)",
@@ -5070,7 +5070,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where colb = 2 and cola = 1",
+    "Query": "select * from multicol_tbl where multicol_tbl.colb = 2 and multicol_tbl.cola = 1",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(1)",
@@ -5111,7 +5111,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where cola in ::__vals0 and colb in ::__vals1",
+    "Query": "select * from multicol_tbl where multicol_tbl.cola in ::__vals0 and multicol_tbl.colb in ::__vals1",
     "Table": "multicol_tbl",
     "Values": [
       "(INT64(1), INT64(2))",
@@ -5152,7 +5152,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where colb in ::__vals1 and cola in ::__vals0",
+    "Query": "select * from multicol_tbl where multicol_tbl.colb in ::__vals1 and multicol_tbl.cola in ::__vals0",
     "Table": "multicol_tbl",
     "Values": [
       "(INT64(1), INT64(2))",
@@ -5193,7 +5193,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where colb = 1 and cola in ::__vals0",
+    "Query": "select * from multicol_tbl where multicol_tbl.colb = 1 and multicol_tbl.cola in ::__vals0",
     "Table": "multicol_tbl",
     "Values": [
       "(INT64(3), INT64(4))",
@@ -5234,7 +5234,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where cola in (1, 10) and cola = 4 and colb in (5, 6) and colb = 7",
+    "Query": "select * from multicol_tbl where multicol_tbl.cola in (1, 10) and multicol_tbl.cola = 4 and multicol_tbl.colb in (5, 6) and multicol_tbl.colb = 7",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(4)",
@@ -5275,7 +5275,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where colb = 4 and colb in ::__vals1 and cola in ::__vals0",
+    "Query": "select * from multicol_tbl where multicol_tbl.colb = 4 and multicol_tbl.colb in ::__vals1 and multicol_tbl.cola in ::__vals0",
     "Table": "multicol_tbl",
     "Values": [
       "(INT64(5), INT64(6))",
@@ -5316,7 +5316,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where colb in (1, 10) and colb = 4 and cola in ::__vals0",
+    "Query": "select * from multicol_tbl where multicol_tbl.colb in (1, 10) and multicol_tbl.colb = 4 and multicol_tbl.cola in ::__vals0",
     "Table": "multicol_tbl",
     "Values": [
       "(INT64(5), INT64(6))",
@@ -5357,7 +5357,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where colb in (1, 2) and cola in (3, 4) and cola = 5 and colb = 6",
+    "Query": "select * from multicol_tbl where multicol_tbl.colb in (1, 2) and multicol_tbl.cola in (3, 4) and multicol_tbl.cola = 5 and multicol_tbl.colb = 6",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(5)",
@@ -5398,7 +5398,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where (cola, colb) in ((1, 2), (3, 4))",
+    "Query": "select * from multicol_tbl where (multicol_tbl.cola, multicol_tbl.colb) in ((1, 2), (3, 4))",
     "Table": "multicol_tbl",
     "Values": [
       "(INT64(1), INT64(3))",
@@ -5439,7 +5439,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where cola = 1",
+    "Query": "select * from multicol_tbl where multicol_tbl.cola = 1",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(1)"
@@ -5479,7 +5479,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where cola = 1 and colb in ::__vals1",
+    "Query": "select * from multicol_tbl where multicol_tbl.cola = 1 and multicol_tbl.colb in ::__vals1",
     "Table": "multicol_tbl",
     "Values": [
       "INT64(1)",
@@ -5565,8 +5565,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
-    "Query": "select col from `user` where id = 1 or id = 2",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+    "Query": "select `user`.col as col from `user` where `user`.id = 1 or `user`.id = 2",
     "Table": "`user`",
     "Values": [
       "(INT64(1), INT64(2))"
@@ -5605,8 +5605,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
-    "Query": "select col from `user` where id = 1 or id = 2 or id = 3",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+    "Query": "select `user`.col as col from `user` where `user`.id = 1 or `user`.id = 2 or `user`.id = 3",
     "Table": "`user`",
     "Values": [
       "(INT64(1), INT64(2), INT64(3))"
@@ -5645,8 +5645,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
-    "Query": "select col from `user` where id = 1 or id = 2 or (id = 3 or id = 4)",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+    "Query": "select `user`.col as col from `user` where `user`.id = 1 or `user`.id = 2 or (`user`.id = 3 or `user`.id = 4)",
     "Table": "`user`",
     "Values": [
       "(INT64(1), INT64(2), INT64(3), INT64(4))"
@@ -5689,8 +5689,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from music where 1 != 1",
-    "Query": "select id from music where id is null and user_id in ::__vals",
+    "FieldQuery": "select music.id as id from music where 1 != 1",
+    "Query": "select music.id as id from music where music.id is null and music.user_id in ::__vals",
     "Table": "music",
     "Values": [
       "(INT64(1), INT64(2))"

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -25,8 +25,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
-    "Query": "select col from `user`",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+    "Query": "select `user`.col as col from `user`",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -3522,8 +3522,8 @@ Gen4 error: symbol id not found
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -3601,8 +3601,8 @@ Gen4 error: symbol id not found
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -3681,8 +3681,8 @@ Gen4 error: symbol id not found
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -3780,8 +3780,8 @@ Gen4 error: symbol id not found
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -3843,8 +3843,8 @@ Gen4 error: symbol id not found
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -3981,8 +3981,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -5186,8 +5186,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select user_id from user_extra where 1 != 1",
-            "Query": "select user_id from user_extra limit :__upper_limit",
+            "FieldQuery": "select user_extra.user_id as user_id from user_extra where 1 != 1",
+            "Query": "select user_extra.user_id as user_id from user_extra limit :__upper_limit",
             "Table": "user_extra"
           }
         ]
@@ -5207,8 +5207,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id from user_extra where 1 != 1",
-            "Query": "select id from user_extra",
+            "FieldQuery": "select user_extra.id as id from user_extra where 1 != 1",
+            "Query": "select user_extra.id as id from user_extra",
             "Table": "user_extra"
           },
           {
@@ -5218,8 +5218,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals and col = :__sq2",
+            "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+            "Query": "select `user`.id as id from `user` where :__sq_has_values1 = 1 and `user`.id in ::__vals and `user`.col = :__sq2",
             "Table": "`user`",
             "Values": [
               ":__sq1"

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
@@ -52,9 +52,9 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, b, count(*), weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, weight_string(a)",
+        "FieldQuery": "select `user`.a as a, `user`.b as b, count(*), weight_string(`user`.a), weight_string(`user`.b) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a)",
         "OrderBy": "(1|4) ASC, (0|3) ASC",
-        "Query": "select a, b, count(*), weight_string(a), weight_string(b) from `user` group by a, weight_string(a) order by b asc, a asc",
+        "Query": "select `user`.a as a, `user`.b as b, count(*), weight_string(`user`.a), weight_string(`user`.b) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.b asc, `user`.a asc",
         "Table": "`user`"
       }
     ]
@@ -120,9 +120,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select a, b, count(*) as k, weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)",
+            "FieldQuery": "select `user`.a as a, `user`.b as b, count(*) as k, weight_string(`user`.a) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a)",
             "OrderBy": "(0|3) ASC",
-            "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc",
+            "Query": "select `user`.a as a, `user`.b as b, count(*) as k, weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc",
             "Table": "`user`"
           }
         ]
@@ -191,9 +191,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select a, b, count(*) as k, weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)",
+            "FieldQuery": "select `user`.a as a, `user`.b as b, count(*) as k, weight_string(`user`.a) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a)",
             "OrderBy": "(0|3) ASC",
-            "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc",
+            "Query": "select `user`.a as a, `user`.b as b, count(*) as k, weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc",
             "Table": "`user`"
           }
         ]
@@ -271,9 +271,9 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select a, b, count(*) as k, weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)",
+                "FieldQuery": "select `user`.a as a, `user`.b as b, count(*) as k, weight_string(`user`.a) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a)",
                 "OrderBy": "(0|3) ASC",
-                "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc",
+                "Query": "select `user`.a as a, `user`.b as b, count(*) as k, weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc",
                 "Table": "`user`"
               }
             ]
@@ -327,30 +327,23 @@
   "QueryType": "SELECT",
   "Original": "select a, b, count(*) k from user group by a order by 1,3",
   "Instructions": {
-    "OperatorType": "Sort",
-    "Variant": "Memory",
-    "OrderBy": "(0|3) ASC, 2 ASC",
+    "OperatorType": "Aggregate",
+    "Variant": "Ordered",
+    "Aggregates": "random(1) AS b, sum_count_star(2) AS k, random(3) AS k",
+    "GroupBy": "(0|4)",
     "ResultColumns": 3,
     "Inputs": [
       {
-        "OperatorType": "Aggregate",
-        "Variant": "Ordered",
-        "Aggregates": "random(1) AS b, sum_count_star(2) AS k",
-        "GroupBy": "(0|3)",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select a, b, count(*) as k, weight_string(a) from `user` where 1 != 1 group by a, weight_string(a)",
-            "OrderBy": "(0|3) ASC",
-            "Query": "select a, b, count(*) as k, weight_string(a) from `user` group by a, weight_string(a) order by a asc",
-            "Table": "`user`"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.a as a, `user`.b as b, count(*) as k, `user`.k, weight_string(`user`.a) from `user` where 1 != 1 group by `user`.a, weight_string(`user`.a)",
+        "OrderBy": "(0|4) ASC, 2 ASC",
+        "Query": "select `user`.a as a, `user`.b as b, count(*) as k, `user`.k, weight_string(`user`.a) from `user` group by `user`.a, weight_string(`user`.a) order by `user`.a asc, `user`.k asc",
+        "Table": "`user`"
       }
     ]
   },
@@ -417,9 +410,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select textcol1 as t, count(*) as k from `user` where 1 != 1 group by textcol1",
+            "FieldQuery": "select `user`.textcol1 as t, count(*) as k from `user` where 1 != 1 group by `user`.textcol1",
             "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
-            "Query": "select textcol1 as t, count(*) as k from `user` group by textcol1 order by textcol1 asc",
+            "Query": "select `user`.textcol1 as t, count(*) as k from `user` group by `user`.textcol1 order by `user`.textcol1 asc",
             "Table": "`user`"
           }
         ]
@@ -732,8 +725,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select `user`.id, `user`.col1 as a, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1",
-            "Query": "select `user`.id, `user`.col1 as a, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where `user`.id = 1",
+            "FieldQuery": "select `user`.id, `user`.col1 as a, `user`.col2, weight_string(`user`.a), weight_string(`user`.col2) from `user` where 1 != 1",
+            "Query": "select `user`.id, `user`.col1 as a, `user`.col2, weight_string(`user`.a), weight_string(`user`.col2) from `user` where `user`.id = 1",
             "Table": "`user`",
             "Values": [
               "INT64(1)"
@@ -1024,9 +1017,9 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select a, convert(a, binary), weight_string(convert(a, binary)) from `user` where 1 != 1",
+    "FieldQuery": "select `user`.a as a, convert(`user`.a, binary), weight_string(convert(`user`.a, binary)) from `user` where 1 != 1",
     "OrderBy": "(1|2) DESC",
-    "Query": "select a, convert(a, binary), weight_string(convert(a, binary)) from `user` order by convert(a, binary) desc",
+    "Query": "select `user`.a as a, convert(`user`.a, binary), weight_string(convert(`user`.a, binary)) from `user` order by convert(`user`.a, binary) desc",
     "ResultColumns": 1,
     "Table": "`user`"
   },
@@ -1057,9 +1050,9 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select u.a, convert(a, binary), weight_string(convert(a, binary)) from `user` as u where 1 != 1",
+        "FieldQuery": "select u.a, convert(u.a, binary), weight_string(convert(u.a, binary)) from `user` as u where 1 != 1",
         "OrderBy": "(1|2) DESC",
-        "Query": "select u.a, convert(a, binary), weight_string(convert(a, binary)) from `user` as u order by convert(a, binary) desc",
+        "Query": "select u.a, convert(u.a, binary), weight_string(convert(u.a, binary)) from `user` as u order by convert(u.a, binary) desc",
         "Table": "`user`"
       },
       {
@@ -1109,9 +1102,9 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id, intcol from `user` where 1 != 1",
+    "FieldQuery": "select `user`.id as id, `user`.intcol as intcol from `user` where 1 != 1",
     "OrderBy": "1 ASC",
-    "Query": "select id, intcol from `user` order by intcol asc",
+    "Query": "select `user`.id as id, `user`.intcol as intcol from `user` order by `user`.intcol asc",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -1132,9 +1125,9 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col, id, weight_string(id) from `user` where 1 != 1",
+    "FieldQuery": "select `user`.col as col, `user`.id, weight_string(`user`.id) from `user` where 1 != 1",
     "OrderBy": "(1|2) ASC",
-    "Query": "select col, id, weight_string(id) from `user` order by id asc",
+    "Query": "select `user`.col as col, `user`.id, weight_string(`user`.id) from `user` order by `user`.id asc",
     "ResultColumns": 1,
     "Table": "`user`"
   },

--- a/go/vt/vtgate/planbuilder/testdata/oltp_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/oltp_cases.txt
@@ -29,8 +29,8 @@
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select c from sbtest34 where 1 != 1",
-    "Query": "select c from sbtest34 where id = 15",
+    "FieldQuery": "select sbtest34.c as c from sbtest34 where 1 != 1",
+    "Query": "select sbtest34.c as c from sbtest34 where sbtest34.id = 15",
     "Table": "sbtest34",
     "Values": [
       "INT64(15)"
@@ -69,8 +69,8 @@
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select c from sbtest12 where 1 != 1",
-    "Query": "select c from sbtest12 where id between 1 and 10",
+    "FieldQuery": "select sbtest12.c as c from sbtest12 where 1 != 1",
+    "Query": "select sbtest12.c as c from sbtest12 where sbtest12.id between 1 and 10",
     "Table": "sbtest12"
   },
   "TablesUsed": [
@@ -117,8 +117,8 @@
           "Name": "main",
           "Sharded": true
         },
-        "FieldQuery": "select sum(k) from sbtest43 where 1 != 1",
-        "Query": "select sum(k) from sbtest43 where id between 90 and 990",
+        "FieldQuery": "select sum(sbtest43.k) as `sum(k)` from sbtest43 where 1 != 1",
+        "Query": "select sum(sbtest43.k) as `sum(k)` from sbtest43 where sbtest43.id between 90 and 990",
         "Table": "sbtest43"
       }
     ]
@@ -157,9 +157,9 @@
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select c from sbtest1 where 1 != 1",
+    "FieldQuery": "select sbtest1.c as c from sbtest1 where 1 != 1",
     "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
-    "Query": "select c from sbtest1 where id between 50 and 235 order by c asc",
+    "Query": "select sbtest1.c as c from sbtest1 where sbtest1.id between 50 and 235 order by sbtest1.c asc",
     "Table": "sbtest1"
   },
   "TablesUsed": [
@@ -210,9 +210,9 @@
           "Name": "main",
           "Sharded": true
         },
-        "FieldQuery": "select c, weight_string(c) from sbtest30 where 1 != 1",
+        "FieldQuery": "select sbtest30.c as c, weight_string(sbtest30.c) from sbtest30 where 1 != 1",
         "OrderBy": "0 ASC COLLATE latin1_swedish_ci, 0 ASC COLLATE latin1_swedish_ci",
-        "Query": "select distinct c, weight_string(c) from sbtest30 where id between 1 and 10 order by c asc, c asc",
+        "Query": "select distinct sbtest30.c as c, weight_string(sbtest30.c) from sbtest30 where sbtest30.id between 1 and 10 order by sbtest30.c asc, c asc",
         "Table": "sbtest30"
       }
     ]
@@ -259,7 +259,7 @@
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update sbtest6 set k = k + 1 where id = 5",
+    "Query": "update sbtest6 set sbtest6.k = sbtest6.k + 1 where sbtest6.id = 5",
     "Table": "sbtest6",
     "Values": [
       "INT64(5)"
@@ -308,7 +308,7 @@
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update sbtest9 set c = 7 where id = 8",
+    "Query": "update sbtest9 set sbtest9.c = 7 where sbtest9.id = 8",
     "Table": "sbtest9",
     "Values": [
       "INT64(8)"

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -26,7 +26,7 @@
       "Sharded": true
     },
     "FieldQuery": "select `user`.col1 from `user` where 1 != 1",
-    "Query": "select `user`.col1 from `user` where col2 = 2",
+    "Query": "select `user`.col1 from `user` where `user`.col2 = 2",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -250,8 +250,8 @@ Gen4 error: Column 'col1' in field list is ambiguous
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -261,8 +261,8 @@ Gen4 error: Column 'col1' in field list is ambiguous
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where :__sq_has_values1 = 1 and `user`.id in ::__vals",
         "Table": "`user`",
         "Values": [
           ":__sq1"
@@ -307,8 +307,8 @@ Gen4 error: Column 'col1' in field list is ambiguous
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
-    "Query": "select col from `user` where id = 5 order by aa asc",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+    "Query": "select `user`.col as col from `user` where `user`.id = 5 order by `user`.aa asc",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -351,8 +351,8 @@ Gen4 error: Column 'col1' in field list is ambiguous
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
-    "Query": "select col from `user` where id = 1 order by col asc",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+    "Query": "select `user`.col as col from `user` where `user`.id = 1 order by `user`.col asc",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -392,9 +392,9 @@ Gen4 error: Column 'col1' in field list is ambiguous
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
     "OrderBy": "0 ASC",
-    "Query": "select col from `user` order by col asc",
+    "Query": "select `user`.col as col from `user` order by `user`.col asc",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -451,9 +451,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select user_id, col1, col2, weight_string(user_id) from authoritative where 1 != 1",
+    "FieldQuery": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2, weight_string(authoritative.user_id) from authoritative where 1 != 1",
     "OrderBy": "(0|3) ASC",
-    "Query": "select user_id, col1, col2, weight_string(user_id) from authoritative order by user_id asc",
+    "Query": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2, weight_string(authoritative.user_id) from authoritative order by authoritative.user_id asc",
     "ResultColumns": 3,
     "Table": "authoritative"
   },
@@ -491,9 +491,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1",
+    "FieldQuery": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2 from authoritative where 1 != 1",
     "OrderBy": "1 ASC COLLATE latin1_swedish_ci",
-    "Query": "select user_id, col1, col2 from authoritative order by col1 asc",
+    "Query": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2 from authoritative order by authoritative.col1 asc",
     "Table": "authoritative"
   },
   "TablesUsed": [
@@ -530,9 +530,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select a, textcol1, b, weight_string(a), weight_string(b) from `user` where 1 != 1",
+    "FieldQuery": "select `user`.a as a, `user`.textcol1 as textcol1, `user`.b as b, weight_string(`user`.a), weight_string(`user`.b) from `user` where 1 != 1",
     "OrderBy": "(0|3) ASC, 1 ASC COLLATE latin1_swedish_ci, (2|4) ASC",
-    "Query": "select a, textcol1, b, weight_string(a), weight_string(b) from `user` order by a asc, textcol1 asc, b asc",
+    "Query": "select `user`.a as a, `user`.textcol1 as textcol1, `user`.b as b, weight_string(`user`.a), weight_string(`user`.b) from `user` order by `user`.a asc, `user`.textcol1 asc, `user`.b asc",
     "ResultColumns": 3,
     "Table": "`user`"
   },
@@ -570,9 +570,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select a, `user`.textcol1, b, weight_string(a), weight_string(b) from `user` where 1 != 1",
+    "FieldQuery": "select `user`.a as a, `user`.textcol1, `user`.b as b, weight_string(`user`.a), weight_string(`user`.b) from `user` where 1 != 1",
     "OrderBy": "(0|3) ASC, 1 ASC COLLATE latin1_swedish_ci, (2|4) ASC",
-    "Query": "select a, `user`.textcol1, b, weight_string(a), weight_string(b) from `user` order by a asc, textcol1 asc, b asc",
+    "Query": "select `user`.a as a, `user`.textcol1, `user`.b as b, weight_string(`user`.a), weight_string(`user`.b) from `user` order by `user`.a asc, `user`.textcol1 asc, `user`.b asc",
     "ResultColumns": 3,
     "Table": "`user`"
   },
@@ -610,9 +610,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select a, textcol1, b, textcol2, weight_string(a), weight_string(b) from `user` where 1 != 1",
+    "FieldQuery": "select `user`.a as a, `user`.textcol1 as textcol1, `user`.b as b, `user`.textcol2 as textcol2, weight_string(`user`.a), weight_string(`user`.b) from `user` where 1 != 1",
     "OrderBy": "(0|4) ASC, 1 ASC COLLATE latin1_swedish_ci, (2|5) ASC, 3 ASC COLLATE latin1_swedish_ci",
-    "Query": "select a, textcol1, b, textcol2, weight_string(a), weight_string(b) from `user` order by a asc, textcol1 asc, b asc, textcol2 asc",
+    "Query": "select `user`.a as a, `user`.textcol1 as textcol1, `user`.b as b, `user`.textcol2 as textcol2, weight_string(`user`.a), weight_string(`user`.b) from `user` order by `user`.a asc, `user`.textcol1 asc, `user`.b asc, `user`.textcol2 asc",
     "ResultColumns": 4,
     "Table": "`user`"
   },
@@ -655,9 +655,9 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id as foo, weight_string(id) from music where 1 != 1",
+    "FieldQuery": "select music.id as foo, weight_string(music.foo) from music where 1 != 1",
     "OrderBy": "(0|1) ASC",
-    "Query": "select id as foo, weight_string(id) from music order by foo asc",
+    "Query": "select music.id as foo, weight_string(music.foo) from music order by music.foo asc",
     "ResultColumns": 1,
     "Table": "music"
   },
@@ -693,8 +693,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
-    "Query": "select col from `user` order by null",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+    "Query": "select `user`.col as col from `user` order by null",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -759,8 +759,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col2 from `user` where 1 != 1",
-        "Query": "select col2 from `user`",
+        "FieldQuery": "select `user`.col2 as col2 from `user` where 1 != 1",
+        "Query": "select `user`.col2 as col2 from `user`",
         "Table": "`user`"
       },
       {
@@ -770,9 +770,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
         "OrderBy": "0 ASC",
-        "Query": "select col from `user` where :__sq_has_values1 = 1 and col in ::__sq1 order by col asc",
+        "Query": "select `user`.col as col from `user` where :__sq_has_values1 = 1 and `user`.col in ::__sq1 order by `user`.col asc",
         "Table": "`user`"
       }
     ]
@@ -1131,8 +1131,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col2 from `user` where 1 != 1",
-        "Query": "select col2 from `user`",
+        "FieldQuery": "select `user`.col2 as col2 from `user` where 1 != 1",
+        "Query": "select `user`.col2 as col2 from `user`",
         "Table": "`user`"
       },
       {
@@ -1142,8 +1142,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user` where :__sq_has_values1 = 1 and col in ::__sq1",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user` where :__sq_has_values1 = 1 and `user`.col in ::__sq1",
         "Table": "`user`"
       }
     ]
@@ -1180,8 +1180,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` where 1 != 1",
-    "Query": "select col from `user` order by RAND()",
+    "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+    "Query": "select `user`.col as col from `user` order by RAND()",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -1342,8 +1342,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col2 from `user` where 1 != 1",
-        "Query": "select col2 from `user`",
+        "FieldQuery": "select `user`.col2 as col2 from `user` where 1 != 1",
+        "Query": "select `user`.col2 as col2 from `user`",
         "Table": "`user`"
       },
       {
@@ -1353,8 +1353,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user` where :__sq_has_values1 = 1 and col in ::__sq1 order by rand()",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user` where :__sq_has_values1 = 1 and `user`.col in ::__sq1 order by rand()",
         "Table": "`user`"
       }
     ]
@@ -1396,7 +1396,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 5 order by col asc",
+    "Query": "select * from `user` where `user`.id = 5 order by `user`.col asc",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -1440,7 +1440,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select `user`.* from `user` where 1 != 1",
-    "Query": "select `user`.* from `user` where id = 5 order by `user`.col asc",
+    "Query": "select `user`.* from `user` where `user`.id = 5 order by `user`.col asc",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -1484,7 +1484,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 5 order by `user`.col asc",
+    "Query": "select * from `user` where `user`.id = 5 order by `user`.col asc",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -1555,7 +1555,7 @@ Gen4 plan same as above
           "Sharded": true
         },
         "FieldQuery": "select u.col, u.id from `user` as u where 1 != 1",
-        "Query": "select u.col, u.id from `user` as u where u.col in (select * from `user` where `user`.id = u.id order by col asc)",
+        "Query": "select u.col, u.id from `user` as u where u.col in (select * from `user` where `user`.id = u.id order by `user`.col asc)",
         "Table": "`user`"
       },
       {
@@ -1591,7 +1591,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select u.id from `user` as u where 1 != 1",
-    "Query": "select u.id from `user` as u where u.id in (select col2 from `user` where `user`.id = u.id order by u.col asc)",
+    "Query": "select u.id from `user` as u where u.id in (select `user`.col2 as col2 from `user` where `user`.id = u.id order by u.col asc)",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -1646,7 +1646,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 5 order by `user`.col collate utf8_general_ci asc",
+    "Query": "select * from `user` where `user`.id = 5 order by `user`.col collate utf8_general_ci asc",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -1690,7 +1690,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 5 order by -col1 asc",
+    "Query": "select * from `user` where `user`.id = 5 order by -`user`.col1 asc",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -1734,7 +1734,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 5 order by concat(col, col1) collate utf8_general_ci desc",
+    "Query": "select * from `user` where `user`.id = 5 order by concat(`user`.col, `user`.col1) collate utf8_general_ci desc",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -1778,7 +1778,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 5 order by id + col collate utf8_general_ci desc",
+    "Query": "select * from `user` where `user`.id = 5 order by `user`.id + `user`.col collate utf8_general_ci desc",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -1866,8 +1866,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from `user` as route1 where 1 != 1",
-    "Query": "select col from `user` as route1 where id = 1 order by col asc",
+    "FieldQuery": "select route1.col as col from `user` as route1 where 1 != 1",
+    "Query": "select route1.col as col from `user` as route1 where route1.id = 1 order by route1.col asc",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -1910,8 +1910,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col1 from `user` where 1 != 1",
-    "Query": "select col1 from `user` where id = 1 limit 1",
+    "FieldQuery": "select `user`.col1 as col1 from `user` where 1 != 1",
+    "Query": "select `user`.col1 as col1 from `user` where `user`.id = 1 limit 1",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -2048,8 +2048,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user` limit :__upper_limit",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user` limit :__upper_limit",
         "Table": "`user`"
       }
     ]
@@ -2096,8 +2096,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user` limit :__upper_limit",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user` limit :__upper_limit",
         "Table": "`user`"
       }
     ]
@@ -2145,7 +2145,7 @@ Gen4 plan same as above
           "Sharded": true
         },
         "FieldQuery": "select * from `user` where 1 != 1",
-        "Query": "select * from `user` where id1 = 4 and name1 = 'abc' limit :__upper_limit",
+        "Query": "select * from `user` where `user`.id1 = 4 and `user`.name1 = 'abc' limit :__upper_limit",
         "Table": "`user`"
       }
     ]
@@ -2221,8 +2221,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select col1 from `user` where 1 != 1",
-            "Query": "select col1 from `user`",
+            "FieldQuery": "select `user`.col1 as col1 from `user` where 1 != 1",
+            "Query": "select `user`.col1 as col1 from `user`",
             "Table": "`user`"
           },
           {
@@ -2232,8 +2232,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user` where :__sq_has_values1 = 1 and col in ::__sq1 limit :__upper_limit",
+            "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+            "Query": "select `user`.col as col from `user` where :__sq_has_values1 = 1 and `user`.col in ::__sq1 limit :__upper_limit",
             "Table": "`user`"
           }
         ]
@@ -2272,8 +2272,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col from ref where 1 != 1",
-    "Query": "select col from ref limit 1",
+    "FieldQuery": "select ref.col as col from ref where 1 != 1",
+    "Query": "select ref.col as col from ref limit 1",
     "Table": "ref"
   },
   "TablesUsed": [
@@ -2318,8 +2318,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` limit :__upper_limit",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` limit :__upper_limit",
         "Table": "`user`"
       }
     ]
@@ -2358,9 +2358,9 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id as foo, weight_string(id) from music where 1 != 1",
+    "FieldQuery": "select music.id as foo, weight_string(music.id) from music where 1 != 1",
     "OrderBy": "(0|1) ASC",
-    "Query": "select id as foo, weight_string(id) from music order by foo asc",
+    "Query": "select music.id as foo, weight_string(music.id) from music order by foo asc",
     "ResultColumns": 1,
     "Table": "music"
   },
@@ -2398,9 +2398,9 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id as foo, id2 as id, weight_string(id2) from music where 1 != 1",
+    "FieldQuery": "select id as foo, music.id2 as id, weight_string(music.id2) from music where 1 != 1",
     "OrderBy": "(1|2) ASC",
-    "Query": "select id as foo, id2 as id, weight_string(id2) from music order by id asc",
+    "Query": "select id as foo, music.id2 as id, weight_string(music.id2) from music order by id asc",
     "ResultColumns": 2,
     "Table": "music"
   },
@@ -2463,9 +2463,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select `name`, weight_string(`name`) from `user` where 1 != 1",
+        "FieldQuery": "select `user`.`name` as ```name```, weight_string(`user`.`name`) from `user` where 1 != 1",
         "OrderBy": "(0|1) ASC",
-        "Query": "select `name`, weight_string(`name`) from `user` order by `name` asc",
+        "Query": "select `user`.`name` as ```name```, weight_string(`user`.`name`) from `user` order by `user`.`name` asc",
         "Table": "`user`"
       },
       {
@@ -2526,8 +2526,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select count(id), num from `user` where 1 != 1",
-        "Query": "select count(id), num from `user`",
+        "FieldQuery": "select count(`user`.id) as `count(id)`, `user`.num as num from `user` where 1 != 1",
+        "Query": "select count(`user`.id) as `count(id)`, `user`.num as num from `user`",
         "Table": "`user`"
       }
     ]
@@ -2586,9 +2586,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select count(id), num, weight_string(num) from `user` where 1 != 1",
+        "FieldQuery": "select count(`user`.id) as `count(id)`, `user`.num as num, weight_string(`user`.num) from `user` where 1 != 1",
         "OrderBy": "(1|2) ASC",
-        "Query": "select count(id), num, weight_string(num) from `user` order by num asc",
+        "Query": "select count(`user`.id) as `count(id)`, `user`.num as num, weight_string(`user`.num) from `user` order by `user`.num asc",
         "Table": "`user`"
       }
     ]
@@ -2642,9 +2642,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select count(id), num, weight_string(num) from `user` where 1 != 1 group by num, weight_string(num)",
+        "FieldQuery": "select count(`user`.id) as `count(id)`, `user`.num as num, weight_string(`user`.num) from `user` where 1 != 1 group by `user`.num, weight_string(`user`.num)",
         "OrderBy": "(1|2) ASC",
-        "Query": "select count(id), num, weight_string(num) from `user` group by num, weight_string(num) order by num asc",
+        "Query": "select count(`user`.id) as `count(id)`, `user`.num as num, weight_string(`user`.num) from `user` group by `user`.num, weight_string(`user`.num) order by `user`.num asc",
         "Table": "`user`"
       }
     ]
@@ -2710,9 +2710,9 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select count(id), num, weight_string(num) from `user` where 1 != 1 group by num, weight_string(num)",
+            "FieldQuery": "select count(`user`.id) as `count(id)`, `user`.num as num, weight_string(`user`.num) from `user` where 1 != 1 group by `user`.num, weight_string(`user`.num)",
             "OrderBy": "(1|2) ASC",
-            "Query": "select count(id), num, weight_string(num) from `user` group by num, weight_string(num) order by num asc",
+            "Query": "select count(`user`.id) as `count(id)`, `user`.num as num, weight_string(`user`.num) from `user` group by `user`.num, weight_string(`user`.num) order by `user`.num asc",
             "Table": "`user`"
           }
         ]
@@ -2733,7 +2733,7 @@ Gen4 plan same as above
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "L:0,L:0",
+    "JoinColumnIndexes": "L:0,L:1",
     "TableName": "`user`_music",
     "Inputs": [
       {
@@ -2743,9 +2743,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select `name`, weight_string(`name`) from `user` where 1 != 1",
-        "OrderBy": "(0|1) ASC",
-        "Query": "select `name`, weight_string(`name`) from `user` order by `name` asc",
+        "FieldQuery": "select `user`.`name` as ```name```, `user`.`name` as ```name```, weight_string(`user`.`name`) from `user` where 1 != 1",
+        "OrderBy": "(0|2) ASC",
+        "Query": "select `user`.`name` as ```name```, `user`.`name` as ```name```, weight_string(`user`.`name`) from `user` order by `user`.`name` asc",
         "Table": "`user`"
       },
       {
@@ -2780,9 +2780,9 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id, id, weight_string(id) from `user` where 1 != 1",
+    "FieldQuery": "select `user`.id as id, `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1",
     "OrderBy": "(0|2) ASC",
-    "Query": "select id, id, weight_string(id) from `user` order by id asc",
+    "Query": "select `user`.id as id, `user`.id as id, weight_string(`user`.id) from `user` order by `user`.id asc",
     "ResultColumns": 2,
     "Table": "`user`"
   },
@@ -2811,9 +2811,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col, count(*), c1, weight_string(c1) from `user` where 1 != 1 group by col",
+        "FieldQuery": "select `user`.col as col, count(*), `user`.c1, weight_string(`user`.c1) from `user` where 1 != 1 group by `user`.col",
         "OrderBy": "(2|3) ASC, 0 ASC",
-        "Query": "select col, count(*), c1, weight_string(c1) from `user` group by col order by c1 asc, col asc",
+        "Query": "select `user`.col as col, count(*), `user`.c1, weight_string(`user`.c1) from `user` group by `user`.col order by `user`.c1 asc, `user`.col asc",
         "Table": "`user`"
       }
     ]
@@ -2954,9 +2954,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a as c, a, weight_string(a) from `user` where 1 != 1",
-        "OrderBy": "(0|2) ASC, (0|2) ASC",
-        "Query": "select distinct a as c, a, weight_string(a) from `user` order by c asc, a asc",
+        "FieldQuery": "select `user`.a as c, `user`.a as a, weight_string(`user`.a) from `user` where 1 != 1",
+        "OrderBy": "(0|2) ASC, (1|2) ASC",
+        "Query": "select distinct `user`.a as c, `user`.a as a, weight_string(`user`.a) from `user` order by c asc, a asc",
         "Table": "`user`"
       }
     ]
@@ -2969,33 +2969,7 @@ Gen4 plan same as above
 # Distinct with same column
 "select distinct a, a from user"
 "generating order by clause: ambiguous symbol reference: a"
-{
-  "QueryType": "SELECT",
-  "Original": "select distinct a, a from user",
-  "Instructions": {
-    "OperatorType": "Aggregate",
-    "Variant": "Ordered",
-    "GroupBy": "(0|2), (1|2)",
-    "ResultColumns": 2,
-    "Inputs": [
-      {
-        "OperatorType": "Route",
-        "Variant": "Scatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select a, a, weight_string(a) from `user` where 1 != 1",
-        "OrderBy": "(0|2) ASC, (0|2) ASC",
-        "Query": "select distinct a, a, weight_string(a) from `user` order by a asc, a asc",
-        "Table": "`user`"
-      }
-    ]
-  },
-  "TablesUsed": [
-    "user.user"
-  ]
-}
+Gen4 plan same as above
 
 # Order by has subqueries
 "select id from unsharded order by (select id from unsharded)"

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -537,8 +537,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select user_id, col1, col2 from authoritative where 1 != 1",
-    "Query": "select user_id, col1, col2 from authoritative",
+    "FieldQuery": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2 from authoritative where 1 != 1",
+    "Query": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2 from authoritative",
     "Table": "authoritative"
   },
   "TablesUsed": [
@@ -791,8 +791,8 @@ Gen4 error: Column 'col' in field list is ambiguous
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user`",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user`",
         "Table": "`user`"
       },
       {
@@ -802,8 +802,8 @@ Gen4 error: Column 'col' in field list is ambiguous
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select user_id from user_extra where 1 != 1",
-        "Query": "select user_id from user_extra",
+        "FieldQuery": "select user_extra.user_id as user_id from user_extra where 1 != 1",
+        "Query": "select user_extra.user_id as user_id from user_extra",
         "Table": "user_extra"
       }
     ]
@@ -1641,7 +1641,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 0x04",
+    "Query": "select * from `user` where `user`.id = 0x04",
     "Table": "`user`",
     "Values": [
       "VARBINARY(\"\\x04\")"
@@ -1694,9 +1694,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select user_id, weight_string(user_id) from music where 1 != 1",
+        "FieldQuery": "select music.user_id as user_id, weight_string(music.user_id) from music where 1 != 1",
         "OrderBy": "(0|1) ASC",
-        "Query": "select user_id, weight_string(user_id) from music order by user_id asc limit :__upper_limit",
+        "Query": "select music.user_id as user_id, weight_string(music.user_id) from music order by music.user_id asc limit :__upper_limit",
         "ResultColumns": 1,
         "Table": "music"
       }
@@ -1739,7 +1739,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where `name` = 'abc' and id = 4 limit 5",
+    "Query": "select * from `user` where `user`.`name` = 'abc' and `user`.id = 4 limit 5",
     "Table": "`user`",
     "Values": [
       "INT64(4)"
@@ -1783,7 +1783,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 4 and `name` = 'abc' limit 5",
+    "Query": "select * from `user` where `user`.id = 4 and `user`.`name` = 'abc' limit 5",
     "Table": "`user`",
     "Values": [
       "INT64(4)"
@@ -1827,7 +1827,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 4 and `name` = 'abc' limit 5",
+    "Query": "select * from `user` where `user`.id = 4 and `user`.`name` = 'abc' limit 5",
     "Table": "`user`",
     "Values": [
       "INT64(4)"
@@ -1871,7 +1871,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select user0_.col as col0_ from `user` as user0_ where 1 != 1",
-    "Query": "select user0_.col as col0_ from `user` as user0_ where id = 1 order by user0_.col desc limit 2",
+    "Query": "select user0_.col as col0_ from `user` as user0_ where user0_.id = 1 order by user0_.col desc limit 2",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -1915,7 +1915,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select user0_.col as col0_ from `user` as user0_ where 1 != 1",
-    "Query": "select user0_.col as col0_ from `user` as user0_ where id = 1 order by col0_ desc limit 3",
+    "Query": "select user0_.col as col0_ from `user` as user0_ where user0_.id = 1 order by col0_ desc limit 3",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -1959,7 +1959,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 1 and `name` = true limit 5",
+    "Query": "select * from `user` where `user`.id = 1 and `user`.`name` = true limit 5",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -2003,7 +2003,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 1 and `name` limit 5",
+    "Query": "select * from `user` where `user`.id = 1 and `user`.`name` limit 5",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -2047,7 +2047,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from `user` where 1 != 1",
-    "Query": "select * from `user` where id = 5 and `name` = true limit 5",
+    "Query": "select * from `user` where `user`.id = 5 and `user`.`name` = true limit 5",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -2114,8 +2114,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -2125,8 +2125,8 @@ Gen4 plan same as above
           "Name": "main",
           "Sharded": false
         },
-        "FieldQuery": "select a, :__sq1 from unsharded where 1 != 1",
-        "Query": "select a, :__sq1 from unsharded",
+        "FieldQuery": "select unsharded.a as a, :__sq1 as `(select col from ``user``)` from unsharded where 1 != 1",
+        "Query": "select unsharded.a as a, :__sq1 as `(select col from ``user``)` from unsharded",
         "Table": "unsharded"
       }
     ]
@@ -2192,8 +2192,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select col from `user` where 1 != 1",
-        "Query": "select col from `user`",
+        "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -2203,8 +2203,8 @@ Gen4 plan same as above
           "Name": "main",
           "Sharded": false
         },
-        "FieldQuery": "select a, 1 + :__sq1 from unsharded where 1 != 1",
-        "Query": "select a, 1 + :__sq1 from unsharded",
+        "FieldQuery": "select unsharded.a as a, 1 + :__sq1 as `1 + (select col from ``user``)` from unsharded where 1 != 1",
+        "Query": "select unsharded.a as a, 1 + :__sq1 as `1 + (select col from ``user``)` from unsharded",
         "Table": "unsharded"
       }
     ]
@@ -2350,7 +2350,7 @@ Gen4 error: symbol t.col not found
       "Sharded": true
     },
     "FieldQuery": "select * from music where 1 != 1 union select * from `user` where 1 != 1",
-    "Query": "select * from music where user_id = 1 union select * from `user` where id = 1",
+    "Query": "select * from music where music.user_id = 1 union select * from `user` where `user`.id = 1",
     "Table": "music",
     "Values": [
       "INT64(1)"
@@ -2395,7 +2395,7 @@ Gen4 error: symbol t.col not found
       "Sharded": true
     },
     "FieldQuery": "select *, :__lastInsertId as `last_insert_id()` from music where 1 != 1 union select * from `user` where 1 != 1",
-    "Query": "select *, :__lastInsertId as `last_insert_id()` from music where user_id = 1 union select * from `user` where id = 1",
+    "Query": "select *, :__lastInsertId as `last_insert_id()` from music where music.user_id = 1 union select * from `user` where `user`.id = 1",
     "Table": "music",
     "Values": [
       "INT64(1)"
@@ -2804,7 +2804,7 @@ Gen4 error: symbol t.col not found
       "Sharded": true
     },
     "FieldQuery": "select * from music where 1 != 1",
-    "Query": "select * from music where user_id = 1",
+    "Query": "select * from music where music.user_id = 1",
     "Table": "music",
     "Values": [
       "INT64(1)"
@@ -2965,7 +2965,7 @@ Gen4 error: symbol t.col not found
           "Sharded": true
         },
         "FieldQuery": "select * from music where 1 != 1",
-        "Query": "select * from music where user_id = 1 limit 2",
+        "Query": "select * from music where music.user_id = 1 limit 2",
         "Table": "music",
         "Values": [
           "INT64(1)"
@@ -2980,7 +2980,7 @@ Gen4 error: symbol t.col not found
           "Sharded": true
         },
         "FieldQuery": "select count(*) from music where 1 != 1",
-        "Query": "select count(*) from music where user_id = 1",
+        "Query": "select count(*) from music where music.user_id = 1",
         "Table": "music",
         "Values": [
           "INT64(1)"
@@ -3059,9 +3059,9 @@ Gen4 error: symbol t.col not found
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select user_id, count(id), weight_string(user_id) from music where 1 != 1 group by user_id",
+            "FieldQuery": "select music.user_id as user_id, count(music.id) as `count(id)`, weight_string(music.user_id) from music where 1 != 1 group by music.user_id",
             "OrderBy": "(0|2) ASC",
-            "Query": "select user_id, count(id), weight_string(user_id) from music group by user_id having count(user_id) = 1 order by user_id asc limit :__upper_limit",
+            "Query": "select music.user_id as user_id, count(music.id) as `count(id)`, weight_string(music.user_id) from music group by music.user_id having count(music.user_id) = 1 order by music.user_id asc limit :__upper_limit",
             "ResultColumns": 2,
             "Table": "music"
           }
@@ -3425,8 +3425,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select 42, id from dual, `user` where 1 != 1",
-    "Query": "select 42, id from dual, `user`",
+    "FieldQuery": "select 42, `user`.id as id from dual, `user` where 1 != 1",
+    "Query": "select 42, `user`.id as id from dual, `user`",
     "Table": "`user`, dual"
   },
   "TablesUsed": [
@@ -3595,8 +3595,8 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user` limit :__upper_limit",
+            "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+            "Query": "select `user`.col as col from `user` limit :__upper_limit",
             "Table": "`user`"
           }
         ]
@@ -3892,8 +3892,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select :user_id * user_id as amount from user_extra where 1 != 1",
-        "Query": "select :user_id * user_id as amount from user_extra",
+        "FieldQuery": "select :user_id * user_extra.user_id as amount from user_extra where 1 != 1",
+        "Query": "select :user_id * user_extra.user_id as amount from user_extra",
         "Table": "user_extra"
       }
     ]
@@ -3925,8 +3925,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select `user`.id, col from `user` where 1 != 1",
-        "Query": "select `user`.id, col from `user`",
+        "FieldQuery": "select `user`.id, `user`.col as col from `user` where 1 != 1",
+        "Query": "select `user`.id, `user`.col as col from `user`",
         "Table": "`user`"
       },
       {
@@ -3973,9 +3973,9 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select `user`.id, col from `user` where 1 != 1",
+        "FieldQuery": "select `user`.id, `user`.col as col from `user` where 1 != 1",
         "OrderBy": "1 ASC",
-        "Query": "select `user`.id, col from `user` order by col asc",
+        "Query": "select `user`.id, `user`.col as col from `user` order by `user`.col asc",
         "Table": "`user`"
       },
       {
@@ -4392,8 +4392,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select jcol, json_storage_size(jcol), json_storage_free(jcol), json_pretty(jcol) from `user` where 1 != 1",
-    "Query": "select jcol, json_storage_size(jcol), json_storage_free(jcol), json_pretty(jcol) from `user`",
+    "FieldQuery": "select `user`.jcol as jcol, json_storage_size(`user`.jcol) as `json_storage_size(jcol)`, json_storage_free(`user`.jcol) as `json_storage_free(jcol)`, json_pretty(`user`.jcol) as `json_pretty(jcol)` from `user` where 1 != 1",
+    "Query": "select `user`.jcol as jcol, json_storage_size(`user`.jcol) as `json_storage_size(jcol)`, json_storage_free(`user`.jcol) as `json_storage_free(jcol)`, json_pretty(`user`.jcol) as `json_pretty(jcol)` from `user`",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -4543,9 +4543,9 @@ Gen4 plan same as above
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
+            "FieldQuery": "select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1",
             "OrderBy": "(0|1) ASC",
-            "Query": "select id, weight_string(id) from `user` order by id asc limit :__upper_limit",
+            "Query": "select `user`.id as id, weight_string(`user`.id) from `user` order by `user`.id asc limit :__upper_limit",
             "ResultColumns": 1,
             "Table": "`user`"
           }
@@ -4558,8 +4558,8 @@ Gen4 plan same as above
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select :__sq1 from user_extra where 1 != 1",
-        "Query": "select :__sq1 from user_extra",
+        "FieldQuery": "select :__sq1 as `(select id from ``user`` order by id asc limit 1)` from user_extra where 1 != 1",
+        "Query": "select :__sq1 as `(select id from ``user`` order by id asc limit 1)` from user_extra",
         "Table": "user_extra"
       }
     ]
@@ -4623,7 +4623,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select exists (select 1 from dual where 1 != 1) from `user` where 1 != 1",
-    "Query": "select exists (select 1 from dual limit 1) from `user` where id = 5",
+    "Query": "select exists (select 1 from dual limit 1) from `user` where `user`.id = 5",
     "Table": "`user`",
     "Values": [
       "INT64(5)"
@@ -4735,8 +4735,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select a -\u003e '$[4]', a -\u003e\u003e '$[3]' from `user` where 1 != 1",
-    "Query": "select a -\u003e '$[4]', a -\u003e\u003e '$[3]' from `user`",
+    "FieldQuery": "select `user`.a -\u003e '$[4]' as `a -\u003e '$[4]'`, `user`.a -\u003e\u003e '$[3]' as `a -\u003e\u003e '$[3]'` from `user` where 1 != 1",
+    "Query": "select `user`.a -\u003e '$[4]' as `a -\u003e '$[4]'`, `user`.a -\u003e\u003e '$[3]' as `a -\u003e\u003e '$[3]'` from `user`",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -4976,8 +4976,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select exists (select 1 from `user` where 1 != 1) from dual where 1 != 1",
-    "Query": "select exists (select 1 from `user` where id = 4 limit 1) from dual",
+    "FieldQuery": "select exists (select 1 from `user` where 1 != 1) as `exists (select 1 from ``user`` where id = 4 limit 1)` from dual where 1 != 1",
+    "Query": "select exists (select 1 from `user` where id = 4 limit 1) as `exists (select 1 from ``user`` where id = 4 limit 1)` from dual",
     "Table": "dual",
     "Values": [
       "INT64(4)"
@@ -5143,8 +5143,8 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select insert(tcol1, id, 3, tcol2) from `user` where 1 != 1",
-    "Query": "select insert(tcol1, id, 3, tcol2) from `user`",
+    "FieldQuery": "select insert(`user`.tcol1, `user`.id, 3, `user`.tcol2) as `insert(tcol1, id, 3, tcol2)` from `user` where 1 != 1",
+    "Query": "select insert(`user`.tcol1, `user`.id, 3, `user`.tcol2) as `insert(tcol1, id, 3, tcol2)` from `user`",
     "Table": "`user`"
   },
   "TablesUsed": [

--- a/go/vt/vtgate/planbuilder/testdata/select_cases_with_default.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases_with_default.txt
@@ -50,8 +50,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select exists (select 1 from `user` where 1 != 1) from dual where 1 != 1",
-    "Query": "select exists (select 1 from `user` where id = 5 limit 1) from dual",
+    "FieldQuery": "select exists (select 1 from `user` where 1 != 1) as `exists (select 1 from ``user`` where id = 5 limit 1)` from dual where 1 != 1",
+    "Query": "select exists (select 1 from `user` where id = 5 limit 1) as `exists (select 1 from ``user`` where id = 5 limit 1)` from dual",
     "Table": "dual",
     "Values": [
       "INT64(5)"

--- a/go/vt/vtgate/planbuilder/testdata/select_cases_with_user_as_default.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases_with_user_as_default.txt
@@ -29,8 +29,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select exists (select 1 from `user` where 1 != 1) from dual where 1 != 1",
-    "Query": "select exists (select 1 from `user` where id = 5 limit 1) from dual",
+    "FieldQuery": "select exists (select 1 from `user` where 1 != 1) as `exists (select 1 from ``user`` where id = 5 limit 1)` from dual where 1 != 1",
+    "Query": "select exists (select 1 from `user` where id = 5 limit 1) as `exists (select 1 from ``user`` where id = 5 limit 1)` from dual",
     "Table": "dual",
     "Values": [
       "INT64(5)"

--- a/go/vt/vtgate/planbuilder/testdata/symtab_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/symtab_cases.txt
@@ -45,9 +45,9 @@
   "Instructions": {
     "OperatorType": "Join",
     "Variant": "Join",
-    "JoinColumnIndexes": "L:0,R:0",
+    "JoinColumnIndexes": "L:1,R:0",
     "JoinVars": {
-      "predef2": 0
+      "user_predef2": 0
     },
     "TableName": "`user`_unsharded",
     "Inputs": [
@@ -58,8 +58,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select predef2 from `user` where 1 != 1",
-        "Query": "select predef2 from `user`",
+        "FieldQuery": "select `user`.predef2, `user`.predef2 as predef2 from `user` where 1 != 1",
+        "Query": "select `user`.predef2, `user`.predef2 as predef2 from `user`",
         "Table": "`user`"
       },
       {
@@ -69,8 +69,8 @@
           "Name": "main",
           "Sharded": false
         },
-        "FieldQuery": "select predef3 from unsharded where 1 != 1",
-        "Query": "select predef3 from unsharded where predef3 = :predef2",
+        "FieldQuery": "select unsharded.predef3 as predef3 from unsharded where 1 != 1",
+        "Query": "select unsharded.predef3 as predef3 from unsharded where unsharded.predef3 = :user_predef2",
         "Table": "unsharded"
       }
     ]

--- a/go/vt/vtgate/planbuilder/testdata/sysschema_default.txt
+++ b/go/vt/vtgate/planbuilder/testdata/sysschema_default.txt
@@ -97,8 +97,8 @@
       "Name": "main",
       "Sharded": false
     },
-    "FieldQuery": "select (select 1 from information_schema.schemata where 1 != 1) from dual where 1 != 1",
-    "Query": "select (select 1 from information_schema.schemata where schema_name = :__vtschemaname limit 1) from dual",
+    "FieldQuery": "select (select 1 from information_schema.schemata where 1 != 1) as `(select 1 from information_schema.schemata where schema_name = 'MyDatabase' limit 1)` from dual where 1 != 1",
+    "Query": "select (select 1 from information_schema.schemata where schema_name = :__vtschemaname limit 1) as `(select 1 from information_schema.schemata where schema_name = 'MyDatabase' limit 1)` from dual",
     "SysTableTableSchema": "[VARCHAR(\"MyDatabase\")]",
     "Table": "dual"
   },

--- a/go/vt/vtgate/planbuilder/testdata/tpcc_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/tpcc_cases.txt
@@ -30,7 +30,7 @@
       "Sharded": true
     },
     "FieldQuery": "select c_discount, c_last, c_credit, w_tax from customer1 as c, warehouse1 as w where 1 != 1",
-    "Query": "select c_discount, c_last, c_credit, w_tax from customer1 as c, warehouse1 as w where c_d_id = 15 and c_id = 10 and w_id = 1 and c_w_id = w_id",
+    "Query": "select c_discount, c_last, c_credit, w_tax from customer1 as c, warehouse1 as w where c_d_id = 15 and c_id = 10 and w.w_id = 1 and c.c_w_id = w.w_id",
     "Table": "customer1, warehouse1",
     "Values": [
       "INT64(1)"
@@ -74,8 +74,8 @@
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select d_next_o_id, d_tax from district1 where 1 != 1",
-    "Query": "select d_next_o_id, d_tax from district1 where d_w_id = 15 and d_id = 95 for update",
+    "FieldQuery": "select district1.d_next_o_id as d_next_o_id, district1.d_tax as d_tax from district1 where 1 != 1",
+    "Query": "select district1.d_next_o_id as d_next_o_id, district1.d_tax as d_tax from district1 where district1.d_w_id = 15 and district1.d_id = 95 for update",
     "Table": "district1",
     "Values": [
       "INT64(15)"
@@ -124,7 +124,7 @@
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update district1 set d_next_o_id = 56 where d_id = 9842 and d_w_id = 8546",
+    "Query": "update district1 set district1.d_next_o_id = 56 where district1.d_id = 9842 and district1.d_w_id = 8546",
     "Table": "district1",
     "Values": [
       "INT64(8546)"
@@ -219,8 +219,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select i_price, i_name, i_data from item1 where 1 != 1",
-    "Query": "select i_price, i_name, i_data from item1 where i_id = 9654",
+    "FieldQuery": "select item1.i_price as i_price, item1.i_name as i_name, item1.i_data as i_data from item1 where 1 != 1",
+    "Query": "select item1.i_price as i_price, item1.i_name as i_name, item1.i_data as i_data from item1 where item1.i_id = 9654",
     "Table": "item1",
     "Values": [
       "INT64(9654)"
@@ -263,8 +263,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select s_quantity, s_data, s_dist_01 as s_dist from stock1 where 1 != 1",
-    "Query": "select s_quantity, s_data, s_dist_01 as s_dist from stock1 where s_i_id = 2198 and s_w_id = 89 for update",
+    "FieldQuery": "select stock1.s_quantity as s_quantity, stock1.s_data as s_data, stock1.s_dist_01 as s_dist from stock1 where 1 != 1",
+    "Query": "select stock1.s_quantity as s_quantity, stock1.s_data as s_data, stock1.s_dist_01 as s_dist from stock1 where stock1.s_i_id = 2198 and stock1.s_w_id = 89 for update",
     "Table": "stock1",
     "Values": [
       "INT64(89)"
@@ -313,7 +313,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update stock1 set s_quantity = 894 where s_i_id = 156 and s_w_id = 6",
+    "Query": "update stock1 set stock1.s_quantity = 894 where stock1.s_i_id = 156 and stock1.s_w_id = 6",
     "Table": "stock1",
     "Values": [
       "INT64(6)"
@@ -388,7 +388,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update warehouse1 set w_ytd = w_ytd + 946879 where w_id = 3",
+    "Query": "update warehouse1 set warehouse1.w_ytd = warehouse1.w_ytd + 946879 where warehouse1.w_id = 3",
     "Table": "warehouse1",
     "Values": [
       "INT64(3)"
@@ -431,8 +431,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select w_street_1, w_street_2, w_city, w_state, w_zip, w_name from warehouse1 where 1 != 1",
-    "Query": "select w_street_1, w_street_2, w_city, w_state, w_zip, w_name from warehouse1 where w_id = 998",
+    "FieldQuery": "select warehouse1.w_street_1 as w_street_1, warehouse1.w_street_2 as w_street_2, warehouse1.w_city as w_city, warehouse1.w_state as w_state, warehouse1.w_zip as w_zip, warehouse1.w_name as w_name from warehouse1 where 1 != 1",
+    "Query": "select warehouse1.w_street_1 as w_street_1, warehouse1.w_street_2 as w_street_2, warehouse1.w_city as w_city, warehouse1.w_state as w_state, warehouse1.w_zip as w_zip, warehouse1.w_name as w_name from warehouse1 where warehouse1.w_id = 998",
     "Table": "warehouse1",
     "Values": [
       "INT64(998)"
@@ -481,7 +481,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update district1 set d_ytd = d_ytd + 2 where d_w_id = 89 and d_id = 9",
+    "Query": "update district1 set district1.d_ytd = district1.d_ytd + 2 where district1.d_w_id = 89 and district1.d_id = 9",
     "Table": "district1",
     "Values": [
       "INT64(89)"
@@ -524,8 +524,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select d_street_1, d_street_2, d_city, d_state, d_zip, d_name from district1 where 1 != 1",
-    "Query": "select d_street_1, d_street_2, d_city, d_state, d_zip, d_name from district1 where d_w_id = 896 and d_id = 9",
+    "FieldQuery": "select district1.d_street_1 as d_street_1, district1.d_street_2 as d_street_2, district1.d_city as d_city, district1.d_state as d_state, district1.d_zip as d_zip, district1.d_name as d_name from district1 where 1 != 1",
+    "Query": "select district1.d_street_1 as d_street_1, district1.d_street_2 as d_street_2, district1.d_city as d_city, district1.d_state as d_state, district1.d_zip as d_zip, district1.d_name as d_name from district1 where district1.d_w_id = 896 and district1.d_id = 9",
     "Table": "district1",
     "Values": [
       "INT64(896)"
@@ -568,8 +568,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select count(c_id) as namecnt from customer1 where 1 != 1",
-    "Query": "select count(c_id) as namecnt from customer1 where c_w_id = 5 and c_d_id = 1 and c_last = 'last'",
+    "FieldQuery": "select count(customer1.c_id) as namecnt from customer1 where 1 != 1",
+    "Query": "select count(customer1.c_id) as namecnt from customer1 where customer1.c_w_id = 5 and customer1.c_d_id = 1 and customer1.c_last = 'last'",
     "Table": "customer1",
     "Values": [
       "INT64(5)"
@@ -612,8 +612,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select c_id from customer1 where 1 != 1",
-    "Query": "select c_id from customer1 where c_w_id = 8 and c_d_id = 5 and c_last = 'item_last' order by c_first asc",
+    "FieldQuery": "select customer1.c_id as c_id from customer1 where 1 != 1",
+    "Query": "select customer1.c_id as c_id from customer1 where customer1.c_w_id = 8 and customer1.c_d_id = 5 and customer1.c_last = 'item_last' order by customer1.c_first asc",
     "Table": "customer1",
     "Values": [
       "INT64(8)"
@@ -656,8 +656,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since from customer1 where 1 != 1",
-    "Query": "select c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since from customer1 where c_w_id = 8965 and c_d_id = 1 and c_id = 9 for update",
+    "FieldQuery": "select customer1.c_first as c_first, customer1.c_middle as c_middle, customer1.c_last as c_last, customer1.c_street_1 as c_street_1, customer1.c_street_2 as c_street_2, customer1.c_city as c_city, customer1.c_state as c_state, customer1.c_zip as c_zip, customer1.c_phone as c_phone, customer1.c_credit as c_credit, customer1.c_credit_lim as c_credit_lim, customer1.c_discount as c_discount, customer1.c_balance as c_balance, customer1.c_ytd_payment as c_ytd_payment, customer1.c_since as c_since from customer1 where 1 != 1",
+    "Query": "select customer1.c_first as c_first, customer1.c_middle as c_middle, customer1.c_last as c_last, customer1.c_street_1 as c_street_1, customer1.c_street_2 as c_street_2, customer1.c_city as c_city, customer1.c_state as c_state, customer1.c_zip as c_zip, customer1.c_phone as c_phone, customer1.c_credit as c_credit, customer1.c_credit_lim as c_credit_lim, customer1.c_discount as c_discount, customer1.c_balance as c_balance, customer1.c_ytd_payment as c_ytd_payment, customer1.c_since as c_since from customer1 where customer1.c_w_id = 8965 and customer1.c_d_id = 1 and customer1.c_id = 9 for update",
     "Table": "customer1",
     "Values": [
       "INT64(8965)"
@@ -700,8 +700,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select c_data from customer1 where 1 != 1",
-    "Query": "select c_data from customer1 where c_w_id = 32 and c_d_id = 68 and c_id = 5",
+    "FieldQuery": "select customer1.c_data as c_data from customer1 where 1 != 1",
+    "Query": "select customer1.c_data as c_data from customer1 where customer1.c_w_id = 32 and customer1.c_d_id = 68 and customer1.c_id = 5",
     "Table": "customer1",
     "Values": [
       "INT64(32)"
@@ -750,7 +750,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update customer1 set c_balance = 508.98, c_ytd_payment = 48941.980301, c_data = 'i am data' where c_w_id = 20 and c_d_id = 387 and c_id = 98",
+    "Query": "update customer1 set customer1.c_balance = 508.98, customer1.c_ytd_payment = 48941.980301, customer1.c_data = 'i am data' where customer1.c_w_id = 20 and customer1.c_d_id = 387 and customer1.c_id = 98",
     "Table": "customer1",
     "Values": [
       "INT64(20)"
@@ -799,7 +799,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update customer1 set c_balance = 508.98, c_ytd_payment = 48941.980301 where c_w_id = 20 and c_d_id = 387 and c_id = 98",
+    "Query": "update customer1 set customer1.c_balance = 508.98, customer1.c_ytd_payment = 48941.980301 where customer1.c_w_id = 20 and customer1.c_d_id = 387 and customer1.c_id = 98",
     "Table": "customer1",
     "Values": [
       "INT64(20)"
@@ -868,8 +868,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select count(c_id) as namecnt from customer1 where 1 != 1",
-    "Query": "select count(c_id) as namecnt from customer1 where c_w_id = 870 and c_d_id = 780 and c_last = 'last'",
+    "FieldQuery": "select count(customer1.c_id) as namecnt from customer1 where 1 != 1",
+    "Query": "select count(customer1.c_id) as namecnt from customer1 where customer1.c_w_id = 870 and customer1.c_d_id = 780 and customer1.c_last = 'last'",
     "Table": "customer1",
     "Values": [
       "INT64(870)"
@@ -912,8 +912,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select c_balance, c_first, c_middle, c_id from customer1 where 1 != 1",
-    "Query": "select c_balance, c_first, c_middle, c_id from customer1 where c_w_id = 840 and c_d_id = 1 and c_last = 'test' order by c_first asc",
+    "FieldQuery": "select customer1.c_balance as c_balance, customer1.c_first as c_first, customer1.c_middle as c_middle, customer1.c_id as c_id from customer1 where 1 != 1",
+    "Query": "select customer1.c_balance as c_balance, customer1.c_first as c_first, customer1.c_middle as c_middle, customer1.c_id as c_id from customer1 where customer1.c_w_id = 840 and customer1.c_d_id = 1 and customer1.c_last = 'test' order by customer1.c_first asc",
     "Table": "customer1",
     "Values": [
       "INT64(840)"
@@ -956,8 +956,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select c_balance, c_first, c_middle, c_last from customer1 where 1 != 1",
-    "Query": "select c_balance, c_first, c_middle, c_last from customer1 where c_w_id = 15 and c_d_id = 5169 and c_id = 1",
+    "FieldQuery": "select customer1.c_balance as c_balance, customer1.c_first as c_first, customer1.c_middle as c_middle, customer1.c_last as c_last from customer1 where 1 != 1",
+    "Query": "select customer1.c_balance as c_balance, customer1.c_first as c_first, customer1.c_middle as c_middle, customer1.c_last as c_last from customer1 where customer1.c_w_id = 15 and customer1.c_d_id = 5169 and customer1.c_id = 1",
     "Table": "customer1",
     "Values": [
       "INT64(15)"
@@ -1000,8 +1000,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select o_id, o_carrier_id, o_entry_d from orders1 where 1 != 1",
-    "Query": "select o_id, o_carrier_id, o_entry_d from orders1 where o_w_id = 9894 and o_d_id = 3 and o_c_id = 159 order by o_id desc",
+    "FieldQuery": "select orders1.o_id as o_id, orders1.o_carrier_id as o_carrier_id, orders1.o_entry_d as o_entry_d from orders1 where 1 != 1",
+    "Query": "select orders1.o_id as o_id, orders1.o_carrier_id as o_carrier_id, orders1.o_entry_d as o_entry_d from orders1 where orders1.o_w_id = 9894 and orders1.o_d_id = 3 and orders1.o_c_id = 159 order by orders1.o_id desc",
     "Table": "orders1",
     "Values": [
       "INT64(9894)"
@@ -1044,8 +1044,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d from order_line1 where 1 != 1",
-    "Query": "select ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d from order_line1 where ol_w_id = 92 and ol_d_id = 5 and ol_o_id = 1",
+    "FieldQuery": "select order_line1.ol_i_id as ol_i_id, order_line1.ol_supply_w_id as ol_supply_w_id, order_line1.ol_quantity as ol_quantity, order_line1.ol_amount as ol_amount, order_line1.ol_delivery_d as ol_delivery_d from order_line1 where 1 != 1",
+    "Query": "select order_line1.ol_i_id as ol_i_id, order_line1.ol_supply_w_id as ol_supply_w_id, order_line1.ol_quantity as ol_quantity, order_line1.ol_amount as ol_amount, order_line1.ol_delivery_d as ol_delivery_d from order_line1 where order_line1.ol_w_id = 92 and order_line1.ol_d_id = 5 and order_line1.ol_o_id = 1",
     "Table": "order_line1",
     "Values": [
       "INT64(92)"
@@ -1088,8 +1088,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select no_o_id from new_orders1 where 1 != 1",
-    "Query": "select no_o_id from new_orders1 where no_d_id = 689 and no_w_id = 15 order by no_o_id asc limit 1 for update",
+    "FieldQuery": "select new_orders1.no_o_id as no_o_id from new_orders1 where 1 != 1",
+    "Query": "select new_orders1.no_o_id as no_o_id from new_orders1 where new_orders1.no_d_id = 689 and new_orders1.no_w_id = 15 order by new_orders1.no_o_id asc limit 1 for update",
     "Table": "new_orders1",
     "Values": [
       "INT64(15)"
@@ -1159,8 +1159,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select o_c_id from orders1 where 1 != 1",
-    "Query": "select o_c_id from orders1 where o_id = 6 and o_d_id = 1983 and o_w_id = 894605",
+    "FieldQuery": "select orders1.o_c_id as o_c_id from orders1 where 1 != 1",
+    "Query": "select orders1.o_c_id as o_c_id from orders1 where orders1.o_id = 6 and orders1.o_d_id = 1983 and orders1.o_w_id = 894605",
     "Table": "orders1",
     "Values": [
       "INT64(894605)"
@@ -1209,7 +1209,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update orders1 set o_carrier_id = 9 where o_id = 56 and o_d_id = 98 and o_w_id = 897",
+    "Query": "update orders1 set orders1.o_carrier_id = 9 where orders1.o_id = 56 and orders1.o_d_id = 98 and orders1.o_w_id = 897",
     "Table": "orders1",
     "Values": [
       "INT64(897)"
@@ -1258,7 +1258,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update order_line1 set ol_delivery_d = now() where ol_o_id = 235 and ol_d_id = 315 and ol_w_id = 8",
+    "Query": "update order_line1 set order_line1.ol_delivery_d = now() where order_line1.ol_o_id = 235 and order_line1.ol_d_id = 315 and order_line1.ol_w_id = 8",
     "Table": "order_line1",
     "Values": [
       "INT64(8)"
@@ -1301,8 +1301,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select sum(ol_amount) as sm from order_line1 where 1 != 1",
-    "Query": "select sum(ol_amount) as sm from order_line1 where ol_o_id = 680 and ol_d_id = 201 and ol_w_id = 87",
+    "FieldQuery": "select sum(order_line1.ol_amount) as sm from order_line1 where 1 != 1",
+    "Query": "select sum(order_line1.ol_amount) as sm from order_line1 where order_line1.ol_o_id = 680 and order_line1.ol_d_id = 201 and order_line1.ol_w_id = 87",
     "Table": "order_line1",
     "Values": [
       "INT64(87)"
@@ -1351,7 +1351,7 @@ Gen4 plan same as above
     },
     "TargetTabletType": "PRIMARY",
     "MultiShardAutocommit": false,
-    "Query": "update customer1 set c_balance = c_balance + 988.01, c_delivery_cnt = c_delivery_cnt + 1 where c_id = 6 and c_d_id = 5 and c_w_id = 160",
+    "Query": "update customer1 set customer1.c_balance = customer1.c_balance + 988.01, customer1.c_delivery_cnt = customer1.c_delivery_cnt + 1 where customer1.c_id = 6 and customer1.c_d_id = 5 and customer1.c_w_id = 160",
     "Table": "customer1",
     "Values": [
       "INT64(160)"
@@ -1394,8 +1394,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select d_next_o_id from district1 where 1 != 1",
-    "Query": "select d_next_o_id from district1 where d_id = 6 and d_w_id = 21",
+    "FieldQuery": "select district1.d_next_o_id as d_next_o_id from district1 where 1 != 1",
+    "Query": "select district1.d_next_o_id as d_next_o_id from district1 where district1.d_id = 6 and district1.d_w_id = 21",
     "Table": "district1",
     "Values": [
       "INT64(21)"
@@ -1483,8 +1483,8 @@ Gen4 plan same as above
       "Name": "main",
       "Sharded": true
     },
-    "FieldQuery": "select ol_i_id from order_line1 where 1 != 1",
-    "Query": "select distinct ol_i_id from order_line1 where ol_w_id = 1 and ol_d_id = 156 and ol_o_id \u003c 500 and ol_o_id \u003e= 56",
+    "FieldQuery": "select order_line1.ol_i_id as ol_i_id from order_line1 where 1 != 1",
+    "Query": "select distinct order_line1.ol_i_id as ol_i_id from order_line1 where order_line1.ol_w_id = 1 and order_line1.ol_d_id = 156 and order_line1.ol_o_id \u003c 500 and order_line1.ol_o_id \u003e= 56",
     "Table": "order_line1",
     "Values": [
       "INT64(1)"
@@ -1528,7 +1528,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select count(*) from stock1 where 1 != 1",
-    "Query": "select count(*) from stock1 where s_w_id = 1 and s_i_id = 8 and s_quantity \u003c 1000",
+    "Query": "select count(*) from stock1 where stock1.s_w_id = 1 and stock1.s_i_id = 8 and stock1.s_quantity \u003c 1000",
     "Table": "stock1",
     "Values": [
       "INT64(1)"

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
@@ -52,7 +52,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                         "Variant": "Join",
                         "JoinColumnIndexes": "L:0,R:0,R:1,L:2,R:2,R:3,L:1,R:4,R:5",
                         "JoinVars": {
-                          "l_orderkey": 0
+                          "lineitem_l_orderkey": 0
                         },
                         "TableName": "lineitem_orders_customer",
                         "Inputs": [
@@ -63,8 +63,8 @@ Gen4 error: unsupported: cross-shard correlated subquery
                               "Name": "main",
                               "Sharded": true
                             },
-                            "FieldQuery": "select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_orderkey) from lineitem where 1 != 1 group by l_orderkey, weight_string(l_orderkey)",
-                            "Query": "select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_orderkey) from lineitem where l_shipdate \u003e date('1995-03-15') group by l_orderkey, weight_string(l_orderkey)",
+                            "FieldQuery": "select lineitem.l_orderkey, sum(lineitem.l_extendedprice * (1 - lineitem.l_discount)) as revenue, weight_string(lineitem.l_orderkey) from lineitem where 1 != 1 group by lineitem.l_orderkey, weight_string(lineitem.l_orderkey)",
+                            "Query": "select lineitem.l_orderkey, sum(lineitem.l_extendedprice * (1 - lineitem.l_discount)) as revenue, weight_string(lineitem.l_orderkey) from lineitem where lineitem.l_shipdate \u003e date('1995-03-15') group by lineitem.l_orderkey, weight_string(lineitem.l_orderkey)",
                             "Table": "lineitem"
                           },
                           {
@@ -72,7 +72,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                             "Variant": "Join",
                             "JoinColumnIndexes": "L:3,L:5,L:4,L:6,L:1,R:1",
                             "JoinVars": {
-                              "o_custkey": 0
+                              "orders_o_custkey": 0
                             },
                             "TableName": "orders_customer",
                             "Inputs": [
@@ -83,11 +83,11 @@ Gen4 error: unsupported: cross-shard correlated subquery
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select o_custkey, count(*), weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority) from orders where 1 != 1 group by o_custkey, weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority)",
-                                "Query": "select o_custkey, count(*), weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority) from orders where o_orderdate \u003c date('1995-03-15') and o_orderkey = :l_orderkey group by o_custkey, weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority)",
+                                "FieldQuery": "select orders.o_custkey, count(*), weight_string(orders.o_custkey), orders.o_orderdate, weight_string(orders.o_orderdate), orders.o_shippriority, weight_string(orders.o_shippriority) from orders where 1 != 1 group by orders.o_custkey, weight_string(orders.o_custkey), orders.o_orderdate, weight_string(orders.o_orderdate), orders.o_shippriority, weight_string(orders.o_shippriority)",
+                                "Query": "select orders.o_custkey, count(*), weight_string(orders.o_custkey), orders.o_orderdate, weight_string(orders.o_orderdate), orders.o_shippriority, weight_string(orders.o_shippriority) from orders where orders.o_orderdate \u003c date('1995-03-15') and orders.o_orderkey = :lineitem_l_orderkey group by orders.o_custkey, weight_string(orders.o_custkey), orders.o_orderdate, weight_string(orders.o_orderdate), orders.o_shippriority, weight_string(orders.o_shippriority)",
                                 "Table": "orders",
                                 "Values": [
-                                  ":l_orderkey"
+                                  ":lineitem_l_orderkey"
                                 ],
                                 "Vindex": "hash"
                               },
@@ -99,10 +99,10 @@ Gen4 error: unsupported: cross-shard correlated subquery
                                   "Sharded": true
                                 },
                                 "FieldQuery": "select 1, count(*) from customer where 1 != 1 group by 1",
-                                "Query": "select 1, count(*) from customer where c_mktsegment = 'BUILDING' and c_custkey = :o_custkey group by 1",
+                                "Query": "select 1, count(*) from customer where customer.c_mktsegment = 'BUILDING' and customer.c_custkey = :orders_o_custkey group by 1",
                                 "Table": "customer",
                                 "Values": [
-                                  ":o_custkey"
+                                  ":orders_o_custkey"
                                 ],
                                 "Vindex": "hash"
                               }
@@ -162,9 +162,9 @@ Gen4 error: unsupported: cross-shard correlated subquery
                   "Name": "main",
                   "Sharded": true
                 },
-                "FieldQuery": "select o_orderkey, o_orderpriority, count(*) as order_count, weight_string(o_orderpriority), weight_string(o_orderkey) from orders where 1 != 1 group by o_orderpriority, weight_string(o_orderpriority), o_orderkey, weight_string(o_orderkey)",
+                "FieldQuery": "select o_orderkey, orders.o_orderpriority as o_orderpriority, count(*) as order_count, weight_string(orders.o_orderpriority), weight_string(o_orderkey) from orders where 1 != 1 group by orders.o_orderpriority, weight_string(orders.o_orderpriority), o_orderkey, weight_string(o_orderkey)",
                 "OrderBy": "(1|3) ASC",
-                "Query": "select o_orderkey, o_orderpriority, count(*) as order_count, weight_string(o_orderpriority), weight_string(o_orderkey) from orders where o_orderdate \u003e= date('1993-07-01') and o_orderdate \u003c date('1993-07-01') + interval '3' month group by o_orderpriority, weight_string(o_orderpriority), o_orderkey, weight_string(o_orderkey) order by o_orderpriority asc",
+                "Query": "select o_orderkey, orders.o_orderpriority as o_orderpriority, count(*) as order_count, weight_string(orders.o_orderpriority), weight_string(o_orderkey) from orders where orders.o_orderdate \u003e= date('1993-07-01') and orders.o_orderdate \u003c date('1993-07-01') + interval '3' month group by orders.o_orderpriority, weight_string(orders.o_orderpriority), o_orderkey, weight_string(o_orderkey) order by orders.o_orderpriority asc",
                 "Table": "orders"
               },
               {
@@ -230,7 +230,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                     "Variant": "Join",
                     "JoinColumnIndexes": "R:0,R:1,L:3,L:4,L:5,L:6,R:2,R:3",
                     "JoinVars": {
-                      "s_nationkey": 0
+                      "supplier_s_nationkey": 0
                     },
                     "TableName": "orders_customer_lineitem_supplier_nation_region",
                     "Inputs": [
@@ -239,8 +239,8 @@ Gen4 error: unsupported: cross-shard correlated subquery
                         "Variant": "Join",
                         "JoinColumnIndexes": "R:0,R:1,R:2,L:6,L:7,R:3,R:4",
                         "JoinVars": {
-                          "c_nationkey": 1,
-                          "o_orderkey": 0
+                          "customer_c_nationkey": 1,
+                          "orders_o_orderkey": 0
                         },
                         "TableName": "orders_customer_lineitem_supplier",
                         "Inputs": [
@@ -249,7 +249,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                             "Variant": "Join",
                             "JoinColumnIndexes": "L:1,R:0,L:1,R:0,L:4,R:2,L:2,R:1",
                             "JoinVars": {
-                              "o_custkey": 0
+                              "orders_o_custkey": 0
                             },
                             "TableName": "orders_customer",
                             "Inputs": [
@@ -260,8 +260,8 @@ Gen4 error: unsupported: cross-shard correlated subquery
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select o_custkey, o_orderkey, count(*), weight_string(o_custkey), weight_string(o_orderkey) from orders where 1 != 1 group by o_custkey, weight_string(o_custkey), o_orderkey, weight_string(o_orderkey)",
-                                "Query": "select o_custkey, o_orderkey, count(*), weight_string(o_custkey), weight_string(o_orderkey) from orders where o_orderdate \u003e= date('1994-01-01') and o_orderdate \u003c date('1994-01-01') + interval '1' year group by o_custkey, weight_string(o_custkey), o_orderkey, weight_string(o_orderkey)",
+                                "FieldQuery": "select orders.o_custkey, orders.o_orderkey, count(*), weight_string(orders.o_custkey), weight_string(orders.o_orderkey) from orders where 1 != 1 group by orders.o_custkey, weight_string(orders.o_custkey), orders.o_orderkey, weight_string(orders.o_orderkey)",
+                                "Query": "select orders.o_custkey, orders.o_orderkey, count(*), weight_string(orders.o_custkey), weight_string(orders.o_orderkey) from orders where orders.o_orderdate \u003e= date('1994-01-01') and orders.o_orderdate \u003c date('1994-01-01') + interval '1' year group by orders.o_custkey, weight_string(orders.o_custkey), orders.o_orderkey, weight_string(orders.o_orderkey)",
                                 "Table": "orders"
                               },
                               {
@@ -271,11 +271,11 @@ Gen4 error: unsupported: cross-shard correlated subquery
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select c_nationkey, count(*), weight_string(c_nationkey) from customer where 1 != 1 group by c_nationkey, weight_string(c_nationkey)",
-                                "Query": "select c_nationkey, count(*), weight_string(c_nationkey) from customer where c_custkey = :o_custkey group by c_nationkey, weight_string(c_nationkey)",
+                                "FieldQuery": "select customer.c_nationkey, count(*), weight_string(customer.c_nationkey) from customer where 1 != 1 group by customer.c_nationkey, weight_string(customer.c_nationkey)",
+                                "Query": "select customer.c_nationkey, count(*), weight_string(customer.c_nationkey) from customer where customer.c_custkey = :orders_o_custkey group by customer.c_nationkey, weight_string(customer.c_nationkey)",
                                 "Table": "customer",
                                 "Values": [
-                                  ":o_custkey"
+                                  ":orders_o_custkey"
                                 ],
                                 "Vindex": "hash"
                               }
@@ -286,7 +286,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                             "Variant": "Join",
                             "JoinColumnIndexes": "R:0,R:0,R:2,L:1,R:1",
                             "JoinVars": {
-                              "l_suppkey": 0
+                              "lineitem_l_suppkey": 0
                             },
                             "TableName": "lineitem_supplier",
                             "Inputs": [
@@ -297,11 +297,11 @@ Gen4 error: unsupported: cross-shard correlated subquery
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select l_suppkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_suppkey) from lineitem where 1 != 1 group by l_suppkey, weight_string(l_suppkey)",
-                                "Query": "select l_suppkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_suppkey) from lineitem where l_orderkey = :o_orderkey group by l_suppkey, weight_string(l_suppkey)",
+                                "FieldQuery": "select lineitem.l_suppkey, sum(lineitem.l_extendedprice * (1 - lineitem.l_discount)) as revenue, weight_string(lineitem.l_suppkey) from lineitem where 1 != 1 group by lineitem.l_suppkey, weight_string(lineitem.l_suppkey)",
+                                "Query": "select lineitem.l_suppkey, sum(lineitem.l_extendedprice * (1 - lineitem.l_discount)) as revenue, weight_string(lineitem.l_suppkey) from lineitem where lineitem.l_orderkey = :orders_o_orderkey group by lineitem.l_suppkey, weight_string(lineitem.l_suppkey)",
                                 "Table": "lineitem",
                                 "Values": [
-                                  ":o_orderkey"
+                                  ":orders_o_orderkey"
                                 ],
                                 "Vindex": "lineitem_map"
                               },
@@ -312,11 +312,11 @@ Gen4 error: unsupported: cross-shard correlated subquery
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select s_nationkey, count(*), weight_string(s_nationkey) from supplier where 1 != 1 group by s_nationkey, weight_string(s_nationkey)",
-                                "Query": "select s_nationkey, count(*), weight_string(s_nationkey) from supplier where s_suppkey = :l_suppkey and s_nationkey = :c_nationkey group by s_nationkey, weight_string(s_nationkey)",
+                                "FieldQuery": "select supplier.s_nationkey, count(*), weight_string(supplier.s_nationkey) from supplier where 1 != 1 group by supplier.s_nationkey, weight_string(supplier.s_nationkey)",
+                                "Query": "select supplier.s_nationkey, count(*), weight_string(supplier.s_nationkey) from supplier where supplier.s_suppkey = :lineitem_l_suppkey and supplier.s_nationkey = :customer_c_nationkey group by supplier.s_nationkey, weight_string(supplier.s_nationkey)",
                                 "Table": "supplier",
                                 "Values": [
-                                  ":l_suppkey"
+                                  ":lineitem_l_suppkey"
                                 ],
                                 "Vindex": "hash"
                               }
@@ -329,7 +329,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                         "Variant": "Join",
                         "JoinColumnIndexes": "L:3,L:4,L:1,R:1",
                         "JoinVars": {
-                          "n_regionkey": 0
+                          "nation_n_regionkey": 0
                         },
                         "TableName": "nation_region",
                         "Inputs": [
@@ -340,11 +340,11 @@ Gen4 error: unsupported: cross-shard correlated subquery
                               "Name": "main",
                               "Sharded": true
                             },
-                            "FieldQuery": "select n_regionkey, count(*), weight_string(n_regionkey), n_name, weight_string(n_name) from nation where 1 != 1 group by n_regionkey, weight_string(n_regionkey), n_name, weight_string(n_name)",
-                            "Query": "select n_regionkey, count(*), weight_string(n_regionkey), n_name, weight_string(n_name) from nation where n_nationkey = :s_nationkey group by n_regionkey, weight_string(n_regionkey), n_name, weight_string(n_name)",
+                            "FieldQuery": "select nation.n_regionkey, count(*), weight_string(nation.n_regionkey), nation.n_name, weight_string(nation.n_name) from nation where 1 != 1 group by nation.n_regionkey, weight_string(nation.n_regionkey), nation.n_name, weight_string(nation.n_name)",
+                            "Query": "select nation.n_regionkey, count(*), weight_string(nation.n_regionkey), nation.n_name, weight_string(nation.n_name) from nation where nation.n_nationkey = :supplier_s_nationkey group by nation.n_regionkey, weight_string(nation.n_regionkey), nation.n_name, weight_string(nation.n_name)",
                             "Table": "nation",
                             "Values": [
-                              ":s_nationkey"
+                              ":supplier_s_nationkey"
                             ],
                             "Vindex": "hash"
                           },
@@ -356,10 +356,10 @@ Gen4 error: unsupported: cross-shard correlated subquery
                               "Sharded": true
                             },
                             "FieldQuery": "select 1, count(*) from region where 1 != 1 group by 1",
-                            "Query": "select 1, count(*) from region where r_name = 'ASIA' and r_regionkey = :n_regionkey group by 1",
+                            "Query": "select 1, count(*) from region where region.r_name = 'ASIA' and region.r_regionkey = :nation_n_regionkey group by 1",
                             "Table": "region",
                             "Values": [
-                              ":n_regionkey"
+                              ":nation_n_regionkey"
                             ],
                             "Vindex": "hash"
                           }
@@ -424,8 +424,8 @@ Gen4 error: unsupported: cross-shard correlated subquery
           "Name": "main",
           "Sharded": true
         },
-        "FieldQuery": "select sum(l_extendedprice * l_discount) as revenue from lineitem where 1 != 1",
-        "Query": "select sum(l_extendedprice * l_discount) as revenue from lineitem where l_shipdate \u003e= date('1994-01-01') and l_shipdate \u003c date('1994-01-01') + interval '1' year and l_discount between 0.06 - 0.01 and 0.06 + 0.01 and l_quantity \u003c 24",
+        "FieldQuery": "select sum(lineitem.l_extendedprice * lineitem.l_discount) as revenue from lineitem where 1 != 1",
+        "Query": "select sum(lineitem.l_extendedprice * lineitem.l_discount) as revenue from lineitem where lineitem.l_shipdate \u003e= date('1994-01-01') and lineitem.l_shipdate \u003c date('1994-01-01') + interval '1' year and lineitem.l_discount between 0.06 - 0.01 and 0.06 + 0.01 and lineitem.l_quantity \u003c 24",
         "Table": "lineitem"
       }
     ]
@@ -684,7 +684,7 @@ Gen4 error: aggregation on columns from different sources not supported yet
                         "Variant": "Join",
                         "JoinColumnIndexes": "R:0,R:1,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13,L:3,L:4,R:14,R:15",
                         "JoinVars": {
-                          "o_custkey": 0
+                          "orders_o_custkey": 0
                         },
                         "TableName": "orders_lineitem_customer_nation",
                         "Inputs": [
@@ -693,7 +693,7 @@ Gen4 error: aggregation on columns from different sources not supported yet
                             "Variant": "Join",
                             "JoinColumnIndexes": "L:1,L:1,L:4,L:2,R:1",
                             "JoinVars": {
-                              "o_orderkey": 0
+                              "orders_o_orderkey": 0
                             },
                             "TableName": "orders_lineitem",
                             "Inputs": [
@@ -704,8 +704,8 @@ Gen4 error: aggregation on columns from different sources not supported yet
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select o_orderkey, o_custkey, count(*), weight_string(o_orderkey), weight_string(o_custkey) from orders where 1 != 1 group by o_orderkey, weight_string(o_orderkey), o_custkey, weight_string(o_custkey)",
-                                "Query": "select o_orderkey, o_custkey, count(*), weight_string(o_orderkey), weight_string(o_custkey) from orders where o_orderdate \u003e= date('1993-10-01') and o_orderdate \u003c date('1993-10-01') + interval '3' month group by o_orderkey, weight_string(o_orderkey), o_custkey, weight_string(o_custkey)",
+                                "FieldQuery": "select orders.o_orderkey, orders.o_custkey, count(*), weight_string(orders.o_orderkey), weight_string(orders.o_custkey) from orders where 1 != 1 group by orders.o_orderkey, weight_string(orders.o_orderkey), orders.o_custkey, weight_string(orders.o_custkey)",
+                                "Query": "select orders.o_orderkey, orders.o_custkey, count(*), weight_string(orders.o_orderkey), weight_string(orders.o_custkey) from orders where orders.o_orderdate \u003e= date('1993-10-01') and orders.o_orderdate \u003c date('1993-10-01') + interval '3' month group by orders.o_orderkey, weight_string(orders.o_orderkey), orders.o_custkey, weight_string(orders.o_custkey)",
                                 "Table": "orders"
                               },
                               {
@@ -715,11 +715,11 @@ Gen4 error: aggregation on columns from different sources not supported yet
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select 1, sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where 1 != 1 group by 1",
-                                "Query": "select 1, sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey group by 1",
+                                "FieldQuery": "select 1, sum(lineitem.l_extendedprice * (1 - lineitem.l_discount)) as revenue from lineitem where 1 != 1 group by 1",
+                                "Query": "select 1, sum(lineitem.l_extendedprice * (1 - lineitem.l_discount)) as revenue from lineitem where lineitem.l_returnflag = 'R' and lineitem.l_orderkey = :orders_o_orderkey group by 1",
                                 "Table": "lineitem",
                                 "Values": [
-                                  ":o_orderkey"
+                                  ":orders_o_orderkey"
                                 ],
                                 "Vindex": "lineitem_map"
                               }
@@ -730,7 +730,7 @@ Gen4 error: aggregation on columns from different sources not supported yet
                             "Variant": "Join",
                             "JoinColumnIndexes": "L:3,L:5,L:7,L:9,R:1,L:11,L:13,L:4,L:6,L:8,L:10,R:2,L:12,L:14,L:1,R:0",
                             "JoinVars": {
-                              "c_nationkey": 0
+                              "customer_c_nationkey": 0
                             },
                             "TableName": "customer_nation",
                             "Inputs": [
@@ -741,11 +741,11 @@ Gen4 error: aggregation on columns from different sources not supported yet
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select c_nationkey, count(*), weight_string(c_nationkey), c_custkey, weight_string(c_custkey), c_name, weight_string(c_name), c_acctbal, weight_string(c_acctbal), c_phone, weight_string(c_phone), c_address, weight_string(c_address), c_comment, weight_string(c_comment) from customer where 1 != 1 group by c_nationkey, weight_string(c_nationkey), c_custkey, weight_string(c_custkey), c_name, weight_string(c_name), c_acctbal, weight_string(c_acctbal), c_phone, weight_string(c_phone), c_address, weight_string(c_address), c_comment, weight_string(c_comment)",
-                                "Query": "select c_nationkey, count(*), weight_string(c_nationkey), c_custkey, weight_string(c_custkey), c_name, weight_string(c_name), c_acctbal, weight_string(c_acctbal), c_phone, weight_string(c_phone), c_address, weight_string(c_address), c_comment, weight_string(c_comment) from customer where c_custkey = :o_custkey group by c_nationkey, weight_string(c_nationkey), c_custkey, weight_string(c_custkey), c_name, weight_string(c_name), c_acctbal, weight_string(c_acctbal), c_phone, weight_string(c_phone), c_address, weight_string(c_address), c_comment, weight_string(c_comment)",
+                                "FieldQuery": "select customer.c_nationkey, count(*), weight_string(customer.c_nationkey), customer.c_custkey, weight_string(customer.c_custkey), customer.c_name, weight_string(customer.c_name), customer.c_acctbal, weight_string(customer.c_acctbal), customer.c_phone, weight_string(customer.c_phone), customer.c_address, weight_string(customer.c_address), customer.c_comment, weight_string(customer.c_comment) from customer where 1 != 1 group by customer.c_nationkey, weight_string(customer.c_nationkey), customer.c_custkey, weight_string(customer.c_custkey), customer.c_name, weight_string(customer.c_name), customer.c_acctbal, weight_string(customer.c_acctbal), customer.c_phone, weight_string(customer.c_phone), customer.c_address, weight_string(customer.c_address), customer.c_comment, weight_string(customer.c_comment)",
+                                "Query": "select customer.c_nationkey, count(*), weight_string(customer.c_nationkey), customer.c_custkey, weight_string(customer.c_custkey), customer.c_name, weight_string(customer.c_name), customer.c_acctbal, weight_string(customer.c_acctbal), customer.c_phone, weight_string(customer.c_phone), customer.c_address, weight_string(customer.c_address), customer.c_comment, weight_string(customer.c_comment) from customer where customer.c_custkey = :orders_o_custkey group by customer.c_nationkey, weight_string(customer.c_nationkey), customer.c_custkey, weight_string(customer.c_custkey), customer.c_name, weight_string(customer.c_name), customer.c_acctbal, weight_string(customer.c_acctbal), customer.c_phone, weight_string(customer.c_phone), customer.c_address, weight_string(customer.c_address), customer.c_comment, weight_string(customer.c_comment)",
                                 "Table": "customer",
                                 "Values": [
-                                  ":o_custkey"
+                                  ":orders_o_custkey"
                                 ],
                                 "Vindex": "hash"
                               },
@@ -756,11 +756,11 @@ Gen4 error: aggregation on columns from different sources not supported yet
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select count(*), n_name, weight_string(n_name) from nation where 1 != 1 group by n_name, weight_string(n_name)",
-                                "Query": "select count(*), n_name, weight_string(n_name) from nation where n_nationkey = :c_nationkey group by n_name, weight_string(n_name)",
+                                "FieldQuery": "select count(*), nation.n_name, weight_string(nation.n_name) from nation where 1 != 1 group by nation.n_name, weight_string(nation.n_name)",
+                                "Query": "select count(*), nation.n_name, weight_string(nation.n_name) from nation where nation.n_nationkey = :customer_c_nationkey group by nation.n_name, weight_string(nation.n_name)",
                                 "Table": "nation",
                                 "Values": [
-                                  ":c_nationkey"
+                                  ":customer_c_nationkey"
                                 ],
                                 "Vindex": "hash"
                               }
@@ -823,7 +823,7 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
                 "Variant": "Join",
                 "JoinColumnIndexes": "R:1,R:2,L:1,R:0,L:2,R:0",
                 "JoinVars": {
-                  "o_orderkey": 0
+                  "orders_o_orderkey": 0
                 },
                 "TableName": "orders_lineitem",
                 "Inputs": [
@@ -834,8 +834,8 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
                       "Name": "main",
                       "Sharded": true
                     },
-                    "FieldQuery": "select o_orderkey, sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, weight_string(o_orderkey) from orders where 1 != 1 group by o_orderkey, weight_string(o_orderkey)",
-                    "Query": "select o_orderkey, sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, weight_string(o_orderkey) from orders group by o_orderkey, weight_string(o_orderkey)",
+                    "FieldQuery": "select orders.o_orderkey, sum(case when orders.o_orderpriority = '1-URGENT' or orders.o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when orders.o_orderpriority != '1-URGENT' and orders.o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, weight_string(orders.o_orderkey) from orders where 1 != 1 group by orders.o_orderkey, weight_string(orders.o_orderkey)",
+                    "Query": "select orders.o_orderkey, sum(case when orders.o_orderpriority = '1-URGENT' or orders.o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when orders.o_orderpriority != '1-URGENT' and orders.o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, weight_string(orders.o_orderkey) from orders group by orders.o_orderkey, weight_string(orders.o_orderkey)",
                     "Table": "orders"
                   },
                   {
@@ -845,11 +845,11 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
                       "Name": "main",
                       "Sharded": true
                     },
-                    "FieldQuery": "select count(*), l_shipmode, weight_string(l_shipmode) from lineitem where 1 != 1 group by l_shipmode, weight_string(l_shipmode)",
-                    "Query": "select count(*), l_shipmode, weight_string(l_shipmode) from lineitem where l_shipmode in ('MAIL', 'SHIP') and l_commitdate \u003c l_receiptdate and l_shipdate \u003c l_commitdate and l_receiptdate \u003e= date('1994-01-01') and l_receiptdate \u003c date('1994-01-01') + interval '1' year and l_orderkey = :o_orderkey group by l_shipmode, weight_string(l_shipmode)",
+                    "FieldQuery": "select count(*), lineitem.l_shipmode, weight_string(lineitem.l_shipmode) from lineitem where 1 != 1 group by lineitem.l_shipmode, weight_string(lineitem.l_shipmode)",
+                    "Query": "select count(*), lineitem.l_shipmode, weight_string(lineitem.l_shipmode) from lineitem where lineitem.l_shipmode in ('MAIL', 'SHIP') and lineitem.l_commitdate \u003c lineitem.l_receiptdate and lineitem.l_shipdate \u003c lineitem.l_commitdate and lineitem.l_receiptdate \u003e= date('1994-01-01') and lineitem.l_receiptdate \u003c date('1994-01-01') + interval '1' year and lineitem.l_orderkey = :orders_o_orderkey group by lineitem.l_shipmode, weight_string(lineitem.l_shipmode)",
                     "Table": "lineitem",
                     "Values": [
-                      ":o_orderkey"
+                      ":orders_o_orderkey"
                     ],
                     "Vindex": "lineitem_map"
                   }
@@ -977,8 +977,8 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
               "Name": "main",
               "Sharded": true
             },
-            "FieldQuery": "select max(total_revenue) from revenue0 where 1 != 1",
-            "Query": "select max(total_revenue) from revenue0",
+            "FieldQuery": "select max(revenue0.total_revenue) as `max(total_revenue)` from revenue0 where 1 != 1",
+            "Query": "select max(revenue0.total_revenue) as `max(total_revenue)` from revenue0",
             "Table": "revenue0"
           }
         ]
@@ -990,9 +990,9 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
           "Name": "main",
           "Sharded": true
         },
-        "FieldQuery": "select s_suppkey, s_name, s_address, s_phone, total_revenue, weight_string(s_suppkey) from supplier, revenue0 where 1 != 1",
+        "FieldQuery": "select supplier.s_suppkey as s_suppkey, supplier.s_name as s_name, supplier.s_address as s_address, supplier.s_phone as s_phone, revenue0.total_revenue as total_revenue, weight_string(supplier.s_suppkey) from supplier, revenue0 where 1 != 1",
         "OrderBy": "(0|5) ASC",
-        "Query": "select s_suppkey, s_name, s_address, s_phone, total_revenue, weight_string(s_suppkey) from supplier, revenue0 where total_revenue = :__sq1 and s_suppkey = supplier_no order by s_suppkey asc",
+        "Query": "select supplier.s_suppkey as s_suppkey, supplier.s_name as s_name, supplier.s_address as s_address, supplier.s_phone as s_phone, revenue0.total_revenue as total_revenue, weight_string(supplier.s_suppkey) from supplier, revenue0 where revenue0.total_revenue = :__sq1 and supplier.s_suppkey = revenue0.supplier_no order by supplier.s_suppkey asc",
         "ResultColumns": 5,
         "Table": "revenue0, supplier"
       }
@@ -1041,10 +1041,10 @@ Gen4 error: unsupported: group by on: *planbuilder.joinGen4
             "Variant": "Join",
             "JoinColumnIndexes": "L:4,R:1",
             "JoinVars": {
-              "l_partkey": 0,
-              "l_quantity": 1,
-              "l_shipinstruct": 3,
-              "l_shipmode": 2
+              "lineitem_l_partkey": 0,
+              "lineitem_l_quantity": 1,
+              "lineitem_l_shipinstruct": 3,
+              "lineitem_l_shipmode": 2
             },
             "TableName": "lineitem_part",
             "Inputs": [
@@ -1055,8 +1055,8 @@ Gen4 error: unsupported: group by on: *planbuilder.joinGen4
                   "Name": "main",
                   "Sharded": true
                 },
-                "FieldQuery": "select l_partkey, l_quantity, l_shipmode, l_shipinstruct, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_partkey), weight_string(l_quantity), weight_string(l_shipmode), weight_string(l_shipinstruct) from lineitem where 1 != 1 group by l_partkey, weight_string(l_partkey), l_quantity, weight_string(l_quantity), l_shipmode, weight_string(l_shipmode), l_shipinstruct, weight_string(l_shipinstruct)",
-                "Query": "select l_partkey, l_quantity, l_shipmode, l_shipinstruct, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_partkey), weight_string(l_quantity), weight_string(l_shipmode), weight_string(l_shipinstruct) from lineitem group by l_partkey, weight_string(l_partkey), l_quantity, weight_string(l_quantity), l_shipmode, weight_string(l_shipmode), l_shipinstruct, weight_string(l_shipinstruct)",
+                "FieldQuery": "select lineitem.l_partkey, lineitem.l_quantity, lineitem.l_shipmode, lineitem.l_shipinstruct, sum(lineitem.l_extendedprice * (1 - lineitem.l_discount)) as revenue, weight_string(lineitem.l_partkey), weight_string(lineitem.l_quantity), weight_string(lineitem.l_shipmode), weight_string(lineitem.l_shipinstruct) from lineitem where 1 != 1 group by lineitem.l_partkey, weight_string(lineitem.l_partkey), lineitem.l_quantity, weight_string(lineitem.l_quantity), lineitem.l_shipmode, weight_string(lineitem.l_shipmode), lineitem.l_shipinstruct, weight_string(lineitem.l_shipinstruct)",
+                "Query": "select lineitem.l_partkey, lineitem.l_quantity, lineitem.l_shipmode, lineitem.l_shipinstruct, sum(lineitem.l_extendedprice * (1 - lineitem.l_discount)) as revenue, weight_string(lineitem.l_partkey), weight_string(lineitem.l_quantity), weight_string(lineitem.l_shipmode), weight_string(lineitem.l_shipinstruct) from lineitem group by lineitem.l_partkey, weight_string(lineitem.l_partkey), lineitem.l_quantity, weight_string(lineitem.l_quantity), lineitem.l_shipmode, weight_string(lineitem.l_shipmode), lineitem.l_shipinstruct, weight_string(lineitem.l_shipinstruct)",
                 "Table": "lineitem"
               },
               {
@@ -1067,7 +1067,7 @@ Gen4 error: unsupported: group by on: *planbuilder.joinGen4
                   "Sharded": true
                 },
                 "FieldQuery": "select 1, count(*) from part where 1 != 1 group by 1",
-                "Query": "select 1, count(*) from part where p_partkey = :l_partkey and p_brand = 'Brand#12' and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and :l_quantity \u003e= 1 and :l_quantity \u003c= 1 + 10 and p_size between 1 and 5 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' or p_partkey = :l_partkey and p_brand = 'Brand#23' and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') and :l_quantity \u003e= 10 and :l_quantity \u003c= 10 + 10 and p_size between 1 and 10 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' or p_partkey = :l_partkey and p_brand = 'Brand#34' and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') and :l_quantity \u003e= 20 and :l_quantity \u003c= 20 + 10 and p_size between 1 and 15 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' group by 1",
+                "Query": "select 1, count(*) from part where part.p_partkey = :lineitem_l_partkey and part.p_brand = 'Brand#12' and part.p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and :lineitem_l_quantity \u003e= 1 and :lineitem_l_quantity \u003c= 1 + 10 and part.p_size between 1 and 5 and :lineitem_l_shipmode in ('AIR', 'AIR REG') and :lineitem_l_shipinstruct = 'DELIVER IN PERSON' or part.p_partkey = :lineitem_l_partkey and part.p_brand = 'Brand#23' and part.p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') and :lineitem_l_quantity \u003e= 10 and :lineitem_l_quantity \u003c= 10 + 10 and part.p_size between 1 and 10 and :lineitem_l_shipmode in ('AIR', 'AIR REG') and :lineitem_l_shipinstruct = 'DELIVER IN PERSON' or part.p_partkey = :lineitem_l_partkey and part.p_brand = 'Brand#34' and part.p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') and :lineitem_l_quantity \u003e= 20 and :lineitem_l_quantity \u003c= 20 + 10 and part.p_size between 1 and 15 and :lineitem_l_shipmode in ('AIR', 'AIR REG') and :lineitem_l_shipinstruct = 'DELIVER IN PERSON' group by 1",
                 "Table": "part"
               }
             ]
@@ -1159,7 +1159,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                                   "Sharded": true
                                 },
                                 "FieldQuery": "select 1, count(*) as numwait from orders where 1 != 1 group by 1",
-                                "Query": "select 1, count(*) as numwait from orders where o_orderstatus = 'F' and exists (select 1 from lineitem as l2 where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey != l1.l_suppkey limit 1) and not exists (select 1 from lineitem as l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey != l1.l_suppkey and l3.l_receiptdate \u003e l3.l_commitdate limit 1) and o_orderkey = :l1_l_orderkey group by 1",
+                                "Query": "select 1, count(*) as numwait from orders where orders.o_orderstatus = 'F' and exists (select 1 from lineitem as l2 where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey != l1.l_suppkey limit 1) and not exists (select 1 from lineitem as l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey != l1.l_suppkey and l3.l_receiptdate \u003e l3.l_commitdate limit 1) and orders.o_orderkey = :l1_l_orderkey group by 1",
                                 "Table": "orders",
                                 "Values": [
                                   ":l1_l_orderkey"
@@ -1173,7 +1173,7 @@ Gen4 error: unsupported: cross-shard correlated subquery
                             "Variant": "Join",
                             "JoinColumnIndexes": "L:3,L:4,L:1,R:1",
                             "JoinVars": {
-                              "s_nationkey": 0
+                              "supplier_s_nationkey": 0
                             },
                             "TableName": "supplier_nation",
                             "Inputs": [
@@ -1184,8 +1184,8 @@ Gen4 error: unsupported: cross-shard correlated subquery
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select s_nationkey, count(*) as numwait, weight_string(s_nationkey), s_name, weight_string(s_name) from supplier where 1 != 1 group by s_nationkey, weight_string(s_nationkey), s_name, weight_string(s_name)",
-                                "Query": "select s_nationkey, count(*) as numwait, weight_string(s_nationkey), s_name, weight_string(s_name) from supplier where exists (select 1 from lineitem as l2 where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey != l1.l_suppkey limit 1) and not exists (select 1 from lineitem as l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey != l1.l_suppkey and l3.l_receiptdate \u003e l3.l_commitdate limit 1) and s_suppkey = :l1_l_suppkey group by s_nationkey, weight_string(s_nationkey), s_name, weight_string(s_name)",
+                                "FieldQuery": "select supplier.s_nationkey, count(*) as numwait, weight_string(supplier.s_nationkey), supplier.s_name, weight_string(supplier.s_name) from supplier where 1 != 1 group by supplier.s_nationkey, weight_string(supplier.s_nationkey), supplier.s_name, weight_string(supplier.s_name)",
+                                "Query": "select supplier.s_nationkey, count(*) as numwait, weight_string(supplier.s_nationkey), supplier.s_name, weight_string(supplier.s_name) from supplier where exists (select 1 from lineitem as l2 where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey != l1.l_suppkey limit 1) and not exists (select 1 from lineitem as l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey != l1.l_suppkey and l3.l_receiptdate \u003e l3.l_commitdate limit 1) and supplier.s_suppkey = :l1_l_suppkey group by supplier.s_nationkey, weight_string(supplier.s_nationkey), supplier.s_name, weight_string(supplier.s_name)",
                                 "Table": "supplier",
                                 "Values": [
                                   ":l1_l_suppkey"
@@ -1200,10 +1200,10 @@ Gen4 error: unsupported: cross-shard correlated subquery
                                   "Sharded": true
                                 },
                                 "FieldQuery": "select 1, count(*) as numwait from nation where 1 != 1 group by 1",
-                                "Query": "select 1, count(*) as numwait from nation where n_name = 'SAUDI ARABIA' and exists (select 1 from lineitem as l2 where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey != l1.l_suppkey limit 1) and not exists (select 1 from lineitem as l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey != l1.l_suppkey and l3.l_receiptdate \u003e l3.l_commitdate limit 1) and n_nationkey = :s_nationkey group by 1",
+                                "Query": "select 1, count(*) as numwait from nation where nation.n_name = 'SAUDI ARABIA' and exists (select 1 from lineitem as l2 where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey != l1.l_suppkey limit 1) and not exists (select 1 from lineitem as l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey != l1.l_suppkey and l3.l_receiptdate \u003e l3.l_commitdate limit 1) and nation.n_nationkey = :supplier_s_nationkey group by 1",
                                 "Table": "nation",
                                 "Values": [
-                                  ":s_nationkey"
+                                  ":supplier_s_nationkey"
                                 ],
                                 "Vindex": "hash"
                               }

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.txt
@@ -25,8 +25,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1 union all select id from music where 1 != 1",
-    "Query": "select id from `user` union all select id from music",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1 union all select music.id as id from music where 1 != 1",
+    "Query": "select `user`.id as id from `user` union all select music.id as id from music",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -90,8 +90,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from music where 1 != 1",
-        "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from music",
+        "FieldQuery": "select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1 union select music.id as id, weight_string(music.id) from music where 1 != 1",
+        "Query": "select `user`.id as id, weight_string(`user`.id) from `user` union select music.id as id, weight_string(music.id) from music",
         "Table": "`user`"
       }
     ]
@@ -156,8 +156,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where id = 1",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where `user`.id = 1",
         "Table": "`user`",
         "Values": [
           "INT64(1)"
@@ -171,8 +171,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user` where id = 5",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where `user`.id = 5",
         "Table": "`user`",
         "Values": [
           "INT64(5)"
@@ -252,9 +252,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
+            "FieldQuery": "select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1",
             "OrderBy": "(0|1) DESC",
-            "Query": "select id, weight_string(id) from `user` order by id desc limit :__upper_limit",
+            "Query": "select `user`.id as id, weight_string(`user`.id) from `user` order by `user`.id desc limit :__upper_limit",
             "ResultColumns": 1,
             "Table": "`user`"
           }
@@ -271,9 +271,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, weight_string(id) from music where 1 != 1",
+            "FieldQuery": "select music.id as id, weight_string(music.id) from music where 1 != 1",
             "OrderBy": "(0|1) DESC",
-            "Query": "select id, weight_string(id) from music order by id desc limit :__upper_limit",
+            "Query": "select music.id as id, weight_string(music.id) from music order by music.id desc limit :__upper_limit",
             "ResultColumns": 1,
             "Table": "music"
           }
@@ -314,8 +314,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select col1, col2 from `user` where 1 != 1 union all select col1, col2 from user_extra where 1 != 1",
-    "Query": "select col1, col2 from `user` union all select col1, col2 from user_extra",
+    "FieldQuery": "select `user`.col1 as col1, `user`.col2 as col2 from `user` where 1 != 1 union all select user_extra.col1 as col1, user_extra.col2 as col2 from user_extra where 1 != 1",
+    "Query": "select `user`.col1 as col1, `user`.col2 as col2 from `user` union all select user_extra.col1 as col1, user_extra.col2 as col2 from user_extra",
     "Table": "`user`"
   },
   "TablesUsed": [
@@ -464,9 +464,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
+            "FieldQuery": "select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1",
             "OrderBy": "(0|1) ASC",
-            "Query": "select id, weight_string(id) from `user` order by id asc limit :__upper_limit",
+            "Query": "select `user`.id as id, weight_string(`user`.id) from `user` order by `user`.id asc limit :__upper_limit",
             "ResultColumns": 1,
             "Table": "`user`"
           }
@@ -483,9 +483,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, weight_string(id) from music where 1 != 1",
+            "FieldQuery": "select music.id as id, weight_string(music.id) from music where 1 != 1",
             "OrderBy": "(0|1) DESC",
-            "Query": "select id, weight_string(id) from music order by id desc limit :__upper_limit",
+            "Query": "select music.id as id, weight_string(music.id) from music order by music.id desc limit :__upper_limit",
             "ResultColumns": 1,
             "Table": "music"
           }
@@ -549,8 +549,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1 union select id from `user` where 1 != 1",
-        "Query": "select id from `user` where id = 1 union select id from `user` where id = 1",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1 union select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user` where `user`.id = 1 union select `user`.id as id from `user` where `user`.id = 1",
         "Table": "`user`",
         "Values": [
           "INT64(1)"
@@ -564,8 +564,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select id from `user` where 1 != 1",
-        "Query": "select id from `user`",
+        "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+        "Query": "select `user`.id as id from `user`",
         "Table": "`user`"
       }
     ]
@@ -810,8 +810,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from music where 1 != 1",
-            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from music",
+            "FieldQuery": "select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1 union select music.id as id, weight_string(music.id) from music where 1 != 1",
+            "Query": "select `user`.id as id, weight_string(`user`.id) from `user` union select music.id as id, weight_string(music.id) from music",
             "Table": "`user`"
           },
           {
@@ -1016,7 +1016,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
               "Sharded": true
             },
             "FieldQuery": "select * from music where 1 != 1",
-            "Query": "select distinct * from music where id = 1",
+            "Query": "select distinct * from music where music.id = 1",
             "Table": "music",
             "Values": [
               "INT64(1)"
@@ -1031,7 +1031,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
               "Sharded": true
             },
             "FieldQuery": "select * from `user` where 1 != 1",
-            "Query": "select distinct * from `user` where id = 1",
+            "Query": "select distinct * from `user` where `user`.id = 1",
             "Table": "`user`",
             "Values": [
               "INT64(1)"
@@ -1114,7 +1114,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
               "Sharded": true
             },
             "FieldQuery": "select 1 from music where 1 != 1",
-            "Query": "select distinct 1 from music where id = 1",
+            "Query": "select distinct 1 from music where music.id = 1",
             "Table": "music",
             "Values": [
               "INT64(1)"
@@ -1129,7 +1129,7 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
               "Sharded": true
             },
             "FieldQuery": "select 1 from music where 1 != 1",
-            "Query": "select distinct 1 from music where id = 2",
+            "Query": "select distinct 1 from music where music.id = 2",
             "Table": "music",
             "Values": [
               "INT64(2)"
@@ -1204,9 +1204,9 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "(select id, weight_string(id) from `user` where 1 != 1) union (select id, weight_string(id) from `user` where 1 != 1)",
+        "FieldQuery": "(select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1) union (select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1)",
         "OrderBy": "(0|1) DESC",
-        "Query": "(select id, weight_string(id) from `user` order by id desc) union (select id, weight_string(id) from `user` order by id asc)",
+        "Query": "(select `user`.id as id, weight_string(`user`.id) from `user` order by `user`.id desc) union (select `user`.id as id, weight_string(`user`.id) from `user` order by `user`.id asc)",
         "ResultColumns": 1,
         "Table": "`user`"
       }
@@ -1779,8 +1779,8 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from music where 1 != 1",
-            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from music",
+            "FieldQuery": "select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1 union select music.id as id, weight_string(music.id) from music where 1 != 1",
+            "Query": "select `user`.id as id, weight_string(`user`.id) from `user` union select music.id as id, weight_string(music.id) from music",
             "Table": "`user`"
           },
           {
@@ -1873,8 +1873,8 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
-                "Query": "select distinct id, weight_string(id) from `user` limit :__upper_limit",
+                "FieldQuery": "select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1",
+                "Query": "select distinct `user`.id as id, weight_string(`user`.id) from `user` limit :__upper_limit",
                 "Table": "`user`"
               },
               {
@@ -2036,8 +2036,8 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
               "Name": "main",
               "Sharded": false
             },
-            "FieldQuery": "select col, weight_string(col) from unsharded where 1 != 1 union select col2, weight_string(col2) from unsharded where 1 != 1",
-            "Query": "select col, weight_string(col) from unsharded union select col2, weight_string(col2) from unsharded",
+            "FieldQuery": "select unsharded.col as col, weight_string(unsharded.col) from unsharded where 1 != 1 union select unsharded.col2 as col2, weight_string(unsharded.col2) from unsharded where 1 != 1",
+            "Query": "select unsharded.col as col, weight_string(unsharded.col) from unsharded union select unsharded.col2 as col2, weight_string(unsharded.col2) from unsharded",
             "Table": "unsharded"
           },
           {
@@ -2047,8 +2047,8 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select col, weight_string(col) from user_extra where 1 != 1",
-            "Query": "select id, weight_string(id) from `user` union select col, weight_string(col) from user_extra",
+            "FieldQuery": "select `user`.id as id, weight_string(`user`.id) from `user` where 1 != 1 union select user_extra.col as col, weight_string(user_extra.col) from user_extra where 1 != 1",
+            "Query": "select `user`.id as id, weight_string(`user`.id) from `user` union select user_extra.col as col, weight_string(user_extra.col) from user_extra",
             "Table": "`user`"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -71,7 +71,7 @@ Gen4 error: cannot use column offsets in group statement when using `*`
 # complex group by expression
 "select a from user group by a+1"
 "unsupported: in scatter query: only simple references allowed"
-Gen4 error: unsupported: in scatter query: complex order by expression: a + 1
+Gen4 error: unsupported: in scatter query: complex order by expression: `user`.a + 1
 
 # Complex aggregate expression on scatter
 "select 1+count(*) from user"
@@ -81,17 +81,17 @@ Gen4 plan same as above
 # Multi-value aggregates not supported
 "select count(a,b) from user"
 "unsupported: only one expression allowed inside aggregates: count(a, b)"
-Gen4 error: aggregate functions take a single argument 'count(a, b)'
+Gen4 error: aggregate functions take a single argument 'count(`user`.a, `user`.b)'
 
 # scatter aggregate complex order by
 "select id from user group by id order by id+1"
 "unsupported: in scatter query: complex order by expression: id + 1"
-Gen4 plan same as above
+Gen4 error: unsupported: in scatter query: complex order by expression: `user`.id + 1
 
 # Scatter order by is complex with aggregates in select
 "select col, count(*) from user group by col order by col+1"
 "unsupported: in scatter query: complex order by expression: col + 1"
-Gen4 plan same as above
+Gen4 error: unsupported: in scatter query: complex order by expression: `user`.col + 1
 
 # Aggregate detection (group_concat)
 "select group_concat(user.a) from user join user_extra"
@@ -106,7 +106,7 @@ Gen4 error: unsupported: subqueries disallowed in GROUP BY
 # Order by uses cross-shard expression
 "select id from user order by id+1"
 "unsupported: in scatter query: complex order by expression: id + 1"
-Gen4 plan same as above
+Gen4 error: unsupported: in scatter query: complex order by expression: `user`.id + 1
 
 # Order by column number with collate
 "select user.col1 as a from user order by 1 collate utf8_general_ci"
@@ -166,7 +166,7 @@ Gen4 plan same as above
 # update with complex set clause
 "update music set id = id + 1 where id = 1"
 "unsupported: Only values are supported. Invalid update on column: `id` with expr: [id + 1]"
-Gen4 plan same as above
+Gen4 error: unsupported: Only values are supported. Invalid update on column: `id` with expr: [music.id + 1]
 
 # update by primary keyspace id, changing one vindex column, limit without order clause
 "update user_metadata set email = 'juan@vitess.io' where user_id = 1 limit 10"
@@ -266,7 +266,7 @@ Gen4 plan same as above
 "unsupported: where clause for vindex function must be of the form id = <val> or id in(<val>,...) (not a comparison)"
 Gen4 plan same as above
 
-"select keyspace_id from user_index where id > 1"
+"select keyspace_id from user_index where id \u003e 1"
 "unsupported: where clause for vindex function must be of the form id = <val> or id in(<val>,...) (not equality)"
 Gen4 plan same as above
 
@@ -425,7 +425,7 @@ Gen4 plan same as above
 # scatter aggregate with complex select list (can't build order by)
 "select distinct a+1 from user"
 "generating order by clause: cannot reference a complex expression"
-Gen4 error: unsupported: in scatter query: complex order by expression: a + 1
+Gen4 error: unsupported: in scatter query: complex order by expression: `user`.a + 1
 
 # aggregation on union
 "select sum(col) from (select col from user union all select col from unsharded) t"

--- a/go/vt/vtgate/planbuilder/testdata/wireup_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/wireup_cases.txt
@@ -1227,7 +1227,7 @@
           "Sharded": true
         },
         "FieldQuery": "select 1 from `user` where 1 != 1",
-        "Query": "select 1 from `user` where :__sq_has_values1 = 1 and id in ::__vals",
+        "Query": "select 1 from `user` where :__sq_has_values1 = 1 and `user`.id in ::__vals",
         "Table": "`user`",
         "Values": [
           ":__sq1"
@@ -1329,8 +1329,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select col from `user` where 1 != 1",
-            "Query": "select col from `user`",
+            "FieldQuery": "select `user`.col as col from `user` where 1 != 1",
+            "Query": "select `user`.col as col from `user`",
             "Table": "`user`"
           },
           {
@@ -1349,8 +1349,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select u.col, u.id, :__sq1 from `user` as u where 1 != 1",
-                "Query": "select u.col, u.id, :__sq1 from `user` as u",
+                "FieldQuery": "select u.col, u.id, :__sq1 as `(select col from ``user``)` from `user` as u where 1 != 1",
+                "Query": "select u.col, u.id, :__sq1 as `(select col from ``user``)` from `user` as u",
                 "Table": "`user`"
               },
               {
@@ -1407,8 +1407,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where id in ::__vals",
+    "FieldQuery": "select `user`.id as id from `user` where 1 != 1",
+    "Query": "select `user`.id as id from `user` where `user`.id in ::__vals",
     "Table": "`user`",
     "Values": [
       "(DECIMAL(18446744073709551616), INT64(1))"

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -56,7 +56,7 @@ func newAnalyzer(dbName string, si SchemaInformation) *analyzer {
 
 	b := newBinder(s, a, a.tables, a.typer)
 	a.binder = b
-	a.rewriter = &earlyRewriter{scoper: s, binder: b}
+	a.rewriter = &earlyRewriter{scoper: s, binder: b, literalRewrites: map[sqlparser.Expr]sqlparser.Expr{}}
 	s.binder = b
 	return a
 }
@@ -85,19 +85,21 @@ func (a analyzer) newSemTable(statement sqlparser.Statement, coll collations.ID)
 	}
 
 	return &SemTable{
-		Recursive:         a.binder.recursive,
-		Direct:            a.binder.direct,
-		ExprTypes:         a.typer.exprTypes,
-		Tables:            a.tables.Tables,
-		selectScope:       a.scoper.rScope,
-		NotSingleRouteErr: a.projErr,
-		NotUnshardedErr:   a.unshardedErr,
-		Warning:           a.warning,
-		Comments:          comments,
-		SubqueryMap:       a.binder.subqueryMap,
-		SubqueryRef:       a.binder.subqueryRef,
-		ColumnEqualities:  map[columnName][]sqlparser.Expr{},
-		Collation:         coll,
+		Recursive:                  a.binder.recursive,
+		Direct:                     a.binder.direct,
+		ExprTypes:                  a.typer.exprTypes,
+		Tables:                     a.tables.Tables,
+		selectScope:                a.scoper.rScope,
+		NotSingleRouteErr:          a.projErr,
+		NotUnshardedErr:            a.unshardedErr,
+		Warning:                    a.warning,
+		Comments:                   comments,
+		SubqueryMap:                a.binder.subqueryMap,
+		SubqueryRef:                a.binder.subqueryRef,
+		ColumnEqualities:           map[columnName][]sqlparser.Expr{},
+		Collation:                  coll,
+		LiteralRewrites:            a.rewriter.literalRewrites,
+		ColNameReferencingSelAlias: a.scoper.colNameReferencingSelAlias,
 	}
 }
 

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -29,6 +29,9 @@ type earlyRewriter struct {
 	scoper  *scoper
 	clause  string
 	warning string
+
+	// this is used to get back
+	literalRewrites map[sqlparser.Expr]sqlparser.Expr
 }
 
 func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
@@ -72,7 +75,7 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 		r.clause = "group statement"
 
 	case *sqlparser.Literal:
-		newNode, err := r.rewriteOrderByExpr(node)
+		newNode, err := r.rewriteOrderAndGroupByExpr(node)
 		if err != nil {
 			return err
 		}
@@ -84,7 +87,7 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 		if !ok {
 			return nil
 		}
-		newNode, err := r.rewriteOrderByExpr(lit)
+		newNode, err := r.rewriteOrderAndGroupByExpr(lit)
 		if err != nil {
 			return err
 		}
@@ -95,7 +98,7 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 	return nil
 }
 
-func (r *earlyRewriter) rewriteOrderByExpr(node *sqlparser.Literal) (sqlparser.Expr, error) {
+func (r *earlyRewriter) rewriteOrderAndGroupByExpr(node *sqlparser.Literal) (sqlparser.Expr, error) {
 	currScope, found := r.scoper.specialExprScopes[node]
 	if !found {
 		return nil, nil
@@ -130,13 +133,14 @@ func (r *earlyRewriter) rewriteOrderByExpr(node *sqlparser.Literal) (sqlparser.E
 		return sqlparser.NewColName(aliasedExpr.As.String()), nil
 	}
 
-	expr := realCloneOfColNames(aliasedExpr.Expr, currScope.isUnion)
+	expr := RealCloneOfColNames(aliasedExpr.Expr, currScope.isUnion)
+	r.literalRewrites[expr] = aliasedExpr.Expr
 	return expr, nil
 }
 
-// realCloneOfColNames clones all the expressions including ColName.
+// RealCloneOfColNames clones all the expressions including ColName.
 // Since sqlparser.CloneRefOfColName does not clone col names, this method is needed.
-func realCloneOfColNames(expr sqlparser.Expr, union bool) sqlparser.Expr {
+func RealCloneOfColNames(expr sqlparser.Expr, union bool) sqlparser.Expr {
 	return sqlparser.Rewrite(sqlparser.CloneExpr(expr), func(cursor *sqlparser.Cursor) bool {
 		switch exp := cursor.Node().(type) {
 		case *sqlparser.ColName:

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -101,6 +101,14 @@ type (
 		Collation collations.ID
 
 		Warning string
+
+		// The key of this map is an expression that was inserted into an ORDER BY, replacing a literal.
+		// ORDER BY 1 -> ORDER BY user.num
+		// The key will be the inserted expression, and the value will be the select expression
+		LiteralRewrites map[sqlparser.Expr]sqlparser.Expr
+
+		// The key will be a ColName that references to an alias in the select list
+		ColNameReferencingSelAlias map[*sqlparser.ColName]bool
 	}
 
 	columnName struct {
@@ -124,6 +132,11 @@ var (
 func (st *SemTable) CopyDependencies(from, to sqlparser.Expr) {
 	st.Recursive[to] = st.RecursiveDeps(from)
 	st.Direct[to] = st.DirectDeps(from)
+}
+
+// CopyExprType copies the expression type from one expression into the other
+func (st *SemTable) CopyExprType(from, to sqlparser.Expr) {
+	st.ExprTypes[to] = st.ExprTypes[from]
 }
 
 // EmptySemTable creates a new empty SemTable


### PR DESCRIPTION
## Description

This Pull Request changes the gen4 planner to produce plans that prefix column names with the table name they belong to.

This makes reading the queries in the plan output easier, and supports other parts of the code base that does not have the semantic analysis available, such as the vttablet.

## Related Issue(s)


## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
