### PR TITLE
BugFix: VTOrc should repair replication if either replication thread is stopped

### DIFF
--- a/go/vt/orchestrator/inst/analysis_dao.go
+++ b/go/vt/orchestrator/inst/analysis_dao.go
@@ -175,7 +175,7 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		) AS is_failing_to_connect_to_primary,
 		MIN(
 			primary_instance.replica_sql_running = 0
-			AND primary_instance.replica_io_running = 0
+			OR primary_instance.replica_io_running = 0
 		) AS replication_stopped,
 		MIN(
 			primary_downtime.downtime_active is not null


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the issue described in https://github.com/vitessio/vitess/issues/10785. 
VTOrc should be repairing replication if either of the threads is stopped and not only when both the threads are stopped. 
In Vitess we only stop 1 thread in the following cases - 
1. `StopReplicationAndGetStatus` RPC of Tablet Manager Client. This RPC is called only from `EmergencyReparentShard` which is run after acquiring a shard lock. By the end, we fix replication on all the tablets, so VTOrc will not interfere in this case.
2. `catchupToGTID` function used in restore. This happens after we change the tablet type to the `RESTORE` type. VTOrc does not fix replication on tablets of this type, so we shouldn't conflict here either.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #10785 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
