### PR TITLE
Backporting to 13: Inject shard name in commit-phase multi-shard errors

### DIFF
--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -108,7 +108,7 @@ func NewTabletGateway(ctx context.Context, hc discovery.HealthCheck, serv srvtop
 		statusAggregators: make(map[string]*TabletStatusAggregator),
 	}
 	gw.setupBuffering(ctx)
-	gw.QueryService = queryservice.Wrap(nil, gw.withRetry)
+	gw.QueryService = queryservice.Wrap(queryservice.Wrap(nil, gw.withRetry), gw.withShardError)
 	return gw
 }
 
@@ -169,7 +169,8 @@ func (gw *TabletGateway) setupBuffering(ctx context.Context) {
 
 // QueryServiceByAlias satisfies the Gateway interface
 func (gw *TabletGateway) QueryServiceByAlias(alias *topodatapb.TabletAlias, target *querypb.Target) (queryservice.QueryService, error) {
-	return gw.hc.TabletConnection(alias, target)
+	qs, err := gw.hc.TabletConnection(alias, target)
+	return queryservice.Wrap(qs, gw.withShardError), NewShardError(err, target)
 }
 
 // RegisterStats registers the stats to export the lag since the last refresh
@@ -325,6 +326,13 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 		}
 		break
 	}
+	return err
+}
+
+// withShardError adds shard information to errors returned from the inner QueryService.
+func (gw *TabletGateway) withShardError(ctx context.Context, target *querypb.Target, conn queryservice.QueryService,
+	_ string, _ bool, inner func(ctx context.Context, target *querypb.Target, conn queryservice.QueryService) (bool, error)) error {
+	_, err := inner(ctx, target, conn)
 	return NewShardError(err, target)
 }
 

--- a/go/vt/vtgate/tx_conn_test.go
+++ b/go/vt/vtgate/tx_conn_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,6 +61,63 @@ func TestTxConnBegin(t *testing.T) {
 		sc.txConn.Begin(ctx, safeSession))
 	utils.MustMatch(t, &wantSession, session, "Session")
 	assert.EqualValues(t, 1, sbc0.CommitCount.Get(), "sbc0.CommitCount")
+}
+
+func TestTxConnCommitFailure(t *testing.T) {
+	sc, sbc0, sbc1, rss0, rss1, rss01 := newTestTxConnEnv(t, "TestTxConn")
+	sc.txConn.mode = vtgatepb.TransactionMode_MULTI
+
+	// Sequence the executes to ensure commit order
+	session := NewSafeSession(&vtgatepb.Session{InTransaction: true})
+	sc.ExecuteMultiShard(ctx, rss0, queries, session, false, false)
+	wantSession := vtgatepb.Session{
+		InTransaction: true,
+		ShardSessions: []*vtgatepb.Session_ShardSession{{
+			Target: &querypb.Target{
+				Keyspace:   "TestTxConn",
+				Shard:      "0",
+				TabletType: topodatapb.TabletType_PRIMARY,
+			},
+			TransactionId: 1,
+			TabletAlias:   sbc0.Tablet().Alias,
+		}},
+	}
+	utils.MustMatch(t, &wantSession, session.Session, "Session")
+	sc.ExecuteMultiShard(ctx, rss01, twoQueries, session, false, false)
+	wantSession = vtgatepb.Session{
+		InTransaction: true,
+		ShardSessions: []*vtgatepb.Session_ShardSession{{
+			Target: &querypb.Target{
+				Keyspace:   "TestTxConn",
+				Shard:      "0",
+				TabletType: topodatapb.TabletType_PRIMARY,
+			},
+			TransactionId: 1,
+			TabletAlias:   sbc0.Tablet().Alias,
+		}, {
+			Target: &querypb.Target{
+				Keyspace:   "TestTxConn",
+				Shard:      "1",
+				TabletType: topodatapb.TabletType_PRIMARY,
+			},
+			TransactionId: 1,
+			TabletAlias:   sbc1.Tablet().Alias,
+		}},
+	}
+	utils.MustMatch(t, &wantSession, session.Session, "Session")
+
+	sbc1.MustFailCodes[vtrpcpb.Code_DEADLINE_EXCEEDED] = 1
+
+	expectErr := NewShardError(vterrors.New(
+		vtrpcpb.Code_DEADLINE_EXCEEDED,
+		fmt.Sprintf("%v error", vtrpcpb.Code_DEADLINE_EXCEEDED)),
+		rss1[0].Target)
+
+	assert.Contains(t, sc.txConn.Commit(ctx, session).Error(), expectErr.Error())
+	wantSession = vtgatepb.Session{}
+	utils.MustMatch(t, &wantSession, session.Session, "Session")
+	assert.EqualValues(t, 1, sbc0.CommitCount.Get(), "sbc0.CommitCount")
+	assert.EqualValues(t, 1, sbc1.CommitCount.Get(), "sbc1.CommitCount")
 }
 
 func TestTxConnCommitSuccess(t *testing.T) {
@@ -467,9 +525,14 @@ func TestTxConnCommitOrderFailure3(t *testing.T) {
 		sc.txConn.Commit(ctx, session))
 
 	// The last failed commit must generate a warning.
+	expectErr := NewShardError(vterrors.New(
+		vtrpcpb.Code_INVALID_ARGUMENT,
+		fmt.Sprintf("%v error", vtrpcpb.Code_INVALID_ARGUMENT)),
+		rss1[0].Target)
+
 	wantSession := vtgatepb.Session{
 		Warnings: []*querypb.QueryWarning{{
-			Message: "post-operation transaction had an error: Code: INVALID_ARGUMENT\nINVALID_ARGUMENT error\n\ntarget: TestTxConn.1.primary",
+			Message: fmt.Sprintf("post-operation transaction had an error: %v", expectErr),
 		}},
 	}
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
@@ -894,7 +957,7 @@ func TestTxConnReservedRollback(t *testing.T) {
 }
 
 func TestTxConnReservedRollbackFailure(t *testing.T) {
-	sc, sbc0, sbc1, rss0, _, rss01 := newTestTxConnEnv(t, "TxConnReservedRollback")
+	sc, sbc0, sbc1, rss0, rss1, rss01 := newTestTxConnEnv(t, "TxConnReservedRollback")
 
 	session := NewSafeSession(&vtgatepb.Session{InTransaction: true, InReservedConn: true})
 	sc.ExecuteMultiShard(ctx, rss0, queries, session, false, false)
@@ -903,10 +966,16 @@ func TestTxConnReservedRollbackFailure(t *testing.T) {
 	sbc1.MustFailCodes[vtrpcpb.Code_INVALID_ARGUMENT] = 1
 	assert.Error(t,
 		sc.txConn.Rollback(ctx, session))
+
+	expectErr := NewShardError(vterrors.New(
+		vtrpcpb.Code_INVALID_ARGUMENT,
+		fmt.Sprintf("%v error", vtrpcpb.Code_INVALID_ARGUMENT)),
+		rss1[0].Target)
+
 	wantSession := vtgatepb.Session{
 		InReservedConn: true,
 		Warnings: []*querypb.QueryWarning{{
-			Message: "rollback encountered an error and connection to all shard for this session is released: Code: INVALID_ARGUMENT\nINVALID_ARGUMENT error\n",
+			Message: fmt.Sprintf("rollback encountered an error and connection to all shard for this session is released: %v", expectErr),
 		}},
 	}
 	utils.MustMatch(t, &wantSession, session.Session, "Session")


### PR DESCRIPTION
## Description

This is a backport of https://github.com/vitessio/vitess/pull/10669 into the release-13.0 branch.

## Related Issue(s)

 * Original PR: #10669 
 * Issue: #10692 

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
