### PR TITLE
Backport v14: fixing onlineddl_vrepl_stress_suite flakiness in CI (#10779)

### DIFF
--- a/go/timer/rate_limiter.go
+++ b/go/timer/rate_limiter.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timer
+
+import (
+	"context"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// RateLimiter runs given tasks, at no more than one per defined duration.
+// For example, we can create a RateLimiter of 1second. Then, we can ask it, over time, to run many
+// tasks. It will only ever run a single task in any 1 second time frame. The rest are ignored.
+type RateLimiter struct {
+	tickerValue int64
+	lastDoValue int64
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+}
+
+// NewRateLimiter creates a new limiter with given duration. It is immediately ready to run tasks.
+func NewRateLimiter(d time.Duration) *RateLimiter {
+	r := &RateLimiter{tickerValue: 1}
+	ctx, cancel := context.WithCancel(context.Background())
+	r.cancel = cancel
+	go func() {
+		ticker := time.NewTicker(d)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				atomic.StoreInt64(&r.tickerValue, r.tickerValue+1)
+			}
+		}
+	}()
+	return r
+}
+
+// Do runs a given func assuming rate limiting allows. This function is thread safe.
+// f may be nil, in which case it is not invoked.
+func (r *RateLimiter) Do(f func() error) (err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.lastDoValue >= atomic.LoadInt64(&r.tickerValue) {
+		return nil // rate limited. Skipped.
+	}
+	if f != nil {
+		err = f()
+	}
+	r.lastDoValue = atomic.LoadInt64(&r.tickerValue)
+	return err
+}
+
+// Stop terminates rate limiter's operation and will not allow any more Do() executions.
+func (r *RateLimiter) Stop() {
+	r.cancel()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.lastDoValue = math.MaxInt64
+}

--- a/go/timer/rate_limiter_test.go
+++ b/go/timer/rate_limiter_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimiterLong(t *testing.T) {
+	r := NewRateLimiter(time.Hour)
+	require.NotNil(t, r)
+	val := 0
+	incr := func() error { val++; return nil }
+	for i := 0; i < 10; i++ {
+		err := r.Do(incr)
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, 1, val)
+}
+
+func TestRateLimiterShort(t *testing.T) {
+	r := NewRateLimiter(time.Millisecond * 250)
+	require.NotNil(t, r)
+	val := 0
+	incr := func() error { val++; return nil }
+	for i := 0; i < 10; i++ {
+		time.Sleep(time.Millisecond * 100)
+		err := r.Do(incr)
+		assert.NoError(t, err)
+	}
+	// we expect some 3-5 entries; this depends on the CI server performance.
+	assert.Greater(t, val, 2)
+	assert.Less(t, val, 10)
+}
+
+func TestRateLimiterStop(t *testing.T) {
+	r := NewRateLimiter(time.Millisecond * 10)
+	require.NotNil(t, r)
+	val := 0
+	incr := func() error { val++; return nil }
+	for i := 0; i < 5; i++ {
+		time.Sleep(time.Millisecond * 10)
+		err := r.Do(incr)
+		assert.NoError(t, err)
+	}
+	// we expect some 3-5 entries; this depends on the CI server performance.
+	assert.Greater(t, val, 2)
+	valSnapshot := val
+	r.Stop()
+	for i := 0; i < 5; i++ {
+		time.Sleep(time.Millisecond * 10)
+		err := r.Do(incr)
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, valSnapshot, val)
+}


### PR DESCRIPTION
Backport of https://github.com/vitessio/vitess/pull/10779