### PR TITLE
VDiff2: Add --wait flag to Create/Resume actions

### DIFF
--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -36,8 +36,9 @@ type testCase struct {
 	retryInsert string
 	resume      bool // test resume functionality with this workflow
 	// If testing resume, what new rows should be diff'd. These rows must have a PK > all initial rows and retry rows.
-	resumeInsert  string
-	testCLIErrors bool // test CLI errors against this workflow
+	resumeInsert      string
+	testCLIErrors     bool // test CLI errors against this workflow (only needs to be done once)
+	testCLICreateWait bool // test CLI create and wait until done against this workflow (only needs to be done once)
 }
 
 const (
@@ -49,20 +50,21 @@ const (
 
 var testCases = []*testCase{
 	{
-		name:           "MoveTables/unsharded to two shards",
-		workflow:       "p1c2",
-		typ:            "MoveTables",
-		sourceKs:       "product",
-		targetKs:       "customer",
-		sourceShards:   "0",
-		targetShards:   "-80,80-",
-		tabletBaseID:   200,
-		tables:         "customer,Lead,Lead-1",
-		autoRetryError: true,
-		retryInsert:    `insert into customer(cid, name, typ) values(91234, 'Testy McTester', 'soho')`,
-		resume:         true,
-		resumeInsert:   `insert into customer(cid, name, typ) values(92234, 'Testy McTester (redux)', 'enterprise')`,
-		testCLIErrors:  true, // test for errors in the simplest workflow
+		name:              "MoveTables/unsharded to two shards",
+		workflow:          "p1c2",
+		typ:               "MoveTables",
+		sourceKs:          "product",
+		targetKs:          "customer",
+		sourceShards:      "0",
+		targetShards:      "-80,80-",
+		tabletBaseID:      200,
+		tables:            "customer,Lead,Lead-1",
+		autoRetryError:    true,
+		retryInsert:       `insert into customer(cid, name, typ) values(91234, 'Testy McTester', 'soho')`,
+		resume:            true,
+		resumeInsert:      `insert into customer(cid, name, typ) values(92234, 'Testy McTester (redux)', 'enterprise')`,
+		testCLIErrors:     true, // test for errors in the simplest workflow
+		testCLICreateWait: true, // test wait on create feature against simplest workflow
 	},
 	{
 		name:           "Reshard Merge/split 2 to 3",
@@ -182,7 +184,10 @@ func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, cells []*Cell) 
 		testResume(t, tc, cells[0].Name)
 	}
 
-	// This is done here so that we have a valid workflow to test the commands against
+	// These are done here so that we have a valid workflow to test the commands against
+	if tc.testCLICreateWait {
+		testCLICreateWait(t, ksWorkflow, allCellNames)
+	}
 	if tc.testCLIErrors {
 		testCLIErrors(t, ksWorkflow, allCellNames)
 	}
@@ -309,5 +314,34 @@ func testAutoRetryError(t *testing.T, tc *testCase, cells string) {
 		info := waitForVDiff2ToComplete(t, ksWorkflow, cells, uuid, ogTime)
 		require.False(t, info.HasMismatch)
 		require.Equal(t, expectedRows, info.RowsCompared)
+	})
+}
+
+func testCLICreateWait(t *testing.T, ksWorkflow string, cells string) {
+	t.Run("vtctl create and wait", func(t *testing.T) {
+		finished := make(chan bool)
+
+		go func() {
+			_, output := performVDiff2Action(t, ksWorkflow, cells, "create", "", false, "--wait")
+			completed := false
+			// We don't try to parse the JSON output as it may contain a series of outputs
+			// that together do not form a valid JSON document. We can change this in the
+			// future if we want to by printing them out as an array of JSON objects.
+			if strings.Contains(output, `"State": "completed"`) {
+				completed = true
+			}
+			finished <- completed
+		}()
+
+		tmr := time.NewTimer(vdiffTimeout)
+		defer tmr.Stop()
+		select {
+		case completed := <-finished:
+			require.Equal(t, true, completed)
+			return
+		case <-tmr.C:
+			require.Fail(t, "timeout waiting for vdiff to complete")
+			return
+		}
 	})
 }

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -321,7 +321,7 @@ func testCLICreateWait(t *testing.T, ksWorkflow string, cells string) {
 	t.Run("vtctl create and wait", func(t *testing.T) {
 		chCompleted := make(chan bool)
 		go func() {
-			_, output := performVDiff2Action(t, ksWorkflow, cells, "create", "", false, "--wait", "--wait-update-interval=5s")
+			_, output := performVDiff2Action(t, ksWorkflow, cells, "create", "", false, "--wait", "--wait-update-interval=1s")
 			completed := false
 			// We don't try to parse the JSON output as it may contain a series of outputs
 			// that together do not form a valid JSON document. We can change this in the

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -340,6 +340,5 @@ func testCLICreateWait(t *testing.T, ksWorkflow string, cells string) {
 		case <-tmr.C:
 			require.Fail(t, "timeout waiting for vdiff to complete")
 		}
-		return
 	})
 }

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -162,12 +162,12 @@ func doVdiff2(t *testing.T, keyspace, workflow, cells string, want *expectedVDif
 
 func performVDiff2Action(t *testing.T, ksWorkflow, cells, action, actionArg string, expectError bool, extraFlags ...string) (uuid string, output string) {
 	var err error
+	args := []string{"VDiff", "--", "--v2", "--tablet_types=primary", "--source_cell=" + cells, "--format=json"}
 	if len(extraFlags) > 0 {
-		output, err = vc.VtctlClient.ExecuteCommandWithOutput("VDiff", "--", "--v2", "--tablet_types=primary", "--source_cell="+cells, "--format=json",
-			strings.Join(extraFlags, " "), ksWorkflow, action, actionArg)
-	} else {
-		output, err = vc.VtctlClient.ExecuteCommandWithOutput("VDiff", "--", "--v2", "--tablet_types=primary", "--source_cell="+cells, "--format=json", ksWorkflow, action, actionArg)
+		args = append(args, extraFlags...)
 	}
+	args = append(args, ksWorkflow, action, actionArg)
+	output, err = vc.VtctlClient.ExecuteCommandWithOutput(args...)
 	log.Infof("vdiff2 output: %+v (err: %+v)", output, err)
 	if !expectError {
 		require.Nil(t, err)

--- a/go/vt/vtctl/vdiff2.go
+++ b/go/vt/vtctl/vdiff2.go
@@ -426,7 +426,7 @@ func displayVDiff2ShowSingleSummary(wr *wrangler.Wrangler, format, keyspace, wor
 			str = str2
 		}
 	}
-	wr.Logger().Printf(fmt.Sprintf("\r%s\n", str))
+	wr.Logger().Printf(str + "\n")
 	return state, nil
 }
 func buildVDiff2SingleSummary(wr *wrangler.Wrangler, keyspace, workflow, uuid string, output *wrangler.VDiffOutput, verbose bool) (*vdiffSummary, error) {

--- a/go/vt/vtctl/vdiff2.go
+++ b/go/vt/vtctl/vdiff2.go
@@ -65,7 +65,7 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 	samplePct := subFlags.Int64("sample_pct", 100, "How many rows to sample, not yet implemented")
 	verbose := subFlags.Bool("verbose", false, "Show verbose vdiff output in summaries")
 	wait := subFlags.Bool("wait", false, "When creating or resuming a vdiff, wait for it to finish before exiting")
-	waitUpdateInterval := subFlags.Duration("wait-update-interval", time.Duration(1*time.Minute), "When waiting on a vdiff to finish, display the current status output this often")
+	waitUpdateInterval := subFlags.Duration("wait-update-interval", time.Duration(1*time.Minute), "When waiting on a vdiff to finish, check and display the current status this often")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -182,8 +182,7 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 				case <-ctx.Done():
 					return vterrors.Errorf(vtrpcpb.Code_CANCELED, "context has expired")
 				case <-tkr.C:
-					output, err = wr.VDiff2(ctx, keyspace, workflowName, vdiff.ShowAction, vdiffUUID.String(), vdiffUUID.String(), options)
-					if err != nil {
+					if output, err = wr.VDiff2(ctx, keyspace, workflowName, vdiff.ShowAction, vdiffUUID.String(), vdiffUUID.String(), options); err != nil {
 						return err
 					}
 					if state, err = displayVDiff2ShowSingleSummary(wr, format, keyspace, workflowName, vdiffUUID.String(), output, *verbose); err != nil {

--- a/go/vt/vtctl/vdiff2.go
+++ b/go/vt/vtctl/vdiff2.go
@@ -37,6 +37,8 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
 	"vitess.io/vitess/go/vt/wrangler"
 )
@@ -62,6 +64,8 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 	checksum := subFlags.Bool("checksum", false, "Use row-level checksums to compare, not yet implemented")
 	samplePct := subFlags.Int64("sample_pct", 100, "How many rows to sample, not yet implemented")
 	verbose := subFlags.Bool("verbose", false, "Show verbose vdiff output in summaries")
+	wait := subFlags.Bool("wait", false, "When creating or resuming a vdiff, wait for it to finish before exiting")
+	waitUpdateInterval := subFlags.Duration("wait-update-interval", time.Duration(1*time.Minute), "When waiting on a vdiff to finish, display the current status output this often")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -168,7 +172,31 @@ func commandVDiff2(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 
 	switch action {
 	case vdiff.CreateAction, vdiff.ResumeAction:
-		displayVDiff2ScheduledResponse(wr, format, vdiffUUID.String(), action)
+		if *wait {
+			tkr := time.NewTicker(*waitUpdateInterval)
+			defer tkr.Stop()
+			var err error
+			var state vdiff.VDiffState
+			for {
+				select {
+				case <-ctx.Done():
+					return vterrors.Errorf(vtrpcpb.Code_CANCELED, "context has expired")
+				case <-tkr.C:
+					output, err = wr.VDiff2(ctx, keyspace, workflowName, vdiff.ShowAction, vdiffUUID.String(), vdiffUUID.String(), options)
+					if err != nil {
+						return err
+					}
+					if state, err = displayVDiff2ShowSingleSummary(wr, format, keyspace, workflowName, vdiffUUID.String(), output, *verbose); err != nil {
+						return err
+					}
+					if state == vdiff.CompletedState {
+						return nil
+					}
+				}
+			}
+		} else {
+			displayVDiff2ScheduledResponse(wr, format, vdiffUUID.String(), action)
+		}
 	case vdiff.ShowAction:
 		if output == nil {
 			// should not happen
@@ -317,7 +345,8 @@ func displayVDiff2ShowResponse(wr *wrangler.Wrangler, format, keyspace, workflow
 		if len(output.Responses) == 0 {
 			return fmt.Errorf("no response received for vdiff show of %s.%s(%s)", keyspace, workflowName, vdiffUUID.String())
 		}
-		return displayVDiff2ShowSingleSummary(wr, format, keyspace, workflowName, vdiffUUID.String(), output, verbose)
+		_, err := displayVDiff2ShowSingleSummary(wr, format, keyspace, workflowName, vdiffUUID.String(), output, verbose)
+		return err
 	}
 }
 
@@ -365,27 +394,29 @@ func buildVDiff2Recent(output *wrangler.VDiffOutput) ([]*VDiffListing, error) {
 	return listings, nil
 }
 
-func displayVDiff2ShowSingleSummary(wr *wrangler.Wrangler, format, keyspace, workflowName, uuid string, output *wrangler.VDiffOutput, verbose bool) error {
+func displayVDiff2ShowSingleSummary(wr *wrangler.Wrangler, format, keyspace, workflowName, uuid string, output *wrangler.VDiffOutput, verbose bool) (vdiff.VDiffState, error) {
+	state := vdiff.UnknownState
 	str := ""
 	summary, err := buildVDiff2SingleSummary(wr, keyspace, workflowName, uuid, output, verbose)
 	if err != nil {
-		return err
+		return state, err
 	}
+	state = summary.State
 	if format == "json" {
 		jsonText, err := json.MarshalIndent(summary, "", "\t")
 		if err != nil {
-			return err
+			return state, err
 		}
 		str = string(jsonText)
 	} else {
 		tmpl, err := template.New("test").Parse(summaryTextTemplate)
 		if err != nil {
-			return err
+			return state, err
 		}
 		sb := new(strings.Builder)
 		err = tmpl.Execute(sb, summary)
 		if err != nil {
-			return err
+			return state, err
 		}
 		str = sb.String()
 		for {
@@ -396,8 +427,8 @@ func displayVDiff2ShowSingleSummary(wr *wrangler.Wrangler, format, keyspace, wor
 			str = str2
 		}
 	}
-	wr.Logger().Printf(str + "\n")
-	return nil
+	wr.Logger().Printf(fmt.Sprintf("\r%s\n", str))
+	return state, nil
 }
 func buildVDiff2SingleSummary(wr *wrangler.Wrangler, keyspace, workflow, uuid string, output *wrangler.VDiffOutput, verbose bool) (*vdiffSummary, error) {
 	summary := &vdiffSummary{

--- a/go/vt/vttablet/tabletmanager/vdiff/engine.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine.go
@@ -39,9 +39,9 @@ import (
 )
 
 type Engine struct {
-	mu     sync.Mutex
 	isOpen bool
 
+	mu          sync.Mutex // guards controllers
 	controllers map[int64]*controller
 
 	// ctx is the root context for all controllers


### PR DESCRIPTION
## Description

This adds the `--wait` flag for the [`Create`](https://vitess.io/docs/15.0/reference/vreplication/vdiff2/#start-a-new-vdiff) and [`Resume`](https://vitess.io/docs/15.0/reference/vreplication/vdiff2/#resume-a-previous-vdiff) actions so that you can see the progress as it runs — current status checked and displayed every `--wait-update-interval` which is 1 minute by default — and be informed  when it successfully completes or exits with an error.

## Related Issue(s)
  - Fixes: https://github.com/vitessio/vitess/issues/10798

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation: https://github.com/vitessio/website/pull/1110