### PR TITLE
Unexplode return values for queryservice

### DIFF
--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -291,7 +291,7 @@ func commandVtTabletBegin(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 	}
 	defer conn.Close(ctx)
 
-	transactionID, _, err := conn.Begin(ctx, &querypb.Target{
+	state, err := conn.Begin(ctx, &querypb.Target{
 		Keyspace:   tabletInfo.Tablet.Keyspace,
 		Shard:      tabletInfo.Tablet.Shard,
 		TabletType: tabletInfo.Tablet.Type,
@@ -300,7 +300,7 @@ func commandVtTabletBegin(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 		return fmt.Errorf("begin failed: %v", err)
 	}
 	result := map[string]int64{
-		"transaction_id": transactionID,
+		"transaction_id": state.TransactionID,
 	}
 	return printJSON(wr.Logger(), result)
 }

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -149,7 +149,7 @@ func (vte *VTExplain) newTablet(opts *Options, t *topodatapb.Tablet) *explainTab
 var _ queryservice.QueryService = (*explainTablet)(nil) // compile-time interface check
 
 // Begin is part of the QueryService interface.
-func (t *explainTablet) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (int64, *topodatapb.TabletAlias, error) {
+func (t *explainTablet) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (queryservice.TransactionState, error) {
 	t.mu.Lock()
 	t.currentTime = t.vte.batchTime.Wait()
 	t.tabletQueries = append(t.tabletQueries, &TabletQuery{
@@ -258,7 +258,7 @@ func (t *explainTablet) ReadTransaction(ctx context.Context, target *querypb.Tar
 }
 
 // BeginExecute is part of the QueryService interface.
-func (t *explainTablet) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, *topodatapb.TabletAlias, error) {
+func (t *explainTablet) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (queryservice.TransactionState, *sqltypes.Result, error) {
 	t.mu.Lock()
 	t.currentTime = t.vte.batchTime.Wait()
 	bindVariables = sqltypes.CopyBindVariables(bindVariables)

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -216,22 +216,39 @@ func (stc *ScatterConn) ExecuteMultiShard(
 					retryRequest(func() {
 						// we seem to have lost our connection. it was a reserved connection, let's try to recreate it
 						info.actionNeeded = reserve
-						innerqr, reservedID, alias, err = qs.ReserveExecute(ctx, rs.Target, session.SetPreQueries(), queries[i].Sql, queries[i].BindVariables, 0 /*transactionId*/, opts)
+						var state queryservice.ReservedState
+						state, innerqr, err = qs.ReserveExecute(ctx, rs.Target, session.SetPreQueries(), queries[i].Sql, queries[i].BindVariables, 0 /*transactionId*/, opts)
+						reservedID = state.ReservedID
+						alias = state.TabletAlias
 					})
 				}
 			case begin:
-				innerqr, transactionID, alias, err = qs.BeginExecute(ctx, rs.Target, session.SavePoints(), queries[i].Sql, queries[i].BindVariables, reservedID, opts)
+				var state queryservice.TransactionState
+				state, innerqr, err = qs.BeginExecute(ctx, rs.Target, session.SavePoints(), queries[i].Sql, queries[i].BindVariables, reservedID, opts)
+				transactionID = state.TransactionID
+				alias = state.TabletAlias
 				if err != nil {
 					retryRequest(func() {
 						// we seem to have lost our connection. it was a reserved connection, let's try to recreate it
 						info.actionNeeded = reserveBegin
-						innerqr, transactionID, reservedID, alias, err = qs.ReserveBeginExecute(ctx, rs.Target, session.SetPreQueries(), session.SavePoints(), queries[i].Sql, queries[i].BindVariables, opts)
+						var state queryservice.ReservedTransactionState
+						state, innerqr, err = qs.ReserveBeginExecute(ctx, rs.Target, session.SetPreQueries(), session.SavePoints(), queries[i].Sql, queries[i].BindVariables, opts)
+						transactionID = state.TransactionID
+						reservedID = state.ReservedID
+						alias = state.TabletAlias
 					})
 				}
 			case reserve:
-				innerqr, reservedID, alias, err = qs.ReserveExecute(ctx, rs.Target, session.SetPreQueries(), queries[i].Sql, queries[i].BindVariables, transactionID, opts)
+				var state queryservice.ReservedState
+				state, innerqr, err = qs.ReserveExecute(ctx, rs.Target, session.SetPreQueries(), queries[i].Sql, queries[i].BindVariables, transactionID, opts)
+				reservedID = state.ReservedID
+				alias = state.TabletAlias
 			case reserveBegin:
-				innerqr, transactionID, reservedID, alias, err = qs.ReserveBeginExecute(ctx, rs.Target, session.SetPreQueries(), session.SavePoints(), queries[i].Sql, queries[i].BindVariables, opts)
+				var state queryservice.ReservedTransactionState
+				state, innerqr, err = qs.ReserveBeginExecute(ctx, rs.Target, session.SetPreQueries(), session.SavePoints(), queries[i].Sql, queries[i].BindVariables, opts)
+				transactionID = state.TransactionID
+				reservedID = state.ReservedID
+				alias = state.TabletAlias
 			default:
 				return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] unexpected actionNeeded on query execution: %v", info.actionNeeded)
 			}
@@ -394,22 +411,39 @@ func (stc *ScatterConn) StreamExecuteMulti(
 					retryRequest(func() {
 						// we seem to have lost our connection. it was a reserved connection, let's try to recreate it
 						info.actionNeeded = reserve
-						reservedID, alias, err = qs.ReserveStreamExecute(ctx, rs.Target, session.SetPreQueries(), query, bindVars[i], 0 /*transactionId*/, opts, callback)
+						var state queryservice.ReservedState
+						state, err = qs.ReserveStreamExecute(ctx, rs.Target, session.SetPreQueries(), query, bindVars[i], 0 /*transactionId*/, opts, callback)
+						reservedID = state.ReservedID
+						alias = state.TabletAlias
 					})
 				}
 			case begin:
-				transactionID, alias, err = qs.BeginStreamExecute(ctx, rs.Target, session.SavePoints(), query, bindVars[i], reservedID, opts, callback)
+				var state queryservice.TransactionState
+				state, err = qs.BeginStreamExecute(ctx, rs.Target, session.SavePoints(), query, bindVars[i], reservedID, opts, callback)
+				transactionID = state.TransactionID
+				alias = state.TabletAlias
 				if err != nil {
 					retryRequest(func() {
 						// we seem to have lost our connection. it was a reserved connection, let's try to recreate it
 						info.actionNeeded = reserveBegin
-						transactionID, reservedID, alias, err = qs.ReserveBeginStreamExecute(ctx, rs.Target, session.SetPreQueries(), session.SavePoints(), query, bindVars[i], opts, callback)
+						var state queryservice.ReservedTransactionState
+						state, err = qs.ReserveBeginStreamExecute(ctx, rs.Target, session.SetPreQueries(), session.SavePoints(), query, bindVars[i], opts, callback)
+						transactionID = state.TransactionID
+						reservedID = state.ReservedID
+						alias = state.TabletAlias
 					})
 				}
 			case reserve:
-				reservedID, alias, err = qs.ReserveStreamExecute(ctx, rs.Target, session.SetPreQueries(), query, bindVars[i], transactionID, opts, callback)
+				var state queryservice.ReservedState
+				state, err = qs.ReserveStreamExecute(ctx, rs.Target, session.SetPreQueries(), query, bindVars[i], transactionID, opts, callback)
+				reservedID = state.ReservedID
+				alias = state.TabletAlias
 			case reserveBegin:
-				transactionID, reservedID, alias, err = qs.ReserveBeginStreamExecute(ctx, rs.Target, session.SetPreQueries(), session.SavePoints(), query, bindVars[i], opts, callback)
+				var state queryservice.ReservedTransactionState
+				state, err = qs.ReserveBeginStreamExecute(ctx, rs.Target, session.SetPreQueries(), session.SavePoints(), query, bindVars[i], opts, callback)
+				transactionID = state.TransactionID
+				reservedID = state.ReservedID
+				alias = state.TabletAlias
 			default:
 				return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] unexpected actionNeeded on query execution: %v", info.actionNeeded)
 			}
@@ -694,7 +728,10 @@ func (stc *ScatterConn) ExecuteLock(ctx context.Context, rs *srvtopo.ResolvedSha
 			session.UpdateLockHeartbeat()
 		}
 	case reserve:
-		qr, reservedID, alias, err = qs.ReserveExecute(ctx, rs.Target, session.SetPreQueries(), query.Sql, query.BindVariables, 0 /* transactionID */, opts)
+		var state queryservice.ReservedState
+		state, qr, err = qs.ReserveExecute(ctx, rs.Target, session.SetPreQueries(), query.Sql, query.BindVariables, 0 /* transactionID */, opts)
+		reservedID = state.ReservedID
+		alias = state.TabletAlias
 		if err != nil && reservedID != 0 {
 			_ = stc.txConn.ReleaseLock(ctx, session)
 		}

--- a/go/vt/vtgate/tabletgateway_test.go
+++ b/go/vt/vtgate/tabletgateway_test.go
@@ -56,7 +56,7 @@ func TestTabletGatewayExecuteStream(t *testing.T) {
 
 func TestTabletGatewayBegin(t *testing.T) {
 	testTabletGatewayGeneric(t, func(tg *TabletGateway, target *querypb.Target) error {
-		_, _, err := tg.Begin(context.Background(), target, nil)
+		_, err := tg.Begin(context.Background(), target, nil)
 		return err
 	})
 }
@@ -77,7 +77,7 @@ func TestTabletGatewayRollback(t *testing.T) {
 
 func TestTabletGatewayBeginExecute(t *testing.T) {
 	testTabletGatewayGeneric(t, func(tg *TabletGateway, target *querypb.Target) error {
-		_, _, _, err := tg.BeginExecute(context.Background(), target, nil, "query", nil, 0, nil)
+		_, _, err := tg.BeginExecute(context.Background(), target, nil, "query", nil, 0, nil)
 		return err
 	})
 }

--- a/go/vt/vttablet/grpcqueryservice/server.go
+++ b/go/vt/vttablet/grpcqueryservice/server.go
@@ -79,14 +79,14 @@ func (q *query) Begin(ctx context.Context, request *querypb.BeginRequest) (respo
 		request.EffectiveCallerId,
 		request.ImmediateCallerId,
 	)
-	transactionID, alias, err := q.server.Begin(ctx, request.Target, request.Options)
+	state, err := q.server.Begin(ctx, request.Target, request.Options)
 	if err != nil {
 		return nil, vterrors.ToGRPC(err)
 	}
 
 	return &querypb.BeginResponse{
-		TransactionId: transactionID,
-		TabletAlias:   alias,
+		TransactionId: state.TransactionID,
+		TabletAlias:   state.TabletAlias,
 	}, nil
 }
 
@@ -239,22 +239,22 @@ func (q *query) BeginExecute(ctx context.Context, request *querypb.BeginExecuteR
 		request.EffectiveCallerId,
 		request.ImmediateCallerId,
 	)
-	result, transactionID, alias, err := q.server.BeginExecute(ctx, request.Target, request.PreQueries, request.Query.Sql, request.Query.BindVariables, request.ReservedId, request.Options)
+	state, result, err := q.server.BeginExecute(ctx, request.Target, request.PreQueries, request.Query.Sql, request.Query.BindVariables, request.ReservedId, request.Options)
 	if err != nil {
 		// if we have a valid transactionID, return the error in-band
-		if transactionID != 0 {
+		if state.TransactionID != 0 {
 			return &querypb.BeginExecuteResponse{
 				Error:         vterrors.ToVTRPC(err),
-				TransactionId: transactionID,
-				TabletAlias:   alias,
+				TransactionId: state.TransactionID,
+				TabletAlias:   state.TabletAlias,
 			}, nil
 		}
 		return nil, vterrors.ToGRPC(err)
 	}
 	return &querypb.BeginExecuteResponse{
 		Result:        sqltypes.ResultToProto3(result),
-		TransactionId: transactionID,
-		TabletAlias:   alias,
+		TransactionId: state.TransactionID,
+		TabletAlias:   state.TabletAlias,
 	}, nil
 }
 
@@ -265,14 +265,14 @@ func (q *query) BeginStreamExecute(request *querypb.BeginStreamExecuteRequest, s
 		request.EffectiveCallerId,
 		request.ImmediateCallerId,
 	)
-	transactionID, alias, err := q.server.BeginStreamExecute(ctx, request.Target, request.PreQueries, request.Query.Sql, request.Query.BindVariables, request.ReservedId, request.Options, func(reply *sqltypes.Result) error {
+	state, err := q.server.BeginStreamExecute(ctx, request.Target, request.PreQueries, request.Query.Sql, request.Query.BindVariables, request.ReservedId, request.Options, func(reply *sqltypes.Result) error {
 		return stream.Send(&querypb.BeginStreamExecuteResponse{
 			Result: sqltypes.ResultToProto3(reply),
 		})
 	})
 	errInLastPacket := stream.Send(&querypb.BeginStreamExecuteResponse{
-		TransactionId: transactionID,
-		TabletAlias:   alias,
+		TransactionId: state.TransactionID,
+		TabletAlias:   state.TabletAlias,
 	})
 	if err != nil {
 		return vterrors.ToGRPC(err)
@@ -365,22 +365,22 @@ func (q *query) ReserveExecute(ctx context.Context, request *querypb.ReserveExec
 		request.EffectiveCallerId,
 		request.ImmediateCallerId,
 	)
-	result, reservedID, alias, err := q.server.ReserveExecute(ctx, request.Target, request.PreQueries, request.Query.Sql, request.Query.BindVariables, request.TransactionId, request.Options)
+	state, result, err := q.server.ReserveExecute(ctx, request.Target, request.PreQueries, request.Query.Sql, request.Query.BindVariables, request.TransactionId, request.Options)
 	if err != nil {
 		// if we have a valid reservedID, return the error in-band
-		if reservedID != 0 {
+		if state.ReservedID != 0 {
 			return &querypb.ReserveExecuteResponse{
 				Error:       vterrors.ToVTRPC(err),
-				ReservedId:  reservedID,
-				TabletAlias: alias,
+				ReservedId:  state.ReservedID,
+				TabletAlias: state.TabletAlias,
 			}, nil
 		}
 		return nil, vterrors.ToGRPC(err)
 	}
 	return &querypb.ReserveExecuteResponse{
 		Result:      sqltypes.ResultToProto3(result),
-		ReservedId:  reservedID,
-		TabletAlias: alias,
+		ReservedId:  state.ReservedID,
+		TabletAlias: state.TabletAlias,
 	}, nil
 }
 
@@ -391,14 +391,14 @@ func (q *query) ReserveStreamExecute(request *querypb.ReserveStreamExecuteReques
 		request.EffectiveCallerId,
 		request.ImmediateCallerId,
 	)
-	reservedID, alias, err := q.server.ReserveStreamExecute(ctx, request.Target, request.PreQueries, request.Query.Sql, request.Query.BindVariables, request.TransactionId, request.Options, func(reply *sqltypes.Result) error {
+	state, err := q.server.ReserveStreamExecute(ctx, request.Target, request.PreQueries, request.Query.Sql, request.Query.BindVariables, request.TransactionId, request.Options, func(reply *sqltypes.Result) error {
 		return stream.Send(&querypb.ReserveStreamExecuteResponse{
 			Result: sqltypes.ResultToProto3(reply),
 		})
 	})
 	errInLastPacket := stream.Send(&querypb.ReserveStreamExecuteResponse{
-		ReservedId:  reservedID,
-		TabletAlias: alias,
+		ReservedId:  state.ReservedID,
+		TabletAlias: state.TabletAlias,
 	})
 	if err != nil {
 		return vterrors.ToGRPC(err)
@@ -414,24 +414,24 @@ func (q *query) ReserveBeginExecute(ctx context.Context, request *querypb.Reserv
 		request.EffectiveCallerId,
 		request.ImmediateCallerId,
 	)
-	result, transactionID, reservedID, alias, err := q.server.ReserveBeginExecute(ctx, request.Target, request.PreQueries, request.PostBeginQueries, request.Query.Sql, request.Query.BindVariables, request.Options)
+	state, result, err := q.server.ReserveBeginExecute(ctx, request.Target, request.PreQueries, request.PostBeginQueries, request.Query.Sql, request.Query.BindVariables, request.Options)
 	if err != nil {
 		// if we have a valid reservedID, return the error in-band
-		if reservedID != 0 {
+		if state.ReservedID != 0 {
 			return &querypb.ReserveBeginExecuteResponse{
 				Error:         vterrors.ToVTRPC(err),
-				TransactionId: transactionID,
-				ReservedId:    reservedID,
-				TabletAlias:   alias,
+				TransactionId: state.TransactionID,
+				ReservedId:    state.ReservedID,
+				TabletAlias:   state.TabletAlias,
 			}, nil
 		}
 		return nil, vterrors.ToGRPC(err)
 	}
 	return &querypb.ReserveBeginExecuteResponse{
 		Result:        sqltypes.ResultToProto3(result),
-		TransactionId: transactionID,
-		ReservedId:    reservedID,
-		TabletAlias:   alias,
+		TransactionId: state.TransactionID,
+		ReservedId:    state.ReservedID,
+		TabletAlias:   state.TabletAlias,
 	}, nil
 }
 
@@ -442,15 +442,15 @@ func (q *query) ReserveBeginStreamExecute(request *querypb.ReserveBeginStreamExe
 		request.EffectiveCallerId,
 		request.ImmediateCallerId,
 	)
-	transactionID, reservedID, alias, err := q.server.ReserveBeginStreamExecute(ctx, request.Target, request.PreQueries, request.PostBeginQueries, request.Query.Sql, request.Query.BindVariables, request.Options, func(reply *sqltypes.Result) error {
+	state, err := q.server.ReserveBeginStreamExecute(ctx, request.Target, request.PreQueries, request.PostBeginQueries, request.Query.Sql, request.Query.BindVariables, request.Options, func(reply *sqltypes.Result) error {
 		return stream.Send(&querypb.ReserveBeginStreamExecuteResponse{
 			Result: sqltypes.ResultToProto3(reply),
 		})
 	})
 	errInLastPacket := stream.Send(&querypb.ReserveBeginStreamExecuteResponse{
-		ReservedId:    reservedID,
-		TransactionId: transactionID,
-		TabletAlias:   alias,
+		ReservedId:    state.ReservedID,
+		TransactionId: state.TransactionID,
+		TabletAlias:   state.TabletAlias,
 	})
 	if err != nil {
 		return vterrors.ToGRPC(err)

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -17,11 +17,10 @@ limitations under the License.
 package grpctabletconn
 
 import (
+	"context"
 	"flag"
 	"io"
 	"sync"
-
-	"context"
 
 	"google.golang.org/grpc"
 
@@ -180,11 +179,11 @@ func (conn *gRPCQueryClient) StreamExecute(ctx context.Context, target *querypb.
 }
 
 // Begin starts a transaction.
-func (conn *gRPCQueryClient) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (transactionID int64, alias *topodatapb.TabletAlias, err error) {
+func (conn *gRPCQueryClient) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (state queryservice.TransactionState, err error) {
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.cc == nil {
-		return 0, nil, tabletconn.ConnClosed
+		return state, tabletconn.ConnClosed
 	}
 
 	req := &querypb.BeginRequest{
@@ -195,9 +194,11 @@ func (conn *gRPCQueryClient) Begin(ctx context.Context, target *querypb.Target, 
 	}
 	br, err := conn.c.Begin(ctx, req)
 	if err != nil {
-		return 0, nil, tabletconn.ErrorFromGRPC(err)
+		return state, tabletconn.ErrorFromGRPC(err)
 	}
-	return br.TransactionId, br.TabletAlias, nil
+	state.TransactionID = br.TransactionId
+	state.TabletAlias = br.TabletAlias
+	return state, nil
 }
 
 // Commit commits the ongoing transaction.
@@ -419,11 +420,11 @@ func (conn *gRPCQueryClient) ReadTransaction(ctx context.Context, target *queryp
 }
 
 // BeginExecute starts a transaction and runs an Execute.
-func (conn *gRPCQueryClient) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, query string, bindVars map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (result *sqltypes.Result, transactionID int64, alias *topodatapb.TabletAlias, err error) {
+func (conn *gRPCQueryClient) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, query string, bindVars map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (state queryservice.TransactionState, result *sqltypes.Result, err error) {
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.cc == nil {
-		return nil, 0, nil, tabletconn.ConnClosed
+		return state, nil, tabletconn.ConnClosed
 	}
 
 	req := &querypb.BeginExecuteRequest{
@@ -440,20 +441,22 @@ func (conn *gRPCQueryClient) BeginExecute(ctx context.Context, target *querypb.T
 	}
 	reply, err := conn.c.BeginExecute(ctx, req)
 	if err != nil {
-		return nil, 0, nil, tabletconn.ErrorFromGRPC(err)
+		return state, nil, tabletconn.ErrorFromGRPC(err)
 	}
+	state.TransactionID = reply.TransactionId
+	state.TabletAlias = conn.tablet.Alias
 	if reply.Error != nil {
-		return nil, reply.TransactionId, conn.tablet.Alias, tabletconn.ErrorFromVTRPC(reply.Error)
+		return state, nil, tabletconn.ErrorFromVTRPC(reply.Error)
 	}
-	return sqltypes.Proto3ToResult(reply.Result), reply.TransactionId, conn.tablet.Alias, nil
+	return state, sqltypes.Proto3ToResult(reply.Result), nil
 }
 
 // BeginStreamExecute starts a transaction and runs an Execute.
-func (conn *gRPCQueryClient) BeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, query string, bindVars map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (transactionID int64, alias *topodatapb.TabletAlias, err error) {
+func (conn *gRPCQueryClient) BeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, query string, bindVars map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (state queryservice.TransactionState, err error) {
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.cc == nil {
-		return 0, nil, tabletconn.ConnClosed
+		return state, tabletconn.ConnClosed
 	}
 
 	stream, err := func() (queryservicepb.Query_BeginStreamExecuteClient, error) {
@@ -482,25 +485,25 @@ func (conn *gRPCQueryClient) BeginStreamExecute(ctx context.Context, target *que
 		return stream, nil
 	}()
 	if err != nil {
-		return 0, nil, err
+		return state, err
 	}
 	var fields []*querypb.Field
 	for {
 		ser, err := stream.Recv()
-		if transactionID == 0 && ser.GetTransactionId() != 0 {
-			transactionID = ser.GetTransactionId()
+		if state.TransactionID == 0 && ser.GetTransactionId() != 0 {
+			state.TransactionID = ser.GetTransactionId()
 		}
-		if alias == nil && ser.GetTabletAlias() != nil {
-			alias = ser.GetTabletAlias()
+		if state.TabletAlias == nil && ser.GetTabletAlias() != nil {
+			state.TabletAlias = ser.GetTabletAlias()
 		}
 
 		if err != nil {
-			return transactionID, alias, tabletconn.ErrorFromGRPC(err)
+			return state, tabletconn.ErrorFromGRPC(err)
 		}
 
 		// The last stream receive will not have a result, so callback will not be called for it.
 		if ser.Result == nil {
-			return transactionID, alias, nil
+			return state, nil
 		}
 
 		if fields == nil {
@@ -508,9 +511,9 @@ func (conn *gRPCQueryClient) BeginStreamExecute(ctx context.Context, target *que
 		}
 		if err := callback(sqltypes.CustomProto3ToResult(fields, ser.Result)); err != nil {
 			if err == nil || err == io.EOF {
-				return transactionID, alias, nil
+				return state, nil
 			}
-			return transactionID, alias, err
+			return state, err
 		}
 	}
 }
@@ -750,11 +753,11 @@ func (conn *gRPCQueryClient) HandlePanic(err *error) {
 }
 
 // ReserveBeginExecute implements the queryservice interface
-func (conn *gRPCQueryClient) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, int64, *topodatapb.TabletAlias, error) {
+func (conn *gRPCQueryClient) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (state queryservice.ReservedTransactionState, result *sqltypes.Result, err error) {
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.cc == nil {
-		return nil, 0, 0, nil, tabletconn.ConnClosed
+		return state, nil, tabletconn.ConnClosed
 	}
 
 	req := &querypb.ReserveBeginExecuteRequest{
@@ -771,21 +774,24 @@ func (conn *gRPCQueryClient) ReserveBeginExecute(ctx context.Context, target *qu
 	}
 	reply, err := conn.c.ReserveBeginExecute(ctx, req)
 	if err != nil {
-		return nil, 0, 0, nil, tabletconn.ErrorFromGRPC(err)
+		return state, nil, tabletconn.ErrorFromGRPC(err)
 	}
+	state.ReservedID = reply.ReservedId
+	state.TransactionID = reply.TransactionId
+	state.TabletAlias = conn.tablet.Alias
 	if reply.Error != nil {
-		return nil, reply.TransactionId, reply.ReservedId, conn.tablet.Alias, tabletconn.ErrorFromVTRPC(reply.Error)
+		return state, nil, tabletconn.ErrorFromVTRPC(reply.Error)
 	}
 
-	return sqltypes.Proto3ToResult(reply.Result), reply.TransactionId, reply.ReservedId, conn.tablet.Alias, nil
+	return state, sqltypes.Proto3ToResult(reply.Result), nil
 }
 
 // ReserveBeginStreamExecute implements the queryservice interface
-func (conn *gRPCQueryClient) ReserveBeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (transactionID int64, reservedID int64, alias *topodatapb.TabletAlias, err error) {
+func (conn *gRPCQueryClient) ReserveBeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (state queryservice.ReservedTransactionState, err error) {
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.cc == nil {
-		return 0, 0, nil, tabletconn.ConnClosed
+		return state, tabletconn.ConnClosed
 	}
 
 	stream, err := func() (queryservicepb.Query_ReserveBeginStreamExecuteClient, error) {
@@ -814,29 +820,29 @@ func (conn *gRPCQueryClient) ReserveBeginStreamExecute(ctx context.Context, targ
 		return stream, nil
 	}()
 	if err != nil {
-		return 0, 0, nil, tabletconn.ErrorFromGRPC(err)
+		return state, tabletconn.ErrorFromGRPC(err)
 	}
 
 	var fields []*querypb.Field
 	for {
 		ser, err := stream.Recv()
-		if transactionID == 0 && ser.GetTransactionId() != 0 {
-			transactionID = ser.GetTransactionId()
+		if state.TransactionID == 0 && ser.GetTransactionId() != 0 {
+			state.TransactionID = ser.GetTransactionId()
 		}
-		if reservedID == 0 && ser.GetReservedId() != 0 {
-			reservedID = ser.GetReservedId()
+		if state.ReservedID == 0 && ser.GetReservedId() != 0 {
+			state.ReservedID = ser.GetReservedId()
 		}
-		if alias == nil && ser.GetTabletAlias() != nil {
-			alias = ser.GetTabletAlias()
+		if state.TabletAlias == nil && ser.GetTabletAlias() != nil {
+			state.TabletAlias = ser.GetTabletAlias()
 		}
 
 		if err != nil {
-			return transactionID, reservedID, alias, tabletconn.ErrorFromGRPC(err)
+			return state, tabletconn.ErrorFromGRPC(err)
 		}
 
 		// The last stream receive will not have a result, so callback will not be called for it.
 		if ser.Result == nil {
-			return transactionID, reservedID, alias, nil
+			return state, nil
 		}
 
 		if fields == nil {
@@ -844,19 +850,19 @@ func (conn *gRPCQueryClient) ReserveBeginStreamExecute(ctx context.Context, targ
 		}
 		if err := callback(sqltypes.CustomProto3ToResult(fields, ser.Result)); err != nil {
 			if err == nil || err == io.EOF {
-				return transactionID, reservedID, alias, nil
+				return state, nil
 			}
-			return transactionID, reservedID, alias, err
+			return state, err
 		}
 	}
 }
 
 // ReserveExecute implements the queryservice interface
-func (conn *gRPCQueryClient) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, *topodatapb.TabletAlias, error) {
+func (conn *gRPCQueryClient) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (state queryservice.ReservedState, result *sqltypes.Result, err error) {
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.cc == nil {
-		return nil, 0, nil, tabletconn.ConnClosed
+		return state, nil, tabletconn.ConnClosed
 	}
 
 	req := &querypb.ReserveExecuteRequest{
@@ -873,21 +879,23 @@ func (conn *gRPCQueryClient) ReserveExecute(ctx context.Context, target *querypb
 	}
 	reply, err := conn.c.ReserveExecute(ctx, req)
 	if err != nil {
-		return nil, 0, nil, tabletconn.ErrorFromGRPC(err)
+		return state, nil, tabletconn.ErrorFromGRPC(err)
 	}
+	state.ReservedID = reply.ReservedId
+	state.TabletAlias = reply.TabletAlias
 	if reply.Error != nil {
-		return nil, reply.ReservedId, conn.tablet.Alias, tabletconn.ErrorFromVTRPC(reply.Error)
+		return state, nil, tabletconn.ErrorFromVTRPC(reply.Error)
 	}
 
-	return sqltypes.Proto3ToResult(reply.Result), reply.ReservedId, conn.tablet.Alias, nil
+	return state, sqltypes.Proto3ToResult(reply.Result), nil
 }
 
 // ReserveStreamExecute implements the queryservice interface
-func (conn *gRPCQueryClient) ReserveStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (reservedID int64, alias *topodatapb.TabletAlias, err error) {
+func (conn *gRPCQueryClient) ReserveStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (state queryservice.ReservedState, err error) {
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.cc == nil {
-		return 0, nil, tabletconn.ConnClosed
+		return state, tabletconn.ConnClosed
 	}
 
 	stream, err := func() (queryservicepb.Query_ReserveStreamExecuteClient, error) {
@@ -916,26 +924,26 @@ func (conn *gRPCQueryClient) ReserveStreamExecute(ctx context.Context, target *q
 		return stream, nil
 	}()
 	if err != nil {
-		return 0, nil, tabletconn.ErrorFromGRPC(err)
+		return state, tabletconn.ErrorFromGRPC(err)
 	}
 
 	var fields []*querypb.Field
 	for {
 		ser, err := stream.Recv()
-		if reservedID == 0 && ser.GetReservedId() != 0 {
-			reservedID = ser.GetReservedId()
+		if state.ReservedID == 0 && ser.GetReservedId() != 0 {
+			state.ReservedID = ser.GetReservedId()
 		}
-		if alias == nil && ser.GetTabletAlias() != nil {
-			alias = ser.GetTabletAlias()
+		if state.TabletAlias == nil && ser.GetTabletAlias() != nil {
+			state.TabletAlias = ser.GetTabletAlias()
 		}
 
 		if err != nil {
-			return reservedID, alias, tabletconn.ErrorFromGRPC(err)
+			return state, tabletconn.ErrorFromGRPC(err)
 		}
 
 		// The last stream receive will not have a result, so callback will not be called for it.
 		if ser.Result == nil {
-			return reservedID, alias, nil
+			return state, nil
 		}
 
 		if fields == nil {
@@ -943,9 +951,9 @@ func (conn *gRPCQueryClient) ReserveStreamExecute(ctx context.Context, target *q
 		}
 		if err := callback(sqltypes.CustomProto3ToResult(fields, ser.Result)); err != nil {
 			if err == nil || err == io.EOF {
-				return reservedID, alias, nil
+				return state, nil
 			}
-			return reservedID, alias, err
+			return state, err
 		}
 	}
 }

--- a/go/vt/vttablet/queryservice/fakes/stream_health_query_service.go
+++ b/go/vt/vttablet/queryservice/fakes/stream_health_query_service.go
@@ -58,8 +58,8 @@ func NewStreamHealthQueryService(target *querypb.Target) *StreamHealthQueryServi
 }
 
 // Begin implemented as a no op
-func (q *StreamHealthQueryService) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (int64, *topodatapb.TabletAlias, error) {
-	return 0, nil, nil
+func (q *StreamHealthQueryService) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (queryservice.TransactionState, error) {
+	return queryservice.TransactionState{}, nil
 }
 
 // Execute implemented as a no op

--- a/go/vt/vttablet/queryservice/wrapped.go
+++ b/go/vt/vttablet/queryservice/wrapped.go
@@ -19,8 +19,6 @@ package queryservice
 import (
 	"context"
 
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -85,13 +83,13 @@ type wrappedService struct {
 	wrapper WrapperFunc
 }
 
-func (ws *wrappedService) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (transactionID int64, alias *topodatapb.TabletAlias, err error) {
+func (ws *wrappedService) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (state TransactionState, err error) {
 	err = ws.wrapper(ctx, target, ws.impl, "Begin", false, func(ctx context.Context, target *querypb.Target, conn QueryService) (bool, error) {
 		var innerErr error
-		transactionID, alias, innerErr = conn.Begin(ctx, target, options)
+		state, innerErr = conn.Begin(ctx, target, options)
 		return canRetry(ctx, innerErr), innerErr
 	})
-	return transactionID, alias, err
+	return state, err
 }
 
 func (ws *wrappedService) Commit(ctx context.Context, target *querypb.Target, transactionID int64) (int64, error) {
@@ -205,25 +203,25 @@ func (ws *wrappedService) StreamExecute(ctx context.Context, target *querypb.Tar
 	})
 }
 
-func (ws *wrappedService) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, query string, bindVars map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (qr *sqltypes.Result, transactionID int64, alias *topodatapb.TabletAlias, err error) {
+func (ws *wrappedService) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, query string, bindVars map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (state TransactionState, qr *sqltypes.Result, err error) {
 	inDedicatedConn := reservedID != 0
 	err = ws.wrapper(ctx, target, ws.impl, "BeginExecute", inDedicatedConn, func(ctx context.Context, target *querypb.Target, conn QueryService) (bool, error) {
 		var innerErr error
-		qr, transactionID, alias, innerErr = conn.BeginExecute(ctx, target, preQueries, query, bindVars, reservedID, options)
+		state, qr, innerErr = conn.BeginExecute(ctx, target, preQueries, query, bindVars, reservedID, options)
 		return canRetry(ctx, innerErr) && !inDedicatedConn, innerErr
 	})
-	return qr, transactionID, alias, err
+	return state, qr, err
 }
 
 // BeginStreamExecute implements the QueryService interface
-func (ws *wrappedService) BeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, query string, bindVars map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (transactionID int64, alias *topodatapb.TabletAlias, err error) {
+func (ws *wrappedService) BeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, query string, bindVars map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (state TransactionState, err error) {
 	inDedicatedConn := reservedID != 0
 	err = ws.wrapper(ctx, target, ws.impl, "BeginStreamExecute", inDedicatedConn, func(ctx context.Context, target *querypb.Target, conn QueryService) (bool, error) {
 		var innerErr error
-		transactionID, alias, innerErr = conn.BeginStreamExecute(ctx, target, preQueries, query, bindVars, reservedID, options, callback)
+		state, innerErr = conn.BeginStreamExecute(ctx, target, preQueries, query, bindVars, reservedID, options, callback)
 		return canRetry(ctx, innerErr) && !inDedicatedConn, innerErr
 	})
-	return transactionID, alias, err
+	return state, err
 }
 
 func (ws *wrappedService) MessageStream(ctx context.Context, target *querypb.Target, name string, callback func(*sqltypes.Result) error) error {
@@ -275,53 +273,47 @@ func (ws *wrappedService) HandlePanic(err *error) {
 }
 
 // ReserveBeginExecute implements the QueryService interface
-func (ws *wrappedService) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, int64, *topodatapb.TabletAlias, error) {
-	var res *sqltypes.Result
-	var transactionID, reservedID int64
-	var alias *topodatapb.TabletAlias
-	err := ws.wrapper(ctx, target, ws.impl, "ReserveBeginExecute", false, func(ctx context.Context, target *querypb.Target, conn QueryService) (bool, error) {
+func (ws *wrappedService) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (state ReservedTransactionState, res *sqltypes.Result, err error) {
+	err = ws.wrapper(ctx, target, ws.impl, "ReserveBeginExecute", false, func(ctx context.Context, target *querypb.Target, conn QueryService) (bool, error) {
 		var err error
-		res, transactionID, reservedID, alias, err = conn.ReserveBeginExecute(ctx, target, preQueries, postBeginQueries, sql, bindVariables, options)
+		state, res, err = conn.ReserveBeginExecute(ctx, target, preQueries, postBeginQueries, sql, bindVariables, options)
 		return canRetry(ctx, err), err
 	})
 
-	return res, transactionID, reservedID, alias, err
+	return state, res, err
 }
 
 // ReserveBeginStreamExecute implements the QueryService interface
-func (ws *wrappedService) ReserveBeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (transactionID int64, reservedID int64, alias *topodatapb.TabletAlias, err error) {
+func (ws *wrappedService) ReserveBeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (state ReservedTransactionState, err error) {
 	err = ws.wrapper(ctx, target, ws.impl, "ReserveBeginStreamExecute", false, func(ctx context.Context, target *querypb.Target, conn QueryService) (bool, error) {
 		var innerErr error
-		transactionID, reservedID, alias, innerErr = conn.ReserveBeginStreamExecute(ctx, target, preQueries, postBeginQueries, sql, bindVariables, options, callback)
+		state, innerErr = conn.ReserveBeginStreamExecute(ctx, target, preQueries, postBeginQueries, sql, bindVariables, options, callback)
 		return canRetry(ctx, innerErr), innerErr
 	})
-	return transactionID, reservedID, alias, err
+	return state, err
 }
 
 // ReserveExecute implements the QueryService interface
-func (ws *wrappedService) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, *topodatapb.TabletAlias, error) {
+func (ws *wrappedService) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (state ReservedState, res *sqltypes.Result, err error) {
 	inDedicatedConn := transactionID != 0
-	var res *sqltypes.Result
-	var reservedID int64
-	var alias *topodatapb.TabletAlias
-	err := ws.wrapper(ctx, target, ws.impl, "ReserveExecute", inDedicatedConn, func(ctx context.Context, target *querypb.Target, conn QueryService) (bool, error) {
+	err = ws.wrapper(ctx, target, ws.impl, "ReserveExecute", inDedicatedConn, func(ctx context.Context, target *querypb.Target, conn QueryService) (bool, error) {
 		var err error
-		res, reservedID, alias, err = conn.ReserveExecute(ctx, target, preQueries, sql, bindVariables, transactionID, options)
+		state, res, err = conn.ReserveExecute(ctx, target, preQueries, sql, bindVariables, transactionID, options)
 		return canRetry(ctx, err) && !inDedicatedConn, err
 	})
 
-	return res, reservedID, alias, err
+	return state, res, err
 }
 
 // ReserveStreamExecute implements the QueryService interface
-func (ws *wrappedService) ReserveStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (reservedID int64, alias *topodatapb.TabletAlias, err error) {
+func (ws *wrappedService) ReserveStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (state ReservedState, err error) {
 	inDedicatedConn := transactionID != 0
 	err = ws.wrapper(ctx, target, ws.impl, "ReserveStreamExecute", inDedicatedConn, func(ctx context.Context, target *querypb.Target, conn QueryService) (bool, error) {
 		var innerErr error
-		reservedID, alias, innerErr = conn.ReserveStreamExecute(ctx, target, preQueries, sql, bindVariables, transactionID, options, callback)
+		state, innerErr = conn.ReserveStreamExecute(ctx, target, preQueries, sql, bindVariables, transactionID, options, callback)
 		return canRetry(ctx, innerErr) && !inDedicatedConn, innerErr
 	})
-	return reservedID, alias, err
+	return state, err
 }
 
 func (ws *wrappedService) Release(ctx context.Context, target *querypb.Target, transactionID, reservedID int64) error {

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -19,14 +19,13 @@ limitations under the License.
 package sandboxconn
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
-
-	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"
@@ -228,15 +227,15 @@ func (sbc *SandboxConn) StreamExecute(ctx context.Context, target *querypb.Targe
 }
 
 // Begin is part of the QueryService interface.
-func (sbc *SandboxConn) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (int64, *topodatapb.TabletAlias, error) {
+func (sbc *SandboxConn) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (queryservice.TransactionState, error) {
 	return sbc.begin(ctx, target, nil, 0, options)
 }
 
-func (sbc *SandboxConn) begin(ctx context.Context, target *querypb.Target, preQueries []string, reservedID int64, options *querypb.ExecuteOptions) (int64, *topodatapb.TabletAlias, error) {
+func (sbc *SandboxConn) begin(ctx context.Context, target *querypb.Target, preQueries []string, reservedID int64, options *querypb.ExecuteOptions) (queryservice.TransactionState, error) {
 	sbc.BeginCount.Add(1)
 	err := sbc.getError()
 	if err != nil {
-		return 0, nil, err
+		return queryservice.TransactionState{}, err
 	}
 
 	transactionID := reservedID
@@ -246,10 +245,10 @@ func (sbc *SandboxConn) begin(ctx context.Context, target *querypb.Target, preQu
 	for _, preQuery := range preQueries {
 		_, err := sbc.Execute(ctx, target, preQuery, nil, transactionID, reservedID, options)
 		if err != nil {
-			return 0, nil, err
+			return queryservice.TransactionState{}, err
 		}
 	}
-	return transactionID, sbc.tablet.Alias, nil
+	return queryservice.TransactionState{TransactionID: transactionID, TabletAlias: sbc.tablet.Alias}, nil
 }
 
 // Commit is part of the QueryService interface.
@@ -360,29 +359,29 @@ func (sbc *SandboxConn) ReadTransaction(ctx context.Context, target *querypb.Tar
 }
 
 // BeginExecute is part of the QueryService interface.
-func (sbc *SandboxConn) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, query string, bindVars map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, *topodatapb.TabletAlias, error) {
-	transactionID, alias, err := sbc.begin(ctx, target, preQueries, reservedID, options)
-	if transactionID != 0 {
-		sbc.setTxReservedID(transactionID, reservedID)
+func (sbc *SandboxConn) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, query string, bindVars map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (queryservice.TransactionState, *sqltypes.Result, error) {
+	state, err := sbc.begin(ctx, target, preQueries, reservedID, options)
+	if state.TransactionID != 0 {
+		sbc.setTxReservedID(state.TransactionID, reservedID)
 	}
 	if err != nil {
-		return nil, 0, nil, err
+		return queryservice.TransactionState{}, nil, err
 	}
-	result, err := sbc.Execute(ctx, target, query, bindVars, transactionID, reservedID, options)
-	return result, transactionID, alias, err
+	result, err := sbc.Execute(ctx, target, query, bindVars, state.TransactionID, reservedID, options)
+	return state, result, err
 }
 
 // BeginStreamExecute is part of the QueryService interface.
-func (sbc *SandboxConn) BeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (int64, *topodatapb.TabletAlias, error) {
-	transactionID, alias, err := sbc.begin(ctx, target, preQueries, reservedID, options)
-	if transactionID != 0 {
-		sbc.setTxReservedID(transactionID, reservedID)
+func (sbc *SandboxConn) BeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (queryservice.TransactionState, error) {
+	state, err := sbc.begin(ctx, target, preQueries, reservedID, options)
+	if state.TransactionID != 0 {
+		sbc.setTxReservedID(state.TransactionID, reservedID)
 	}
 	if err != nil {
-		return 0, nil, err
+		return queryservice.TransactionState{}, err
 	}
-	err = sbc.StreamExecute(ctx, target, sql, bindVariables, transactionID, reservedID, options, callback)
-	return transactionID, alias, err
+	err = sbc.StreamExecute(ctx, target, sql, bindVariables, state.TransactionID, reservedID, options, callback)
+	return state, err
 }
 
 // MessageStream is part of the QueryService interface.
@@ -507,49 +506,57 @@ func (sbc *SandboxConn) HandlePanic(err *error) {
 }
 
 // ReserveBeginExecute implements the QueryService interface
-func (sbc *SandboxConn) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, int64, *topodatapb.TabletAlias, error) {
+func (sbc *SandboxConn) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (queryservice.ReservedTransactionState, *sqltypes.Result, error) {
 	reservedID := sbc.reserve(ctx, target, preQueries, bindVariables, 0, options)
-	result, transactionID, alias, err := sbc.BeginExecute(ctx, target, postBeginQueries, sql, bindVariables, reservedID, options)
-	if transactionID != 0 {
-		sbc.setTxReservedID(transactionID, reservedID)
+	state, result, err := sbc.BeginExecute(ctx, target, postBeginQueries, sql, bindVariables, reservedID, options)
+	if state.TransactionID != 0 {
+		sbc.setTxReservedID(state.TransactionID, reservedID)
 	}
-	if err != nil {
-		return nil, transactionID, reservedID, alias, err
-	}
-	return result, transactionID, reservedID, alias, nil
+	return queryservice.ReservedTransactionState{
+		ReservedID:    reservedID,
+		TransactionID: state.TransactionID,
+		TabletAlias:   state.TabletAlias,
+	}, result, err
 }
 
 // ReserveBeginStreamExecute is part of the QueryService interface.
-func (sbc *SandboxConn) ReserveBeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (int64, int64, *topodatapb.TabletAlias, error) {
+func (sbc *SandboxConn) ReserveBeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (queryservice.ReservedTransactionState, error) {
 	reservedID := sbc.reserve(ctx, target, preQueries, bindVariables, 0, options)
-	transactionID, alias, err := sbc.BeginStreamExecute(ctx, target, postBeginQueries, sql, bindVariables, reservedID, options, callback)
-	if transactionID != 0 {
-		sbc.setTxReservedID(transactionID, reservedID)
+	state, err := sbc.BeginStreamExecute(ctx, target, postBeginQueries, sql, bindVariables, reservedID, options, callback)
+	if state.TransactionID != 0 {
+		sbc.setTxReservedID(state.TransactionID, reservedID)
 	}
-	return transactionID, reservedID, alias, err
+	return queryservice.ReservedTransactionState{
+		ReservedID:    reservedID,
+		TransactionID: state.TransactionID,
+		TabletAlias:   state.TabletAlias,
+	}, err
 }
 
 // ReserveExecute implements the QueryService interface
-func (sbc *SandboxConn) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, *topodatapb.TabletAlias, error) {
+func (sbc *SandboxConn) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (queryservice.ReservedState, *sqltypes.Result, error) {
 	reservedID := sbc.reserve(ctx, target, preQueries, bindVariables, transactionID, options)
 	result, err := sbc.Execute(ctx, target, sql, bindVariables, transactionID, reservedID, options)
 	if transactionID != 0 {
 		sbc.setTxReservedID(transactionID, reservedID)
 	}
-	if err != nil {
-		return nil, 0, nil, err
-	}
-	return result, reservedID, sbc.tablet.Alias, nil
+	return queryservice.ReservedState{
+		ReservedID:  reservedID,
+		TabletAlias: sbc.tablet.Alias,
+	}, result, err
 }
 
 // ReserveStreamExecute is part of the QueryService interface.
-func (sbc *SandboxConn) ReserveStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (int64, *topodatapb.TabletAlias, error) {
+func (sbc *SandboxConn) ReserveStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (queryservice.ReservedState, error) {
 	reservedID := sbc.reserve(ctx, target, preQueries, bindVariables, transactionID, options)
 	err := sbc.StreamExecute(ctx, target, sql, bindVariables, transactionID, reservedID, options, callback)
 	if transactionID != 0 {
 		sbc.setTxReservedID(transactionID, reservedID)
 	}
-	return reservedID, sbc.tablet.Alias, err
+	return queryservice.ReservedState{
+		ReservedID:  reservedID,
+		TabletAlias: sbc.tablet.Alias,
+	}, err
 }
 
 func (sbc *SandboxConn) reserve(ctx context.Context, target *querypb.Target, preQueries []string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) int64 {

--- a/go/vt/vttablet/tabletconntest/fakequeryservice.go
+++ b/go/vt/vttablet/tabletconntest/fakequeryservice.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tabletconntest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
-
-	"context"
 
 	"google.golang.org/protobuf/proto"
 
@@ -140,9 +139,9 @@ func (f *FakeQueryService) checkTargetCallerID(ctx context.Context, name string,
 const beginTransactionID int64 = 9990
 
 // Begin is part of the queryservice.QueryService interface
-func (f *FakeQueryService) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (int64, *topodatapb.TabletAlias, error) {
+func (f *FakeQueryService) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (queryservice.TransactionState, error) {
 	if f.HasBeginError {
-		return 0, nil, f.TabletError
+		return queryservice.TransactionState{}, f.TabletError
 	}
 	if f.Panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -151,7 +150,7 @@ func (f *FakeQueryService) Begin(ctx context.Context, target *querypb.Target, op
 	if !proto.Equal(options, TestExecuteOptions) {
 		f.t.Errorf("invalid Execute.ExecuteOptions: got %v expected %v", options, TestExecuteOptions)
 	}
-	return beginTransactionID, TestAlias, nil
+	return queryservice.TransactionState{TransactionID: beginTransactionID, TabletAlias: TestAlias}, nil
 }
 
 // commitTransactionID is a test transaction id for Commit.
@@ -554,19 +553,19 @@ var ExecuteBatchQueryResultList = []sqltypes.Result{
 }
 
 // BeginExecute combines Begin and Execute.
-func (f *FakeQueryService) BeginExecute(ctx context.Context, target *querypb.Target, _ []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, *topodatapb.TabletAlias, error) {
-	transactionID, _, err := f.Begin(ctx, target, options)
+func (f *FakeQueryService) BeginExecute(ctx context.Context, target *querypb.Target, _ []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (queryservice.TransactionState, *sqltypes.Result, error) {
+	state, err := f.Begin(ctx, target, options)
 	if err != nil {
-		return nil, 0, nil, err
+		return state, nil, err
 	}
 
 	// TODO(deepthi): what alias should we actually return here?
-	result, err := f.Execute(ctx, target, sql, bindVariables, transactionID, reservedID, options)
-	return result, transactionID, nil, err
+	result, err := f.Execute(ctx, target, sql, bindVariables, state.TransactionID, reservedID, options)
+	return state, result, err
 }
 
 // BeginStreamExecute combines Begin and StreamExecute.
-func (f *FakeQueryService) BeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (int64, *topodatapb.TabletAlias, error) {
+func (f *FakeQueryService) BeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (queryservice.TransactionState, error) {
 	panic("FakeQueryService does not implement BeginStreamExecute")
 }
 
@@ -695,22 +694,22 @@ func (f *FakeQueryService) QueryServiceByAlias(_ *topodatapb.TabletAlias, _ *que
 }
 
 // ReserveBeginExecute satisfies the Gateway interface
-func (f *FakeQueryService) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, int64, *topodatapb.TabletAlias, error) {
+func (f *FakeQueryService) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (queryservice.ReservedTransactionState, *sqltypes.Result, error) {
 	panic("implement me")
 }
 
 // ReserveBeginStreamExecute satisfies the Gateway interface
-func (f *FakeQueryService) ReserveBeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (int64, int64, *topodatapb.TabletAlias, error) {
+func (f *FakeQueryService) ReserveBeginStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (queryservice.ReservedTransactionState, error) {
 	panic("implement me")
 }
 
 // ReserveExecute implements the QueryService interface
-func (f *FakeQueryService) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, *topodatapb.TabletAlias, error) {
+func (f *FakeQueryService) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (queryservice.ReservedState, *sqltypes.Result, error) {
 	panic("implement me")
 }
 
 // ReserveStreamExecute satisfies the Gateway interface
-func (f *FakeQueryService) ReserveStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (int64, *topodatapb.TabletAlias, error) {
+func (f *FakeQueryService) ReserveStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (queryservice.ReservedState, error) {
 	panic("implement me")
 }
 

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -476,11 +476,12 @@ func (tsv *TabletServer) SchemaEngine() *schema.Engine {
 }
 
 // Begin starts a new transaction. This is allowed only if the state is StateServing.
-func (tsv *TabletServer) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (transactionID int64, tablet *topodatapb.TabletAlias, err error) {
+func (tsv *TabletServer) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (state queryservice.TransactionState, err error) {
 	return tsv.begin(ctx, target, nil, 0, options)
 }
 
-func (tsv *TabletServer) begin(ctx context.Context, target *querypb.Target, preQueries []string, reservedID int64, options *querypb.ExecuteOptions) (transactionID int64, tablet *topodatapb.TabletAlias, err error) {
+func (tsv *TabletServer) begin(ctx context.Context, target *querypb.Target, preQueries []string, reservedID int64, options *querypb.ExecuteOptions) (state queryservice.TransactionState, err error) {
+	state.TabletAlias = tsv.alias
 	err = tsv.execRequest(
 		ctx, tsv.QueryTimeout.Get(),
 		"Begin", "begin", nil,
@@ -490,8 +491,8 @@ func (tsv *TabletServer) begin(ctx context.Context, target *querypb.Target, preQ
 			if tsv.txThrottler.Throttle() {
 				return vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "Transaction throttled")
 			}
-			var beginSQL string
-			transactionID, beginSQL, err = tsv.te.Begin(ctx, preQueries, reservedID, options)
+			transactionID, beginSQL, err := tsv.te.Begin(ctx, preQueries, reservedID, options)
+			state.TransactionID = transactionID
 			logStats.TransactionID = transactionID
 			logStats.ReservedID = reservedID
 
@@ -508,7 +509,7 @@ func (tsv *TabletServer) begin(ctx context.Context, target *querypb.Target, preQ
 			return err
 		},
 	)
-	return transactionID, tsv.alias, err
+	return state, err
 }
 
 // Commit commits the specified transaction.
@@ -845,26 +846,26 @@ func (tsv *TabletServer) StreamExecute(ctx context.Context, target *querypb.Targ
 }
 
 // BeginExecute combines Begin and Execute.
-func (tsv *TabletServer) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, *topodatapb.TabletAlias, error) {
+func (tsv *TabletServer) BeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, reservedID int64, options *querypb.ExecuteOptions) (queryservice.TransactionState, *sqltypes.Result, error) {
 
 	// Disable hot row protection in case of reserve connection.
 	if tsv.enableHotRowProtection && reservedID == 0 {
 		txDone, err := tsv.beginWaitForSameRangeTransactions(ctx, target, options, sql, bindVariables)
 		if err != nil {
-			return nil, 0, nil, err
+			return queryservice.TransactionState{}, nil, err
 		}
 		if txDone != nil {
 			defer txDone()
 		}
 	}
 
-	transactionID, alias, err := tsv.begin(ctx, target, preQueries, reservedID, options)
+	state, err := tsv.begin(ctx, target, preQueries, reservedID, options)
 	if err != nil {
-		return nil, 0, nil, err
+		return state, nil, err
 	}
 
-	result, err := tsv.Execute(ctx, target, sql, bindVariables, transactionID, reservedID, options)
-	return result, transactionID, alias, err
+	result, err := tsv.Execute(ctx, target, sql, bindVariables, state.TransactionID, reservedID, options)
+	return state, result, err
 }
 
 // BeginStreamExecute combines Begin and StreamExecute.
@@ -877,14 +878,14 @@ func (tsv *TabletServer) BeginStreamExecute(
 	reservedID int64,
 	options *querypb.ExecuteOptions,
 	callback func(*sqltypes.Result) error,
-) (int64, *topodatapb.TabletAlias, error) {
-	transactionID, alias, err := tsv.begin(ctx, target, preQueries, reservedID, options)
+) (queryservice.TransactionState, error) {
+	state, err := tsv.begin(ctx, target, preQueries, reservedID, options)
 	if err != nil {
-		return 0, nil, err
+		return state, err
 	}
 
-	err = tsv.StreamExecute(ctx, target, sql, bindVariables, transactionID, reservedID, options, callback)
-	return transactionID, alias, err
+	err = tsv.StreamExecute(ctx, target, sql, bindVariables, state.TransactionID, reservedID, options, callback)
+	return state, err
 }
 
 func (tsv *TabletServer) beginWaitForSameRangeTransactions(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions, sql string, bindVariables map[string]*querypb.BindVariable) (txserializer.DoneFunc, error) {
@@ -1040,26 +1041,26 @@ func (tsv *TabletServer) execDML(ctx context.Context, target *querypb.Target, qu
 		return 0, err
 	}
 
-	transactionID, _, err := tsv.Begin(ctx, target, nil)
+	state, err := tsv.Begin(ctx, target, nil)
 	if err != nil {
 		return 0, err
 	}
 	// If transaction was not committed by the end, it means
 	// that there was an error, roll it back.
 	defer func() {
-		if transactionID != 0 {
-			tsv.Rollback(ctx, target, transactionID)
+		if state.TransactionID != 0 {
+			tsv.Rollback(ctx, target, state.TransactionID)
 		}
 	}()
-	qr, err := tsv.Execute(ctx, target, query, bv, transactionID, 0, nil)
+	qr, err := tsv.Execute(ctx, target, query, bv, state.TransactionID, 0, nil)
 	if err != nil {
 		return 0, err
 	}
-	if _, err = tsv.Commit(ctx, target, transactionID); err != nil {
-		transactionID = 0
+	if _, err = tsv.Commit(ctx, target, state.TransactionID); err != nil {
+		state.TransactionID = 0
 		return 0, err
 	}
-	transactionID = 0
+	state.TransactionID = 0
 	return int64(qr.RowsAffected), nil
 }
 
@@ -1096,10 +1097,9 @@ func (tsv *TabletServer) VStreamResults(ctx context.Context, target *querypb.Tar
 }
 
 // ReserveBeginExecute implements the QueryService interface
-func (tsv *TabletServer) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, int64, *topodatapb.TabletAlias, error) {
-
+func (tsv *TabletServer) ReserveBeginExecute(ctx context.Context, target *querypb.Target, preQueries []string, postBeginQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (state queryservice.ReservedTransactionState, result *sqltypes.Result, err error) {
 	var connID int64
-	var err error
+	state.TabletAlias = tsv.alias
 
 	err = tsv.execRequest(
 		ctx, tsv.QueryTimeout.Get(),
@@ -1118,11 +1118,13 @@ func (tsv *TabletServer) ReserveBeginExecute(ctx context.Context, target *queryp
 	)
 
 	if err != nil {
-		return nil, 0, 0, nil, err
+		return state, nil, err
 	}
+	state.ReservedID = connID
+	state.TransactionID = connID
 
-	result, err := tsv.Execute(ctx, target, sql, bindVariables, connID, connID, options)
-	return result, connID, connID, tsv.alias, err
+	result, err = tsv.Execute(ctx, target, sql, bindVariables, state.TransactionID, state.ReservedID, options)
+	return state, result, err
 }
 
 // ReserveBeginStreamExecute combines Begin and StreamExecute.
@@ -1135,9 +1137,9 @@ func (tsv *TabletServer) ReserveBeginStreamExecute(
 	bindVariables map[string]*querypb.BindVariable,
 	options *querypb.ExecuteOptions,
 	callback func(*sqltypes.Result) error,
-) (int64, int64, *topodatapb.TabletAlias, error) {
+) (state queryservice.ReservedTransactionState, err error) {
 	var connID int64
-	var err error
+	state.TabletAlias = tsv.alias
 
 	err = tsv.execRequest(
 		ctx, tsv.QueryTimeout.Get(),
@@ -1156,17 +1158,19 @@ func (tsv *TabletServer) ReserveBeginStreamExecute(
 	)
 
 	if err != nil {
-		return 0, 0, nil, err
+		return state, err
 	}
+	state.ReservedID = connID
+	state.TransactionID = connID
+	state.TabletAlias = tsv.alias
 
-	err = tsv.StreamExecute(ctx, target, sql, bindVariables, connID, connID, options, callback)
-	return connID, connID, tsv.alias, err
+	err = tsv.StreamExecute(ctx, target, sql, bindVariables, state.TransactionID, state.ReservedID, options, callback)
+	return state, err
 }
 
 // ReserveExecute implements the QueryService interface
-func (tsv *TabletServer) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, int64, *topodatapb.TabletAlias, error) {
-	var connID int64
-	var err error
+func (tsv *TabletServer) ReserveExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (state queryservice.ReservedState, result *sqltypes.Result, err error) {
+	state.TabletAlias = tsv.alias
 
 	allowOnShutdown := false
 	timeout := tsv.QueryTimeout.Get()
@@ -1182,22 +1186,22 @@ func (tsv *TabletServer) ReserveExecute(ctx context.Context, target *querypb.Tar
 		target, options, allowOnShutdown,
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
-			connID, err = tsv.te.Reserve(ctx, options, transactionID, preQueries)
+			state.ReservedID, err = tsv.te.Reserve(ctx, options, transactionID, preQueries)
 			if err != nil {
 				return err
 			}
 			logStats.TransactionID = transactionID
-			logStats.ReservedID = connID
+			logStats.ReservedID = state.ReservedID
 			return nil
 		},
 	)
 
 	if err != nil {
-		return nil, 0, nil, err
+		return state, nil, err
 	}
 
-	result, err := tsv.Execute(ctx, target, sql, bindVariables, connID, connID, options)
-	return result, connID, tsv.alias, err
+	result, err = tsv.Execute(ctx, target, sql, bindVariables, state.ReservedID, state.ReservedID, options)
+	return state, result, err
 }
 
 // ReserveStreamExecute combines Begin and StreamExecute.
@@ -1210,9 +1214,8 @@ func (tsv *TabletServer) ReserveStreamExecute(
 	transactionID int64,
 	options *querypb.ExecuteOptions,
 	callback func(*sqltypes.Result) error,
-) (int64, *topodatapb.TabletAlias, error) {
-	var connID int64
-	var err error
+) (state queryservice.ReservedState, err error) {
+	state.TabletAlias = tsv.alias
 
 	allowOnShutdown := false
 	var timeout time.Duration
@@ -1228,22 +1231,22 @@ func (tsv *TabletServer) ReserveStreamExecute(
 		target, options, allowOnShutdown,
 		func(ctx context.Context, logStats *tabletenv.LogStats) error {
 			defer tsv.stats.QueryTimings.Record("RESERVE", time.Now())
-			connID, err = tsv.te.Reserve(ctx, options, transactionID, preQueries)
+			state.ReservedID, err = tsv.te.Reserve(ctx, options, transactionID, preQueries)
 			if err != nil {
 				return err
 			}
-			logStats.TransactionID = connID
-			logStats.ReservedID = connID
+			logStats.TransactionID = state.ReservedID
+			logStats.ReservedID = state.ReservedID
 			return nil
 		},
 	)
 
 	if err != nil {
-		return 0, nil, err
+		return state, err
 	}
 
-	err = tsv.StreamExecute(ctx, target, sql, bindVariables, connID, connID, options, callback)
-	return connID, tsv.alias, err
+	err = tsv.StreamExecute(ctx, target, sql, bindVariables, state.ReservedID, state.ReservedID, options, callback)
+	return state, err
 }
 
 // Release implements the QueryService interface

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -125,17 +125,17 @@ func TestBeginOnReplica(t *testing.T) {
 	options := querypb.ExecuteOptions{
 		TransactionIsolation: querypb.ExecuteOptions_CONSISTENT_SNAPSHOT_READ_ONLY,
 	}
-	txID, alias, err := tsv.Begin(ctx, &target, &options)
+	state, err := tsv.Begin(ctx, &target, &options)
 	require.NoError(t, err, "failed to create read only tx on replica")
-	assert.Equal(t, tsv.alias, alias, "Wrong tablet alias from Begin")
-	_, err = tsv.Rollback(ctx, &target, txID)
+	assert.Equal(t, tsv.alias, state.TabletAlias, "Wrong tablet alias from Begin")
+	_, err = tsv.Rollback(ctx, &target, state.TransactionID)
 	require.NoError(t, err, "failed to rollback read only tx")
 
 	// test that we can still create transactions even in read-only mode
 	options = querypb.ExecuteOptions{}
-	txID, _, err = tsv.Begin(ctx, &target, &options)
+	state, err = tsv.Begin(ctx, &target, &options)
 	require.NoError(t, err, "expected write tx to be allowed")
-	_, err = tsv.Rollback(ctx, &target, txID)
+	_, err = tsv.Rollback(ctx, &target, state.TransactionID)
 	require.NoError(t, err)
 }
 
@@ -145,18 +145,18 @@ func TestTabletServerPrimaryToReplica(t *testing.T) {
 	defer tsv.StopService()
 	defer db.Close()
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-	txid1, _, err := tsv.Begin(ctx, &target, nil)
+	state1, err := tsv.Begin(ctx, &target, nil)
 	require.NoError(t, err)
 
-	_, err = tsv.Execute(ctx, &target, "update test_table set `name` = 2 where pk = 1", nil, txid1, 0, nil)
+	_, err = tsv.Execute(ctx, &target, "update test_table set `name` = 2 where pk = 1", nil, state1.TransactionID, 0, nil)
 	require.NoError(t, err)
-	err = tsv.Prepare(ctx, &target, txid1, "aa")
+	err = tsv.Prepare(ctx, &target, state1.TransactionID, "aa")
 	require.NoError(t, err)
-	txid2, _, err := tsv.Begin(ctx, &target, nil)
+	state2, err := tsv.Begin(ctx, &target, nil)
 	require.NoError(t, err)
 
 	// This makes txid2 busy
-	conn2, err := tsv.te.txPool.GetAndLock(txid2, "for query")
+	conn2, err := tsv.te.txPool.GetAndLock(state2.TransactionID, "for query")
 	require.NoError(t, err)
 	ch := make(chan bool)
 	go func() {
@@ -430,7 +430,7 @@ func TestTabletServerBeginFail(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
 	tsv.Begin(ctx, &target, nil)
-	_, _, err := tsv.Begin(ctx, &target, nil)
+	_, err := tsv.Begin(ctx, &target, nil)
 	require.EqualError(t, err, "transaction pool aborting request due to already expired context", "Begin err")
 }
 
@@ -451,11 +451,11 @@ func TestTabletServerCommitTransaction(t *testing.T) {
 	db.AddQuery(executeSQL, executeSQLResult)
 
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-	transactionID, _, err := tsv.Begin(ctx, &target, nil)
+	state, err := tsv.Begin(ctx, &target, nil)
 	require.NoError(t, err)
-	_, err = tsv.Execute(ctx, &target, executeSQL, nil, transactionID, 0, nil)
+	_, err = tsv.Execute(ctx, &target, executeSQL, nil, state.TransactionID, 0, nil)
 	require.NoError(t, err)
-	_, err = tsv.Commit(ctx, &target, transactionID)
+	_, err = tsv.Commit(ctx, &target, state.TransactionID)
 	require.NoError(t, err)
 }
 
@@ -489,14 +489,14 @@ func TestTabletServerRollback(t *testing.T) {
 	db.AddQuery(executeSQL, executeSQLResult)
 
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-	transactionID, _, err := tsv.Begin(ctx, &target, nil)
+	state, err := tsv.Begin(ctx, &target, nil)
 	require.NoError(t, err)
 	if err != nil {
 		t.Fatalf("call TabletServer.Begin failed: %v", err)
 	}
-	_, err = tsv.Execute(ctx, &target, executeSQL, nil, transactionID, 0, nil)
+	_, err = tsv.Execute(ctx, &target, executeSQL, nil, state.TransactionID, 0, nil)
 	require.NoError(t, err)
-	_, err = tsv.Rollback(ctx, &target, transactionID)
+	_, err = tsv.Rollback(ctx, &target, state.TransactionID)
 	require.NoError(t, err)
 }
 
@@ -506,12 +506,12 @@ func TestTabletServerPrepare(t *testing.T) {
 	defer tsv.StopService()
 	defer db.Close()
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-	transactionID, _, err := tsv.Begin(ctx, &target, nil)
+	state, err := tsv.Begin(ctx, &target, nil)
 	require.NoError(t, err)
-	_, err = tsv.Execute(ctx, &target, "update test_table set `name` = 2 where pk = 1", nil, transactionID, 0, nil)
+	_, err = tsv.Execute(ctx, &target, "update test_table set `name` = 2 where pk = 1", nil, state.TransactionID, 0, nil)
 	require.NoError(t, err)
 	defer tsv.RollbackPrepared(ctx, &target, "aa", 0)
-	err = tsv.Prepare(ctx, &target, transactionID, "aa")
+	err = tsv.Prepare(ctx, &target, state.TransactionID, "aa")
 	require.NoError(t, err)
 }
 
@@ -521,11 +521,11 @@ func TestTabletServerCommitPrepared(t *testing.T) {
 	defer tsv.StopService()
 	defer db.Close()
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-	transactionID, _, err := tsv.Begin(ctx, &target, nil)
+	state, err := tsv.Begin(ctx, &target, nil)
 	require.NoError(t, err)
-	_, err = tsv.Execute(ctx, &target, "update test_table set `name` = 2 where pk = 1", nil, transactionID, 0, nil)
+	_, err = tsv.Execute(ctx, &target, "update test_table set `name` = 2 where pk = 1", nil, state.TransactionID, 0, nil)
 	require.NoError(t, err)
-	err = tsv.Prepare(ctx, &target, transactionID, "aa")
+	err = tsv.Prepare(ctx, &target, state.TransactionID, "aa")
 	require.NoError(t, err)
 	defer tsv.RollbackPrepared(ctx, &target, "aa", 0)
 	err = tsv.CommitPrepared(ctx, &target, "aa")
@@ -572,15 +572,15 @@ func TestTabletServerReserveConnection(t *testing.T) {
 	options := &querypb.ExecuteOptions{}
 
 	// reserve a connection
-	_, rID, _, err := tsv.ReserveExecute(ctx, &target, nil, "select 42", nil, 0, options)
+	state, _, err := tsv.ReserveExecute(ctx, &target, nil, "select 42", nil, 0, options)
 	require.NoError(t, err)
 
 	// run a query in it
-	_, err = tsv.Execute(ctx, &target, "select 42", nil, 0, rID, options)
+	_, err = tsv.Execute(ctx, &target, "select 42", nil, 0, state.ReservedID, options)
 	require.NoError(t, err)
 
 	// release the connection
-	err = tsv.Release(ctx, &target, 0, rID)
+	err = tsv.Release(ctx, &target, 0, state.ReservedID)
 	require.NoError(t, err)
 }
 
@@ -621,7 +621,7 @@ func TestMakeSureToCloseDbConnWhenBeginQueryFails(t *testing.T) {
 	options := &querypb.ExecuteOptions{}
 
 	// run a query with a non-existent reserved id
-	_, _, _, _, err := tsv.ReserveBeginExecute(ctx, &target, []string{}, nil, "select 42", nil, options)
+	_, _, err := tsv.ReserveBeginExecute(ctx, &target, []string{}, nil, "select 42", nil, options)
 	require.Error(t, err)
 }
 
@@ -635,36 +635,36 @@ func TestTabletServerReserveAndBeginCommit(t *testing.T) {
 	options := &querypb.ExecuteOptions{}
 
 	// reserve a connection and a transaction
-	_, txID, rID, _, err := tsv.ReserveBeginExecute(ctx, &target, nil, nil, "select 42", nil, options)
+	state, _, err := tsv.ReserveBeginExecute(ctx, &target, nil, nil, "select 42", nil, options)
 	require.NoError(t, err)
 	defer func() {
 		// fallback so the test finishes quickly
-		tsv.Release(ctx, &target, txID, rID)
+		tsv.Release(ctx, &target, state.TransactionID, state.ReservedID)
 	}()
 
 	// run a query in it
-	_, err = tsv.Execute(ctx, &target, "select 42", nil, txID, rID, options)
+	_, err = tsv.Execute(ctx, &target, "select 42", nil, state.TransactionID, state.ReservedID, options)
 	require.NoError(t, err)
 
 	// run a query in a non-existent connection
-	_, err = tsv.Execute(ctx, &target, "select 42", nil, txID, rID+100, options)
+	_, err = tsv.Execute(ctx, &target, "select 42", nil, state.TransactionID, state.ReservedID+100, options)
 	require.Error(t, err)
-	_, err = tsv.Execute(ctx, &target, "select 42", nil, txID+100, rID, options)
+	_, err = tsv.Execute(ctx, &target, "select 42", nil, state.TransactionID+100, state.ReservedID, options)
 	require.Error(t, err)
 
 	// commit
-	newRID, err := tsv.Commit(ctx, &target, txID)
+	newRID, err := tsv.Commit(ctx, &target, state.TransactionID)
 	require.NoError(t, err)
-	assert.NotEqual(t, rID, newRID)
-	rID = newRID
+	assert.NotEqual(t, state.ReservedID, newRID)
+	rID := newRID
 
 	// begin and rollback
-	_, txID, _, err = tsv.BeginExecute(ctx, &target, nil, "select 42", nil, rID, options)
+	beginState, _, err := tsv.BeginExecute(ctx, &target, nil, "select 42", nil, rID, options)
 	require.NoError(t, err)
-	assert.Equal(t, newRID, txID)
+	assert.Equal(t, newRID, beginState.TransactionID)
 	rID = newRID
 
-	newRID, err = tsv.Rollback(ctx, &target, txID)
+	newRID, err = tsv.Rollback(ctx, &target, beginState.TransactionID)
 	require.NoError(t, err)
 	assert.NotEqual(t, rID, newRID)
 	rID = newRID
@@ -684,13 +684,13 @@ func TestTabletServerRollbackPrepared(t *testing.T) {
 	defer tsv.StopService()
 	defer db.Close()
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-	transactionID, _, err := tsv.Begin(ctx, &target, nil)
+	state, err := tsv.Begin(ctx, &target, nil)
 	require.NoError(t, err)
-	_, err = tsv.Execute(ctx, &target, "update test_table set `name` = 2 where pk = 1", nil, transactionID, 0, nil)
+	_, err = tsv.Execute(ctx, &target, "update test_table set `name` = 2 where pk = 1", nil, state.TransactionID, 0, nil)
 	require.NoError(t, err)
-	err = tsv.Prepare(ctx, &target, transactionID, "aa")
+	err = tsv.Prepare(ctx, &target, state.TransactionID, "aa")
 	require.NoError(t, err)
-	err = tsv.RollbackPrepared(ctx, &target, "aa", transactionID)
+	err = tsv.RollbackPrepared(ctx, &target, "aa", state.TransactionID)
 	require.NoError(t, err)
 }
 
@@ -820,11 +820,11 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		_, tx1, _, err := tsv.BeginExecute(ctx, &target, nil, q1, bvTx1, 0, nil)
+		state1, _, err := tsv.BeginExecute(ctx, &target, nil, q1, bvTx1, 0, nil)
 		if err != nil {
 			t.Errorf("failed to execute query: %s: %s", q1, err)
 		}
-		if _, err := tsv.Commit(ctx, &target, tx1); err != nil {
+		if _, err := tsv.Commit(ctx, &target, state1.TransactionID); err != nil {
 			t.Errorf("call TabletServer.Commit failed: %v", err)
 		}
 	}()
@@ -835,7 +835,7 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 		defer wg.Done()
 
 		<-tx1Started
-		_, tx2, _, err := tsv.BeginExecute(ctx, &target, nil, q2, bvTx2, 0, nil)
+		state2, _, err := tsv.BeginExecute(ctx, &target, nil, q2, bvTx2, 0, nil)
 		if err != nil {
 			t.Errorf("failed to execute query: %s: %s", q2, err)
 		}
@@ -844,7 +844,7 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 		// open a second connection while the request of the first connection is
 		// still pending.
 		<-tx3Finished
-		if _, err := tsv.Commit(ctx, &target, tx2); err != nil {
+		if _, err := tsv.Commit(ctx, &target, state2.TransactionID); err != nil {
 			t.Errorf("call TabletServer.Commit failed: %v", err)
 		}
 	}()
@@ -855,11 +855,11 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 		defer wg.Done()
 
 		<-tx1Started
-		_, tx3, _, err := tsv.BeginExecute(ctx, &target, nil, q3, bvTx3, 0, nil)
+		state3, _, err := tsv.BeginExecute(ctx, &target, nil, q3, bvTx3, 0, nil)
 		if err != nil {
 			t.Errorf("failed to execute query: %s: %s", q3, err)
 		}
-		if _, err := tsv.Commit(ctx, &target, tx3); err != nil {
+		if _, err := tsv.Commit(ctx, &target, state3.TransactionID); err != nil {
 			t.Errorf("call TabletServer.Commit failed: %v", err)
 		}
 		close(tx3Finished)
@@ -888,9 +888,9 @@ func TestDMLQueryWithoutWhereClause(t *testing.T) {
 
 	db.AddQuery(q+" limit 10001", &sqltypes.Result{})
 
-	_, txid, _, err := tsv.BeginExecute(ctx, &target, nil, q, nil, 0, nil)
+	state, _, err := tsv.BeginExecute(ctx, &target, nil, q, nil, 0, nil)
 	require.NoError(t, err)
-	_, err = tsv.Commit(ctx, &target, txid)
+	_, err = tsv.Commit(ctx, &target, state.TransactionID)
 	require.NoError(t, err)
 }
 
@@ -946,12 +946,12 @@ func TestSerializeTransactionsSameRow_ConcurrentTransactions(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		_, tx1, _, err := tsv.BeginExecute(ctx, &target, nil, q1, bvTx1, 0, nil)
+		state1, _, err := tsv.BeginExecute(ctx, &target, nil, q1, bvTx1, 0, nil)
 		if err != nil {
 			t.Errorf("failed to execute query: %s: %s", q1, err)
 		}
 
-		if _, err := tsv.Commit(ctx, &target, tx1); err != nil {
+		if _, err := tsv.Commit(ctx, &target, state1.TransactionID); err != nil {
 			t.Errorf("call TabletServer.Commit failed: %v", err)
 		}
 	}()
@@ -965,12 +965,12 @@ func TestSerializeTransactionsSameRow_ConcurrentTransactions(t *testing.T) {
 		// In that case, we would see less than 3 pending transactions.
 		<-tx1Started
 
-		_, tx2, _, err := tsv.BeginExecute(ctx, &target, nil, q2, bvTx2, 0, nil)
+		state2, _, err := tsv.BeginExecute(ctx, &target, nil, q2, bvTx2, 0, nil)
 		if err != nil {
 			t.Errorf("failed to execute query: %s: %s", q2, err)
 		}
 
-		if _, err := tsv.Commit(ctx, &target, tx2); err != nil {
+		if _, err := tsv.Commit(ctx, &target, state2.TransactionID); err != nil {
 			t.Errorf("call TabletServer.Commit failed: %v", err)
 		}
 	}()
@@ -984,12 +984,12 @@ func TestSerializeTransactionsSameRow_ConcurrentTransactions(t *testing.T) {
 		// In that case, we would see less than 3 pending transactions.
 		<-tx1Started
 
-		_, tx3, _, err := tsv.BeginExecute(ctx, &target, nil, q3, bvTx3, 0, nil)
+		state3, _, err := tsv.BeginExecute(ctx, &target, nil, q3, bvTx3, 0, nil)
 		if err != nil {
 			t.Errorf("failed to execute query: %s: %s", q3, err)
 		}
 
-		if _, err := tsv.Commit(ctx, &target, tx3); err != nil {
+		if _, err := tsv.Commit(ctx, &target, state3.TransactionID); err != nil {
 			t.Errorf("call TabletServer.Commit failed: %v", err)
 		}
 	}()
@@ -1078,11 +1078,11 @@ func TestSerializeTransactionsSameRow_TooManyPendingRequests(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		_, tx1, _, err := tsv.BeginExecute(ctx, &target, nil, q1, bvTx1, 0, nil)
+		state1, _, err := tsv.BeginExecute(ctx, &target, nil, q1, bvTx1, 0, nil)
 		if err != nil {
 			t.Errorf("failed to execute query: %s: %s", q1, err)
 		}
-		if _, err := tsv.Commit(ctx, &target, tx1); err != nil {
+		if _, err := tsv.Commit(ctx, &target, state1.TransactionID); err != nil {
 			t.Errorf("call TabletServer.Commit failed: %v", err)
 		}
 	}()
@@ -1094,7 +1094,7 @@ func TestSerializeTransactionsSameRow_TooManyPendingRequests(t *testing.T) {
 		defer close(tx2Failed)
 
 		<-tx1Started
-		_, _, _, err := tsv.BeginExecute(ctx, &target, nil, q2, bvTx2, 0, nil)
+		_, _, err := tsv.BeginExecute(ctx, &target, nil, q2, bvTx2, 0, nil)
 		if err == nil || vterrors.Code(err) != vtrpcpb.Code_RESOURCE_EXHAUSTED || err.Error() != "hot row protection: too many queued transactions (1 >= 1) for the same row (table + WHERE clause: 'test_table where pk = 1 and `name` = 1')" {
 			t.Errorf("tx2 should have failed because there are too many pending requests: %v", err)
 		}
@@ -1165,12 +1165,12 @@ func TestSerializeTransactionsSameRow_RequestCanceled(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		_, tx1, _, err := tsv.BeginExecute(ctx, &target, nil, q1, bvTx1, 0, nil)
+		state1, _, err := tsv.BeginExecute(ctx, &target, nil, q1, bvTx1, 0, nil)
 		if err != nil {
 			t.Errorf("failed to execute query: %s: %s", q1, err)
 		}
 
-		if _, err := tsv.Commit(ctx, &target, tx1); err != nil {
+		if _, err := tsv.Commit(ctx, &target, state1.TransactionID); err != nil {
 			t.Errorf("call TabletServer.Commit failed: %v", err)
 		}
 	}()
@@ -1185,7 +1185,7 @@ func TestSerializeTransactionsSameRow_RequestCanceled(t *testing.T) {
 		// Wait until tx1 has started to make the test deterministic.
 		<-tx1Started
 
-		_, _, _, err := tsv.BeginExecute(ctxTx2, &target, nil, q2, bvTx2, 0, nil)
+		_, _, err := tsv.BeginExecute(ctxTx2, &target, nil, q2, bvTx2, 0, nil)
 		if err == nil || vterrors.Code(err) != vtrpcpb.Code_CANCELED || err.Error() != "context canceled" {
 			t.Errorf("tx2 should have failed because the context was canceled: %v", err)
 		}
@@ -1202,12 +1202,12 @@ func TestSerializeTransactionsSameRow_RequestCanceled(t *testing.T) {
 			t.Error(err)
 		}
 
-		_, tx3, _, err := tsv.BeginExecute(ctx, &target, nil, q3, bvTx3, 0, nil)
+		state3, _, err := tsv.BeginExecute(ctx, &target, nil, q3, bvTx3, 0, nil)
 		if err != nil {
 			t.Errorf("failed to execute query: %s: %s", q3, err)
 		}
 
-		if _, err := tsv.Commit(ctx, &target, tx3); err != nil {
+		if _, err := tsv.Commit(ctx, &target, state3.TransactionID); err != nil {
 			t.Errorf("call TabletServer.Commit failed: %v", err)
 		}
 	}()
@@ -1767,11 +1767,11 @@ func TestReserveBeginExecute(t *testing.T) {
 	defer db.Close()
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
 
-	_, transactionID, reservedID, _, err := tsv.ReserveBeginExecute(ctx, &target, []string{"select 43"}, nil, "select 42", nil, &querypb.ExecuteOptions{})
+	state, _, err := tsv.ReserveBeginExecute(ctx, &target, []string{"select 43"}, nil, "select 42", nil, &querypb.ExecuteOptions{})
 	require.NoError(t, err)
 
-	assert.Greater(t, transactionID, int64(0), "transactionID")
-	assert.Equal(t, reservedID, transactionID, "reservedID should equal transactionID")
+	assert.Greater(t, state.TransactionID, int64(0), "transactionID")
+	assert.Equal(t, state.ReservedID, state.TransactionID, "reservedID should equal transactionID")
 	expected := []string{
 		"select 43",
 		"begin",
@@ -1781,7 +1781,7 @@ func TestReserveBeginExecute(t *testing.T) {
 	for _, exp := range expected {
 		assert.Contains(t, splitOutput, exp, "expected queries to run")
 	}
-	err = tsv.Release(ctx, &target, transactionID, reservedID)
+	err = tsv.Release(ctx, &target, state.TransactionID, state.ReservedID)
 	require.NoError(t, err)
 }
 
@@ -1792,9 +1792,9 @@ func TestReserveExecute_WithoutTx(t *testing.T) {
 
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
 
-	_, reservedID, _, err := tsv.ReserveExecute(ctx, &target, []string{"select 43"}, "select 42", nil, 0, &querypb.ExecuteOptions{})
+	state, _, err := tsv.ReserveExecute(ctx, &target, []string{"select 43"}, "select 42", nil, 0, &querypb.ExecuteOptions{})
 	require.NoError(t, err)
-	assert.NotEqual(t, int64(0), reservedID, "reservedID should not be zero")
+	assert.NotEqual(t, int64(0), state.ReservedID, "reservedID should not be zero")
 	expected := []string{
 		"select 43",
 		"select 42 from dual limit 10001",
@@ -1803,7 +1803,7 @@ func TestReserveExecute_WithoutTx(t *testing.T) {
 	for _, exp := range expected {
 		assert.Contains(t, splitOutput, exp, "expected queries to run")
 	}
-	err = tsv.Release(ctx, &target, 0, reservedID)
+	err = tsv.Release(ctx, &target, 0, state.ReservedID)
 	require.NoError(t, err)
 }
 
@@ -1813,15 +1813,15 @@ func TestReserveExecute_WithTx(t *testing.T) {
 	defer db.Close()
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
 
-	transactionID, _, err := tsv.Begin(ctx, &target, &querypb.ExecuteOptions{})
+	beginState, err := tsv.Begin(ctx, &target, &querypb.ExecuteOptions{})
 	require.NoError(t, err)
-	require.NotEqual(t, int64(0), transactionID)
+	require.NotEqual(t, int64(0), beginState.TransactionID)
 	db.ResetQueryLog()
 
-	_, reservedID, _, err := tsv.ReserveExecute(ctx, &target, []string{"select 43"}, "select 42", nil, transactionID, &querypb.ExecuteOptions{})
+	reserveState, _, err := tsv.ReserveExecute(ctx, &target, []string{"select 43"}, "select 42", nil, beginState.TransactionID, &querypb.ExecuteOptions{})
 	require.NoError(t, err)
-	defer tsv.Release(ctx, &target, transactionID, reservedID)
-	assert.Equal(t, transactionID, reservedID, "reservedID should be equal to transactionID")
+	defer tsv.Release(ctx, &target, beginState.TransactionID, reserveState.ReservedID)
+	assert.Equal(t, beginState.TransactionID, reserveState.ReservedID, "reservedID should be equal to transactionID")
 	expected := []string{
 		"select 43",
 		"select 42 from dual limit 10001",
@@ -1830,7 +1830,7 @@ func TestReserveExecute_WithTx(t *testing.T) {
 	for _, exp := range expected {
 		assert.Contains(t, splitOutput, exp, "expected queries to run")
 	}
-	err = tsv.Release(ctx, &target, transactionID, reservedID)
+	err = tsv.Release(ctx, &target, beginState.TransactionID, reserveState.ReservedID)
 	require.NoError(t, err)
 }
 
@@ -1873,26 +1873,31 @@ func TestRelease(t *testing.T) {
 			db.AddQueryPattern(".*", &sqltypes.Result{})
 			target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
 
-			var err error
 			var transactionID, reservedID int64
 
 			switch {
 			case test.begin && test.reserve:
-				_, transactionID, reservedID, _, err = tsv.ReserveBeginExecute(ctx, &target, []string{"select 1212"}, nil, "select 42", nil, &querypb.ExecuteOptions{})
+				state, _, err := tsv.ReserveBeginExecute(ctx, &target, []string{"select 1212"}, nil, "select 42", nil, &querypb.ExecuteOptions{})
+				require.NoError(t, err)
+				transactionID = state.TransactionID
+				reservedID = state.ReservedID
 				require.NotEqual(t, int64(0), transactionID)
 				require.NotEqual(t, int64(0), reservedID)
 			case test.begin:
-				_, transactionID, _, err = tsv.BeginExecute(ctx, &target, nil, "select 42", nil, 0, &querypb.ExecuteOptions{})
+				state, _, err := tsv.BeginExecute(ctx, &target, nil, "select 42", nil, 0, &querypb.ExecuteOptions{})
+				require.NoError(t, err)
+				transactionID = state.TransactionID
 				require.NotEqual(t, int64(0), transactionID)
 			case test.reserve:
-				_, reservedID, _, err = tsv.ReserveExecute(ctx, &target, nil, "select 42", nil, 0, &querypb.ExecuteOptions{})
+				state, _, err := tsv.ReserveExecute(ctx, &target, nil, "select 42", nil, 0, &querypb.ExecuteOptions{})
+				require.NoError(t, err)
+				reservedID = state.ReservedID
 				require.NotEqual(t, int64(0), reservedID)
 			}
-			require.NoError(t, err)
 
 			db.ResetQueryLog()
 
-			err = tsv.Release(ctx, &target, transactionID, reservedID)
+			err := tsv.Release(ctx, &target, transactionID, reservedID)
 			if test.err {
 				require.Error(t, err)
 			} else {
@@ -1916,41 +1921,41 @@ func TestReserveStats(t *testing.T) {
 	ctx := callerid.NewContext(context.Background(), nil, callerID)
 
 	// Starts reserved connection and transaction
-	_, rbeTxID, rbeRID, _, err := tsv.ReserveBeginExecute(ctx, &target, nil, nil, "select 42", nil, &querypb.ExecuteOptions{})
+	rbeState, _, err := tsv.ReserveBeginExecute(ctx, &target, nil, nil, "select 42", nil, &querypb.ExecuteOptions{})
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, tsv.te.txPool.env.Stats().UserActiveReservedCount.Counts()["test"])
 
 	// Starts reserved connection
-	_, reRID, _, err := tsv.ReserveExecute(ctx, &target, nil, "select 42", nil, 0, &querypb.ExecuteOptions{})
+	reState, _, err := tsv.ReserveExecute(ctx, &target, nil, "select 42", nil, 0, &querypb.ExecuteOptions{})
 	require.NoError(t, err)
 	assert.EqualValues(t, 2, tsv.te.txPool.env.Stats().UserActiveReservedCount.Counts()["test"])
 
 	// Use previous reserved connection to start transaction
-	_, reBeTxID, _, err := tsv.BeginExecute(ctx, &target, nil, "select 42", nil, reRID, &querypb.ExecuteOptions{})
+	reBeState, _, err := tsv.BeginExecute(ctx, &target, nil, "select 42", nil, reState.ReservedID, &querypb.ExecuteOptions{})
 	require.NoError(t, err)
 	assert.EqualValues(t, 2, tsv.te.txPool.env.Stats().UserActiveReservedCount.Counts()["test"])
 
 	// Starts transaction.
-	_, beTxID, _, err := tsv.BeginExecute(ctx, &target, nil, "select 42", nil, 0, &querypb.ExecuteOptions{})
+	beState, _, err := tsv.BeginExecute(ctx, &target, nil, "select 42", nil, 0, &querypb.ExecuteOptions{})
 	require.NoError(t, err)
 	assert.EqualValues(t, 2, tsv.te.txPool.env.Stats().UserActiveReservedCount.Counts()["test"])
 
 	// Reserved the connection on previous transaction
-	_, beReRID, _, err := tsv.ReserveExecute(ctx, &target, nil, "select 42", nil, beTxID, &querypb.ExecuteOptions{})
+	beReState, _, err := tsv.ReserveExecute(ctx, &target, nil, "select 42", nil, beState.TransactionID, &querypb.ExecuteOptions{})
 	require.NoError(t, err)
 	assert.EqualValues(t, 3, tsv.te.txPool.env.Stats().UserActiveReservedCount.Counts()["test"])
 
-	err = tsv.Release(ctx, &target, rbeTxID, rbeRID)
+	err = tsv.Release(ctx, &target, rbeState.TransactionID, rbeState.ReservedID)
 	require.NoError(t, err)
 	assert.EqualValues(t, 2, tsv.te.txPool.env.Stats().UserActiveReservedCount.Counts()["test"])
 	assert.EqualValues(t, 1, tsv.te.txPool.env.Stats().UserReservedCount.Counts()["test"])
 
-	err = tsv.Release(ctx, &target, reBeTxID, reRID)
+	err = tsv.Release(ctx, &target, reBeState.TransactionID, reState.ReservedID)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, tsv.te.txPool.env.Stats().UserActiveReservedCount.Counts()["test"])
 	assert.EqualValues(t, 2, tsv.te.txPool.env.Stats().UserReservedCount.Counts()["test"])
 
-	err = tsv.Release(ctx, &target, beTxID, beReRID)
+	err = tsv.Release(ctx, &target, beState.TransactionID, beReState.ReservedID)
 	require.NoError(t, err)
 	assert.Zero(t, tsv.te.txPool.env.Stats().UserActiveReservedCount.Counts()["test"])
 	assert.EqualValues(t, 3, tsv.te.txPool.env.Stats().UserReservedCount.Counts()["test"])
@@ -1980,16 +1985,16 @@ func TestDatabaseNameReplaceByKeyspaceNameExecuteMethod(t *testing.T) {
 	target := tsv.sm.target
 
 	// Testing Execute Method
-	transactionID, _, err := tsv.Begin(ctx, target, nil)
+	state, err := tsv.Begin(ctx, target, nil)
 	require.NoError(t, err)
-	res, err := tsv.Execute(ctx, target, executeSQL, nil, transactionID, 0, &querypb.ExecuteOptions{
+	res, err := tsv.Execute(ctx, target, executeSQL, nil, state.TransactionID, 0, &querypb.ExecuteOptions{
 		IncludedFields: querypb.ExecuteOptions_ALL,
 	})
 	require.NoError(t, err)
 	for _, field := range res.Fields {
 		require.Equal(t, "keyspaceName", field.Database)
 	}
-	_, err = tsv.Commit(ctx, target, transactionID)
+	_, err = tsv.Commit(ctx, target, state.TransactionID)
 	require.NoError(t, err)
 }
 
@@ -2053,14 +2058,14 @@ func TestDatabaseNameReplaceByKeyspaceNameBeginExecuteMethod(t *testing.T) {
 	target := tsv.sm.target
 
 	// Test BeginExecute Method
-	res, transactionID, _, err := tsv.BeginExecute(ctx, target, nil, executeSQL, nil, 0, &querypb.ExecuteOptions{
+	state, res, err := tsv.BeginExecute(ctx, target, nil, executeSQL, nil, 0, &querypb.ExecuteOptions{
 		IncludedFields: querypb.ExecuteOptions_ALL,
 	})
 	require.NoError(t, err)
 	for _, field := range res.Fields {
 		require.Equal(t, "keyspaceName", field.Database)
 	}
-	_, err = tsv.Commit(ctx, target, transactionID)
+	_, err = tsv.Commit(ctx, target, state.TransactionID)
 	require.NoError(t, err)
 }
 
@@ -2092,14 +2097,14 @@ func TestDatabaseNameReplaceByKeyspaceNameReserveExecuteMethod(t *testing.T) {
 	target := tsv.sm.target
 
 	// Test ReserveExecute
-	res, rID, _, err := tsv.ReserveExecute(ctx, target, nil, executeSQL, nil, 0, &querypb.ExecuteOptions{
+	state, res, err := tsv.ReserveExecute(ctx, target, nil, executeSQL, nil, 0, &querypb.ExecuteOptions{
 		IncludedFields: querypb.ExecuteOptions_ALL,
 	})
 	require.NoError(t, err)
 	for _, field := range res.Fields {
 		require.Equal(t, "keyspaceName", field.Database)
 	}
-	err = tsv.Release(ctx, target, 0, rID)
+	err = tsv.Release(ctx, target, 0, state.ReservedID)
 	require.NoError(t, err)
 }
 
@@ -2126,14 +2131,14 @@ func TestDatabaseNameReplaceByKeyspaceNameReserveBeginExecuteMethod(t *testing.T
 	target := tsv.sm.target
 
 	// Test for ReserveBeginExecute
-	res, transactionID, reservedID, _, err := tsv.ReserveBeginExecute(ctx, target, nil, nil, executeSQL, nil, &querypb.ExecuteOptions{
+	state, res, err := tsv.ReserveBeginExecute(ctx, target, nil, nil, executeSQL, nil, &querypb.ExecuteOptions{
 		IncludedFields: querypb.ExecuteOptions_ALL,
 	})
 	require.NoError(t, err)
 	for _, field := range res.Fields {
 		require.Equal(t, "keyspaceName", field.Database)
 	}
-	err = tsv.Release(ctx, target, transactionID, reservedID)
+	err = tsv.Release(ctx, target, state.TransactionID, state.ReservedID)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This adds a small wrapper struct instead of separate return arguments to make it easier to refactor and change this in the future.

This is a much simpler alternative to https://github.com/vitessio/vitess/pull/10775 which ended up being much more invasive with all the conversion changes etc.

The changes here are much more targeted and only specifically for transaction / reservation related return values so we can simplify those explicitly. 

## Related Issue(s)

See https://github.com/vitessio/vitess/pull/10671 for similar refactors.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required