### PR TITLE
Add semgrep CI workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,21 @@
+on:
+   pull_request: {}
+   push:
+     branches:
+     - main
+     paths:
+     - .github/workflows/semgrep.yml
+   schedule:
+   - cron: '0 0 * * 0'
+ name: Semgrep
+ jobs:
+   semgrep:
+     name: Scan
+     runs-on: ubuntu-20.04
+     env:
+       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+     container:
+       image: returntocorp/semgrep
+     steps:
+     - uses: actions/checkout@v3
+     - run: semgrep ci


### PR DESCRIPTION
## Description

This adds CI integration with [Semgrep](https://semgrep.dev). This is a trial run of the integration — to back out we would revert this PR and remove the `SEMGREP_APP_TOKEN` GitHub secret that it uses. The hope is that this helps us find and fix more issues before merging, such as goroutine leaks. It will utilize a set of rules in the workflow run which are configured in the semgrep.dev dashboard (I will invite more people if/as needed on that side — log in using GitHub OAuth). 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required