### PR TITLE
[14.0] fix: evalengine - check compare numeric of same type (#10793)

### DIFF
--- a/go/test/endtoend/vtgate/gen4/sharded_schema.sql
+++ b/go/test/endtoend/vtgate/gen4/sharded_schema.sql
@@ -45,3 +45,22 @@ create table multicol_tbl
     msg  varchar(50),
     primary key (cola, colb, colc)
 ) Engine = InnoDB;
+
+create table team(
+     id     int,
+     name   varchar(64),
+     primary key (id)
+) Engine = InnoDB;
+
+create table team_fact(
+    id   int,
+    team int,
+    fact char,
+    primary key (id)
+) Engine = InnoDB;
+
+create table team_member(
+    team int,
+    user int,
+    primary key (team, user)
+) Engine = InnoDB;

--- a/go/test/endtoend/vtgate/gen4/sharded_vschema.json
+++ b/go/test/endtoend/vtgate/gen4/sharded_vschema.json
@@ -89,6 +89,30 @@
           "name": "multicol_vdx"
         }
       ]
+    },
+    "team": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "team_fact": {
+      "column_vindexes": [
+        {
+          "column": "id",
+          "name": "xxhash"
+        }
+      ]
+    },
+    "team_member": {
+      "column_vindexes": [
+        {
+          "column": "team",
+          "name": "xxhash"
+        }
+      ]
     }
   }
 }

--- a/go/vt/vtgate/engine/filter_test.go
+++ b/go/vt/vtgate/engine/filter_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+)
+
+func TestFilterPass(t *testing.T) {
+	predicate := &evalengine.ComparisonExpr{
+		BinaryExpr: evalengine.BinaryExpr{
+			Left:  evalengine.NewColumn(0, defaultCollation()),
+			Right: evalengine.NewColumn(1, defaultCollation()),
+		},
+		Op: evalengine.CompareGT{},
+	}
+
+	tcases := []struct {
+		name   string
+		res    *sqltypes.Result
+		expRes string
+	}{{
+		name:   "int32",
+		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "int32|int32"), "0|1", "1|0", "2|3"),
+		expRes: `[[INT32(1) INT32(0)]]`,
+	}, {
+		name:   "uint16",
+		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "uint16|uint16"), "0|1", "1|0", "2|3"),
+		expRes: `[[UINT16(1) UINT16(0)]]`,
+	}, {
+		name:   "uint64_int64",
+		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "uint64|int64"), "0|1", "1|0", "2|3"),
+		expRes: `[[UINT64(1) INT64(0)]]`,
+	}}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &Filter{
+				Predicate: predicate,
+				Input:     &fakePrimitive{results: []*sqltypes.Result{tc.res}},
+			}
+			qr, err := filter.TryExecute(&noopVCursor{}, nil, false)
+			require.NoError(t, err)
+			require.Equal(t, tc.expRes, fmt.Sprintf("%v", qr.Rows))
+		})
+	}
+}
+
+func TestFilterMixedFail(t *testing.T) {
+	predicate := &evalengine.ComparisonExpr{
+		BinaryExpr: evalengine.BinaryExpr{
+			Left:  evalengine.NewColumn(0, defaultCollation()),
+			Right: evalengine.NewColumn(1, defaultCollation()),
+		},
+		Op: evalengine.CompareGT{},
+	}
+
+	tcases := []struct {
+		name   string
+		res    *sqltypes.Result
+		expErr string
+	}{{
+		name:   "int32_uint32",
+		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "int32|uint32"), "0|1", "1|0", "2|3"),
+		expErr: `unsupported: cannot compare INT32 and UINT32`,
+	}, {
+		name:   "uint16_int8",
+		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "uint16|int8"), "0|1", "1|0", "2|3"),
+		expErr: `unsupported: cannot compare UINT16 and INT8`,
+	}, {
+		name:   "uint64_int32",
+		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "uint64|int32"), "0|1", "1|0", "2|3"),
+		expErr: `unsupported: cannot compare UINT64 and INT32`,
+	}}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &Filter{
+				Predicate: predicate,
+				Input:     &fakePrimitive{results: []*sqltypes.Result{tc.res}},
+			}
+			_, err := filter.TryExecute(&noopVCursor{}, nil, false)
+			require.EqualError(t, err, tc.expErr)
+		})
+	}
+}
+
+func defaultCollation() collations.TypedCollation {
+	return collations.TypedCollation{
+		Collation:    collationEnv.LookupByName("utf8mb4_bin").ID(),
+		Coercibility: collations.CoerceImplicit,
+		Repertoire:   collations.RepertoireASCII,
+	}
+}

--- a/go/vt/vtgate/evalengine/comparisons.go
+++ b/go/vt/vtgate/evalengine/comparisons.go
@@ -54,7 +54,7 @@ type (
 	compareNE         struct{}
 	compareLT         struct{}
 	compareLE         struct{}
-	compareGT         struct{}
+	CompareGT         struct{}
 	compareGE         struct{}
 	compareNullSafeEQ struct{}
 )
@@ -83,8 +83,8 @@ func (compareLE) compare(left, right *EvalResult) (boolean, error) {
 	return makeboolean2(cmp <= 0, isNull), err
 }
 
-func (compareGT) String() string { return ">" }
-func (compareGT) compare(left, right *EvalResult) (boolean, error) {
+func (CompareGT) String() string { return ">" }
+func (CompareGT) compare(left, right *EvalResult) (boolean, error) {
 	cmp, isNull, err := evalCompareAll(left, right, false)
 	return makeboolean2(cmp > 0, isNull), err
 }
@@ -205,16 +205,12 @@ func evalCompare(lVal, rVal *EvalResult) (comp int, err error) {
 	switch {
 	case evalResultsAreStrings(lVal, rVal):
 		return compareStrings(lVal, rVal), nil
-
 	case evalResultsAreSameNumericType(lVal, rVal), needsDecimalHandling(lVal, rVal):
 		return compareNumeric(lVal, rVal)
-
 	case evalResultsAreDates(lVal, rVal):
 		return compareDates(lVal, rVal)
-
 	case evalResultsAreDateAndString(lVal, rVal):
 		return compareDateAndString(lVal, rVal)
-
 	case evalResultsAreDateAndNumeric(lVal, rVal):
 		// TODO: support comparison between a date and a numeric value
 		// 		queries like the ones below should be supported:
@@ -222,10 +218,8 @@ func evalCompare(lVal, rVal *EvalResult) (comp int, err error) {
 		// 			- select 1 where 2021210101 = cast("2021-01-01" as date)
 		// 			- select 1 where 104200 = cast("10:42:00" as time)
 		return 0, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "cannot compare a date with a numeric value")
-
 	case lVal.typeof() == sqltypes.Tuple || rVal.typeof() == sqltypes.Tuple:
-		panic("evalCompare: tuple comparison should be handled early")
-
+		return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "BUG: evalCompare: tuple comparison should be handled early")
 	default:
 		// Quoting MySQL Docs:
 		//

--- a/go/vt/vtgate/evalengine/evalengine.go
+++ b/go/vt/vtgate/evalengine/evalengine.go
@@ -187,9 +187,14 @@ func compareNumeric(v1, v2 *EvalResult) (int, error) {
 		}
 	}
 
+	// The types are not comparable.
+	if v1.typeof() != v2.typeof() {
+		return 0, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: cannot compare %v and %v", v1.typeof(), v2.typeof())
+	}
+
 	// Both values are of the same type.
 	switch v1.typeof() {
-	case sqltypes.Int64:
+	case sqltypes.Int8, sqltypes.Int16, sqltypes.Int24, sqltypes.Int32, sqltypes.Int64:
 		v1v, v2v := v1.int64(), v2.int64()
 		switch {
 		case v1v == v2v:
@@ -197,14 +202,14 @@ func compareNumeric(v1, v2 *EvalResult) (int, error) {
 		case v1v < v2v:
 			return -1, nil
 		}
-	case sqltypes.Uint64:
+	case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint24, sqltypes.Uint32, sqltypes.Uint64:
 		switch {
 		case v1.uint64() == v2.uint64():
 			return 0, nil
 		case v1.uint64() < v2.uint64():
 			return -1, nil
 		}
-	case sqltypes.Float64:
+	case sqltypes.Float32, sqltypes.Float64:
 		v1v, v2v := v1.float64(), v2.float64()
 		switch {
 		case v1v == v2v:
@@ -215,8 +220,6 @@ func compareNumeric(v1, v2 *EvalResult) (int, error) {
 	case sqltypes.Decimal:
 		return v1.decimal().Cmp(v2.decimal()), nil
 	}
-
-	// v1>v2
 	return 1, nil
 }
 

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -75,7 +75,7 @@ func translateComparisonExpr2(op sqlparser.ComparisonExprOperator, left, right E
 	case sqlparser.LessEqualOp:
 		return &ComparisonExpr{binaryExpr, compareLE{}}, nil
 	case sqlparser.GreaterThanOp:
-		return &ComparisonExpr{binaryExpr, compareGT{}}, nil
+		return &ComparisonExpr{binaryExpr, CompareGT{}}, nil
 	case sqlparser.GreaterEqualOp:
 		return &ComparisonExpr{binaryExpr, compareGE{}}, nil
 	case sqlparser.NullSafeEqualOp:


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Backport of https://github.com/vitessio/vitess/pull/10793

This PR fails the numeric compare if the type are not same after the type conversion.
This is to prevent from accidentally returning wrong result.

The follow up PR should handle the type conversion for all the missing numeric types.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Fixes https://github.com/vitessio/vitess/issues/10789

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
