### PR TITLE
Revert "[go/mysql/*] Move all authserver–related flags off of global flagset"

### DIFF
--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -85,7 +85,7 @@ Usage of vtgate:
       --mysql_auth_server_impl string                                    Which auth server implementation to use. Options: none, ldap, clientcert, static, vault. (default "static")
       --mysql_auth_server_static_file string                             JSON File to read the users/passwords from.
       --mysql_auth_server_static_string string                           JSON representation of the users/passwords config.
-      --mysql_auth_static_reload_interval duration                       Ticker to reload credentials
+      --mysql_auth_static_reload_interval duration                       Ticker to reload credentials (default 0s)
       --mysql_auth_vault_addr string                                     URL to Vault server
       --mysql_auth_vault_path string                                     Vault path to vtgate credentials JSON blob, e.g.: secret/data/prod/vtgatecreds
       --mysql_auth_vault_role_mountpoint string                          Vault AppRole mountpoint; can also be passed using VAULT_MOUNTPOINT environment variable (default "approle")

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -291,6 +291,10 @@ Usage of vttablet:
       --mycnf_slow_log_path string                                       mysql slow query log path
       --mycnf_socket_file string                                         mysql socket file
       --mycnf_tmp_dir string                                             mysql tmp directory
+      --mysql_auth_server_static_file string                             JSON File to read the users/passwords from.
+      --mysql_auth_server_static_string string                           JSON representation of the users/passwords config.
+      --mysql_auth_static_reload_interval duration                       Ticker to reload credentials (default 0s)
+      --mysql_clientcert_auth_method string                              client-side authentication method to use. Supported values: mysql_clear_password, dialog. (default "mysql_clear_password")
       --mysql_server_flush_delay duration                                Delay after which buffered response will be flushed to the client. (default 100ms)
       --mysql_server_version string                                      MySQL server version to advertise.
       --mysqlctl_client_protocol string                                  the protocol to use to talk to the mysqlctl server (default "grpc")

--- a/go/mysql/auth_server_clientcert.go
+++ b/go/mysql/auth_server_clientcert.go
@@ -17,22 +17,14 @@ limitations under the License.
 package mysql
 
 import (
+	"flag"
 	"fmt"
 	"net"
 
-	"github.com/spf13/pflag"
-
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/servenv"
 )
 
-var clientcertAuthMethod string
-
-func init() {
-	servenv.OnParseFor("vtgate", func(fs *pflag.FlagSet) {
-		fs.StringVar(&clientcertAuthMethod, "mysql_clientcert_auth_method", string(MysqlClearPassword), "client-side authentication method to use. Supported values: mysql_clear_password, dialog.")
-	})
-}
+var clientcertAuthMethod = flag.String("mysql_clientcert_auth_method", string(MysqlClearPassword), "client-side authentication method to use. Supported values: mysql_clear_password, dialog.")
 
 // AuthServerClientCert implements AuthServer which enforces client side certificates
 type AuthServerClientCert struct {
@@ -42,11 +34,11 @@ type AuthServerClientCert struct {
 
 // InitAuthServerClientCert is public so it can be called from plugin_auth_clientcert.go (go/cmd/vtgate)
 func InitAuthServerClientCert() {
-	if pflag.CommandLine.Lookup("mysql_server_ssl_ca").Value.String() == "" {
+	if flag.CommandLine.Lookup("mysql_server_ssl_ca").Value.String() == "" {
 		log.Info("Not configuring AuthServerClientCert because mysql_server_ssl_ca is empty")
 		return
 	}
-	if clientcertAuthMethod != string(MysqlClearPassword) && clientcertAuthMethod != string(MysqlDialog) {
+	if *clientcertAuthMethod != string(MysqlClearPassword) && *clientcertAuthMethod != string(MysqlDialog) {
 		log.Exitf("Invalid mysql_clientcert_auth_method value: only support mysql_clear_password or dialog")
 	}
 
@@ -56,11 +48,11 @@ func InitAuthServerClientCert() {
 
 func newAuthServerClientCert() *AuthServerClientCert {
 	ascc := &AuthServerClientCert{
-		Method: AuthMethodDescription(clientcertAuthMethod),
+		Method: AuthMethodDescription(*clientcertAuthMethod),
 	}
 
 	var authMethod AuthMethod
-	switch AuthMethodDescription(clientcertAuthMethod) {
+	switch AuthMethodDescription(*clientcertAuthMethod) {
 	case MysqlClearPassword:
 		authMethod = NewMysqlClearAuthMethod(ascc, ascc)
 	case MysqlDialog:

--- a/go/mysql/auth_server_clientcert_test.go
+++ b/go/mysql/auth_server_clientcert_test.go
@@ -30,12 +30,6 @@ import (
 
 const clientCertUsername = "Client Cert"
 
-func init() {
-	// These tests do not invoke the servenv.Parse codepaths, so this default
-	// does not get set by the OnParseFor hook.
-	clientcertAuthMethod = string(MysqlClearPassword)
-}
-
 func TestValidCert(t *testing.T) {
 	th := &testHandler{}
 

--- a/go/mysql/auth_server_static.go
+++ b/go/mysql/auth_server_static.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/subtle"
 	"encoding/json"
+	"flag"
 	"net"
 	"os"
 	"os/signal"
@@ -27,29 +28,17 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/spf13/pflag"
-
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/servenv"
-	"vitess.io/vitess/go/vt/vterrors"
-
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 var (
-	mysqlAuthServerStaticFile           string
-	mysqlAuthServerStaticString         string
-	mysqlAuthServerStaticReloadInterval time.Duration
+	mysqlAuthServerStaticFile           = flag.String("mysql_auth_server_static_file", "", "JSON File to read the users/passwords from.")
+	mysqlAuthServerStaticString         = flag.String("mysql_auth_server_static_string", "", "JSON representation of the users/passwords config.")
+	mysqlAuthServerStaticReloadInterval = flag.Duration("mysql_auth_static_reload_interval", 0, "Ticker to reload credentials")
 )
-
-func init() {
-	servenv.OnParseFor("vtgate", func(fs *pflag.FlagSet) {
-		fs.StringVar(&mysqlAuthServerStaticFile, "mysql_auth_server_static_file", "", "JSON File to read the users/passwords from.")
-		fs.StringVar(&mysqlAuthServerStaticString, "mysql_auth_server_static_string", "", "JSON representation of the users/passwords config.")
-		fs.DurationVar(&mysqlAuthServerStaticReloadInterval, "mysql_auth_static_reload_interval", 0, "Ticker to reload credentials")
-	})
-}
 
 const (
 	localhostName = "localhost"
@@ -92,18 +81,18 @@ type AuthServerStaticEntry struct {
 // InitAuthServerStatic Handles initializing the AuthServerStatic if necessary.
 func InitAuthServerStatic() {
 	// Check parameters.
-	if mysqlAuthServerStaticFile == "" && mysqlAuthServerStaticString == "" {
+	if *mysqlAuthServerStaticFile == "" && *mysqlAuthServerStaticString == "" {
 		// Not configured, nothing to do.
 		log.Infof("Not configuring AuthServerStatic, as mysql_auth_server_static_file and mysql_auth_server_static_string are empty")
 		return
 	}
-	if mysqlAuthServerStaticFile != "" && mysqlAuthServerStaticString != "" {
+	if *mysqlAuthServerStaticFile != "" && *mysqlAuthServerStaticString != "" {
 		// Both parameters specified, can only use one.
 		log.Exitf("Both mysql_auth_server_static_file and mysql_auth_server_static_string specified, can only use one.")
 	}
 
 	// Create and register auth server.
-	RegisterAuthServerStaticFromParams(mysqlAuthServerStaticFile, mysqlAuthServerStaticString, mysqlAuthServerStaticReloadInterval)
+	RegisterAuthServerStaticFromParams(*mysqlAuthServerStaticFile, *mysqlAuthServerStaticString, *mysqlAuthServerStaticReloadInterval)
 }
 
 // RegisterAuthServerStaticFromParams creates and registers a new

--- a/go/mysql/ldapauthserver/auth_server_ldap.go
+++ b/go/mysql/ldapauthserver/auth_server_ldap.go
@@ -18,37 +18,27 @@ package ldapauthserver
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"net"
 	"os"
 	"sync"
 	"time"
 
-	"github.com/spf13/pflag"
 	ldap "gopkg.in/ldap.v2"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/servenv"
-	"vitess.io/vitess/go/vt/vttls"
-
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vttls"
 )
 
 var (
-	ldapAuthConfigFile   string
-	ldapAuthConfigString string
-	ldapAuthMethod       string
+	ldapAuthConfigFile   = flag.String("mysql_ldap_auth_config_file", "", "JSON File from which to read LDAP server config.")
+	ldapAuthConfigString = flag.String("mysql_ldap_auth_config_string", "", "JSON representation of LDAP server config.")
+	ldapAuthMethod       = flag.String("mysql_ldap_auth_method", string(mysql.MysqlClearPassword), "client-side authentication method to use. Supported values: mysql_clear_password, dialog.")
 )
-
-func init() {
-	servenv.OnParseFor("vtgate", func(fs *pflag.FlagSet) {
-		fs.StringVar(&ldapAuthConfigFile, "mysql_ldap_auth_config_file", "", "JSON File from which to read LDAP server config.")
-		fs.StringVar(&ldapAuthConfigString, "mysql_ldap_auth_config_string", "", "JSON representation of LDAP server config.")
-		fs.StringVar(&ldapAuthMethod, "mysql_ldap_auth_method", string(mysql.MysqlClearPassword), "client-side authentication method to use. Supported values: mysql_clear_password, dialog.")
-	})
-}
 
 // AuthServerLdap implements AuthServer with an LDAP backend
 type AuthServerLdap struct {
@@ -64,16 +54,16 @@ type AuthServerLdap struct {
 
 // Init is public so it can be called from plugin_auth_ldap.go (go/cmd/vtgate)
 func Init() {
-	if ldapAuthConfigFile == "" && ldapAuthConfigString == "" {
+	if *ldapAuthConfigFile == "" && *ldapAuthConfigString == "" {
 		log.Infof("Not configuring AuthServerLdap because mysql_ldap_auth_config_file and mysql_ldap_auth_config_string are empty")
 		return
 	}
-	if ldapAuthConfigFile != "" && ldapAuthConfigString != "" {
+	if *ldapAuthConfigFile != "" && *ldapAuthConfigString != "" {
 		log.Infof("Both mysql_ldap_auth_config_file and mysql_ldap_auth_config_string are non-empty, can only use one.")
 		return
 	}
 
-	if ldapAuthMethod != string(mysql.MysqlClearPassword) && ldapAuthMethod != string(mysql.MysqlDialog) {
+	if *ldapAuthMethod != string(mysql.MysqlClearPassword) && *ldapAuthMethod != string(mysql.MysqlDialog) {
 		log.Exitf("Invalid mysql_ldap_auth_method value: only support mysql_clear_password or dialog")
 	}
 	ldapAuthServer := &AuthServerLdap{
@@ -81,10 +71,10 @@ func Init() {
 		ServerConfig: ServerConfig{},
 	}
 
-	data := []byte(ldapAuthConfigString)
-	if ldapAuthConfigFile != "" {
+	data := []byte(*ldapAuthConfigString)
+	if *ldapAuthConfigFile != "" {
 		var err error
-		data, err = os.ReadFile(ldapAuthConfigFile)
+		data, err = os.ReadFile(*ldapAuthConfigFile)
 		if err != nil {
 			log.Exitf("Failed to read mysql_ldap_auth_config_file: %v", err)
 		}
@@ -94,7 +84,7 @@ func Init() {
 	}
 
 	var authMethod mysql.AuthMethod
-	switch mysql.AuthMethodDescription(ldapAuthMethod) {
+	switch mysql.AuthMethodDescription(*ldapAuthMethod) {
 	case mysql.MysqlClearPassword:
 		authMethod = mysql.NewMysqlClearAuthMethod(ldapAuthServer, ldapAuthServer)
 	case mysql.MysqlDialog:

--- a/go/mysql/vault/auth_server_vault.go
+++ b/go/mysql/vault/auth_server_vault.go
@@ -18,6 +18,7 @@ package vault
 
 import (
 	"crypto/subtle"
+	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -28,38 +29,22 @@ import (
 	"time"
 
 	vaultapi "github.com/aquarapid/vaultlib"
-	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/servenv"
 )
 
 var (
-	vaultAddr             string
-	vaultTimeout          time.Duration
-	vaultCACert           string
-	vaultPath             string
-	vaultCacheTTL         time.Duration
-	vaultTokenFile        string
-	vaultRoleID           string
-	vaultRoleSecretIDFile string
-	vaultRoleMountPoint   string
+	vaultAddr             = flag.String("mysql_auth_vault_addr", "", "URL to Vault server")
+	vaultTimeout          = flag.Duration("mysql_auth_vault_timeout", 10*time.Second, "Timeout for vault API operations")
+	vaultCACert           = flag.String("mysql_auth_vault_tls_ca", "", "Path to CA PEM for validating Vault server certificate")
+	vaultPath             = flag.String("mysql_auth_vault_path", "", "Vault path to vtgate credentials JSON blob, e.g.: secret/data/prod/vtgatecreds")
+	vaultCacheTTL         = flag.Duration("mysql_auth_vault_ttl", 30*time.Minute, "How long to cache vtgate credentials from the Vault server")
+	vaultTokenFile        = flag.String("mysql_auth_vault_tokenfile", "", "Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable")
+	vaultRoleID           = flag.String("mysql_auth_vault_roleid", "", "Vault AppRole id; can also be passed using VAULT_ROLEID environment variable")
+	vaultRoleSecretIDFile = flag.String("mysql_auth_vault_role_secretidfile", "", "Path to file containing Vault AppRole secret_id; can also be passed using VAULT_SECRETID environment variable")
+	vaultRoleMountPoint   = flag.String("mysql_auth_vault_role_mountpoint", "approle", "Vault AppRole mountpoint; can also be passed using VAULT_MOUNTPOINT environment variable")
 )
-
-func init() {
-	servenv.OnParseFor("vtgate", func(fs *pflag.FlagSet) {
-		fs.StringVar(&vaultAddr, "mysql_auth_vault_addr", "", "URL to Vault server")
-		fs.DurationVar(&vaultTimeout, "mysql_auth_vault_timeout", 10*time.Second, "Timeout for vault API operations")
-		fs.StringVar(&vaultCACert, "mysql_auth_vault_tls_ca", "", "Path to CA PEM for validating Vault server certificate")
-		fs.StringVar(&vaultPath, "mysql_auth_vault_path", "", "Vault path to vtgate credentials JSON blob, e.g.: secret/data/prod/vtgatecreds")
-		fs.DurationVar(&vaultCacheTTL, "mysql_auth_vault_ttl", 30*time.Minute, "How long to cache vtgate credentials from the Vault server")
-		fs.StringVar(&vaultTokenFile, "mysql_auth_vault_tokenfile", "", "Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable")
-		fs.StringVar(&vaultRoleID, "mysql_auth_vault_roleid", "", "Vault AppRole id; can also be passed using VAULT_ROLEID environment variable")
-		fs.StringVar(&vaultRoleSecretIDFile, "mysql_auth_vault_role_secretidfile", "", "Path to file containing Vault AppRole secret_id; can also be passed using VAULT_SECRETID environment variable")
-		fs.StringVar(&vaultRoleMountPoint, "mysql_auth_vault_role_mountpoint", "approle", "Vault AppRole mountpoint; can also be passed using VAULT_MOUNTPOINT environment variable")
-	})
-}
 
 // AuthServerVault implements AuthServer with a config loaded from Vault.
 type AuthServerVault struct {
@@ -80,15 +65,15 @@ type AuthServerVault struct {
 // InitAuthServerVault - entrypoint for initialization of Vault AuthServer implementation
 func InitAuthServerVault() {
 	// Check critical parameters.
-	if vaultAddr == "" {
+	if *vaultAddr == "" {
 		log.Infof("Not configuring AuthServerVault, as --mysql_auth_vault_addr is empty.")
 		return
 	}
-	if vaultPath == "" {
+	if *vaultPath == "" {
 		log.Exitf("If using Vault auth server, --mysql_auth_vault_path is required.")
 	}
 
-	registerAuthServerVault(vaultAddr, vaultTimeout, vaultCACert, vaultPath, vaultCacheTTL, vaultTokenFile, vaultRoleID, vaultRoleSecretIDFile, vaultRoleMountPoint)
+	registerAuthServerVault(*vaultAddr, *vaultTimeout, *vaultCACert, *vaultPath, *vaultCacheTTL, *vaultTokenFile, *vaultRoleID, *vaultRoleSecretIDFile, *vaultRoleMountPoint)
 }
 
 func registerAuthServerVault(addr string, timeout time.Duration, caCertPath string, path string, ttl time.Duration, tokenFilePath string, roleID string, secretIDPath string, roleMountPoint string) {


### PR DESCRIPTION
Reverts vitessio/vitess#10752

Am seeing issue with any and all flags in `vtctl/vtctlclient` not accepted. Checking if vitessio/vitess#10752 is the culprit

e.g.:
```
vtctlclient ApplySchema --skip_preflight --ddl_strategy "online -allow-zero-in-date --allow-concurrent --postpone-completion" --sql "alter table corder engine=innodb" commerce
unknown flag: --skip_preflight
```