### PR TITLE
Always close body for HTTP requests in tests

### DIFF
--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -303,10 +303,8 @@ func (topo *TopoProcess) IsHealthy() bool {
 	if err != nil {
 		return false
 	}
-	if resp.StatusCode == 200 {
-		return true
-	}
-	return false
+	defer resp.Body.Close()
+	return resp.StatusCode == 200
 }
 
 func (topo *TopoProcess) removeTopoDirectories(Cell string) {
@@ -325,11 +323,17 @@ func (topo *TopoProcess) ManageTopoDir(command string, directory string) (err er
 	if command == "mkdir" {
 		req, _ := http.NewRequest("PUT", url, payload)
 		req.Header.Add("content-type", "application/json")
-		_, err = http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			defer resp.Body.Close()
+		}
 		return err
 	} else if command == "rmdir" {
 		req, _ := http.NewRequest("DELETE", url+"?dir=true", payload)
-		_, err = http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			defer resp.Body.Close()
+		}
 		return err
 	} else {
 		return nil

--- a/go/test/endtoend/cluster/vtctld_process.go
+++ b/go/test/endtoend/cluster/vtctld_process.go
@@ -118,10 +118,8 @@ func (vtctld *VtctldProcess) IsHealthy() bool {
 	if err != nil {
 		return false
 	}
-	if resp.StatusCode == 200 {
-		return true
-	}
-	return false
+	defer resp.Body.Close()
+	return resp.StatusCode == 200
 }
 
 // TearDown shutdowns the running vtctld service

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -164,10 +164,9 @@ func (vtgate *VtgateProcess) WaitForStatus() bool {
 	if err != nil {
 		return false
 	}
-	if resp.StatusCode == 200 {
-		return true
-	}
-	return false
+	defer resp.Body.Close()
+
+	return resp.StatusCode == 200
 }
 
 // GetStatusForTabletOfShard function gets status for a specific tablet of a shard in keyspace
@@ -177,6 +176,8 @@ func (vtgate *VtgateProcess) GetStatusForTabletOfShard(name string, endPointsCou
 	if err != nil {
 		return false
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == 200 {
 		resultMap := make(map[string]any)
 		respByte, _ := io.ReadAll(resp.Body)
@@ -286,6 +287,8 @@ func (vtgate *VtgateProcess) GetVars() (map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting response from %s", vtgate.VerifyURL)
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == 200 {
 		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)
@@ -305,6 +308,7 @@ func (vtgate *VtgateProcess) ReadVSchema() (*interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	res, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -164,9 +164,9 @@ func (vttablet *VttabletProcess) GetStatus() string {
 	if err != nil {
 		return ""
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == 200 {
 		respByte, _ := io.ReadAll(resp.Body)
-		defer resp.Body.Close()
 		return string(respByte)
 	}
 	return ""
@@ -178,6 +178,8 @@ func (vttablet *VttabletProcess) GetVars() map[string]any {
 	if err != nil {
 		return nil
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == 200 {
 		resultMap := make(map[string]any)
 		respByte, _ := io.ReadAll(resp.Body)
@@ -196,6 +198,8 @@ func (vttablet *VttabletProcess) GetStatusDetails() string {
 	if err != nil {
 		return fmt.Sprintf("Status details failed: %v", err.Error())
 	}
+	defer resp.Body.Close()
+
 	respByte, _ := io.ReadAll(resp.Body)
 	return string(respByte)
 }


### PR DESCRIPTION
Not closing the body leads to leaking goroutines for the reader / writer of the body.

Found when validating that tests don't leak goroutines (to ensure other things get closed properly, but these cases where also found).

## Related Issue(s)

See also https://github.com/vitessio/vitess/pull/10756 for another set of leak fixes.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required