### PR TITLE
CI Fix: Collation tests

### DIFF
--- a/go/mysql/collations/integration/coercion_test.go
+++ b/go/mysql/collations/integration/coercion_test.go
@@ -202,7 +202,7 @@ func TestComparisonSemantics(t *testing.T) {
 							t.Errorf("expected %s vs %s to fail coercion: %v", collA.Collation.Name(), collB.Collation.Name(), errRemote)
 							continue
 						}
-						if !strings.HasPrefix(errRemote.Error(), errLocal.Error()) {
+						if !strings.HasPrefix(normalizeCollationInError(errRemote.Error()), normalizeCollationInError(errLocal.Error())) {
 							t.Fatalf("bad error message: expected %q, got %q", errRemote, errLocal)
 						}
 						continue
@@ -224,4 +224,14 @@ func TestComparisonSemantics(t *testing.T) {
 			}
 		})
 	}
+}
+
+// normalizeCollationInError normalizes the collation name in the error output.
+// Starting with mysql 8.0.30 collations prefixed with `utf8_` have been changed to use `utf8mb3_` instead
+// This is inconsistent with older MySQL versions and causes the tests to fail against it.
+// As a stop-gap solution, this functions normalizes the error messages so that the tests pass until we
+// have a fix for it.
+// TODO: Remove error normalization
+func normalizeCollationInError(errMessage string) string {
+	return strings.ReplaceAll(errMessage, "utf8_", "utf8mb3_")
 }


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

MySQL 8.0.30 was released today and it broke our CI. In MySQL 8.0.30, an incompatible change was introduced - 
```
Important Change: A previous change renamed character sets having deprecated names prefixed with utf8_ to use utf8mb3_ instead. In this release, we rename the utf8_ collations as well, using the utf8mb3_ prefix; this is to make the collation names consistent with those of the character sets, not to rely any longer on the deprecated collation names, and to clarify the distinction between utf8mb3 and utf8mb4. The names using the utf8mb3_ prefix are now used exclusively for these collations in the output of SHOW statements such as SHOW CREATE TABLE, as well as in the values displayed in the columns of Information Schema tables including the COLLATIONS and COLUMNS tables. (Bug #33787300)
```

This change causes our collations test `TestComparisonSemantics` to fail. The test asserts on the error that vtgate produces and the test MySQL gives us. In our CI we always install the latest version of MySQL, causing the test to fail - 
```
--- FAIL: TestComparisonSemantics (2.76s)
    --- FAIL: TestComparisonSemantics/equals (1.35s)
        coercion_test.go:206: bad error message: expected "Illegal mix of collations (utf8mb3_general_ci,EXPLICIT) and (ucs2_general_ci,EXPLICIT) for operation '=' (errno 1267) (sqlstate HY000) during query: SELECT CAST(((_utf8mb3 X'61626364414243443031323334' COLLATE \"utf8_general_ci\") = (_ucs2 X'0061006200630064004100420043004400300031003200330034' COLLATE \"ucs2_general_ci\")) AS BINARY), COLLATION((_utf8mb3 X'61626364414243443031323334' COLLATE \"utf8_general_ci\") = (_ucs2 X'0061006200630064004100420043004400300031003200330034' COLLATE \"ucs2_general_ci\")), COERCIBILITY((_utf8mb3 X'61626364414243443031323334' COLLATE \"utf8_general_ci\") = (_ucs2 X'0061006200630064004100420043004400300031003200330034' COLLATE \"ucs2_general_ci\"))", got "Illegal mix of collations (utf8_general_ci,EXPLICIT) and (ucs2_general_ci,EXPLICIT)"
```

This PR fixes the test by normalizing the error messages from both sources before checking for equality.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
