### PR TITLE
[cli] [mysqlctl] Scope all backupstorage implementation flags to `pflag` and relevant binaries

### DIFF
--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -3,11 +3,11 @@ Usage of vttablet:
       --alsologtostderr                                                  log to standard error as well as files
       --app_idle_timeout duration                                        Idle timeout for app connections (default 1m0s)
       --app_pool_size int                                                Size of the connection pool for app connections (default 40)
-      --azblob_backup_account_key_file string                            Path to a file containing the Azure Storage account key; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_KEY will be used as the key itself (NOT a file path)
-      --azblob_backup_account_name string                                Azure Storage Account name for backups; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_NAME will be used
-      --azblob_backup_container_name string                              Azure Blob Container Name
-      --azblob_backup_parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased) (default 1)
-      --azblob_backup_storage_root string                                Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/')
+      --azblob_backup_account_key_file string                            Path to a file containing the Azure Storage account key; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_KEY will be used as the key itself (NOT a file path).
+      --azblob_backup_account_name string                                Azure Storage Account name for backups; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_NAME will be used.
+      --azblob_backup_container_name string                              Azure Blob Container Name.
+      --azblob_backup_parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased). (default 1)
+      --azblob_backup_storage_root string                                Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
       --backup_engine_implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
       --backup_storage_block_size int                                    if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup_storage_compress                                          if set, the backup files will be compressed (default is true). Set to false for instance if a backup_storage_hook is specified and it compresses the data. (default true)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -33,7 +33,7 @@ Usage of vttablet:
       --builtinbackup_mysqld_timeout duration                            how long to wait for mysqld to shutdown at the start of the backup (default 10m0s)
       --builtinbackup_progress duration                                  how often to send progress updates when backing up large files (default 5s)
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
-      --ceph_backup_storage_config string                                Path to JSON config file for ceph backup storage (default "ceph_backup_config.json")
+      --ceph_backup_storage_config string                                Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
       --compression-level int                                            what level to pass to the compressor (default 1)
       --consul_auth_static_file string                                   JSON File to read the topos/tokens from.
       --cpu_profile string                                               deprecated: use '-pprof=cpu' instead

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -357,15 +357,15 @@ Usage of vttablet:
       --restore_from_backup                                              (init restore parameter) will check BackupStorage for a recent backup at startup and start there
       --restore_from_backup_ts string                                    (init restore parameter) if set, restore the latest backup taken at or before this timestamp. Example: '2021-04-29.133050'
       --retain_online_ddl_tables duration                                How long should vttablet keep an old migrated table before purging it (default 24h0m0s)
-      --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided)
-      --s3_backup_aws_region string                                      AWS region to use (default "us-east-1")
-      --s3_backup_aws_retries int                                        AWS request retries (default -1)
-      --s3_backup_force_path_style                                       force the s3 path style
-      --s3_backup_log_level string                                       determine the S3 loglevel to use from LogOff, LogDebug, LogDebugWithSigning, LogDebugWithHTTPBody, LogDebugWithRequestRetries, LogDebugWithRequestErrors (default "LogOff")
-      --s3_backup_server_side_encryption string                          server-side encryption algorithm (e.g., AES256, aws:kms, sse_c:/path/to/key/file)
-      --s3_backup_storage_bucket string                                  S3 bucket to use for backups
-      --s3_backup_storage_root string                                    root prefix for all backup-related object names
-      --s3_backup_tls_skip_verify_cert                                   skip the 'certificate is valid' check for SSL connections
+      --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
+      --s3_backup_aws_retries int                                        AWS request retries. (default -1)
+      --s3_backup_force_path_style                                       force the s3 path style.
+      --s3_backup_log_level string                                       determine the S3 loglevel to use from LogOff, LogDebug, LogDebugWithSigning, LogDebugWithHTTPBody, LogDebugWithRequestRetries, LogDebugWithRequestErrors. (default "LogOff")
+      --s3_backup_server_side_encryption string                          server-side encryption algorithm (e.g., AES256, aws:kms, sse_c:/path/to/key/file).
+      --s3_backup_storage_bucket string                                  S3 bucket to use for backups.
+      --s3_backup_storage_root string                                    root prefix for all backup-related object names.
+      --s3_backup_tls_skip_verify_cert                                   skip the 'certificate is valid' check for SSL connections.
       --sanitize_log_messages                                            Remove potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service_map StringList                                           comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -211,8 +211,8 @@ Usage of vttablet:
       --filecustomrules_watch                                            set up a watch on the target file and reload query rules when it changes
       --gc_check_interval duration                                       Interval between garbage collection checks (default 1h0m0s)
       --gc_purge_check_interval duration                                 Interval between purge discovery checks (default 1m0s)
-      --gcs_backup_storage_bucket string                                 Google Cloud Storage bucket to use for backups
-      --gcs_backup_storage_root string                                   root prefix for all backup-related object names
+      --gcs_backup_storage_bucket string                                 Google Cloud Storage bucket to use for backups.
+      --gcs_backup_storage_root string                                   Root prefix for all backup-related object names.
       --gh-ost-path string                                               override default gh-ost binary full path
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -206,7 +206,7 @@ Usage of vttablet:
       --external-compressor string                                       command with arguments to use when compressing a backup
       --external-compressor-extension string                             extension to use when using an external compressor
       --external-decompressor string                                     command with arguments to use when decompressing a backup
-      --file_backup_storage_root string                                  root directory for the file backup storage
+      --file_backup_storage_root string                                  Root directory for the file backup storage.
       --filecustomrules string                                           file based custom rule path
       --filecustomrules_watch                                            set up a watch on the target file and reload query rules when it changes
       --gc_check_interval duration                                       Interval between garbage collection checks (default 1h0m0s)

--- a/go/vt/mysqlctl/builtinbackupengine_test.go
+++ b/go/vt/mysqlctl/builtinbackupengine_test.go
@@ -47,7 +47,7 @@ func createBackupDir(root string, dirs ...string) error {
 func TestExecuteBackup(t *testing.T) {
 	// Set up local backup directory
 	backupRoot := "testdata/builtinbackup_test"
-	*filebackupstorage.FileBackupStorageRoot = backupRoot
+	filebackupstorage.FileBackupStorageRoot = backupRoot
 	require.NoError(t, createBackupDir(backupRoot, "innodb", "log", "datadir"))
 	defer os.RemoveAll(backupRoot)
 

--- a/go/vt/mysqlctl/cephbackupstorage/ceph.go
+++ b/go/vt/mysqlctl/cephbackupstorage/ceph.go
@@ -318,7 +318,6 @@ func init() {
 
 // objName joins path parts into an object name.
 // Unlike path.Join, it doesn't collapse ".." or strip trailing slashes.
-// It also adds the value of the -gcs_backup_storage_root flag if set.
 func objName(parts ...string) string {
 	return strings.Join(parts, "/")
 }

--- a/go/vt/mysqlctl/cephbackupstorage/ceph.go
+++ b/go/vt/mysqlctl/cephbackupstorage/ceph.go
@@ -19,8 +19,9 @@ limitations under the License.
 package cephbackupstorage
 
 import (
+	"context"
 	"encoding/json"
-	"flag"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,22 +29,31 @@ import (
 	"strings"
 	"sync"
 
-	"errors"
-
-	"context"
-
 	minio "github.com/minio/minio-go"
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 var (
 	// configFilePath is where the configs/credentials for backups will be stored.
-	configFilePath = flag.String("ceph_backup_storage_config", "ceph_backup_config.json",
-		"Path to JSON config file for ceph backup storage")
+	configFilePath string
 )
+
+func registerFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&configFilePath, "ceph_backup_storage_config", "ceph_backup_config.json",
+		"Path to JSON config file for ceph backup storage.")
+}
+
+func init() {
+	servenv.OnParseFor("vtbackup", registerFlags)
+	servenv.OnParseFor("vtctl", registerFlags)
+	servenv.OnParseFor("vtctld", registerFlags)
+	servenv.OnParseFor("vttablet", registerFlags)
+}
 
 var storageConfig struct {
 	AccessKey string `json:"accessKey"`
@@ -278,7 +288,7 @@ func (bs *CephBackupStorage) client() (*minio.Client, error) {
 	defer bs.mu.Unlock()
 
 	if bs._client == nil {
-		configFile, err := os.Open(*configFilePath)
+		configFile, err := os.Open(configFilePath)
 		if err != nil {
 			return nil, fmt.Errorf("file not present : %v", err)
 		}

--- a/go/vt/mysqlctl/filebackupstorage/file_test.go
+++ b/go/vt/mysqlctl/filebackupstorage/file_test.go
@@ -32,7 +32,7 @@ import (
 // setupFileBackupStorage creates a temporary directory, and
 // returns a FileBackupStorage based on it
 func setupFileBackupStorage(t *testing.T) *FileBackupStorage {
-	*FileBackupStorageRoot = t.TempDir()
+	FileBackupStorageRoot = t.TempDir()
 	return &FileBackupStorage{}
 }
 

--- a/go/vt/mysqlctl/gcsbackupstorage/gcs.go
+++ b/go/vt/mysqlctl/gcsbackupstorage/gcs.go
@@ -19,16 +19,15 @@ limitations under the License.
 package gcsbackupstorage
 
 import (
-	"flag"
+	"context"
 	"fmt"
 	"io"
 	"sort"
 	"strings"
 	"sync"
 
-	"context"
-
 	"cloud.google.com/go/storage"
+	"github.com/spf13/pflag"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -36,15 +35,28 @@ import (
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 var (
 	// bucket is where the backups will go.
-	bucket = flag.String("gcs_backup_storage_bucket", "", "Google Cloud Storage bucket to use for backups")
+	bucket string
 
 	// root is a prefix added to all object names.
-	root = flag.String("gcs_backup_storage_root", "", "root prefix for all backup-related object names")
+	root string
 )
+
+func registerFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&bucket, "gcs_backup_storage_bucket", "", "Google Cloud Storage bucket to use for backups.")
+	fs.StringVar(&root, "gcs_backup_storage_root", "", "Root prefix for all backup-related object names.")
+}
+
+func init() {
+	servenv.OnParseFor("vtbackup", registerFlags)
+	servenv.OnParseFor("vtctl", registerFlags)
+	servenv.OnParseFor("vtctld", registerFlags)
+	servenv.OnParseFor("vttablet", registerFlags)
+}
 
 // GCSBackupHandle implements BackupHandle for Google Cloud Storage.
 type GCSBackupHandle struct {
@@ -87,7 +99,7 @@ func (bh *GCSBackupHandle) AddFile(ctx context.Context, filename string, filesiz
 		return nil, fmt.Errorf("AddFile cannot be called on read-only backup")
 	}
 	object := objName(bh.dir, bh.name, filename)
-	return bh.client.Bucket(*bucket).Object(object).NewWriter(ctx), nil
+	return bh.client.Bucket(bucket).Object(object).NewWriter(ctx), nil
 }
 
 // EndBackup implements BackupHandle.
@@ -112,7 +124,7 @@ func (bh *GCSBackupHandle) ReadFile(ctx context.Context, filename string) (io.Re
 		return nil, fmt.Errorf("ReadFile cannot be called on read-write backup")
 	}
 	object := objName(bh.dir, bh.name, filename)
-	return bh.client.Bucket(*bucket).Object(object).NewReader(ctx)
+	return bh.client.Bucket(bucket).Object(object).NewReader(ctx)
 }
 
 // GCSBackupStorage implements BackupStorage for Google Cloud Storage.
@@ -146,7 +158,7 @@ func (bs *GCSBackupStorage) ListBackups(ctx context.Context, dir string) ([]back
 		Prefix:    searchPrefix,
 	}
 
-	it := c.Bucket(*bucket).Objects(ctx, query)
+	it := c.Bucket(bucket).Objects(ctx, query)
 	for {
 		obj, err := it.Next()
 		if err == iterator.Done {
@@ -208,7 +220,7 @@ func (bs *GCSBackupStorage) RemoveBackup(ctx context.Context, dir, name string) 
 		Prefix: objName(dir, name, "" /* include trailing slash */),
 	}
 	// Delete all the found objects.
-	it := c.Bucket(*bucket).Objects(ctx, query)
+	it := c.Bucket(bucket).Objects(ctx, query)
 	for {
 		obj, err := it.Next()
 		if err == iterator.Done {
@@ -217,8 +229,8 @@ func (bs *GCSBackupStorage) RemoveBackup(ctx context.Context, dir, name string) 
 		if err != nil {
 			return err
 		}
-		if err := c.Bucket(*bucket).Object(obj.Name).Delete(ctx); err != nil {
-			return fmt.Errorf("unable to delete %q from bucket %q: %v", obj.Name, *bucket, err)
+		if err := c.Bucket(bucket).Object(obj.Name).Delete(ctx); err != nil {
+			return fmt.Errorf("unable to delete %q from bucket %q: %v", obj.Name, bucket, err)
 		}
 	}
 	return nil
@@ -268,10 +280,10 @@ func (bs *GCSBackupStorage) client(ctx context.Context) (*storage.Client, error)
 
 // objName joins path parts into an object name.
 // Unlike path.Join, it doesn't collapse ".." or strip trailing slashes.
-// It also adds the value of the -gcs_backup_storage_root flag if set.
+// It also adds the value of the --gcs_backup_storage_root flag if set.
 func objName(parts ...string) string {
-	if *root != "" {
-		return *root + "/" + strings.Join(parts, "/")
+	if root != "" {
+		return root + "/" + strings.Join(parts, "/")
 	}
 	return strings.Join(parts, "/")
 }

--- a/go/vt/mysqlctl/s3backupstorage/README.txt
+++ b/go/vt/mysqlctl/s3backupstorage/README.txt
@@ -1,8 +1,8 @@
 Recently added options to enable usage of an S3 appliance: Cloudian
 HyperStore:
-        -s3_backup_aws_endpoint <host:port> (port is required)
-        -s3_backup_force_path_style=true/false
-        -s3_backup_log_level <level> can be one of: LogOff, LogDebug, LogDebugWithSigning, LogDebugWithHTTPBody, LogDebugWithRequestRetries, LogDebugWithRequestErrors.  Default: LogOff
+        --s3_backup_aws_endpoint <host:port> (port is required)
+        --s3_backup_force_path_style=true/false
+        --s3_backup_log_level <level> can be one of: LogOff, LogDebug, LogDebugWithSigning, LogDebugWithHTTPBody, LogDebugWithRequestRetries, LogDebugWithRequestErrors.  Default: LogOff
 
 By default the s3 client will try to connect to
 <path>.<region>.amazonaws.com.  Adjusting the endpoint will allow this
@@ -10,8 +10,8 @@ to be changed.
 
 Given the way the FQDN is configured the TLS certificate may not match the
 server's "base" (<region>.<end_point_address>) due to the leading <path>
-so setting -s3_backup_force_path_style=true will force the s3 client to
+so setting --3_backup_force_path_style=true will force the s3 client to
 connect to <region>.<endpoint> and then make a request using the full
 path within the http calls.
 
--s3backup_log_level enables more verbose logging of the S3 calls.
+--s3backup_log_level enables more verbose logging of the S3 calls.

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -24,10 +24,10 @@ limitations under the License.
 package s3backupstorage
 
 import (
+	"context"
 	"crypto/md5"
 	"crypto/tls"
 	"encoding/base64"
-	"flag"
 	"fmt"
 	"io"
 	"math"
@@ -37,10 +37,6 @@ import (
 	"strings"
 	"sync"
 
-	"vitess.io/vitess/go/vt/log"
-
-	"context"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -48,41 +44,63 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/concurrency"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 var (
 	// AWS API region
-	region = flag.String("s3_backup_aws_region", "us-east-1", "AWS region to use")
+	region string
 
 	// AWS request retries
-	retryCount = flag.Int("s3_backup_aws_retries", -1, "AWS request retries")
+	retryCount int
 
 	// AWS endpoint, defaults to amazonaws.com but appliances may use a different location
-	endpoint = flag.String("s3_backup_aws_endpoint", "", "endpoint of the S3 backend (region must be provided)")
+	endpoint string
 
 	// bucket is where the backups will go.
-	bucket = flag.String("s3_backup_storage_bucket", "", "S3 bucket to use for backups")
+	bucket string
 
 	// root is a prefix added to all object names.
-	root = flag.String("s3_backup_storage_root", "", "root prefix for all backup-related object names")
+	root string
 
 	// forcePath is used to ensure that the certificate and path used match the endpoint + region
-	forcePath = flag.Bool("s3_backup_force_path_style", false, "force the s3 path style")
+	forcePath bool
 
-	tlsSkipVerifyCert = flag.Bool("s3_backup_tls_skip_verify_cert", false, "skip the 'certificate is valid' check for SSL connections")
+	tlsSkipVerifyCert bool
 
 	// verboseLogging provides more verbose logging of AWS actions
-	requiredLogLevel = flag.String("s3_backup_log_level", "LogOff", "determine the S3 loglevel to use from LogOff, LogDebug, LogDebugWithSigning, LogDebugWithHTTPBody, LogDebugWithRequestRetries, LogDebugWithRequestErrors")
+	requiredLogLevel string
 
 	// sse is the server-side encryption algorithm used when storing this object in S3
-	sse = flag.String("s3_backup_server_side_encryption", "", "server-side encryption algorithm (e.g., AES256, aws:kms, sse_c:/path/to/key/file)")
+	sse string
 
 	// path component delimiter
 	delimiter = "/"
 )
+
+func registerFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&region, "s3_backup_aws_region", "us-east-1", "AWS region to use.")
+	fs.IntVar(&retryCount, "s3_backup_aws_retries", -1, "AWS request retries.")
+	fs.StringVar(&endpoint, "s3_backup_aws_endpoint", "", "endpoint of the S3 backend (region must be provided).")
+	fs.StringVar(&bucket, "s3_backup_storage_bucket", "", "S3 bucket to use for backups.")
+	fs.StringVar(&root, "s3_backup_storage_root", "", "root prefix for all backup-related object names.")
+	fs.BoolVar(&forcePath, "s3_backup_force_path_style", false, "force the s3 path style.")
+	fs.BoolVar(&tlsSkipVerifyCert, "s3_backup_tls_skip_verify_cert", false, "skip the 'certificate is valid' check for SSL connections.")
+	fs.StringVar(&requiredLogLevel, "s3_backup_log_level", "LogOff", "determine the S3 loglevel to use from LogOff, LogDebug, LogDebugWithSigning, LogDebugWithHTTPBody, LogDebugWithRequestRetries, LogDebugWithRequestErrors.")
+	fs.StringVar(&sse, "s3_backup_server_side_encryption", "", "server-side encryption algorithm (e.g., AES256, aws:kms, sse_c:/path/to/key/file).")
+}
+
+func init() {
+	servenv.OnParseFor("vtbackup", registerFlags)
+	servenv.OnParseFor("vtctl", registerFlags)
+	servenv.OnParseFor("vtctld", registerFlags)
+	servenv.OnParseFor("vttablet", registerFlags)
+}
 
 type logNameToLogLevel map[string]aws.LogLevelType
 
@@ -154,7 +172,7 @@ func (bh *S3BackupHandle) AddFile(ctx context.Context, filename string, filesize
 		object := objName(bh.dir, bh.name, filename)
 
 		_, err := uploader.Upload(&s3manager.UploadInput{
-			Bucket:               bucket,
+			Bucket:               &bucket,
 			Key:                  object,
 			Body:                 reader,
 			ServerSideEncryption: bh.bs.s3SSE.awsAlg,
@@ -195,7 +213,7 @@ func (bh *S3BackupHandle) ReadFile(ctx context.Context, filename string) (io.Rea
 	}
 	object := objName(bh.dir, bh.name, filename)
 	out, err := bh.client.GetObject(&s3.GetObjectInput{
-		Bucket:               bucket,
+		Bucket:               &bucket,
 		Key:                  object,
 		SSECustomerAlgorithm: bh.bs.s3SSE.customerAlg,
 		SSECustomerKey:       bh.bs.s3SSE.customerKey,
@@ -219,8 +237,8 @@ type S3ServerSideEncryption struct {
 func (s3ServerSideEncryption *S3ServerSideEncryption) init() error {
 	s3ServerSideEncryption.reset()
 
-	if strings.HasPrefix(*sse, sseCustomerPrefix) {
-		sseCustomerKeyFile := strings.TrimPrefix(*sse, sseCustomerPrefix)
+	if strings.HasPrefix(sse, sseCustomerPrefix) {
+		sseCustomerKeyFile := strings.TrimPrefix(sse, sseCustomerPrefix)
 		base64CodedKey, err := os.ReadFile(sseCustomerKeyFile)
 		if err != nil {
 			log.Errorf(err.Error())
@@ -236,8 +254,8 @@ func (s3ServerSideEncryption *S3ServerSideEncryption) init() error {
 		s3ServerSideEncryption.customerAlg = aws.String("AES256")
 		s3ServerSideEncryption.customerKey = aws.String(string(decodedKey))
 		s3ServerSideEncryption.customerMd5 = aws.String(base64.StdEncoding.EncodeToString(md5Hash[:]))
-	} else if *sse != "" {
-		s3ServerSideEncryption.awsAlg = sse
+	} else if sse != "" {
+		s3ServerSideEncryption.awsAlg = &sse
 	}
 	return nil
 }
@@ -258,7 +276,7 @@ type S3BackupStorage struct {
 
 // ListBackups is part of the backupstorage.BackupStorage interface.
 func (bs *S3BackupStorage) ListBackups(ctx context.Context, dir string) ([]backupstorage.BackupHandle, error) {
-	log.Infof("ListBackups: [s3] dir: %v, bucket: %v", dir, *bucket)
+	log.Infof("ListBackups: [s3] dir: %v, bucket: %v", dir, bucket)
 	c, err := bs.client()
 	if err != nil {
 		return nil, err
@@ -273,7 +291,7 @@ func (bs *S3BackupStorage) ListBackups(ctx context.Context, dir string) ([]backu
 	log.Infof("objName: %v", searchPrefix)
 
 	query := &s3.ListObjectsV2Input{
-		Bucket:    bucket,
+		Bucket:    &bucket,
 		Delimiter: &delimiter,
 		Prefix:    searchPrefix,
 	}
@@ -314,7 +332,7 @@ func (bs *S3BackupStorage) ListBackups(ctx context.Context, dir string) ([]backu
 
 // StartBackup is part of the backupstorage.BackupStorage interface.
 func (bs *S3BackupStorage) StartBackup(ctx context.Context, dir, name string) (backupstorage.BackupHandle, error) {
-	log.Infof("StartBackup: [s3] dir: %v, name: %v, bucket: %v", dir, name, *bucket)
+	log.Infof("StartBackup: [s3] dir: %v, name: %v, bucket: %v", dir, name, bucket)
 	c, err := bs.client()
 	if err != nil {
 		return nil, err
@@ -331,7 +349,7 @@ func (bs *S3BackupStorage) StartBackup(ctx context.Context, dir, name string) (b
 
 // RemoveBackup is part of the backupstorage.BackupStorage interface.
 func (bs *S3BackupStorage) RemoveBackup(ctx context.Context, dir, name string) error {
-	log.Infof("RemoveBackup: [s3] dir: %v, name: %v, bucket: %v", dir, name, *bucket)
+	log.Infof("RemoveBackup: [s3] dir: %v, name: %v, bucket: %v", dir, name, bucket)
 
 	c, err := bs.client()
 	if err != nil {
@@ -339,7 +357,7 @@ func (bs *S3BackupStorage) RemoveBackup(ctx context.Context, dir, name string) e
 	}
 
 	query := &s3.ListObjectsV2Input{
-		Bucket: bucket,
+		Bucket: &bucket,
 		Prefix: objName(dir, name),
 	}
 
@@ -358,7 +376,7 @@ func (bs *S3BackupStorage) RemoveBackup(ctx context.Context, dir, name string) e
 
 		quiet := true // return less in the Delete response
 		out, err := c.DeleteObjects(&s3.DeleteObjectsInput{
-			Bucket: bucket,
+			Bucket: &bucket,
 			Delete: &s3.Delete{
 				Objects: objIds,
 				Quiet:   &quiet,
@@ -398,7 +416,7 @@ var _ backupstorage.BackupStorage = (*S3BackupStorage)(nil)
 func getLogLevel() *aws.LogLevelType {
 	l := new(aws.LogLevelType)
 	*l = aws.LogOff // default setting
-	if level, found := logNameMap[*requiredLogLevel]; found {
+	if level, found := logNameMap[requiredLogLevel]; found {
 		*l = level // adjust as required
 	}
 	return l
@@ -410,7 +428,7 @@ func (bs *S3BackupStorage) client() (*s3.S3, error) {
 	if bs._client == nil {
 		logLevel := getLogLevel()
 
-		tlsClientConf := &tls.Config{InsecureSkipVerify: *tlsSkipVerifyCert}
+		tlsClientConf := &tls.Config{InsecureSkipVerify: tlsSkipVerifyCert}
 		httpTransport := &http.Transport{TLSClientConfig: tlsClientConf}
 		httpClient := &http.Client{Transport: httpTransport}
 
@@ -422,26 +440,26 @@ func (bs *S3BackupStorage) client() (*s3.S3, error) {
 		awsConfig := aws.Config{
 			HTTPClient:       httpClient,
 			LogLevel:         logLevel,
-			Endpoint:         aws.String(*endpoint),
-			Region:           aws.String(*region),
-			S3ForcePathStyle: aws.Bool(*forcePath),
+			Endpoint:         aws.String(endpoint),
+			Region:           aws.String(region),
+			S3ForcePathStyle: aws.Bool(forcePath),
 		}
 
-		if *retryCount >= 0 {
+		if retryCount >= 0 {
 			awsConfig = *request.WithRetryer(&awsConfig, &ClosedConnectionRetryer{
 				awsRetryer: &client.DefaultRetryer{
-					NumMaxRetries: *retryCount,
+					NumMaxRetries: retryCount,
 				},
 			})
 		}
 
 		bs._client = s3.New(session, &awsConfig)
 
-		if len(*bucket) == 0 {
-			return nil, fmt.Errorf("-s3_backup_storage_bucket required")
+		if len(bucket) == 0 {
+			return nil, fmt.Errorf("--s3_backup_storage_bucket required")
 		}
 
-		if _, err := bs._client.HeadBucket(&s3.HeadBucketInput{Bucket: bucket}); err != nil {
+		if _, err := bs._client.HeadBucket(&s3.HeadBucketInput{Bucket: &bucket}); err != nil {
 			return nil, err
 		}
 
@@ -454,8 +472,8 @@ func (bs *S3BackupStorage) client() (*s3.S3, error) {
 
 func objName(parts ...string) *string {
 	res := ""
-	if *root != "" {
-		res += *root + delimiter
+	if root != "" {
+		res += root + delimiter
 	}
 	res += strings.Join(parts, delimiter)
 	return &res

--- a/go/vt/mysqlctl/s3backupstorage/s3_test.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_test.go
@@ -61,7 +61,7 @@ func TestNoSSE(t *testing.T) {
 }
 
 func TestSSEAws(t *testing.T) {
-	sse = aws.String("aws:kms")
+	sse = "aws:kms"
 	sseData := S3ServerSideEncryption{}
 	err := sseData.init()
 	require.NoErrorf(t, err, "init() expected to succeed")
@@ -91,7 +91,7 @@ func TestSSECustomerFileNotFound(t *testing.T) {
 	err = os.Remove(tempFile.Name())
 	require.NoErrorf(t, err, "Remove() expected to succeed")
 
-	sse = aws.String(sseCustomerPrefix + tempFile.Name())
+	sse = sseCustomerPrefix + tempFile.Name()
 	sseData := S3ServerSideEncryption{}
 	err = sseData.init()
 	require.Errorf(t, err, "init() expected to fail")
@@ -110,7 +110,7 @@ func TestSSECustomerFileBinaryKey(t *testing.T) {
 	err = tempFile.Close()
 	require.NoErrorf(t, err, "Close() expected to succeed")
 
-	sse = aws.String(sseCustomerPrefix + tempFile.Name())
+	sse = sseCustomerPrefix + tempFile.Name()
 	sseData := S3ServerSideEncryption{}
 	err = sseData.init()
 	require.NoErrorf(t, err, "init() expected to succeed")
@@ -145,7 +145,7 @@ func TestSSECustomerFileBase64Key(t *testing.T) {
 	err = tempFile.Close()
 	require.NoErrorf(t, err, "Close() expected to succeed")
 
-	sse = aws.String(sseCustomerPrefix + tempFile.Name())
+	sse = sseCustomerPrefix + tempFile.Name()
 	sseData := S3ServerSideEncryption{}
 	err = sseData.init()
 	require.NoErrorf(t, err, "init() expected to succeed")

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -115,7 +115,7 @@ func testBackupRestore(t *testing.T, cDetails *compressionDetails) error {
 
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
-	*filebackupstorage.FileBackupStorageRoot = fbsRoot
+	filebackupstorage.FileBackupStorageRoot = fbsRoot
 	*backupstorage.BackupStorageImplementation = "file"
 	if cDetails != nil {
 		if cDetails.BuiltinCompressor != "" {
@@ -348,7 +348,7 @@ func TestBackupRestoreLagged(t *testing.T) {
 
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
-	*filebackupstorage.FileBackupStorageRoot = fbsRoot
+	filebackupstorage.FileBackupStorageRoot = fbsRoot
 	*backupstorage.BackupStorageImplementation = "file"
 
 	// Initialize the fake mysql root directories
@@ -552,7 +552,7 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
-	*filebackupstorage.FileBackupStorageRoot = fbsRoot
+	filebackupstorage.FileBackupStorageRoot = fbsRoot
 	*backupstorage.BackupStorageImplementation = "file"
 
 	// Initialize the fake mysql root directories
@@ -712,7 +712,7 @@ func TestDisableActiveReparents(t *testing.T) {
 
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
-	*filebackupstorage.FileBackupStorageRoot = fbsRoot
+	filebackupstorage.FileBackupStorageRoot = fbsRoot
 	*backupstorage.BackupStorageImplementation = "file"
 
 	// Initialize the fake mysql root directories


### PR DESCRIPTION
## Description

This scopes all the flags of our backupstorage _implementation_ packages to `pflag` and the associated binaries. Each of these is only used by `vtbackup`, `vtctl`, `vtctld`, and `vttablet`. I'm punting on the one flag in `go/vt/mysqlctl/backupstorage` (#10812) because it ends up being being imported by a lot more things, so I need to do more analysis first.

## Related Issue(s)

- Closes #10811 
- Closes #10813 
- Closes #10814 
- Closes #10815 
- Closes #10816 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported - n/a
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
