### PR TITLE
[cli] [mysqlctl] Scope `backup_storage_implementation` flag to `pflag`

### DIFF
--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -12,7 +12,7 @@ Usage of vttablet:
       --backup_storage_block_size int                                    if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup_storage_compress                                          if set, the backup files will be compressed (default is true). Set to false for instance if a backup_storage_hook is specified and it compresses the data. (default true)
       --backup_storage_hook string                                       if set, we send the contents of the backup files through this hook.
-      --backup_storage_implementation string                             which implementation to use for the backup storage feature
+      --backup_storage_implementation string                             Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, at once, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression (default 2)
       --binlog_host string                                               PITR restore parameter: hostname/IP of binlog server.
       --binlog_password string                                           PITR restore parameter: password of binlog server.

--- a/go/vt/mysqlctl/s3backupstorage/README.txt
+++ b/go/vt/mysqlctl/s3backupstorage/README.txt
@@ -10,7 +10,7 @@ to be changed.
 
 Given the way the FQDN is configured the TLS certificate may not match the
 server's "base" (<region>.<end_point_address>) due to the leading <path>
-so setting --3_backup_force_path_style=true will force the s3 client to
+so setting --s3_backup_force_path_style=true will force the s3 client to
 connect to <region>.<endpoint> and then make a request using the full
 path within the http calls.
 

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -56,7 +56,7 @@ import (
 )
 
 func init() {
-	*backupstorage.BackupStorageImplementation = testutil.BackupStorageImplementation
+	backupstorage.BackupStorageImplementation = testutil.BackupStorageImplementation
 
 	// For tests that don't actually care about mocking the tmclient (i.e. they
 	// call NewVtctldServer to initialize the unit under test), this needs to be
@@ -4047,8 +4047,8 @@ func TestGetBackups(t *testing.T) {
 	utils.MustMatch(t, expected, resp)
 
 	t.Run("no backupstorage", func(t *testing.T) {
-		*backupstorage.BackupStorageImplementation = "doesnotexist"
-		defer func() { *backupstorage.BackupStorageImplementation = testutil.BackupStorageImplementation }()
+		backupstorage.BackupStorageImplementation = "doesnotexist"
+		defer func() { backupstorage.BackupStorageImplementation = testutil.BackupStorageImplementation }()
 
 		_, err := vtctld.GetBackups(ctx, &vtctldatapb.GetBackupsRequest{
 			Keyspace: "testkeyspace",

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -116,7 +116,7 @@ func testBackupRestore(t *testing.T, cDetails *compressionDetails) error {
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
 	filebackupstorage.FileBackupStorageRoot = fbsRoot
-	*backupstorage.BackupStorageImplementation = "file"
+	backupstorage.BackupStorageImplementation = "file"
 	if cDetails != nil {
 		if cDetails.BuiltinCompressor != "" {
 			*mysqlctl.BuiltinCompressor = cDetails.BuiltinCompressor
@@ -349,7 +349,7 @@ func TestBackupRestoreLagged(t *testing.T) {
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
 	filebackupstorage.FileBackupStorageRoot = fbsRoot
-	*backupstorage.BackupStorageImplementation = "file"
+	backupstorage.BackupStorageImplementation = "file"
 
 	// Initialize the fake mysql root directories
 	sourceInnodbDataDir := path.Join(root, "source_innodb_data")
@@ -553,7 +553,7 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
 	filebackupstorage.FileBackupStorageRoot = fbsRoot
-	*backupstorage.BackupStorageImplementation = "file"
+	backupstorage.BackupStorageImplementation = "file"
 
 	// Initialize the fake mysql root directories
 	sourceInnodbDataDir := path.Join(root, "source_innodb_data")
@@ -713,7 +713,7 @@ func TestDisableActiveReparents(t *testing.T) {
 	// Initialize BackupStorage
 	fbsRoot := path.Join(root, "fbs")
 	filebackupstorage.FileBackupStorageRoot = fbsRoot
-	*backupstorage.BackupStorageImplementation = "file"
+	backupstorage.BackupStorageImplementation = "file"
 
 	// Initialize the fake mysql root directories
 	sourceInnodbDataDir := path.Join(root, "source_innodb_data")


### PR DESCRIPTION
## Description

Builds on #10844 and will need a rebase after that merges.

This package is imported by the following commands, which I've annotated as follows (**reviewers please call out any analysis you disagree with**):
- `go/cmd/mysqlctl` => no need for this flag, imports `mysqlctl` for other functionality
- `go/cmd/mysqlctld` => doesn't need it, "only starts and stops mysql"
- `go/cmd/rulesctl` => imports `go/cmd/rulesctl/cmd`, see below
- `go/cmd/rulesctl/cmd` =>  doesn't need it; imports `go/cmd/rulesctl/common` (see next) and `go/vt/vttablet/tabletserver/rules`, which imports `../tabletserver/schema` which imports `mysqlctl` for `mysqlctl.GetColumns`
- `go/cmd/vtadmin` => doesn't need it, is importing `go/vt/vtexplain` (see below)
- `go/cmd/vtbackup` => **needs the flag**
- `go/cmd/vtcombo` => i'm _mostly_ sure it doesn't need it? i don't see any references to backups in the vtcombo code, but i'm not an expert so i need a second opinion here (cc @deepthi )
- `go/cmd/vtctl` => **yes**
- `go/cmd/vtctld` => **yes**
- `go/cmd/vtctldclient` => doesn't need it, imports `go/cmd/vtctldclient/command` (see next)
- `go/cmd/vtctldclient/command` => doesn't need it, imports `mysqlctl` only for `mysqlctl.BackupTimestampFormat`
- `go/cmd/vtexplain` => doesn't need it, imports `go/vt/vtexplain`, which imports `go/vt/vttablet/tabletserver/*` packages, which per previous lines, reach `mysqlctl` but not for backup functionality
- `go/cmd/vttablet` => **needs the flag**
- `go/cmd/vttestserver` => doesn't need it, does import `mysqlctl` but only for parts that reference `backupstorage` _types_ (`BackupHandle` mostly), but never the actual flag value.
- `go/cmd/zk` => doesn't need it, just imports `vtctl` to use `vtctl.DecodeContent`

## Related Issue(s)

- Closes #10812 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported - n/a
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
