### PR TITLE
[cli] [vtgate] Add `pflag.Value` implementation to `topoproto.TabletTypeFlag`, migrate only flag instance

### DIFF
--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -17,7 +17,7 @@ Usage of vtgate:
       --datadog-agent-port string                                        port to send spans to. if empty, no tracing will be done
       --dbddl_plugin string                                              controls how to handle CREATE/DROP DATABASE. use it if you are using your own database provisioning service (default "fail")
       --ddl_strategy string                                              Set default strategy for DDL statements. Override with @@ddl_strategy session variable (default "direct")
-      --default_tablet_type TabletTypeFlag                               The default tablet type to set for queries, when one is not explicitly selected (default PRIMARY)
+      --default_tablet_type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
       --disable_local_gateway                                            deprecated: if specified, this process will not route any queries to local tablets in the local cell
       --discovery_high_replication_lag_minimum_serving duration          the replication lag that is considered too high when applying the min_number_serving_vttablets threshold (default 2h0m0s)
       --discovery_low_replication_lag duration                           the replication lag that is considered low enough to be healthy (default 30s)

--- a/go/vt/topo/topoproto/flag.go
+++ b/go/vt/topo/topoproto/flag.go
@@ -29,13 +29,6 @@ func TabletTypeListVar(p *[]topodatapb.TabletType, name string, usage string) {
 	flag.Var((*TabletTypeListValue)(p), name, usage)
 }
 
-// TabletTypeVar defines a TabletType flag with the specified name, default value and usage
-// string. The argument 'p' points to a tabletType in which to store the value of the flag.
-func TabletTypeVar(p *topodatapb.TabletType, name string, defaultValue topodatapb.TabletType, usage string) {
-	*p = defaultValue
-	flag.Var((*TabletTypeFlag)(p), name, usage)
-}
-
 // TabletTypeListValue implements the flag.Value interface, for parsing a command-line comma-separated
 // list of value into a slice of TabletTypes.
 type TabletTypeListValue []topodatapb.TabletType
@@ -56,20 +49,23 @@ func (ttlv *TabletTypeListValue) Get() any {
 	return *ttlv
 }
 
-// TabletTypeFlag implements the flag.Value interface, for parsing a command-line value into a TabletType.
+// TabletTypeFlag implements the flag.Value and pflag.Value interfaces, for parsing a command-line value into a TabletType.
 type TabletTypeFlag topodatapb.TabletType
 
-// String is part of the flag.Value interface.
+// String is part of the flag.Value and pflag.Value interfaces.
 func (ttf *TabletTypeFlag) String() string {
 	return topodatapb.TabletType(*ttf).String()
 }
 
-// Set is part of the flag.Value interface.
+// Set is part of the flag.Value and pflag.Value interfaces.
 func (ttf *TabletTypeFlag) Set(v string) error {
 	t, err := ParseTabletType(v)
 	*ttf = TabletTypeFlag(t)
 	return err
 }
+
+// Type is part of the pflag.Value interface.
+func (*TabletTypeFlag) Type() string { return "topodatapb.TabletType" }
 
 // Get is for satisflying the internal flag interface.
 func (ttf *TabletTypeFlag) Get() any {


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This extends the `topoproto.TabletTypeFlag` type to also implement `pflag.Value`, and then switches the single occurrence (in `go/vt/vtgate/`) to pflag and scopes to the binaries that need it (N.B. `vtadmin` also imports it but does not care about the flag being registered).

Then, we no longer need the helper function, so I deleted it.

## Related Issue(s)

Partially fixes #10861.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported - n/a
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
