### PR TITLE
Fix the MySQL connection is closed incorrectly

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -692,6 +692,11 @@ func (c *Conn) String() string {
 // routine to interrupt the current connection.
 func (c *Conn) Close() {
 	if c.closed.CompareAndSwap(false, true) {
+		// The connection is on the client side.
+		if c.listener == nil {
+			// Send a ComQuit to avoid the error message on the server side.
+			c.writeComQuit()
+		}
 		c.conn.Close()
 	}
 }


### PR DESCRIPTION
Signed-off-by: Zhang,Yuheng <zhangeek@qq.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#10832

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
