### PR TITLE
Fix client session state tracking logic

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1466,8 +1466,12 @@ func (c *Conn) parseOKPacket(in []byte) (*PacketOK, error) {
 				return fail("invalid OK packet session state change length: %v", data)
 			}
 			sscType, ok := data.readByte()
-			if !ok || sscType != SessionTrackGtids {
+			if !ok {
 				return fail("invalid OK packet session state change type: %v", sscType)
+			}
+			// If it's not a GTID, we don't care about it so we can return.
+			if sscType != SessionTrackGtids {
+				return packetOK, nil
 			}
 
 			// Move past the total length of the changed entity: 1 byte

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1363,9 +1363,12 @@ func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
 // Packet parsing methods, for generic packets.
 //
 
-// isEOFPacket determines whether or not a data packet is a "true" EOF. DO NOT blindly compare the
-// first byte of a packet to EOFPacket as you might do for other packet types, as 0xfe is overloaded
-// as a first byte.
+// isEOFPacket determines whether a data packet is an EOF. In case the client capabilities
+// do not have DEPRECATE_EOF set, DO NOT blindly compare the first byte of a packet to EOFPacket
+// as you might do for other packet types, as 0xfe is overloaded as a first byte.
+
+// In case that DEPRECATE_EOF is set, we have really an OK packet which is always maximum a single
+// packet and not multiple, but otherwise 0xfe definitely indicates it is an EOF.
 //
 // Per https://dev.mysql.com/doc/internals/en/packet-EOF_Packet.html, a packet starting with 0xfe
 // but having length >= 9 (on top of 4 byte header) is not a true EOF but a LengthEncodedInteger
@@ -1379,8 +1382,14 @@ func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
 //
 // More docs here:
 // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_response_packets.html
-func isEOFPacket(data []byte) bool {
-	return data[0] == EOFPacket && len(data) < 9
+func (c *Conn) isEOFPacket(data []byte) bool {
+	if data[0] != EOFPacket {
+		return false
+	}
+	if c.Capabilities&CapabilityClientDeprecateEOF == 0 {
+		return len(data) < 9
+	}
+	return len(data) < MaxPacketSize
 }
 
 // parseEOFPacket returns the warning count and a boolean to indicate if there

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -396,7 +396,7 @@ func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (*sqltypes.Result, 
 		if err != nil {
 			return nil, false, 0, NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
 		}
-		if isEOFPacket(data) {
+		if c.isEOFPacket(data) {
 
 			// This is what we expect.
 			// Warnings and status flags are ignored.
@@ -419,10 +419,7 @@ func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (*sqltypes.Result, 
 			return nil, false, 0, err
 		}
 
-		// TODO: harshit - the EOF packet is deprecated as of MySQL 5.7.5.
-		// https://dev.mysql.com/doc/internals/en/packet-EOF_Packet.html
-		// It will be OK Packet with EOF Header. This needs to change in the code here.
-		if isEOFPacket(data) {
+		if c.isEOFPacket(data) {
 			defer c.recycleReadPacket()
 
 			// Strip the partial Fields before returning.
@@ -486,7 +483,7 @@ func (c *Conn) drainResults() error {
 		if err != nil {
 			return NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
 		}
-		if isEOFPacket(data) {
+		if c.isEOFPacket(data) {
 			c.recycleReadPacket()
 			return nil
 		} else if isErrorPacket(data) {

--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -78,7 +78,7 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 			return NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
 		}
 		defer c.recycleReadPacket()
-		if isEOFPacket(data) {
+		if c.isEOFPacket(data) {
 			// This is what we expect.
 			// Warnings and status flags are ignored.
 			// goto: end
@@ -123,7 +123,7 @@ func (c *Conn) FetchNext(in []sqltypes.Value) ([]sqltypes.Value, error) {
 		return nil, err
 	}
 
-	if isEOFPacket(data) {
+	if c.isEOFPacket(data) {
 		// Warnings and status flags are ignored.
 		c.fields = nil
 		return nil, nil


### PR DESCRIPTION
The existing logic to track GTIDs doesn't really work when using it, because there's things lacking and it blows up as well.

First of all, only by manually setting up capability overrides can it be enabled during the handshake. I think we should always send the flag though based on whether the server supports the capability during the handshake.

This removes the need for custom startup flag configuration if anything wants to use GTID tracking.

Secondly, once session level tracking is enabled, things blow up quickly. Session tracking is not only about GTIDs, but it also tracks other session level changes.

Specifically the session tracking when the schema changes is something that affects things here.

https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_session_track_schema

This setting is enabled by default on MySQL and means that without any action, if the capability is enabled, MySQL sends down the new schema name if it changes.

That immediately blows up in the OK packet parsing though. It fails because it only accepts the GTID type. I think it's preferable to ignore other types than GTIDs because we don't expose that internally yet but we should not blow up when we see those.

## Related Issue(s)

Having working GTID tracking will help with experiments like https://github.com/vitessio/vitess/pull/10663

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required