### PR TITLE
Improve OnlineDDL VRepl Flakes

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -254,7 +254,7 @@ func TestSchemaChange(t *testing.T) {
 	providedMigrationContext := ""
 	testWithInitialSchema(t)
 	t.Run("alter non_online", func(t *testing.T) {
-		testOnlineDDLStatement(t, alterTableNormalStatement, string(schema.DDLStrategyDirect), providedUUID, providedMigrationContext, "vtctl", "non_online", "")
+		_ = testOnlineDDLStatement(t, alterTableNormalStatement, string(schema.DDLStrategyDirect), providedUUID, providedMigrationContext, "vtctl", "non_online", "")
 		insertRows(t, 2)
 		testRows(t)
 	})
@@ -313,7 +313,7 @@ func TestSchemaChange(t *testing.T) {
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 	})
 	t.Run("fail duplicate migration with different context", func(t *testing.T) {
-		testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, "endtoend:different-context-0000", "vtctl", "vrepl_col", "rejected")
+		_ = testOnlineDDLStatement(t, alterTableTrivialStatement, "online", providedUUID, "endtoend:different-context-0000", "vtctl", "vrepl_col", "rejected")
 	})
 	providedUUID = ""
 	providedMigrationContext = ""
@@ -322,7 +322,7 @@ func TestSchemaChange(t *testing.T) {
 		insertRows(t, 2)
 		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "vitess -postpone-completion", providedUUID, providedMigrationContext, "vtgate", "test_val", "")
 		// Should be running!
-		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusRunning)
+		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusRunning)
 		// Issue a complete and wait for successful completion
 		onlineddl.CheckCompleteMigration(t, &vtParams, shards, uuid, true)
 		// This part may take a while, because we depend on vreplicatoin polling
@@ -346,10 +346,10 @@ func TestSchemaChange(t *testing.T) {
 		defer onlineddl.UnthrottleAllMigrations(t, &vtParams)
 
 		uuid := testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", schema.OnlineDDLStatusRunning)
-		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusRunning)
+		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusRunning)
 		testRows(t)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, true)
-		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusFailed)
+		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusFailed)
 	})
 
 	t.Run("throttled and unthrottled migration", func(t *testing.T) {
@@ -362,7 +362,7 @@ func TestSchemaChange(t *testing.T) {
 		onlineddl.CheckThrottledApps(t, &vtParams, onlineDDLThrottlerAppName, true)
 
 		uuid := testOnlineDDLStatement(t, alterTableTrivialStatement, "vitess", providedUUID, providedMigrationContext, "vtgate", "test_val", "", schema.OnlineDDLStatusRunning)
-		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusRunning)
+		_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, schema.OnlineDDLStatusRunning)
 		testRows(t)
 
 		// gotta give the migration a few seconds to read throttling info from _vt.vreplication and write
@@ -451,7 +451,7 @@ func TestSchemaChange(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				testOnlineDDLStatement(t, alterTableThrottlingStatement, "vitess", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", schema.OnlineDDLStatusRunning, schema.OnlineDDLStatusReady)
+				_ = testOnlineDDLStatement(t, alterTableThrottlingStatement, "vitess", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", schema.OnlineDDLStatusRunning, schema.OnlineDDLStatusReady)
 			}()
 		}
 		wg.Wait()
@@ -470,7 +470,7 @@ func TestSchemaChange(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", schema.OnlineDDLStatusRunning, schema.OnlineDDLStatusReady)
+				_ = testOnlineDDLStatement(t, alterTableThrottlingStatement, "online", providedUUID, providedMigrationContext, "vtgate", "vrepl_col", "", schema.OnlineDDLStatusRunning, schema.OnlineDDLStatusReady)
 			}()
 		}
 		wg.Wait()
@@ -558,7 +558,7 @@ func TestSchemaChange(t *testing.T) {
 					assert.Contains(t, body, onlineDDLThrottlerAppName)
 				}
 
-				onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, extendedMigrationWait, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+				_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, extendedMigrationWait, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 			})
 
 			t.Run("Check tablet post PRS", func(t *testing.T) {
@@ -584,7 +584,7 @@ func TestSchemaChange(t *testing.T) {
 				}
 				onlineddl.CheckRetryPartialMigration(t, &vtParams, uuid)
 				// Now it should complete on the failed shard
-				onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, extendedMigrationWait, schema.OnlineDDLStatusComplete)
+				_ = onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, extendedMigrationWait, schema.OnlineDDLStatusComplete)
 			})
 		})
 	}

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -852,14 +852,14 @@ func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy str
 	}
 	if strategySetting.IsPostponeCompletion() {
 		// We expect it to be running by default
-		if expectStatuses == nil || len(expectStatuses) == 0 {
+		if len(expectStatuses) == 0 {
 			expectStatuses = []schema.OnlineDDLStatus{schema.OnlineDDLStatusRunning}
 		}
 	}
 	if expectError == "" {
 		if waitFor == "migration" {
 			// Unless otherwise specified, the migration should be completed
-			if expectStatuses == nil || len(expectStatuses) == 0 {
+			if len(expectStatuses) == 0 {
 				expectStatuses = []schema.OnlineDDLStatus{schema.OnlineDDLStatusComplete}
 			}
 			status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalMigrationWait, expectStatuses...)

--- a/go/test/endtoend/onlineddl/vtgate_util.go
+++ b/go/test/endtoend/onlineddl/vtgate_util.go
@@ -228,8 +228,6 @@ func WaitForMigrationStatus(t *testing.T, vtParams *mysql.ConnParams, shards []c
 		}
 		time.Sleep(1 * time.Second)
 	}
-	require.Fail(t, fmt.Sprintf("migration %s did not reach an expected status (%v) before hitting the timeout of %v, last known status: %v",
-		uuid, expectStatuses, timeout, lastKnownStatus))
 	return schema.OnlineDDLStatus(lastKnownStatus)
 }
 

--- a/go/test/endtoend/onlineddl/vtgate_util.go
+++ b/go/test/endtoend/onlineddl/vtgate_util.go
@@ -316,6 +316,7 @@ func WaitForThrottledTimestamp(t *testing.T, vtParams *mysql.ConnParams, uuid st
 		}
 		time.Sleep(1 * time.Second)
 	}
-	require.Fail(t, fmt.Sprintf("failed to get a last_throttled_timestamp value before timeout of %v", timeout))
+	require.Fail(t, fmt.Sprintf("failed to get a last_throttled_timestamp value for migration %s before hitting the timeout of %v",
+		uuid, timeout))
 	return
 }

--- a/test/config.json
+++ b/test/config.json
@@ -261,7 +261,7 @@
 		},
 		"onlineddl_vrepl": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/vrepl"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/vrepl", "-timeout", "20m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "onlineddl_vrepl",


### PR DESCRIPTION
## Description

The OnlineDDL VRepl tests are still flaky (especially the MySQL 8.0 ones), although they are much better. We still have some timing issues and 8.0 seems to trigger them more frequently. 

This PR makes some minor changes to what/how we wait for things in order to remove the race/timing issues and make them more consistent. 

ℹ️ We should also make the OnlineDDL VRepl tests *required* again once this is merged (I can do that).

## Related Issue(s)

 - Limited follow-up to: https://github.com/vitessio/vitess/pull/10759

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation is not required