### PR TITLE
feat: don't use the vtgatehandler unless it is known to have been initialized

### DIFF
--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -550,6 +550,11 @@ func rollbackAtShutdown() {
 		}
 	}()
 
+	if vtgateHandle == nil {
+		// we still haven't been able to initialise the vtgateHandler, so we don't need to rollback anything
+		return
+	}
+
 	// If vtgate is instead busy executing a query, the number of open conns
 	// will be non-zero. Give another second for those queries to finish.
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
## Description

When a vtgate is started and very quickly terminated, it can panic. This is because the shutdown process tried to use parts of the system that have not yet been fully initialized. This change protects the `vtgateHandler` from accidental use before init has happened.
