### PR TITLE
BugFix: Vttablet semi-sync settings on startup

### DIFF
--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -307,3 +307,8 @@ func (mysqld *vtcomboMysqld) StartReplicationUntilAfter(ctx context.Context, pos
 func (mysqld *vtcomboMysqld) StopReplication(hookExtraEnv map[string]string) error {
 	return nil
 }
+
+// SetSemiSyncEnabled implements the MysqlDaemon interface
+func (mysqld *vtcomboMysqld) SetSemiSyncEnabled(source, replica bool) error {
+	return nil
+}

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -28,15 +28,12 @@ import (
 	"strings"
 	"time"
 
-	"vitess.io/vitess/go/vt/env"
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-
-	"vitess.io/vitess/go/vt/vttest"
-
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/exit"
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/env"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
@@ -48,7 +45,9 @@ import (
 	"vitess.io/vitess/go/vt/vtcombo"
 	"vitess.io/vitess/go/vt/vtctld"
 	"vitess.io/vitess/go/vt/vtgate"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+	"vitess.io/vitess/go/vt/vttest"
 	"vitess.io/vitess/go/vt/wrangler"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -160,10 +159,10 @@ func main() {
 	servenv.Init()
 	tabletenv.Init()
 
-	var mysqld *mysqlctl.Mysqld
+	mysqld := &vtcomboMysqld{}
 	var cnf *mysqlctl.Mycnf
 	if *startMysql {
-		mysqld, cnf = startMysqld(1)
+		mysqld.Mysqld, cnf = startMysqld(1)
 		servenv.OnClose(func() {
 			mysqld.Shutdown(context.TODO(), cnf, true)
 		})
@@ -172,7 +171,7 @@ func main() {
 
 	} else {
 		dbconfigs.GlobalDBConfigs.InitWithSocket("")
-		mysqld = mysqlctl.NewMysqld(&dbconfigs.GlobalDBConfigs)
+		mysqld.Mysqld = mysqlctl.NewMysqld(&dbconfigs.GlobalDBConfigs)
 		servenv.OnClose(mysqld.Close)
 	}
 
@@ -274,4 +273,37 @@ func main() {
 		ts.Close()
 	})
 	servenv.RunDefault()
+}
+
+// vtcomboMysqld is a wrapper on top of mysqlctl.Mysqld.
+// We need this wrapper because vtcombo runs with a single MySQL instance
+// which all the tablets connect to. (replica, primary, all). This means that we shouldn't
+// be trying to run any replication related commands on it, otherwise they fail.
+type vtcomboMysqld struct {
+	*mysqlctl.Mysqld
+}
+
+// SetReplicationSource implements the MysqlDaemon interface
+func (mysqld *vtcomboMysqld) SetReplicationSource(ctx context.Context, host string, port int, replicationStopBefore bool, replicationStartAfter bool) error {
+	return nil
+}
+
+//StartReplication implements the MysqlDaemon interface
+func (mysqld *vtcomboMysqld) StartReplication(hookExtraEnv map[string]string) error {
+	return nil
+}
+
+//RestartReplication implements the MysqlDaemon interface
+func (mysqld *vtcomboMysqld) RestartReplication(hookExtraEnv map[string]string) error {
+	return nil
+}
+
+//StartReplicationUntilAfter implements the MysqlDaemon interface
+func (mysqld *vtcomboMysqld) StartReplicationUntilAfter(ctx context.Context, pos mysql.Position) error {
+	return nil
+}
+
+//StopReplication implements the MysqlDaemon interface
+func (mysqld *vtcomboMysqld) StopReplication(hookExtraEnv map[string]string) error {
+	return nil
 }

--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -55,12 +55,14 @@ func TestCrossCellDurability(t *testing.T) {
 		utils.CheckSemiSyncSetupCorrectly(t, tablet, "ON")
 	}
 
-	// Bring up a new replica tablet
-	// In this new tablet, we do not disable active reparents, otherwise replication will not be started.
-	newReplica := utils.StartNewVTTablet(t, clusterInstance)
-	// Add the tablet to the list of tablets in this shard
-	clusterInstance.Keyspaces[0].Shards[0].Vttablets = append(clusterInstance.Keyspaces[0].Shards[0].Vttablets, newReplica)
-	// Check that we can replicate to it and semi-sync is setup correctly on it
-	utils.ConfirmReplication(t, tablets[3], []*cluster.Vttablet{tablets[0], tablets[1], tablets[2], newReplica})
-	utils.CheckSemiSyncSetupCorrectly(t, newReplica, "ON")
+	for i, supportsBackup := range []bool{false, true} {
+		// Bring up a new replica tablet
+		// In this new tablet, we do not disable active reparents, otherwise replication will not be started.
+		newReplica := utils.StartNewVTTablet(t, clusterInstance, 300+i, supportsBackup)
+		// Add the tablet to the list of tablets in this shard
+		clusterInstance.Keyspaces[0].Shards[0].Vttablets = append(clusterInstance.Keyspaces[0].Shards[0].Vttablets, newReplica)
+		// Check that we can replicate to it and semi-sync is setup correctly on it
+		utils.ConfirmReplication(t, tablets[3], []*cluster.Vttablet{tablets[0], tablets[1], tablets[2], newReplica})
+		utils.CheckSemiSyncSetupCorrectly(t, newReplica, "ON")
+	}
 }

--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -25,6 +25,9 @@ import (
 	"vitess.io/vitess/go/test/endtoend/reparent/utils"
 )
 
+// TestCrossCellDurability tests 2 things -
+// 1. When PRS is run with the cross_cell durability policy setup, then the semi-sync settings on all the tablets are as expected
+// 2. Bringing up a new vttablet should have its replication and semi-sync setup correctly without any external interference
 func TestCrossCellDurability(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "cross_cell")
@@ -51,4 +54,13 @@ func TestCrossCellDurability(t *testing.T) {
 	for _, tablet := range tablets {
 		utils.CheckSemiSyncSetupCorrectly(t, tablet, "ON")
 	}
+
+	// Bring up a new replica tablet
+	// In this new tablet, we do not disable active reparents, otherwise replication will not be started.
+	newReplica := utils.StartNewVTTablet(t, clusterInstance)
+	// Add the tablet to the list of tablets in this shard
+	clusterInstance.Keyspaces[0].Shards[0].Vttablets = append(clusterInstance.Keyspaces[0].Shards[0].Vttablets, newReplica)
+	// Check that we can replicate to it and semi-sync is setup correctly on it
+	utils.ConfirmReplication(t, tablets[3], []*cluster.Vttablet{tablets[0], tablets[1], tablets[2], newReplica})
+	utils.CheckSemiSyncSetupCorrectly(t, newReplica, "ON")
 }

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -193,6 +193,51 @@ func setupShard(ctx context.Context, t *testing.T, clusterInstance *cluster.Loca
 	WaitForReplicationToStart(t, clusterInstance, KeyspaceName, shardName, len(tablets), true)
 }
 
+// StartNewVTTablet starts a new vttablet instance
+func StartNewVTTablet(t *testing.T, clusterInstance *cluster.LocalProcessCluster) *cluster.Vttablet {
+	tablet := clusterInstance.NewVttabletInstance("replica", 300, cell1)
+	keyspace := clusterInstance.Keyspaces[0]
+	shard := keyspace.Shards[0]
+
+	// Setup MysqlctlProcess
+	tablet.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, clusterInstance.TmpDirectory)
+	// Setup VttabletProcess
+	tablet.VttabletProcess = cluster.VttabletProcessInstance(
+		tablet.HTTPPort,
+		tablet.GrpcPort,
+		tablet.TabletUID,
+		tablet.Cell,
+		shard.Name,
+		keyspace.Name,
+		clusterInstance.VtctldProcess.Port,
+		tablet.Type,
+		clusterInstance.TopoProcess.Port,
+		clusterInstance.Hostname,
+		clusterInstance.TmpDirectory,
+		[]string{
+			"--lock_tables_timeout", "5s",
+			"--init_populate_metadata",
+			"--track_schema_versions=true",
+			"--queryserver_enable_online_ddl=false",
+		},
+		clusterInstance.EnableSemiSync,
+		clusterInstance.DefaultCharset)
+
+	log.Infof("Starting MySql for tablet %v", tablet.Alias)
+	proc, err := tablet.MysqlctlProcess.StartProcess()
+	require.NoError(t, err, "Error starting start mysql")
+	if err := proc.Wait(); err != nil {
+		clusterInstance.PrintMysqlctlLogFiles()
+		require.FailNow(t, "Error starting mysql: %s", err.Error())
+	}
+
+	err = tablet.VttabletProcess.Setup()
+	require.NoError(t, err)
+	err = tablet.VttabletProcess.WaitForTabletStatuses([]string{"SERVING", "NOT_SERVING"})
+	require.NoError(t, err)
+	return tablet
+}
+
 //endregion
 
 //region database queries
@@ -379,20 +424,33 @@ func isHealthyPrimaryTablet(t *testing.T, clusterInstance *cluster.LocalProcessC
 func CheckInsertedValues(ctx context.Context, t *testing.T, tablet *cluster.Vttablet, index int) error {
 	query := fmt.Sprintf("select msg from vt_insert_test where id=%d", index)
 	tabletParams := getMysqlConnParam(tablet)
-	conn, err := mysql.Connect(ctx, &tabletParams)
-	require.Nil(t, err)
-	defer conn.Close()
+	var conn *mysql.Conn
 
 	// wait until it gets the data
 	timeout := time.Now().Add(replicationWaitTimeout)
 	i := 0
 	for time.Now().Before(timeout) {
-		// We'll get a mysql.ERNoSuchTable (1146) error if the CREATE TABLE has not replicated yet and
-		// it's possible that we get other ephemeral errors too, so we make the tests more robust by
-		// retrying with the timeout.
-		qr, err := conn.ExecuteFetch(query, 1, true)
-		if err == nil && len(qr.Rows) == 1 {
-			return nil
+		// We start with no connection to MySQL
+		if conn == nil {
+			// Try connecting to MySQL
+			mysqlConn, err := mysql.Connect(ctx, &tabletParams)
+			// This can fail if the database create hasn't been replicated yet.
+			// We ignore this failure and try again later
+			if err == nil {
+				// If we succeed, then we store the connection
+				// and reuse it for checking the rows in the table.
+				conn = mysqlConn
+				defer conn.Close()
+			}
+		}
+		if conn != nil {
+			// We'll get a mysql.ERNoSuchTable (1146) error if the CREATE TABLE has not replicated yet and
+			// it's possible that we get other ephemeral errors too, so we make the tests more robust by
+			// retrying with the timeout.
+			qr, err := conn.ExecuteFetch(query, 1, true)
+			if err == nil && len(qr.Rows) == 1 {
+				return nil
+			}
 		}
 		t := time.Duration(300 * i)
 		time.Sleep(t * time.Millisecond)

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -194,8 +194,8 @@ func setupShard(ctx context.Context, t *testing.T, clusterInstance *cluster.Loca
 }
 
 // StartNewVTTablet starts a new vttablet instance
-func StartNewVTTablet(t *testing.T, clusterInstance *cluster.LocalProcessCluster) *cluster.Vttablet {
-	tablet := clusterInstance.NewVttabletInstance("replica", 300, cell1)
+func StartNewVTTablet(t *testing.T, clusterInstance *cluster.LocalProcessCluster, uuid int, supportsBackup bool) *cluster.Vttablet {
+	tablet := clusterInstance.NewVttabletInstance("replica", uuid, cell1)
 	keyspace := clusterInstance.Keyspaces[0]
 	shard := keyspace.Shards[0]
 
@@ -222,6 +222,7 @@ func StartNewVTTablet(t *testing.T, clusterInstance *cluster.LocalProcessCluster
 		},
 		clusterInstance.EnableSemiSync,
 		clusterInstance.DefaultCharset)
+	tablet.VttabletProcess.SupportsBackup = supportsBackup
 
 	log.Infof("Starting MySql for tablet %v", tablet.Alias)
 	proc, err := tablet.MysqlctlProcess.StartProcess()

--- a/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
@@ -62,7 +62,10 @@ func TestInitShardPrimary(t *testing.T) {
 	}
 
 	tablet2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
-		"FAKE RESET ALL REPLICATION",
+		// These come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
+		// These come from InitShardPrimary
 		"FAKE RESET ALL REPLICATION",
 		"FAKE SET SLAVE POSITION",
 		"FAKE SET MASTER",
@@ -71,7 +74,8 @@ func TestInitShardPrimary(t *testing.T) {
 	tablet2.FakeMysqlDaemon.SetReplicationSourceInputs = append(tablet2.FakeMysqlDaemon.SetReplicationSourceInputs, fmt.Sprintf("%v:%v", tablet1.Tablet.Hostname, tablet1.Tablet.MysqlPort))
 
 	tablet3.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
-		"FAKE RESET ALL REPLICATION",
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"FAKE RESET ALL REPLICATION",
 		"FAKE SET SLAVE POSITION",
 		"FAKE SET MASTER",

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -506,7 +506,7 @@ func (tm *TabletManager) startReplication(ctx context.Context, pos mysql.Positio
 
 	primary, err := tm.initializeReplication(ctx, tabletType)
 	// If we ran into an error while initializing replication, then there is no point in waiting for catch-up.
-	// Also, if there is primary tablet in the shard, we don't need to proceed further.
+	// Also, if there is no primary tablet in the shard, we don't need to proceed further.
 	if err != nil || primary == nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -243,7 +243,12 @@ func (tm *TabletManager) restoreDataLocked(ctx context.Context, logger logutil.L
 			}
 		}
 	case mysqlctl.ErrNoBackup:
-		// No-op, starting with empty database.
+		// Starting with empty database.
+		// We just need to initialize replication
+		_, err := tm.initializeReplication(ctx, originalType)
+		if err != nil {
+			return err
+		}
 	default:
 		// If anything failed, we should reset the original tablet type
 		if err := tm.tmState.ChangeTabletType(ctx, originalType, DBActionNone); err != nil {
@@ -499,50 +504,11 @@ func (tm *TabletManager) startReplication(ctx context.Context, pos mysql.Positio
 		return vterrors.Wrap(err, "failed to set replication position")
 	}
 
-	// At this point we've restored the data from the backup _and_ we've saved the
-	// replication state metadata that is consistent with the snapshot of the data
-	// contained in the backup. This means that we have everything needed to start
-	// replication at a later time, and since with active parents disabled we do
-	// not ever start replication automatically, we can now safely return.
-	if *mysqlctl.DisableActiveReparents {
-		return nil
-	}
-
-	// Read the shard to find the current primary, and its location.
-	tablet := tm.Tablet()
-	si, err := tm.TopoServer.GetShard(ctx, tablet.Keyspace, tablet.Shard)
-	if err != nil {
-		return vterrors.Wrap(err, "can't read shard")
-	}
-	if si.PrimaryAlias == nil {
-		// We've restored, but there's no primary. This is fine, since we've
-		// already set the position at which to resume when we're later reparented.
-		// If we had instead considered this fatal, all tablets would crash-loop
-		// until a primary appears, which would make it impossible to elect a primary.
-		log.Warningf("Can't start replication after restore: shard %v/%v has no primary.", tablet.Keyspace, tablet.Shard)
-		return nil
-	}
-	if topoproto.TabletAliasEqual(si.PrimaryAlias, tablet.Alias) {
-		// We used to be the primary before we got restarted in an empty data dir,
-		// and no other primary has been elected in the meantime.
-		// This shouldn't happen, so we'll let the operator decide which tablet
-		// should actually be promoted to primary.
-		log.Warningf("Can't start replication after restore: primary in shard record still points to this tablet.")
-		return nil
-	}
-	ti, err := tm.TopoServer.GetTablet(ctx, si.PrimaryAlias)
-	if err != nil {
-		return vterrors.Wrapf(err, "Cannot read primary tablet %v", si.PrimaryAlias)
-	}
-
-	// If using semi-sync, we need to enable it before connecting to primary.
-	if err := tm.fixSemiSync(tabletType, SemiSyncActionNone); err != nil {
+	primary, err := tm.initializeReplication(ctx, tabletType)
+	// If we ran into an error while initializing replication, then there is no point in waiting for catch-up.
+	// Also, if there is primary tablet in the shard, we don't need to proceed further.
+	if err != nil || primary == nil {
 		return err
-	}
-
-	// Set primary and start replication.
-	if err := tm.MysqlDaemon.SetReplicationSource(ctx, ti.Tablet.MysqlHostname, int(ti.Tablet.MysqlPort), false /* stopReplicationBefore */, !*mysqlctl.DisableActiveReparents /* startReplicationAfter */); err != nil {
-		return vterrors.Wrap(err, "MysqlDaemon.SetReplicationSource failed")
 	}
 
 	// wait for reliable replication_lag_seconds
@@ -555,7 +521,7 @@ func (tm *TabletManager) startReplication(ctx context.Context, pos mysql.Positio
 	defer tmc.Close()
 	remoteCtx, remoteCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer remoteCancel()
-	posStr, err := tmc.PrimaryPosition(remoteCtx, ti.Tablet)
+	posStr, err := tmc.PrimaryPosition(remoteCtx, primary.Tablet)
 	if err != nil {
 		// It is possible that though PrimaryAlias is set, the primary tablet is unreachable
 		// Log a warning and let tablet restore in that case

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -864,33 +864,33 @@ func (tm *TabletManager) initializeReplication(ctx context.Context, tabletType t
 	tablet := tm.Tablet()
 	si, err := tm.TopoServer.GetShard(ctx, tablet.Keyspace, tablet.Shard)
 	if err != nil {
-		return nil, vterrors.Wrap(err, "can't read shard")
+		return nil, vterrors.Wrap(err, "cannot read shard")
 	}
 	if si.PrimaryAlias == nil {
 		// There's no primary. This is fine, since there might be no primary currently
-		log.Warningf("Cannot start replication during initialization: shard %v/%v has no primary.", tablet.Keyspace, tablet.Shard)
+		log.Warningf("cannot start replication during initialization: shard %v/%v has no primary.", tablet.Keyspace, tablet.Shard)
 		return nil, nil
 	}
 	if topoproto.TabletAliasEqual(si.PrimaryAlias, tablet.Alias) {
 		// We used to be the primary before we got restarted,
 		// and no other primary has been elected in the meantime.
 		// There isn't anything to do here either.
-		log.Warningf("Cannot start replication during initialization: primary in shard record still points to this tablet.")
+		log.Warningf("cannot start replication during initialization: primary in shard record still points to this tablet.")
 		return nil, nil
 	}
 	currentPrimary, err := tm.TopoServer.GetTablet(ctx, si.PrimaryAlias)
 	if err != nil {
-		return nil, vterrors.Wrapf(err, "Cannot read primary tablet %v", si.PrimaryAlias)
+		return nil, vterrors.Wrapf(err, "cannot read primary tablet %v", si.PrimaryAlias)
 	}
 
 	durabilityName, err := tm.TopoServer.GetKeyspaceDurability(ctx, tablet.Keyspace)
 	if err != nil {
-		return nil, vterrors.Wrapf(err, "Cannot read keyspace durability %v", tablet.Keyspace)
+		return nil, vterrors.Wrapf(err, "cannot read keyspace durability policy %v", tablet.Keyspace)
 	}
 	log.Infof("Getting a new durability policy for %v", durabilityName)
 	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
 	if err != nil {
-		return nil, vterrors.Wrapf(err, "Cannot get durability policy %v", durabilityName)
+		return nil, vterrors.Wrapf(err, "cannot get durability policy %v", durabilityName)
 	}
 	// If using semi-sync, we need to enable it before connecting to primary.
 	// We should set the correct type, since it is used in replica semi-sync

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -44,6 +44,7 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/vt/vtctl/reparentutil"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -403,12 +404,13 @@ func (tm *TabletManager) Start(tablet *topodatapb.Tablet, healthCheckInterval ti
 	}
 	if restoring {
 		// If restore was triggered, it will take care
-		// of updating the tablet state.
+		// of updating the tablet state and initializing replication.
 		return nil
 	}
 
+	_, err = tm.initializeReplication(ctx, tm.baseTabletType)
 	tm.tmState.Open()
-	return nil
+	return err
 }
 
 // Close prepares a tablet for shutdown. First we check our tablet ownership and
@@ -838,4 +840,60 @@ func (tm *TabletManager) hookExtraEnv() map[string]string {
 		"KEYSPACE":     tablet.Keyspace,
 		"SHARD":        tablet.Shard,
 	}
+}
+
+// initializeReplication is used to initialize the replication when the tablet starts.
+// It returns the current primary tablet for use externally
+func (tm *TabletManager) initializeReplication(ctx context.Context, tabletType topodatapb.TabletType) (primary *topo.TabletInfo, err error) {
+	// If active reparents are disabled, we do not touch replication.
+	// There is nothing to do
+	if *mysqlctl.DisableActiveReparents {
+		return nil, nil
+	}
+
+	// Read the shard to find the current primary, and its location.
+	tablet := tm.Tablet()
+	si, err := tm.TopoServer.GetShard(ctx, tablet.Keyspace, tablet.Shard)
+	if err != nil {
+		return nil, vterrors.Wrap(err, "can't read shard")
+	}
+	if si.PrimaryAlias == nil {
+		// There's no primary. This is fine, since there might be no primary currently
+		log.Warningf("Cannot start replication during initialization: shard %v/%v has no primary.", tablet.Keyspace, tablet.Shard)
+		return nil, nil
+	}
+	if topoproto.TabletAliasEqual(si.PrimaryAlias, tablet.Alias) {
+		// We used to be the primary before we got restarted,
+		// and no other primary has been elected in the meantime.
+		// There isn't anything to do here either.
+		log.Warningf("Cannot start replication during initialization: primary in shard record still points to this tablet.")
+		return nil, nil
+	}
+	currentPrimary, err := tm.TopoServer.GetTablet(ctx, si.PrimaryAlias)
+	if err != nil {
+		return nil, vterrors.Wrapf(err, "Cannot read primary tablet %v", si.PrimaryAlias)
+	}
+
+	durabilityName, err := tm.TopoServer.GetKeyspaceDurability(ctx, tablet.Keyspace)
+	if err != nil {
+		return nil, vterrors.Wrapf(err, "Cannot read keyspace durability %v", tablet.Keyspace)
+	}
+	log.Infof("Getting a new durability policy for %v", durabilityName)
+	durability, err := reparentutil.GetDurabilityPolicy(durabilityName)
+	if err != nil {
+		return nil, vterrors.Wrapf(err, "Cannot get durability policy %v", durabilityName)
+	}
+	// If using semi-sync, we need to enable it before connecting to primary.
+	// We should set the correct type, since it is used in replica semi-sync
+	tablet.Type = tabletType
+	if err := tm.fixSemiSync(tabletType, convertBoolToSemiSyncAction(reparentutil.IsReplicaSemiSync(durability, currentPrimary.Tablet, tablet))); err != nil {
+		return nil, err
+	}
+
+	// Set primary and start replication.
+	if err := tm.MysqlDaemon.SetReplicationSource(ctx, currentPrimary.Tablet.MysqlHostname, int(currentPrimary.Tablet.MysqlPort), false /* stopReplicationBefore */, true /* startReplicationAfter */); err != nil {
+		return nil, vterrors.Wrap(err, "MysqlDaemon.SetReplicationSource failed")
+	}
+
+	return currentPrimary, nil
 }

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -181,6 +181,9 @@ func testBackupRestore(t *testing.T, cDetails *compressionDetails) error {
 		},
 	}
 	sourceTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		// This first set of STOP and START commands come from
 		// the builtinBackupEngine implementation which stops the replication
 		// while taking the backup
@@ -225,6 +228,9 @@ func testBackupRestore(t *testing.T, cDetails *compressionDetails) error {
 		},
 	}
 	destTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE",
 		"RESET SLAVE ALL",
 		"FAKE SET SLAVE POSITION",
@@ -397,6 +403,9 @@ func TestBackupRestoreLagged(t *testing.T) {
 	}
 	sourceTablet.FakeMysqlDaemon.SetReplicationSourceInputs = []string{fmt.Sprintf("%s:%d", primary.Tablet.MysqlHostname, primary.Tablet.MysqlPort)}
 	sourceTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		// This first set of STOP and START commands come from
 		// the builtinBackupEngine implementation which stops the replication
 		// while taking the backup
@@ -462,6 +471,9 @@ func TestBackupRestoreLagged(t *testing.T) {
 		},
 	}
 	destTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE",
 		"RESET SLAVE ALL",
 		"FAKE SET SLAVE POSITION",
@@ -600,6 +612,9 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 	}
 	sourceTablet.FakeMysqlDaemon.SetReplicationSourceInputs = []string{fmt.Sprintf("%s:%d", primary.Tablet.MysqlHostname, primary.Tablet.MysqlPort)}
 	sourceTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		// This first set of STOP and START commands come from
 		// the builtinBackupEngine implementation which stops the replication
 		// while taking the backup
@@ -637,6 +652,9 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 		},
 	}
 	destTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE",
 		"RESET SLAVE ALL",
 		"FAKE SET SLAVE POSITION",

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -73,6 +73,12 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 	defer sourceRdonlyDb.Close()
 	sourceRdonly := NewFakeTablet(t, wr, "cell1", 1,
 		topodatapb.TabletType_RDONLY, sourceRdonlyDb, TabletKeyspaceShard(t, "ks", "-80"))
+	sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
+	sourceRdonly.FakeMysqlDaemon.SetReplicationSourceInputs = append(sourceRdonly.FakeMysqlDaemon.SetReplicationSourceInputs, fmt.Sprintf("%v:%v", sourcePrimary.Tablet.MysqlHostname, sourcePrimary.Tablet.MysqlPort))
 
 	destinationPrimaryDb := fakesqldb.New(t).SetName("destinationPrimaryDb")
 	defer destinationPrimaryDb.Close()

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -135,8 +135,11 @@ func TestEmergencyReparentShard(t *testing.T) {
 		GTIDSet: goodReplica1RelayLogPos,
 	}
 	goodReplica1.FakeMysqlDaemon.WaitPrimaryPositions = append(goodReplica1.FakeMysqlDaemon.WaitPrimaryPositions, goodReplica1.FakeMysqlDaemon.CurrentSourceFilePosition)
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE IO_THREAD",
 		"STOP SLAVE",
 		"FAKE SET MASTER",
@@ -162,11 +165,14 @@ func TestEmergencyReparentShard(t *testing.T) {
 		GTIDSet: goodReplica2RelayLogPos,
 	}
 	goodReplica2.FakeMysqlDaemon.WaitPrimaryPositions = append(goodReplica2.FakeMysqlDaemon.WaitPrimaryPositions, goodReplica2.FakeMysqlDaemon.CurrentSourceFilePosition)
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
-	goodReplica2.StartActionLoop(t, wr)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"FAKE SET MASTER",
 	}
+	goodReplica2.StartActionLoop(t, wr)
 	defer goodReplica2.StopActionLoop(t)
 
 	// run EmergencyReparentShard
@@ -257,10 +263,13 @@ func TestEmergencyReparentShardPrimaryElectNotBest(t *testing.T) {
 	moreAdvancedReplica.FakeMysqlDaemon.CurrentSourceFilePosition = mysql.Position{
 		GTIDSet: moreAdvancedReplicaLogPos,
 	}
-	moreAdvancedReplica.FakeMysqlDaemon.SetReplicationSourceInputs = append(moreAdvancedReplica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
+	moreAdvancedReplica.FakeMysqlDaemon.SetReplicationSourceInputs = append(moreAdvancedReplica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	moreAdvancedReplica.FakeMysqlDaemon.WaitPrimaryPositions = append(moreAdvancedReplica.FakeMysqlDaemon.WaitPrimaryPositions, moreAdvancedReplica.FakeMysqlDaemon.CurrentSourceFilePosition)
 	newPrimary.FakeMysqlDaemon.WaitPrimaryPositions = append(newPrimary.FakeMysqlDaemon.WaitPrimaryPositions, moreAdvancedReplica.FakeMysqlDaemon.CurrentPrimaryPosition)
 	moreAdvancedReplica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE IO_THREAD",
 		"STOP SLAVE",
 		"FAKE SET MASTER",

--- a/go/vt/wrangler/testlib/external_reparent_test.go
+++ b/go/vt/wrangler/testlib/external_reparent_test.go
@@ -258,6 +258,12 @@ func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
 
 	// On the good replicas, we will respond to
 	// TabletActionReplicaWasRestarted and point to the new mysql port
+	goodReplica.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(oldPrimary.Tablet))
+	goodReplica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
 	goodReplica.StartActionLoop(t, wr)
 	defer goodReplica.StopActionLoop(t)
 
@@ -339,6 +345,12 @@ func TestTabletExternallyReparentedContinueOnUnexpectedPrimary(t *testing.T) {
 
 	// On the good replica, we will respond to
 	// TabletActionReplicaWasRestarted and point to a bad host
+	goodReplica.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(oldPrimary.Tablet))
+	goodReplica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
 	goodReplica.StartActionLoop(t, wr)
 	defer goodReplica.StopActionLoop(t)
 
@@ -414,9 +426,14 @@ func TestTabletExternallyReparentedRerun(t *testing.T) {
 	oldPrimary.StartActionLoop(t, wr)
 	defer oldPrimary.StopActionLoop(t)
 
-	goodReplica.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
+	goodReplica.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	// On the good replica, we will respond to
 	// TabletActionReplicaWasRestarted.
+	goodReplica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
 	goodReplica.StartActionLoop(t, wr)
 	defer goodReplica.StopActionLoop(t)
 

--- a/go/vt/wrangler/testlib/fake_tablet.go
+++ b/go/vt/wrangler/testlib/fake_tablet.go
@@ -173,6 +173,7 @@ func NewFakeTablet(t *testing.T, wr *wrangler.Wrangler, cell string, uid uint32,
 // StartActionLoop will start the action loop for a fake tablet,
 // using ft.FakeMysqlDaemon as the backing mysqld.
 func (ft *FakeTablet) StartActionLoop(t *testing.T, wr *wrangler.Wrangler) {
+	t.Helper()
 	if ft.TM != nil {
 		t.Fatalf("TM for %v is already running", ft.Tablet.Alias)
 	}
@@ -213,7 +214,7 @@ func (ft *FakeTablet) StartActionLoop(t *testing.T, wr *wrangler.Wrangler) {
 		VREngine:            vreplication.NewTestEngine(wr.TopoServer(), ft.Tablet.Alias.Cell, ft.FakeMysqlDaemon, binlogplayer.NewFakeDBClient, binlogplayer.NewFakeDBClient, topoproto.TabletDbName(ft.Tablet), nil),
 	}
 	if err := ft.TM.Start(ft.Tablet, 0); err != nil {
-		t.Fatal(err)
+		t.Fatalf("Error in tablet - %v, err - %v", topoproto.TabletAliasString(ft.Tablet.Alias), err.Error())
 	}
 	ft.Tablet = ft.TM.Tablet()
 

--- a/go/vt/wrangler/testlib/permissions_test.go
+++ b/go/vt/wrangler/testlib/permissions_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/vt/discovery"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 
 	"context"
 
@@ -560,6 +561,12 @@ func TestPermissions(t *testing.T) {
 	replica.FakeMysqlDaemon.FetchSuperQueryMap = map[string]*sqltypes.Result{
 		"SELECT * FROM mysql.user ORDER BY host, user":   &user,
 		"SELECT * FROM mysql.db ORDER BY host, db, user": primary.FakeMysqlDaemon.FetchSuperQueryMap["SELECT * FROM mysql.db ORDER BY host, db, user"],
+	}
+	replica.FakeMysqlDaemon.SetReplicationSourceInputs = append(replica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(primary.Tablet))
+	replica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 	}
 	replica.StartActionLoop(t, wr)
 	defer replica.StopActionLoop(t)

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -112,8 +112,11 @@ func TestPlannedReparentShardNoPrimaryProvided(t *testing.T) {
 	// good replica 1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -224,8 +227,11 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 	// goodReplica1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -235,12 +241,15 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 
 	// goodReplica2 is not replicating
 	goodReplica2.FakeMysqlDaemon.ReadOnly = true
-	goodReplica2.FakeMysqlDaemon.Replicating = false
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
-	goodReplica2.StartActionLoop(t, wr)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"FAKE SET MASTER",
 	}
+	goodReplica2.StartActionLoop(t, wr)
+	goodReplica2.FakeMysqlDaemon.Replicating = false
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard
@@ -434,8 +443,11 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 	// good replica 1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -445,12 +457,15 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 
 	// good replica 2 is not replicating
 	goodReplica2.FakeMysqlDaemon.ReadOnly = true
-	goodReplica2.FakeMysqlDaemon.Replicating = false
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
-	goodReplica2.StartActionLoop(t, wr)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"FAKE SET MASTER",
 	}
+	goodReplica2.StartActionLoop(t, wr)
+	goodReplica2.FakeMysqlDaemon.Replicating = false
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard
@@ -535,23 +550,29 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 	// good replica 1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE",
 		"FAKE SET MASTER",
-		"START replica",
+		"START SLAVE",
 	}
 	goodReplica1.StartActionLoop(t, wr)
 	defer goodReplica1.StopActionLoop(t)
 
 	// good replica 2 is not replicating
 	goodReplica2.FakeMysqlDaemon.ReadOnly = true
-	goodReplica2.FakeMysqlDaemon.Replicating = false
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
-	goodReplica2.StartActionLoop(t, wr)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"FAKE SET MASTER",
 	}
+	goodReplica2.StartActionLoop(t, wr)
+	goodReplica2.FakeMysqlDaemon.Replicating = false
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard
@@ -607,14 +628,17 @@ func TestPlannedReparentShardRelayLogError(t *testing.T) {
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
 	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(primary.Tablet))
-	// simulate error that will trigger a call to RestartReplication
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceError = errors.New("Slave failed to initialize relay log info structure from the repository")
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
+		// simulate error that will trigger a call to RestartReplication
 		"STOP SLAVE",
 		"RESET SLAVE",
 		"START SLAVE",
 	}
 	goodReplica1.StartActionLoop(t, wr)
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceError = errors.New("Slave failed to initialize relay log info structure from the repository")
 	defer goodReplica1.StopActionLoop(t)
 
 	// run PlannedReparentShard
@@ -687,9 +711,11 @@ func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
 	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(primary.Tablet))
 	goodReplica1.FakeMysqlDaemon.CurrentSourceHost = primary.Tablet.MysqlHostname
 	goodReplica1.FakeMysqlDaemon.CurrentSourcePort = int(primary.Tablet.MysqlPort)
-	// simulate error that will trigger a call to RestartReplication
-	goodReplica1.FakeMysqlDaemon.StartReplicationError = errors.New("Slave failed to initialize relay log info structure from the repository")
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// simulate error that will trigger a call to RestartReplication
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		// In SetReplicationSource, we find that the source host and port was already set correctly,
 		// So we try to stop and start replication. The first STOP SLAVE comes from there
 		"STOP SLAVE",
@@ -699,6 +725,7 @@ func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
 		"START SLAVE",
 	}
 	goodReplica1.StartActionLoop(t, wr)
+	goodReplica1.FakeMysqlDaemon.StartReplicationError = errors.New("Slave failed to initialize relay log info structure from the repository")
 	defer goodReplica1.StopActionLoop(t)
 
 	// run PlannedReparentShard
@@ -794,8 +821,11 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	// good replica 1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -805,12 +835,15 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 
 	// good replica 2 is not replicating
 	goodReplica2.FakeMysqlDaemon.ReadOnly = true
-	goodReplica2.FakeMysqlDaemon.Replicating = false
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet))
-	goodReplica2.StartActionLoop(t, wr)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(newPrimary.Tablet), topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"FAKE SET MASTER",
 	}
+	goodReplica2.StartActionLoop(t, wr)
+	goodReplica2.FakeMysqlDaemon.Replicating = false
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard
@@ -903,6 +936,9 @@ func TestPlannedReparentShardSamePrimary(t *testing.T) {
 	goodReplica1.FakeMysqlDaemon.Replicating = true
 	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica1.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(oldPrimary.Tablet))
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -912,12 +948,15 @@ func TestPlannedReparentShardSamePrimary(t *testing.T) {
 
 	// goodReplica2 is not replicating
 	goodReplica2.FakeMysqlDaemon.ReadOnly = true
-	goodReplica2.FakeMysqlDaemon.Replicating = false
 	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs = append(goodReplica2.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(oldPrimary.Tablet))
-	goodReplica2.StartActionLoop(t, wr)
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"FAKE SET MASTER",
 	}
+	goodReplica2.StartActionLoop(t, wr)
+	goodReplica2.FakeMysqlDaemon.Replicating = false
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -89,6 +89,12 @@ func TestShardReplicationStatuses(t *testing.T) {
 	}
 	replica.FakeMysqlDaemon.CurrentSourceHost = primary.Tablet.MysqlHostname
 	replica.FakeMysqlDaemon.CurrentSourcePort = int(primary.Tablet.MysqlPort)
+	replica.FakeMysqlDaemon.SetReplicationSourceInputs = append(replica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(primary.Tablet))
+	replica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
 	replica.StartActionLoop(t, wr)
 	defer replica.StopActionLoop(t)
 
@@ -153,6 +159,9 @@ func TestReparentTablet(t *testing.T) {
 	replica.FakeMysqlDaemon.IOThreadRunning = true
 	replica.FakeMysqlDaemon.SetReplicationSourceInputs = append(replica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(primary.Tablet))
 	replica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",

--- a/go/vt/wrangler/testlib/version_test.go
+++ b/go/vt/wrangler/testlib/version_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/vt/discovery"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -90,6 +91,12 @@ func TestVersion(t *testing.T) {
 
 	// sourceReplica loop
 	sourceReplicaGitRev := "fake git rev"
+	sourceReplica.FakeMysqlDaemon.SetReplicationSourceInputs = append(sourceReplica.FakeMysqlDaemon.SetReplicationSourceInputs, topoproto.MysqlAddr(sourcePrimary.Tablet))
+	sourceReplica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		// These 2 statements come from tablet startup
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
 	sourceReplica.StartActionLoop(t, wr)
 	sourceReplica.HTTPServer.Handler.(*http.ServeMux).HandleFunc("/debug/vars", expvarHandler(&sourceReplicaGitRev))
 	defer sourceReplica.StopActionLoop(t)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR addresses the issue raised in https://github.com/vitessio/vitess/issues/10880. 

The proposed fix for the problem is to initialize the replication once on startup. Since we have moved to the architecture of storing the durability policy in the topo server instead of being passed in vtctld flags, even vttablets can access that information.

This allows the vttablets to find the current primary when they start and consult the durability policies to know whether they should be setting semi-sync or not.

A new method called `initializeReplication` has been added to the tablet manager which (as the name suggests) is responsible for initializing replication. This method is called in 3 places - 
1. In restoreDataLocked in the case where no backup exists.
2. In restoreDataLocked when a backup exists (as part of `tm.startReplication` call)
3. At the end of `Start` of tablet manager which handles the case wherein we don't restore at all.4. 

Together these 3 calls ensure that we run `initializeReplication` once in all the cases of different restores.

An end to end test has also been added which exercises the `initializeReplication` logic and checks that semi-sync is setup correctly.


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/10880

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
