### PR TITLE
Separate function for creating bind variables

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -117,7 +117,7 @@ func (nz *normalizer) convertLiteralDedup(node *Literal, cursor *Cursor) {
 	}
 
 	// Make the bindvar
-	bval := nz.sqlToBindvar(node)
+	bval := SQLToBindvar(node)
 	if bval == nil {
 		return
 	}
@@ -146,7 +146,7 @@ func (nz *normalizer) convertLiteralDedup(node *Literal, cursor *Cursor) {
 
 // convertLiteral converts an Literal without the dedup.
 func (nz *normalizer) convertLiteral(node *Literal, cursor *Cursor) {
-	bval := nz.sqlToBindvar(node)
+	bval := SQLToBindvar(node)
 	if bval == nil {
 		return
 	}
@@ -176,7 +176,7 @@ func (nz *normalizer) convertComparison(node *ComparisonExpr) {
 		Type: querypb.Type_TUPLE,
 	}
 	for _, val := range tupleVals {
-		bval := nz.sqlToBindvar(val)
+		bval := SQLToBindvar(val)
 		if bval == nil {
 			return
 		}
@@ -191,7 +191,7 @@ func (nz *normalizer) convertComparison(node *ComparisonExpr) {
 	node.Right = ListArg(bvname)
 }
 
-func (nz *normalizer) sqlToBindvar(node SQLNode) *querypb.BindVariable {
+func SQLToBindvar(node SQLNode) *querypb.BindVariable {
 	if node, ok := node.(*Literal); ok {
 		var v sqltypes.Value
 		var err error


### PR DESCRIPTION
This doesn't depend on state in the normalizer, so it can be an independent function.

Also makes it public since it can be useful for library style usage of Vitess for example.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required