### PR TITLE
[vtcombo] Delete `flag.Set` call on non-existent flag

### DIFF
--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -18,7 +18,6 @@ package vtcombo
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"path"
@@ -90,7 +89,6 @@ func CreateTablet(
 		Uid:  uid,
 	}
 	log.Infof("Creating %v tablet %v for %v/%v", tabletType, topoproto.TabletAliasString(alias), keyspace, shard)
-	flag.Set("debug-url-prefix", fmt.Sprintf("/debug-%d", uid))
 
 	controller := tabletserver.NewServer(topoproto.TabletAliasString(alias), ts, alias)
 	initTabletType := tabletType


### PR DESCRIPTION
## Description

`git grep` doesn't turn up a definition for this flag anywhere. As I describe in the issue, this is almost certainly returning a non-nil error, which we also are ignoring. 

## Related Issue(s)

Fixes #10888.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
