### PR TITLE
Revert temporary workflow changes made in #10847

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -10,8 +10,8 @@ concurrency:
 jobs:
   get_previous_release:
     if: always() && github.event_name == 'pull_request'
-    name: Get a recent LTS release
-    runs-on: ubuntu-20.04
+    name: Get latest release
+    runs-on: ubuntu-latest
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - get_previous_release
 
@@ -106,29 +106,13 @@ jobs:
         sudo deluser mysql
         sudo rm -rf /var/lib/mysql
         sudo rm -rf /etc/mysql
-
-        # Install MySQL 8.0
-        ####
-        ## Temporarily pin the MySQL version at 8.0.29 as Vitess 14.0 does not have the fix to support
-        ## backups of 8.0.30+. See: https://github.com/vitessio/vitess/pull/10847
-        ## TODO: remove this pin once the above fixes are backported to release-14.0 OR
-        ##       Vitess 16.0.0-SNAPSHOT becomes the dev version on vitessio/main
-        #sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        #wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
-        #echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
-        #sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
-        #sudo apt-get update
-        #sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
-        ####
-        wget -c https://cdn.mysql.com/archives/mysql-8.0/mysql-common_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-core_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-plugins_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-client_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-server-core_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-server_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client_8.0.29-1ubuntu20.04_amd64.deb
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y ./mysql-*.deb
-
+        # Install mysql80
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
         # Install everything else we need, and configure
         sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata grep
         sudo service mysql stop


### PR DESCRIPTION
## Description

This should not be merged until after the backport is merged: https://github.com/vitessio/vitess/pull/10895

Once that PR is merged then `release-14.0` will also have the backup fixes and the upgrade/downgrade backup tests will be working again with the latest MySQL releases (8.0.30+).

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/10847
  - Dependent-on: https://github.com/vitessio/vitess/pull/10895

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required