### PR TITLE
BugFix: vtctld panic with `enable_realtime_stats`

### DIFF
--- a/go/flags/endtoend/flags_test.go
+++ b/go/flags/endtoend/flags_test.go
@@ -38,9 +38,13 @@ var (
 	//go:embed vttablet.txt
 	vttabletTxt string
 
+	//go:embed vtctld.txt
+	vtctldTxt string
+
 	helpOutput = map[string]string{
 		"vtgate":   vtgateTxt,
 		"vttablet": vttabletTxt,
+		"vtctld":   vtctldTxt,
 	}
 )
 

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -1,0 +1,311 @@
+Usage of vtctld:
+      --action_timeout duration                                          time to wait for an action before resorting to force (default 2m0s)
+      --allowed_tablet_types []topodatapb.TabletType                     Specifies the tablet types this vtgate is allowed to route queries to.
+      --alsologtostderr                                                  log to standard error as well as files
+      --app_idle_timeout duration                                        Idle timeout for app connections (default 1m0s)
+      --app_pool_size int                                                Size of the connection pool for app connections (default 40)
+      --azblob_backup_account_key_file string                            Path to a file containing the Azure Storage account key; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_KEY will be used as the key itself (NOT a file path).
+      --azblob_backup_account_name string                                Azure Storage Account name for backups; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_NAME will be used.
+      --azblob_backup_container_name string                              Azure Blob Container Name.
+      --azblob_backup_parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased). (default 1)
+      --azblob_backup_storage_root string                                Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
+      --backup_engine_implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
+      --backup_storage_block_size int                                    if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)
+      --backup_storage_compress                                          if set, the backup files will be compressed (default is true). Set to false for instance if a backup_storage_hook is specified and it compresses the data. (default true)
+      --backup_storage_hook string                                       if set, we send the contents of the backup files through this hook.
+      --backup_storage_implementation string                             Which backup storage implementation to use for creating and restoring backups.
+      --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, at once, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression (default 2)
+      --binlog_player_protocol string                                    the protocol to download binlogs from a vttablet (default "grpc")
+      --builtin-compressor string                                        builtin compressor engine to use (default "pgzip")
+      --builtin-decompressor string                                      builtin decompressor engine to use (default "auto")
+      --builtinbackup_mysqld_timeout duration                            how long to wait for mysqld to shutdown at the start of the backup (default 10m0s)
+      --builtinbackup_progress duration                                  how often to send progress updates when backing up large files (default 5s)
+      --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
+      --cell string                                                      cell to use
+      --ceph_backup_storage_config string                                Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
+      --compression-level int                                            what level to pass to the compressor (default 1)
+      --consul_auth_static_file string                                   JSON File to read the topos/tokens from.
+      --cpu_profile string                                               deprecated: use '-pprof=cpu' instead
+      --datadog-agent-host string                                        host to send spans to. if empty, no tracing will be done
+      --datadog-agent-port string                                        port to send spans to. if empty, no tracing will be done
+      --db-credentials-file string                                       db credentials file; send SIGHUP to reload this file
+      --db-credentials-server string                                     db credentials server type ('file' - file implementation; 'vault' - HashiCorp Vault implementation) (default "file")
+      --db-credentials-vault-addr string                                 URL to Vault server
+      --db-credentials-vault-path string                                 Vault path to credentials JSON blob, e.g.: secret/data/prod/dbcreds
+      --db-credentials-vault-role-mountpoint string                      Vault AppRole mountpoint; can also be passed using VAULT_MOUNTPOINT environment variable (default "approle")
+      --db-credentials-vault-role-secretidfile string                    Path to file containing Vault AppRole secret_id; can also be passed using VAULT_SECRETID environment variable
+      --db-credentials-vault-roleid string                               Vault AppRole id; can also be passed using VAULT_ROLEID environment variable
+      --db-credentials-vault-timeout duration                            Timeout for vault API operations (default 10s)
+      --db-credentials-vault-tls-ca string                               Path to CA PEM for validating Vault server certificate
+      --db-credentials-vault-tokenfile string                            Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
+      --db-credentials-vault-ttl duration                                How long to cache DB credentials from the Vault server (default 30m0s)
+      --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
+      --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
+      --degraded_threshold duration                                      replication lag after which a replica is considered degraded (default 30s)
+      --disable_active_reparents                                         if set, do not allow active reparents. Use this to protect a cluster using external reparents.
+      --durability_policy string                                         type of durability to enforce. Default is none. Other values are dictated by registered plugins (default "none")
+      --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
+      --enable-consolidator                                              Synonym to -enable_consolidator (default true)
+      --enable-consolidator-replicas                                     Synonym to -enable_consolidator_replicas
+      --enable-lag-throttler                                             Synonym to -enable_lag_throttler
+      --enable-query-plan-field-caching                                  Synonym to -enable_query_plan_field_caching (default true)
+      --enable-tx-throttler                                              Synonym to -enable_tx_throttler
+      --enable_consolidator                                              This option enables the query consolidator. (default true)
+      --enable_consolidator_replicas                                     This option enables the query consolidator only on replicas.
+      --enable_hot_row_protection                                        If true, incoming transactions for the same row (range) will be queued and cannot consume all txpool slots.
+      --enable_hot_row_protection_dry_run                                If true, hot row protection is not enforced but logs if transactions would have been queued.
+      --enable_lag_throttler                                             If true, vttablet will run a throttler service, and will implicitly enable heartbeats
+      --enable_query_plan_field_caching                                  (DEPRECATED) This option fetches & caches fields (columns) when storing query plans (default true)
+      --enable_realtime_stats                                            Required for the Realtime Stats view. If set, vtctld will maintain a streaming RPC to each tablet (in all cells) to gather the realtime health stats.
+      --enable_replication_reporter                                      Use polling to track replication lag.
+      --enable_transaction_limit                                         If true, limit on number of transactions open at the same time will be enforced for all users. User trying to open a new transaction after exhausting their limit will receive an error immediately, regardless of whether there are available slots or not.
+      --enable_transaction_limit_dry_run                                 If true, limit on number of transactions open at the same time will be tracked for all users, but not enforced.
+      --enable_tx_throttler                                              If true replication-lag-based throttling on transactions will be enabled.
+      --enable_vtctld_ui                                                 If true, the vtctld web interface will be enabled. Default is true. (default true)
+      --enforce_strict_trans_tables                                      If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database. (default true)
+      --external-compressor string                                       command with arguments to use when compressing a backup
+      --external-compressor-extension string                             extension to use when using an external compressor
+      --external-decompressor string                                     command with arguments to use when decompressing a backup
+      --file_backup_storage_root string                                  Root directory for the file backup storage.
+      --gcs_backup_storage_bucket string                                 Google Cloud Storage bucket to use for backups.
+      --gcs_backup_storage_root string                                   Root prefix for all backup-related object names.
+      --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
+      --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
+      --grpc_auth_static_client_creds string                             when using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server
+      --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
+      --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
+      --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
+      --grpc_crl string                                                  path to a certificate revocation list in PEM format, client certificates will be further verified against this file during TLS handshake
+      --grpc_enable_optional_tls                                         enable optional TLS mode when a server accepts both TLS and plain-text connections on the same port
+      --grpc_enable_tracing                                              Enable GRPC tracing
+      --grpc_initial_conn_window_size int                                gRPC initial connection window size
+      --grpc_initial_window_size int                                     gRPC initial window size
+      --grpc_keepalive_time duration                                     After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
+      --grpc_keepalive_timeout duration                                  After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
+      --grpc_key string                                                  server private key to use for gRPC connections, requires grpc_cert, enables TLS
+      --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
+      --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
+      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_port int                                                    Port to listen on for gRPC calls
+      --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus
+      --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
+      --grpc_server_initial_conn_window_size int                         gRPC server initial connection window size
+      --grpc_server_initial_window_size int                              gRPC server initial window size
+      --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
+      --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
+      --health_check_interval duration                                   Interval between health checks (default 20s)
+      --heartbeat_enable                                                 If true, vttablet records (if master) or checks (if replica) the current time of a replication heartbeat in the table _vt.heartbeat. The result is used to inform the serving state of the vttablet via healthchecks.
+      --heartbeat_interval duration                                      How frequently to read and write replication heartbeat. (default 1s)
+      --heartbeat_on_demand_duration duration                            If non-zero, heartbeats are only written upon consumer request, and only run for up to given duration following the request. Frequent requests can keep the heartbeat running consistently; when requests are infrequent heartbeat may completely stop between requests (default 0s)
+  -h, --help                                                             display usage and exit
+      --hot_row_protection_concurrent_transactions int                   Number of concurrent transactions let through to the txpool/MySQL for the same hot row. Should be > 1 to have enough 'ready' transactions in MySQL and benefit from a pipelining effect. (default 5)
+      --hot_row_protection_max_global_queue_size int                     Global queue limit across all row (ranges). Useful to prevent that the queue can grow unbounded. (default 1000)
+      --hot_row_protection_max_queue_size int                            Maximum number of BeginExecute RPCs which will be queued for the same row (range). (default 20)
+      --jaeger-agent-host string                                         host and port to send spans to. if empty, no tracing will be done
+      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever) (default 0s)
+      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever) (default 0s)
+      --keyspaces_to_watch strings                                       Specifies which keyspaces this vtgate should have access to while routing queries or accessing the vschema.
+      --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
+      --log_backtrace_at traceLocation                                   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                                                   If non-empty, write log files in this directory
+      --log_err_stacks                                                   log stack traces for errors
+      --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
+      --logtostderr                                                      log to standard error instead of files
+      --master_connect_retry duration                                    Deprecated, use -replication_connect_retry (default 10s)
+      --mem-profile-rate int                                             deprecated: use '-pprof=mem' instead (default 524288)
+      --mutex-profile-fraction int                                       deprecated: use '-pprof=mutex' instead
+      --mysql_server_flush_delay duration                                Delay after which buffered response will be flushed to the client. (default 100ms)
+      --mysql_server_version string                                      MySQL server version to advertise.
+      --mysqlctl_client_protocol string                                  the protocol to use to talk to the mysqlctl server (default "grpc")
+      --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
+      --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
+      --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 1ns)
+      --online_ddl_check_interval duration                               deprecated. Will be removed in next Vitess version (default 0s)
+      --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
+      --opentsdb_uri string                                              URI of opentsdb /api/put method
+      --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
+      --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled) (default 0s)
+      --port int                                                         port for the server
+      --pprof string                                                     enable profiling
+      --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them
+      --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
+      --query-log-stream-handler string                                  URL handler for streaming queries log (default "/debug/querylog")
+      --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
+      --querylog-format string                                           format for query logs ("text" or "json") (default "text")
+      --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
+      --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
+      --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
+      --queryserver-config-enable-table-acl-dry-run                      If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results
+      --queryserver-config-idle-timeout float                            query server idle timeout (in seconds), vttablet manages various mysql connection pools. This config means if a connection has not been used in given idle timeout, this connection will be removed from pool. This effectively manages number of connection objects and optimize the pool performance. (default 1800)
+      --queryserver-config-max-result-size int                           query server max result size, maximum number of rows allowed to return from vttablet for non-streaming queries. (default 10000)
+      --queryserver-config-message-postpone-cap int                      query server message postpone cap is the maximum number of messages that can be postponed at any given time. Set this number to substantially lower than transaction cap, so that the transaction pool isn't exhausted by the message subsystem. (default 4)
+      --queryserver-config-passthrough-dmls                              query server pass through all dml statements without rewriting
+      --queryserver-config-pool-prefill-parallelism int                  query server read pool prefill parallelism, a non-zero value will prefill the pool using the specified parallism.
+      --queryserver-config-pool-size int                                 query server read pool size, connection pool is used by regular queries (non streaming, not in a transaction) (default 16)
+      --queryserver-config-query-cache-lfu                               query server cache algorithm. when set to true, a new cache algorithm based on a TinyLFU admission policy will be used to improve cache behavior and prevent pollution from sparse queries (default true)
+      --queryserver-config-query-cache-memory int                        query server query cache size in bytes, maximum amount of memory to be used for caching. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
+      --queryserver-config-query-cache-size int                          query server query cache size, maximum number of queries to be cached. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 5000)
+      --queryserver-config-query-pool-timeout float                      query server query pool timeout (in seconds), it is how long vttablet waits for a connection from the query pool. If set to 0 (default) then the overall query timeout is used instead.
+      --queryserver-config-query-pool-waiter-cap int                     query server query pool waiter limit, this is the maximum number of queries that can be queued waiting to get a connection (default 5000)
+      --queryserver-config-query-timeout float                           query server query timeout (in seconds), this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed. (default 30)
+      --queryserver-config-schema-change-signal                          query server schema signal, will signal connected vtgates that schema has changed whenever this is detected. VTGates will need to have -schema_change_signal enabled for this to work (default true)
+      --queryserver-config-schema-change-signal-interval float           query server schema change signal interval defines at which interval the query server shall send schema updates to vtgate. (default 5)
+      --queryserver-config-schema-reload-time float                      query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance in seconds. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time. (default 1800)
+      --queryserver-config-stream-buffer-size int                        query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size. (default 32768)
+      --queryserver-config-stream-pool-prefill-parallelism int           query server stream pool prefill parallelism, a non-zero value will prefill the pool using the specified parallelism
+      --queryserver-config-stream-pool-size int                          query server stream connection pool size, stream pool is used by stream queries: queries that return results to client in a streaming fashion (default 200)
+      --queryserver-config-stream-pool-timeout float                     query server stream pool timeout (in seconds), it is how long vttablet waits for a connection from the stream pool. If set to 0 (default) then there is no timeout.
+      --queryserver-config-stream-pool-waiter-cap int                    query server stream pool waiter limit, this is the maximum number of streaming queries that can be queued waiting to get a connection
+      --queryserver-config-strict-table-acl                              only allow queries that pass table acl checks
+      --queryserver-config-terse-errors                                  prevent bind vars from escaping in client error messages
+      --queryserver-config-transaction-cap int                           query server transaction cap is the maximum number of transactions allowed to happen at any given point of a time for a single vttablet. E.g. by setting transaction cap to 100, there are at most 100 transactions will be processed by a vttablet and the 101th transaction will be blocked (and fail if it cannot get connection within specified timeout) (default 20)
+      --queryserver-config-transaction-prefill-parallelism int           query server transaction prefill parallelism, a non-zero value will prefill the pool using the specified parallism.
+      --queryserver-config-transaction-timeout float                     query server transaction timeout (in seconds), a transaction will be killed if it takes longer than this value (default 30)
+      --queryserver-config-txpool-timeout float                          query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1)
+      --queryserver-config-txpool-waiter-cap int                         query server transaction pool waiter limit, this is the maximum number of transactions that can be queued waiting to get a connection (default 5000)
+      --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
+      --queryserver_enable_online_ddl                                    Enable online DDL. (default true)
+      --redact-debug-ui-queries                                          redact full queries and bind variables from debug UI
+      --relay_log_max_items int                                          Maximum number of rows for VReplication target buffering. (default 5000)
+      --relay_log_max_size int                                           Maximum buffer size (in bytes) for VReplication target buffering. If single rows are larger than this, a single row is buffered at a time. (default 250000)
+      --remote_operation_timeout duration                                time to wait for a remote operation (default 30s)
+      --replication_connect_retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
+      --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
+      --s3_backup_aws_retries int                                        AWS request retries. (default -1)
+      --s3_backup_force_path_style                                       force the s3 path style.
+      --s3_backup_log_level string                                       determine the S3 loglevel to use from LogOff, LogDebug, LogDebugWithSigning, LogDebugWithHTTPBody, LogDebugWithRequestRetries, LogDebugWithRequestErrors. (default "LogOff")
+      --s3_backup_server_side_encryption string                          server-side encryption algorithm (e.g., AES256, aws:kms, sse_c:/path/to/key/file).
+      --s3_backup_storage_bucket string                                  S3 bucket to use for backups.
+      --s3_backup_storage_root string                                    root prefix for all backup-related object names.
+      --s3_backup_tls_skip_verify_cert                                   skip the 'certificate is valid' check for SSL connections.
+      --sanitize_log_messages                                            Remove potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.
+      --schema_change_check_interval int                                 this value decides how often we check schema change dir, in seconds (default 60)
+      --schema_change_controller string                                  schema change controller is responsible for finding schema changes and responding to schema change events
+      --schema_change_dir string                                         directory contains schema changes for all keyspaces. Each keyspace has its own directory and schema changes are expected to live in '$KEYSPACE/input' dir. e.g. test_keyspace/input/*sql, each sql file represents a schema change
+      --schema_change_replicas_timeout duration                          how long to wait for replicas to receive the schema change (default 10s)
+      --schema_change_user string                                        The user who submits this schema change.
+      --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
+      --service_map StringList                                           comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
+      --serving_state_grace_period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state (default 0s)
+      --shutdown_grace_period float                                      how long to wait (in seconds) for queries and transactions to complete during graceful shutdown.
+      --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
+      --sql-max-length-ui int                                            truncate queries in debug UIs to the given length (default 512) (default 512)
+      --srv_topo_cache_refresh duration                                  how frequently to refresh the topology for cached entries (default 1s)
+      --srv_topo_cache_ttl duration                                      how long to use cached entries for topology (default 1s)
+      --srv_topo_timeout duration                                        topo server timeout (default 5s)
+      --stats_backend string                                             The name of the registered push-based monitoring/stats backend to use
+      --stats_combine_dimensions string                                  List of dimensions to be combined into a single "all" value in exported stats vars
+      --stats_common_tags string                                         Comma-separated list of common tags for the stats backend. It provides both label and values. Example: label1:value1,label2:value2
+      --stats_drop_variables string                                      Variables to be dropped from the list of exported variables.
+      --stats_emit_period duration                                       Interval between emitting stats to all registered backends (default 1m0s)
+      --stderrthreshold severity                                         logs at or above this threshold go to stderr (default 1)
+      --tablet_dir string                                                The directory within the vtdataroot to store vttablet/mysql files. Defaults to being generated by the tablet uid.
+      --tablet_filters strings                                           Specifies a comma-separated list of 'keyspace|shard_name or keyrange' values to filter the tablets to watch.
+      --tablet_grpc_ca string                                            the server ca to use to validate servers when connecting
+      --tablet_grpc_cert string                                          the cert to use to connect
+      --tablet_grpc_crl string                                           the server crl to use to validate server certificates when connecting
+      --tablet_grpc_key string                                           the key to use to connect
+      --tablet_grpc_server_name string                                   the server name to use to validate server certificate
+      --tablet_health_keep_alive duration                                close streaming tablet health connection if there are no requests for this long (default 5m0s)
+      --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
+      --tablet_manager_grpc_cert string                                  the cert to use to connect
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
+      --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
+      --tablet_manager_grpc_key string                                   the key to use to connect
+      --tablet_manager_grpc_server_name string                           the server name to use to validate server certificate
+      --tablet_manager_protocol string                                   the protocol to use to talk to vttablet (default "grpc")
+      --tablet_protocol string                                           how to talk to the vttablets (default "grpc")
+      --tablet_refresh_interval duration                                 Tablet refresh interval. (default 1m0s)
+      --tablet_refresh_known_tablets                                     Whether to reload the tablet's address/port map from topo in case they change. (default true)
+      --tablet_url_template string                                       Format string describing debug tablet url formatting. See getTabletDebugURL() for how to customize this. (default "http://{{.GetTabletHostPort}}")
+      --throttle_check_as_check_self                                     Should throttler/check return a throttler/check-self result (changes throttler behavior for writes)
+      --throttle_metrics_query SELECT                                    Override default heartbeat/lag metric. Use either SELECT (must return single row, single value) or `SHOW GLOBAL ... LIKE ...` queries. Set -throttle_metrics_threshold respectively.
+      --throttle_metrics_threshold float                                 Override default throttle threshold, respective to -throttle_metrics_query (default 1.7976931348623157e+308)
+      --throttle_tablet_types string                                     Comma separated VTTablet types to be considered by the throttler. default: 'replica'. example: 'replica,rdonly'. 'replica' aways implicitly included (default "replica")
+      --throttle_threshold duration                                      Replication lag threshold for default lag throttling (default 1s)
+      --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
+      --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
+      --topo_consul_lock_session_ttl string                              TTL for consul session.
+      --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
+      --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
+      --topo_etcd_tls_ca string                                          path to the ca to use to validate the server cert when connecting to the etcd topo server
+      --topo_etcd_tls_cert string                                        path to the client cert to use to connect to the etcd topo server, requires topo_etcd_tls_key, enables TLS
+      --topo_etcd_tls_key string                                         path to the client key to use to connect to the etcd topo server, enables TLS
+      --topo_global_root string                                          the path of the global topology data in the global topology server
+      --topo_global_server_address string                                the address of the global topology server
+      --topo_implementation string                                       the topology implementation to use
+      --topo_k8s_context string                                          The kubeconfig context to use, overrides the 'current-context' from the config
+      --topo_k8s_kubeconfig string                                       Path to a valid kubeconfig file. When running as a k8s pod inside the same cluster you wish to use as the topo, you may omit this and the below arguments, and Vitess is capable of auto-discovering the correct values. https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+      --topo_k8s_namespace string                                        The kubernetes namespace to use for all objects. Default comes from the context or in-cluster config
+      --topo_read_concurrency int                                        Concurrency of topo reads. (default 32)
+      --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
+      --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)
+      --topo_zk_max_concurrency int                                      maximum number of pending requests to send to a Zookeeper server. (default 64)
+      --topo_zk_tls_ca string                                            the server ca to use to validate servers when connecting to the zk topo server
+      --topo_zk_tls_cert string                                          the cert to use to connect to the zk topo server, requires topo_zk_tls_key, enables TLS
+      --topo_zk_tls_key string                                           the key to use to connect to the zk topo server, enables TLS
+      --tracer string                                                    tracing service to use (default "noop")
+      --tracing-enable-logging                                           whether to enable logging in the tracing service
+      --tracing-sampling-rate OptionalFloat64                            sampling rate for the probabilistic jaeger sampler (default 0.1)
+      --tracing-sampling-type OptionalString                             sampling strategy to use for jaeger. possible values are 'const', 'probabilistic', 'rateLimiting', or 'remote' (default const)
+      --track_schema_versions                                            When enabled, vttablet will store versions of schemas at each position that a DDL is applied and allow retrieval of the schema corresponding to a position
+      --transaction-log-stream-handler string                            URL handler for streaming transactions log (default "/debug/txlog")
+      --transaction_limit_by_component                                   Include CallerID.component when considering who the user is for the purpose of transaction limit.
+      --transaction_limit_by_principal                                   Include CallerID.principal when considering who the user is for the purpose of transaction limit. (default true)
+      --transaction_limit_by_subcomponent                                Include CallerID.subcomponent when considering who the user is for the purpose of transaction limit.
+      --transaction_limit_by_username                                    Include VTGateCallerID.username when considering who the user is for the purpose of transaction limit. (default true)
+      --transaction_limit_per_user float                                 Maximum number of transactions a single user is allowed to use at any time, represented as fraction of -transaction_cap. (default 0.4)
+      --twopc_abandon_age float                                          time in seconds. Any unresolved transaction older than this time will be sent to the coordinator to be resolved.
+      --twopc_coordinator_address string                                 address of the (VTGate) process(es) that will be used to notify of abandoned transactions.
+      --twopc_enable                                                     if the flag is on, 2pc is enabled. Other 2pc flags must be supplied.
+      --tx-throttler-config string                                       Synonym to -tx_throttler_config (default "target_replication_lag_sec: 2\nmax_replication_lag_sec: 10\ninitial_rate: 100\nmax_increase: 1\nemergency_decrease: 0.5\nmin_duration_between_increases_sec: 40\nmax_duration_between_increases_sec: 62\nmin_duration_between_decreases_sec: 20\nspread_backlog_across_sec: 20\nage_bad_rate_after_sec: 180\nbad_rate_increase: 0.1\nmax_rate_approach_threshold: 0.9\n")
+      --tx-throttler-healthcheck-cells StringList                        Synonym to -tx_throttler_healthcheck_cells
+      --tx_throttler_config string                                       The configuration of the transaction throttler as a text formatted throttlerdata.Configuration protocol buffer message (default "target_replication_lag_sec: 2\nmax_replication_lag_sec: 10\ninitial_rate: 100\nmax_increase: 1\nemergency_decrease: 0.5\nmin_duration_between_increases_sec: 40\nmax_duration_between_increases_sec: 62\nmin_duration_between_decreases_sec: 20\nspread_backlog_across_sec: 20\nage_bad_rate_after_sec: 180\nbad_rate_increase: 0.1\nmax_rate_approach_threshold: 0.9\n")
+      --tx_throttler_healthcheck_cells StringList                        A comma-separated list of cells. Only tabletservers running in these cells will be monitored for replication lag by the transaction throttler.
+      --unhealthy_threshold duration                                     replication lag after which a replica is considered unhealthy (default 2h0m0s)
+  -v, --v Level                                                          log level for V logs
+      --version                                                          print binary version
+      --vmodule moduleSpec                                               comma-separated list of pattern=N settings for file-filtered logging
+      --vreplication_copy_phase_duration duration                        Duration for each copy phase loop (before running the next catchup: default 1h) (default 1h0m0s)
+      --vreplication_copy_phase_max_innodb_history_list_length int       The maximum InnoDB transaction history that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet. (default 1000000)
+      --vreplication_copy_phase_max_mysql_replication_lag int            The maximum MySQL replication lag (in seconds) that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet. (default 43200)
+      --vreplication_experimental_flags int                              (Bitmask) of experimental features in vreplication to enable (default 1)
+      --vreplication_healthcheck_retry_delay duration                    healthcheck retry delay (default 5s)
+      --vreplication_healthcheck_timeout duration                        healthcheck retry delay (default 1m0s)
+      --vreplication_healthcheck_topology_refresh duration               refresh interval for re-reading the topology (default 30s)
+      --vreplication_heartbeat_update_interval int                       Frequency (in seconds, default 1, max 60) at which the time_updated column of a vreplication stream when idling (default 1)
+      --vreplication_max_time_to_retry_on_error duration                 stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence (default 15m0s)
+      --vreplication_replica_lag_tolerance duration                      Replica lag threshold duration: once lag is below this we switch from copy phase to the replication (streaming) phase (default 1m0s)
+      --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
+      --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of _vt.vreplication
+      --vreplication_tablet_type string                                  comma separated list of tablet types used as a source (default "in_order:REPLICA,PRIMARY")
+      --vstream_dynamic_packet_size                                      Enable dynamic packet sizing for VReplication. This will adjust the packet size during replication to improve performance. (default true)
+      --vstream_packet_size int                                          Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount. (default 250000)
+      --vtctl_healthcheck_retry_delay duration                           delay before retrying a failed healthcheck (default 5s)
+      --vtctl_healthcheck_timeout duration                               the health check timeout period (default 1m0s)
+      --vtctl_healthcheck_topology_refresh duration                      refresh interval for re-reading the topology (default 30s)
+      --vtctld_sanitize_log_messages                                     When true, vtctld sanitizes logging.
+      --vtctld_show_topology_crud                                        Controls the display of the CRUD topology actions in the vtctld UI. (default true)
+      --vtgate_grpc_ca string                                            the server ca to use to validate servers when connecting
+      --vtgate_grpc_cert string                                          the cert to use to connect
+      --vtgate_grpc_crl string                                           the server crl to use to validate server certificates when connecting
+      --vtgate_grpc_key string                                           the key to use to connect
+      --vtgate_grpc_server_name string                                   the server name to use to validate server certificate
+      --vtgate_protocol string                                           how to talk to vtgate (default "grpc")
+      --watch_replication_stream                                         When enabled, vttablet will stream the MySQL replication stream from the local server, and use it to update schema when it sees a DDL.
+      --web_dir string                                                   NOT USED, here for backward compatibility
+      --web_dir2 string                                                  NOT USED, here for backward compatibility
+      --workflow_manager_disable StringList                              comma separated list of workflow types to disable
+      --workflow_manager_init                                            Initialize the workflow manager in this vtctld instance.
+      --workflow_manager_use_election                                    if specified, will use a topology server-based master election to ensure only one workflow manager is active at a time.
+      --xbstream_restore_flags string                                    flags to pass to xbstream command during restore. These should be space separated and will be added to the end of the command. These need to match the ones used for backup e.g. --compress / --decompress, --encrypt / --decrypt
+      --xtrabackup_backup_flags string                                   flags to pass to backup command. These should be space separated and will be added to the end of the command
+      --xtrabackup_prepare_flags string                                  flags to pass to prepare command. These should be space separated and will be added to the end of the command
+      --xtrabackup_root_path string                                      directory location of the xtrabackup and xbstream executables, e.g., /usr/bin
+      --xtrabackup_stream_mode string                                    which mode to use if streaming, valid values are tar and xbstream (default "tar")
+      --xtrabackup_stripe_block_size uint                                Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe (default 102400)
+      --xtrabackup_stripes uint                                          If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression
+      --xtrabackup_user string                                           User that xtrabackup will use to connect to the database server. This user must have all necessary privileges. For details, please refer to xtrabackup documentation.

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -66,7 +66,7 @@ var (
 	healthcheckOnce           sync.Once
 
 	// TabletURLTemplateString is a flag to generate URLs for the tablets that vtgate discovers.
-	TabletURLTemplateString string
+	TabletURLTemplateString = "http://{{.GetTabletHostPort}}"
 	tabletURLTemplate       *template.Template
 
 	// AllowedTabletTypes is the list of allowed tablet types. e.g. {PRIMARY, REPLICA}.
@@ -80,13 +80,13 @@ var (
 	tabletFilters []string
 
 	// refreshInterval is the interval at which healthcheck refreshes its list of tablets from topo.
-	refreshInterval time.Duration
+	refreshInterval = 1 * time.Minute
 
 	// refreshKnownTablets tells us whether to process all tablets or only new tablets.
-	refreshKnownTablets bool
+	refreshKnownTablets = true
 
 	// topoReadConcurrency tells us how many topo reads are allowed in parallel.
-	topoReadConcurrency int
+	topoReadConcurrency = 32
 
 	// How much to sleep between each check.
 	waitAvailableTabletInterval = 100 * time.Millisecond

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -149,6 +149,7 @@ func ParseTabletURLTemplateFromFlag() {
 func init() {
 	servenv.OnParseFor("vtgate", registerDiscoveryFlags)
 	servenv.OnParseFor("vtcombo", registerDiscoveryFlags)
+	servenv.OnParseFor("vtctld", registerDiscoveryFlags)
 }
 
 func registerDiscoveryFlags(fs *pflag.FlagSet) {
@@ -312,6 +313,7 @@ func NewHealthCheck(ctx context.Context, retryDelay, healthCheckTimeout time.Dur
 	if cellsToWatch == "" {
 		cells = append(cells, localCell)
 	}
+	log.Errorf("Refresh Interval - %v", refreshInterval)
 	for _, c := range cells {
 		log.Infof("Setting up healthcheck for cell: %v", c)
 		if c == "" {

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -313,7 +313,7 @@ func NewHealthCheck(ctx context.Context, retryDelay, healthCheckTimeout time.Dur
 	if cellsToWatch == "" {
 		cells = append(cells, localCell)
 	}
-	log.Errorf("Refresh Interval - %v", refreshInterval)
+
 	for _, c := range cells {
 		log.Infof("Setting up healthcheck for cell: %v", c)
 		if c == "" {


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the panic as described in https://github.com/vitessio/vitess/issues/10901.

The problem was traced back to https://github.com/vitessio/vitess/pull/10863. In this refactor of flags, we accidentally removed discovery flags for being registered for vtctld, which caused the default value of the flag not being used while starting the timer, causing it to panic.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #10901 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
