### PR TITLE
evalengine: expose Filter operations

### DIFF
--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -38,6 +38,10 @@ func dataOutOfRangeError(v1, v2 any, typ, sign string) error {
 
 // FormatFloat formats a float64 as a byte string in a similar way to what MySQL does
 func FormatFloat(typ sqltypes.Type, f float64) []byte {
+	return AppendFloat(nil, typ, f)
+}
+
+func AppendFloat(buf []byte, typ sqltypes.Type, f float64) []byte {
 	format := byte('g')
 	if typ == sqltypes.Decimal {
 		format = 'f'
@@ -48,7 +52,7 @@ func FormatFloat(typ sqltypes.Type, f float64) []byte {
 	// do that, and there's no way to customize it, so we must strip the
 	// redundant positive sign manually
 	// e.g. 1.234E+56789 -> 1.234E56789
-	fstr := strconv.AppendFloat(nil, f, format, -1, 64)
+	fstr := strconv.AppendFloat(buf, f, format, -1, 64)
 	if idx := bytes.IndexByte(fstr, 'e'); idx >= 0 {
 		if fstr[idx+1] == '+' {
 			fstr = append(fstr[:idx+1], fstr[idx+2:]...)

--- a/go/vt/vtgate/evalengine/comparisons.go
+++ b/go/vt/vtgate/evalengine/comparisons.go
@@ -27,6 +27,13 @@ import (
 )
 
 type (
+	Filter interface {
+		Expr
+		LeftExpr() Expr
+		RightExpr() Expr
+		filterExpr()
+	}
+
 	ComparisonExpr struct {
 		BinaryExpr
 		Op ComparisonOp
@@ -54,10 +61,13 @@ type (
 	compareNE         struct{}
 	compareLT         struct{}
 	compareLE         struct{}
-	CompareGT         struct{}
+	compareGT         struct{}
 	compareGE         struct{}
 	compareNullSafeEQ struct{}
 )
+
+func (*ComparisonExpr) filterExpr() {}
+func (*InExpr) filterExpr()         {}
 
 func (compareEQ) String() string { return "=" }
 func (compareEQ) compare(left, right *EvalResult) (boolean, error) {
@@ -83,8 +93,8 @@ func (compareLE) compare(left, right *EvalResult) (boolean, error) {
 	return makeboolean2(cmp <= 0, isNull), err
 }
 
-func (CompareGT) String() string { return ">" }
-func (CompareGT) compare(left, right *EvalResult) (boolean, error) {
+func (compareGT) String() string { return ">" }
+func (compareGT) compare(left, right *EvalResult) (boolean, error) {
 	cmp, isNull, err := evalCompareAll(left, right, false)
 	return makeboolean2(cmp > 0, isNull), err
 }

--- a/go/vt/vtgate/evalengine/eval_result.go
+++ b/go/vt/vtgate/evalengine/eval_result.go
@@ -475,6 +475,84 @@ func (er *EvalResult) nullSafeHashcode() (HashCode, error) {
 	}
 }
 
+// NullsafeHashCodeInPlace behaves like NullsafeHashCode but the type coercion is performed
+// in-place for performance reasons. Eventually this method will replace the old implementation.
+func NullsafeHashCodeInPlace(v sqltypes.Value, collation collations.ID, typ sqltypes.Type) (HashCode, error) {
+	switch {
+	case typ == sqltypes.Null:
+		return HashCode(math.MaxUint64), nil
+
+	case sqltypes.IsFloat(typ):
+		var f float64
+		var err error
+
+		switch {
+		case v.IsSigned():
+			var ival int64
+			ival, err = v.ToInt64()
+			f = float64(ival)
+		case v.IsUnsigned():
+			var uval uint64
+			uval, err = v.ToUint64()
+			f = float64(uval)
+		case v.IsFloat() || v.Type() == sqltypes.Decimal:
+			f, err = v.ToFloat64()
+		case v.IsText() || v.IsBinary():
+			f = parseStringToFloat(v.RawStr())
+		default:
+			return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "coercion should not try to coerce this value to a float: %v", v)
+		}
+		return HashCode(math.Float64bits(f)), err
+
+	case sqltypes.IsSigned(typ):
+		var i int64
+		var err error
+
+		switch {
+		case v.IsSigned():
+			i, err = v.ToInt64()
+		case v.IsUnsigned():
+			var uval uint64
+			uval, err = v.ToUint64()
+			i = int64(uval)
+		default:
+			return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "coercion should not try to coerce this value to a signed int: %v", v)
+		}
+		return HashCode(uint64(i)), err
+
+	case sqltypes.IsUnsigned(typ):
+		var u uint64
+		var err error
+
+		switch {
+		case v.IsSigned():
+			var ival int64
+			ival, err = v.ToInt64()
+			u = uint64(ival)
+		case v.IsUnsigned():
+			u, err = v.ToUint64()
+		default:
+			return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "coercion should not try to coerce this value to a unsigned int: %v", v)
+		}
+
+		return HashCode(u), err
+
+	case sqltypes.IsBinary(typ):
+		coll := collations.Local().LookupByID(collations.CollationBinaryID)
+		return coll.Hash(v.Raw(), 0), nil
+
+	case sqltypes.IsText(typ):
+		coll := collations.Local().LookupByID(collation)
+		if coll == nil {
+			return 0, UnsupportedCollationHashError
+		}
+		return coll.Hash(v.Raw(), 0), nil
+
+	default:
+		return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unsupported hash type: %v", v)
+	}
+}
+
 func (er *EvalResult) setValueCast(v sqltypes.Value, typ sqltypes.Type) error {
 	switch {
 	case typ == sqltypes.Null:
@@ -1014,6 +1092,14 @@ func (er *EvalResult) TupleValues() []sqltypes.Value {
 		result = append(result, val.value())
 	}
 	return result
+}
+
+func (er *EvalResult) MustBoolean() bool {
+	b, err := er.ToBooleanStrict()
+	if err != nil {
+		panic(err)
+	}
+	return b
 }
 
 // ToBooleanStrict is used when the casting to a boolean has to be minimally forgiving,

--- a/go/vt/vtgate/evalengine/evalengine.go
+++ b/go/vt/vtgate/evalengine/evalengine.go
@@ -23,6 +23,7 @@ import (
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/evalengine/internal/decimal"
 )
@@ -104,6 +105,14 @@ func ToFloat64(v sqltypes.Value) (float64, error) {
 	}
 	num.makeFloat()
 	return num.float64(), nil
+}
+
+func LiteralToValue(literal *sqlparser.Literal) (sqltypes.Value, error) {
+	lit, err := translateLiteral(literal, nil)
+	if err != nil {
+		return sqltypes.Value{}, err
+	}
+	return lit.Val.Value(), nil
 }
 
 // ToNative converts Value to a native go type.

--- a/go/vt/vtgate/evalengine/expressions.go
+++ b/go/vt/vtgate/evalengine/expressions.go
@@ -79,6 +79,14 @@ type (
 	}
 )
 
+func (expr *BinaryExpr) LeftExpr() Expr {
+	return expr.Left
+}
+
+func (expr *BinaryExpr) RightExpr() Expr {
+	return expr.Right
+}
+
 var _ Expr = (*Literal)(nil)
 var _ Expr = (*BindVariable)(nil)
 var _ Expr = (*Column)(nil)
@@ -140,6 +148,10 @@ func (env *ExpressionEnv) subexpr(expr Expr, nth int) (Expr, int) {
 	case *BindVariable:
 		tt, _ := expr.typeof(env)
 		if tt == sqltypes.Tuple {
+			return nil, 1
+		}
+	case *Literal:
+		if expr.Val.typeof() == sqltypes.Tuple {
 			return nil, 1
 		}
 	case TupleExpr:

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -75,7 +75,7 @@ func translateComparisonExpr2(op sqlparser.ComparisonExprOperator, left, right E
 	case sqlparser.LessEqualOp:
 		return &ComparisonExpr{binaryExpr, compareLE{}}, nil
 	case sqlparser.GreaterThanOp:
-		return &ComparisonExpr{binaryExpr, CompareGT{}}, nil
+		return &ComparisonExpr{binaryExpr, compareGT{}}, nil
 	case sqlparser.GreaterEqualOp:
 		return &ComparisonExpr{binaryExpr, compareGE{}}, nil
 	case sqlparser.NullSafeEqualOp:


### PR DESCRIPTION
## Description

This PR includes a few small fixes to the `evalengine` and some new exports that will make working with the engine as a library less painful.

## Related Issue(s)

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
