### PR TITLE
Improve topo handling and add additional functionality

### DIFF
--- a/go/vt/srvtopo/watch_srvkeyspace.go
+++ b/go/vt/srvtopo/watch_srvkeyspace.go
@@ -40,14 +40,19 @@ func (k *srvKeyspaceKey) String() string {
 func NewSrvKeyspaceWatcher(topoServer *topo.Server, counts *stats.CountersWithSingleLabel, cacheRefresh, cacheTTL time.Duration) *SrvKeyspaceWatcher {
 	watch := func(ctx context.Context, entry *watchEntry) {
 		key := entry.key.(*srvKeyspaceKey)
-		current, changes, cancel := topoServer.WatchSrvKeyspace(context.Background(), key.cell, key.keyspace)
+		watchCtx, watchCancel := context.WithCancel(ctx)
+		defer watchCancel()
+
+		current, changes, err := topoServer.WatchSrvKeyspace(watchCtx, key.cell, key.keyspace)
+		if err != nil {
+			return
+		}
 
 		entry.update(ctx, current.Value, current.Err, true)
 		if current.Err != nil {
 			return
 		}
 
-		defer cancel()
 		for c := range changes {
 			entry.update(ctx, c.Value, c.Err, false)
 			if c.Err != nil {

--- a/go/vt/srvtopo/watch_srvkeyspace.go
+++ b/go/vt/srvtopo/watch_srvkeyspace.go
@@ -45,6 +45,7 @@ func NewSrvKeyspaceWatcher(topoServer *topo.Server, counts *stats.CountersWithSi
 
 		current, changes, err := topoServer.WatchSrvKeyspace(watchCtx, key.cell, key.keyspace)
 		if err != nil {
+			entry.update(ctx, nil, err, true)
 			return
 		}
 

--- a/go/vt/srvtopo/watch_srvvschema.go
+++ b/go/vt/srvtopo/watch_srvvschema.go
@@ -38,7 +38,13 @@ func (k cellName) String() string {
 func NewSrvVSchemaWatcher(topoServer *topo.Server, counts *stats.CountersWithSingleLabel, cacheRefresh, cacheTTL time.Duration) *SrvVSchemaWatcher {
 	watch := func(ctx context.Context, entry *watchEntry) {
 		key := entry.key.(cellName)
-		current, changes, cancel := topoServer.WatchSrvVSchema(context.Background(), key.String())
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		current, changes, err := topoServer.WatchSrvVSchema(ctx, key.String())
+		if err != nil {
+			return
+		}
 
 		entry.update(ctx, current.Value, current.Err, true)
 		if current.Err != nil {

--- a/go/vt/srvtopo/watch_srvvschema.go
+++ b/go/vt/srvtopo/watch_srvvschema.go
@@ -43,6 +43,7 @@ func NewSrvVSchemaWatcher(topoServer *topo.Server, counts *stats.CountersWithSin
 
 		current, changes, err := topoServer.WatchSrvVSchema(ctx, key.String())
 		if err != nil {
+			entry.update(ctx, nil, err, true)
 			return
 		}
 

--- a/go/vt/topo/conn.go
+++ b/go/vt/topo/conn.go
@@ -386,4 +386,14 @@ type LeaderParticipation interface {
 	// GetCurrentLeaderID returns the current primary id.
 	// This may not work after Stop has been called.
 	GetCurrentLeaderID(ctx context.Context) (string, error)
+
+	// WaitForNewLeader allows for nodes to wait until a leadership
+	// election cycle completes and to get subsequent updates of
+	// leadership changes. This way logic that needs to know if leadership
+	// changes also if we're not the leader ourselves doesn't need to
+	// poll for leadership status.
+	//
+	// For topo implementation that have this, it can be used more
+	// efficiently than needing a busy wait loop.
+	WaitForNewLeader(ctx context.Context) (<-chan string, error)
 }

--- a/go/vt/topo/conn.go
+++ b/go/vt/topo/conn.go
@@ -17,9 +17,8 @@ limitations under the License.
 package topo
 
 import (
-	"sort"
-
 	"context"
+	"sort"
 )
 
 // Conn defines the interface that must be implemented by topology
@@ -120,17 +119,13 @@ type Conn interface {
 
 	// Watch starts watching a file in the provided cell.  It
 	// returns the current value, a 'changes' channel to read the
-	// changes from, and a 'cancel' function to call to stop the
-	// watch.  If the initial read fails, or the file doesn't
-	// exist, current.Err is set, and 'changes'/'cancel' are nil.
-	// Otherwise current.Err is nil, and current.Contents /
-	// current.Version are accurate. The provided context is only
-	// used to setup the current watch, and not after Watch()
-	// returns.
+	// changes from, and an error.
+	// If the initial read fails, or the file doesn't
+	// exist, an error is returned.
 	//
-	// To stop the watch, just call the returned 'cancel' function.
+	// To stop the watch, cancel the provided context.
 	// This will eventually result in a final WatchData result with Err =
-	// ErrInterrupted. It should be safe to call the 'cancel' function
+	// ErrInterrupted. It should be safe to cancel the context
 	// multiple times, or after the Watch already errored out.
 	//
 	// The 'changes' channel may return a record with Err != nil.
@@ -158,7 +153,7 @@ type Conn interface {
 	// being correct quickly, as long as it eventually gets there.
 	//
 	// filePath is a path relative to the root directory of the cell.
-	Watch(ctx context.Context, filePath string) (current *WatchData, changes <-chan *WatchData, cancel CancelFunc)
+	Watch(ctx context.Context, filePath string) (current *WatchData, changes <-chan *WatchData, err error)
 
 	//
 	// Leader election methods. This is meant to have a small

--- a/go/vt/topo/consultopo/election.go
+++ b/go/vt/topo/consultopo/election.go
@@ -17,9 +17,8 @@ limitations under the License.
 package consultopo
 
 import (
-	"path"
-
 	"context"
+	"path"
 
 	"github.com/hashicorp/consul/api"
 
@@ -132,4 +131,12 @@ func (mp *consulLeaderParticipation) GetCurrentLeaderID(ctx context.Context) (st
 		return "", nil
 	}
 	return string(pair.Value), nil
+}
+
+// WaitForNewLeader is part of the topo.LeaderParticipation interface
+func (mp *consulLeaderParticipation) WaitForNewLeader(context.Context) (<-chan string, error) {
+	// This isn't implemented yet, but likely can be implemented using List
+	// with blocking logic on election path.
+	// See also how WatchRecursive could be implemented as well.
+	return nil, topo.NewError(topo.NoImplementation, "wait for leader not supported in Consul topo")
 }

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -128,3 +128,12 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 
 	return wd, notifications, nil
 }
+
+// WatchRecursive is part of the topo.Conn interface.
+func (s *Server) WatchRecursive(_ context.Context, path string) ([]*topo.WatchDataRecursive, <-chan *topo.WatchDataRecursive, error) {
+	// This isn't implemented yet, but likely can be implemented using List
+	// with blocking logic like how we use Get with blocking for regular Watch.
+	// See also how https://www.consul.io/docs/dynamic-app-config/watches#keyprefix
+	// works under the hood.
+	return nil, nil, topo.NewError(topo.NoImplementation, path)
+}

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -17,11 +17,10 @@ limitations under the License.
 package consultopo
 
 import (
+	"context"
 	"flag"
 	"path"
 	"time"
-
-	"context"
 
 	"github.com/hashicorp/consul/api"
 
@@ -33,16 +32,21 @@ var (
 )
 
 // Watch is part of the topo.Conn interface.
-func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, topo.CancelFunc) {
+func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, error) {
 	// Initial get.
 	nodePath := path.Join(s.root, filePath)
-	pair, _, err := s.kv.Get(nodePath, nil)
+	options := &api.QueryOptions{}
+
+	initialCtx, initialCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
+	defer initialCancel()
+
+	pair, _, err := s.kv.Get(nodePath, options.WithContext(initialCtx))
 	if err != nil {
-		return &topo.WatchData{Err: err}, nil, nil
+		return nil, nil, err
 	}
 	if pair == nil {
 		// Node doesn't exist.
-		return &topo.WatchData{Err: topo.NewError(topo.NoNode, nodePath)}, nil, nil
+		return nil, nil, topo.NewError(topo.NoNode, nodePath)
 	}
 
 	// Initial value to return.
@@ -50,9 +54,6 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 		Contents: pair.Value,
 		Version:  ConsulVersion(pair.ModifyIndex),
 	}
-
-	// Create a context, will be used to cancel the watch.
-	watchCtx, watchCancel := context.WithCancel(context.Background())
 
 	// Create the notifications channel, send updates to it.
 	notifications := make(chan *topo.WatchData, 10)
@@ -83,7 +84,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 			// This essentially uses WaitTime as a heartbeat interval to detect
 			// a dead connection.
 			cancelGetCtx()
-			getCtx, cancelGetCtx = context.WithTimeout(watchCtx, 2*opts.WaitTime)
+			getCtx, cancelGetCtx = context.WithTimeout(ctx, 2*opts.WaitTime)
 
 			pair, _, err = s.kv.Get(nodePath, opts.WithContext(getCtx))
 			if err != nil {
@@ -114,9 +115,9 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 
 			// See if the watch was canceled.
 			select {
-			case <-watchCtx.Done():
+			case <-ctx.Done():
 				notifications <- &topo.WatchData{
-					Err: convertError(watchCtx.Err(), nodePath),
+					Err: convertError(ctx.Err(), nodePath),
 				}
 				cancelGetCtx()
 				return
@@ -125,5 +126,5 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 		}
 	}()
 
-	return wd, notifications, topo.CancelFunc(watchCancel)
+	return wd, notifications, nil
 }

--- a/go/vt/topo/etcd2topo/election.go
+++ b/go/vt/topo/etcd2topo/election.go
@@ -17,9 +17,8 @@ limitations under the License.
 package etcd2topo
 
 import (
-	"path"
-
 	"context"
+	"path"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
@@ -76,7 +75,11 @@ func (mp *etcdLeaderParticipation) WaitForLeadership() (context.Context, error) 
 	// we just cancel that context.
 	lockCtx, lockCancel := context.WithCancel(context.Background())
 	go func() {
-		<-mp.stop
+		select {
+		case <-mp.s.running:
+			return
+		case <-mp.stop:
+		}
 		if ld != nil {
 			if err := ld.Unlock(context.Background()); err != nil {
 				log.Errorf("failed to unlock electionPath %v: %v", electionPath, err)
@@ -122,4 +125,68 @@ func (mp *etcdLeaderParticipation) GetCurrentLeaderID(ctx context.Context) (stri
 		return "", nil
 	}
 	return string(resp.Kvs[0].Value), nil
+}
+
+func (mp *etcdLeaderParticipation) WaitForNewLeader(ctx context.Context) (<-chan string, error) {
+	electionPath := path.Join(mp.s.root, electionsPath, mp.name)
+
+	notifications := make(chan string, 8)
+	ctx, cancel := context.WithCancel(ctx)
+
+	// Get the current leader
+	initial, err := mp.s.cli.Get(ctx, electionPath+"/",
+		clientv3.WithPrefix(),
+		clientv3.WithSort(clientv3.SortByModRevision, clientv3.SortAscend),
+		clientv3.WithLimit(1))
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	if len(initial.Kvs) == 1 {
+		leader := initial.Kvs[0].Value
+		notifications <- string(leader)
+	}
+
+	// Create the Watcher.  We start watching from the response we
+	// got, not from the file original version, as the server may
+	// not have that much history.
+	watcher := mp.s.cli.Watch(ctx, electionPath, clientv3.WithPrefix(), clientv3.WithRev(initial.Header.Revision))
+	if watcher == nil {
+		cancel()
+		return nil, convertError(err, electionPath)
+	}
+
+	go func() {
+		defer cancel()
+		defer close(notifications)
+		for {
+			select {
+			case <-mp.s.running:
+				return
+			case <-mp.done:
+				return
+			case <-ctx.Done():
+				return
+			case wresp, ok := <-watcher:
+				if !ok || wresp.Canceled {
+					return
+				}
+
+				currentLeader, err := mp.s.cli.Get(ctx, electionPath+"/",
+					clientv3.WithPrefix(),
+					clientv3.WithSort(clientv3.SortByModRevision, clientv3.SortAscend),
+					clientv3.WithLimit(1))
+				if err != nil {
+					continue
+				}
+				if len(currentLeader.Kvs) != 1 {
+					continue
+				}
+				notifications <- string(currentLeader.Kvs[0].Value)
+			}
+		}
+	}()
+
+	return notifications, nil
 }

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -74,12 +74,15 @@ type Server struct {
 
 	// root is the root path for this client.
 	root string
+
+	running chan struct{}
 }
 
 // Close implements topo.Server.Close.
 // It will nil out the global and cells fields, so any attempt to
 // re-use this server will panic.
 func (s *Server) Close() {
+	close(s.running)
 	s.cli.Close()
 	s.cli = nil
 }
@@ -140,8 +143,9 @@ func NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath string) (*Ser
 	}
 
 	return &Server{
-		cli:  cli,
-		root: root,
+		cli:     cli,
+		root:    root,
+		running: make(chan struct{}),
 	}, nil
 }
 

--- a/go/vt/topo/etcd2topo/watch.go
+++ b/go/vt/topo/etcd2topo/watch.go
@@ -19,6 +19,7 @@ package etcd2topo
 import (
 	"context"
 	"path"
+	"strings"
 	"time"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -75,7 +76,6 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 		var watchRetries int
 		for {
 			select {
-
 			case <-watchCtx.Done():
 				// This includes context cancellation errors.
 				notifications <- &topo.WatchData{
@@ -85,7 +85,11 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 			case wresp, ok := <-watcher:
 				if !ok {
 					if watchRetries > 10 {
-						time.Sleep(time.Duration(watchRetries) * time.Second)
+						select {
+						case <-time.After(time.Duration(watchRetries) * time.Second):
+						case <-watchCtx.Done():
+							continue
+						}
 					}
 					watchRetries++
 					// Cancel inner context on retry and create new one.
@@ -137,4 +141,116 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 	}()
 
 	return wd, notifications, nil
+}
+
+// WatchRecursive is part of the topo.Conn interface.
+func (s *Server) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.WatchDataRecursive, <-chan *topo.WatchDataRecursive, error) {
+	nodePath := path.Join(s.root, dirpath)
+	if !strings.HasSuffix(nodePath, "/") {
+		nodePath = nodePath + "/"
+	}
+
+	// Get the initial version of the file
+	initial, err := s.cli.Get(ctx, nodePath, clientv3.WithPrefix())
+	if err != nil {
+		return nil, nil, convertError(err, nodePath)
+	}
+
+	var initialwd []*topo.WatchDataRecursive
+
+	for _, kv := range initial.Kvs {
+		var wd topo.WatchDataRecursive
+		wd.Path = string(kv.Key)
+		wd.Contents = kv.Value
+		wd.Version = EtcdVersion(initial.Kvs[0].ModRevision)
+		initialwd = append(initialwd, &wd)
+	}
+
+	// Create a context, will be used to cancel the watch on retry.
+	watchCtx, watchCancel := context.WithCancel(ctx)
+
+	// Create the Watcher.  We start watching from the response we
+	// got, not from the file original version, as the server may
+	// not have that much history.
+	watcher := s.cli.Watch(watchCtx, nodePath, clientv3.WithRev(initial.Header.Revision), clientv3.WithPrefix())
+	if watcher == nil {
+		watchCancel()
+		return nil, nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "Watch failed")
+	}
+
+	// Create the notifications channel, send updates to it.
+	notifications := make(chan *topo.WatchDataRecursive, 10)
+	go func() {
+		defer close(notifications)
+		defer watchCancel()
+
+		var currVersion = initial.Header.Revision
+		var watchRetries int
+		for {
+			select {
+			case <-watchCtx.Done():
+				// This includes context cancellation errors.
+				notifications <- &topo.WatchDataRecursive{
+					WatchData: topo.WatchData{Err: convertError(watchCtx.Err(), nodePath)},
+				}
+				return
+			case wresp, ok := <-watcher:
+				if !ok {
+					if watchRetries > 10 {
+						select {
+						case <-time.After(time.Duration(watchRetries) * time.Second):
+						case <-watchCtx.Done():
+							continue
+						}
+					}
+					watchRetries++
+					// Cancel inner context on retry and create new one.
+					watchCancel()
+					watchCtx, watchCancel = context.WithCancel(ctx)
+
+					newWatcher := s.cli.Watch(watchCtx, nodePath, clientv3.WithRev(currVersion), clientv3.WithPrefix())
+					if newWatcher == nil {
+						log.Warningf("watch %v failed and get a nil channel returned, currVersion: %v", nodePath, currVersion)
+					} else {
+						watcher = newWatcher
+					}
+					continue
+				}
+
+				watchRetries = 0
+
+				if wresp.Canceled {
+					// Final notification.
+					notifications <- &topo.WatchDataRecursive{
+						WatchData: topo.WatchData{Err: convertError(wresp.Err(), nodePath)},
+					}
+					return
+				}
+
+				currVersion = wresp.Header.GetRevision()
+
+				for _, ev := range wresp.Events {
+					switch ev.Type {
+					case mvccpb.PUT:
+						notifications <- &topo.WatchDataRecursive{
+							Path: string(ev.Kv.Key),
+							WatchData: topo.WatchData{
+								Contents: ev.Kv.Value,
+								Version:  EtcdVersion(ev.Kv.Version),
+							},
+						}
+					case mvccpb.DELETE:
+						notifications <- &topo.WatchDataRecursive{
+							Path: string(ev.Kv.Key),
+							WatchData: topo.WatchData{
+								Err: topo.NewError(topo.NoNode, nodePath),
+							},
+						}
+					}
+				}
+			}
+		}
+	}()
+
+	return initialwd, notifications, nil
 }

--- a/go/vt/topo/etcd2topo/watch.go
+++ b/go/vt/topo/etcd2topo/watch.go
@@ -76,6 +76,8 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 		var watchRetries int
 		for {
 			select {
+			case <-s.running:
+				return
 			case <-watchCtx.Done():
 				// This includes context cancellation errors.
 				notifications <- &topo.WatchData{
@@ -87,6 +89,8 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 					if watchRetries > 10 {
 						select {
 						case <-time.After(time.Duration(watchRetries) * time.Second):
+						case <-s.running:
+							continue
 						case <-watchCtx.Done():
 							continue
 						}
@@ -188,6 +192,8 @@ func (s *Server) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.Wa
 		var watchRetries int
 		for {
 			select {
+			case <-s.running:
+				return
 			case <-watchCtx.Done():
 				// This includes context cancellation errors.
 				notifications <- &topo.WatchDataRecursive{
@@ -199,6 +205,8 @@ func (s *Server) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.Wa
 					if watchRetries > 10 {
 						select {
 						case <-time.After(time.Duration(watchRetries) * time.Second):
+						case <-s.running:
+							continue
 						case <-watchCtx.Done():
 							continue
 						}

--- a/go/vt/topo/faketopo/faketopo.go
+++ b/go/vt/topo/faketopo/faketopo.go
@@ -288,12 +288,12 @@ func (f *FakeConn) Lock(ctx context.Context, dirPath, contents string) (topo.Loc
 }
 
 // Watch implements the Conn interface
-func (f *FakeConn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, topo.CancelFunc) {
+func (f *FakeConn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	res, isPresent := f.getResultMap[filePath]
 	if !isPresent {
-		return &topo.WatchData{Err: topo.NewError(topo.NoNode, filePath)}, nil, nil
+		return nil, nil, topo.NewError(topo.NoNode, filePath)
 	}
 	current := &topo.WatchData{
 		Contents: res.contents,
@@ -303,7 +303,9 @@ func (f *FakeConn) Watch(ctx context.Context, filePath string) (*topo.WatchData,
 	notifications := make(chan *topo.WatchData, 100)
 	f.watches[filePath] = append(f.watches[filePath], notifications)
 
-	cancel := func() {
+	go func() {
+		defer close(notifications)
+		<-ctx.Done()
 		watches, isPresent := f.watches[filePath]
 		if !isPresent {
 			return
@@ -315,8 +317,8 @@ func (f *FakeConn) Watch(ctx context.Context, filePath string) (*topo.WatchData,
 				break
 			}
 		}
-	}
-	return current, notifications, cancel
+	}()
+	return current, notifications, nil
 }
 
 // NewLeaderParticipation implements the Conn interface

--- a/go/vt/topo/faketopo/faketopo.go
+++ b/go/vt/topo/faketopo/faketopo.go
@@ -321,6 +321,10 @@ func (f *FakeConn) Watch(ctx context.Context, filePath string) (*topo.WatchData,
 	return current, notifications, nil
 }
 
+func (f *FakeConn) WatchRecursive(ctx context.Context, path string) ([]*topo.WatchDataRecursive, <-chan *topo.WatchDataRecursive, error) {
+	panic("implement me")
+}
+
 // NewLeaderParticipation implements the Conn interface
 func (f *FakeConn) NewLeaderParticipation(string, string) (topo.LeaderParticipation, error) {
 	panic("implement me")

--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -164,7 +164,7 @@ func (c *TeeConn) Delete(ctx context.Context, filePath string, version topo.Vers
 }
 
 // Watch is part of the topo.Conn interface
-func (c *TeeConn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, topo.CancelFunc) {
+func (c *TeeConn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, error) {
 	return c.primary.Watch(ctx, filePath)
 }
 

--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -168,6 +168,10 @@ func (c *TeeConn) Watch(ctx context.Context, filePath string) (*topo.WatchData, 
 	return c.primary.Watch(ctx, filePath)
 }
 
+func (c *TeeConn) WatchRecursive(ctx context.Context, path string) ([]*topo.WatchDataRecursive, <-chan *topo.WatchDataRecursive, error) {
+	return c.primary.WatchRecursive(ctx, path)
+}
+
 //
 // Lock management.
 //

--- a/go/vt/topo/k8stopo/election.go
+++ b/go/vt/topo/k8stopo/election.go
@@ -17,9 +17,8 @@ limitations under the License.
 package k8stopo
 
 import (
-	"path"
-
 	"context"
+	"path"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
@@ -120,4 +119,11 @@ func (mp *kubernetesLeaderParticipation) GetCurrentLeaderID(ctx context.Context)
 		return "", err
 	}
 	return string(id), nil
+}
+
+// WaitForNewLeader is part of the topo.LeaderParticipation interface
+func (mp *kubernetesLeaderParticipation) WaitForNewLeader(context.Context) (<-chan string, error) {
+	// Kubernetes doesn't seem to provide a primitive that watches a prefix
+	// or directory, so this likely can never be implemented.
+	return nil, topo.NewError(topo.NoImplementation, "wait for leader not supported in K8s topo")
 }

--- a/go/vt/topo/k8stopo/watch.go
+++ b/go/vt/topo/k8stopo/watch.go
@@ -119,3 +119,10 @@ func closeOnDone(ctx context.Context, filePath string, informerChan chan struct{
 	close(informerChan)
 	close(changes)
 }
+
+// WatchRecursive is part of the topo.Conn interface.
+func (s *Server) WatchRecursive(_ context.Context, path string) ([]*topo.WatchDataRecursive, <-chan *topo.WatchDataRecursive, error) {
+	// Kubernetes doesn't seem to provide a primitive that watches a prefix
+	// or directory, so this likely can never be implemented.
+	return nil, nil, topo.NewError(topo.NoImplementation, path)
+}

--- a/go/vt/topo/k8stopo/watch.go
+++ b/go/vt/topo/k8stopo/watch.go
@@ -28,25 +28,21 @@ import (
 )
 
 // Watch is part of the topo.Conn interface.
-func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, topo.CancelFunc) {
+func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, error) {
 	log.Info("Starting Kubernetes topo Watch on ", filePath)
 
 	current := &topo.WatchData{}
 
 	// get current
-	contents, ver, err := s.Get(ctx, filePath)
+	initialCtx, initialCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
+	defer initialCancel()
+
+	contents, ver, err := s.Get(initialCtx, filePath)
 	if err != nil {
-		// Per the topo.Conn interface:
-		// "If the initial read fails, or the file doesn't
-		// exist, current.Err is set, and 'changes'/'cancel' are nil."
-		current.Err = err
-		return current, nil, nil
+		return nil, nil, err
 	}
 	current.Contents = contents
 	current.Version = ver
-
-	// Create a context, will be used to cancel the watch.
-	watchCtx, watchCancel := context.WithCancel(context.Background())
 
 	// Create the changes channel
 	changes := make(chan *topo.WatchData, 10)
@@ -56,11 +52,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 
 	resource, err := s.buildFileResource(filePath, []byte{})
 	if err != nil {
-		// Per the topo.Conn interface:
-		// current.Err is set, and 'changes'/'cancel' are nil
-		watchCancel()
-		current.Err = err
-		return current, nil, nil
+		return nil, nil, err
 	}
 
 	// Create the informer / indexer to watch the single resource
@@ -111,9 +103,9 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 	go memberInformer.Run(informerChan)
 
 	// Handle interrupts
-	go closeOnDone(watchCtx, filePath, informerChan, gracefulShutdown, changes)
+	go closeOnDone(ctx, filePath, informerChan, gracefulShutdown, changes)
 
-	return current, changes, topo.CancelFunc(watchCancel)
+	return current, changes, nil
 }
 
 func closeOnDone(ctx context.Context, filePath string, informerChan chan struct{}, gracefulShutdown chan struct{}, changes chan *topo.WatchData) {

--- a/go/vt/topo/memorytopo/lock.go
+++ b/go/vt/topo/memorytopo/lock.go
@@ -17,9 +17,8 @@ limitations under the License.
 package memorytopo
 
 import (
-	"fmt"
-
 	"context"
+	"fmt"
 
 	"vitess.io/vitess/go/vt/topo"
 )
@@ -77,6 +76,12 @@ func (c *Conn) Lock(ctx context.Context, dirPath, contents string) (topo.LockDes
 		// No one has the lock, grab it.
 		n.lock = make(chan struct{})
 		n.lockContents = contents
+		for _, w := range n.watches {
+			if w.lock == nil {
+				continue
+			}
+			w.lock <- contents
+		}
 		c.factory.mu.Unlock()
 		return &memoryTopoLockDescriptor{
 			c:       c,

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -43,13 +43,12 @@ There are two test sub-packages associated with this code:
 package topo
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"sync"
 
 	"vitess.io/vitess/go/vt/proto/topodata"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -245,6 +244,9 @@ func Open() *Server {
 func (ts *Server) ConnForCell(ctx context.Context, cell string) (Conn, error) {
 	// Global cell is the easy case.
 	if cell == GlobalCell {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		return ts.globalCell, nil
 	}
 

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -656,11 +656,14 @@ type WatchShardData struct {
 // WatchShard will set a watch on the Shard object.
 // It has the same contract as conn.Watch, but it also unpacks the
 // contents into a Shard object
-func (ts *Server) WatchShard(ctx context.Context, keyspace, shard string) (*WatchShardData, <-chan *WatchShardData, CancelFunc) {
+func (ts *Server) WatchShard(ctx context.Context, keyspace, shard string) (*WatchShardData, <-chan *WatchShardData, error) {
 	shardPath := shardFilePath(keyspace, shard)
-	current, wdChannel, cancel := ts.globalCell.Watch(ctx, shardPath)
-	if current.Err != nil {
-		return &WatchShardData{Err: current.Err}, nil, nil
+	ctx, cancel := context.WithCancel(ctx)
+
+	current, wdChannel, err := ts.globalCell.Watch(ctx, shardPath)
+	if err != nil {
+		cancel()
+		return nil, nil, err
 	}
 	value := &topodatapb.Shard{}
 	if err := proto.Unmarshal(current.Contents, value); err != nil {
@@ -668,7 +671,7 @@ func (ts *Server) WatchShard(ctx context.Context, keyspace, shard string) (*Watc
 		cancel()
 		for range wdChannel {
 		}
-		return &WatchShardData{Err: vterrors.Wrapf(err, "error unpacking initial Shard object")}, nil, nil
+		return nil, nil, vterrors.Wrapf(err, "error unpacking initial Shard object")
 	}
 
 	changes := make(chan *WatchShardData, 10)
@@ -678,6 +681,7 @@ func (ts *Server) WatchShard(ctx context.Context, keyspace, shard string) (*Watc
 	// send an ErrInterrupted and then close the channel. We'll
 	// just propagate that back to our caller.
 	go func() {
+		defer cancel()
 		defer close(changes)
 
 		for wd := range wdChannel {
@@ -702,5 +706,5 @@ func (ts *Server) WatchShard(ctx context.Context, keyspace, shard string) (*Watc
 		}
 	}()
 
-	return &WatchShardData{Value: value}, changes, cancel
+	return &WatchShardData{Value: value}, changes, nil
 }

--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -168,6 +168,13 @@ func (st *StatsConn) Watch(ctx context.Context, filePath string) (current *Watch
 	return st.conn.Watch(ctx, filePath)
 }
 
+func (st *StatsConn) WatchRecursive(ctx context.Context, path string) ([]*WatchDataRecursive, <-chan *WatchDataRecursive, error) {
+	startTime := time.Now()
+	statsKey := []string{"WatchRecursive", st.cell}
+	defer topoStatsConnTimings.Record(statsKey, startTime)
+	return st.conn.WatchRecursive(ctx, path)
+}
+
 // NewLeaderParticipation is part of the Conn interface
 func (st *StatsConn) NewLeaderParticipation(name, id string) (LeaderParticipation, error) {
 	startTime := time.Now()

--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -17,9 +17,8 @@ limitations under the License.
 package topo
 
 import (
-	"time"
-
 	"context"
+	"time"
 
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
@@ -162,7 +161,7 @@ func (st *StatsConn) Lock(ctx context.Context, dirPath, contents string) (LockDe
 }
 
 // Watch is part of the Conn interface
-func (st *StatsConn) Watch(ctx context.Context, filePath string) (current *WatchData, changes <-chan *WatchData, cancel CancelFunc) {
+func (st *StatsConn) Watch(ctx context.Context, filePath string) (current *WatchData, changes <-chan *WatchData, err error) {
 	startTime := time.Now()
 	statsKey := []string{"Watch", st.cell}
 	defer topoStatsConnTimings.Record(statsKey, startTime)

--- a/go/vt/topo/stats_conn_test.go
+++ b/go/vt/topo/stats_conn_test.go
@@ -109,6 +109,11 @@ func (st *fakeConn) Watch(ctx context.Context, filePath string) (current *WatchD
 	return current, changes, err
 }
 
+// WatchRecursive is part of the Conn interface
+func (st *fakeConn) WatchRecursive(ctx context.Context, path string) (current []*WatchDataRecursive, changes <-chan *WatchDataRecursive, err error) {
+	return current, changes, err
+}
+
 // NewLeaderParticipation is part of the Conn interface
 func (st *fakeConn) NewLeaderParticipation(name, id string) (mp LeaderParticipation, err error) {
 	if name == "error" {

--- a/go/vt/topo/stats_conn_test.go
+++ b/go/vt/topo/stats_conn_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package topo
 
 import (
+	"context"
 	"fmt"
 	"testing"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -106,8 +105,8 @@ func (st *fakeConn) Lock(ctx context.Context, dirPath, contents string) (lock Lo
 }
 
 // Watch is part of the Conn interface
-func (st *fakeConn) Watch(ctx context.Context, filePath string) (current *WatchData, changes <-chan *WatchData, cancel CancelFunc) {
-	return current, changes, cancel
+func (st *fakeConn) Watch(ctx context.Context, filePath string) (current *WatchData, changes <-chan *WatchData, err error) {
+	return current, changes, err
 }
 
 // NewLeaderParticipation is part of the Conn interface

--- a/go/vt/topo/test/file.go
+++ b/go/vt/topo/test/file.go
@@ -17,10 +17,10 @@ limitations under the License.
 package test
 
 import (
-	"reflect"
-	"testing"
-
 	"context"
+	"reflect"
+	"strings"
+	"testing"
 
 	"vitess.io/vitess/go/vt/topo"
 )
@@ -200,4 +200,48 @@ func checkFileInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	// ListDir root: nothing.
 	expected = expected[:len(expected)-1]
 	checkListDir(ctx, t, conn, "/", expected)
+}
+
+// checkList tests the file part of the Conn API.
+func checkList(t *testing.T, ts *topo.Server) {
+	ctx := context.Background()
+	// global cell
+	conn, err := ts.ConnForCell(ctx, LocalCellName)
+	if err != nil {
+		t.Fatalf("ConnForCell(LocalCellName) failed: %v", err)
+	}
+	_, err = conn.List(ctx, "/")
+	if topo.IsErrType(err, topo.NoImplementation) {
+		// If this is not supported, skip the test
+		t.Skipf("%T does not support List()", conn)
+		return
+	}
+	if err != nil {
+		t.Fatalf("List(test) failed: %v", err)
+	}
+
+	_, err = conn.Create(ctx, "/toplevel/nested/myfile", []byte{'a'})
+	if err != nil {
+		t.Fatalf("Create('/myfile') failed: %v", err)
+	}
+
+	for _, path := range []string{"/top", "/toplevel", "/toplevel/", "/toplevel/nes", "/toplevel/nested/myfile"} {
+		entries, err := conn.List(ctx, path)
+		if err != nil {
+			t.Fatalf("List failed(path: %q): %v", path, err)
+		}
+
+		if len(entries) != 1 {
+			t.Fatalf("List(test) returned incorrect number of elements for path %q. Expected 1, got %d: %v", path, len(entries), entries)
+		}
+
+		if !strings.HasSuffix(string(entries[0].Key), "/toplevel/nested/myfile") {
+			t.Fatalf("found entry doesn't end with /toplevel/nested/myfile for path %q: %s", path, string(entries[0].Key))
+		}
+
+		if string(entries[0].Value) != "a" {
+			t.Fatalf("found entry doesn't have value \"a\" for path %q: %s", path, string(entries[0].Value))
+		}
+	}
+
 }

--- a/go/vt/topo/test/file.go
+++ b/go/vt/topo/test/file.go
@@ -243,5 +243,4 @@ func checkList(t *testing.T, ts *topo.Server) {
 			t.Fatalf("found entry doesn't have value \"a\" for path %q: %s", path, string(entries[0].Value))
 		}
 	}
-
 }

--- a/go/vt/topo/test/testing.go
+++ b/go/vt/topo/test/testing.go
@@ -115,5 +115,8 @@ func TopoServerTestSuite(t *testing.T, factory func() *topo.Server) {
 	t.Log("=== checkList")
 	checkList(t, ts)
 
+	t.Log("=== checkWatchRecursive")
+	checkWatchRecursive(t, ts)
+
 	ts.Close()
 }

--- a/go/vt/topo/test/testing.go
+++ b/go/vt/topo/test/testing.go
@@ -96,6 +96,11 @@ func TopoServerTestSuite(t *testing.T, factory func() *topo.Server) {
 	checkElection(t, ts)
 	ts.Close()
 
+	t.Log("=== checkWaitForNewLeader")
+	ts = factory()
+	checkWaitForNewLeader(t, ts)
+	ts.Close()
+
 	t.Log("=== checkDirectory")
 	ts = factory()
 	checkDirectory(t, ts)

--- a/go/vt/topo/test/testing.go
+++ b/go/vt/topo/test/testing.go
@@ -111,5 +111,9 @@ func TopoServerTestSuite(t *testing.T, factory func() *topo.Server) {
 	checkWatch(t, ts)
 	t.Log("=== checkWatchInterrupt")
 	checkWatchInterrupt(t, ts)
+
+	t.Log("=== checkList")
+	checkList(t, ts)
+
 	ts.Close()
 }

--- a/go/vt/topo/test/watch.go
+++ b/go/vt/topo/test/watch.go
@@ -33,7 +33,7 @@ import (
 // waitForInitialValue waits for the initial value of
 // keyspaces/test_keyspace/SrvKeyspace to appear, and match the
 // provided srvKeyspace.
-func waitForInitialValue(t *testing.T, conn topo.Conn, srvKeyspace *topodatapb.SrvKeyspace) (changes <-chan *topo.WatchData, cancel func()) {
+func waitForInitialValue(t *testing.T, conn topo.Conn, srvKeyspace *topodatapb.SrvKeyspace) (changes <-chan *topo.WatchData, cancel context.CancelFunc) {
 	var current *topo.WatchData
 	ctx, cancel := context.WithCancel(context.Background())
 	start := time.Now()
@@ -51,7 +51,7 @@ func waitForInitialValue(t *testing.T, conn topo.Conn, srvKeyspace *topodatapb.S
 		}
 		if err != nil {
 			cancel()
-			t.Fatalf("watch failed: %v", current.Err)
+			t.Fatalf("watch failed: %v", err)
 		}
 		// we got a valid result
 		break
@@ -67,6 +67,49 @@ func waitForInitialValue(t *testing.T, conn topo.Conn, srvKeyspace *topodatapb.S
 	}
 
 	return changes, cancel
+}
+
+// waitForInitialValue waits for the initial value of
+// keyspaces/test_keyspace/SrvKeyspace to appear, and match the
+// provided srvKeyspace.
+func waitForInitialValueRecursive(t *testing.T, conn topo.Conn, srvKeyspace *topodatapb.SrvKeyspace) (changes <-chan *topo.WatchDataRecursive, cancel context.CancelFunc, err error) {
+	var current []*topo.WatchDataRecursive
+	ctx, cancel := context.WithCancel(context.Background())
+	start := time.Now()
+	for {
+		current, changes, err = conn.WatchRecursive(ctx, "keyspaces/test_keyspace")
+		if topo.IsErrType(err, topo.NoNode) {
+			// hasn't appeared yet
+			if time.Since(start) > 10*time.Second {
+				cancel()
+				t.Fatalf("time out waiting for file to appear")
+			}
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if topo.IsErrType(err, topo.NoImplementation) {
+			// If this is not supported, skip the test
+			cancel()
+			return nil, nil, err
+		}
+		if err != nil {
+			cancel()
+			t.Fatalf("watch failed: %v", err)
+		}
+		// we got a valid result
+		break
+	}
+	got := &topodatapb.SrvKeyspace{}
+	if err := proto.Unmarshal(current[0].Contents, got); err != nil {
+		cancel()
+		t.Fatalf("cannot proto-unmarshal data: %v", err)
+	}
+	if !proto.Equal(got, srvKeyspace) {
+		cancel()
+		t.Fatalf("got bad data: %v expected: %v", got, srvKeyspace)
+	}
+
+	return changes, cancel, nil
 }
 
 // checkWatch runs the tests on the Watch part of the Conn API.
@@ -252,4 +295,150 @@ func checkWatchInterrupt(t *testing.T, ts *topo.Server) {
 
 	// And calling cancel() again should just work.
 	cancel()
+}
+
+// checkWatchRecursive tests we can setup a recursive watch
+func checkWatchRecursive(t *testing.T, ts *topo.Server) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conn, err := ts.ConnForCell(ctx, LocalCellName)
+	if err != nil {
+		t.Fatalf("ConnForCell(test) failed: %v", err)
+	}
+
+	// create some data
+	keyRange, err := key.ParseShardingSpec("-")
+	if err != nil || len(keyRange) != 1 {
+		t.Fatalf("ParseShardingSpec failed. Expected non error and only one element. Got err: %v, len(%v)", err, len(keyRange))
+	}
+
+	srvKeyspace := &topodatapb.SrvKeyspace{
+		Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+			{
+				ServedType: topodatapb.TabletType_PRIMARY,
+				ShardReferences: []*topodatapb.ShardReference{
+					{
+						Name:     "name",
+						KeyRange: keyRange[0],
+					},
+				},
+			},
+		},
+	}
+	if err := ts.UpdateSrvKeyspace(ctx, LocalCellName, "test_keyspace", srvKeyspace); err != nil {
+		t.Fatalf("UpdateSrvKeyspace(1): %v", err)
+	}
+
+	// start watching again, it should work
+	changes, secondCancel, err := waitForInitialValueRecursive(t, conn, srvKeyspace)
+	if topo.IsErrType(err, topo.NoImplementation) {
+		// Skip the rest if there's no implementation
+		t.Logf("%T does not support WatchRecursive()", conn)
+		return
+	}
+	defer secondCancel()
+
+	// change the data
+	srvKeyspace.Partitions[0].ShardReferences[0].Name = "new_name"
+	if err := ts.UpdateSrvKeyspace(ctx, LocalCellName, "test_keyspace", srvKeyspace); err != nil {
+		t.Fatalf("UpdateSrvKeyspace(2): %v", err)
+	}
+
+	// Make sure we get the watch data, maybe not as first notice,
+	// but eventually. The API specifies it is possible to get duplicate
+	// notifications.
+	for {
+		wd, ok := <-changes
+		if !ok {
+			t.Fatalf("watch channel unexpectedly closed")
+		}
+		if wd.Err != nil {
+			t.Fatalf("watch interrupted: %v", wd.Err)
+		}
+		got := &topodatapb.SrvKeyspace{}
+		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+			t.Fatalf("cannot proto-unmarshal data: %v", err)
+		}
+
+		if got.Partitions[0].ShardReferences[0].Name == "name" {
+			// extra first value, still good
+			continue
+		}
+		if got.Partitions[0].ShardReferences[0].Name == "new_name" {
+			// watch worked, good
+			break
+		}
+		t.Fatalf("got unknown SrvKeyspace: %v", got)
+	}
+
+	// remove the SrvKeyspace
+	if err := ts.DeleteSrvKeyspace(ctx, LocalCellName, "test_keyspace"); err != nil {
+		t.Fatalf("DeleteSrvKeyspace: %v", err)
+	}
+
+	// Make sure we get the ErrNoNode notification eventually.
+	// The API specifies it is possible to get duplicate
+	// notifications.
+	for {
+		wd, ok := <-changes
+		if !ok {
+			t.Fatalf("watch channel unexpectedly closed")
+		}
+
+		if topo.IsErrType(wd.Err, topo.NoNode) {
+			// good
+			break
+		}
+		if wd.Err != nil {
+			t.Fatalf("bad error returned for deletion: %v", wd.Err)
+		}
+		// we got something, better be the right value
+		got := &topodatapb.SrvKeyspace{}
+		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+			t.Fatalf("cannot proto-unmarshal data: %v", err)
+		}
+		if got.Partitions[0].ShardReferences[0].Name == "new_name" {
+			// good value
+			continue
+		}
+		t.Fatalf("got unknown SrvKeyspace waiting for deletion: %v", got)
+	}
+
+	// We now have to stop watching. This doesn't automatically
+	// happen for recursive watches on a single file since others
+	// can still be seen.
+	secondCancel()
+
+	// Make sure we get the topo.ErrInterrupted notification eventually.
+	for {
+		wd, ok := <-changes
+		if !ok {
+			t.Fatalf("watch channel unexpectedly closed")
+		}
+		if topo.IsErrType(wd.Err, topo.Interrupted) {
+			// good
+			break
+		}
+		if wd.Err != nil {
+			t.Fatalf("bad error returned for cancellation: %v", wd.Err)
+		}
+		// we got something, better be the right value
+		got := &topodatapb.SrvKeyspace{}
+		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+			t.Fatalf("cannot proto-unmarshal data: %v", err)
+		}
+		if got.Partitions[0].ShardReferences[0].Name == "name" {
+			// good value
+			continue
+		}
+		t.Fatalf("got unknown SrvKeyspace waiting for deletion: %v", got)
+	}
+
+	// Now the channel should be closed.
+	if wd, ok := <-changes; ok {
+		t.Fatalf("got unexpected event after error: %v", wd)
+	}
+
+	// And calling cancel() again should just work.
+	secondCancel()
 }

--- a/go/vt/topo/topotests/shard_watch_test.go
+++ b/go/vt/topo/topotests/shard_watch_test.go
@@ -31,23 +31,24 @@ import (
 )
 
 // waitForInitialShard waits for the initial Shard to appear.
-func waitForInitialShard(t *testing.T, ts *topo.Server, keyspace, shard string) (current *topo.WatchShardData, changes <-chan *topo.WatchShardData, cancel topo.CancelFunc) {
-	ctx := context.Background()
+func waitForInitialShard(t *testing.T, ts *topo.Server, keyspace, shard string) (current *topo.WatchShardData, changes <-chan *topo.WatchShardData, cancel context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
 	start := time.Now()
+	var err error
 	for {
-		current, changes, cancel = ts.WatchShard(ctx, keyspace, shard)
+		current, changes, err = ts.WatchShard(ctx, keyspace, shard)
 		switch {
-		case topo.IsErrType(current.Err, topo.NoNode):
+		case topo.IsErrType(err, topo.NoNode):
 			// hasn't appeared yet
 			if time.Since(start) > 10*time.Second {
 				t.Fatalf("time out waiting for file to appear")
 			}
 			time.Sleep(10 * time.Millisecond)
 			continue
-		case current.Err == nil:
+		case err == nil:
 			return
 		default:
-			t.Fatalf("watch failed: %v", current.Err)
+			t.Fatalf("watch failed: %v", err)
 		}
 	}
 }
@@ -59,8 +60,8 @@ func TestWatchShardNoNode(t *testing.T) {
 	ts := memorytopo.NewServer("cell1")
 
 	// No Shard -> ErrNoNode
-	current, _, _ := ts.WatchShard(ctx, keyspace, shard)
-	if !topo.IsErrType(current.Err, topo.NoNode) {
+	current, _, err := ts.WatchShard(ctx, keyspace, shard)
+	if !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("Got invalid result from WatchShard(not there): %v", current.Err)
 	}
 }
@@ -145,9 +146,9 @@ func TestWatchShard(t *testing.T) {
 	cancel()
 
 	// Bad data in topo, setting the watch should now fail.
-	current, _, _ = ts.WatchShard(ctx, keyspace, shard)
-	if current.Err == nil || !strings.Contains(current.Err.Error(), "error unpacking initial Shard object") {
-		t.Fatalf("expected an initial error setting watch on bad content, but got: %v", current.Err)
+	_, _, err = ts.WatchShard(ctx, keyspace, shard)
+	if err == nil || !strings.Contains(err.Error(), "error unpacking initial Shard object") {
+		t.Fatalf("expected an initial error setting watch on bad content, but got: %v", err)
 	}
 
 	data, err := proto.Marshal(wanted)
@@ -160,9 +161,9 @@ func TestWatchShard(t *testing.T) {
 	}
 	start := time.Now()
 	for {
-		current, changes, _ = ts.WatchShard(ctx, keyspace, shard)
-		if current.Err != nil {
-			if strings.Contains(current.Err.Error(), "error unpacking initial Shard object") {
+		current, changes, err = ts.WatchShard(ctx, keyspace, shard)
+		if err != nil {
+			if strings.Contains(err.Error(), "error unpacking initial Shard object") {
 				// hasn't changed yet
 				if time.Since(start) > 10*time.Second {
 					t.Fatalf("time out waiting for file to appear")
@@ -208,9 +209,9 @@ func TestWatchShardCancel(t *testing.T) {
 	ts := memorytopo.NewServer(cell)
 
 	// No Shard -> ErrNoNode
-	current, _, _ := ts.WatchShard(ctx, keyspace, shard)
-	if !topo.IsErrType(current.Err, topo.NoNode) {
-		t.Errorf("Got invalid result from WatchShard(not there): %v", current.Err)
+	_, _, err := ts.WatchShard(ctx, keyspace, shard)
+	if !topo.IsErrType(err, topo.NoNode) {
+		t.Errorf("Got invalid result from WatchShard(not there): %v", err)
 	}
 
 	// Create keyspace

--- a/go/vt/topo/topotests/shard_watch_test.go
+++ b/go/vt/topo/topotests/shard_watch_test.go
@@ -60,9 +60,9 @@ func TestWatchShardNoNode(t *testing.T) {
 	ts := memorytopo.NewServer("cell1")
 
 	// No Shard -> ErrNoNode
-	current, _, err := ts.WatchShard(ctx, keyspace, shard)
+	_, _, err := ts.WatchShard(ctx, keyspace, shard)
 	if !topo.IsErrType(err, topo.NoNode) {
-		t.Errorf("Got invalid result from WatchShard(not there): %v", current.Err)
+		t.Errorf("Got invalid result from WatchShard(not there): %v", err)
 	}
 }
 

--- a/go/vt/topo/topotests/srv_keyspace_test.go
+++ b/go/vt/topo/topotests/srv_keyspace_test.go
@@ -37,23 +37,24 @@ import (
 
 // waitForInitialSrvKeyspace waits for the initial SrvKeyspace to
 // appear, and match the provided srvKeyspace.
-func waitForInitialSrvKeyspace(t *testing.T, ts *topo.Server, cell, keyspace string) (current *topo.WatchSrvKeyspaceData, changes <-chan *topo.WatchSrvKeyspaceData, cancel topo.CancelFunc) {
-	ctx := context.Background()
+func waitForInitialSrvKeyspace(t *testing.T, ts *topo.Server, cell, keyspace string) (current *topo.WatchSrvKeyspaceData, changes <-chan *topo.WatchSrvKeyspaceData, cancel context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
 	start := time.Now()
+	var err error
 	for {
-		current, changes, cancel = ts.WatchSrvKeyspace(ctx, cell, keyspace)
+		current, changes, err = ts.WatchSrvKeyspace(ctx, cell, keyspace)
 		switch {
-		case topo.IsErrType(current.Err, topo.NoNode):
+		case topo.IsErrType(err, topo.NoNode):
 			// hasn't appeared yet
 			if time.Since(start) > 10*time.Second {
 				t.Fatalf("time out waiting for file to appear")
 			}
 			time.Sleep(10 * time.Millisecond)
 			continue
-		case current.Err == nil:
+		case err == nil:
 			return
 		default:
-			t.Fatalf("watch failed: %v", current.Err)
+			t.Fatalf("watch failed: %v", err)
 		}
 	}
 }
@@ -65,9 +66,9 @@ func TestWatchSrvKeyspaceNoNode(t *testing.T) {
 	ts := memorytopo.NewServer(cell)
 
 	// No SrvKeyspace -> ErrNoNode
-	current, _, _ := ts.WatchSrvKeyspace(ctx, cell, keyspace)
-	if !topo.IsErrType(current.Err, topo.NoNode) {
-		t.Errorf("Got invalid result from WatchSrvKeyspace(not there): %v", current.Err)
+	_, _, err := ts.WatchSrvKeyspace(ctx, cell, keyspace)
+	if !topo.IsErrType(err, topo.NoNode) {
+		t.Errorf("Got invalid result from WatchSrvKeyspace(not there): %v", err)
 	}
 }
 
@@ -120,9 +121,9 @@ func TestWatchSrvKeyspace(t *testing.T) {
 	cancel()
 
 	// Bad data in topo, setting the watch should now fail.
-	current, _, _ = ts.WatchSrvKeyspace(ctx, cell, keyspace)
-	if current.Err == nil || !strings.Contains(current.Err.Error(), "error unpacking initial SrvKeyspace object") {
-		t.Fatalf("expected an initial error setting watch on bad content, but got: %v", current.Err)
+	_, _, err = ts.WatchSrvKeyspace(ctx, cell, keyspace)
+	if err == nil || !strings.Contains(err.Error(), "error unpacking initial SrvKeyspace object") {
+		t.Fatalf("expected an initial error setting watch on bad content, but got: %v", err)
 	}
 
 	// Update content, wait until Watch works again
@@ -131,9 +132,9 @@ func TestWatchSrvKeyspace(t *testing.T) {
 	}
 	start := time.Now()
 	for {
-		current, changes, _ = ts.WatchSrvKeyspace(ctx, cell, keyspace)
-		if current.Err != nil {
-			if strings.Contains(current.Err.Error(), "error unpacking initial SrvKeyspace object") {
+		current, changes, err = ts.WatchSrvKeyspace(ctx, cell, keyspace)
+		if err != nil {
+			if strings.Contains(err.Error(), "error unpacking initial SrvKeyspace object") {
 				// hasn't changed yet
 				if time.Since(start) > 10*time.Second {
 					t.Fatalf("time out waiting for file to appear")
@@ -178,9 +179,9 @@ func TestWatchSrvKeyspaceCancel(t *testing.T) {
 	ts := memorytopo.NewServer(cell)
 
 	// No SrvKeyspace -> ErrNoNode
-	current, _, _ := ts.WatchSrvKeyspace(ctx, cell, keyspace)
-	if !topo.IsErrType(current.Err, topo.NoNode) {
-		t.Errorf("Got invalid result from WatchSrvKeyspace(not there): %v", current.Err)
+	_, _, err := ts.WatchSrvKeyspace(ctx, cell, keyspace)
+	if !topo.IsErrType(err, topo.NoNode) {
+		t.Errorf("Got invalid result from WatchSrvKeyspace(not there): %v", err)
 	}
 
 	// Create initial value

--- a/go/vt/topo/zk2topo/election.go
+++ b/go/vt/topo/zk2topo/election.go
@@ -17,10 +17,9 @@ limitations under the License.
 package zk2topo
 
 import (
+	"context"
 	"path"
 	"sort"
-
-	"context"
 
 	"github.com/z-division/go-zookeeper/zk"
 
@@ -197,4 +196,11 @@ func (mp *zkLeaderParticipation) GetCurrentLeaderID(ctx context.Context) (string
 
 		return string(data), nil
 	}
+}
+
+// WaitForNewLeader is part of the topo.LeaderParticipation interface
+func (mp *zkLeaderParticipation) WaitForNewLeader(context.Context) (<-chan string, error) {
+	// This isn't implemented yet, but likely can be implemented in the same way
+	// as how WatchRecursive could be implemented as well.
+	return nil, topo.NewError(topo.NoImplementation, "wait for leader not supported in ZK2 topo")
 }

--- a/go/vt/topo/zk2topo/watch.go
+++ b/go/vt/topo/zk2topo/watch.go
@@ -17,11 +17,9 @@ limitations under the License.
 package zk2topo
 
 import (
+	"context"
 	"fmt"
 	"path"
-	"sync"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -29,39 +27,28 @@ import (
 )
 
 // Watch is part of the topo.Conn interface.
-func (zs *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, topo.CancelFunc) {
+func (zs *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, error) {
 	zkPath := path.Join(zs.root, filePath)
 
 	// Get the initial value, set the initial watch
-	data, stats, watch, err := zs.conn.GetW(ctx, zkPath)
+	initialCtx, initialCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
+	defer initialCancel()
+
+	data, stats, watch, err := zs.conn.GetW(initialCtx, zkPath)
 	if err != nil {
-		return &topo.WatchData{Err: convertError(err, zkPath)}, nil, nil
+		return nil, nil, convertError(err, zkPath)
 	}
 	if stats == nil {
 		// No stats --> node doesn't exist.
-		return &topo.WatchData{Err: topo.NewError(topo.NoNode, zkPath)}, nil, nil
+		return nil, nil, topo.NewError(topo.NoNode, zkPath)
 	}
 	wd := &topo.WatchData{
 		Contents: data,
 		Version:  ZKVersion(stats.Version),
 	}
 
-	// mu protects the stop channel. We need to make sure the 'cancel'
-	// func can be called multiple times, and that we don't close 'stop'
-	// too many times.
-	mu := sync.Mutex{}
-	stop := make(chan struct{})
-	cancel := func() {
-		mu.Lock()
-		defer mu.Unlock()
-		if stop != nil {
-			close(stop)
-			stop = nil
-		}
-	}
-
 	c := make(chan *topo.WatchData, 10)
-	go func(stop chan struct{}) {
+	go func() {
 		defer close(c)
 
 		for {
@@ -78,7 +65,7 @@ func (zs *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, 
 					return
 				}
 
-			case <-stop:
+			case <-ctx.Done():
 				// user is not interested any more
 				c <- &topo.WatchData{Err: topo.NewError(topo.Interrupted, "watch")}
 				return
@@ -104,7 +91,7 @@ func (zs *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, 
 				return
 			}
 		}
-	}(stop)
+	}()
 
-	return wd, c, cancel
+	return wd, c, nil
 }

--- a/go/vt/topo/zk2topo/watch.go
+++ b/go/vt/topo/zk2topo/watch.go
@@ -95,3 +95,11 @@ func (zs *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, 
 
 	return wd, c, nil
 }
+
+// WatchRecursive is part of the topo.Conn interface.
+func (zs *Server) WatchRecursive(_ context.Context, path string) ([]*topo.WatchDataRecursive, <-chan *topo.WatchDataRecursive, error) {
+	// This isn't implemented yet, but potentially can be implemented if we want
+	// to update the minimum ZooKeeper requirement to 3.6.0 and use recursive watches.
+	// Also see https://zookeeper.apache.org/doc/r3.6.3/zookeeperProgrammers.html#sc_WatchPersistentRecursive
+	return nil, nil, topo.NewError(topo.NoImplementation, path)
+}

--- a/go/vt/vttablet/customrule/topocustomrule/topocustomrule.go
+++ b/go/vt/vttablet/customrule/topocustomrule/topocustomrule.go
@@ -138,10 +138,11 @@ func (cr *topoCustomRule) oneWatch() error {
 		cr.mu.Unlock()
 	}()
 
-	ctx := context.Background()
-	current, wdChannel, cancel := cr.conn.Watch(ctx, cr.filePath)
-	if current.Err != nil {
-		return current.Err
+	ctx, cancel := context.WithCancel(context.Background())
+	current, wdChannel, err := cr.conn.Watch(ctx, cr.filePath)
+	if err != nil {
+		cancel()
+		return err
 	}
 
 	cr.mu.Lock()

--- a/go/vt/vttablet/tabletmanager/shard_sync.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync.go
@@ -17,10 +17,9 @@ limitations under the License.
 package tabletmanager
 
 import (
+	"context"
 	"flag"
 	"time"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
@@ -133,7 +132,7 @@ func (tm *TabletManager) shardSyncLoop(ctx context.Context, notifyChan <-chan st
 				// We already have an active watch. Nothing to do.
 				continue
 			}
-			if err := shardWatch.start(ctx, tm.TopoServer, tablet.Keyspace, tablet.Shard); err != nil {
+			if err := shardWatch.start(tm.TopoServer, tablet.Keyspace, tablet.Shard); err != nil {
 				log.Errorf("Failed to start shard watch: %v", err)
 				// Start retry timer and go back to sleep.
 				retryChan = time.After(*shardSyncRetryDelay)

--- a/go/vt/vttablet/tabletmanager/shard_watcher.go
+++ b/go/vt/vttablet/tabletmanager/shard_watcher.go
@@ -25,26 +25,25 @@ import (
 
 type shardWatcher struct {
 	watchChan   <-chan *topo.WatchShardData
-	watchCancel topo.CancelFunc
+	watchCancel context.CancelFunc
 }
 
 func (sw *shardWatcher) active() bool {
 	return sw.watchChan != nil
 }
 
-func (sw *shardWatcher) start(ctx context.Context, ts *topo.Server, keyspace, shard string) error {
-	ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
-	defer cancel()
-
+func (sw *shardWatcher) start(ts *topo.Server, keyspace, shard string) error {
 	log.Infof("Starting shard watch of %v/%v", keyspace, shard)
 
-	event, c, watchCancel := ts.WatchShard(ctx, keyspace, shard)
-	if event.Err != nil {
-		return event.Err
+	ctx, cancel := context.WithCancel(context.Background())
+	_, c, err := ts.WatchShard(ctx, keyspace, shard)
+	if err != nil {
+		cancel()
+		return err
 	}
 
 	sw.watchChan = c
-	sw.watchCancel = watchCancel
+	sw.watchCancel = cancel
 	return nil
 }
 


### PR DESCRIPTION
The change here adds specific additional functionality to the topo. It adds `WatchRecursive` which allows for watching a specific prefix or directory which means we can more efficiently monitor changes in the topo without having to busy loop, or without having to setup multiple watchers.

It also adds a more efficient way to track leadership changes which under the hood work in a similar way. 

Lastly, this series of changes starts with a refactor on `Watch` to make it more idiomatic Go and better match the added `WatchRecursive`. 

The changes are best reviewed commit by commit here as they build it up incrementally. 

Nothing immediately starts using these new methods here, that is something to be added separately. 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required