### PR TITLE
add vttablet cli flags for stream consolidator

### DIFF
--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -34,6 +34,8 @@ Usage of vttablet:
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
       --ceph_backup_storage_config string                                Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
       --compression-level int                                            what level to pass to the compressor (default 1)
+      --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
+      --consolidator-stream-total-size int                               Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)
       --consul_auth_static_file string                                   JSON File to read the topos/tokens from.
       --cpu_profile string                                               deprecated: use '-pprof=cpu' instead
       --datadog-agent-host string                                        host to send spans to. if empty, no tracing will be done

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -178,6 +178,8 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	qe.consolidator = sync2.NewConsolidator()
 	if config.ConsolidatorStreamTotalSize > 0 && config.ConsolidatorStreamQuerySize > 0 {
 		qe.streamConsolidator = NewStreamConsolidator(config.ConsolidatorStreamTotalSize, config.ConsolidatorStreamQuerySize, returnStreamResult)
+	} else {
+		log.Info("Disabling stream consolidator.")
 	}
 	qe.txSerializer = txserializer.New(env)
 

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -179,7 +179,7 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	if config.ConsolidatorStreamTotalSize > 0 && config.ConsolidatorStreamQuerySize > 0 {
 		qe.streamConsolidator = NewStreamConsolidator(config.ConsolidatorStreamTotalSize, config.ConsolidatorStreamQuerySize, returnStreamResult)
 	} else {
-		log.Info("Disabling stream consolidator.")
+		log.Info("Stream consolidator is not enabled.")
 	}
 	qe.txSerializer = txserializer.New(env)
 

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -177,6 +177,8 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	qe.consolidatorMode.Set(config.Consolidator)
 	qe.consolidator = sync2.NewConsolidator()
 	if config.ConsolidatorStreamTotalSize > 0 && config.ConsolidatorStreamQuerySize > 0 {
+		log.Info("Stream consolidator is enabled with query size set to %d and total size set to %d.",
+			config.ConsolidatorStreamQuerySize, config.ConsolidatorStreamTotalSize)
 		qe.streamConsolidator = NewStreamConsolidator(config.ConsolidatorStreamTotalSize, config.ConsolidatorStreamQuerySize, returnStreamResult)
 	} else {
 		log.Info("Stream consolidator is not enabled.")

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -139,6 +139,8 @@ func init() {
 	flag.BoolVar(&currentConfig.EnforceStrictTransTables, "enforce_strict_trans_tables", defaultConfig.EnforceStrictTransTables, "If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database.")
 	flagutil.DualFormatBoolVar(&enableConsolidator, "enable_consolidator", true, "This option enables the query consolidator.")
 	flagutil.DualFormatBoolVar(&enableConsolidatorReplicas, "enable_consolidator_replicas", false, "This option enables the query consolidator only on replicas.")
+	flagutil.DualFormatInt64Var(&currentConfig.ConsolidatorStreamQuerySize, "consolidator_stream_query_size", defaultConfig.ConsolidatorStreamQuerySize, "Configure the stream consolidator query size. Setting to 0 disables the stream consolidator.")
+	flagutil.DualFormatInt64Var(&currentConfig.ConsolidatorStreamTotalSize, "consolidator_stream_total_size", defaultConfig.ConsolidatorStreamTotalSize, "Configure the stream consolidator total size. Setting to 0 disables the stream consolidator.")
 	flagutil.DualFormatBoolVar(&currentConfig.DeprecatedCacheResultFields, "enable_query_plan_field_caching", defaultConfig.DeprecatedCacheResultFields, "(DEPRECATED) This option fetches & caches fields (columns) when storing query plans")
 
 	flag.DurationVar(&healthCheckInterval, "health_check_interval", 20*time.Second, "Interval between health checks")

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -139,8 +139,8 @@ func init() {
 	flag.BoolVar(&currentConfig.EnforceStrictTransTables, "enforce_strict_trans_tables", defaultConfig.EnforceStrictTransTables, "If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database.")
 	flagutil.DualFormatBoolVar(&enableConsolidator, "enable_consolidator", true, "This option enables the query consolidator.")
 	flagutil.DualFormatBoolVar(&enableConsolidatorReplicas, "enable_consolidator_replicas", false, "This option enables the query consolidator only on replicas.")
-	flagutil.DualFormatInt64Var(&currentConfig.ConsolidatorStreamQuerySize, "consolidator_stream_query_size", defaultConfig.ConsolidatorStreamQuerySize, "Configure the stream consolidator query size. Setting to 0 disables the stream consolidator.")
-	flagutil.DualFormatInt64Var(&currentConfig.ConsolidatorStreamTotalSize, "consolidator_stream_total_size", defaultConfig.ConsolidatorStreamTotalSize, "Configure the stream consolidator total size. Setting to 0 disables the stream consolidator.")
+	flag.Int64Var(&currentConfig.ConsolidatorStreamQuerySize, "consolidator-stream-query-size", defaultConfig.ConsolidatorStreamQuerySize, "Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator.")
+	flag.Int64Var(&currentConfig.ConsolidatorStreamTotalSize, "consolidator-stream-total-size", defaultConfig.ConsolidatorStreamTotalSize, "Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator.")
 	flagutil.DualFormatBoolVar(&currentConfig.DeprecatedCacheResultFields, "enable_query_plan_field_caching", defaultConfig.DeprecatedCacheResultFields, "(DEPRECATED) This option fetches & caches fields (columns) when storing query plans")
 
 	flag.DurationVar(&healthCheckInterval, "health_check_interval", 20*time.Second, "Interval between health checks")

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -213,6 +213,8 @@ func TestFlags(t *testing.T) {
 			MaxConcurrency:     5,
 		},
 		StreamBufferSize:                        32768,
+		ConsolidatorStreamTotalSize:             128 * 1024 * 1024,
+		ConsolidatorStreamQuerySize:             2 * 1024 * 1024,
 		QueryCacheSize:                          int(cache.DefaultConfig.MaxEntries),
 		QueryCacheMemory:                        cache.DefaultConfig.MaxMemoryUsage,
 		QueryCacheLFU:                           cache.DefaultConfig.LFU,


### PR DESCRIPTION
## Description

When stream consolidation was added to VTTablet, fields were included in
the YAML configuration interface to set stream consolidator query/total
size. The fields are were set to non-zero by default.

However, equivalent flags were not added to the CLI configuration
interface, which resulted in the default values for stream consolidator
query/total size set to zero, effectively disabling the stream
consolidator, with no way for users to enable it via CLI flags.

This change adds `--consolidator-stream-query-size` and
`--consolidator-stream-query-total` flags to the VTTablet CLI
configuration interface. The default values for these flags are set to
the same values as the default values for the YAML configuration fields.

## Related Issue(s)

Addresses #10660

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->