### PR TITLE
schemadiff: ordering and applying a RenameColumn

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -1457,14 +1457,16 @@ func sortAlterOptions(diff *AlterTableEntityDiff) {
 			return 2
 		case *sqlparser.ModifyColumn:
 			return 3
-		case *sqlparser.AddColumns:
+		case *sqlparser.RenameColumn:
 			return 4
-		case *sqlparser.AddIndexDefinition:
+		case *sqlparser.AddColumns:
 			return 5
-		case *sqlparser.AddConstraintDefinition:
+		case *sqlparser.AddIndexDefinition:
 			return 6
-		case sqlparser.TableOptions, *sqlparser.TableOptions:
+		case *sqlparser.AddConstraintDefinition:
 			return 7
+		case sqlparser.TableOptions, *sqlparser.TableOptions:
+			return 8
 		default:
 			return math.MaxInt
 		}
@@ -1704,6 +1706,8 @@ func (c *CreateTableEntity) apply(diff *AlterTableEntityDiff) error {
 					found = true
 					// redefine. see if we need to position it anywhere other than end of table
 					c.TableSpec.Columns[i].Name = opt.NewName.Name
+					delete(columnExists, opt.OldName.Name.Lowered())
+					columnExists[opt.NewName.Name.Lowered()] = true
 					break
 				}
 			}

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -160,6 +160,14 @@ func TestCreateTableDiff(t *testing.T) {
 			cdiff:     "ALTER TABLE `t1` RENAME COLUMN `i1` TO `i2`, RENAME COLUMN `v1` TO `v2`",
 		},
 		{
+			name:      "rename mid column and add an index. statement",
+			from:      "create table t1 (id int primary key, i1 int not null, c char(3) default '')",
+			to:        "create table t2 (id int primary key, i2 int not null, c char(3) default '', key i2_idx(i2))",
+			colrename: ColumnRenameHeuristicStatement,
+			diff:      "alter table t1 rename column i1 to i2, add key i2_idx (i2)",
+			cdiff:     "ALTER TABLE `t1` RENAME COLUMN `i1` TO `i2`, ADD KEY `i2_idx` (`i2`)",
+		},
+		{
 			// in a future iteration, this will generate a RENAME for both column, like in the previous test. Until then, we do not RENAME two successive columns
 			name:      "rename two successive columns. statement",
 			from:      "create table t1 (id int primary key, i1 int not null, v1 varchar(32))",


### PR DESCRIPTION
## Description

This PR fixes handling of a `RENAME COLUMN` clause:

1. By correctly ordering the `RenameColumn` statement among other table statements
2. By applying changes to known columns map

Unit test case added.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/10203

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
