### PR TITLE
Revert: Revert temporary workflow changes made in #10847

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -10,8 +10,8 @@ concurrency:
 jobs:
   get_previous_release:
     if: always() && github.event_name == 'pull_request'
-    name: Get latest release
-    runs-on: ubuntu-latest
+    name: Get a recent LTS release
+    runs-on: ubuntu-20.04
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 40
     if: always() && (needs.get_previous_release.result == 'success')
     name: Run Upgrade Downgrade Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - get_previous_release
 
@@ -106,13 +106,29 @@ jobs:
         sudo deluser mysql
         sudo rm -rf /var/lib/mysql
         sudo rm -rf /etc/mysql
-        # Install mysql80
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
-        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
-        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
-        sudo apt-get update
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+
+        # Install MySQL 8.0
+        ####
+        ## Temporarily pin the MySQL version at 8.0.29 as Vitess 14.0.1 does not have the fix to support
+        ## backups of 8.0.30+. See: https://github.com/vitessio/vitess/pull/10847
+        ## TODO: remove this pin once the above fixes are included in a v14 release (will be in v14.0.2) OR
+        ##       Vitess 16.0.0-SNAPSHOT becomes the dev version on vitessio/main
+        #sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+        #wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        #echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        #sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+        #sudo apt-get update
+        #sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+        ####
+        wget -c https://cdn.mysql.com/archives/mysql-8.0/mysql-common_8.0.29-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-core_8.0.29-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-plugins_8.0.29-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-client_8.0.29-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-server-core_8.0.29-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-server_8.0.29-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client_8.0.29-1ubuntu20.04_amd64.deb
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y ./mysql-*.deb
+
         # Install everything else we need, and configure
         sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata grep
         sudo service mysql stop


### PR DESCRIPTION
## Description

In https://github.com/vitessio/vitess/pull/10896 we reverted the temporary [upgrade/downgrade backup manual workflow](https://github.com/vitessio/vitess/blob/main/.github/workflows/upgrade_downgrade_test_backups_manual.yml) changes made in https://github.com/vitessio/vitess/pull/10847. 

This was done because the MySQL 8.0.30 backup fixes were merged into the `release-14.0` branch via https://github.com/vitessio/vitess/pull/10895 and given that "v14 had the fix" (though not in an official release) we should no longer need to pin the MySQL version.

Well... I was mistaken about what we downgraded *to* in [this workflow](https://github.com/vitessio/vitess/blob/main/.github/workflows/upgrade_downgrade_test_backups_manual.yml). I thought we built binaries on the previous release branch, in this case `release-14.0`, but instead we checkout the latest release tag which is `v14.0.1` today.

You can see this here: https://github.com/vitessio/vitess/blob/853d88d4eb3928d132d2cb8f717c062f4e9bb73a/.github/workflows/upgrade_downgrade_test_backups_manual.yml#L24-L29

And here: https://github.com/vitessio/vitess/blob/main/tools/get_previous_release.sh

And you can see an example workflow which fails to perform the backup on the downgraded v14.0.1 binaries here: https://github.com/vitessio/vitess/runs/7642110846?check_suite_focus=true

So in this PR we put the temporary workflow changes _*back*_ in place and update the comment in the workflow to reflect that these MySQL version pinning changes cannot be removed until either of the following occur:
1. `v14.0.2` is released 
2. The dev version on main becomes `16.0.0-SNAPSHOT` (meaning the `v15.0.0` release candidate has been cut)

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/10847
  - Reverts: https://github.com/vitessio/vitess/pull/10896

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required