### PR TITLE
Fix flakiness in TestReplicationStatus

### DIFF
--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -774,8 +774,8 @@ func ReplicationThreadsStatus(t *testing.T, status *replicationdatapb.Status, vt
 		// and should agree with the new ones
 		require.NotEqual(t, mysql.ReplicationStateUnknown, mysql.ReplicationState(status.IoState))
 		require.NotEqual(t, mysql.ReplicationStateUnknown, mysql.ReplicationState(status.SqlState))
-		require.Equal(t, status.IoThreadRunning, mysql.ReplicationState(status.IoState) == mysql.ReplicationStateRunning)
-		require.Equal(t, status.SqlThreadRunning, mysql.ReplicationState(status.SqlState) == mysql.ReplicationStateRunning)
+		require.Equal(t, status.IoThreadRunning, mysql.ReplicationState(status.IoState) == mysql.ReplicationStateRunning || mysql.ReplicationState(status.IoState) == mysql.ReplicationStateConnecting)
+		require.Equal(t, status.SqlThreadRunning, mysql.ReplicationState(status.SqlState) == mysql.ReplicationStateRunning || mysql.ReplicationState(status.SqlState) == mysql.ReplicationStateConnecting)
 	}
 
 	// if vtctlVersion provided is 13, then we should read the old parameters, since that is what old vtctl would do
@@ -786,12 +786,12 @@ func ReplicationThreadsStatus(t *testing.T, status *replicationdatapb.Status, vt
 	ioState := mysql.ReplicationState(status.IoState)
 	ioThread := status.IoThreadRunning
 	if ioState != mysql.ReplicationStateUnknown {
-		ioThread = ioState == mysql.ReplicationStateRunning
+		ioThread = ioState == mysql.ReplicationStateRunning || ioState == mysql.ReplicationStateConnecting
 	}
 	sqlState := mysql.ReplicationState(status.SqlState)
 	sqlThread := status.SqlThreadRunning
 	if sqlState != mysql.ReplicationStateUnknown {
-		sqlThread = sqlState == mysql.ReplicationStateRunning
+		sqlThread = sqlState == mysql.ReplicationStateRunning || sqlState == mysql.ReplicationStateConnecting
 	}
 	return ioThread, sqlThread
 }


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

When IoState is `ReplicationStateConnecting`, then too we should be considering the IOThread to be running. The same goes for the SQL thread. This PR fixes the test expectations to reduce the flakiness.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
