### PR TITLE
Remove potential double close of channel

### DIFF
--- a/go/vt/topo/faketopo/faketopo.go
+++ b/go/vt/topo/faketopo/faketopo.go
@@ -304,7 +304,6 @@ func (f *FakeConn) Watch(ctx context.Context, filePath string) (*topo.WatchData,
 	f.watches[filePath] = append(f.watches[filePath], notifications)
 
 	go func() {
-		defer close(notifications)
 		<-ctx.Done()
 		watches, isPresent := f.watches[filePath]
 		if !isPresent {


### PR DESCRIPTION
The refactor of the Watch implementation led me to accidentally adding this to the watcher, but we should keep the same implementation and not add those close here.

## Related Issue(s)

Accidentally added in https://github.com/vitessio/vitess/pull/10906

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required