### PR TITLE
[cli] [vtgate] Migrate `vtgate/buffer` flags to `pflag`

### DIFF
--- a/go/vt/vtgate/buffer/flags.go
+++ b/go/vt/vtgate/buffer/flags.go
@@ -18,61 +18,80 @@ package buffer
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 )
 
 var (
-	bufferEnabled       = flag.Bool("enable_buffer", false, "Enable buffering (stalling) of primary traffic during failovers.")
-	bufferEnabledDryRun = flag.Bool("enable_buffer_dry_run", false, "Detect and log failover events, but do not actually buffer requests.")
+	bufferEnabled       bool
+	bufferEnabledDryRun bool
 
-	bufferWindow                  = flag.Duration("buffer_window", 10*time.Second, "Duration for how long a request should be buffered at most.")
-	bufferSize                    = flag.Int("buffer_size", 1000, "Maximum number of buffered requests in flight (across all ongoing failovers).")
-	bufferMaxFailoverDuration     = flag.Duration("buffer_max_failover_duration", 20*time.Second, "Stop buffering completely if a failover takes longer than this duration.")
-	bufferMinTimeBetweenFailovers = flag.Duration("buffer_min_time_between_failovers", 1*time.Minute, "Minimum time between the end of a failover and the start of the next one (tracked per shard). Faster consecutive failovers will not trigger buffering.")
+	bufferWindow                  time.Duration
+	bufferSize                    int
+	bufferMaxFailoverDuration     time.Duration
+	bufferMinTimeBetweenFailovers time.Duration
 
-	bufferDrainConcurrency = flag.Int("buffer_drain_concurrency", 1, "Maximum number of requests retried simultaneously. More concurrency will increase the load on the PRIMARY vttablet when draining the buffer.")
-	bufferKeyspaceShards   = flag.String("buffer_keyspace_shards", "", "If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable_buffer=true.")
+	bufferDrainConcurrency int
+	bufferKeyspaceShards   string
 )
 
+func registerFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&bufferEnabled, "enable_buffer", false, "Enable buffering (stalling) of primary traffic during failovers.")
+	fs.BoolVar(&bufferEnabledDryRun, "enable_buffer_dry_run", false, "Detect and log failover events, but do not actually buffer requests.")
+
+	fs.DurationVar(&bufferWindow, "buffer_window", 10*time.Second, "Duration for how long a request should be buffered at most.")
+	fs.IntVar(&bufferSize, "buffer_size", 1000, "Maximum number of buffered requests in flight (across all ongoing failovers).")
+	fs.DurationVar(&bufferMaxFailoverDuration, "buffer_max_failover_duration", 20*time.Second, "Stop buffering completely if a failover takes longer than this duration.")
+	fs.DurationVar(&bufferMinTimeBetweenFailovers, "buffer_min_time_between_failovers", 1*time.Minute, "Minimum time between the end of a failover and the start of the next one (tracked per shard). Faster consecutive failovers will not trigger buffering.")
+
+	fs.IntVar(&bufferDrainConcurrency, "buffer_drain_concurrency", 1, "Maximum number of requests retried simultaneously. More concurrency will increase the load on the PRIMARY vttablet when draining the buffer.")
+	fs.StringVar(&bufferKeyspaceShards, "buffer_keyspace_shards", "", "If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable_buffer=true.")
+}
+
+func init() {
+	servenv.OnParseFor("vtgate", registerFlags)
+}
+
 func verifyFlags() error {
-	if *bufferWindow < 1*time.Second {
-		return fmt.Errorf("-buffer_window must be >= 1s (specified value: %v)", *bufferWindow)
+	if bufferWindow < 1*time.Second {
+		return fmt.Errorf("--buffer_window must be >= 1s (specified value: %v)", bufferWindow)
 	}
-	if *bufferWindow > *bufferMaxFailoverDuration {
-		return fmt.Errorf("-buffer_window must be <= -buffer_max_failover_duration: %v vs. %v", *bufferWindow, *bufferMaxFailoverDuration)
+	if bufferWindow > bufferMaxFailoverDuration {
+		return fmt.Errorf("--buffer_window must be <= --buffer_max_failover_duration: %v vs. %v", bufferWindow, bufferMaxFailoverDuration)
 	}
-	if *bufferSize < 1 {
-		return fmt.Errorf("-buffer_size must be >= 1 (specified value: %d)", *bufferSize)
+	if bufferSize < 1 {
+		return fmt.Errorf("--buffer_size must be >= 1 (specified value: %d)", bufferSize)
 	}
-	if *bufferMinTimeBetweenFailovers < *bufferMaxFailoverDuration*time.Duration(2) {
-		return fmt.Errorf("-buffer_min_time_between_failovers should be at least twice the length of -buffer_max_failover_duration: %v vs. %v", *bufferMinTimeBetweenFailovers, *bufferMaxFailoverDuration)
-	}
-
-	if *bufferDrainConcurrency < 1 {
-		return fmt.Errorf("-buffer_drain_concurrency must be >= 1 (specified value: %d)", *bufferDrainConcurrency)
+	if bufferMinTimeBetweenFailovers < bufferMaxFailoverDuration*time.Duration(2) {
+		return fmt.Errorf("--buffer_min_time_between_failovers should be at least twice the length of --buffer_max_failover_duration: %v vs. %v", bufferMinTimeBetweenFailovers, bufferMaxFailoverDuration)
 	}
 
-	if *bufferKeyspaceShards != "" && !*bufferEnabled {
-		return fmt.Errorf("-buffer_keyspace_shards=%v also requires that -enable_buffer is set", *bufferKeyspaceShards)
+	if bufferDrainConcurrency < 1 {
+		return fmt.Errorf("--buffer_drain_concurrency must be >= 1 (specified value: %d)", bufferDrainConcurrency)
 	}
-	if *bufferEnabled && *bufferEnabledDryRun && *bufferKeyspaceShards == "" {
+
+	if bufferKeyspaceShards != "" && !bufferEnabled {
+		return fmt.Errorf("--buffer_keyspace_shards=%v also requires that --enable_buffer is set", bufferKeyspaceShards)
+	}
+	if bufferEnabled && bufferEnabledDryRun && bufferKeyspaceShards == "" {
 		return errors.New("both the dry-run mode and actual buffering is enabled. To avoid ambiguity, keyspaces and shards for actual buffering must be explicitly listed in --buffer_keyspace_shards")
 	}
 
-	keyspaces, shards := keyspaceShardsToSets(*bufferKeyspaceShards)
+	keyspaces, shards := keyspaceShardsToSets(bufferKeyspaceShards)
 	for s := range shards {
 		keyspace, _, err := topoproto.ParseKeyspaceShard(s)
 		if err != nil {
 			return err
 		}
 		if keyspaces[keyspace] {
-			return fmt.Errorf("-buffer_keyspace_shards has overlapping entries (keyspace only vs. keyspace/shard): %v vs. %v Please remove one or the other", keyspace, s)
+			return fmt.Errorf("--buffer_keyspace_shards has overlapping entries (keyspace only vs. keyspace/shard): %v vs. %v Please remove one or the other", keyspace, s)
 		}
 	}
 
@@ -149,14 +168,14 @@ func NewConfigFromFlags() *Config {
 	if err := verifyFlags(); err != nil {
 		log.Fatalf("Invalid buffer configuration: %v", err)
 	}
-	bufferSizeStat.Set(int64(*bufferSize))
-	keyspaces, shards := keyspaceShardsToSets(*bufferKeyspaceShards)
+	bufferSizeStat.Set(int64(bufferSize))
+	keyspaces, shards := keyspaceShardsToSets(bufferKeyspaceShards)
 
-	if *bufferEnabledDryRun {
+	if bufferEnabledDryRun {
 		log.Infof("vtgate buffer in dry-run mode enabled for all requests. Dry-run bufferings will log failovers but not buffer requests.")
 	}
 
-	if *bufferEnabled {
+	if bufferEnabled {
 		log.Infof("vtgate buffer enabled. PRIMARY requests will be buffered during detected failovers.")
 
 		// Log a second line if it's only enabled for some keyspaces or shards.
@@ -174,27 +193,27 @@ func NewConfigFromFlags() *Config {
 		if limited != "" {
 			limited = header + limited
 			dryRunOverride := ""
-			if *bufferEnabledDryRun {
+			if bufferEnabledDryRun {
 				dryRunOverride = " Dry-run mode is overridden for these entries and actual buffering will take place."
 			}
 			log.Infof("%v.%v", limited, dryRunOverride)
 		}
 	}
 
-	if !*bufferEnabledDryRun && !*bufferEnabled {
+	if !bufferEnabledDryRun && !bufferEnabled {
 		log.Infof("vtgate buffer not enabled.")
 	}
 
 	return &Config{
-		Enabled: *bufferEnabled,
-		DryRun:  *bufferEnabledDryRun,
+		Enabled: bufferEnabled,
+		DryRun:  bufferEnabledDryRun,
 
-		Window:                  *bufferWindow,
-		Size:                    *bufferSize,
-		MaxFailoverDuration:     *bufferMaxFailoverDuration,
-		MinTimeBetweenFailovers: *bufferMinTimeBetweenFailovers,
+		Window:                  bufferWindow,
+		Size:                    bufferSize,
+		MaxFailoverDuration:     bufferMaxFailoverDuration,
+		MinTimeBetweenFailovers: bufferMinTimeBetweenFailovers,
 
-		DrainConcurrency: *bufferDrainConcurrency,
+		DrainConcurrency: bufferDrainConcurrency,
 
 		Keyspaces: keyspaces,
 		Shards:    shards,

--- a/go/vt/vtgate/buffer/flags.go
+++ b/go/vt/vtgate/buffer/flags.go
@@ -33,12 +33,12 @@ var (
 	bufferEnabled       bool
 	bufferEnabledDryRun bool
 
-	bufferWindow                  time.Duration
-	bufferSize                    int
-	bufferMaxFailoverDuration     time.Duration
-	bufferMinTimeBetweenFailovers time.Duration
+	bufferWindow                  = 10 * time.Second
+	bufferSize                    = 1000
+	bufferMaxFailoverDuration     = 20 * time.Second
+	bufferMinTimeBetweenFailovers = time.Minute
 
-	bufferDrainConcurrency int
+	bufferDrainConcurrency = 1
 	bufferKeyspaceShards   string
 )
 

--- a/go/vt/vtgate/buffer/flags.go
+++ b/go/vt/vtgate/buffer/flags.go
@@ -57,6 +57,7 @@ func registerFlags(fs *pflag.FlagSet) {
 
 func init() {
 	servenv.OnParseFor("vtgate", registerFlags)
+	servenv.OnParseFor("vtcombo", registerFlags)
 }
 
 func verifyFlags() error {

--- a/go/vt/vtgate/buffer/flags_test.go
+++ b/go/vt/vtgate/buffer/flags_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package buffer
 
 import (
-	"flag"
 	"strings"
 	"testing"
 
@@ -62,8 +61,6 @@ func TestVerifyFlags(t *testing.T) {
 		"--enable_buffer",
 		"--buffer_keyspace_shards", "ks1//0",
 	})
-	flag.Set("enable_buffer", "true")
-	flag.Set("buffer_keyspace_shards", "ks1//0")
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "invalid shard path") {
 		t.Fatalf("Invalid shard names are not allowed. err: %v", err)
 	}

--- a/go/vt/vtgate/buffer/flags_test.go
+++ b/go/vt/vtgate/buffer/flags_test.go
@@ -20,36 +20,48 @@ import (
 	"flag"
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 func TestVerifyFlags(t *testing.T) {
+	parse := func(args []string) {
+		fs := pflag.NewFlagSet("vtgate_buffer_test", pflag.ContinueOnError)
+		registerFlags(fs)
+
+		if err := fs.Parse(args); err != nil {
+			t.Errorf("failed to parse args %v: %s", args, err)
+		}
+	}
 	resetFlagsForTesting := func() {
 		// Set all flags to their default value.
-		flag.Set("enable_buffer", "false")
-		flag.Set("enable_buffer_dry_run", "false")
-		flag.Set("buffer_size", "1000")
-		flag.Set("buffer_window", "10s")
-		flag.Set("buffer_keyspace_shards", "")
-		flag.Set("buffer_max_failover_duration", "20s")
-		flag.Set("buffer_min_time_between_failovers", "1m")
+		parse([]string{})
 	}
 
 	// Verify that the non-allowed (non-trivial) flag combinations are caught.
 	defer resetFlagsForTesting()
 
-	flag.Set("buffer_keyspace_shards", "ks1/0")
+	parse([]string{"--buffer_keyspace_shards", "ks1/0"})
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "also requires that") {
 		t.Fatalf("List of shards requires --enable_buffer. err: %v", err)
 	}
 
 	resetFlagsForTesting()
-	flag.Set("enable_buffer", "true")
-	flag.Set("enable_buffer_dry_run", "true")
+
+	parse([]string{
+		"--enable_buffer",
+		"--enable_buffer_dry_run",
+	})
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "To avoid ambiguity") {
 		t.Fatalf("Dry-run and non-dry-run mode together require an explicit list of shards for actual buffering. err: %v", err)
 	}
 
 	resetFlagsForTesting()
+
+	parse([]string{
+		"--enable_buffer",
+		"--buffer_keyspace_shards", "ks1//0",
+	})
 	flag.Set("enable_buffer", "true")
 	flag.Set("buffer_keyspace_shards", "ks1//0")
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "invalid shard path") {
@@ -57,8 +69,11 @@ func TestVerifyFlags(t *testing.T) {
 	}
 
 	resetFlagsForTesting()
-	flag.Set("enable_buffer", "true")
-	flag.Set("buffer_keyspace_shards", "ks1,ks1/0")
+
+	parse([]string{
+		"--enable_buffer",
+		"--buffer_keyspace_shards", "ks1,ks1/0",
+	})
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "has overlapping entries") {
 		t.Fatalf("Listed keyspaces and shards must not overlap. err: %v", err)
 	}

--- a/go/vt/vtgate/buffer/test_util.go
+++ b/go/vt/vtgate/buffer/test_util.go
@@ -18,5 +18,5 @@ package buffer
 
 // SetBufferingModeInTestingEnv should only be used from testing code to change the flag (enable_buffer) default value
 func SetBufferingModeInTestingEnv(enabled bool) {
-	*bufferEnabled = enabled
+	bufferEnabled = enabled
 }

--- a/go/vt/vtgate/buffer/variables_test.go
+++ b/go/vt/vtgate/buffer/variables_test.go
@@ -18,18 +18,25 @@ package buffer
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/stats"
 )
 
 func TestVariables(t *testing.T) {
-	flag.Set("buffer_size", "23")
+	fs := pflag.NewFlagSet("vtgate_buffer_variables_test", pflag.ContinueOnError)
+	registerFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Errorf("failed to parse with default values: %v", err)
+	}
+
+	fs.Set("buffer_size", "23")
 	defer func() {
-		flag.Set("buffer_size", "1")
+		fs.Set("buffer_size", "1")
 	}()
 
 	// Create new buffer which will the flags.

--- a/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package grpcvtgateconn
 
 import (
+	"context"
 	"flag"
 	"io"
 	"net"
@@ -24,8 +25,6 @@ import (
 	"testing"
 
 	"google.golang.org/grpc"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtgate/grpcvtgateservice"


### PR DESCRIPTION
## Description

This migrates the flags in `go/vt/vtgate/buffer` to `pflag` and scopes them to just the `vtgate` binary.

**Note to reviewers**: the following binaries also import this package. I know `vtexplain` does not actually use them, but I need a consult on the others because I'm not sure:

- `vitess.io/vitess/go/cmd/vtcombo`
- `vitess.io/vitess/go/cmd/vtexplain`
- `vitess.io/vitess/go/cmd/vtgateclienttest`

## Related Issue(s)

Closes #10932 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
