### PR TITLE
schemadiff: rich error for unmet view dependencies

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -560,7 +560,7 @@ func TestDiffSchemas(t *testing.T) {
 			name:        "create view: unresolved dependencies",
 			from:        "create table t(id int)",
 			to:          "create table t(id int); create view v1 as select id from t2",
-			expectError: ErrViewDependencyUnresolved.Error(),
+			expectError: (&ApplyViewNotFoundError{View: "v1"}).Error(),
 		},
 		{
 			name: "convert table to view",

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -14,7 +14,6 @@ var (
 	ErrUnexpectedTableSpec            = errors.New("unexpected table spec")
 	ErrExpectedCreateTable            = errors.New("expected a CREATE TABLE statement")
 	ErrExpectedCreateView             = errors.New("expected a CREATE VIEW statement")
-	ErrViewDependencyUnresolved       = errors.New("views have unresolved/loop dependencies")
 )
 
 type UnsupportedEntityError struct {
@@ -238,4 +237,12 @@ type InvalidColumnInForeignKeyConstraintError struct {
 func (e *InvalidColumnInForeignKeyConstraintError) Error() string {
 	return fmt.Sprintf("invalid column %s referenced by foreign key constraint %s in table %s",
 		sqlescape.EscapeID(e.Column), sqlescape.EscapeID(e.Constraint), sqlescape.EscapeID(e.Table))
+}
+
+type ViewDependencyUnresolvedError struct {
+	View string
+}
+
+func (e *ViewDependencyUnresolvedError) Error() string {
+	return fmt.Sprintf("view %s has unresolved/loops dependencies", sqlescape.EscapeID(e.View))
 }

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -244,5 +244,5 @@ type ViewDependencyUnresolvedError struct {
 }
 
 func (e *ViewDependencyUnresolvedError) Error() string {
-	return fmt.Sprintf("view %s has unresolved/loops dependencies", sqlescape.EscapeID(e.View))
+	return fmt.Sprintf("view %s has unresolved/loop dependencies", sqlescape.EscapeID(e.View))
 }

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -230,7 +230,13 @@ func (s *Schema) normalize() error {
 		// We have leftover views. This can happen if the schema definition is invalid:
 		// - a view depends on a nonexistent table
 		// - two views have a circular dependency
-		return ErrViewDependencyUnresolved
+		for _, v := range s.views {
+			if _, ok := dependencyLevels[v.Name()]; !ok {
+				// We _know_ that in this iteration, at least one view is found unassugned a dependency level.
+				// We return the first one.
+				return &ApplyViewNotFoundError{View: v.ViewName.Name.String()}
+			}
+		}
 	}
 	return nil
 }

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -232,7 +232,7 @@ func (s *Schema) normalize() error {
 		// - two views have a circular dependency
 		for _, v := range s.views {
 			if _, ok := dependencyLevels[v.Name()]; !ok {
-				// We _know_ that in this iteration, at least one view is found unassugned a dependency level.
+				// We _know_ that in this iteration, at least one view is found unassigned a dependency level.
 				// We return the first one.
 				return &ApplyViewNotFoundError{View: v.ViewName.Name.String()}
 			}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -110,7 +110,7 @@ func TestNewSchemaFromQueriesUnresolved(t *testing.T) {
 	)
 	_, err := NewSchemaFromQueries(queries)
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrViewDependencyUnresolved)
+	assert.EqualError(t, err, (&ApplyViewNotFoundError{View: "v7"}).Error())
 }
 
 func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {
@@ -120,7 +120,7 @@ func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {
 	)
 	_, err := NewSchemaFromQueries(queries)
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrViewDependencyUnresolved)
+	assert.EqualError(t, err, (&ApplyViewNotFoundError{View: "v7"}).Error())
 }
 
 func TestNewSchemaFromQueriesLoop(t *testing.T) {
@@ -131,7 +131,7 @@ func TestNewSchemaFromQueriesLoop(t *testing.T) {
 	)
 	_, err := NewSchemaFromQueries(queries)
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrViewDependencyUnresolved)
+	assert.EqualError(t, err, (&ApplyViewNotFoundError{View: "v7"}).Error())
 }
 
 func TestToSQL(t *testing.T) {


### PR DESCRIPTION

## Description

This PR turns the flat `ErrViewDependencyUnresolved` error into a richer `ViewDependencyUnresolvedError`, indicating the identity of the view in question.

Existing tests adapted to new error type.

## Related Issue(s)

- Tracking: https://github.com/vitessio/vitess/issues/10203

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
