### PR TITLE
Avoid race condition in memory topo watch shutdown

### DIFF
--- a/go/vt/topo/memorytopo/memorytopo.go
+++ b/go/vt/topo/memorytopo/memorytopo.go
@@ -142,6 +142,9 @@ func (c *Conn) dial(ctx context.Context) error {
 // Close is part of the topo.Conn interface.
 // It nils out factory, so any subsequent call will panic.
 func (c *Conn) Close() {
+	c.factory.Lock()
+	f := c.factory
+	defer f.Unlock()
 	c.factory = nil
 }
 

--- a/go/vt/topo/memorytopo/watch.go
+++ b/go/vt/topo/memorytopo/watch.go
@@ -25,8 +25,8 @@ import (
 
 // Watch is part of the topo.Conn interface.
 func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, error) {
-	c.factory.mu.Lock()
-	defer c.factory.mu.Unlock()
+	c.factory.Lock()
+	defer c.factory.Unlock()
 
 	if c.factory.err != nil {
 		return nil, nil, c.factory.err
@@ -54,10 +54,11 @@ func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-c
 		<-ctx.Done()
 		// This function can be called at any point, so we first need
 		// to make sure the watch is still valid.
-		c.factory.mu.Lock()
-		defer c.factory.mu.Unlock()
+		c.factory.Lock()
+		f := c.factory
+		defer f.Unlock()
 
-		n := c.factory.nodeByPath(c.cell, filePath)
+		n := f.nodeByPath(c.cell, filePath)
 		if n == nil {
 			return
 		}
@@ -73,8 +74,8 @@ func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-c
 
 // WatchRecursive is part of the topo.Conn interface.
 func (c *Conn) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.WatchDataRecursive, <-chan *topo.WatchDataRecursive, error) {
-	c.factory.mu.Lock()
-	defer c.factory.mu.Unlock()
+	c.factory.Lock()
+	defer c.factory.Unlock()
 
 	if c.factory.err != nil {
 		return nil, nil, c.factory.err
@@ -106,10 +107,11 @@ func (c *Conn) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.Watc
 
 		<-ctx.Done()
 
-		c.factory.mu.Lock()
-		defer c.factory.mu.Unlock()
+		c.factory.Lock()
+		f := c.factory
+		defer f.Unlock()
 
-		n := c.factory.nodeByPath(c.cell, dirpath)
+		n := f.nodeByPath(c.cell, dirpath)
 		if n != nil {
 			delete(n.watches, watchIndex)
 		}


### PR DESCRIPTION
When we call close we want to lock around clearing out the factory object. In the watch goroutine shutdown we want to grab a reference to the factory to ensure that it can keep going with the shutdown procedure.

It's still possible to panic here on wrong usage but that's deliberate to avoid reuse of the memory topo.

Found with the race detector on a build:

```
==================
WARNING: DATA RACE
Write at 0x00c00047c780 by goroutine 19:
  vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).Close()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/memorytopo/memorytopo.go:145 +0x30
  vitess.io/vitess/go/vt/topo.(*StatsConn).Close()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/stats_conn.go:201 +0x17e
  vitess.io/vitess/go/vt/topo.(*Server).Close()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/server.go:335 +0x25a
  vitess.io/vitess/go/vt/topo/test.TopoServerTestSuite()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/test/testing.go:125 +0x605
  vitess.io/vitess/go/vt/topo/memorytopo.TestMemoryTopo()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/memorytopo/server_test.go:28 +0x35
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/testing.go:1486 +0x47

Previous read at 0x00c00047c780 by goroutine 32:
  vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).Watch.func1()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/memorytopo/watch.go:58 +0xbc

Goroutine 19 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/testing.go:1486 +0x724
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/testing.go:1839 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/testing.go:1439 +0x213
  testing.runTests()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/testing.go:1837 +0x7e4
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/testing.go:1719 +0xa71
  main.main()
      _testmain.go:47 +0x2e4

Goroutine 32 (finished) created at:
  vitess.io/vitess/go/vt/topo/memorytopo.(*Conn).Watch()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/memorytopo/watch.go:53 +0x564
  vitess.io/vitess/go/vt/topo.(*StatsConn).Watch()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/stats_conn.go:168 +0x201
  vitess.io/vitess/go/vt/topo/test.waitForInitialValue()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/test/watch.go:42 +0xdb
  vitess.io/vitess/go/vt/topo/test.checkWatch()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/test/watch.go:140 +0x414
  vitess.io/vitess/go/vt/topo/test.TopoServerTestSuite()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/test/testing.go:116 +0x564
  vitess.io/vitess/go/vt/topo/memorytopo.TestMemoryTopo()
      /home/runner/work/vitess-private/vitess-private/go/vt/topo/memorytopo/server_test.go:28 +0x35
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/testing.go:1486 +0x47
==================

Signed-off-by: Dirkjan Bussink <d.bussink@gmail.com>
--- FAIL: TestMemoryTopo (0.06s)
    testing.go:49: === checkKeyspace
    testing.go:54: === checkShard
    testing.go:59: === checkTablet
    testing.go:64: === checkShardReplication
    testing.go:69: === checkSrvKeyspace
    testing.go:74: === checkSrvVSchema
    testing.go:79: === checkLock
    lock.go:49: ===      checkLockTimeout
    lock.go:52: ===      checkLockMissing
    lock.go:55: ===      checkLockUnblocks
    testing.go:84: === checkVSchema
    testing.go:89: === checkRoutingRules
    testing.go:94: === checkElection
    testing.go:99: === checkWaitForNewLeader
    testing.go:104: === checkDirectory
    directory.go:33: ===   checkDirectoryInCell global
    directory.go:41: ===   checkDirectoryInCell test
    testing.go:109: === checkFile
    file.go:33: ===   checkFileInCell global
    file.go:41: ===   checkFileInCell global
    testing.go:114: === checkWatch
    testing.go:119: === checkList
    testing.go:122: === checkWatchRecursive
    testing.go:1312: race detected during execution of test
FAIL
FAIL	vitess.io/vitess/go/vt/topo/memorytopo	0.087s
```

## Related Issue(s)

Follow up on https://github.com/vitessio/vitess/pull/10906 although this wasn't introduced there, but this problem already existed.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required