### PR TITLE
Fixing flakiness in TestCrossCellDurability and TestHealthCheckCacheWithTabletChurn

### DIFF
--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -229,9 +229,9 @@ func StartNewVTTablet(t *testing.T, clusterInstance *cluster.LocalProcessCluster
 		require.FailNow(t, "Error starting mysql: %s", err.Error())
 	}
 
+	// The tablet should come up as serving since the primary for the shard already exists
+	tablet.VttabletProcess.ServingStatus = "SERVING"
 	err = tablet.VttabletProcess.Setup()
-	require.NoError(t, err)
-	err = tablet.VttabletProcess.WaitForTabletStatuses([]string{"SERVING", "NOT_SERVING"})
 	require.NoError(t, err)
 	return tablet
 }

--- a/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
+++ b/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
@@ -208,6 +208,7 @@ func addTablet(t *testing.T, tabletUID int, tabletType string) *cluster.Vttablet
 	err = proc.Wait()
 	require.Nil(t, err)
 
+	tablet.VttabletProcess.ServingStatus = ""
 	err = tablet.VttabletProcess.Setup()
 	require.Nil(t, err)
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR attempts to fix the flakiness observed in `TestCrossCellDurability` and `TestHealthCheckCacheWithTabletChurn`.
The flakiness was tracked to the part where we bring up a new vttablet. When this tablet comes up, a shard primary already exists and the tablet goes to serving status very quickly. 
However, the test code waits for the tablet to reach the non-serving status. This led to a race between the code that checks the non-serving status and the tablet process which goes to serving status eventually.

This has been resolved by waiting for the tablet to reach the Serving status since that is the end state instead of waiting for the non-serving status which is the default.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
