### PR TITLE
Remove accidentally added fmt.Printf from debugging

### DIFF
--- a/go/vt/vtctld/vtctld_test.go
+++ b/go/vt/vtctld/vtctld_test.go
@@ -18,7 +18,6 @@ package vtctld
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +39,6 @@ func TestWebApp(t *testing.T) {
 	defer res.Body.Close()
 
 	data, err := ioutil.ReadAll(res.Body)
-	fmt.Printf("body: %s\n", string(data))
 
 	assert.NoError(t, err)
 	assert.Contains(t, string(data), "<!doctype html>")


### PR DESCRIPTION
Accidentally added in https://github.com/vitessio/vitess/pull/10956

## Related Issue(s)

Added because of debugging in https://github.com/vitessio/vitess/pull/10956

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required