### PR TITLE
fix building logtail, logrotate and vtadmin docker image in Dockerhub

### DIFF
--- a/docker/k8s/logrotate/Dockerfile
+++ b/docker/k8s/logrotate/Dockerfile
@@ -16,9 +16,9 @@ ARG DEBIAN_VER=stable-slim
 
 FROM debian:${DEBIAN_VER}
 
-ADD logrotate.conf /vt/logrotate.conf
+COPY docker/k8s/logrotate/logrotate.conf /vt/logrotate.conf
 
-ADD rotate.sh /vt/rotate.sh
+COPY docker/k8s/logrotate/rotate.sh /vt/rotate.sh
 
 RUN mkdir -p /vt && \
    apt-get update && \

--- a/docker/k8s/logtail/Dockerfile
+++ b/docker/k8s/logtail/Dockerfile
@@ -18,7 +18,7 @@ FROM debian:${DEBIAN_VER}
 
 ENV TAIL_FILEPATH /dev/null
 
-ADD tail.sh /vt/tail.sh
+COPY docker/k8s/logtail/tail.sh /vt/tail.sh
 
 RUN mkdir -p /vt && \
    apt-get update && \

--- a/docker/k8s/vtadmin/Dockerfile
+++ b/docker/k8s/vtadmin/Dockerfile
@@ -45,7 +45,7 @@ FROM nginxinc/nginx-unprivileged:1.22-alpine AS nginx
 ENV VTADMIN_WEB_PORT=14201
 
 COPY --chown=nginx --from=node /vt/web/vtadmin/build /var/www/
-COPY --chown=nginx default.conf /etc/nginx/templates/default.conf.template
+COPY --chown=nginx docker/k8s/vtadmin/default.conf /etc/nginx/templates/default.conf.template
 
 # command to run nginx is in the base image
 # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/stable/alpine/Dockerfile#L150


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

We noticed that logtail, logrotate and vtadmin docker image were not building (in Dockerhub) anymore as it use / build context. 
We took this opportunity to move from `ADD` to `COPY` as from the [documentation](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy) it seems to be the preferred way.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
