### PR TITLE
[cli] [go/mysql/collations/...] Migrate all flags to `pflag`

### DIFF
--- a/go/internal/flag/flag.go
+++ b/go/internal/flag/flag.go
@@ -66,6 +66,17 @@ func Parse(fs *flag.FlagSet) {
 	flag.Parse()
 }
 
+// Parsed returns true if the command-line flags have been parsed.
+//
+// It is agnostic to whether the standard library `flag` package or `pflag` was
+// used for parsing, in order to facilitate the migration to `pflag` for
+// VEP-4 [1].
+//
+// [1]: https://github.com/vitessio/vitess/issues/10697.
+func Parsed() bool {
+	return goflag.Parsed() || flag.Parsed()
+}
+
 // Args returns the positional arguments with the first double-dash ("--")
 // removed. If no double-dash was specified on the command-line, this is
 // equivalent to flag.Args() from the standard library flag package.

--- a/go/mysql/collations/integration/collations_test.go
+++ b/go/mysql/collations/integration/collations_test.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"os"
 	"path"
@@ -28,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/text/encoding/unicode/utf32"
 
@@ -185,7 +185,7 @@ func processSQLTest(t *testing.T, testfile string, conn *mysql.Conn) {
 	}
 }
 
-var testOneCollation = flag.String("test-one-collation", "", "")
+var testOneCollation = pflag.String("test-one-collation", "", "")
 
 func TestCollationsOnMysqld(t *testing.T) {
 	conn := mysqlconn(t)

--- a/go/mysql/collations/integration/main_test.go
+++ b/go/mysql/collations/integration/main_test.go
@@ -18,12 +18,13 @@ package integration
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/vttest"
@@ -35,7 +36,7 @@ var (
 	connParams mysql.ConnParams
 )
 
-var waitmysql = flag.Bool("waitmysql", false, "")
+var waitmysql = pflag.Bool("waitmysql", false, "")
 
 func mysqlconn(t *testing.T) *mysql.Conn {
 	conn, err := mysql.Connect(context.Background(), &connParams)
@@ -55,7 +56,7 @@ func mysqlconn(t *testing.T) *mysql.Conn {
 }
 
 func TestMain(m *testing.M) {
-	flag.Parse()
+	pflag.Parse()
 
 	exitCode := func() int {
 		// Launch MySQL.

--- a/go/mysql/collations/local.go
+++ b/go/mysql/collations/local.go
@@ -19,9 +19,9 @@ limitations under the License.
 package collations
 
 import (
-	"flag"
 	"sync"
 
+	"vitess.io/vitess/go/internal/flag"
 	"vitess.io/vitess/go/vt/servenv"
 )
 

--- a/go/mysql/collations/platform32.go
+++ b/go/mysql/collations/platform32.go
@@ -29,4 +29,4 @@ const (
 
 // Generate all the metadata used for collations from the JSON data dumped from MySQL
 // In 32 bit systems, do not use memory embedding, it's not worth it
-//go:generate go run ./tools/makecolldata/ -embed=false
+//go:generate go run ./tools/makecolldata/ --embed=false

--- a/go/mysql/collations/platform64.go
+++ b/go/mysql/collations/platform64.go
@@ -27,4 +27,4 @@ const (
 )
 
 // Generate all the metadata used for collations from the JSON data dumped from MySQL
-//go:generate go run ./tools/makecolldata/ -embed=true
+//go:generate go run ./tools/makecolldata/ --embed=true

--- a/go/mysql/collations/tools/makecolldata/main.go
+++ b/go/mysql/collations/tools/makecolldata/main.go
@@ -18,12 +18,13 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
+
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/mysql/collations/internal/charset"
 	"vitess.io/vitess/go/mysql/collations/internal/uca"
@@ -57,8 +58,8 @@ type CollationMetadata struct {
 	UpperCaseFirst bool
 }
 
-var Mysqldata = flag.String("mysqldata", "testdata/mysqldata", "")
-var Embed = flag.Bool("embed", false, "")
+var Mysqldata = pflag.String("mysqldata", "testdata/mysqldata", "")
+var Embed = pflag.Bool("embed", false, "")
 
 func loadMysqlMetadata() (all AllMetadata) {
 	mysqdata, err := filepath.Glob(path.Join(*Mysqldata, "*.json"))
@@ -109,7 +110,7 @@ const PkgCollations codegen.Package = "vitess.io/vitess/go/mysql/collations"
 const PkgCharset codegen.Package = "vitess.io/vitess/go/mysql/collations/internal/charset"
 
 func main() {
-	flag.Parse()
+	pflag.Parse()
 	metadata := loadMysqlMetadata()
 	maketables(*Embed, ".", metadata)
 	makeversions(".")

--- a/go/mysql/collations/tools/makecolldata/mysqldata.go
+++ b/go/mysql/collations/tools/makecolldata/mysqldata.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"path"
@@ -25,12 +24,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/pflag"
+
 	"vitess.io/vitess/go/mysql/collations/internal/charset"
 	"vitess.io/vitess/go/mysql/collations/internal/uca"
 	"vitess.io/vitess/go/mysql/collations/tools/makecolldata/codegen"
 )
 
-var Print8BitData = flag.Bool("full8bit", false, "")
+var Print8BitData = pflag.Bool("full8bit", false, "")
 
 type TableGenerator struct {
 	*codegen.Generator

--- a/go/mysql/collations/tools/makecolldata/mysqlversions.go
+++ b/go/mysql/collations/tools/makecolldata/mysqlversions.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -28,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/mysql/collations/tools/makecolldata/codegen"
 )
@@ -51,7 +52,7 @@ var CharsetAliases = map[string]string{
 }
 
 func makeversions(output string) {
-	flag.Parse()
+	pflag.Parse()
 
 	versionfiles, err := filepath.Glob("testdata/versions/collations_*.csv")
 	if err != nil {


### PR DESCRIPTION
## Description

I decided to migrate the tests/tools as well, just for consistency's sake.

@vmg do you mind checking if you have any other scripts that use `makecolldata` (I did a `git grep` and updated everything I found, but I am not sure if you have a local workflow) still work on this branch? If not, I can back out just those changes and revisit that piece.

## Related Issue(s)

- Closes #10963 
- Closes #10964 
- Closes #10965 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
