### PR TITLE
[cli] [vttest] Extend vttest.TopoData to implement `pflag.Value`, and make function return types implicit

### DIFF
--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -34,19 +33,18 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/proto/logutil"
+	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
+
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	vttestpb "vitess.io/vitess/go/vt/proto/vttest"
 
 	// we need to import the grpcvtctlclient library so the gRPC
 	// vtctl client is registered and can be used.
 	_ "vitess.io/vitess/go/vt/vtctl/grpcvtctlclient"
-	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
-
-	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/log"
-
-	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
-	vttestpb "vitess.io/vitess/go/vt/proto/vttest"
 )
 
 // Config are the settings used to configure the self-contained Vitess cluster.
@@ -206,27 +204,40 @@ func (cfg *Config) DbName() string {
 	return ""
 }
 
+// TopoData is a struct representing a test topology.
+//
+// It implements pflag.Value and can be used as a destination command-line via
+// pflag.Var or pflag.VarP.
 type TopoData struct {
 	vtTestTopology *vttestpb.VTTestTopology
 	unmarshal      func(b []byte, m proto.Message) error
 }
 
+// String is part of the pflag.Value interface.
 func (td *TopoData) String() string {
 	return prototext.Format(td.vtTestTopology)
 }
 
+// Set is part of the pflag.Value interface.
 func (td *TopoData) Set(value string) error {
 	return td.unmarshal([]byte(value), td.vtTestTopology)
 }
 
-func TextTopoData(tpb *vttestpb.VTTestTopology) flag.Value {
+// Type is part of the pflag.Value interface.
+func (td *TopoData) Type() string { return "vttest.TopoData" }
+
+// TextTopoData returns a test TopoData that unmarshals using
+// prototext.Unmarshal.
+func TextTopoData(tpb *vttestpb.VTTestTopology) *TopoData {
 	return &TopoData{
 		vtTestTopology: tpb,
 		unmarshal:      prototext.Unmarshal,
 	}
 }
 
-func JSONTopoData(tpb *vttestpb.VTTestTopology) flag.Value {
+// JSONTopoData returns a test TopoData that unmarshals using
+// protojson.Unmarshal.
+func JSONTopoData(tpb *vttestpb.VTTestTopology) *TopoData {
 	return &TopoData{
 		vtTestTopology: tpb,
 		unmarshal:      protojson.Unmarshal,


### PR DESCRIPTION




<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Before, these helper functions explicitly returned the `flag.Value` type,
making it impossible to use with `pflag`. Attempting to do so would
produce compiler errors like:

```
cannot use vttest.JSONTopoData(&tpb) (value of type "flag".Value) as pflag.Value value in argument to pflag.Var: "flag".Value does not implement pflag.Value (missing method Type)
```

Changing the return type to the struct, which _implicitly_ implements both
`flag.Value` and `pflag.Value` allows us to use these function in both old
(`flag`) and new (`pflag`) Var functions.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Closes #10988 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
