### PR TITLE
`vtexplain` fails for vindex lookup queries with duplicate / equivalent values.

### DIFF
--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -201,3 +201,9 @@ SELECT user.id, user.name, name_info.info FROM user INNER JOIN music ON (user.id
 5 ks_sharded/80-c0: select name_info.info from name_info where name_info.`name` = 'name_val_1' limit 10001
 
 ----------------------------------------------------------------------
+SELECT id FROM orders WHERE id IN (1, "1", 1)
+
+1 ks_sharded/-40: select id, keyspace_id from orders_id_lookup where id in (1, '1', 1) limit 10001
+2 ks_sharded/40-80: select id from orders where id in (1, '1', 1) limit 10001
+
+----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/selectsharded-queries.sql
+++ b/go/vt/vtexplain/testdata/selectsharded-queries.sql
@@ -37,3 +37,5 @@ select id, 'abc' as test from user where id = 1 union all select id, 'def' as te
 select id from user where not id in (select col from music where music.user_id = 42) and id in (select col from music where music.user_id = 411);
 
 SELECT user.id, user.name, name_info.info FROM user INNER JOIN music ON (user.id = music.user_id) LEFT OUTER JOIN name_info ON (user.name = name_info.name);
+
+SELECT id FROM orders WHERE id IN (1, "1", 1)

--- a/go/vt/vtexplain/testdata/test-schema.sql
+++ b/go/vt/vtexplain/testdata/test-schema.sql
@@ -94,3 +94,14 @@ create table lkp_idx (
     id bigint,
     primary key (lkp)
 ) Engine=InnoDB;
+
+CREATE TABLE orders (
+  id bigint,
+	customer_id bigint
+);
+
+CREATE TABLE orders_id_lookup (
+  id int NOT NULL,
+  keyspace_id varbinary(128),
+  primary key(id)
+);

--- a/go/vt/vtexplain/testdata/test-vschema.json
+++ b/go/vt/vtexplain/testdata/test-vschema.json
@@ -9,6 +9,15 @@
 	"ks_sharded": {
 		"sharded": true,
 		"vindexes": {
+			"orders_id_vdx": {
+				"type": "lookup_unique",
+				"params": {
+					"table": "orders_id_lookup",
+					"from": "id",
+					"to": "keyspace_id"
+				},
+				"owner": "orders"
+			},
 			"music_user_map": {
 				"type": "lookup_hash_unique",
 				"owner": "music",
@@ -132,6 +141,26 @@
 					{
 						"column": "email",
 						"name": "email_customer_map"
+					}
+				]
+			},
+			"orders": {
+				"column_vindexes": [
+					{
+						"column": "customer_id",
+						"name": "hash"
+					},
+					{
+						"column": "id",
+						"name": "orders_id_vdx"
+					}
+				]
+			},
+			"orders_id_lookup": {
+				"column_vindexes": [
+					{
+						"column": "id",
+						"name": "hash"
 					}
 				]
 			},

--- a/go/vt/vtexplain/testdata/twopc-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/twopc-output/selectsharded-output.txt
@@ -87,3 +87,9 @@ select * from (select id from user) s /* scatter paren select */
 1 ks_sharded/c0-: select * from (select id from user) as s limit 10001 /* scatter paren select */
 
 ----------------------------------------------------------------------
+SELECT id FROM orders WHERE id IN (1, "1", 1)
+
+1 ks_sharded/-40: select id, keyspace_id from orders_id_lookup where id in (1, '1', 1) limit 10001
+2 ks_sharded/40-80: select id from orders where id in (1, '1', 1) limit 10001
+
+----------------------------------------------------------------------

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -25,9 +25,11 @@ import (
 	"sync"
 
 	"vitess.io/vitess/go/sqlescape"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vttablet/onlineddl"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -587,7 +589,8 @@ func (t *explainTablet) HandleQuery(c *mysql.Conn, query string, callback func(*
 
 		// the query against lookup table is in-query, handle it specifically
 		var inColName string
-		inVal := make([][]byte, 0, 10)
+		inVal := make([]sqltypes.Value, 0, 10)
+
 		rowCount := 1
 		if selStmt.Where != nil {
 			switch v := selStmt.Where.Expr.(type) {
@@ -595,12 +598,42 @@ func (t *explainTablet) HandleQuery(c *mysql.Conn, query string, callback func(*
 				if v.Operator == sqlparser.InOp {
 					switch c := v.Left.(type) {
 					case *sqlparser.ColName:
+						colName := strings.ToLower(c.Name.String())
+						colType := tableColumnMap[sqlparser.GetTableName(selStmt.From[0].(*sqlparser.AliasedTableExpr).Expr)][colName]
+
 						switch values := v.Right.(type) {
 						case sqlparser.ValTuple:
 							for _, val := range values {
 								switch v := val.(type) {
 								case *sqlparser.Literal:
-									inVal = append(inVal, v.Bytes())
+									value, err := evalengine.LiteralToValue(v)
+									if err != nil {
+										return err
+									}
+
+									// Cast the value in the tuple to the expected value of the column
+									castedValue, err := evalengine.Cast(value, colType)
+									if err != nil {
+										return err
+									}
+
+									// Check if we have a duplicate value
+									isNewValue := true
+									for _, v := range inVal {
+										result, err := evalengine.NullsafeCompare(v, value, collations.Default())
+										if err != nil {
+											return err
+										}
+
+										if result == 0 {
+											isNewValue = false
+											break
+										}
+									}
+
+									if isNewValue {
+										inVal = append(inVal, castedValue)
+									}
 								}
 							}
 							rowCount = len(inVal)
@@ -630,7 +663,7 @@ func (t *explainTablet) HandleQuery(c *mysql.Conn, query string, callback func(*
 				// a string type that encodes the column name + index.
 				colType := colTypes[i]
 				if len(inVal) > j && col == inColName {
-					values[i], _ = sqltypes.NewValue(querypb.Type_VARBINARY, inVal[j])
+					values[i], _ = sqltypes.NewValue(querypb.Type_VARBINARY, inVal[j].Raw())
 				} else if sqltypes.IsIntegral(colType) {
 					values[i] = sqltypes.NewInt32(int32(i + 1))
 				} else if sqltypes.IsFloat(colType) {


### PR DESCRIPTION
## Description

If a query contains an `IN` condition with multiple equivalent values for `lookup_unique` vindexes, `vtexplain` fails with:

```
Lookup.Map: unexpected multiple results from vindex <vindex>
```

This is due to `vtexplain` "simulating" that each value of the tuple in a lookup vindex query returns a result row, but when values are equivalent (e.g. `1` and `"1"`), only a single row should be returned.

I tried to implement this by determining the type of the column being matched against, converting each value of the tuple to that type, and then making sure `vtexplain` only considers non-duplicate values.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
