### PR TITLE
evalengine: support mismatched numerical types

### DIFF
--- a/go/test/endtoend/vtgate/gen4/gen4_test.go
+++ b/go/test/endtoend/vtgate/gen4/gen4_test.go
@@ -493,7 +493,5 @@ func TestFilterOnLeftOuterJoin(t *testing.T) {
 				  and team_fact.team >= 22
 				)`
 
-	// Ideally we should get `[[INT32(22)] [INT32(33)]]`
-	// Change the expectation when we support better conversion handling in numeric comparison.
-	utils.AssertContainsError(t, mcmp.VtConn, query, `unsupported: cannot compare INT32 and INT64`)
+	mcmp.AssertMatches(query, "[[INT32(22)] [INT32(33)]]")
 }

--- a/go/test/endtoend/vtgate/gen4/gen4_test.go
+++ b/go/test/endtoend/vtgate/gen4/gen4_test.go
@@ -479,8 +479,8 @@ func TestFilterOnLeftOuterJoin(t *testing.T) {
 	defer closer()
 
 	// insert some data.
-	utils.Exec(t, mcmp.VtConn, `insert into team (id, name) values (11, 'Acme'), (22, 'B'), (33, 'C')`)
-	utils.Exec(t, mcmp.VtConn, `insert into team_fact (id, team, fact) values (1, 11, 'A'), (2, 22, 'A'), (3, 33, 'A')`)
+	mcmp.Exec(`insert into team (id, name) values (11, 'Acme'), (22, 'B'), (33, 'C')`)
+	mcmp.Exec(`insert into team_fact (id, team, fact) values (1, 11, 'A'), (2, 22, 'A'), (3, 33, 'A')`)
 
 	// Gen4 only supported query.
 	query := `select team.id

--- a/go/vt/vtgate/engine/filter_test.go
+++ b/go/vt/vtgate/engine/filter_test.go
@@ -76,6 +76,18 @@ func TestFilterPass(t *testing.T) {
 		name:   "uint64_int64",
 		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "uint64|int64"), "0|1", "1|0", "2|3"),
 		expRes: `[[UINT64(1) INT64(0)]]`,
+	}, {
+		name:   "int32_uint32",
+		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "int32|uint32"), "0|1", "1|0", "2|3"),
+		expRes: `[[INT32(1) UINT32(0)]]`,
+	}, {
+		name:   "uint16_int8",
+		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "uint16|int8"), "0|1", "1|0", "2|3"),
+		expRes: `[[UINT16(1) INT8(0)]]`,
+	}, {
+		name:   "uint64_int32",
+		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "uint64|int32"), "0|1", "1|0", "2|3"),
+		expRes: `[[UINT64(1) INT32(0)]]`,
 	}}
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -86,45 +98,6 @@ func TestFilterPass(t *testing.T) {
 			qr, err := filter.TryExecute(context.Background(), &noopVCursor{}, nil, false)
 			require.NoError(t, err)
 			require.Equal(t, tc.expRes, fmt.Sprintf("%v", qr.Rows))
-		})
-	}
-}
-
-func TestFilterMixedFail(t *testing.T) {
-	predicate := &sqlparser.ComparisonExpr{
-		Operator: sqlparser.GreaterThanOp,
-		Left:     sqlparser.NewColName("left"),
-		Right:    sqlparser.NewColName("right"),
-	}
-
-	pred, err := evalengine.Translate(predicate, &dummyTranslator{})
-	require.NoError(t, err)
-
-	tcases := []struct {
-		name   string
-		res    *sqltypes.Result
-		expErr string
-	}{{
-		name:   "int32_uint32",
-		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "int32|uint32"), "0|1", "1|0", "2|3"),
-		expErr: `unsupported: cannot compare INT32 and UINT32`,
-	}, {
-		name:   "uint16_int8",
-		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "uint16|int8"), "0|1", "1|0", "2|3"),
-		expErr: `unsupported: cannot compare UINT16 and INT8`,
-	}, {
-		name:   "uint64_int32",
-		res:    sqltypes.MakeTestResult(sqltypes.MakeTestFields("a|b", "uint64|int32"), "0|1", "1|0", "2|3"),
-		expErr: `unsupported: cannot compare UINT64 and INT32`,
-	}}
-	for _, tc := range tcases {
-		t.Run(tc.name, func(t *testing.T) {
-			filter := &Filter{
-				Predicate: pred,
-				Input:     &fakePrimitive{results: []*sqltypes.Result{tc.res}},
-			}
-			_, err := filter.TryExecute(context.Background(), &noopVCursor{}, nil, false)
-			require.EqualError(t, err, tc.expErr)
 		})
 	}
 }

--- a/go/vt/vtgate/evalengine/comparisons_test.go
+++ b/go/vt/vtgate/evalengine/comparisons_test.go
@@ -446,6 +446,36 @@ func TestCompareNumerics(t *testing.T) {
 			out: &T, op: sqlparser.LessEqualOp,
 			row: []sqltypes.Value{sqltypes.NewDecimal("1.000101"), sqltypes.NewFloat64(1.00101)},
 		},
+		{
+			name: "different int types are equal for 8 bit",
+			v1:   NewColumn(0, defaultCollation()), v2: NewLiteralInt(0),
+			out: &T, op: sqlparser.EqualOp,
+			row: []sqltypes.Value{sqltypes.NewInt8(0)},
+		},
+		{
+			name: "different int types are equal for 32 bit",
+			v1:   NewColumn(0, defaultCollation()), v2: NewLiteralInt(0),
+			out: &T, op: sqlparser.EqualOp,
+			row: []sqltypes.Value{sqltypes.NewInt32(0)},
+		},
+		{
+			name: "different int types are equal for float32 bit",
+			v1:   NewColumn(0, defaultCollation()), v2: NewLiteralFloat(1.0),
+			out: &T, op: sqlparser.EqualOp,
+			row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Float32, []byte("1.0"))},
+		},
+		{
+			name: "different unsigned int types are equal for 8 bit",
+			v1:   NewColumn(0, defaultCollation()), v2: NewLiteralInt(0),
+			out: &T, op: sqlparser.EqualOp,
+			row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Uint8, []byte("0"))},
+		},
+		{
+			name: "different unsigned int types are equal for 32 bit",
+			v1:   NewColumn(0, defaultCollation()), v2: NewLiteralInt(0),
+			out: &T, op: sqlparser.EqualOp,
+			row: []sqltypes.Value{sqltypes.NewUint32(0)},
+		},
 	}
 
 	for i, tcase := range tests {

--- a/go/vt/vtgate/evalengine/eval_result.go
+++ b/go/vt/vtgate/evalengine/eval_result.go
@@ -836,6 +836,20 @@ func (er *EvalResult) makeNumeric() {
 	er.setFloat(parseStringToFloat(er.string()))
 }
 
+func (er *EvalResult) upcastNumeric() {
+	if !er.isNumeric() {
+		panic("upcastNumeric on non-numeric")
+	}
+	switch tt := er.typeof(); {
+	case sqltypes.IsSigned(tt):
+		er.type_ = int16(sqltypes.Int64)
+	case sqltypes.IsUnsigned(tt):
+		er.type_ = int16(sqltypes.Uint64)
+	case sqltypes.IsFloat(tt):
+		er.type_ = int16(sqltypes.Float64)
+	}
+}
+
 func (er *EvalResult) makeUnsignedIntegral() {
 	er.makeNumeric()
 	switch tt := er.typeof(); {

--- a/go/vt/vtgate/evalengine/evalengine.go
+++ b/go/vt/vtgate/evalengine/evalengine.go
@@ -201,14 +201,9 @@ func compareNumeric(v1, v2 *EvalResult) (int, error) {
 		}
 	}
 
-	// The types are not comparable.
-	if v1.typeof() != v2.typeof() {
-		return 0, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: cannot compare %v and %v", v1.typeof(), v2.typeof())
-	}
-
 	// Both values are of the same type.
 	switch v1.typeof() {
-	case sqltypes.Int8, sqltypes.Int16, sqltypes.Int24, sqltypes.Int32, sqltypes.Int64:
+	case sqltypes.Int64:
 		v1v, v2v := v1.int64(), v2.int64()
 		switch {
 		case v1v == v2v:
@@ -216,14 +211,14 @@ func compareNumeric(v1, v2 *EvalResult) (int, error) {
 		case v1v < v2v:
 			return -1, nil
 		}
-	case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint24, sqltypes.Uint32, sqltypes.Uint64:
+	case sqltypes.Uint64:
 		switch {
 		case v1.uint64() == v2.uint64():
 			return 0, nil
 		case v1.uint64() < v2.uint64():
 			return -1, nil
 		}
-	case sqltypes.Float32, sqltypes.Float64:
+	case sqltypes.Float64:
 		v1v, v2v := v1.float64(), v2.float64()
 		switch {
 		case v1v == v2v:

--- a/go/vt/vtgate/evalengine/evalengine.go
+++ b/go/vt/vtgate/evalengine/evalengine.go
@@ -138,6 +138,11 @@ func ToNative(v sqltypes.Value) (any, error) {
 }
 
 func compareNumeric(v1, v2 *EvalResult) (int, error) {
+	// upcast all <64 bit numeric types to 64 bit, e.g. int8 -> int64, uint8 -> uint64, float32 -> float64
+	// so we don't have to consider integer types which aren't 64 bit
+	v1.upcastNumeric()
+	v2.upcastNumeric()
+
 	// Equalize the types the same way MySQL does
 	// https://dev.mysql.com/doc/refman/8.0/en/type-conversion.html
 	switch v1.typeof() {


### PR DESCRIPTION
## Description

Found this while working on some internal stuff. The `evalengine` does not properly handle mismatched numeric types because we were not properly normalizing. E.g. an UINT8(0) would fail to compare equally to an UINT64(0), even though an INT8(0) would actually compare equally to a UINT64(0). This PR fixes this issue by upcasting all comparison types before performing a numeric comparison.

It probably requires a backport. 

cc @systay @deepthi 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
