### PR TITLE
Add more robust go version handling

### DIFF
--- a/tools/shell_functions.inc
+++ b/tools/shell_functions.inc
@@ -16,13 +16,14 @@
 
 # Library of functions which are used by bootstrap.sh or the Makefile.
 
-# goversion_min returns true if major.minor go version is at least some value.
+# goversion_min returns true if the installed go version is at least
+# the version passed as the first parameter
 function goversion_min() {
-  [[ "$(go version)" =~ go([0-9]+)\.([0-9]+)\.([0-9]+) ]]
+  [[ "$(go version)" =~ go([0-9]+)[\.]?([0-9]*)[\.]?([0-9]*) ]]
   gotmajor=${BASH_REMATCH[1]}
   gotminor=${BASH_REMATCH[2]}
   gotpatch=${BASH_REMATCH[3]}
-  [[ "$1" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]
+  [[ "$1" =~ ([0-9]+)[\.]?([0-9]*)[\.]?([0-9]*) ]]
   wantmajor=${BASH_REMATCH[1]}
   wantminor=${BASH_REMATCH[2]}
   wantpatch=${BASH_REMATCH[3]}
@@ -30,8 +31,8 @@ function goversion_min() {
   [[ $gotmajor -gt $wantmajor ]] && return 0
   [[ $gotminor -lt $wantminor ]] && return 1
   [[ $gotminor -gt $wantminor ]] && return 0
-  [[ $gotpatch -lt $wantpatch ]] && return 1
-  return 0
+  [[ $gotpatch -ge $wantpatch ]] && return 0
+  return 1
 }
 
 # prepend_path returns $2 prepended the colon separated path $1.


### PR DESCRIPTION
## Description

[Go 1.19](https://tip.golang.org/doc/go1.19) was just released and as reported in https://github.com/vitessio/vitess/issues/11000 it caused builds to fail when installed:
```
ERROR: Go version reported: go version go1.19 linux/amd64. Version 1.18.4+ required. See https://vitess.io/contributing/build-from-source for install instructions.
make: *** [Makefile:85: build] Error 1
```

To demonstrate the new handling added in this PR:
```
$ go version
go version go1.19 darwin/arm64

$ bash -c 'source ./tools/shell_functions.inc && goversion_min || fail "No good"'

$ bash -c 'source ./tools/shell_functions.inc && goversion_min 1 || fail "No good"'

$ bash -c 'source ./tools/shell_functions.inc && goversion_min 2 || fail "No good"'
ERROR: No good

$ bash -c 'source ./tools/shell_functions.inc && goversion_min 1.18.9999-foo || fail "No good"'

$ bash -c 'source ./tools/shell_functions.inc && goversion_min 1.19 || fail "No good"'

$ bash -c 'source ./tools/shell_functions.inc && goversion_min 1.19.0 || fail "No good"'

$ bash -c 'source ./tools/shell_functions.inc && goversion_min 1.19.1 || fail "No good"'
ERROR: No good

$ bash -c 'source ./tools/shell_functions.inc && goversion_min 1.19.55-dev || fail "No good"'
ERROR: No good

$ bash -c 'source ./tools/shell_functions.inc && goversion_min 1.20 || fail "No good"'
ERROR: No good

$ bash -c 'source ./tools/shell_functions.inc && goversion_min 1.20.2 || fail "No good"'
ERROR: No good
```

## Related Issue(s)
  - Fixes: https://github.com/vitessio/vitess/issues/11000

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests are not required
-   [x] Documentation is not required