### PR TITLE
Flakes: Expect SERVING status for tablets added to shard with a PRIMARY

### DIFF
--- a/go/test/endtoend/topoconncache/main_test.go
+++ b/go/test/endtoend/topoconncache/main_test.go
@@ -89,7 +89,9 @@ var (
 	shard2 cluster.Shard
 )
 
-/* This end-to-end test validates the cache fix in topo/server.go inside ConnForCell.
+/*
+	This end-to-end test validates the cache fix in topo/server.go inside ConnForCell.
+
 The issue was, if we delete and add back a cell with same name but at different path, the map of cells
 in server.go returned the connection object of the previous cell instead of newly-created one
 with the same name.

--- a/go/test/endtoend/topoconncache/topo_conn_cache_test.go
+++ b/go/test/endtoend/topoconncache/topo_conn_cache_test.go
@@ -164,12 +164,16 @@ func addCellback(t *testing.T) {
 
 	for _, tablet := range []*cluster.Vttablet{shard1Replica, shard1Rdonly} {
 		tablet.VttabletProcess.Shard = shard1.Name
+		// The tablet should come up as serving since the primary for the shard already exists
+		tablet.VttabletProcess.ServingStatus = "SERVING"
 		err := tablet.VttabletProcess.Setup()
 		require.NoError(t, err)
 	}
 
 	for _, tablet := range []*cluster.Vttablet{shard2Replica, shard2Rdonly} {
 		tablet.VttabletProcess.Shard = shard2.Name
+		// The tablet should come up as serving since the primary for the shard already exists
+		tablet.VttabletProcess.ServingStatus = "SERVING"
 		err := tablet.VttabletProcess.Setup()
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
## Description

This is the same basic fix made to other tests in: https://github.com/vitessio/vitess/pull/10961

When [re-]adding replica and rdonly tablets to a shard with a healthy serving PRIMARY tablet, they quickly become SERVING. This led to a timing issue where we added them and waited for them to become NON_SERVING, but they became SERVING by the time we checked.

## Related Issue(s)

  - Related to: https://github.com/vitessio/vitess/pull/10961

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required