### PR TITLE
schemadiff: FullTextKeyStrategy, handling multiple 'ADD FULLTEXT key' alter options

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -1180,14 +1180,12 @@ func (c *CreateTableEntity) diffKeys(alterTable *sqlparser.AlterTable,
 			if t2Key.Info.Fulltext {
 				if addedFulltextKeys > 0 && hints.FullTextKeyStrategy == FullTextKeyDistinctStatements {
 					// Special case: MySQL does not support multiple ADD FULLTEXT KEY statements in a single ALTER
-					fmt.Printf("Added  superfluous key: %v\n", sqlparser.CanonicalString(t2Key))
 					superfluousFulltextKeys = append(superfluousFulltextKeys, addKey)
 					addedAsSuperfluousStatement = true
 				}
 				addedFulltextKeys++
 			}
 			if !addedAsSuperfluousStatement {
-				fmt.Printf("Added key: %v\n", sqlparser.CanonicalString(t2Key))
 				alterTable.AlterOptions = append(alterTable.AlterOptions, addKey)
 			}
 		}

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -621,7 +621,9 @@ func (c *CreateTableEntity) TableDiff(other *CreateTableEntity, hints *DiffHints
 		Table: otherStmt.Table,
 	}
 	diffedTableCharset := ""
+	var parentAlterTableEntityDiff *AlterTableEntityDiff
 	var partitionSpecs []*sqlparser.PartitionSpec
+	var superfluousFulltextKeys []*sqlparser.AddIndexDefinition
 	{
 		t1Options := c.CreateTable.TableSpec.Options
 		t2Options := other.CreateTable.TableSpec.Options
@@ -639,7 +641,7 @@ func (c *CreateTableEntity) TableDiff(other *CreateTableEntity, hints *DiffHints
 		// ordered keys for both tables:
 		t1Keys := c.CreateTable.TableSpec.Indexes
 		t2Keys := other.CreateTable.TableSpec.Indexes
-		c.diffKeys(alterTable, t1Keys, t2Keys, hints)
+		superfluousFulltextKeys = c.diffKeys(alterTable, t1Keys, t2Keys, hints)
 	}
 	{
 		// diff constraints
@@ -668,10 +670,19 @@ func (c *CreateTableEntity) TableDiff(other *CreateTableEntity, hints *DiffHints
 			return nil, err
 		}
 	}
-	var parentAlterTableEntityDiff *AlterTableEntityDiff
 	tableSpecHasChanged := len(alterTable.AlterOptions) > 0 || alterTable.PartitionOption != nil || alterTable.PartitionSpec != nil
 	if tableSpecHasChanged {
 		parentAlterTableEntityDiff = &AlterTableEntityDiff{alterTable: alterTable, from: c, to: other}
+	}
+	for _, superfluousFulltextKey := range superfluousFulltextKeys {
+		alterTable := &sqlparser.AlterTable{
+			Table:        otherStmt.Table,
+			AlterOptions: []sqlparser.AlterOption{superfluousFulltextKey},
+		}
+		diff := &AlterTableEntityDiff{alterTable: alterTable, from: c, to: other}
+		// if we got superfluous fulltext keys, that means the table spec has changed, ie
+		// parentAlterTableEntityDiff is not nil
+		parentAlterTableEntityDiff.addSubsequentDiff(diff)
 	}
 	for _, partitionSpec := range partitionSpecs {
 		alterTable := &sqlparser.AlterTable{
@@ -1103,7 +1114,7 @@ func (c *CreateTableEntity) diffKeys(alterTable *sqlparser.AlterTable,
 	t1Keys []*sqlparser.IndexDefinition,
 	t2Keys []*sqlparser.IndexDefinition,
 	hints *DiffHints,
-) {
+) (superfluousFulltextKeys []*sqlparser.AddIndexDefinition) {
 	t1KeysMap := map[string]*sqlparser.IndexDefinition{}
 	t2KeysMap := map[string]*sqlparser.IndexDefinition{}
 	for _, key := range t1Keys {
@@ -1134,6 +1145,7 @@ func (c *CreateTableEntity) diffKeys(alterTable *sqlparser.AlterTable,
 		}
 	}
 
+	addedFulltextKeys := 0
 	for _, t2Key := range t2Keys {
 		t2KeyName := t2Key.Info.Name.String()
 		// evaluate modified & added keys:
@@ -1164,9 +1176,23 @@ func (c *CreateTableEntity) diffKeys(alterTable *sqlparser.AlterTable,
 			addKey := &sqlparser.AddIndexDefinition{
 				IndexDefinition: t2Key,
 			}
-			alterTable.AlterOptions = append(alterTable.AlterOptions, addKey)
+			addedAsSuperfluousStatement := false
+			if t2Key.Info.Fulltext {
+				if addedFulltextKeys > 0 && hints.FullTextKeyStrategy == FullTextKeyDistinctStatements {
+					// Special case: MySQL does not support multiple ADD FULLTEXT KEY statements in a single ALTER
+					fmt.Printf("Added  superfluous key: %v\n", sqlparser.CanonicalString(t2Key))
+					superfluousFulltextKeys = append(superfluousFulltextKeys, addKey)
+					addedAsSuperfluousStatement = true
+				}
+				addedFulltextKeys++
+			}
+			if !addedAsSuperfluousStatement {
+				fmt.Printf("Added key: %v\n", sqlparser.CanonicalString(t2Key))
+				alterTable.AlterOptions = append(alterTable.AlterOptions, addKey)
+			}
 		}
 	}
+	return superfluousFulltextKeys
 }
 
 // indexOnlyVisibilityChange checks whether the change on an index is only

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -81,6 +81,11 @@ const (
 	TableRenameHeuristicStatement
 )
 
+const (
+	FullTextKeyDistinctStatements = iota
+	FullTextKeyUnifyStatements
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
 	StrictIndexOrdering     bool
@@ -89,4 +94,5 @@ type DiffHints struct {
 	ConstraintNamesStrategy int
 	ColumnRenameStrategy    int
 	TableRenameStrategy     int
+	FullTextKeyStrategy     int
 }


### PR DESCRIPTION

## Description

MySQL does not support multiple `ADD FULLTEXT KEY` clauses in the same `ALTER TABLE` statement.

`schemadiff` now supports a `FullTextKeyStrategy` with the following options:

- `FullTextKeyDistinctStatements` (default): generate distinct `ALTER` statements when there's more than one `ADD FULLTEXT` clause; these statements will be valid to run on MySQL
- `FullTextKeyUnifyStatements`, generate a single `ALTER` statement with multiple `ADD FULLTEXT` clauses. Reasons to use this strategy:
  - We will make this statement valid for Vitess's Online DDL
  - MySQL may remove this limitation in the future.

Tests added.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/10203
- https://github.com/vitessio/vitess/issues/6926

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
