### PR TITLE
Add additional tests for EOF packet checks

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1371,14 +1371,9 @@ func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
 // packet and not multiple, but otherwise 0xfe definitely indicates it is an EOF.
 //
 // Per https://dev.mysql.com/doc/internals/en/packet-EOF_Packet.html, a packet starting with 0xfe
-// but having length >= 9 (on top of 4 byte header) is not a true EOF but a LengthEncodedInteger
-// (typically preceding a LengthEncodedString). Thus, all EOF checks must validate the payload size
-// before exiting.
-//
-// More specifically, an EOF packet can have 3 different lengths (1, 5, 7) depending on the client
-// flags that are set. 7 comes from server versions of 5.7.5 or greater where ClientDeprecateEOF is
-// set (i.e. uses an OK packet starting with 0xfe instead of 0x00 to signal EOF). Regardless, 8 is
-// an upper bound otherwise it would be ambiguous w.r.t. LengthEncodedIntegers.
+// but having length >= 9 (on top of 4 byte header)  without DEPRECATE_EOF set is not a true EOF but
+// a LengthEncodedInteger (typically preceding a LengthEncodedString). Thus, all EOF checks without
+// DEPRECATE_EOF must validate the payload size before exiting.
 //
 // More docs here:
 // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_response_packets.html


### PR DESCRIPTION
Also updates the comment to be more specific that the additional length check is only there if DEPRECATE_EOF is set.

## Description

Follow-up to https://github.com/vitessio/vitess/pull/10871 to add some additional coverage. 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required