### PR TITLE
Use the correct error type for dependencies

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -560,7 +560,7 @@ func TestDiffSchemas(t *testing.T) {
 			name:        "create view: unresolved dependencies",
 			from:        "create table t(id int)",
 			to:          "create table t(id int); create view v1 as select id from t2",
-			expectError: (&ApplyViewNotFoundError{View: "v1"}).Error(),
+			expectError: (&ViewDependencyUnresolvedError{View: "v1"}).Error(),
 		},
 		{
 			name: "convert table to view",

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -234,7 +234,7 @@ func (s *Schema) normalize() error {
 			if _, ok := dependencyLevels[v.Name()]; !ok {
 				// We _know_ that in this iteration, at least one view is found unassigned a dependency level.
 				// We return the first one.
-				return &ApplyViewNotFoundError{View: v.ViewName.Name.String()}
+				return &ViewDependencyUnresolvedError{View: v.ViewName.Name.String()}
 			}
 		}
 	}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -110,7 +110,7 @@ func TestNewSchemaFromQueriesUnresolved(t *testing.T) {
 	)
 	_, err := NewSchemaFromQueries(queries)
 	assert.Error(t, err)
-	assert.EqualError(t, err, (&ApplyViewNotFoundError{View: "v7"}).Error())
+	assert.EqualError(t, err, (&ViewDependencyUnresolvedError{View: "v7"}).Error())
 }
 
 func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {
@@ -120,7 +120,7 @@ func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {
 	)
 	_, err := NewSchemaFromQueries(queries)
 	assert.Error(t, err)
-	assert.EqualError(t, err, (&ApplyViewNotFoundError{View: "v7"}).Error())
+	assert.EqualError(t, err, (&ViewDependencyUnresolvedError{View: "v7"}).Error())
 }
 
 func TestNewSchemaFromQueriesLoop(t *testing.T) {
@@ -131,7 +131,7 @@ func TestNewSchemaFromQueriesLoop(t *testing.T) {
 	)
 	_, err := NewSchemaFromQueries(queries)
 	assert.Error(t, err)
-	assert.EqualError(t, err, (&ApplyViewNotFoundError{View: "v7"}).Error())
+	assert.EqualError(t, err, (&ViewDependencyUnresolvedError{View: "v7"}).Error())
 }
 
 func TestToSQL(t *testing.T) {


### PR DESCRIPTION
This was using accidentally the wrong error type that was for views not found during diff application. Nothing was using this new error type yet, which is incorrect.

## Related Issue(s)

Changed in https://github.com/vitessio/vitess/pull/10940 which added the type but didn't use it. 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required