### PR TITLE
refactor: group all system setting query into single set statement

### DIFF
--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -384,18 +383,9 @@ func TestSetSystemVariables(t *testing.T) {
 
 	wantQueries = []*querypb.BoundQuery{
 		{Sql: "select 1 from dual where @@max_tmp_tables != 1"},
-		{Sql: "set @@sql_mode = 'only_full_group_by'", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
-		{Sql: "set @@sql_safe_updates = '0'", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
-		{Sql: "set @@max_tmp_tables = '1'", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
+		{Sql: "set @@max_tmp_tables = '1', @@sql_mode = 'only_full_group_by', @@sql_safe_updates = '0'", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
 		{Sql: "select :vtg1 from information_schema.`table`", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
 	}
-
-	sort.Slice(wantQueries, func(i, j int) bool {
-		return wantQueries[i].Sql < wantQueries[j].Sql
-	})
-	sort.Slice(lookup.Queries, func(i, j int) bool {
-		return lookup.Queries[i].Sql < lookup.Queries[j].Sql
-	})
 	utils.MustMatch(t, wantQueries, lookup.Queries)
 }
 

--- a/go/vt/vtgate/legacy_scatter_conn_test.go
+++ b/go/vt/vtgate/legacy_scatter_conn_test.go
@@ -575,7 +575,7 @@ func TestReservePrequeries(t *testing.T) {
 	destinations := []key.Destination{key.DestinationShard("0")}
 
 	executeOnShards(t, res, keyspace, sc, session, destinations)
-	assert.Equal(t, 2+1, len(sbc0.StringQueries()))
+	assert.Equal(t, 1+1, len(sbc0.StringQueries()))
 }
 
 func newTestScatterConn(hc discovery.HealthCheck, serv srvtopo.Server, cell string) *ScatterConn {

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -18,17 +18,16 @@ package vtgate
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/vt/sqlparser"
-
-	"vitess.io/vitess/go/vt/vtgate/engine"
-
 	"google.golang.org/protobuf/proto"
 
+	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/engine"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -543,13 +542,31 @@ func (session *SafeSession) SetReservedConn(reservedConn bool) {
 func (session *SafeSession) SetPreQueries() []string {
 	session.mu.Lock()
 	defer session.mu.Unlock()
-	result := make([]string, len(session.SystemVariables))
-	idx := 0
-	for k, v := range session.SystemVariables {
-		result[idx] = fmt.Sprintf("set @@%s = %s", k, v)
-		idx++
+
+	if len(session.SystemVariables) == 0 {
+		return nil
 	}
-	return result
+
+	// extract keys
+	keys := make([]string, 0, len(session.SystemVariables))
+	for k := range session.SystemVariables {
+		keys = append(keys, k)
+	}
+	// sort the keys
+	sort.Strings(keys)
+
+	// build the query using sorted keys
+	var preQuery strings.Builder
+	first := true
+	for _, k := range keys {
+		if first {
+			preQuery.WriteString(fmt.Sprintf("set @@%s = %s", k, session.SystemVariables[k]))
+			first = false
+		} else {
+			preQuery.WriteString(fmt.Sprintf(", @@%s = %s", k, session.SystemVariables[k]))
+		}
+	}
+	return []string{preQuery.String()}
 }
 
 // SetLockSession sets the lock session.

--- a/go/vt/vtgate/safe_session_test.go
+++ b/go/vt/vtgate/safe_session_test.go
@@ -57,13 +57,10 @@ func TestPrequeries(t *testing.T) {
 		},
 	})
 
-	q1 := "set @@s1 = 'apa'"
-	q2 := "set @@s2 = 42"
-	want := []string{q1, q2}
-	wantReversed := []string{q2, q1}
+	want := []string{"set @@s1 = 'apa', @@s2 = 42"}
 	preQueries := session.SetPreQueries()
 
-	if !reflect.DeepEqual(want, preQueries) && !reflect.DeepEqual(wantReversed, preQueries) {
+	if !reflect.DeepEqual(want, preQueries) {
 		t.Errorf("got %v but wanted %v", preQueries, want)
 	}
 }


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR sends the multiple set statements into a single set statement to vttablet.
This will avoid multiple round trips at vttablet-mysql with a single call.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

- #9706 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
