### PR TITLE
Run upgrade/downgrade tests on main

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name == 'pull_request'
+    if: always()
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name == 'pull_request'
+    if: always()
     name: Get a recent LTS release
     runs-on: ubuntu-20.04
     outputs:

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name == 'pull_request'
+    if: always()
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name == 'pull_request'
+    if: always()
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name == 'pull_request'
+    if: always()
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   get_previous_release:
-    if: always() && github.event_name == 'pull_request'
+    if: always()
     name: Get latest release
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Description

This PR enables upgrade downgrade tests on the `main` branch of this repository. It was previously disabled to ensure we ran the tests only when the `Skip Upgrade/Downgrade tests` label was not set. But since we have removed this assertion, we can safely re-run the tests on `main`.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
