### PR TITLE
Add upgrade-downgrade tests for next releases

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -1,0 +1,193 @@
+name: Upgrade Downgrade Testing - Backups - E2E - Next Release
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing - Backups - E2E - Next Release')
+  cancel-in-progress: true
+
+jobs:
+  get_next_release:
+    if: always()
+    name: Get latest release
+    runs-on: ubuntu-latest
+    outputs:
+      next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
+
+    steps:
+      - name: Check out to HEAD
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set output with latest release branch
+        id: output-next-release-ref
+        run: |
+          next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $next_release_ref
+          echo "::set-output name=next_release_ref::${next_release_ref}"
+
+  upgrade_downgrade_test_e2e:
+    timeout-minutes: 60
+    if: always() && needs.get_next_release.result == 'success'
+    name: Run Upgrade Downgrade Test
+    runs-on: ubuntu-18.04
+    needs:
+      - get_next_release
+
+    steps:
+    - name: Check if workflow needs to be skipped
+      id: skip-workflow
+      run: |
+        skip='false'
+        if [[ "${{github.event.pull_request}}" ==  "" ]] && [[ "${{github.ref}}" != "refs/heads/main" ]] && [[ ! "${{github.ref}}" =~ ^refs/heads/release-[0-9]+\.[0-9]$ ]] && [[ ! "${{github.ref}}" =~ "refs/tags/.*" ]]; then
+          skip='true'
+        fi
+        if [[ "${{needs.get_next_release.outputs.next_release}}" == "" ]]; then
+          skip='true'
+        fi
+        echo Skip ${skip}
+        echo "::set-output name=skip-workflow::${skip}"
+
+    - name: Check out commit's code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
+      uses: frouioui/paths-filter@main
+      id: changes
+      with:
+        token: ''
+        filters: |
+          end_to_end:
+            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+            - '.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml'
+
+    - name: Set up Go
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.4
+
+    - name: Set up python
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/setup-python@v2
+
+    - name: Tune the OS
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+
+    - name: Get base dependencies
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        go mod download
+
+        # install JUnit report formatter
+        go install github.com/vitessio/go-junit-report@HEAD
+
+        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get install -y gnupg2
+        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get update
+        sudo apt-get install percona-xtrabackup-24
+
+    # Checkout to the next release of Vitess
+    - name: Check out other version's code (${{ needs.get_next_release.outputs.next_release }})
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ needs.get_next_release.outputs.next_release }}
+
+    - name: Get dependencies for the next release
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building next release's binaries
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-other/
+        cp -R bin /tmp/vitess-build-other/
+        rm -Rf bin/*
+
+    # Checkout to this build's commit
+    - name: Check out commit's code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@v2
+
+    - name: Get dependencies for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building the binaries for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-current/
+        cp -R bin /tmp/vitess-build-current/
+
+    # Swap binaries, use next release's VTTablet
+    - name: Use next release's VTTablet
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env
+
+        rm -f $PWD/bin/vttablet
+        cp /tmp/vitess-build-other/bin/vttablet $PWD/bin/vttablet
+        vttablet --version
+
+    # Run test with VTTablet at version N+1 and VTBackup at version N
+    - name: Run backups tests (vttablet=N+1, vtbackup=N)
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+        set -x
+        source build.env
+        eatmydata -- go run test.go -skip-build -docker=false -print-log -follow -tag upgrade_downgrade_backups
+
+    # Swap binaries again, use current version's VTTablet, and next release's VTBackup
+    - name: Use current version VTTablet, and other version VTBackup
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env
+
+        rm -f $PWD/bin/vtbackup $PWD/bin/vttablet
+        cp /tmp/vitess-build-current/bin/vtbackup $PWD/bin/vtbackup
+        cp /tmp/vitess-build-other/bin/vttablet $PWD/bin/vttablet
+        vtbackup --version
+        vttablet --version
+
+    # Run test again with VTTablet at version N, and VTBackup at version N+1
+    - name: Run backups tests (vttablet=N, vtbackup=N+1)
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+        set -x
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_backups

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -1,0 +1,330 @@
+name: Upgrade Downgrade Testing - Backups - Manual - Next Release
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing - Backups - Manual - Next Release')
+  cancel-in-progress: true
+
+jobs:
+  get_next_release:
+    if: always()
+    name: Get a recent LTS release
+    runs-on: ubuntu-20.04
+    outputs:
+      next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
+
+    steps:
+      - name: Check out to HEAD
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set output with latest release branch
+        id: output-next-release-ref
+        run: |
+          next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $next_release_ref
+          echo "::set-output name=next_release_ref::${next_release_ref}"
+
+  # This job usually execute in ± 20 minutes
+  upgrade_downgrade_test_manual:
+    timeout-minutes: 40
+    if: always() && (needs.get_next_release.result == 'success')
+    name: Run Upgrade Downgrade Test
+    runs-on: ubuntu-20.04
+    needs:
+      - get_next_release
+
+    steps:
+    - name: Check if workflow needs to be skipped
+      id: skip-workflow
+      run: |
+        skip='false'
+        if [[ "${{github.event.pull_request}}" ==  "" ]] && [[ "${{github.ref}}" != "refs/heads/main" ]] && [[ ! "${{github.ref}}" =~ ^refs/heads/release-[0-9]+\.[0-9]$ ]] && [[ ! "${{github.ref}}" =~ "refs/tags/.*" ]]; then
+          skip='true'
+        fi
+        if [[ "${{needs.get_next_release.outputs.next_release}}" == "" ]]; then
+          skip='true'
+        fi
+        echo Skip ${skip}
+        echo "::set-output name=skip-workflow::${skip}"
+
+    # Checkout to this build's commit
+    - name: Checkout to commit's code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
+      uses: frouioui/paths-filter@main
+      id: changes
+      with:
+        token: ''
+        filters: |
+          end_to_end:
+            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+            - '.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml'
+
+    - name: Set up Go
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.4
+
+    - name: Set up python
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/setup-python@v2
+
+    - name: Tune the OS
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+
+    # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
+    - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+    # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
+
+    - name: Get base dependencies
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+        # Uninstall any nextly installed MySQL first
+        sudo systemctl stop apparmor
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
+        sudo apt-get -y autoremove
+        sudo apt-get -y autoclean
+        sudo deluser mysql
+        sudo rm -rf /var/lib/mysql
+        sudo rm -rf /etc/mysql
+
+        # Install MySQL 8.0
+        ####
+        ## Temporarily pin the MySQL version at 8.0.29 as Vitess 14.0.1 does not have the fix to support
+        ## backups of 8.0.30+. See: https://github.com/vitessio/vitess/pull/10847
+        ## TODO: remove this pin once the above fixes are included in a v14 release (will be in v14.0.2) OR
+        ##       Vitess 16.0.0-SNAPSHOT becomes the dev version on vitessio/main
+        #sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+        #wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        #echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        #sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+        #sudo apt-get update
+        #sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+        ####
+        wget -c https://cdn.mysql.com/archives/mysql-8.0/mysql-common_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-core_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-plugins_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-client_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-server-core_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-server_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client_8.0.28-1ubuntu20.04_amd64.deb
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y ./mysql-*.deb
+
+        # Install everything else we need, and configure
+        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata grep
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+
+        # install JUnit report formatter
+        go install github.com/vitessio/go-junit-report@HEAD
+
+        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get install -y gnupg2
+        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get update
+        sudo apt-get install percona-xtrabackup-24
+
+    # Checkout to the next release of Vitess
+    - name: Checkout to the other version's code (${{ needs.get_next_release.outputs.next_release }})
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ needs.get_next_release.outputs.next_release }}
+
+    - name: Get dependencies for the next release
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building next release's binaries
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
+      run: |
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-other/
+        cp -R bin /tmp/vitess-build-other/
+        rm -Rf bin/*
+
+    # Checkout to this build's commit
+    - name: Checkout to commit's code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@v2
+
+    - name: Get dependencies for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Run make minimaltools
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        make minimaltools
+
+    - name: Building the binaries for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
+      run: |
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-current/
+        cp -R bin /tmp/vitess-build-current/
+
+    # We create a sharded Vitess cluster following the local example.
+    # We also insert a few rows in our three tables.
+    - name: Create the example Vitess cluster with all components using version N
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
+      run: |
+        source build.env ; cd examples/local
+        ./backups/start_cluster.sh
+
+    # Taking a backup
+    - name: Take a backup of all the shards
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 2
+      run: |
+        source build.env ; cd examples/local
+        ./backups/take_backups.sh
+
+    # We insert more data in every table after the backup.
+    # When we restore the backup made in the next step, we do not want to see the rows we are about to insert now.
+    # The initial number of rows for each table is:
+    #     - customer: 5
+    #     - product:  2
+    #     - corder:   5
+    # We shall see the same number of rows after restoring the backup.
+    - name: Insert more data after the backup
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env ; cd examples/local ; source ./env.sh
+
+        echo "insert into customer(email) values('new_user_1@domain.com');" | mysql
+        echo "insert into product(sku, description, price) values('SKU-1009', 'description', 89);" | mysql
+        echo "insert into corder(customer_id, sku, price) values(1, 'SKU-1009', 100);" | mysql
+
+    # Stop all the tablets and remove their data
+    - name: Stop tablets
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
+      run: |
+        source build.env ; cd examples/local
+        ./backups/stop_tablets.sh
+
+    # We downgrade: we use the version N+1 of vttablet
+    - name: Downgrade - Swap binaries, use VTTablet N+1
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env
+
+        rm -f $PWD/bin/vttablet
+        cp /tmp/vitess-build-other/bin/vttablet $PWD/bin/vttablet
+        vttablet --version
+
+    # Starting the tablets again, they will automatically start restoring the last backup.
+    - name: Start new tablets and restore
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
+      run: |
+        source build.env ; cd examples/local
+        ./backups/restart_tablets.sh
+        # give enough time to the tablets to restore the backup
+        sleep 60
+
+    # Count the number of rows in each table to make sure the restoration is successful.
+    - name: Assert the number of rows in every table
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env ; cd examples/local ; source ./env.sh
+
+        echo "select count(sku) from product;" | mysql 2>&1| grep 2
+        echo "select count(email) from customer;" | mysql 2>&1| grep 5
+        echo "select count(sku) from corder;" | mysql 2>&1| grep 5
+
+    # We insert one more row in every table.
+    - name: Insert more rows in the tables
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env ; cd examples/local ; source ./env.sh
+
+        echo "insert into customer(email) values('new_user_2@domain.com');" | mysql
+        echo "insert into product(sku, description, price) values('SKU-1011', 'description', 111);" | mysql
+        echo "insert into corder(customer_id, sku, price) values(1, 'SKU-1011', 111);" | mysql
+
+    # Taking a second backup of the cluster.
+    - name: Take a second backup of all the shards
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 2
+      run: |
+        source build.env ; cd examples/local
+        ./backups/take_backups.sh
+
+    # Stopping the tablets so we can perform the upgrade.
+    - name: Stop tablets
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
+      run: |
+        source build.env ; cd examples/local
+        ./backups/stop_tablets.sh
+
+    # We upgrade: we swap binaries and use the version N of the tablet.
+    - name: Upgrade - Swap binaries, use VTTablet N
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env
+
+        rm -f $PWD/bin/vttablet
+        cp /tmp/vitess-build-current/bin/vttablet $PWD/bin/vttablet
+        vttablet --version
+
+    # Starting the tablets again and restoring the next backup.
+    - name: Start new tablets and restore
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
+      run: |
+        source build.env ; cd examples/local
+        ./backups/restart_tablets.sh
+        # give enough time to the tablets to restore the backup
+        sleep 60
+
+    # We count the number of rows in every table to check that the restore step was successful.
+    - name: Assert the number of rows in every table
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env ; cd examples/local ; source ./env.sh
+
+        echo "select count(sku) from product;" | mysql 2>&1| grep 3
+        echo "select count(email) from customer;" | mysql 2>&1| grep 6
+        echo "select count(sku) from corder;" | mysql 2>&1| grep 6
+
+    - name: Stop the Vitess cluster
+      if: always() && steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env ; cd examples/local
+        ./401_teardown.sh || true

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -1,22 +1,22 @@
-name: Upgrade Downgrade Testing Query Serving (Queries)
+name: Upgrade Downgrade Testing Query Serving (Queries) Next Release
 on:
   push:
   pull_request:
 
 concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing Query Serving (Queries)')
+  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing Query Serving (Queries) Next Release')
   cancel-in-progress: true
 
 # This test ensures that our end-to-end tests work using Vitess components
 # (vtgate, vttablet, etc) built on different versions.
 
 jobs:
-  get_previous_release:
+  get_next_release:
     if: always()
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:
-      previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
+      next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
     steps:
       - name: Check out to HEAD
@@ -25,18 +25,18 @@ jobs:
           fetch-depth: 0
 
       - name: Set output with latest release branch
-        id: output-previous-release-ref
+        id: output-next-release-ref
         run: |
-          previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
-          echo $previous_release_ref
-          echo "::set-output name=previous_release_ref::${previous_release_ref}"
+          next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $next_release_ref
+          echo "::set-output name=next_release_ref::${next_release_ref}"
 
   upgrade_downgrade_test:
-    if: always() && (needs.get_previous_release.result == 'success')
+    if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:
-      - get_previous_release
+      - get_next_release
 
     steps:
     - name: Check if workflow needs to be skipped
@@ -44,6 +44,9 @@ jobs:
       run: |
         skip='false'
         if [[ "${{github.event.pull_request}}" ==  "" ]] && [[ "${{github.ref}}" != "refs/heads/main" ]] && [[ ! "${{github.ref}}" =~ ^refs/heads/release-[0-9]+\.[0-9]$ ]] && [[ ! "${{github.ref}}" =~ "refs/tags/.*" ]]; then
+          skip='true'
+        fi
+        if [[ "${{needs.get_next_release.outputs.next_release}}" == "" ]]; then
           skip='true'
         fi
         echo Skip ${skip}
@@ -71,6 +74,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml'
 
     - name: Set up Go
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
@@ -91,7 +95,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo DEBIAN_FRONTEND="noninteractive" apt-get update
-        # Uninstall any previously installed MySQL first
+        # Uninstall any nextly installed MySQL first
         sudo systemctl stop apparmor
         sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
         sudo apt-get -y autoremove
@@ -123,19 +127,19 @@ jobs:
         sudo apt-get update
         sudo apt-get install percona-xtrabackup-24
 
-    # Checkout to the last release of Vitess
-    - name: Check out other version's code (${{ needs.get_previous_release.outputs.previous_release }})
+    # Checkout to the next release of Vitess
+    - name: Check out other version's code (${{ needs.get_next_release.outputs.next_release }})
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
       with:
-        ref: ${{ needs.get_previous_release.outputs.previous_release }}
+        ref: ${{ needs.get_next_release.outputs.next_release }}
 
-    - name: Get dependencies for the last release
+    - name: Get dependencies for the next release
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
-    - name: Building last release's binaries
+    - name: Building next release's binaries
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 10
       run: |
@@ -174,8 +178,8 @@ jobs:
         source build.env
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
 
-    # Swap the binaries in the bin. Use vtgate version n-1 and keep vttablet at version n
-    - name: Use last release's VTGate
+    # Swap the binaries in the bin. Use vtgate version n+1 and keep vttablet at version n
+    - name: Use next release's VTGate
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
@@ -184,8 +188,8 @@ jobs:
         cp /tmp/vitess-build-other/bin/vtgate $PWD/bin/vtgate
         vtgate --version
 
-    # Running a test with vtgate at version n-1 and vttablet at version n
-    - name: Run query serving tests (vtgate=N-1, vttablet=N)
+    # Running a test with vtgate at version n+1 and vttablet at version n
+    - name: Run query serving tests (vtgate=N+1, vttablet=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
@@ -194,7 +198,7 @@ jobs:
         source build.env
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
 
-    # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n-1
+    # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n+1
     - name: Use current version VTGate, and other version VTTablet
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
@@ -206,8 +210,8 @@ jobs:
         vtgate --version
         vttablet --version
 
-    # Running a test with vtgate at version n and vttablet at version n-1
-    - name: Run query serving tests (vtgate=N, vttablet=N-1)
+    # Running a test with vtgate at version n and vttablet at version n+1
+    - name: Run query serving tests (vtgate=N, vttablet=N+1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -1,22 +1,22 @@
-name: Upgrade Downgrade Testing Query Serving (Queries)
+name: Upgrade Downgrade Testing Query Serving (Schema) Next Release
 on:
   push:
   pull_request:
 
 concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing Query Serving (Queries)')
+  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing Query Serving (Schema) Next Release')
   cancel-in-progress: true
 
 # This test ensures that our end-to-end tests work using Vitess components
 # (vtgate, vttablet, etc) built on different versions.
 
 jobs:
-  get_previous_release:
+  get_next_release:
     if: always()
     name: Get latest release
     runs-on: ubuntu-latest
     outputs:
-      previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
+      next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 
     steps:
       - name: Check out to HEAD
@@ -25,18 +25,18 @@ jobs:
           fetch-depth: 0
 
       - name: Set output with latest release branch
-        id: output-previous-release-ref
+        id: output-next-release-ref
         run: |
-          previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
-          echo $previous_release_ref
-          echo "::set-output name=previous_release_ref::${previous_release_ref}"
+          next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $next_release_ref
+          echo "::set-output name=next_release_ref::${next_release_ref}"
 
   upgrade_downgrade_test:
-    if: always() && (needs.get_previous_release.result == 'success')
+    if: always() && (needs.get_next_release.result == 'success')
     name: Run Upgrade Downgrade Test
     runs-on: ubuntu-latest
     needs:
-      - get_previous_release
+      - get_next_release
 
     steps:
     - name: Check if workflow needs to be skipped
@@ -44,6 +44,9 @@ jobs:
       run: |
         skip='false'
         if [[ "${{github.event.pull_request}}" ==  "" ]] && [[ "${{github.ref}}" != "refs/heads/main" ]] && [[ ! "${{github.ref}}" =~ ^refs/heads/release-[0-9]+\.[0-9]$ ]] && [[ ! "${{github.ref}}" =~ "refs/tags/.*" ]]; then
+          skip='true'
+        fi
+        if [[ "${{needs.get_next_release.outputs.next_release}}" == "" ]]; then
           skip='true'
         fi
         echo Skip ${skip}
@@ -71,6 +74,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml'
 
     - name: Set up Go
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
@@ -91,7 +95,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo DEBIAN_FRONTEND="noninteractive" apt-get update
-        # Uninstall any previously installed MySQL first
+        # Uninstall any nextly installed MySQL first
         sudo systemctl stop apparmor
         sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
         sudo apt-get -y autoremove
@@ -123,19 +127,19 @@ jobs:
         sudo apt-get update
         sudo apt-get install percona-xtrabackup-24
 
-    # Checkout to the last release of Vitess
-    - name: Check out other version's code (${{ needs.get_previous_release.outputs.previous_release }})
+    # Checkout to the next release of Vitess
+    - name: Check out other version's code (${{ needs.get_next_release.outputs.next_release }})
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/checkout@v2
       with:
-        ref: ${{ needs.get_previous_release.outputs.previous_release }}
+        ref: ${{ needs.get_next_release.outputs.next_release }}
 
-    - name: Get dependencies for the last release
+    - name: Get dependencies for the next release
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         go mod download
 
-    - name: Building last release's binaries
+    - name: Building next release's binaries
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       timeout-minutes: 10
       run: |
@@ -172,10 +176,10 @@ jobs:
         mkdir -p /tmp/vtdataroot
 
         source build.env
-        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
 
-    # Swap the binaries in the bin. Use vtgate version n-1 and keep vttablet at version n
-    - name: Use last release's VTGate
+    # Swap the binaries in the bin. Use vtgate version n+1 and keep vttablet at version n
+    - name: Use next release's VTGate
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         source build.env
@@ -184,17 +188,17 @@ jobs:
         cp /tmp/vitess-build-other/bin/vtgate $PWD/bin/vtgate
         vtgate --version
 
-    # Running a test with vtgate at version n-1 and vttablet at version n
-    - name: Run query serving tests (vtgate=N-1, vttablet=N)
+    # Running a test with vtgate at version n+1 and vttablet at version n
+    - name: Run query serving tests (vtgate=N+1, vttablet=N)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
 
         source build.env
-        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema
 
-    # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n-1
+    # Swap the binaries again. This time, vtgate will be at version n, and vttablet will be at version n+1
     - name: Use current version VTGate, and other version VTTablet
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
@@ -206,12 +210,12 @@ jobs:
         vtgate --version
         vttablet --version
 
-    # Running a test with vtgate at version n and vttablet at version n-1
-    - name: Run query serving tests (vtgate=N, vttablet=N-1)
+    # Running a test with vtgate at version n and vttablet at version n+1
+    - name: Run query serving tests (vtgate=N, vttablet=N+1)
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
 
         source build.env
-        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_queries
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_query_serving_schema

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -1,0 +1,193 @@
+name: Upgrade Downgrade Testing Reparent New Vtctl
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing Reparent New Vtctl')
+  cancel-in-progress: true
+
+# This test ensures that our end-to-end tests work using Vitess components
+# (vtctl, vttablet, etc) built on different versions.
+
+jobs:
+  get_next_release:
+    if: always()
+    name: Get latest release
+    runs-on: ubuntu-latest
+    outputs:
+      next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
+
+    steps:
+      - name: Check out to HEAD
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set output with latest release branch
+        id: output-next-release-ref
+        run: |
+          next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $next_release_ref
+          echo "::set-output name=next_release_ref::${next_release_ref}"
+
+  upgrade_downgrade_test:
+    if: always() && (needs.get_next_release.result == 'success')
+    name: Run Upgrade Downgrade Test
+    runs-on: ubuntu-latest
+    needs:
+      - get_next_release
+
+    steps:
+    - name: Check if workflow needs to be skipped
+      id: skip-workflow
+      run: |
+        skip='false'
+        if [[ "${{github.event.pull_request}}" ==  "" ]] && [[ "${{github.ref}}" != "refs/heads/main" ]] && [[ ! "${{github.ref}}" =~ ^refs/heads/release-[0-9]+\.[0-9]$ ]] && [[ ! "${{github.ref}}" =~ "refs/tags/.*" ]]; then
+          skip='true'
+        fi
+        if [[ "${{needs.get_next_release.outputs.next_release}}" == "" ]]; then
+          skip='true'
+        fi
+        echo Skip ${skip}
+        echo "::set-output name=skip-workflow::${skip}"
+
+    - name: Check out commit's code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
+      uses: frouioui/paths-filter@main
+      id: changes
+      with:
+        token: ''
+        filters: |
+          end_to_end:
+            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+            - '.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml'
+
+    - name: Set up Go
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.4
+
+    - name: Set up python
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/setup-python@v2
+
+    - name: Tune the OS
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+
+    - name: Get base dependencies
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+        # Uninstall any nextly installed MySQL first
+        sudo systemctl stop apparmor
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
+        sudo apt-get -y autoremove
+        sudo apt-get -y autoclean
+        sudo deluser mysql
+        sudo rm -rf /var/lib/mysql
+        sudo rm -rf /etc/mysql
+        # Install mysql80
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+        # Install everything else we need, and configure
+        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+
+        # install JUnit report formatter
+        go install github.com/vitessio/go-junit-report@HEAD
+
+        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get install -y gnupg2
+        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get update
+        sudo apt-get install percona-xtrabackup-24
+
+    # Checkout to the next release of Vitess
+    - name: Check out other version's code (${{ needs.get_next_release.outputs.next_release }})
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ needs.get_next_release.outputs.next_release }}
+
+    - name: Get dependencies for the next release
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building next release's binaries
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-other/
+        cp -R bin /tmp/vitess-build-other/
+        rm -Rf bin/*
+
+    # Checkout to this build's commit
+    - name: Check out commit's code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@v2
+
+    - name: Get dependencies for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building the binaries for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-current/
+        cp -R bin /tmp/vitess-build-current/
+
+    # Swap the binaries in the bin. Use vtctl version n+1 and keep vttablet at version n
+    - name: Use next release's Vtctl
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env
+
+        rm -f $PWD/bin/vtctl $PWD/bin/vtctld $PWD/bin/vtctlclient $PWD/bin/vtctldclient
+        cp /tmp/vitess-build-other/bin/vtctl $PWD/bin/vtctl
+        cp /tmp/vitess-build-other/bin/vtctld $PWD/bin/vtctld
+        cp /tmp/vitess-build-other/bin/vtctlclient $PWD/bin/vtctlclient
+        cp /tmp/vitess-build-other/bin/vtctldclient $PWD/bin/vtctldclient
+        vtctl --version
+        vttablet --version
+
+    # Running a test with vtctl at version n+1 and vttablet at version n
+    - name: Run reparent tests (vtctl=N+1, vttablet=N)
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_reparent

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -15,8 +15,6 @@ jobs:
     if: always()
     name: Get latest release
     runs-on: ubuntu-latest
-    needs:
-      - get_upgrade_downgrade_label
     outputs:
       next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -1,0 +1,192 @@
+name: Upgrade Downgrade Testing Reparent New VTTablet
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Upgrade Downgrade Testing Reparent New VTTablet')
+  cancel-in-progress: true
+
+# This test ensures that our end-to-end tests work using Vitess components
+# (vtctl, vttablet, etc) built on different versions.
+
+jobs:
+  get_next_release:
+    if: always()
+    name: Get latest release
+    runs-on: ubuntu-latest
+    needs:
+      - get_upgrade_downgrade_label
+    outputs:
+      next_release: ${{ steps.output-next-release-ref.outputs.next_release_ref }}
+
+    steps:
+      - name: Check out to HEAD
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set output with latest release branch
+        id: output-next-release-ref
+        run: |
+          next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+          echo $next_release_ref
+          echo "::set-output name=next_release_ref::${next_release_ref}"
+
+  upgrade_downgrade_test:
+    if: always() && (needs.get_next_release.result == 'success')
+    name: Run Upgrade Downgrade Test
+    runs-on: ubuntu-latest
+    needs:
+      - get_next_release
+
+    steps:
+    - name: Check if workflow needs to be skipped
+      id: skip-workflow
+      run: |
+        skip='false'
+        if [[ "${{github.event.pull_request}}" ==  "" ]] && [[ "${{github.ref}}" != "refs/heads/main" ]] && [[ ! "${{github.ref}}" =~ ^refs/heads/release-[0-9]+\.[0-9]$ ]] && [[ ! "${{github.ref}}" =~ "refs/tags/.*" ]]; then
+          skip='true'
+        fi
+        if [[ "${{needs.get_next_release.outputs.next_release}}" == "" ]]; then
+          skip='true'
+        fi
+        echo Skip ${skip}
+        echo "::set-output name=skip-workflow::${skip}"
+
+    - name: Check out commit's code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
+      uses: actions/checkout@v2
+
+    - name: Check for changes in relevant files
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
+      uses: frouioui/paths-filter@main
+      id: changes
+      with:
+        token: ''
+        filters: |
+          end_to_end:
+            - 'go/**'
+            - 'go/**/*.go'
+            - 'test.go'
+            - 'Makefile'
+            - 'build.env'
+            - 'go.[sumod]'
+            - 'proto/*.proto'
+            - 'tools/**'
+            - 'config/**'
+            - 'bootstrap.sh'
+            - '.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml'
+
+    - name: Set up Go
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.4
+
+    - name: Set up python
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/setup-python@v2
+
+    - name: Tune the OS
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+
+    - name: Get base dependencies
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+        # Uninstall any nextly installed MySQL first
+        sudo systemctl stop apparmor
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
+        sudo apt-get -y autoremove
+        sudo apt-get -y autoclean
+        sudo deluser mysql
+        sudo rm -rf /var/lib/mysql
+        sudo rm -rf /etc/mysql
+        # Install mysql80
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+        # Install everything else we need, and configure
+        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+
+        # install JUnit report formatter
+        go install github.com/vitessio/go-junit-report@HEAD
+
+        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get install -y gnupg2
+        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get update
+        sudo apt-get install percona-xtrabackup-24
+
+    # Checkout to the next release of Vitess
+    - name: Check out other version's code (${{ needs.get_next_release.outputs.next_release }})
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ needs.get_next_release.outputs.next_release }}
+
+    - name: Get dependencies for the next release
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building next release's binaries
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-other/
+        cp -R bin /tmp/vitess-build-other/
+        rm -Rf bin/*
+
+    # Checkout to this build's commit
+    - name: Check out commit's code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      uses: actions/checkout@v2
+
+    - name: Get dependencies for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        go mod download
+
+    - name: Building the binaries for this commit
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
+      run: |
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-current/
+        cp -R bin /tmp/vitess-build-current/
+
+    # Swap the binaries. Use vtctl version n and keep vttablet at version n+1
+    - name: Use current version Vtctl, and other version VTTablet
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        source build.env
+
+        rm -f $PWD/bin/vttablet
+        cp /tmp/vitess-build-other/bin/vttablet $PWD/bin/vttablet
+        vtctl --version
+        vttablet --version
+
+    # Running a test with vtctl at version n and vttablet at version n+1
+    - name: Run reparent tests (vtctl=N, vttablet=N+1)
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
+      run: |
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -tag upgrade_downgrade_reparent

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -15,8 +15,6 @@ jobs:
     if: always()
     name: Get latest release
     runs-on: ubuntu-latest
-    needs:
-      - get_upgrade_downgrade_label
     outputs:
       previous_release: ${{ steps.output-previous-release-ref.outputs.previous_release_ref }}
 

--- a/tools/get_next_release.sh
+++ b/tools/get_next_release.sh
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script is used to build and copy the Angular 2 based vtctld UI
-# into the release folder (app) for checkin. Prior to running this script,
-# bootstrap.sh and bootstrap_web.sh should already have been run.
-
 # github.base_ref $1
 
 target_release=""

--- a/tools/get_next_release.sh
+++ b/tools/get_next_release.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2022 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to build and copy the Angular 2 based vtctld UI
+# into the release folder (app) for checkin. Prior to running this script,
+# bootstrap.sh and bootstrap_web.sh should already have been run.
+
+# github.base_ref $1
+
+target_release=""
+
+base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*.0$')
+if [ "$base_release_branch" == "" ]; then
+  base_release_branch=$(echo "$2" | grep -E 'release-[0-9]*.0$')
+fi
+if [ "$base_release_branch" != "" ]; then
+  latest_major_release=$(git show-ref | grep -E 'refs/remotes/origin/release-[0-9]*\.0$' | sed 's/[a-z0-9]* refs\/remotes\/origin\/release-//' | sed 's/\.0//' | sort -nr | head -n1)
+  major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
+  target_major_release=$((major_release+1))
+  target_release_number=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | awk -v FS=. -v RELEASE="$target_major_release" '{if ($1 == RELEASE) print; }' | sort -nr | head -n1)
+  target_release="v$target_release_number"
+  if [ -z "$target_release_number" ]
+  then
+    target_release="release-$target_major_release.0"
+  fi
+  if [ "$major_release" == "$latest_major_release" ]; then
+    target_release="main"
+  fi
+fi
+
+echo "$target_release"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds the next-release counterparts of the current upgrade-downgrade tests. Currently, we have tests that test the upgrade process from the previous release to the current one. For example on `main` the tests run against release-14.0. On release-14.0 they run against 13.0.2 and so on.
But it is essential to also run the tests against the next release. For example, if we introduce a change in release-13.0 which would prevent it from upgrading to 14.0.1, we won't catch it at all until a new patch release is done, in which case it would fail in a PR based against release-14.0

To also catch these scenarios, we have chosen to add upgrade-downgrade tests to test against the next release apart from just the previous release. For `main`, the tests will just be skipped. For release-14.0, `main` will be used, for release-13.0, `14.0.1` will be used and so on.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
