### PR TITLE
schemadiff performance improvements

### DIFF
--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -469,6 +469,19 @@ func (s *Schema) ToSQL() string {
 	return buf.String()
 }
 
+// Clone returns a deep copy of the schema. This is used when applying changes for example. It
+// will first create copies of all entities which depend on the sqlparser deep copy logic and
+// then creates a new schema from those copies.
+func (s *Schema) Clone() *Schema {
+	entities := make([]Entity, 0, len(s.Entities()))
+	for _, e := range s.Entities() {
+		entities = append(entities, e.Clone())
+	}
+	// Can't error since we're valid ourselves.
+	schema, _ := NewSchemaFromEntities(entities)
+	return schema
+}
+
 // apply attempts to apply given list of diffs to this object.
 // These diffs are CREATE/DROP/ALTER TABLE/VIEW.
 func (s *Schema) apply(diffs []EntityDiff) error {
@@ -591,14 +604,7 @@ func (s *Schema) apply(diffs []EntityDiff) error {
 // These diffs are CREATE/DROP/ALTER TABLE/VIEW.
 // The operation does not modify this object. Instead, if successful, a new (modified) Schema is returned.
 func (s *Schema) Apply(diffs []EntityDiff) (*Schema, error) {
-	// we export to queries, then import back.
-	// The reason we don't just clone this object's fields, or even export/import to Statements,
-	// is that we want this schema to be immutable an unaffected by the apply() on the duplicate.
-	// statements/slices/maps will have shared pointers and changes will propagate back to this schema.
-	dup, err := NewSchemaFromQueries(s.ToQueries())
-	if err != nil {
-		return nil, err
-	}
+	dup := s.Clone()
 	for k, v := range s.named {
 		dup.named[k] = v
 	}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -142,3 +142,13 @@ func TestToSQL(t *testing.T) {
 	sql := schema.ToSQL()
 	assert.Equal(t, toSQL, sql)
 }
+
+func TestClone(t *testing.T) {
+	schema, err := NewSchemaFromQueries(createQueries)
+	assert.NoError(t, err)
+	assert.NotNil(t, schema)
+
+	schemaClone := schema.Clone()
+	assert.Equal(t, schema, schemaClone)
+	assert.False(t, schema == schemaClone)
+}

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -468,6 +468,9 @@ func (c *CreateTableEntity) normalizeIndexOptions() {
 		// This name is taking straight from the input string
 		// so we want to normalize this to always lowercase.
 		idx.Info.Type = strings.ToLower(idx.Info.Type)
+		for _, opt := range idx.Options {
+			opt.Name = strings.ToLower(opt.Name)
+		}
 	}
 }
 

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -307,18 +307,19 @@ func (c *CreateTableEntity) normalize() *CreateTableEntity {
 
 func (c *CreateTableEntity) normalizeTableOptions() {
 	for _, opt := range c.CreateTable.TableSpec.Options {
-		switch strings.ToUpper(opt.Name) {
-		case "CHARSET", "COLLATE":
+		opt.Name = strings.ToLower(opt.Name)
+		switch opt.Name {
+		case "charset", "collate":
 			opt.String = strings.ToLower(opt.String)
 			if charset, ok := collationEnv.CharsetAlias(opt.String); ok {
 				opt.String = charset
 			}
-		case "ENGINE":
+		case "engine":
 			opt.String = strings.ToUpper(opt.String)
 			if engineName, ok := engineCasing[opt.String]; ok {
 				opt.String = engineName
 			}
-		case "ROW_FORMAT":
+		case "row_format":
 			opt.String = strings.ToUpper(opt.String)
 		}
 	}

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -323,6 +323,10 @@ func (c *CreateTableEntity) normalizeTableOptions() {
 	}
 }
 
+func (c *CreateTableEntity) Clone() Entity {
+	return &CreateTableEntity{CreateTable: *sqlparser.CloneRefOfCreateTable(&c.CreateTable)}
+}
+
 // Right now we assume MySQL 8.0 for the collation normalization handling.
 const mysqlCollationVersion = "8.0.0"
 

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -423,6 +423,13 @@ func TestCreateTableDiff(t *testing.T) {
 			diff:  "alter table t1 alter index i_idx invisible",
 			cdiff: "ALTER TABLE `t1` ALTER INDEX `i_idx` INVISIBLE",
 		},
+		{
+			name:  "key made invisible with different case",
+			from:  "create table t1 (`id` int primary key, i int, key i_idx(i))",
+			to:    "create table t1 (`id` int primary key, i int, key i_idx(i) INVISIBLE)",
+			diff:  "alter table t1 alter index i_idx invisible",
+			cdiff: "ALTER TABLE `t1` ALTER INDEX `i_idx` INVISIBLE",
+		},
 		// FULLTEXT keys
 		{
 			name:  "add one fulltext key",

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -857,7 +857,7 @@ func TestCreateTableDiff(t *testing.T) {
 			name:  "remove table option 2",
 			from:  "create table t1 (id int primary key) CHECKSUM=1",
 			to:    "create table t1 (id int primary key) ",
-			diff:  "alter table t1 CHECKSUM 0",
+			diff:  "alter table t1 checksum 0",
 			cdiff: "ALTER TABLE `t1` CHECKSUM 0",
 		},
 		{
@@ -871,7 +871,7 @@ func TestCreateTableDiff(t *testing.T) {
 			name:  "remove table option 4",
 			from:  "create table t1 (id int auto_increment primary key) KEY_BLOCK_SIZE=16 COMPRESSION='zlib'",
 			to:    "create table t2 (id int auto_increment primary key)",
-			diff:  "alter table t1 KEY_BLOCK_SIZE 0 COMPRESSION ''",
+			diff:  "alter table t1 key_block_size 0 compression ''",
 			cdiff: "ALTER TABLE `t1` KEY_BLOCK_SIZE 0 COMPRESSION ''",
 		},
 		{
@@ -891,7 +891,7 @@ func TestCreateTableDiff(t *testing.T) {
 			from:    "create table t1 (id int auto_increment primary key)",
 			to:      "create table t2 (id int auto_increment primary key) AUTO_INCREMENT=300",
 			autoinc: AutoIncrementApplyHigher,
-			diff:    "alter table t1 AUTO_INCREMENT 300",
+			diff:    "alter table t1 auto_increment 300",
 			cdiff:   "ALTER TABLE `t1` AUTO_INCREMENT 300",
 		},
 		{
@@ -915,7 +915,7 @@ func TestCreateTableDiff(t *testing.T) {
 			from:    "create table t1 (id int auto_increment primary key) AUTO_INCREMENT=100",
 			to:      "create table t2 (id int auto_increment primary key) AUTO_INCREMENT=300",
 			autoinc: AutoIncrementApplyHigher,
-			diff:    "alter table t1 AUTO_INCREMENT 300",
+			diff:    "alter table t1 auto_increment 300",
 			cdiff:   "ALTER TABLE `t1` AUTO_INCREMENT 300",
 		},
 		{
@@ -929,7 +929,7 @@ func TestCreateTableDiff(t *testing.T) {
 			from:    "create table t1 (id int auto_increment primary key) AUTO_INCREMENT=300",
 			to:      "create table t2 (id int auto_increment primary key) AUTO_INCREMENT=100",
 			autoinc: AutoIncrementApplyAlways,
-			diff:    "alter table t1 AUTO_INCREMENT 100",
+			diff:    "alter table t1 auto_increment 100",
 			cdiff:   "ALTER TABLE `t1` AUTO_INCREMENT 100",
 		},
 		{

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -30,8 +30,10 @@ type Entity interface {
 	Diff(other Entity, hints *DiffHints) (diff EntityDiff, err error)
 	// Create returns an entity diff that describes how to create this entity
 	Create() EntityDiff
-	// Create returns an entity diff that describes how to drop this entity
+	// Drop returns an entity diff that describes how to drop this entity
 	Drop() EntityDiff
+	// Clone returns a deep copy of the entity.
+	Clone() Entity
 }
 
 // EntityDiff represents the diff between two entities

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -289,11 +289,11 @@ func (c *CreateViewEntity) Apply(diff EntityDiff) (Entity, error) {
 	if !ok {
 		return nil, ErrEntityTypeMismatch
 	}
-	dupCreateView := &sqlparser.CreateView{}
-	dup := &CreateViewEntity{CreateView: *dupCreateView}
+	dup := c.Clone().(*CreateViewEntity)
 	if err := dup.apply(alterDiff); err != nil {
 		return nil, err
 	}
+	dup.normalize()
 	return dup, nil
 }
 

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -296,3 +296,7 @@ func (c *CreateViewEntity) Apply(diff EntityDiff) (Entity, error) {
 	}
 	return dup, nil
 }
+
+func (c *CreateViewEntity) Clone() Entity {
+	return &CreateViewEntity{CreateView: *sqlparser.CloneRefOfCreateView(&c.CreateView)}
+}


### PR DESCRIPTION
This change includes two commits that address two specific issues. First there is the way that we clone a schema for an `Apply` operation. This is switched to using the already available `sqlparser` clone helpers instead of serializing to string and then parsing again.

The second change is to use the `sqlparser` comparison methods instead of serializing to a string and then comparing.

Both these impact performance significantly when dealing with large schemas. The improvements here show a 4x performance improvement on internal PSDB usage of `schemadiff` when dealing with large schemas. 

## Related Issue(s)

#10203

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required