### PR TITLE
[log] Migrate `go/vt/log` flags to `pflag`

### DIFF
--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -250,7 +250,9 @@ func main() {
 		exit.Return(1)
 	}
 	dbconfigs.RegisterFlags(dbconfigs.Dba)
-	_flag.Parse(pflag.NewFlagSet("mysqlctl", pflag.ExitOnError))
+	fs := pflag.NewFlagSet("mysqlctl", pflag.ExitOnError)
+	log.RegisterFlags(fs)
+	_flag.Parse(fs)
 
 	tabletAddr = netutil.JoinHostPort("localhost", int32(*port))
 

--- a/go/cmd/query_analyzer/query_analyzer.go
+++ b/go/cmd/query_analyzer/query_analyzer.go
@@ -61,7 +61,9 @@ func (a stats) Less(i, j int) bool { return a[i].Count > a[j].Count }
 
 func main() {
 	defer exit.Recover()
-	_flag.Parse(pflag.NewFlagSet("query_analyzer", pflag.ExitOnError))
+	fs := pflag.NewFlagSet("query_analyzer", pflag.ExitOnError)
+	log.RegisterFlags(fs)
+	_flag.Parse(fs)
 	for _, filename := range _flag.Args() {
 		fmt.Printf("processing: %s\n", filename)
 		if err := processFile(filename); err != nil {

--- a/go/cmd/rulesctl/main.go
+++ b/go/cmd/rulesctl/main.go
@@ -4,10 +4,12 @@ import (
 	"log"
 
 	"vitess.io/vitess/go/cmd/rulesctl/cmd"
+	vtlog "vitess.io/vitess/go/vt/log"
 )
 
 func main() {
 	rootCmd := cmd.Main()
+	vtlog.RegisterFlags(rootCmd.PersistentFlags())
 	if err := rootCmd.Execute(); err != nil {
 		log.Printf("%v", err)
 	}

--- a/go/cmd/topo2topo/topo2topo.go
+++ b/go/cmd/topo2topo/topo2topo.go
@@ -55,7 +55,9 @@ func main() {
 	defer exit.RecoverAll()
 	defer logutil.Flush()
 
-	_flag.Parse(pflag.NewFlagSet("topo2topo", pflag.ExitOnError))
+	fs := pflag.NewFlagSet("topo2topo", pflag.ExitOnError)
+	log.RegisterFlags(fs)
+	_flag.Parse(fs)
 	args := _flag.Args()
 	if len(args) != 0 {
 		flag.Usage()

--- a/go/cmd/vtbench/vtbench.go
+++ b/go/cmd/vtbench/vtbench.go
@@ -106,7 +106,9 @@ func main() {
 	defer exit.Recover()
 
 	flag.Lookup("logtostderr").Value.Set("true")
-	_flag.Parse(pflag.NewFlagSet("vtbench", pflag.ExitOnError))
+	fs := pflag.NewFlagSet("vtbench", pflag.ExitOnError)
+	log.RegisterFlags(fs)
+	_flag.Parse(fs)
 
 	clientProto := vtbench.MySQL
 	switch *protocol {

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -148,7 +148,9 @@ func main() {
 }
 
 func run() (*results, error) {
-	_flag.Parse(pflag.NewFlagSet("vtclient", pflag.ExitOnError))
+	fs := pflag.NewFlagSet("vtclient", pflag.ExitOnError)
+	log.RegisterFlags(fs)
+	_flag.Parse(fs)
 	args := _flag.Args()
 
 	if len(args) == 0 {

--- a/go/cmd/vtctlclient/main.go
+++ b/go/cmd/vtctlclient/main.go
@@ -72,7 +72,9 @@ func checkDeprecations(args []string) {
 func main() {
 	defer exit.Recover()
 
-	_flag.Parse(pflag.NewFlagSet("vtctlclient", pflag.ExitOnError))
+	fs := pflag.NewFlagSet("vtctlclient", pflag.ExitOnError)
+	log.RegisterFlags(fs)
+	_flag.Parse(fs)
 
 	closer := trace.StartTracing("vtctlclient")
 	defer trace.LogErrorsWhenClosing(closer)

--- a/go/cmd/vtctldclient/main.go
+++ b/go/cmd/vtctldclient/main.go
@@ -30,6 +30,7 @@ func main() {
 
 	// Grab all those global flags across the codebase and shove 'em on in.
 	command.Root.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	log.RegisterFlags(command.Root.PersistentFlags())
 
 	// hack to get rid of an "ERROR: logging before flag.Parse"
 	args := os.Args[:]

--- a/go/cmd/vtorc/main.go
+++ b/go/cmd/vtorc/main.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/spf13/pflag"
 
+	vtlog "vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/orchestrator/app"
 	"vitess.io/vitess/go/vt/orchestrator/config"
 	"vitess.io/vitess/go/vt/orchestrator/external/golib/log"
@@ -101,6 +102,7 @@ func main() {
 	// TODO(ajm188): after v15, remove this pflag hack and use servenv.ParseFlags
 	// directly.
 	fs := pflag.NewFlagSet("vtorc", pflag.ExitOnError)
+	vtlog.RegisterFlags(fs)
 
 	args := append([]string{}, os.Args...)
 	os.Args = os.Args[0:1]

--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/spf13/pflag"
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/vt/log"
@@ -201,6 +202,12 @@ func (t *topoFlags) buildTopology() (*vttestpb.VTTestTopology, error) {
 }
 
 func parseFlags() (env vttest.Environment, err error) {
+	fs := pflag.NewFlagSet("vtgateclienttest", pflag.ExitOnError)
+	log.RegisterFlags(fs)
+
+	f := fs.Lookup("log_rotate_max_size")
+	flag.Var(f.Value, f.Name, f.Usage)
+
 	flag.Parse()
 
 	if basePort != 0 {

--- a/go/cmd/zk/zkcmd.go
+++ b/go/cmd/zk/zkcmd.go
@@ -142,6 +142,7 @@ func main() {
 	defer logutil.Flush()
 
 	fs := pflag.NewFlagSet("zkcmd", pflag.ExitOnError)
+	log.RegisterFlags(fs)
 	_flag.SetUsage(flag.CommandLine, _flag.UsageOptions{ // TODO: hmmm
 		Epilogue: func(w io.Writer) { fmt.Fprint(w, doc) },
 	})

--- a/go/cmd/zkctl/zkctl.go
+++ b/go/cmd/zkctl/zkctl.go
@@ -62,7 +62,9 @@ func main() {
 	defer exit.Recover()
 	defer logutil.Flush()
 
-	_flag.Parse(pflag.NewFlagSet("zkctl", pflag.ExitOnError))
+	fs := pflag.NewFlagSet("zkctl", pflag.ExitOnError)
+	log.RegisterFlags(fs)
+	_flag.Parse(fs)
 	args := _flag.Args()
 
 	if len(args) == 0 {

--- a/go/vt/log/log.go
+++ b/go/vt/log/log.go
@@ -22,9 +22,8 @@ limitations under the License.
 package log
 
 import (
-	"flag"
-
 	"github.com/golang/glog"
+	"github.com/spf13/pflag"
 )
 
 // Level is used with V() to test log verbosity.
@@ -73,6 +72,11 @@ var (
 	FatalDepth = glog.FatalDepth
 )
 
-func init() {
-	flag.Uint64Var(&glog.MaxSize, "log_rotate_max_size", glog.MaxSize, "size in bytes at which logs are rotated (glog.MaxSize)")
+// RegisterFlags installs log flags on the given FlagSet.
+//
+// `go/cmd/*` entrypoints should either use servenv.ParseFlags(WithArgs)? which
+// calls this function, or call this function directly before parsing
+// command-line arguments.
+func RegisterFlags(fs *pflag.FlagSet) {
+	fs.Uint64Var(&glog.MaxSize, "log_rotate_max_size", glog.MaxSize, "size in bytes at which logs are rotated (glog.MaxSize)")
 }

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -323,10 +323,11 @@ func ParseFlagsWithArgs(cmd string) []string {
 	return args
 }
 
+// Flag installations for packages that servenv imports. We need to register
+// here rather than in those packages (which is what we would normally do)
+// because that would create a dependency cycle.
 func init() {
-	// These are the binaries that call trace.StartTracing. We need to register
-	// here because package trace cannot import package servenv without creating
-	// a dependency cycle.
+	// These are the binaries that call trace.StartTracing.
 	for _, cmd := range []string{
 		"vtadmin",
 		"vtclient",
@@ -340,4 +341,7 @@ func init() {
 	} {
 		OnParseFor(cmd, trace.RegisterFlags)
 	}
+
+	// Log flags are installed for all binaries.
+	OnParse(log.RegisterFlags)
 }


### PR DESCRIPTION

## Description

This migrates the flags defined in `go/vt/log` to pflag. Similar to #11028, the flag registration has to happen backwards, and then for double-fun, (a) every binary needs logging and (b) not every binary uses `servenv.ParseFlags(WithArgs)?`, so this one needed some additional special handling, on top of the aforementioned special handling.

## Related Issue(s)

Closes #10808.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
