### PR TITLE
System Settings connections pool implementation

### DIFF
--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -40,7 +40,7 @@ type (
 		Close()
 		Name() string
 		Get(ctx context.Context, settings []string) (resource Resource, err error)
-		Put(resource Resource, settingHash uint64)
+		Put(resource Resource)
 		SetCapacity(capacity int) error
 		SetIdleTimeout(idleTimeout time.Duration)
 		StatsJSON() string
@@ -346,14 +346,16 @@ func hash(settings []string) (uint64, error) {
 // a corresponding Put is required. If you no longer need a resource,
 // you will need to call Put(nil) instead of returning the closed resource.
 // This will cause a new resource to be created in its place.
-func (rp *ResourcePool) Put(resource Resource, settingHash uint64) {
+func (rp *ResourcePool) Put(resource Resource) {
 	var wrapper resourceWrapper
-	recreated := false
+	var recreated bool
+	var settingHash uint64
 	if resource != nil {
 		wrapper = resourceWrapper{
 			resource: resource,
 			timeUsed: time.Now(),
 		}
+		settingHash = resource.SettingHash()
 	} else {
 		rp.reopenResource(&wrapper)
 		recreated = true

--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -385,6 +385,7 @@ func (rp *ResourcePool) SetCapacity(capacity int) error {
 		if oldcap == 0 && capacity > 0 {
 			// Closed this before, re-open the channel
 			rp.resources = make(chan resourceWrapper, cap(rp.resources))
+			rp.settingResources = make(chan resourceWrapper, cap(rp.settingResources))
 		}
 		if oldcap == capacity {
 			return nil

--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -425,12 +425,9 @@ func (rp *ResourcePool) SetCapacity(capacity int) error {
 	if capacity < oldcap {
 		for i := 0; i < oldcap-capacity; i++ {
 			var wrapper resourceWrapper
-			for {
-				select {
-				case wrapper = <-rp.resources:
-				case wrapper = <-rp.settingResources:
-				}
-				break
+			select {
+			case wrapper = <-rp.resources:
+			case wrapper = <-rp.settingResources:
 			}
 			if wrapper.resource != nil {
 				wrapper.resource.Close()

--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -417,6 +417,11 @@ func (rp *ResourcePool) SetCapacity(capacity int) error {
 		}
 	}
 
+	// If the required capacity is less than the current capacity,
+	// then we need to wait till the current resources are returned
+	// to the pool and close them from any of the channel.
+	// Otherwise, if the required capacity is more than the current capacity,
+	// then we just add empty resource to the channel.
 	if capacity < oldcap {
 		for i := 0; i < oldcap-capacity; i++ {
 			var wrapper resourceWrapper

--- a/go/pools/rp_bench_test.go
+++ b/go/pools/rp_bench_test.go
@@ -162,8 +162,8 @@ func BenchmarkApplySettings(b *testing.B) {
 				if err := resource.ApplySettings(ctx, tcase.settings); err != nil {
 					b.Error(err)
 				}
-				if resource.SettingHash() == 0 {
-					b.Error("setting hash is 0")
+				if !resource.IsSettingsApplied() {
+					b.Error("setting should have been applied")
 				}
 			}
 		})

--- a/go/pools/rp_bench_test.go
+++ b/go/pools/rp_bench_test.go
@@ -47,10 +47,10 @@ func BenchmarkGetPut(b *testing.B) {
 					b.RunParallel(func(pb *testing.PB) {
 						var ctx = context.Background()
 						for pb.Next() {
-							if conn, err := pool.Get(ctx); err != nil {
+							if conn, err := pool.Get(ctx, nil); err != nil {
 								b.Error(err)
 							} else {
-								pool.Put(conn)
+								pool.Put(conn, 0)
 							}
 						}
 					})

--- a/go/pools/rp_bench_test.go
+++ b/go/pools/rp_bench_test.go
@@ -38,7 +38,7 @@ func BenchmarkGetPut(b *testing.B) {
 						if conn, err := pool.Get(ctx, nil); err != nil {
 							b.Error(err)
 						} else {
-							pool.Put(conn, 0)
+							pool.Put(conn)
 						}
 					}
 				})
@@ -67,7 +67,7 @@ func BenchmarkGetPutWithSettings(b *testing.B) {
 						if conn, err := pool.Get(ctx, settings); err != nil {
 							b.Error(err)
 						} else {
-							pool.Put(conn, conn.SettingHash())
+							pool.Put(conn)
 						}
 					}
 				})
@@ -97,7 +97,7 @@ func BenchmarkGetPutMixed(b *testing.B) {
 						if conn, err := pool.Get(ctx, settings[i]); err != nil {
 							b.Error(err)
 						} else {
-							pool.Put(conn, conn.SettingHash())
+							pool.Put(conn)
 						}
 						i = (i + 1) % 2
 					}
@@ -128,7 +128,7 @@ func BenchmarkGetPutMixedMulti(b *testing.B) {
 						if conn, err := pool.Get(ctx, settings[i]); err != nil {
 							b.Error(err)
 						} else {
-							pool.Put(conn, conn.SettingHash())
+							pool.Put(conn)
 						}
 						i = (i + 1) % 5
 					}

--- a/go/pools/rpc_pool.go
+++ b/go/pools/rpc_pool.go
@@ -76,7 +76,7 @@ func (pool *RPCPool) Acquire(ctx context.Context) error {
 
 // Release frees a slot in the pool. It must only be called after a successful
 // call to Acquire.
-func (pool *RPCPool) Release() { pool.rp.Put(rpc, 0) }
+func (pool *RPCPool) Release() { pool.rp.Put(rpc) }
 
 // Close empties the pool, preventing further Acquire calls from succeeding.
 // It waits for all slots to be freed via Release.

--- a/go/pools/rpc_pool.go
+++ b/go/pools/rpc_pool.go
@@ -98,8 +98,7 @@ func (r *_rpc) ApplySettings(_ context.Context, _ []string) error {
 }
 
 func (r *_rpc) SettingHash() uint64 {
-	// should be unreachable
-	panic("[BUG]: _rpc does not support SettingHash")
+	return 0
 }
 
 // we only ever return the same rpc pointer. it's used as a sentinel and is

--- a/go/pools/rpc_pool.go
+++ b/go/pools/rpc_pool.go
@@ -97,8 +97,12 @@ func (r *_rpc) ApplySettings(_ context.Context, _ []string) error {
 	return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG]: _rpc does not support ApplySettings")
 }
 
-func (r *_rpc) SettingHash() uint64 {
-	return 0
+func (r *_rpc) IsSettingsApplied() bool {
+	return false
+}
+
+func (r *_rpc) IsSameSetting(_ []string) bool {
+	return true
 }
 
 // we only ever return the same rpc pointer. it's used as a sentinel and is

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -144,7 +144,7 @@ func (cp *ConnectionPool) Get(ctx context.Context) (*PooledDBConnection, error) 
 	if p == nil {
 		return nil, ErrConnPoolClosed
 	}
-	r, err := p.Get(ctx)
+	r, err := p.Get(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -162,10 +162,10 @@ func (cp *ConnectionPool) Put(conn *PooledDBConnection) {
 		// conn has a type, if we just Put(conn), we end up
 		// putting an interface with a nil value, that is not
 		// equal to a nil value. So just put a plain nil.
-		p.Put(nil)
+		p.Put(nil, 0)
 		return
 	}
-	p.Put(conn)
+	p.Put(conn, 0)
 }
 
 // SetCapacity alters the size of the pool at runtime.

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -162,10 +162,10 @@ func (cp *ConnectionPool) Put(conn *PooledDBConnection) {
 		// conn has a type, if we just Put(conn), we end up
 		// putting an interface with a nil value, that is not
 		// equal to a nil value. So just put a plain nil.
-		p.Put(nil, 0)
+		p.Put(nil)
 		return
 	}
-	p.Put(conn, 0)
+	p.Put(conn)
 }
 
 // SetCapacity alters the size of the pool at runtime.

--- a/go/vt/dbconnpool/pooled_connection.go
+++ b/go/vt/dbconnpool/pooled_connection.go
@@ -29,8 +29,12 @@ func (pc *PooledDBConnection) ApplySettings(ctx context.Context, settings []stri
 	panic("implement me")
 }
 
-func (pc *PooledDBConnection) SettingHash() uint64 {
-	return 0
+func (pc *PooledDBConnection) IsSettingsApplied() bool {
+	return false
+}
+
+func (pc *PooledDBConnection) IsSameSetting(_ []string) bool {
+	return true
 }
 
 // Recycle should be called to return the PooledDBConnection to the pool.

--- a/go/vt/dbconnpool/pooled_connection.go
+++ b/go/vt/dbconnpool/pooled_connection.go
@@ -24,6 +24,16 @@ type PooledDBConnection struct {
 	pool *ConnectionPool
 }
 
+func (pc *PooledDBConnection) ApplySettings(ctx context.Context, settings []string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (pc *PooledDBConnection) SettingHash() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
 // Recycle should be called to return the PooledDBConnection to the pool.
 func (pc *PooledDBConnection) Recycle() {
 	if pc.IsClosed() {

--- a/go/vt/dbconnpool/pooled_connection.go
+++ b/go/vt/dbconnpool/pooled_connection.go
@@ -30,8 +30,7 @@ func (pc *PooledDBConnection) ApplySettings(ctx context.Context, settings []stri
 }
 
 func (pc *PooledDBConnection) SettingHash() uint64 {
-	//TODO implement me
-	panic("implement me")
+	return 0
 }
 
 // Recycle should be called to return the PooledDBConnection to the pool.

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -23,6 +23,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
+
+	"vitess.io/vitess/go/pools"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -46,12 +49,14 @@ import (
 // its own queries and the underlying connection.
 // It will also trigger a CheckMySQL whenever applicable.
 type DBConn struct {
-	conn    *dbconnpool.DBConnection
-	info    dbconfigs.Connector
-	pool    *Pool
-	dbaPool *dbconnpool.ConnectionPool
-	stats   *tabletenv.Stats
-	current sync2.AtomicString
+	conn         *dbconnpool.DBConnection
+	info         dbconfigs.Connector
+	pool         *Pool
+	dbaPool      *dbconnpool.ConnectionPool
+	stats        *tabletenv.Stats
+	current      sync2.AtomicString
+	settings     string
+	settingsHash uint64
 
 	// err will be set if a query is killed through a Kill.
 	errmu sync.Mutex
@@ -313,6 +318,29 @@ func (dbc *DBConn) VerifyMode(strictTransTables bool) error {
 func (dbc *DBConn) Close() {
 	dbc.conn.Close()
 }
+
+func (dbc *DBConn) ApplySettings(ctx context.Context, settings []string) error {
+	var s strings.Builder
+	digest := xxhash.New()
+	for _, q := range settings {
+		if _, err := dbc.execOnce(ctx, q, 1, false); err != nil {
+			return err
+		}
+		if _, err := digest.WriteString(q); err != nil {
+			return err
+		}
+		s.WriteString(q)
+	}
+	dbc.settings = s.String()
+	dbc.settingsHash = digest.Sum64()
+	return nil
+}
+
+func (dbc *DBConn) SettingHash() uint64 {
+	return dbc.settingsHash
+}
+
+var _ pools.Resource = (*DBConn)(nil)
 
 // IsClosed returns true if DBConn is closed.
 func (dbc *DBConn) IsClosed() bool {

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -194,7 +194,7 @@ func (cp *Pool) Get(ctx context.Context) (*DBConn, error) {
 		ctx, cancel = context.WithTimeout(ctx, cp.timeout)
 		defer cancel()
 	}
-	r, err := p.Get(ctx)
+	r, err := p.Get(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -208,9 +208,9 @@ func (cp *Pool) Put(conn *DBConn) {
 		panic(ErrConnPoolClosed)
 	}
 	if conn == nil {
-		p.Put(nil)
+		p.Put(nil, 0)
 	} else {
-		p.Put(conn)
+		p.Put(conn, 0)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -208,9 +208,9 @@ func (cp *Pool) Put(conn *DBConn) {
 		panic(ErrConnPoolClosed)
 	}
 	if conn == nil {
-		p.Put(nil, 0)
+		p.Put(nil)
 	} else {
-		p.Put(conn, 0)
+		p.Put(conn)
 	}
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds a separate channel to keep the connections which has different settings from the default connection settings and on a get it will return the connection with the correct settings. 
On a put the connection will go to the right channel.
Similarly other methods like closeIdleConnection, refresh pool, etc. are modified to accomodate the settings channel.

This is an initial implementation and there will be further modiffication to make the implementation better
1. Currently the resource is closed if the settings mismatch on the existing connection. This will be changed to reset old settings and apply new settings
2. Add metrics around the new channel usage

This PR will atleast for now enable to intergrate other parts of the query serving flow in vttablet.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #9706 

## Checklist

-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
