### PR TITLE
fix: objname was not logged correctly

### DIFF
--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -288,7 +288,7 @@ func (bs *S3BackupStorage) ListBackups(ctx context.Context, dir string) ([]backu
 	} else {
 		searchPrefix = objName(dir, "")
 	}
-	log.Infof("objName: %v", searchPrefix)
+	log.Infof("objName: %v", *searchPrefix)
 
 	query := &s3.ListObjectsV2Input{
 		Bucket:    &bucket,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

```
I0818 19:08:27.040771       1 s3.go:261] ListBackups: [s3] dir: mytestshard/-80, bucket: mytestbucket
I0818 19:08:27.040823       1 shard_sync.go:70] Change to tablet state
I0818 19:08:27.061923       1 s3.go:273] objName: 0xc0012faaa0
```

objName is currently printing the memory address of searchPrefix instead of the string.

