### PR TITLE
schemadiff: Shallow copy of the schema

### DIFF
--- a/go/vt/schemadiff/column.go
+++ b/go/vt/schemadiff/column.go
@@ -22,13 +22,6 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-func colWithMaskedName(col *sqlparser.ColumnDefinition) *sqlparser.ColumnDefinition {
-	col = sqlparser.CloneRefOfColumnDefinition(col)
-	col.Name = sqlparser.NewIdentifierCI("mask")
-	return col
-
-}
-
 // columnDetails decorates a column with more details, used by diffing logic
 type columnDetails struct {
 	col     *sqlparser.ColumnDefinition
@@ -40,7 +33,7 @@ func (c *columnDetails) identicalOtherThanName(other *sqlparser.ColumnDefinition
 	if other == nil {
 		return false
 	}
-	return sqlparser.EqualsRefOfColumnDefinition(colWithMaskedName(c.col), colWithMaskedName(other))
+	return sqlparser.EqualsColumnType(c.col.Type, other.Type)
 }
 
 func (c *columnDetails) prevColName() string {

--- a/go/vt/schemadiff/column.go
+++ b/go/vt/schemadiff/column.go
@@ -22,10 +22,10 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-func colWithMaskedName(col *sqlparser.ColumnDefinition) string {
+func colWithMaskedName(col *sqlparser.ColumnDefinition) *sqlparser.ColumnDefinition {
 	col = sqlparser.CloneRefOfColumnDefinition(col)
 	col.Name = sqlparser.NewIdentifierCI("mask")
-	return sqlparser.CanonicalString(col)
+	return col
 
 }
 
@@ -40,7 +40,7 @@ func (c *columnDetails) identicalOtherThanName(other *sqlparser.ColumnDefinition
 	if other == nil {
 		return false
 	}
-	return colWithMaskedName(c.col) == colWithMaskedName(other)
+	return sqlparser.EqualsRefOfColumnDefinition(colWithMaskedName(c.col), colWithMaskedName(other))
 }
 
 func (c *columnDetails) prevColName() string {
@@ -88,10 +88,8 @@ func NewColumnDefinitionEntity(c *sqlparser.ColumnDefinition) *ColumnDefinitionE
 // change this table to look like the other table.
 // It returns an AlterTable statement if changes are found, or nil if not.
 // the other table may be of different name; its name is ignored.
-func (c *ColumnDefinitionEntity) ColumnDiff(other *ColumnDefinitionEntity, hints *DiffHints) *ModifyColumnDiff {
-	format := sqlparser.CanonicalString(c.columnDefinition)
-	otherFormat := sqlparser.CanonicalString(other.columnDefinition)
-	if format == otherFormat {
+func (c *ColumnDefinitionEntity) ColumnDiff(other *ColumnDefinitionEntity, _ *DiffHints) *ModifyColumnDiff {
+	if sqlparser.EqualsRefOfColumnDefinition(c.columnDefinition, other.columnDefinition) {
 		return nil
 	}
 

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -143,8 +143,8 @@ func getViewDependentTableNames(createView *sqlparser.CreateView) (names []strin
 // normalize is called as part of Schema creation process. The user may only get a hold of normalized schema.
 // It validates some cross-entity constraints, and orders entity based on dependencies (e.g. tables, views that read from tables, 2nd level views, etc.)
 func (s *Schema) normalize() error {
-	s.named = map[string]Entity{}
-	s.sorted = []Entity{}
+	s.named = make(map[string]Entity, len(s.tables)+len(s.views))
+	s.sorted = make([]Entity, 0, len(s.tables)+len(s.views))
 	// Verify no two entities share same name
 	for _, t := range s.tables {
 		name := t.Name()
@@ -174,7 +174,7 @@ func (s *Schema) normalize() error {
 	// We actually prioritise all tables first, then views.
 	// If a view v1 depends on v2, then v2 must come before v1, even though v1
 	// precedes v2 alphabetically
-	dependencyLevels := map[string]int{}
+	dependencyLevels := make(map[string]int, len(s.tables)+len(s.views))
 	for _, t := range s.tables {
 		s.sorted = append(s.sorted, t)
 		dependencyLevels[t.Name()] = 0
@@ -204,14 +204,14 @@ func (s *Schema) normalize() error {
 	// - etc.
 	// we stop when we have been unable to find a view in an iteration.
 	for iterationLevel := 1; ; iterationLevel++ {
-		handledAnyViewsInItration := false
+		handledAnyViewsInIteration := false
 		for _, v := range s.views {
 			name := v.Name()
 			if _, ok := dependencyLevels[name]; ok {
 				// already handled; skip
 				continue
 			}
-			// Not handled. Is this view dependant on already handled objects?
+			// Not handled. Is this view dependent on already handled objects?
 			dependentNames, err := getViewDependentTableNames(&v.CreateView)
 			if err != nil {
 				return err
@@ -219,10 +219,10 @@ func (s *Schema) normalize() error {
 			if allNamesFoundInLowerLevel(dependentNames, iterationLevel) {
 				s.sorted = append(s.sorted, v)
 				dependencyLevels[v.Name()] = iterationLevel
-				handledAnyViewsInItration = true
+				handledAnyViewsInIteration = true
 			}
 		}
-		if !handledAnyViewsInItration {
+		if !handledAnyViewsInIteration {
 			break
 		}
 	}
@@ -275,7 +275,7 @@ func (s *Schema) TableNames() []string {
 	return names
 }
 
-// Tables returns this schema's views in good order (may be applied without error)
+// Views returns this schema's views in good order (may be applied without error)
 func (s *Schema) Views() []*CreateViewEntity {
 	var views []*CreateViewEntity
 	for _, entity := range s.sorted {
@@ -362,7 +362,7 @@ func (s *Schema) heuristicallyDetectTableRenames(
 
 	findRenamedTable := func() bool {
 		// What we're doing next is to try and identify a table RENAME.
-		// We do so by cross referencing dropped and created tables.
+		// We do so by cross-referencing dropped and created tables.
 		// The check is heuristic, and looks like this:
 		// We consider a table renamed iff:
 		// - the DROP and CREATE table definitions are identical other than the table name
@@ -371,7 +371,7 @@ func (s *Schema) heuristicallyDetectTableRenames(
 		// Once we heuristically decide that we found a RENAME, we cancel the DROP,
 		// cancel the CREATE, and inject a RENAME in place of both.
 
-		// findRenamedTable cross references dropped and created tables to find a single renamed table. If such is found:
+		// findRenamedTable cross-references dropped and created tables to find a single renamed table. If such is found:
 		// we remove the entry from DROPped tables, remove the entry from CREATEd tables, add an entry for RENAMEd tables,
 		// and return 'true'.
 		// Successive calls to this function will then find the next heuristic RENAMEs.
@@ -469,17 +469,21 @@ func (s *Schema) ToSQL() string {
 	return buf.String()
 }
 
-// Clone returns a deep copy of the schema. This is used when applying changes for example. It
-// will first create copies of all entities which depend on the sqlparser deep copy logic and
-// then creates a new schema from those copies.
-func (s *Schema) Clone() *Schema {
-	entities := make([]Entity, 0, len(s.Entities()))
-	for _, e := range s.Entities() {
-		entities = append(entities, e.Clone())
+// copy returns a shallow copy of the schema. This is used when applying changes for example.
+// applying changes will ensure we copy new entities themselves separately.
+func (s *Schema) copy() *Schema {
+	dup := newEmptySchema()
+	dup.tables = make([]*CreateTableEntity, len(s.tables))
+	copy(dup.tables, s.tables)
+	dup.views = make([]*CreateViewEntity, len(s.views))
+	copy(dup.views, s.views)
+	dup.named = make(map[string]Entity, len(s.named))
+	for k, v := range s.named {
+		dup.named[k] = v
 	}
-	// Can't error since we're valid ourselves.
-	schema, _ := NewSchemaFromEntities(entities)
-	return schema
+	dup.sorted = make([]Entity, len(s.sorted))
+	copy(dup.sorted, s.sorted)
+	return dup
 }
 
 // apply attempts to apply given list of diffs to this object.
@@ -604,7 +608,7 @@ func (s *Schema) apply(diffs []EntityDiff) error {
 // These diffs are CREATE/DROP/ALTER TABLE/VIEW.
 // The operation does not modify this object. Instead, if successful, a new (modified) Schema is returned.
 func (s *Schema) Apply(diffs []EntityDiff) (*Schema, error) {
-	dup := s.Clone()
+	dup := s.copy()
 	for k, v := range s.named {
 		dup.named[k] = v
 	}

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -69,7 +69,7 @@ func NewSchemaFromEntities(entities []Entity) (*Schema, error) {
 
 // NewSchemaFromStatements creates a valid and normalized schema based on list of valid statements
 func NewSchemaFromStatements(statements []sqlparser.Statement) (*Schema, error) {
-	entities := []Entity{}
+	entities := make([]Entity, 0, len(statements))
 	for _, s := range statements {
 		switch stmt := s.(type) {
 		case *sqlparser.CreateTable:
@@ -93,7 +93,7 @@ func NewSchemaFromStatements(statements []sqlparser.Statement) (*Schema, error) 
 
 // NewSchemaFromQueries creates a valid and normalized schema based on list of queries
 func NewSchemaFromQueries(queries []string) (*Schema, error) {
-	statements := []sqlparser.Statement{}
+	statements := make([]sqlparser.Statement, 0, len(queries))
 	for _, q := range queries {
 		stmt, err := sqlparser.ParseStrictDDL(q)
 		if err != nil {
@@ -107,7 +107,7 @@ func NewSchemaFromQueries(queries []string) (*Schema, error) {
 // NewSchemaFromSQL creates a valid and normalized schema based on a SQL blob that contains
 // CREATE statements for various objects (tables, views)
 func NewSchemaFromSQL(sql string) (*Schema, error) {
-	statements := []sqlparser.Statement{}
+	var statements []sqlparser.Statement
 	tokenizer := sqlparser.NewStringTokenizer(sql)
 	for {
 		stmt, err := sqlparser.ParseNextStrictDDL(tokenizer)
@@ -443,7 +443,7 @@ func (s *Schema) View(name string) *CreateViewEntity {
 
 // ToStatements returns an ordered list of statements which can be applied to create the schema
 func (s *Schema) ToStatements() []sqlparser.Statement {
-	stmts := []sqlparser.Statement{}
+	stmts := make([]sqlparser.Statement, 0, len(s.Entities()))
 	for _, e := range s.Entities() {
 		stmts = append(stmts, e.Create().Statement())
 	}
@@ -452,7 +452,7 @@ func (s *Schema) ToStatements() []sqlparser.Statement {
 
 // ToQueries returns an ordered list of queries which can be applied to create the schema
 func (s *Schema) ToQueries() []string {
-	queries := []string{}
+	queries := make([]string, 0, len(s.Entities()))
 	for _, e := range s.Entities() {
 		queries = append(queries, e.Create().CanonicalStatementString())
 	}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -143,12 +143,12 @@ func TestToSQL(t *testing.T) {
 	assert.Equal(t, toSQL, sql)
 }
 
-func TestClone(t *testing.T) {
+func TestCopy(t *testing.T) {
 	schema, err := NewSchemaFromQueries(createQueries)
 	assert.NoError(t, err)
 	assert.NotNil(t, schema)
 
-	schemaClone := schema.Clone()
+	schemaClone := schema.copy()
 	assert.Equal(t, schema, schemaClone)
 	assert.Equal(t, schema.ToSQL(), schemaClone.ToSQL())
 	assert.False(t, schema == schemaClone)

--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -2105,12 +2105,6 @@ func (c *CreateTableEntity) identicalOtherThanName(other *CreateTableEntity) boo
 	if other == nil {
 		return false
 	}
-	return sqlparser.EqualsRefOfCreateTable(tableWithMaskedName(&c.CreateTable), tableWithMaskedName(&other.CreateTable))
-}
-
-// tableWithMaskedName returns the CREATE TABLE statement but with table's name replaced with a constant arbitrary name
-func tableWithMaskedName(createTable *sqlparser.CreateTable) *sqlparser.CreateTable {
-	createTable = sqlparser.CloneRefOfCreateTable(createTable)
-	createTable.Table.Name = sqlparser.NewIdentifierCS("mask")
-	return createTable
+	return sqlparser.EqualsRefOfTableSpec(c.TableSpec, other.TableSpec) &&
+		sqlparser.EqualsRefOfParsedComments(c.Comments, other.Comments)
 }

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -45,9 +45,9 @@ type EntityDiff interface {
 	// Statement returns a valid SQL statement that applies the diff, e.g. an ALTER TABLE ...
 	// It returns nil if the diff is empty
 	Statement() sqlparser.Statement
-	// StatementString "stringifies" the this diff's Statement(). It returns an empty string if the diff is empty
+	// StatementString "stringifies" this diff's Statement(). It returns an empty string if the diff is empty
 	StatementString() string
-	// CanonicalStatementString "stringifies" the this diff's Statement() to a canonical string. It returns an empty string if the diff is empty
+	// CanonicalStatementString "stringifies" this diff's Statement() to a canonical string. It returns an empty string if the diff is empty
 	CanonicalStatementString() string
 	// SubsequentDiff returns a followup diff to this one, if exists
 	SubsequentDiff() EntityDiff

--- a/go/vt/schemadiff/view.go
+++ b/go/vt/schemadiff/view.go
@@ -33,7 +33,7 @@ func (d *AlterViewEntityDiff) IsEmpty() bool {
 	return d.Statement() == nil
 }
 
-// IsEmpty implements EntityDiff
+// Entities implements EntityDiff
 func (d *AlterViewEntityDiff) Entities() (from Entity, to Entity) {
 	return d.from, d.to
 }
@@ -233,7 +233,7 @@ func (c *CreateViewEntity) Diff(other Entity, hints *DiffHints) (EntityDiff, err
 // change this view to look like the other view.
 // It returns an AlterView statement if changes are found, or nil if not.
 // the other view may be of different name; its name is ignored.
-func (c *CreateViewEntity) ViewDiff(other *CreateViewEntity, hints *DiffHints) (*AlterViewEntityDiff, error) {
+func (c *CreateViewEntity) ViewDiff(other *CreateViewEntity, _ *DiffHints) (*AlterViewEntityDiff, error) {
 	otherStmt := other.CreateView
 	otherStmt.ViewName = c.CreateView.ViewName
 
@@ -244,9 +244,7 @@ func (c *CreateViewEntity) ViewDiff(other *CreateViewEntity, hints *DiffHints) (
 		return nil, &NotFullyParsedError{Entity: c.Name(), Statement: sqlparser.CanonicalString(&otherStmt)}
 	}
 
-	format := sqlparser.CanonicalString(&c.CreateView)
-	otherFormat := sqlparser.CanonicalString(&otherStmt)
-	if format == otherFormat {
+	if sqlparser.EqualsRefOfCreateView(&c.CreateView, &otherStmt) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Since each entity `Alter()` operation already returns a copy itself of the entity that is modified, it is enough to only shallow copy the schema.

The shallow copy includes the references to the tables, views etc. and will return an already correct new schema when creating or dropping entities with no further issues.

When executing an `Apply()` on a specific entity, that already returns a clone of that entity itself so it also ensures that the new returned value is only changed and the original is unmodified.

This avoids a huge deal of copying when working with large schemas which greatly improves performance there. We're seeing another 6x improvement here in dealing with some large schemas.

## Related Issue(s)

#10203

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required