### PR TITLE
Improve schema reload performance by pre-filtering joined rows.

### DIFF
--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -327,8 +327,12 @@ const TablesWithSize57 = `SELECT t.table_name,
 	IFNULL(SUM(i.file_size), SUM(t.data_length + t.index_length)),
 	IFNULL(SUM(i.allocated_size), SUM(t.data_length + t.index_length))
 FROM information_schema.tables t
-LEFT OUTER JOIN information_schema.innodb_sys_tablespaces i
-	ON i.name LIKE CONCAT(database(), '/%') AND (i.name = CONCAT(t.table_schema, '/', t.table_name) OR i.name LIKE CONCAT(t.table_schema, '/', t.table_name, '#p#%'))
+LEFT OUTER JOIN (
+	SELECT space, file_size, allocated_size, name
+	FROM information_schema.innodb_sys_tablespaces
+	WHERE name LIKE CONCAT(database(), '/%')
+	GROUP BY space, file_size, allocated_size, name
+) i ON i.name = CONCAT(t.table_schema, '/', t.table_name) or i.name LIKE CONCAT(t.table_schema, '/', t.table_name, '#p#%')
 WHERE t.table_schema = database()
 GROUP BY t.table_name, t.table_type, t.create_time, t.table_comment`
 


### PR DESCRIPTION
## Description

When reloading the database schema, a query to fetch table information and tablespace information is executed. This query can take a long time when run on a mysql instance with many tables across many databases.

We notice the impact of this query during database setup in our CI environments, as this query is executed on each DDL statement (and thus gets incrementally slower the more tables are being created).

Performance of this query was improved before in https://github.com/vitessio/vitess/pull/9632 by pre-filtering the rows of the `information_schema.innodb_sys_tablespaces` before joining them to rows from `information_schema.tables`, but that change was accidentally reverted in https://github.com/vitessio/vitess/pull/10703.

This brings back the pre-filtering.

---

Can this be backported to the 14.x releases? 🙇‍♂️ 

## Related Issue(s)

https://github.com/vitessio/vitess/pull/9632
https://github.com/vitessio/vitess/pull/10703

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
