### PR TITLE
[cli] [logutil] Migrate flags defined in `go/vt/logutil` to `pflag`

### DIFF
--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -252,6 +252,7 @@ func main() {
 	dbconfigs.RegisterFlags(dbconfigs.Dba)
 	fs := pflag.NewFlagSet("mysqlctl", pflag.ExitOnError)
 	log.RegisterFlags(fs)
+	logutil.RegisterFlags(fs)
 	_flag.Parse(fs)
 
 	tabletAddr = netutil.JoinHostPort("localhost", int32(*port))

--- a/go/cmd/query_analyzer/query_analyzer.go
+++ b/go/cmd/query_analyzer/query_analyzer.go
@@ -28,6 +28,7 @@ import (
 
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	// Include deprecation warnings for soon-to-be-unsupported flag invocations.
@@ -63,6 +64,7 @@ func main() {
 	defer exit.Recover()
 	fs := pflag.NewFlagSet("query_analyzer", pflag.ExitOnError)
 	log.RegisterFlags(fs)
+	logutil.RegisterFlags(fs)
 	_flag.Parse(fs)
 	for _, filename := range _flag.Args() {
 		fmt.Printf("processing: %s\n", filename)

--- a/go/cmd/rulesctl/main.go
+++ b/go/cmd/rulesctl/main.go
@@ -5,11 +5,13 @@ import (
 
 	"vitess.io/vitess/go/cmd/rulesctl/cmd"
 	vtlog "vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
 )
 
 func main() {
 	rootCmd := cmd.Main()
 	vtlog.RegisterFlags(rootCmd.PersistentFlags())
+	logutil.RegisterFlags(rootCmd.PersistentFlags())
 	if err := rootCmd.Execute(); err != nil {
 		log.Printf("%v", err)
 	}

--- a/go/cmd/topo2topo/topo2topo.go
+++ b/go/cmd/topo2topo/topo2topo.go
@@ -57,6 +57,7 @@ func main() {
 
 	fs := pflag.NewFlagSet("topo2topo", pflag.ExitOnError)
 	log.RegisterFlags(fs)
+	logutil.RegisterFlags(fs)
 	_flag.Parse(fs)
 	args := _flag.Args()
 	if len(args) != 0 {

--- a/go/cmd/vtbench/vtbench.go
+++ b/go/cmd/vtbench/vtbench.go
@@ -108,6 +108,7 @@ func main() {
 	flag.Lookup("logtostderr").Value.Set("true")
 	fs := pflag.NewFlagSet("vtbench", pflag.ExitOnError)
 	log.RegisterFlags(fs)
+	logutil.RegisterFlags(fs)
 	_flag.Parse(fs)
 
 	clientProto := vtbench.MySQL

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -150,6 +150,7 @@ func main() {
 func run() (*results, error) {
 	fs := pflag.NewFlagSet("vtclient", pflag.ExitOnError)
 	log.RegisterFlags(fs)
+	logutil.RegisterFlags(fs)
 	_flag.Parse(fs)
 	args := _flag.Args()
 

--- a/go/cmd/vtctldclient/main.go
+++ b/go/cmd/vtctldclient/main.go
@@ -23,6 +23,7 @@ import (
 	"vitess.io/vitess/go/cmd/vtctldclient/command"
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
 )
 
 func main() {
@@ -31,6 +32,7 @@ func main() {
 	// Grab all those global flags across the codebase and shove 'em on in.
 	command.Root.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	log.RegisterFlags(command.Root.PersistentFlags())
+	logutil.RegisterFlags(command.Root.PersistentFlags())
 
 	// hack to get rid of an "ERROR: logging before flag.Parse"
 	args := os.Args[:]

--- a/go/cmd/vtorc/main.go
+++ b/go/cmd/vtorc/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/pflag"
 
 	vtlog "vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/orchestrator/app"
 	"vitess.io/vitess/go/vt/orchestrator/config"
 	"vitess.io/vitess/go/vt/orchestrator/external/golib/log"
@@ -103,6 +104,7 @@ func main() {
 	// directly.
 	fs := pflag.NewFlagSet("vtorc", pflag.ExitOnError)
 	vtlog.RegisterFlags(fs)
+	logutil.RegisterFlags(fs)
 
 	args := append([]string{}, os.Args...)
 	os.Args = os.Args[0:1]

--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/vttest"
 
 	vttestpb "vitess.io/vitess/go/vt/proto/vttest"
@@ -212,9 +213,12 @@ func parseFlags() (env vttest.Environment, err error) {
 	logFlagsOnce.Do(func() {
 		fs := pflag.NewFlagSet("vtgateclienttest", pflag.ExitOnError)
 		log.RegisterFlags(fs)
+		logutil.RegisterFlags(fs)
 
-		f := fs.Lookup("log_rotate_max_size")
-		flag.Var(f.Value, f.Name, f.Usage)
+		// Move all pflag flags back to the goflag CommandLine.
+		fs.VisitAll(func(f *pflag.Flag) {
+			flag.Var(f.Value, f.Name, f.Usage)
+		})
 	})
 
 	flag.Parse()

--- a/go/cmd/zk/zkcmd.go
+++ b/go/cmd/zk/zkcmd.go
@@ -143,6 +143,7 @@ func main() {
 
 	fs := pflag.NewFlagSet("zkcmd", pflag.ExitOnError)
 	log.RegisterFlags(fs)
+	logutil.RegisterFlags(fs)
 	_flag.SetUsage(flag.CommandLine, _flag.UsageOptions{ // TODO: hmmm
 		Epilogue: func(w io.Writer) { fmt.Fprint(w, doc) },
 	})

--- a/go/cmd/zkctl/zkctl.go
+++ b/go/cmd/zkctl/zkctl.go
@@ -64,6 +64,7 @@ func main() {
 
 	fs := pflag.NewFlagSet("zkctl", pflag.ExitOnError)
 	log.RegisterFlags(fs)
+	logutil.RegisterFlags(fs)
 	_flag.Parse(fs)
 	args := _flag.Args()
 

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -104,8 +104,8 @@ Usage of vtctld:
       --hot_row_protection_max_global_queue_size int                     Global queue limit across all row (ranges). Useful to prevent that the queue can grow unbounded. (default 1000)
       --hot_row_protection_max_queue_size int                            Maximum number of BeginExecute RPCs which will be queued for the same row (range). (default 20)
       --jaeger-agent-host string                                         host and port to send spans to. if empty, no tracing will be done
-      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever) (default 0s)
-      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever) (default 0s)
+      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
+      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --keyspaces_to_watch strings                                       Specifies which keyspaces this vtgate should have access to while routing queries or accessing the vschema.
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
       --log_backtrace_at traceLocation                                   when logging hits line file:N, emit a stack trace (default :0)

--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -104,8 +104,8 @@ Usage of vtexplain:
       --hot_row_protection_concurrent_transactions int                   Number of concurrent transactions let through to the txpool/MySQL for the same hot row. Should be > 1 to have enough 'ready' transactions in MySQL and benefit from a pipelining effect. (default 5)
       --hot_row_protection_max_global_queue_size int                     Global queue limit across all row (ranges). Useful to prevent that the queue can grow unbounded. (default 1000)
       --hot_row_protection_max_queue_size int                            Maximum number of BeginExecute RPCs which will be queued for the same row (range). (default 20)
-      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever) (default 0s)
-      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever) (default 0s)
+      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
+      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --ks-shard-map string                                              JSON map of keyspace name -> shard name -> ShardReference object. The inner map is the same as the output of FindAllShardsInKeyspace
       --ks-shard-map-file string                                         File containing json blob of keyspace name -> shard name -> ShardReference object
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -63,8 +63,8 @@ Usage of vtgate:
       --healthcheck_timeout duration                                     the health check timeout period (default 1m0s)
   -h, --help                                                             display usage and exit
       --jaeger-agent-host string                                         host and port to send spans to. if empty, no tracing will be done
-      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever) (default 0s)
-      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever) (default 0s)
+      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
+      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --keyspaces_to_watch strings                                       Specifies which keyspaces this vtgate should have access to while routing queries or accessing the vschema.
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
       --legacy_replication_lag_algorithm                                 Use the legacy algorithm when selecting vttablets for serving. (default true)

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -38,8 +38,8 @@ Usage of vtgr:
       --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
       --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
   -h, --help                                                             display usage and exit
-      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever) (default 0s)
-      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever) (default 0s)
+      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
+      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
       --log_backtrace_at traceLocation                                   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                                                   If non-empty, write log files in this directory

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -253,8 +253,8 @@ Usage of vttablet:
       --init_tags StringMap                                              (init parameter) comma separated list of key:value pairs used to tag the tablet
       --init_timeout duration                                            (init parameter) timeout to use for the init phase. (default 1m0s)
       --jaeger-agent-host string                                         host and port to send spans to. if empty, no tracing will be done
-      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever) (default 0s)
-      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever) (default 0s)
+      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
+      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
       --lock_tables_timeout duration                                     How long to keep the table locked before timing out (default 1m0s)
       --log_backtrace_at traceLocation                                   when logging hits line file:N, emit a stack trace (default :0)

--- a/go/internal/flag/flag.go
+++ b/go/internal/flag/flag.go
@@ -77,6 +77,21 @@ func Parsed() bool {
 	return goflag.Parsed() || flag.Parsed()
 }
 
+// Lookup returns a pflag.Flag with the given name, from either the pflag or
+// standard library `flag` CommandLine. If found in the latter, it is converted
+// to a pflag.Flag first. If found in neither, this function returns nil.
+func Lookup(name string) *flag.Flag {
+	if f := flag.Lookup(name); f != nil {
+		return f
+	}
+
+	if f := goflag.Lookup(name); f != nil {
+		return flag.PFlagFromGoFlag(f)
+	}
+
+	return nil
+}
+
 // Args returns the positional arguments with the first double-dash ("--")
 // removed. If no double-dash was specified on the command-line, this is
 // equivalent to flag.Args() from the standard library flag package.

--- a/go/vt/logutil/level.go
+++ b/go/vt/logutil/level.go
@@ -17,11 +17,11 @@ limitations under the License.
 package logutil
 
 import (
-	"flag"
+	_flag "vitess.io/vitess/go/internal/flag"
 )
 
 func init() {
-	threshold := flag.Lookup("stderrthreshold")
+	threshold := _flag.Lookup("stderrthreshold")
 	if threshold == nil {
 		// the logging module doesn't specify a stderrthreshold flag
 		return

--- a/go/vt/logutil/purge.go
+++ b/go/vt/logutil/purge.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	_flag "vitess.io/vitess/go/internal/flag"
 )
 
 var (
@@ -103,7 +105,7 @@ func purgeLogsOnce(now time.Time, dir, program string, ctimeDelta time.Duration,
 // PurgeLogs removes any log files that were started more than
 // keepLogs ago and that aren't the current log.
 func PurgeLogs() {
-	f := flag.Lookup("log_dir")
+	f := _flag.Lookup("log_dir")
 	if f == nil {
 		panic("the logging module doesn't specify a log_dir flag")
 	}

--- a/go/vt/logutil/purge.go
+++ b/go/vt/logutil/purge.go
@@ -17,7 +17,6 @@ limitations under the License.
 package logutil
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path"
@@ -25,14 +24,27 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	_flag "vitess.io/vitess/go/internal/flag"
 )
 
 var (
-	keepLogsByCtime   = flag.Duration("keep_logs", 0, "keep logs for this long (using ctime) (zero to keep forever)")
-	keepLogsByMtime   = flag.Duration("keep_logs_by_mtime", 0, "keep logs for this long (using mtime) (zero to keep forever)")
-	purgeLogsInterval = flag.Duration("purge_logs_interval", 1*time.Hour, "how often try to remove old logs")
+	keepLogsByCtime   time.Duration
+	keepLogsByMtime   time.Duration
+	purgeLogsInterval = 1 * time.Hour
 )
+
+// RegisterFlags installs logutil flags on the given FlagSet.
+//
+// `go/cmd/*` entrypoints should either use servenv.ParseFlags(WithArgs)? which
+// calls this function, or call this function directly before parsing
+// command-line arguments.
+func RegisterFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&keepLogsByCtime, "keep_logs", keepLogsByCtime, "keep logs for this long (using ctime) (zero to keep forever)")
+	fs.DurationVar(&keepLogsByMtime, "keep_logs_by_mtime", keepLogsByMtime, "keep logs for this long (using mtime) (zero to keep forever)")
+	fs.DurationVar(&purgeLogsInterval, "purge_logs_interval", purgeLogsInterval, "how often try to remove old logs")
+}
 
 // parse parses a file name (as used by glog) and returns its process
 // name and timestamp.
@@ -109,13 +121,13 @@ func PurgeLogs() {
 	if f == nil {
 		panic("the logging module doesn't specify a log_dir flag")
 	}
-	if *keepLogsByCtime == 0 && *keepLogsByMtime == 0 {
+	if keepLogsByCtime == 0 && keepLogsByMtime == 0 {
 		return
 	}
 	logDir := f.Value.String()
 	program := filepath.Base(os.Args[0])
-	ticker := time.NewTicker(*purgeLogsInterval)
+	ticker := time.NewTicker(purgeLogsInterval)
 	for range ticker.C {
-		purgeLogsOnce(time.Now(), logDir, program, *keepLogsByCtime, *keepLogsByMtime)
+		purgeLogsOnce(time.Now(), logDir, program, keepLogsByCtime, keepLogsByMtime)
 	}
 }

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -48,6 +48,7 @@ import (
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	// register the proper init and shutdown hooks for logging
@@ -342,6 +343,8 @@ func init() {
 		OnParseFor(cmd, trace.RegisterFlags)
 	}
 
-	// Log flags are installed for all binaries.
+	// Flags in package log are installed for all binaries.
 	OnParse(log.RegisterFlags)
+	// Flags in package logutil are installed for all binaries.
+	OnParse(logutil.RegisterFlags)
 }


### PR DESCRIPTION


## Description

Basically the same general shape of #11036, but this time for `go/vt/logutil`. The other notable callouts:
- We have a `_flag.Lookup` helper which tries to find a pflag Flag globally defined; failing that, a go flag Flag (which we convert to a pflag Flag).
- The vttestserver Once wrapper is now generic to flag names, so it'll be less cumbersome to keep up to date in the future.

## Related Issue(s)

Closes #10809

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
