### PR TITLE
Improve merging for `None` route opcodes.

### DIFF
--- a/go/vt/vtgate/planbuilder/physical/route_planning.go
+++ b/go/vt/vtgate/planbuilder/physical/route_planning.go
@@ -659,7 +659,7 @@ func tryMerge(
 		// can merge via join predicates instead.
 		fallthrough
 
-	case engine.Scatter, engine.IN:
+	case engine.Scatter, engine.IN, engine.None:
 		if len(joinPredicates) == 0 {
 			// If we are doing two Scatters, we have to make sure that the
 			// joins are on the correct vindex to allow them to be merged
@@ -678,7 +678,13 @@ func tryMerge(
 		if err != nil {
 			return nil, err
 		}
-		r.PickBestAvailableVindex()
+
+		// If we have a `None` route opcode, we want to keep it -
+		// we only try to find a better Vindex for other route opcodes
+		if aRoute.RouteOpCode != engine.None {
+			r.PickBestAvailableVindex()
+		}
+
 		return r, nil
 	}
 	return nil, nil

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -5505,3 +5505,40 @@ Gen4 plan same as above
     "user.user"
   ]
 }
+
+# `None` route being merged with another route via join predicate on Vindex columns
+"SELECT `music`.id FROM `music` INNER JOIN `user` ON music.user_id = user.id WHERE music.user_id IN (NULL) AND user.id = 5"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT `music`.id FROM `music` INNER JOIN `user` ON music.user_id = user.id WHERE music.user_id IN (NULL) AND user.id = 5",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "None",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select music.id from music join `user` on music.user_id = `user`.id where 1 != 1",
+    "Query": "select music.id from music join `user` on music.user_id = `user`.id where music.user_id in (null) and `user`.id = 5",
+    "Table": "music, `user`"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT `music`.id FROM `music` INNER JOIN `user` ON music.user_id = user.id WHERE music.user_id IN (NULL) AND user.id = 5",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "None",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select music.id from music, `user` where 1 != 1",
+    "Query": "select music.id from music, `user` where music.user_id in (null) and `user`.id = 5 and music.user_id = `user`.id",
+    "Table": "`user`, music"
+  },
+  "TablesUsed": [
+    "user.music",
+    "user.user"
+  ]
+}


### PR DESCRIPTION
In the Gen4 planner, routes with a `None` opcode do not be merged with other routes (e.g. for `JOIN`s). Instead, queries are broken up.

For example, the following query (using the schema defined in `go/vt/vtgate/planbuilder/testdata/schema_test.json`):

```sql
SELECT `music`.id FROM `music` INNER JOIN `user` ON music.user_id = user.id WHERE music.user_id IN (NULL) AND user.id = 5
```

Will result in this Gen4 plan:

```json
{
  "QueryType": "SELECT",
  "Original": "SELECT `music`.id FROM `music` INNER JOIN `user` ON music.user_id = user.id WHERE music.user_id IN (NULL) AND user.id = 5",
  "Instructions": {
    "OperatorType": "Join",
    "Variant": "Join",
    "JoinColumnIndexes": "L:1",
    "JoinVars": {
      "music_user_id": 0
    },
    "TableName": "music_`user`",
    "Inputs": [
      {
        "OperatorType": "Route",
        "Variant": "None",
        "Keyspace": {
          "Name": "user",
          "Sharded": true
        },
        "FieldQuery": "select music.user_id, music.id from music where 1 != 1",
        "Query": "select music.user_id, music.id from music where music.user_id in (null)",
        "Table": "music"
      },
      {
        "OperatorType": "Route",
        "Variant": "EqualUnique",
        "Keyspace": {
          "Name": "user",
          "Sharded": true
        },
        "FieldQuery": "select 1 from `user` where 1 != 1",
        "Query": "select 1 from `user` where `user`.id = 5 and `user`.id = :music_user_id",
        "Table": "`user`",
        "Values": [
          ":music_user_id"
        ],
        "Vindex": "user_index"
      }
    ]
  },
  "TablesUsed": [
    "user.music",
    "user.user"
  ]
}
```

This change makes the Gen4 planner behave more closely to V3, and will generate the following plan:

```json
{
  "QueryType": "SELECT",
  "Original": "SELECT `music`.id FROM `music` INNER JOIN `user` ON music.user_id = user.id WHERE music.user_id IN (NULL) AND user.id = 5",
  "Instructions": {
    "OperatorType": "Route",
    "Variant": "None",
    "Keyspace": {
      "Name": "user",
      "Sharded": true
    },
    "FieldQuery": "select music.id from music, `user` where 1 != 1",
    "Query": "select music.id from music, `user` where music.user_id in (null) and `user`.id = 5 and music.user_id = `user`.id",
    "Table": "`user`, music"
  },
  "TablesUsed": [
    "user.music",
    "user.user"
  ]
}
```

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
