### PR TITLE
Remove deprecated flag `enable_queries` from end to end tests in v14 

### DIFF
--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -18,8 +18,10 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"net"
@@ -34,9 +36,20 @@ import (
 	"syscall"
 	"time"
 
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-
+	"vitess.io/vitess/go/json2"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+	"vitess.io/vitess/go/vt/vttablet/tabletconn"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+
+	// Ensure dialers are registered (needed by ExecOnTablet and ExecOnVTGate).
+	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
+	_ "vitess.io/vitess/go/vt/vttablet/grpctabletconn"
 )
 
 // DefaultCell : If no cell name is passed, then use following
@@ -783,6 +796,103 @@ func (cluster *LocalProcessCluster) Teardown() {
 	os.Setenv("VTDATAROOT", cluster.OriginalVTDATAROOT)
 
 	cluster.teardownCompleted = true
+}
+
+// ExecOnTablet executes a query on the local cluster Vttablet and returns the
+// result.
+func (cluster *LocalProcessCluster) ExecOnTablet(ctx context.Context, vttablet *Vttablet, sql string, binds map[string]any, opts *querypb.ExecuteOptions) (*sqltypes.Result, error) {
+	bindvars, err := sqltypes.BuildBindVariables(binds)
+	if err != nil {
+		return nil, err
+	}
+
+	tablet, err := cluster.vtctlclientGetTablet(vttablet)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := tabletconn.GetDialer()(tablet, grpcclient.FailFast(false))
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close(ctx)
+
+	txID, reservedID := 0, 0
+
+	return conn.Execute(ctx, &querypb.Target{
+		Keyspace:   tablet.Keyspace,
+		Shard:      tablet.Shard,
+		TabletType: tablet.Type,
+	}, sql, bindvars, int64(txID), int64(reservedID), opts)
+}
+
+// ExecOnVTGate executes a query on a local cluster VTGate with the provided
+// target, bindvars, and execute options.
+func (cluster *LocalProcessCluster) ExecOnVTGate(ctx context.Context, addr string, target string, sql string, binds map[string]any, opts *querypb.ExecuteOptions) (*sqltypes.Result, error) {
+	bindvars, err := sqltypes.BuildBindVariables(binds)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := vtgateconn.Dial(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	session := conn.Session(target, opts)
+	defer conn.Close()
+
+	return session.Execute(ctx, sql, bindvars)
+}
+
+// StreamTabletHealth invokes a HealthStream on a local cluster Vttablet and
+// returns the responses. It returns an error if the stream ends with fewer than
+// `count` responses.
+func (cluster *LocalProcessCluster) StreamTabletHealth(ctx context.Context, vttablet *Vttablet, count int) (responses []*querypb.StreamHealthResponse, err error) {
+	tablet, err := cluster.vtctlclientGetTablet(vttablet)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := tabletconn.GetDialer()(tablet, grpcclient.FailFast(false))
+	if err != nil {
+		return nil, err
+	}
+
+	i := 0
+	err = conn.StreamHealth(ctx, func(shr *querypb.StreamHealthResponse) error {
+		responses = append(responses, shr)
+
+		i++
+		if i >= count {
+			return io.EOF
+		}
+
+		return nil
+	})
+
+	switch {
+	case err != nil:
+		return nil, err
+	case len(responses) < count:
+		return nil, errors.New("stream ended early")
+	}
+
+	return responses, nil
+}
+
+func (cluster *LocalProcessCluster) vtctlclientGetTablet(tablet *Vttablet) (*topodatapb.Tablet, error) {
+	result, err := cluster.VtctlclientProcess.ExecuteCommandWithOutput("GetTablet", "--", tablet.Alias)
+	if err != nil {
+		return nil, err
+	}
+
+	var ti topodatapb.Tablet
+	if err := json2.Unmarshal([]byte(result), &ti); err != nil {
+		return nil, err
+	}
+
+	return &ti, nil
 }
 
 func (cluster *LocalProcessCluster) waitForMySQLProcessToExit(mysqlctlProcessList []*exec.Cmd, mysqlctlTabletUIDs []int) {

--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -72,7 +72,6 @@ func (vtctl *VtctlProcess) CreateKeyspace(keyspace string) (err error) {
 func (vtctl *VtctlProcess) ExecuteCommandWithOutput(args ...string) (result string, err error) {
 	args = append([]string{
 		"--log_dir", vtctl.LogDir,
-		"--enable_queries",
 		"--topo_implementation", vtctl.TopoImplementation,
 		"--topo_global_server_address", vtctl.TopoGlobalAddress,
 		"--topo_global_root", vtctl.TopoGlobalRoot}, args...)
@@ -91,7 +90,6 @@ func (vtctl *VtctlProcess) ExecuteCommandWithOutput(args ...string) (result stri
 // ExecuteCommand executes any vtctlclient command
 func (vtctl *VtctlProcess) ExecuteCommand(args ...string) (err error) {
 	args = append([]string{
-		"--enable_queries",
 		"--topo_implementation", vtctl.TopoImplementation,
 		"--topo_global_server_address", vtctl.TopoGlobalAddress,
 		"--topo_global_root", vtctl.TopoGlobalRoot}, args...)

--- a/go/test/endtoend/cluster/vtctld_process.go
+++ b/go/test/endtoend/cluster/vtctld_process.go
@@ -54,7 +54,6 @@ func (vtctld *VtctldProcess) Setup(cell string, extraArgs ...string) (err error)
 	_ = createDirectory(path.Join(vtctld.Directory, "backups"), 0700)
 	vtctld.proc = exec.Command(
 		vtctld.Binary,
-		"--enable_queries",
 		"--topo_implementation", vtctld.CommonArg.TopoImplementation,
 		"--topo_global_server_address", vtctld.CommonArg.TopoGlobalAddress,
 		"--topo_global_root", vtctld.CommonArg.TopoGlobalRoot,

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -28,20 +28,18 @@ import (
 	"testing"
 	"time"
 
-	tmc "vitess.io/vitess/go/vt/vttablet/grpctmclient"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/json2"
-	"vitess.io/vitess/go/vt/log"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/vt/log"
+	tmc "vitess.io/vitess/go/vt/vttablet/grpctmclient"
+
+	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 var (
@@ -480,12 +478,9 @@ func CheckPrimaryTablet(t *testing.T, clusterInstance *cluster.LocalProcessClust
 	assert.Equal(t, topodatapb.TabletType_PRIMARY, tabletInfo.GetType())
 
 	// make sure the health stream is updated
-	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("VtTabletStreamHealth", "--", "--count", "1", tablet.Alias)
+	shrs, err := clusterInstance.StreamTabletHealth(context.Background(), tablet, 1)
 	require.NoError(t, err)
-	var streamHealthResponse querypb.StreamHealthResponse
-
-	err = json2.Unmarshal([]byte(result), &streamHealthResponse)
-	require.NoError(t, err)
+	streamHealthResponse := shrs[0]
 
 	assert.True(t, streamHealthResponse.GetServing())
 	tabletType := streamHealthResponse.GetTarget().GetTabletType()
@@ -504,12 +499,9 @@ func isHealthyPrimaryTablet(t *testing.T, clusterInstance *cluster.LocalProcessC
 	}
 
 	// make sure the health stream is updated
-	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("VtTabletStreamHealth", "--", "--count", "1", tablet.Alias)
-	require.Nil(t, err)
-	var streamHealthResponse querypb.StreamHealthResponse
-
-	err = json2.Unmarshal([]byte(result), &streamHealthResponse)
-	require.Nil(t, err)
+	shrs, err := clusterInstance.StreamTabletHealth(context.Background(), tablet, 1)
+	require.NoError(t, err)
+	streamHealthResponse := shrs[0]
 
 	assert.True(t, streamHealthResponse.GetServing())
 	tabletType := streamHealthResponse.GetTarget().GetTabletType()
@@ -665,14 +657,10 @@ func CheckReparentFromOutside(t *testing.T, clusterInstance *cluster.LocalProces
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RunHealthCheck", tablet.Alias)
 	require.NoError(t, err)
 
-	streamHealth, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(
-		"VtTabletStreamHealth", "--",
-		"--count", "1", tablet.Alias)
+	shrs, err := clusterInstance.StreamTabletHealth(context.Background(), tablet, 1)
 	require.NoError(t, err)
 
-	var streamHealthResponse querypb.StreamHealthResponse
-	err = json.Unmarshal([]byte(streamHealth), &streamHealthResponse)
-	require.NoError(t, err)
+	streamHealthResponse := shrs[0]
 	assert.Equal(t, streamHealthResponse.Target.TabletType, topodatapb.TabletType_PRIMARY)
 	assert.True(t, streamHealthResponse.TabletExternallyReparentedTimestamp >= baseTime)
 }

--- a/go/test/endtoend/sharding/base_sharding.go
+++ b/go/test/endtoend/sharding/base_sharding.go
@@ -190,12 +190,9 @@ func checkStreamHealthEqualsBinlogPlayerVars(t *testing.T, vttablet cluster.Vtta
 	// Enforce health check because it's not running by default as
 	// tablets may not be started with it, or may not run it in time.
 	_ = ci.VtctlclientProcess.ExecuteCommand("RunHealthCheck", vttablet.Alias)
-	streamHealth, err := ci.VtctlclientProcess.ExecuteCommandWithOutput("VtTabletStreamHealth", "--", "--count", "1", vttablet.Alias)
-	require.Nil(t, err)
-
-	var streamHealthResponse querypb.StreamHealthResponse
-	err = json2.Unmarshal([]byte(streamHealth), &streamHealthResponse)
-	require.Nil(t, err, "error should be Nil")
+	shrs, err := ci.StreamTabletHealth(context.Background(), &vttablet, 1)
+	require.NoError(t, err)
+	streamHealthResponse := shrs[0]
 	assert.Equal(t, streamHealthResponse.Serving, false)
 	assert.NotNil(t, streamHealthResponse.RealtimeStats)
 	assert.Equal(t, streamHealthResponse.RealtimeStats.HealthError, "")

--- a/go/test/endtoend/sharding/mergesharding/mergesharding_base.go
+++ b/go/test/endtoend/sharding/mergesharding/mergesharding_base.go
@@ -412,15 +412,9 @@ func TestMergesharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	require.NoError(t, err)
 
 	sharding.CheckTabletQueryService(t, *shard3Primary, "NOT_SERVING", false, *clusterInstance)
-	streamHealth, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(
-		"VtTabletStreamHealth", "--",
-		"--count", "1", shard3Primary.Alias)
+	shrs, err := clusterInstance.StreamTabletHealth(context.Background(), shard3Primary, 1)
 	require.NoError(t, err)
-	log.Info("Got health: ", streamHealth)
-
-	var streamHealthResponse querypb.StreamHealthResponse
-	err = json.Unmarshal([]byte(streamHealth), &streamHealthResponse)
-	require.NoError(t, err)
+	streamHealthResponse := shrs[0]
 	assert.Equal(t, streamHealthResponse.Serving, false)
 	assert.NotNil(t, streamHealthResponse.RealtimeStats)
 

--- a/go/test/endtoend/sharding/resharding/resharding_base.go
+++ b/go/test/endtoend/sharding/resharding/resharding_base.go
@@ -621,20 +621,14 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RunHealthCheck", shard3Primary.Alias)
 	require.Nil(t, err)
 
-	for _, primary := range []cluster.Vttablet{*shard2Primary, *shard3Primary} {
-		sharding.CheckTabletQueryService(t, primary, "NOT_SERVING", false, *clusterInstance)
-		streamHealth, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(
-			"VtTabletStreamHealth", "--",
-			"--count", "1", primary.Alias)
-		require.Nil(t, err)
-		log.Info("Got health: ", streamHealth)
+	for _, primary := range []*cluster.Vttablet{shard2Primary, shard3Primary} {
+		sharding.CheckTabletQueryService(t, *primary, "NOT_SERVING", false, *clusterInstance)
+		shrs, err := clusterInstance.StreamTabletHealth(context.Background(), primary, 1)
+		require.NoError(t, err)
+		streamHealthResponse := shrs[0]
 
-		var streamHealthResponse querypb.StreamHealthResponse
-		err = json.Unmarshal([]byte(streamHealth), &streamHealthResponse)
-		require.Nil(t, err)
 		assert.Equal(t, streamHealthResponse.Serving, false)
 		assert.NotNil(t, streamHealthResponse.RealtimeStats)
-
 	}
 
 	// now serve rdonly from the split shards, in cell1 only

--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -58,16 +58,8 @@ func TestTabletCommands(t *testing.T) {
 	utils.Exec(t, conn, "insert into t1(id, value) values(1,'a'), (2,'b')")
 	checkDataOnReplica(t, replicaConn, `[[VARCHAR("a")] [VARCHAR("b")]]`)
 
-	// test exclude_field_names to vttablet works as expected
-	sql := "select id, value from t1"
-	args := []string{
-		"VtTabletExecute", "--",
-		"--options", "included_fields:TYPE_ONLY",
-		"--json",
-		primaryTablet.Alias,
-		sql,
-	}
-	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(args...)
+	sql := "select * from t1"
+	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDba", "--", "--json", primaryTablet.Alias, sql)
 	require.Nil(t, err)
 	assertExcludeFields(t, result)
 

--- a/go/test/endtoend/tabletmanager/primary/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/primary/tablet_test.go
@@ -16,21 +16,19 @@ limitations under the License.
 package primary
 
 import (
-	"encoding/json"
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
 	"os"
 	"testing"
 
-	"vitess.io/vitess/go/json2"
-
-	"vitess.io/vitess/go/test/endtoend/cluster"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/json2"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
@@ -173,13 +171,10 @@ func TestPrimaryRestartSetsTERTimestamp(t *testing.T) {
 	require.Nil(t, err)
 
 	// Capture the current TER.
-	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(
-		"VtTabletStreamHealth", "--", "--count", "1", replicaTablet.Alias)
+	shrs, err := clusterInstance.StreamTabletHealth(context.Background(), &replicaTablet, 1)
 	require.Nil(t, err)
 
-	var streamHealthRes1 querypb.StreamHealthResponse
-	err = json.Unmarshal([]byte(result), &streamHealthRes1)
-	require.Nil(t, err)
+	streamHealthRes1 := shrs[0]
 	actualType := streamHealthRes1.GetTarget().GetTabletType()
 	tabletType := topodatapb.TabletType_value["PRIMARY"]
 	got := fmt.Sprintf("%d", actualType)
@@ -200,13 +195,10 @@ func TestPrimaryRestartSetsTERTimestamp(t *testing.T) {
 	require.Nil(t, err)
 
 	// Make sure that the TER did not change
-	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(
-		"VtTabletStreamHealth", "--", "--count", "1", replicaTablet.Alias)
+	shrs, err = clusterInstance.StreamTabletHealth(context.Background(), &replicaTablet, 1)
 	require.Nil(t, err)
 
-	var streamHealthRes2 querypb.StreamHealthResponse
-	err = json.Unmarshal([]byte(result), &streamHealthRes2)
-	require.Nil(t, err)
+	streamHealthRes2 := shrs[0]
 
 	actualType = streamHealthRes2.GetTarget().GetTabletType()
 	tabletType = topodatapb.TabletType_value["PRIMARY"]

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -45,7 +45,6 @@ import (
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 
-	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
@@ -397,12 +396,10 @@ func CheckPrimaryTablet(t *testing.T, clusterInfo *VtOrcClusterInfo, tablet *clu
 			continue
 		}
 		// make sure the health stream is updated
-		result, err = clusterInfo.ClusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("VtTabletStreamHealth", "--", "--count", "1", tablet.Alias)
+		shrs, err := clusterInfo.ClusterInstance.StreamTabletHealth(context.Background(), tablet, 1)
 		require.NoError(t, err)
-		var streamHealthResponse querypb.StreamHealthResponse
+		streamHealthResponse := shrs[0]
 
-		err = json2.Unmarshal([]byte(result), &streamHealthResponse)
-		require.NoError(t, err)
 		if checkServing && !streamHealthResponse.GetServing() {
 			log.Warningf("Tablet %v is not serving in health stream yet, sleep for 1 second\n", tablet.Alias)
 			time.Sleep(time.Second)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR removes the usage of a deprecated flag `enable_queries` from our end-to-end tests. Essentially, this PR is a backport of https://github.com/vitessio/vitess/pull/10646, but it only backports the end-to-end test changes and not the code changes. 

There is a two-fold reason for this change. The first one is that https://github.com/vitessio/vitess/pull/11034 is attempting to introduce upgrade tests that are failing because of this flag's usage. The second reason is that we shouldn't be using the deprecated flags ourselves since we expect users to stop using them too.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
