### PR TITLE
Fix AST copying of basic types in release-14.0

### DIFF
--- a/go/tools/asthelpergen/clone_gen.go
+++ b/go/tools/asthelpergen/clone_gen.go
@@ -93,7 +93,7 @@ func (c *cloneGen) sliceMethod(t types.Type, slice *types.Slice, spi generatorSP
 			// if n == nil { return nil }
 			ifNilReturnNil("n"),
 			//	res := make(Bytes, len(n))
-			jen.Id("res").Op(":=").Id("make").Call(jen.Id(typeString), jen.Lit(0), jen.Id("len").Call(jen.Id("n"))),
+			jen.Id("res").Op(":=").Id("make").Call(jen.Id(typeString), jen.Id("len").Call(jen.Id("n"))),
 			c.copySliceElement(t, slice.Elem(), spi),
 			//	return res
 			jen.Return(jen.Id("res")),
@@ -111,13 +111,13 @@ func (c *cloneGen) copySliceElement(t types.Type, elType types.Type, spi generat
 		return jen.Id("copy").Call(jen.Id("res"), jen.Id("n"))
 	}
 
-	//for _, x := range n {
-	//  res = append(res, CloneAST(x))
+	//for i := range n {
+	//  res[i] = CloneAST(x)
 	//}
 	spi.addType(elType)
 
-	return jen.For(jen.List(jen.Op("_"), jen.Id("x"))).Op(":=").Range().Id("n").Block(
-		jen.Id("res").Op("=").Id("append").Call(jen.Id("res"), c.readValueOfType(elType, jen.Id("x"), spi)),
+	return jen.For(jen.List(jen.Id("i"), jen.Id("x"))).Op(":=").Range().Id("n").Block(
+		jen.Id("res").Index(jen.Id("i")).Op("=").Add(c.readValueOfType(elType, jen.Id("x"), spi)),
 	)
 }
 

--- a/go/tools/asthelpergen/integration/ast_clone.go
+++ b/go/tools/asthelpergen/integration/ast_clone.go
@@ -58,9 +58,9 @@ func CloneBytes(n Bytes) Bytes {
 	if n == nil {
 		return nil
 	}
-	res := make(Bytes, 0, len(n))
-	for _, x := range n {
-		res = append(res, x)
+	res := make(Bytes, len(n))
+	for i, x := range n {
+		res[i] = x
 	}
 	return res
 }
@@ -75,9 +75,9 @@ func CloneInterfaceSlice(n InterfaceSlice) InterfaceSlice {
 	if n == nil {
 		return nil
 	}
-	res := make(InterfaceSlice, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneAST(x))
+	res := make(InterfaceSlice, len(n))
+	for i, x := range n {
+		res[i] = CloneAST(x)
 	}
 	return res
 }
@@ -96,9 +96,9 @@ func CloneLeafSlice(n LeafSlice) LeafSlice {
 	if n == nil {
 		return nil
 	}
-	res := make(LeafSlice, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfLeaf(x))
+	res := make(LeafSlice, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfLeaf(x)
 	}
 	return res
 }
@@ -181,9 +181,9 @@ func CloneSliceOfAST(n []AST) []AST {
 	if n == nil {
 		return nil
 	}
-	res := make([]AST, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneAST(x))
+	res := make([]AST, len(n))
+	for i, x := range n {
+		res[i] = CloneAST(x)
 	}
 	return res
 }
@@ -193,7 +193,7 @@ func CloneSliceOfInt(n []int) []int {
 	if n == nil {
 		return nil
 	}
-	res := make([]int, 0, len(n))
+	res := make([]int, len(n))
 	copy(res, n)
 	return res
 }
@@ -203,9 +203,9 @@ func CloneSliceOfRefOfLeaf(n []*Leaf) []*Leaf {
 	if n == nil {
 		return nil
 	}
-	res := make([]*Leaf, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfLeaf(x))
+	res := make([]*Leaf, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfLeaf(x)
 	}
 	return res
 }

--- a/go/vt/sqlparser/ast_clone.go
+++ b/go/vt/sqlparser/ast_clone.go
@@ -798,9 +798,9 @@ func CloneColumns(n Columns) Columns {
 	if n == nil {
 		return nil
 	}
-	res := make(Columns, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneColIdent(x))
+	res := make(Columns, len(n))
+	for i, x := range n {
+		res[i] = CloneColIdent(x)
 	}
 	return res
 }
@@ -1088,9 +1088,9 @@ func CloneExprs(n Exprs) Exprs {
 	if n == nil {
 		return nil
 	}
-	res := make(Exprs, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneExpr(x))
+	res := make(Exprs, len(n))
+	for i, x := range n {
+		res[i] = CloneExpr(x)
 	}
 	return res
 }
@@ -1220,9 +1220,9 @@ func CloneGroupBy(n GroupBy) GroupBy {
 	if n == nil {
 		return nil
 	}
-	res := make(GroupBy, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneExpr(x))
+	res := make(GroupBy, len(n))
+	for i, x := range n {
+		res[i] = CloneExpr(x)
 	}
 	return res
 }
@@ -1266,9 +1266,9 @@ func CloneIndexHints(n IndexHints) IndexHints {
 	if n == nil {
 		return nil
 	}
-	res := make(IndexHints, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfIndexHint(x))
+	res := make(IndexHints, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfIndexHint(x)
 	}
 	return res
 }
@@ -1757,9 +1757,9 @@ func CloneNamedWindows(n NamedWindows) NamedWindows {
 	if n == nil {
 		return nil
 	}
-	res := make(NamedWindows, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfNamedWindow(x))
+	res := make(NamedWindows, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfNamedWindow(x)
 	}
 	return res
 }
@@ -1827,9 +1827,9 @@ func CloneOnDup(n OnDup) OnDup {
 	if n == nil {
 		return nil
 	}
-	res := make(OnDup, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfUpdateExpr(x))
+	res := make(OnDup, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfUpdateExpr(x)
 	}
 	return res
 }
@@ -1870,9 +1870,9 @@ func CloneOrderBy(n OrderBy) OrderBy {
 	if n == nil {
 		return nil
 	}
-	res := make(OrderBy, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfOrder(x))
+	res := make(OrderBy, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfOrder(x)
 	}
 	return res
 }
@@ -2014,9 +2014,9 @@ func ClonePartitions(n Partitions) Partitions {
 	if n == nil {
 		return nil
 	}
-	res := make(Partitions, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneColIdent(x))
+	res := make(Partitions, len(n))
+	for i, x := range n {
+		res[i] = CloneColIdent(x)
 	}
 	return res
 }
@@ -2211,9 +2211,9 @@ func CloneSelectExprs(n SelectExprs) SelectExprs {
 	if n == nil {
 		return nil
 	}
-	res := make(SelectExprs, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneSelectExpr(x))
+	res := make(SelectExprs, len(n))
+	for i, x := range n {
+		res[i] = CloneSelectExpr(x)
 	}
 	return res
 }
@@ -2255,9 +2255,9 @@ func CloneSetExprs(n SetExprs) SetExprs {
 	if n == nil {
 		return nil
 	}
-	res := make(SetExprs, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfSetExpr(x))
+	res := make(SetExprs, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfSetExpr(x)
 	}
 	return res
 }
@@ -2409,9 +2409,9 @@ func CloneSubPartitionDefinitions(n SubPartitionDefinitions) SubPartitionDefinit
 	if n == nil {
 		return nil
 	}
-	res := make(SubPartitionDefinitions, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfSubPartitionDefinition(x))
+	res := make(SubPartitionDefinitions, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfSubPartitionDefinition(x)
 	}
 	return res
 }
@@ -2443,9 +2443,9 @@ func CloneTableExprs(n TableExprs) TableExprs {
 	if n == nil {
 		return nil
 	}
-	res := make(TableExprs, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneTableExpr(x))
+	res := make(TableExprs, len(n))
+	for i, x := range n {
+		res[i] = CloneTableExpr(x)
 	}
 	return res
 }
@@ -2465,9 +2465,9 @@ func CloneTableNames(n TableNames) TableNames {
 	if n == nil {
 		return nil
 	}
-	res := make(TableNames, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneTableName(x))
+	res := make(TableNames, len(n))
+	for i, x := range n {
+		res[i] = CloneTableName(x)
 	}
 	return res
 }
@@ -2477,9 +2477,9 @@ func CloneTableOptions(n TableOptions) TableOptions {
 	if n == nil {
 		return nil
 	}
-	res := make(TableOptions, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfTableOption(x))
+	res := make(TableOptions, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfTableOption(x)
 	}
 	return res
 }
@@ -2605,9 +2605,9 @@ func CloneUpdateExprs(n UpdateExprs) UpdateExprs {
 	if n == nil {
 		return nil
 	}
-	res := make(UpdateExprs, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfUpdateExpr(x))
+	res := make(UpdateExprs, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfUpdateExpr(x)
 	}
 	return res
 }
@@ -2653,9 +2653,9 @@ func CloneValTuple(n ValTuple) ValTuple {
 	if n == nil {
 		return nil
 	}
-	res := make(ValTuple, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneExpr(x))
+	res := make(ValTuple, len(n))
+	for i, x := range n {
+		res[i] = CloneExpr(x)
 	}
 	return res
 }
@@ -2674,9 +2674,9 @@ func CloneValues(n Values) Values {
 	if n == nil {
 		return nil
 	}
-	res := make(Values, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneValTuple(x))
+	res := make(Values, len(n))
+	for i, x := range n {
+		res[i] = CloneValTuple(x)
 	}
 	return res
 }
@@ -2756,9 +2756,9 @@ func CloneWindowDefinitions(n WindowDefinitions) WindowDefinitions {
 	if n == nil {
 		return nil
 	}
-	res := make(WindowDefinitions, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfWindowDefinition(x))
+	res := make(WindowDefinitions, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfWindowDefinition(x)
 	}
 	return res
 }
@@ -3590,9 +3590,9 @@ func CloneSliceOfRefOfColumnDefinition(n []*ColumnDefinition) []*ColumnDefinitio
 	if n == nil {
 		return nil
 	}
-	res := make([]*ColumnDefinition, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfColumnDefinition(x))
+	res := make([]*ColumnDefinition, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfColumnDefinition(x)
 	}
 	return res
 }
@@ -3611,9 +3611,9 @@ func CloneSliceOfDatabaseOption(n []DatabaseOption) []DatabaseOption {
 	if n == nil {
 		return nil
 	}
-	res := make([]DatabaseOption, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneDatabaseOption(x))
+	res := make([]DatabaseOption, len(n))
+	for i, x := range n {
+		res[i] = CloneDatabaseOption(x)
 	}
 	return res
 }
@@ -3623,9 +3623,9 @@ func CloneSliceOfAlterOption(n []AlterOption) []AlterOption {
 	if n == nil {
 		return nil
 	}
-	res := make([]AlterOption, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneAlterOption(x))
+	res := make([]AlterOption, len(n))
+	for i, x := range n {
+		res[i] = CloneAlterOption(x)
 	}
 	return res
 }
@@ -3635,9 +3635,9 @@ func CloneSliceOfColIdent(n []ColIdent) []ColIdent {
 	if n == nil {
 		return nil
 	}
-	res := make([]ColIdent, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneColIdent(x))
+	res := make([]ColIdent, len(n))
+	for i, x := range n {
+		res[i] = CloneColIdent(x)
 	}
 	return res
 }
@@ -3647,9 +3647,9 @@ func CloneSliceOfRefOfWhen(n []*When) []*When {
 	if n == nil {
 		return nil
 	}
-	res := make([]*When, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfWhen(x))
+	res := make([]*When, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfWhen(x)
 	}
 	return res
 }
@@ -3697,7 +3697,7 @@ func CloneSliceOfString(n []string) []string {
 	if n == nil {
 		return nil
 	}
-	res := make([]string, 0, len(n))
+	res := make([]string, len(n))
 	copy(res, n)
 	return res
 }
@@ -3707,9 +3707,9 @@ func CloneSliceOfRefOfIndexColumn(n []*IndexColumn) []*IndexColumn {
 	if n == nil {
 		return nil
 	}
-	res := make([]*IndexColumn, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfIndexColumn(x))
+	res := make([]*IndexColumn, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfIndexColumn(x)
 	}
 	return res
 }
@@ -3719,9 +3719,9 @@ func CloneSliceOfRefOfIndexOption(n []*IndexOption) []*IndexOption {
 	if n == nil {
 		return nil
 	}
-	res := make([]*IndexOption, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfIndexOption(x))
+	res := make([]*IndexOption, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfIndexOption(x)
 	}
 	return res
 }
@@ -3731,9 +3731,9 @@ func CloneSliceOfJSONPathParam(n []JSONPathParam) []JSONPathParam {
 	if n == nil {
 		return nil
 	}
-	res := make([]JSONPathParam, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneJSONPathParam(x))
+	res := make([]JSONPathParam, len(n))
+	for i, x := range n {
+		res[i] = CloneJSONPathParam(x)
 	}
 	return res
 }
@@ -3743,9 +3743,9 @@ func CloneSliceOfRefOfJSONObjectParam(n []*JSONObjectParam) []*JSONObjectParam {
 	if n == nil {
 		return nil
 	}
-	res := make([]*JSONObjectParam, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfJSONObjectParam(x))
+	res := make([]*JSONObjectParam, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfJSONObjectParam(x)
 	}
 	return res
 }
@@ -3766,9 +3766,9 @@ func CloneSliceOfRefOfJtColumnDefinition(n []*JtColumnDefinition) []*JtColumnDef
 	if n == nil {
 		return nil
 	}
-	res := make([]*JtColumnDefinition, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfJtColumnDefinition(x))
+	res := make([]*JtColumnDefinition, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfJtColumnDefinition(x)
 	}
 	return res
 }
@@ -3813,9 +3813,9 @@ func CloneTableAndLockTypes(n TableAndLockTypes) TableAndLockTypes {
 	if n == nil {
 		return nil
 	}
-	res := make(TableAndLockTypes, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfTableAndLockType(x))
+	res := make(TableAndLockTypes, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfTableAndLockType(x)
 	}
 	return res
 }
@@ -3825,9 +3825,9 @@ func CloneComments(n Comments) Comments {
 	if n == nil {
 		return nil
 	}
-	res := make(Comments, 0, len(n))
-	for _, x := range n {
-		res = append(res, x)
+	res := make(Comments, len(n))
+	for i, x := range n {
+		res[i] = x
 	}
 	return res
 }
@@ -3846,9 +3846,9 @@ func CloneSliceOfRefOfPartitionDefinition(n []*PartitionDefinition) []*Partition
 	if n == nil {
 		return nil
 	}
-	res := make([]*PartitionDefinition, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfPartitionDefinition(x))
+	res := make([]*PartitionDefinition, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfPartitionDefinition(x)
 	}
 	return res
 }
@@ -3858,9 +3858,9 @@ func CloneSliceOfRefOfRenameTablePair(n []*RenameTablePair) []*RenameTablePair {
 	if n == nil {
 		return nil
 	}
-	res := make([]*RenameTablePair, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfRenameTablePair(x))
+	res := make([]*RenameTablePair, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfRenameTablePair(x)
 	}
 	return res
 }
@@ -3880,9 +3880,9 @@ func CloneSliceOfTableExpr(n []TableExpr) []TableExpr {
 	if n == nil {
 		return nil
 	}
-	res := make([]TableExpr, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneTableExpr(x))
+	res := make([]TableExpr, len(n))
+	for i, x := range n {
+		res[i] = CloneTableExpr(x)
 	}
 	return res
 }
@@ -3892,9 +3892,9 @@ func CloneSliceOfCharacteristic(n []Characteristic) []Characteristic {
 	if n == nil {
 		return nil
 	}
-	res := make([]Characteristic, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneCharacteristic(x))
+	res := make([]Characteristic, len(n))
+	for i, x := range n {
+		res[i] = CloneCharacteristic(x)
 	}
 	return res
 }
@@ -3935,9 +3935,9 @@ func CloneSliceOfRefOfIndexDefinition(n []*IndexDefinition) []*IndexDefinition {
 	if n == nil {
 		return nil
 	}
-	res := make([]*IndexDefinition, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfIndexDefinition(x))
+	res := make([]*IndexDefinition, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfIndexDefinition(x)
 	}
 	return res
 }
@@ -3947,9 +3947,9 @@ func CloneSliceOfRefOfConstraintDefinition(n []*ConstraintDefinition) []*Constra
 	if n == nil {
 		return nil
 	}
-	res := make([]*ConstraintDefinition, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfConstraintDefinition(x))
+	res := make([]*ConstraintDefinition, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfConstraintDefinition(x)
 	}
 	return res
 }
@@ -3969,9 +3969,9 @@ func CloneSliceOfVindexParam(n []VindexParam) []VindexParam {
 	if n == nil {
 		return nil
 	}
-	res := make([]VindexParam, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneVindexParam(x))
+	res := make([]VindexParam, len(n))
+	for i, x := range n {
+		res[i] = CloneVindexParam(x)
 	}
 	return res
 }
@@ -3981,9 +3981,9 @@ func CloneSliceOfRefOfCommonTableExpr(n []*CommonTableExpr) []*CommonTableExpr {
 	if n == nil {
 		return nil
 	}
-	res := make([]*CommonTableExpr, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneRefOfCommonTableExpr(x))
+	res := make([]*CommonTableExpr, len(n))
+	for i, x := range n {
+		res[i] = CloneRefOfCommonTableExpr(x)
 	}
 	return res
 }


### PR DESCRIPTION
Backport of https://github.com/vitessio/vitess/pull/11046 to release-14.0.

## Related Issue(s)

Original fix in https://github.com/vitessio/vitess/pull/11046

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required