### PR TITLE
Flakes: Prevent VDiff2 test failures when operating near the second boundary

### DIFF
--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -111,7 +111,9 @@ func waitForVDiff2ToComplete(t *testing.T, ksWorkflow, cells, uuid string, compl
 				// We don't test that the ETA always increases as it can decrease based on how
 				// quickly we're doing work.
 				if info.Progress.ETA != "" {
-					require.GreaterOrEqual(t, info.Progress.ETA, time.Now().Format(vdiff2.TimestampFormat))
+					// If we're operating at the second boundary then the ETA can be up
+					// to 1 second in the past due to using second based precision.
+					require.GreaterOrEqual(t, info.Progress.ETA, time.Now().Add(-time.Second).Format(vdiff2.TimestampFormat))
 				}
 				if !first {
 					require.GreaterOrEqual(t, info.Progress.Percentage, previousProgress.Percentage)


### PR DESCRIPTION
## Description

I noticed that the VDiff2 e2e test was failing ~ 1% of the time — and the error was always due to the ETA being 1 second in the past.

This is NOT indicative of a program error but instead can result when operating near the second boundary as the ETAs use second precision. This PR adjusts the test to account for this.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests are not required
-   [x] Documentation is not required