### PR TITLE
[vtadmin] Update how tracing flags are registered

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -163,10 +163,7 @@ func main() {
 	rootCmd.Flags().BoolVar(&enableDynamicClusters, "enable-dynamic-clusters", false, "whether to enable dynamic clusters that are set by request header cookies or gRPC metadata")
 
 	// Tracing flags
-	rootCmd.Flags().AddGoFlag(flag.Lookup("tracer"))                 // defined in go/vt/trace
-	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-enable-logging")) // defined in go/vt/trace
-	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-sampling-type"))  // defined in go/vt/trace
-	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-sampling-rate"))  // defined in go/vt/trace
+	trace.RegisterFlags(rootCmd.Flags()) // defined in go/vt/trace
 	rootCmd.Flags().BoolVar(&opts.EnableTracing, "grpc-tracing", false, "whether to enable tracing on the gRPC server")
 	rootCmd.Flags().BoolVar(&httpOpts.EnableTracing, "http-tracing", false, "whether to enable tracing on the HTTP server")
 


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

In #11028, we moved the tracing flags off the global flagset, which of
course means doing a global lookup on the flagset now returns `nil`.
Unfortunately, it didn't occur to me at the time that this would break
vtadmin's hacky way of getting global flags into its FlagSet.

This fixes that issue.

### Demo

**Before**
```
✗ vtadmin --help                                                
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x102b9e7c4]

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).AddGoFlag(0x140003e0500, 0x0)
        github.com/spf13/pflag@v1.0.5/golangflag.go:86 +0x24
main.main()
        vitess.io/vitess/go/cmd/vtadmin/main.go:166 +0x23c
```

**After**

<details><summary><code>vtadmin --help</code></summary>

```
✗ vtadmin --help
Usage:
  vtadmin [flags]

Flags:
      --addr string                             address to serve on (default ":15000")
      --alsologtostderr                         log to standard error as well as files
      --cache-refresh-key string                instructs a request to ignore any cached data (if applicable) and refresh the cache;usable as an HTTP header named 'X-<key>' and as a gRPC metadata key '<key>'
                                                Note: any whitespace characters are replaced with hyphens. (default "vt-cache-refresh")
      --cluster cluster.ClustersFlag            per-cluster configuration. any values here take precedence over those in -cluster-defaults or -cluster-config (default [])
      --cluster-config cluster.FileConfig       path to a yaml cluster configuration. see clusters.example.yaml (default {defaults: *cluster.Config:{ID: Name: DiscoveryImpl: DiscoveryFlagsByImpl:map[] TabletFQDNTmplStr: VtSQLFlags:map[] VtctldFlags:map[] BackupReadPoolConfig:<nil> SchemaReadPoolConfig:<nil> TopoRWPoolConfig:<nil> TopoReadPoolConfig:<nil> WorkflowReadPoolConfig:<nil> EmergencyFailoverPoolConfig:<nil> FailoverPoolConfig:<nil> SchemaCacheConfig:<nil> vtctldConfigOpts:[] vtsqlConfigOpts:[]}, clusters: []})
      --cluster-defaults cluster.Config         default options for all clusters (default *cluster.Config:{ID: Name: DiscoveryImpl: DiscoveryFlagsByImpl:map[] TabletFQDNTmplStr: VtSQLFlags:map[] VtctldFlags:map[] BackupReadPoolConfig:<nil> SchemaReadPoolConfig:<nil> TopoRWPoolConfig:<nil> TopoReadPoolConfig:<nil> WorkflowReadPoolConfig:<nil> EmergencyFailoverPoolConfig:<nil> FailoverPoolConfig:<nil> SchemaCacheConfig:<nil> vtctldConfigOpts:[] vtsqlConfigOpts:[]})
      --datadog-agent-host string               host to send spans to. if empty, no tracing will be done
      --datadog-agent-port string               port to send spans to. if empty, no tracing will be done
      --enable-dynamic-clusters                 whether to enable dynamic clusters that are set by request header cookies or gRPC metadata
      --grpc-allow-reflection grpc_cli          whether to register the gRPC server for reflection; this is required to use tools like grpc_cli
      --grpc-enable-channelz                    whether to enable the channelz service on the gRPC server
      --grpc-tracing                            whether to enable tracing on the gRPC server
  -h, --help                                    help for vtadmin
      --http-debug-omit-env StringSetFlag       name of an environment variable to omit from /debug/env, if http debug endpoints are enabled. specify multiple times to omit multiple env vars
      --http-debug-sanitize-env StringSetFlag   name of an environment variable to sanitize in /debug/env, if http debug endpoints are enabled. specify multiple times to sanitize multiple env vars
      --http-metrics-endpoint string            HTTP endpoint to expose prometheus metrics on. Omit to disable scraping metrics. Using a path used by VTAdmin's http API is unsupported and causes undefined behavior. (default "/metrics")
      --http-no-compress                        whether to disable compression of HTTP API responses
      --http-no-debug                           whether to disable /debug/pprof/* and /debug/env HTTP endpoints
      --http-origin strings                     repeated, comma-separated flag of allowed CORS origins. omit to disable CORS
      --http-tablet-url-tmpl string             [EXPERIMENTAL] Go template string to generate a reachable http(s) address for a tablet. Currently used to make passthrough requests to /debug/vars endpoints. (default "https://{{ .Tablet.Hostname }}:80")
      --http-tracing                            whether to enable tracing on the HTTP server
      --jaeger-agent-host string                host and port to send spans to. if empty, no tracing will be done
      --lame-duck-duration duration             length of lame duck period at shutdown (default 5s)
      --lmux-read-timeout duration              how long to spend connection muxing (default 1s)
      --log_dir string                          If non-empty, write log files in this directory
      --logtostderr                             log to standard error instead of files
      --no-rbac                                 whether to disable RBAC. must be set if not passing --no-rbac
      --rbac                                    whether to enable RBAC. must be set if not passing --rbac
      --rbac-config string                      path to an RBAC config file. must be set if passing --rbac
      --stderrthreshold severity                logs at or above this threshold go to stderr (default 1)
      --tracer string                           tracing service to use (default "noop")
      --tracing-enable-logging                  whether to enable logging in the tracing service
      --tracing-sampling-rate float             sampling rate for the probabilistic jaeger sampler (default 0.1)
      --tracing-sampling-type string            sampling strategy to use for jaeger. possible values are 'const', 'probabilistic', 'rateLimiting', or 'remote' (default "const")
  -v, --v Level                                 log level for V logs
```

</details>

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

- #11028
- #10770 
- Closes #11062

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
