### PR TITLE
FlakinessFix: Reparent tests by removing `restore_from_backup`

### DIFF
--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -165,6 +165,7 @@ func setupCluster(ctx context.Context, t *testing.T, shardName string, cells []s
 
 func setupShard(ctx context.Context, t *testing.T, clusterInstance *cluster.LocalProcessCluster, shardName string, tablets []*cluster.Vttablet) {
 	for _, tablet := range tablets {
+		tablet.VttabletProcess.SupportsBackup = false
 		// Start the tablet
 		err := tablet.VttabletProcess.Setup()
 		require.NoError(t, err)
@@ -231,6 +232,7 @@ func StartNewVTTablet(t *testing.T, clusterInstance *cluster.LocalProcessCluster
 
 	// The tablet should come up as serving since the primary for the shard already exists
 	tablet.VttabletProcess.ServingStatus = "SERVING"
+	tablet.VttabletProcess.SupportsBackup = false
 	err = tablet.VttabletProcess.Setup()
 	require.NoError(t, err)
 	return tablet


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Some tests of ERS and PRS have been flaky. The following steps are followed leading to failure -  

1. We bring up a new cluster with new tablets
2. We try to run PRS
3. Meanwhile, tablets go to RESTORE mode as part of the startup
4. PRS sees the tablets are of type RESTORE and doesn’t set semi-sync on them
5. Tablet complete RESTORE and go to type REPLICA (but semi-sync is off). Here initializing logic for replication exists, but that doesn't run since we run our tests with `disable_active_reparents` to prevent the replication manager from running.
6. Test fails assuming semi-sync is on (Blocks on a write)7. 

The proposed fix is to remove the flag `restore_from_backup` from the vttablets which are coming up for the first time. This will prevent the vttablets from going into the RESTORE state at all and everything will work fine from their on.

After this fix, the test was run 222 times without a failure locally.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
