### PR TITLE
Fix races in memory topo and watcher

### DIFF
--- a/go/vt/srvtopo/watch.go
+++ b/go/vt/srvtopo/watch.go
@@ -219,7 +219,8 @@ func (entry *watchEntry) onErrorLocked(callerCtx context.Context, err error, ini
 
 	entry.watchState = watchStateIdle
 
-	if len(entry.listeners) > 0 {
+	// only retry the watch if we haven't been explicitly interrupted
+	if len(entry.listeners) > 0 && !topo.IsErrType(err, topo.Interrupted) {
 		go func() {
 			time.Sleep(entry.rw.cacheRefreshInterval)
 


### PR DESCRIPTION
We should only setup the goroutine after we've grabbed the lock to safely start the watcher.

Additionally, the watcher should only be retried if we're not interrupted and shutting down for example.

## Related Issue(s)

Follow up fixes after changes in https://github.com/vitessio/vitess/pull/10954 & https://github.com/vitessio/vitess/pull/10906

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required