### PR TITLE
[vtctld] Fix nil-ness in healthcheck

### DIFF
--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -142,7 +142,7 @@ func InitVtctld(ts *topo.Server) error {
 
 	http.Handle(appPrefix, staticContentHandler(*enableUI))
 
-	var healthCheck *discovery.HealthCheckImpl
+	var healthCheck discovery.HealthCheck
 	if *enableRealtimeStats {
 		ctx := context.Background()
 		cells, err := ts.GetKnownCells(ctx)


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Because `healthCheck` was being explicitly declared as a concrete type,
later, in `newTabletWithStatsAndURL` (in api.go), when we compare the
_interface_ to `nil`, we get `false` (despite the underlying
implementation being itself `nil`), and so we attempt to call
`GetTabletHealth` on `nil`, resulting in a panic.

See one of [my favorite talks](https://youtu.be/ynoY2xz-F8s?t=796) on why
this is.

### Testing

I was able to produce the panic listing `/api/keyspace/commerce/tablets` prior to this change, but it works with this change. This is happening in 14.0, so we need to back port there (<= v13 is fine, I think)

## Related Issue(s)

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
