### PR TITLE
Fix handling zero byte string for session state changed

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1465,9 +1465,14 @@ func (c *Conn) parseOKPacket(in []byte) (*PacketOK, error) {
 	if c.Capabilities&uint32(CapabilityClientSessionTrack) == CapabilityClientSessionTrack {
 		// session tracking
 		if statusFlags&ServerSessionStateChanged == ServerSessionStateChanged {
-			_, ok := data.readLenEncInt()
+			length, ok := data.readLenEncInt()
 			if !ok {
 				return fail("invalid OK packet session state change length: %v", data)
+			}
+			// In case we have a zero length string, there's no additional information so
+			// we can return the packet.
+			if length == 0 {
+				return packetOK, nil
 			}
 			sscType, ok := data.readByte()
 			if !ok {


### PR DESCRIPTION
On MySQL 8.0 it's possible we get back a zero length state for session state changed information. In this case, we treat this as no data being present and continue.

This was exposed in https://github.com/vitessio/vitess/pull/11026 but I'm extracted this as a separate fix until that lands since this can trigger spurious errors when it shouldn't.

## Related Issue(s)

Found through https://github.com/vitessio/vitess/pull/11026 where we have a test failed fixed by this change:

```
--- FAIL: TestCallProcedureChangedTx (0.00s)
    call_test.go:154: 
        	Error Trace:	call_test.go:154
        	Error:      	Received unexpected error:
        	            	Code: INTERNAL
        	            	invalid OK packet session state change type: 0 (CallerID: dev)
        	Test:       	TestCallProcedureChangedTx

```

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required