### PR TITLE
[Gen4] Only remove extracted subquery from predicates on merge

### DIFF
--- a/go/vt/vtgate/planbuilder/physical/route.go
+++ b/go/vt/vtgate/planbuilder/physical/route.go
@@ -600,28 +600,6 @@ func (r *Route) planCompositeInOpRecursive(
 	return foundVindex
 }
 
-func (r *Route) resetRoutingSelections(ctx *plancontext.PlanningContext) error {
-	switch r.RouteOpCode {
-	case engine.DBA, engine.Next, engine.Reference, engine.Unsharded:
-		// these we keep as is
-	default:
-		r.RouteOpCode = engine.Scatter
-	}
-
-	r.Selected = nil
-	for i, vp := range r.VindexPreds {
-		r.VindexPreds[i] = &VindexPlusPredicates{ColVindex: vp.ColVindex, TableID: vp.TableID}
-	}
-
-	for _, predicate := range r.SeenPredicates {
-		err := r.tryImprovingVindex(ctx, predicate)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func tupleAccess(expr sqlparser.Expr, coordinates []int) sqlparser.Expr {
 	tuple, _ := expr.(sqlparser.ValTuple)
 	for _, idx := range coordinates {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -4114,6 +4114,51 @@ Gen4 plan same as above
 "unsupported: cross-shard correlated subquery"
 Gen4 error: exists sub-queries are only supported with AND clause
 
+# correlated subquery that is dependent on one side of a join, fully mergeable
+"SELECT music.id FROM music INNER JOIN user ON music.user_id = user.id WHERE music.user_id = 5 AND music.id = (SELECT MAX(m2.id) FROM music m2 WHERE m2.user_id = user.id)"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT music.id FROM music INNER JOIN user ON music.user_id = user.id WHERE music.user_id = 5 AND music.id = (SELECT MAX(m2.id) FROM music m2 WHERE m2.user_id = user.id)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select music.id from music join `user` on music.user_id = `user`.id where 1 != 1",
+    "Query": "select music.id from music join `user` on music.user_id = `user`.id where music.user_id = 5 and music.id = (select max(m2.id) from music as m2 where m2.user_id = `user`.id)",
+    "Table": "music, `user`",
+    "Values": [
+      "INT64(5)"
+    ],
+    "Vindex": "user_index"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT music.id FROM music INNER JOIN user ON music.user_id = user.id WHERE music.user_id = 5 AND music.id = (SELECT MAX(m2.id) FROM music m2 WHERE m2.user_id = user.id)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select music.id from music, `user` where 1 != 1",
+    "Query": "select music.id from music, `user` where music.user_id = 5 and music.id = (select max(m2.id) from music as m2 where m2.user_id = `user`.id) and music.user_id = `user`.id",
+    "Table": "`user`, music",
+    "Values": [
+      "INT64(5)"
+    ],
+    "Vindex": "user_index"
+  },
+  "TablesUsed": [
+    "user.music",
+    "user.user"
+  ]
+}
+
 # union as a derived table
 "select found from (select id as found from user union all (select id from unsharded)) as t"
 {


### PR DESCRIPTION
## Description

When merging a subquery into an outer route, all vindex predicates are currently reset and filled again from the outer route's `SeenPredicates`.

https://github.com/vitessio/vitess/blob/3d376eaf12b5fbc6705a5375b1868edf2bcfc2dc/go/vt/vtgate/planbuilder/physical/route.go#L603-L623

For routes of `ApplyJoin` nodes, the `SeenPredicates` list is empty and thus routing information could not be restored correctly.

Instead of resetting the vindex predicates, we can just remove all vindex predicate options for the merged subquery instead, and leave all other options untouched. This ensures that we still can pick any vindexes derived from the join operation, instead of falling back to a `Scatter` route.

## Related Issue(s)

This fixes https://github.com/vitessio/vitess/issues/10823.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
