### PR TITLE
fix missing vtadmin binary in docker image

### DIFF
--- a/docker/k8s/vtadmin/Dockerfile
+++ b/docker/k8s/vtadmin/Dockerfile
@@ -19,18 +19,8 @@ FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
 FROM node:16-${DEBIAN_VER} as node
 
-# Set up Vitess environment (just enough to run pre-built Go binaries)
-ENV VTROOT /vt
-
 # Prepare directory structure.
-RUN mkdir -p /vt/bin && \
-   mkdir -p /vt/web && mkdir -p /vtdataroot
-
-# Copy binaries
-COPY --from=k8s /vt/bin/vtadmin /vt/bin/
-
-# Copy certs to allow https calls
-COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+RUN mkdir -p /vt/web
 
 # copy web admin files
 COPY --from=k8s /vt/web/vtadmin /vt/web/vtadmin
@@ -39,10 +29,18 @@ COPY --from=k8s /vt/web/vtadmin /vt/web/vtadmin
 RUN npm --prefix /vt/web/vtadmin ci && \
     npm run --prefix /vt/web/vtadmin build
 
-
-FROM nginxinc/nginx-unprivileged:1.22-alpine AS nginx
+FROM nginxinc/nginx-unprivileged:1.22 AS nginx
 
 ENV VTADMIN_WEB_PORT=14201
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+
+# Copy binaries
+COPY --from=k8s /vt/bin/vtadmin /vt/bin/
+
+# Copy certs to allow https calls
+COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY --chown=nginx --from=node /vt/web/vtadmin/build /var/www/
 COPY --chown=nginx docker/k8s/vtadmin/default.conf /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
vtadmin binary was missing from the docker image

fix #10770

Signed-off-by: Leopold Jacquot <leopold.jacquot@infomaniak.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
