### PR TITLE
Fix incorrect use of loop variable in parallel test

### DIFF
--- a/go/vt/topo/topoproto/tablet_test.go
+++ b/go/vt/topo/topoproto/tablet_test.go
@@ -118,6 +118,10 @@ func TestIsTabletsInList(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
+		// We create an explicit copy of the range variable for each parallel runner
+		// to be sure that they each run as expected. You can see more information on
+		// this here: https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks
+		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			out := IsTabletInList(testcase.tablet, testcase.allTablets)


### PR DESCRIPTION
This commit fixes an occurrence of a loop variable being captured in a
parallel test. With very high probability, only the last test case
will actually be exercised. To work around this problem, we create a
local copy of the range variable before the parallel test, as advised
by the Go documentation at:

https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks

Issue was found automatically using the `loopvarcapture` linter.