### PR TITLE
Add SKIP check to workflows removed in v15

### DIFF
--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -5,7 +5,18 @@ jobs:
   build:
     name: cluster initial sharding multi
     runs-on: ubuntu-latest
+
     steps:
+    - name: Check if workflow needs to be skipped
+      id: skip-workflow
+      run: |
+        skip='false'
+        if [[ "${{github.event.pull_request}}" ==  "" ]] && [[ "${{github.ref}}" != "refs/heads/main" ]] && [[ ! "${{github.ref}}" =~ ^refs/heads/release-[0-9]+\.[0-9]$ ]] && [[ ! "${{github.ref}}" =~ "refs/tags/.*" ]]; then
+          skip='true'
+        fi
+        echo Skip ${skip}
+        echo "::set-output name=skip-workflow::${skip}"
+
     - name: Check out code
       uses: actions/checkout@v2
 

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -18,9 +18,11 @@ jobs:
         echo "::set-output name=skip-workflow::${skip}"
 
     - name: Check out code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: frouioui/paths-filter@main
       id: changes
       with:
@@ -38,24 +40,24 @@ jobs:
             - 'bootstrap.sh'
 
     - name: Set up Go
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18.4
 
     - name: Tune the OS
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
     - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
     - name: Run initial sharding multi
-      if: steps.changes.outputs.end_to_end == 'true'
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
         go run test.go -print-log initial_sharding_multi

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -22,9 +22,11 @@ jobs:
         echo "::set-output name=skip-workflow::${skip}"
 
     - name: Check out code
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/checkout@v2
 
     - name: Check for changes in relevant files
+      if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: frouioui/paths-filter@main
       id: changes
       with:
@@ -43,18 +45,18 @@ jobs:
             - 'examples/**'
 
     - name: Set up Go
-      if: steps.changes.outputs.examples == 'true'
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18.4
 
     - name: Tune the OS
-      if: steps.changes.outputs.examples == 'true'
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     - name: Get dependencies
-      if: steps.changes.outputs.examples == 'true'
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
           # Setup MySQL 8.0
@@ -76,17 +78,17 @@ jobs:
         go mod download
 
     - name: Run make minimaltools
-      if: steps.changes.outputs.examples == 'true'
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
       run: |
         make minimaltools
 
     - name: Build
-      if: steps.changes.outputs.examples == 'true'
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
       run: |
         make build
 
     - name: local_example
-      if: steps.changes.outputs.examples == 'true'
+      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.examples == 'true'
       timeout-minutes: 30
       run: |
         export TOPO=${{matrix.topo}}

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -11,6 +11,16 @@ jobs:
         topo: [etcd,k8s]
 
     steps:
+    - name: Check if workflow needs to be skipped
+      id: skip-workflow
+      run: |
+        skip='false'
+        if [[ "${{github.event.pull_request}}" ==  "" ]] && [[ "${{github.ref}}" != "refs/heads/main" ]] && [[ ! "${{github.ref}}" =~ ^refs/heads/release-[0-9]+\.[0-9]$ ]] && [[ ! "${{github.ref}}" =~ "refs/tags/.*" ]]; then
+          skip='true'
+        fi
+        echo Skip ${skip}
+        echo "::set-output name=skip-workflow::${skip}"
+
     - name: Check out code
       uses: actions/checkout@v2
 


### PR DESCRIPTION
## Description

These `cluster_initial_sharding_multi.yml` and `legacy_local_example.yml` workflows did not exist on main — they were removed in https://github.com/vitessio/vitess/pull/10278 — so they were not updated when https://github.com/vitessio/vitess/pull/10768 was backported.

This means that we'll need to backport this PR to `release-13.0` and `release-12.0` as well.

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/10768
  - Follow-up to: https://github.com/vitessio/vitess/pull/10278
  - Fixes test failures in: https://github.com/vitessio/vitess/pull/11077

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests are not required
-   [x] Documentation is not required