### PR TITLE
Fix Upgrade Downgrade manual backup dependencies install

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -126,22 +126,27 @@ jobs:
         sudo deluser mysql
         sudo rm -rf /var/lib/mysql
         sudo rm -rf /etc/mysql
-
         # Install MySQL 8.0
         ####
-        ## Pin the MySQL version at 8.0.29 as Vitess 13.0 does not have the fix to support
-        ## backups of 8.0.30+ and no backport to v13.0 is currently planned.
-        ##   See: https://github.com/vitessio/vitess/pull/10847
+        ## Temporarily pin the MySQL version at 8.0.29 as Vitess 14.0.1 does not have the fix to support
+        ## backups of 8.0.30+. See: https://github.com/vitessio/vitess/pull/10847
+        ## TODO: remove this pin once the above fixes are included in a v14 release (will be in v14.0.2) OR
+        ##       Vitess 16.0.0-SNAPSHOT becomes the dev version on vitessio/main
+        #sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
+        #wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        #echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        #sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+        #sudo apt-get update
+        #sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
         ####
-        wget -c https://cdn.mysql.com/archives/mysql-8.0/mysql-common_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-core_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-plugins_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-client_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-server-core_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-server_8.0.29-1ubuntu20.04_amd64.deb \
-                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client_8.0.29-1ubuntu20.04_amd64.deb
+        wget -c https://cdn.mysql.com/archives/mysql-8.0/mysql-common_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-core_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-plugins_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-client_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-server-core_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-server_8.0.28-1ubuntu20.04_amd64.deb \
+                https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client_8.0.28-1ubuntu20.04_amd64.deb
         sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y ./mysql-*.deb
-
         # Install everything else we need, and configure
         sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata grep
         sudo service mysql stop
@@ -149,10 +154,8 @@ jobs:
         sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
-
         # install JUnit report formatter
         go install github.com/vitessio/go-junit-report@HEAD
-
         wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
         sudo apt-get install -y gnupg2
         sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -127,18 +127,14 @@ jobs:
         sudo rm -rf /var/lib/mysql
         sudo rm -rf /etc/mysql
         # Install MySQL 8.0
-        ####
-        ## Temporarily pin the MySQL version at 8.0.29 as Vitess 14.0.1 does not have the fix to support
-        ## backups of 8.0.30+. See: https://github.com/vitessio/vitess/pull/10847
-        ## TODO: remove this pin once the above fixes are included in a v14 release (will be in v14.0.2) OR
-        ##       Vitess 16.0.0-SNAPSHOT becomes the dev version on vitessio/main
+        ## Temporarily pin the MySQL version at 8.0.28
         #sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
         #wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
         #echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
         #sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         #sudo apt-get update
         #sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
-        ####
+        #### 
         wget -c https://cdn.mysql.com/archives/mysql-8.0/mysql-common_8.0.28-1ubuntu20.04_amd64.deb \
                 https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-core_8.0.28-1ubuntu20.04_amd64.deb \
                 https://cdn.mysql.com/archives/mysql-8.0/mysql-community-client-plugins_8.0.28-1ubuntu20.04_amd64.deb \

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -112,11 +112,7 @@ jobs:
         sudo rm -rf /etc/mysql
 
         # Install MySQL 8.0
-        ####
-        ## Temporarily pin the MySQL version at 8.0.29 as Vitess 14.0.1 does not have the fix to support
-        ## backups of 8.0.30+. See: https://github.com/vitessio/vitess/pull/10847
-        ## TODO: remove this pin once the above fixes are included in a v14 release (will be in v14.0.2) OR
-        ##       Vitess 16.0.0-SNAPSHOT becomes the dev version on vitessio/main
+        ## Temporarily pin the MySQL version at 8.0.28
         #sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
         #wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
         #echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections


### PR DESCRIPTION
## Description

This Pull Request fixes the installation of dependencies in the manual backup upgrade downgrade test. It uses MySQL8.0.29 instead of 8.0.28. The issue can be observed in the following build:

- https://github.com/vitessio/vitess/runs/7980238746?check_suite_focus=true

This PR unblocks the following PRs:
- https://github.com/vitessio/vitess/pull/11052
- https://github.com/vitessio/vitess/pull/11078
- https://github.com/vitessio/vitess/pull/11077
- https://github.com/vitessio/vitess/pull/11068
- https://github.com/vitessio/vitess/pull/11051
- https://github.com/vitessio/vitess/pull/11040
- https://github.com/vitessio/vitess/pull/10928

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
