### PR TITLE
Fix logging formatting mistake

### DIFF
--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -177,7 +177,7 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	qe.consolidatorMode.Set(config.Consolidator)
 	qe.consolidator = sync2.NewConsolidator()
 	if config.ConsolidatorStreamTotalSize > 0 && config.ConsolidatorStreamQuerySize > 0 {
-		log.Info("Stream consolidator is enabled with query size set to %d and total size set to %d.",
+		log.Infof("Stream consolidator is enabled with query size set to %d and total size set to %d.",
 			config.ConsolidatorStreamQuerySize, config.ConsolidatorStreamTotalSize)
 		qe.streamConsolidator = NewStreamConsolidator(config.ConsolidatorStreamTotalSize, config.ConsolidatorStreamQuerySize, returnStreamResult)
 	} else {


### PR DESCRIPTION
## Description

Tiny fix for a logging mistake: the 2 arguments weren't formatted into the message but placed at the end.

Before the fix:
> I0824 09:35:56.867155    2521 query_engine.go:180] Stream consolidator is enabled with query size set to **%d** and total size set to **%d**.**2097152 134217728**

After the fix:
> I0824 09:42:03.335050    1602 query_engine.go:180] Stream consolidator is enabled with query size set to **2097152** and total size set to **134217728**.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label ~has been added if this change should be backported~ not required
-   [x] Tests ~were added or are~ not required
-   [x] Documentation ~was added or is~ not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
