### PR TITLE
Online DDL: introduce '--max_concurrent_online_ddl'

### DIFF
--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -117,6 +117,7 @@ Usage of vtexplain:
       --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                      log to standard error instead of files
       --master_connect_retry duration                                    Deprecated, use -replication_connect_retry (default 10s)
+      --max_concurrent_online_ddl int                                    Maximum number of online DDL changes that may run concurrently (default 256)
       --max_memory_rows int                                              Maximum number of rows that will be held in memory for intermediate results as well as the final result. (default 300000)
       --max_payload_size int                                             The threshold for query payloads in bytes. A payload greater than this threshold will result in a failure to handle the query.
       --mem-profile-rate int                                             deprecated: use '-pprof=mem' instead (default 524288)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -264,6 +264,7 @@ Usage of vttablet:
       --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                      log to standard error instead of files
       --master_connect_retry duration                                    Deprecated, use -replication_connect_retry (default 10s)
+      --max_concurrent_online_ddl int                                    Maximum number of online DDL changes that may run concurrently (default 256)
       --mem-profile-rate int                                             deprecated: use '-pprof=mem' instead (default 524288)
       --migration_check_interval duration                                Interval between migration checks (default 1m0s)
       --mutex-profile-fraction int                                       deprecated: use '-pprof=mutex' instead

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -214,6 +214,10 @@ func NewExecutor(env tabletenv.Env, tabletAlias *topodatapb.TabletAlias, ts *top
 	tabletTypeFunc func() topodatapb.TabletType,
 	toggleBufferTableFunc func(cancelCtx context.Context, tableName string, bufferQueries bool),
 ) *Executor {
+	// sanitize flags
+	if *maxConcurrentOnlineDDLs < 1 {
+		*maxConcurrentOnlineDDLs = 1 // or else nothing will ever run
+	}
 	return &Executor{
 		env:         env,
 		tabletAlias: proto.Clone(tabletAlias).(*topodatapb.TabletAlias),


### PR DESCRIPTION
## Description

In https://github.com/vitessio/vitess/pull/10410 we introduced concurrent `vitess` migrations. A constant named `maxConcurrentMigrations` was created with the value `256`. @mattlord commented in /files#diff-059c9f46e8d270d9c5514ef2b08679035eb0daaa8d95074e34ef43a81d50dc37R127 that the value should be configurable, and this is what this PR does.

We introduce a new flag called `--max_concurrent_online_ddl'. It applies to the maximum number of possible concurrent `vitess` strategy `ALTER TABLE` statements. `CREATE TABLE|VIEW`, `DROP TABLE|VIEW` and `ALTER VIEW` are almost instantaneous operations and are not part of the concurrency limitation.

The minimum value for this flag is `1` (even if set below `1`, the value will be `1`). The default is `256`, which is a bit high and optimistic.


## Related Issue(s)

#6926

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

