### PR TITLE
Move sqlparser flags to use pflags

### DIFF
--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -62,8 +62,6 @@ Usage of vtgr:
       --scan_repair_timeout duration                                     Time to wait for a Diagnose and repair operation. (default 3s)
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service_map StringList                                           comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
-      --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
-      --sql-max-length-ui int                                            truncate queries in debug UIs to the given length (default 512) (default 512)
       --stats_backend string                                             The name of the registered push-based monitoring/stats backend to use
       --stats_combine_dimensions string                                  List of dimensions to be combined into a single "all" value in exported stats vars
       --stats_common_tags string                                         Comma-separated list of common tags for the stats backend. It provides both label and values. Example: label1:value1,label2:value2

--- a/go/vt/sqlparser/truncate_query.go
+++ b/go/vt/sqlparser/truncate_query.go
@@ -17,16 +17,27 @@ limitations under the License.
 package sqlparser
 
 import (
-	"flag"
+	"github.com/spf13/pflag"
+
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 var (
 	// TruncateUILen truncate queries in debug UIs to the given length. 0 means unlimited.
-	TruncateUILen = flag.Int("sql-max-length-ui", 512, "truncate queries in debug UIs to the given length (default 512)")
+	TruncateUILen int
 
 	// TruncateErrLen truncate queries in error logs to the given length. 0 means unlimited.
-	TruncateErrLen = flag.Int("sql-max-length-errors", 0, "truncate queries in error logs to the given length (default unlimited)")
+	TruncateErrLen int
 )
+
+func registerQueryTruncationFlags(fs *pflag.FlagSet) {
+	fs.IntVar(&TruncateUILen, "sql-max-length-ui", 512, "truncate queries in debug UIs to the given length (default 512)")
+	fs.IntVar(&TruncateErrLen, "sql-max-length-errors", 0, "truncate queries in error logs to the given length (default unlimited)")
+}
+
+func init() {
+	servenv.OnParse(registerQueryTruncationFlags)
+}
 
 func truncateQuery(query string, max int) string {
 	sql, comments := SplitMarginComments(query)
@@ -41,12 +52,12 @@ func truncateQuery(query string, max int) string {
 // TruncateForUI is used when displaying queries on various Vitess status pages
 // to keep the pages small enough to load and render properly
 func TruncateForUI(query string) string {
-	return truncateQuery(query, *TruncateUILen)
+	return truncateQuery(query, TruncateUILen)
 }
 
 // TruncateForLog is used when displaying queries as part of error logs
 // to avoid overwhelming logging systems with potentially long queries and
 // bind value data.
 func TruncateForLog(query string) string {
-	return truncateQuery(query, *TruncateErrLen)
+	return truncateQuery(query, TruncateErrLen)
 }

--- a/go/vt/sqlparser/truncate_query.go
+++ b/go/vt/sqlparser/truncate_query.go
@@ -36,7 +36,15 @@ func registerQueryTruncationFlags(fs *pflag.FlagSet) {
 }
 
 func init() {
-	servenv.OnParse(registerQueryTruncationFlags)
+	servenv.OnParseFor("vtgate", registerQueryTruncationFlags)
+	servenv.OnParseFor("vttablet", registerQueryTruncationFlags)
+	servenv.OnParseFor("vtcombo", registerQueryTruncationFlags)
+	servenv.OnParseFor("vtctld", registerQueryTruncationFlags)
+	servenv.OnParseFor("vtctl", registerQueryTruncationFlags)
+	servenv.OnParseFor("vtexplain", registerQueryTruncationFlags)
+	servenv.OnParseFor("vtbackup", registerQueryTruncationFlags)
+	servenv.OnParseFor("vttestserver", registerQueryTruncationFlags)
+	servenv.OnParseFor("vtbench", registerQueryTruncationFlags)
 }
 
 // GetTruncateErrLen is a function used to read the value of truncateErrLen

--- a/go/vt/sqlparser/truncate_query.go
+++ b/go/vt/sqlparser/truncate_query.go
@@ -23,20 +23,31 @@ import (
 )
 
 var (
-	// TruncateUILen truncate queries in debug UIs to the given length. 0 means unlimited.
-	TruncateUILen int
+	// truncateUILen truncate queries in debug UIs to the given length. 0 means unlimited.
+	truncateUILen = 512
 
-	// TruncateErrLen truncate queries in error logs to the given length. 0 means unlimited.
-	TruncateErrLen int
+	// truncateErrLen truncate queries in error logs to the given length. 0 means unlimited.
+	truncateErrLen = 0
 )
 
 func registerQueryTruncationFlags(fs *pflag.FlagSet) {
-	fs.IntVar(&TruncateUILen, "sql-max-length-ui", 512, "truncate queries in debug UIs to the given length (default 512)")
-	fs.IntVar(&TruncateErrLen, "sql-max-length-errors", 0, "truncate queries in error logs to the given length (default unlimited)")
+	fs.IntVar(&truncateUILen, "sql-max-length-ui", truncateUILen, "truncate queries in debug UIs to the given length (default 512)")
+	fs.IntVar(&truncateErrLen, "sql-max-length-errors", truncateErrLen, "truncate queries in error logs to the given length (default unlimited)")
 }
 
 func init() {
 	servenv.OnParse(registerQueryTruncationFlags)
+}
+
+// GetTruncateErrLen is a function used to read the value of truncateErrLen
+func GetTruncateErrLen() int {
+	return truncateErrLen
+}
+
+// SetTruncateErrLen is a function used to override the value of truncateErrLen
+// It is only meant to be used from tests and not from production code.
+func SetTruncateErrLen(errLen int) {
+	truncateErrLen = errLen
 }
 
 func truncateQuery(query string, max int) string {
@@ -52,12 +63,12 @@ func truncateQuery(query string, max int) string {
 // TruncateForUI is used when displaying queries on various Vitess status pages
 // to keep the pages small enough to load and render properly
 func TruncateForUI(query string) string {
-	return truncateQuery(query, TruncateUILen)
+	return truncateQuery(query, truncateUILen)
 }
 
 // TruncateForLog is used when displaying queries as part of error logs
 // to avoid overwhelming logging systems with potentially long queries and
 // bind value data.
 func TruncateForLog(query string) string {
-	return truncateQuery(query, TruncateErrLen)
+	return truncateQuery(query, truncateErrLen)
 }

--- a/go/vt/sqlparser/truncate_query_test.go
+++ b/go/vt/sqlparser/truncate_query_test.go
@@ -1,0 +1,32 @@
+package sqlparser
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncateQuery(t *testing.T) {
+	tests := []struct {
+		query string
+		max   int
+		want  string
+	}{
+		{
+			query: "select * from test where name = 'abc'",
+			max:   30,
+			want:  "select * from test [TRUNCATED]",
+		},
+		{
+			query: "select * from test where name = 'abc'",
+			max:   1005,
+			want:  "select * from test where name = 'abc'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s-%d", tt.query, tt.max), func(t *testing.T) {
+			assert.Equalf(t, tt.want, truncateQuery(tt.query, tt.max), "truncateQuery(%v, %v)", tt.query, tt.max)
+		})
+	}
+}

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -654,7 +654,7 @@ func TestLogTruncation(t *testing.T) {
 	}
 
 	// Test that the data too long error is truncated once the option is set
-	*sqlparser.TruncateErrLen = 30
+	sqlparser.TruncateErrLen = 30
 	_, err = client.Execute(
 		"insert into vitess_test values(123, null, :data, null)",
 		map[string]*querypb.BindVariable{"data": sqltypes.StringBindVariable("THIS IS A LONG LONG LONG LONG QUERY STRING THAT SHOULD BE SHORTENED")},
@@ -672,7 +672,7 @@ func TestLogTruncation(t *testing.T) {
 	}
 
 	// Test that trailing comments are preserved data too long error is truncated once the option is set
-	*sqlparser.TruncateErrLen = 30
+	sqlparser.TruncateErrLen = 30
 	_, err = client.Execute(
 		"insert into vitess_test values(123, null, :data, null) /* KEEP ME */",
 		map[string]*querypb.BindVariable{"data": sqltypes.StringBindVariable("THIS IS A LONG LONG LONG LONG QUERY STRING THAT SHOULD BE SHORTENED")},

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -654,7 +654,7 @@ func TestLogTruncation(t *testing.T) {
 	}
 
 	// Test that the data too long error is truncated once the option is set
-	sqlparser.TruncateErrLen = 30
+	sqlparser.SetTruncateErrLen(30)
 	_, err = client.Execute(
 		"insert into vitess_test values(123, null, :data, null)",
 		map[string]*querypb.BindVariable{"data": sqltypes.StringBindVariable("THIS IS A LONG LONG LONG LONG QUERY STRING THAT SHOULD BE SHORTENED")},
@@ -672,7 +672,7 @@ func TestLogTruncation(t *testing.T) {
 	}
 
 	// Test that trailing comments are preserved data too long error is truncated once the option is set
-	sqlparser.TruncateErrLen = 30
+	sqlparser.SetTruncateErrLen(30)
 	_, err = client.Execute(
 		"insert into vitess_test values(123, null, :data, null) /* KEEP ME */",
 		map[string]*querypb.BindVariable{"data": sqltypes.StringBindVariable("THIS IS A LONG LONG LONG LONG QUERY STRING THAT SHOULD BE SHORTENED")},

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1449,7 +1449,7 @@ func truncateSQLAndBindVars(sql string, bindVariables map[string]*querypb.BindVa
 	}
 	fmt.Fprintf(buf, "}")
 	bv := buf.String()
-	maxLen := *sqlparser.TruncateErrLen
+	maxLen := sqlparser.TruncateErrLen
 	if maxLen != 0 && len(bv) > maxLen {
 		bv = bv[:maxLen-12] + " [TRUNCATED]"
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1449,7 +1449,7 @@ func truncateSQLAndBindVars(sql string, bindVariables map[string]*querypb.BindVa
 	}
 	fmt.Fprintf(buf, "}")
 	bv := buf.String()
-	maxLen := sqlparser.TruncateErrLen
+	maxLen := sqlparser.GetTruncateErrLen()
 	if maxLen != 0 && len(bv) > maxLen {
 		bv = bv[:maxLen-12] + " [TRUNCATED]"
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1564,7 +1564,7 @@ func TestTruncateMessages(t *testing.T) {
 	tl := newTestLogger()
 	defer tl.Close()
 
-	*sqlparser.TruncateErrLen = 52
+	sqlparser.TruncateErrLen = 52
 	sql := "select * from test_table where xyz = :vtg1 order by abc desc"
 	sqlErr := mysql.NewSQLError(10, "HY000", "sensitive message")
 	sqlErr.Query = "select * from test_table where xyz = 'this is kinda long eh'"
@@ -1588,7 +1588,7 @@ func TestTruncateMessages(t *testing.T) {
 		t.Errorf("log got '%s', want '%s'", tl.getLog(0), wantLog)
 	}
 
-	*sqlparser.TruncateErrLen = 140
+	sqlparser.TruncateErrLen = 140
 	err = tsv.convertAndLogError(
 		ctx,
 		sql,
@@ -1608,7 +1608,7 @@ func TestTruncateMessages(t *testing.T) {
 	if wantLog != tl.getLog(1) {
 		t.Errorf("log got '%s', want '%s'", tl.getLog(1), wantLog)
 	}
-	*sqlparser.TruncateErrLen = 0
+	sqlparser.TruncateErrLen = 0
 }
 
 func TestTerseErrorsIgnoreFailoverInProgress(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1564,7 +1564,7 @@ func TestTruncateMessages(t *testing.T) {
 	tl := newTestLogger()
 	defer tl.Close()
 
-	sqlparser.TruncateErrLen = 52
+	sqlparser.SetTruncateErrLen(52)
 	sql := "select * from test_table where xyz = :vtg1 order by abc desc"
 	sqlErr := mysql.NewSQLError(10, "HY000", "sensitive message")
 	sqlErr.Query = "select * from test_table where xyz = 'this is kinda long eh'"
@@ -1588,7 +1588,7 @@ func TestTruncateMessages(t *testing.T) {
 		t.Errorf("log got '%s', want '%s'", tl.getLog(0), wantLog)
 	}
 
-	sqlparser.TruncateErrLen = 140
+	sqlparser.SetTruncateErrLen(140)
 	err = tsv.convertAndLogError(
 		ctx,
 		sql,
@@ -1608,7 +1608,7 @@ func TestTruncateMessages(t *testing.T) {
 	if wantLog != tl.getLog(1) {
 		t.Errorf("log got '%s', want '%s'", tl.getLog(1), wantLog)
 	}
-	sqlparser.TruncateErrLen = 0
+	sqlparser.SetTruncateErrLen(0)
 }
 
 func TestTerseErrorsIgnoreFailoverInProgress(t *testing.T) {


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR moves the flags in sqlparser to use pflags package. It is part of https://github.com/vitessio/vitess/issues/10697#movers-guide work. The only flags available here are the ones that control query truncation for logging and UI, so they have been deemed to be required by all the binaries that import the package.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/10697#movers-guide
- Fixes https://github.com/vitessio/vitess/issues/10824

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
