### PR TITLE
return resource back to pool on apply settings failure

### DIFF
--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -333,6 +333,9 @@ func (rp *ResourcePool) getWithSettings(ctx context.Context, settings []string) 
 
 	if !wrapper.resource.IsSettingsApplied() {
 		if err = wrapper.resource.ApplySettings(ctx, settings); err != nil {
+			// as we are not able to apply settings, we can return this connection to non-settings channel.
+			// TODO: may check the error code to see if it is recoverable or not.
+			rp.resources <- wrapper
 			return nil, err
 		}
 	}


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR on ApplySettings failure return the resource back to the pool for accounting and avoiding leaking the connection.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- #9706 

## Checklist

-   [x] Tests were added or are not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
