### PR TITLE
Fix `TestInvalidDateTimeTimestampVals` linter issues

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -82,7 +82,10 @@ func TestInvalidDateTimeTimestampVals(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()
 
-	mcmp.ExecAllowAndCompareError(`select date'2022'`)
-	mcmp.ExecAllowAndCompareError(`select time'12:34:56:78'`)
-	mcmp.ExecAllowAndCompareError(`select timestamp'2022'`)
+	_, err := mcmp.ExecAllowAndCompareError(`select date'2022'`)
+	require.Error(t, err)
+	_, err = mcmp.ExecAllowAndCompareError(`select time'12:34:56:78'`)
+	require.Error(t, err)
+	_, err = mcmp.ExecAllowAndCompareError(`select timestamp'2022'`)
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Description

This PR changes `TestInvalidDateTimeTimestampVals` to check we got an error back from the MySQL client. By doing this, the existing linting issues will be fixed. 

```
Error: endtoend/queries/misc/misc_test.go: Error return value of `mcmp.ExecAllowAndCompareError` is not checked (errcheck)
	mcmp.ExecAllowAndCompareError(`select date'2022'`)
```

## Related Issue(s)


## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
