### PR TITLE
Use vtparams instead of clusterInstance in TestNormalizeAllFields

### DIFF
--- a/go/test/endtoend/vtgate/queries/normalize/normalize_test.go
+++ b/go/test/endtoend/vtgate/queries/normalize/normalize_test.go
@@ -46,7 +46,7 @@ func TestNormalizeAllFields(t *testing.T) {
 	assert.Equal(t, 1, len(qr.Rows), "wrong number of table rows, expected 1 but had %d. Results: %v", len(qr.Rows), qr.Rows)
 
 	// Now need to figure out the best way to check the normalized query in the planner cache...
-	results, err := getPlanCache(fmt.Sprintf("%s:%d", clusterInstance.Hostname, clusterInstance.VtgateProcess.Port))
+	results, err := getPlanCache(fmt.Sprintf("%s:%d", vtParams.Host, clusterInstance.VtgateProcess.Port))
 	require.Nil(t, err)
 	found := false
 	for _, record := range results {


### PR DESCRIPTION
## Description

Use `vtParams.Host` instead of `clusterInstance.Hostname` in `TestNormalizeAllFields` to keep the same format throughout the Gen4 e2e tests.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
