### PR TITLE
[cli] [stats] Migrate stats/opentsdb + stats/statsd flags to pflag

### DIFF
--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -151,7 +151,7 @@ Usage of vtgate:
       --stats_drop_variables string                                      Variables to be dropped from the list of exported variables.
       --stats_emit_period duration                                       Interval between emitting stats to all registered backends (default 1m0s)
       --statsd_address string                                            Address for statsd client
-      --statsd_sample_rate float                                          (default 1)
+      --statsd_sample_rate float                                         Sample rate for statsd metrics (default 1)
       --stderrthreshold severity                                         logs at or above this threshold go to stderr (default 1)
       --stream_buffer_size int                                           the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size. (default 32768)
       --tablet_filters strings                                           Specifies a comma-separated list of 'keyspace|shard_name or keyrange' values to filter the tablets to watch.

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -378,7 +378,7 @@ Usage of vttablet:
       --stats_drop_variables string                                      Variables to be dropped from the list of exported variables.
       --stats_emit_period duration                                       Interval between emitting stats to all registered backends (default 1m0s)
       --statsd_address string                                            Address for statsd client
-      --statsd_sample_rate float                                          (default 1)
+      --statsd_sample_rate float                                         Sample rate for statsd metrics (default 1)
       --stderrthreshold severity                                         logs at or above this threshold go to stderr (default 1)
       --stream_health_buffer_size uint                                   max streaming health entries to buffer per streaming health client (default 20)
       --table-acl-config string                                          path to table access checker config file; send SIGHUP to reload this file

--- a/go/stats/opentsdb/opentsdb.go
+++ b/go/stats/opentsdb/opentsdb.go
@@ -21,20 +21,29 @@ import (
 	"bytes"
 	"encoding/json"
 	"expvar"
-	"flag"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 	"unicode"
 
+	"github.com/spf13/pflag"
+
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/servenv"
 )
 
-var (
-	openTsdbURI = flag.String("opentsdb_uri", "", "URI of opentsdb /api/put method")
-)
+var openTsdbURI string
+
+func registerFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&openTsdbURI, "opentsdb_uri", openTsdbURI, "URI of opentsdb /api/put method")
+}
+
+func init() {
+	servenv.OnParseFor("vtctld", registerFlags)
+	servenv.OnParseFor("vtgate", registerFlags)
+	servenv.OnParseFor("vttablet", registerFlags)
+}
 
 // dataPoint represents a single OpenTSDB data point.
 type dataPoint struct {
@@ -55,7 +64,7 @@ func sendDataPoints(data []dataPoint) error {
 		return err
 	}
 
-	resp, err := http.Post(*openTsdbURI, "application/json", bytes.NewReader(json))
+	resp, err := http.Post(openTsdbURI, "application/json", bytes.NewReader(json))
 	if err != nil {
 		return err
 	}
@@ -93,7 +102,7 @@ func Init(prefix string) {
 
 // InitWithoutServenv initializes the opentsdb without servenv
 func InitWithoutServenv(prefix string) {
-	if *openTsdbURI == "" {
+	if openTsdbURI == "" {
 		return
 	}
 


### PR DESCRIPTION

## Description

This migrates _just_ the flags for the stats backends to pflag. The top-level `go/stats` flags were a bit more complex to analyze dependencies on, so I want to do that separately.

### `opentsdb`

```
go list -f '{{ .ImportPath }}| {{ join .Deps " " }} ' ./go/cmd/... ./go/vt/servenv | awk -F"|" '$2 ~ " vitess.io/vitess/go/stats/opentsdb " {print $1}'
vitess.io/vitess/go/cmd/vtctld
vitess.io/vitess/go/cmd/vtgate
vitess.io/vitess/go/cmd/vttablet
```

### `statsd`

```
go list -f '{{ .ImportPath }}| {{ join .Deps " " }} ' ./go/cmd/... ./go/vt/servenv | awk -F"|" '$2 ~ " vitess.io/vitess/go/stats/statsd " {print $1}'           
vitess.io/vitess/go/cmd/vtgate
vitess.io/vitess/go/cmd/vttablet
```

### `prometheusbackend`

no flags

## Related Issue(s)

- Closes #10745.
- Closes #10744.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
