### PR TITLE
[cli] [topo/consultopo] Migrate consul flags to pflags

### DIFF
--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -38,9 +38,10 @@ import (
 
 var (
 	consulAuthClientStaticFile string
-	consulLockSessionChecks    = "serfHealth"
-	consulLockSessionTTL       string
-	consulLockDelay            = 15 * time.Second
+	// serfHealth is the default check from consul
+	consulLockSessionChecks = "serfHealth"
+	consulLockSessionTTL    string
+	consulLockDelay         = 15 * time.Second
 )
 
 func init() {
@@ -51,7 +52,6 @@ func init() {
 
 func registerServerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&consulAuthClientStaticFile, "consul_auth_static_file", consulAuthClientStaticFile, "JSON File to read the topos/tokens from.")
-	// serfHealth is the default check from consul
 	fs.StringVar(&consulLockSessionChecks, "topo_consul_lock_session_checks", consulLockSessionChecks, "List of checks for consul session.")
 	fs.StringVar(&consulLockSessionTTL, "topo_consul_lock_session_ttl", consulLockSessionTTL, "TTL for consul session.")
 	fs.DurationVar(&consulLockDelay, "topo_consul_lock_delay", consulLockDelay, "LockDelay for consul session.")

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -27,38 +27,29 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/spf13/pflag"
 
-	"vitess.io/vitess/go/vt/servenv"
-
-	"github.com/hashicorp/consul/api"
-
-	"vitess.io/vitess/go/vt/vterrors"
-
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 var (
-	// flag vars
-	consulAuthClientStaticFile = ""
+	consulAuthClientStaticFile string
 	consulLockSessionChecks    = "serfHealth"
-	consulLockSessionTTL       = ""
+	consulLockSessionTTL       string
 	consulLockDelay            = 15 * time.Second
 )
 
 func init() {
-	servenv.OnParseFor("vtbackup", registerConsulFlags)
-	servenv.OnParseFor("vtcombo", registerConsulFlags)
-	servenv.OnParseFor("vtctl", registerConsulFlags)
-	servenv.OnParseFor("vtctld", registerConsulFlags)
-	servenv.OnParseFor("vtgate", registerConsulFlags)
-	servenv.OnParseFor("vtgr", registerConsulFlags)
-	servenv.OnParseFor("vttablet", registerConsulFlags)
-	servenv.OnParseFor("vttablet", registerConsulFlags)
+	for _, cmd := range []string{"vtbackup", "vtcombo", "vtctl", "vtctld", "vtgate", "vtgr", "vttablet", "vttestserver", "zk"} {
+		servenv.OnParseFor(cmd, registerServerFlags)
+	}
 }
 
-func registerConsulFlags(fs *pflag.FlagSet) {
+func registerServerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&consulAuthClientStaticFile, "consul_auth_static_file", consulAuthClientStaticFile, "JSON File to read the topos/tokens from.")
 	// serfHealth is the default check from consul
 	fs.StringVar(&consulLockSessionChecks, "topo_consul_lock_session_checks", consulLockSessionChecks, "List of checks for consul session.")

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -48,17 +48,14 @@ var (
 )
 
 func init() {
-	servenv.OnParseFor("topo2topo", registerConsulFlags)
 	servenv.OnParseFor("vtbackup", registerConsulFlags)
 	servenv.OnParseFor("vtcombo", registerConsulFlags)
 	servenv.OnParseFor("vtctl", registerConsulFlags)
 	servenv.OnParseFor("vtctld", registerConsulFlags)
 	servenv.OnParseFor("vtgate", registerConsulFlags)
 	servenv.OnParseFor("vtgr", registerConsulFlags)
-	servenv.OnParseFor("vtorc", registerConsulFlags)
 	servenv.OnParseFor("vttablet", registerConsulFlags)
-	servenv.OnParseFor("vttestserver", registerConsulFlags)
-	servenv.OnParseFor("zk", registerConsulFlags)
+	servenv.OnParseFor("vttablet", registerConsulFlags)
 }
 
 func registerConsulFlags(fs *pflag.FlagSet) {

--- a/go/vt/topo/consultopo/server_flaky_test.go
+++ b/go/vt/topo/consultopo/server_flaky_test.go
@@ -125,7 +125,7 @@ func startConsul(t *testing.T, authToken string) (*exec.Cmd, string, string) {
 
 func TestConsulTopo(t *testing.T) {
 	// One test is going to wait that full period, so make it shorter.
-	*watchPollDuration = 100 * time.Millisecond
+	watchPollDuration = 100 * time.Millisecond
 
 	// Start a single consul in the background.
 	cmd, configFilename, serverAddr := startConsul(t, "")
@@ -169,9 +169,9 @@ func TestConsulTopo(t *testing.T) {
 
 func TestConsulTopoWithChecks(t *testing.T) {
 	// One test is going to wait that full period, so make it shorter.
-	*watchPollDuration = 100 * time.Millisecond
-	*consulLockSessionChecks = "serfHealth"
-	*consulLockSessionTTL = "15s"
+	watchPollDuration = 100 * time.Millisecond
+	consulLockSessionChecks = "serfHealth"
+	consulLockSessionTTL = "15s"
 
 	// Start a single consul in the background.
 	cmd, configFilename, serverAddr := startConsul(t, "")
@@ -215,7 +215,7 @@ func TestConsulTopoWithChecks(t *testing.T) {
 
 func TestConsulTopoWithAuth(t *testing.T) {
 	// One test is going to wait that full period, so make it shorter.
-	*watchPollDuration = 100 * time.Millisecond
+	watchPollDuration = 100 * time.Millisecond
 
 	// Start a single consul in the background.
 	cmd, configFilename, serverAddr := startConsul(t, "123456")
@@ -240,7 +240,7 @@ func TestConsulTopoWithAuth(t *testing.T) {
 	}
 	defer os.Remove(tmpFile.Name())
 
-	*consulAuthClientStaticFile = tmpFile.Name()
+	consulAuthClientStaticFile = tmpFile.Name()
 
 	jsonConfig := "{\"global\":{\"acl_token\":\"123456\"}, \"test\":{\"acl_token\":\"123456\"}}"
 	if err := os.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
@@ -272,7 +272,7 @@ func TestConsulTopoWithAuth(t *testing.T) {
 
 func TestConsulTopoWithAuthFailure(t *testing.T) {
 	// One test is going to wait that full period, so make it shorter.
-	*watchPollDuration = 100 * time.Millisecond
+	watchPollDuration = 100 * time.Millisecond
 
 	// Start a single consul in the background.
 	cmd, configFilename, serverAddr := startConsul(t, "123456")
@@ -289,7 +289,7 @@ func TestConsulTopoWithAuthFailure(t *testing.T) {
 	}
 	defer os.Remove(tmpFile.Name())
 
-	*consulAuthClientStaticFile = tmpFile.Name()
+	consulAuthClientStaticFile = tmpFile.Name()
 
 	jsonConfig := "{\"global\":{\"acl_token\":\"badtoken\"}}"
 	if err := os.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -21,29 +21,21 @@ import (
 	"path"
 	"time"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/servenv"
-
-	"github.com/hashicorp/consul/api"
-
 	"vitess.io/vitess/go/vt/topo"
 )
 
 var (
-	// flag vars
 	watchPollDuration = 30 * time.Second
 )
 
 func init() {
-	servenv.OnParseFor("vtbackup", registerWatchFlags)
-	servenv.OnParseFor("vtcombo", registerWatchFlags)
-	servenv.OnParseFor("vtctl", registerWatchFlags)
-	servenv.OnParseFor("vtctld", registerWatchFlags)
-	servenv.OnParseFor("vtgate", registerWatchFlags)
-	servenv.OnParseFor("vtgr", registerWatchFlags)
-	servenv.OnParseFor("vttablet", registerWatchFlags)
-	servenv.OnParseFor("vttablet", registerWatchFlags)
+	for _, cmd := range []string{"vtbackup", "vtcombo", "vtctl", "vtctld", "vtgate", "vtgr", "vttablet", "vttestserver", "zk"} {
+		servenv.OnParseFor(cmd, registerWatchFlags)
+	}
 }
 
 func registerWatchFlags(fs *pflag.FlagSet) {

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -36,17 +36,14 @@ var (
 )
 
 func init() {
-	servenv.OnParseFor("topo2topo", registerWatchFlags)
 	servenv.OnParseFor("vtbackup", registerWatchFlags)
 	servenv.OnParseFor("vtcombo", registerWatchFlags)
 	servenv.OnParseFor("vtctl", registerWatchFlags)
 	servenv.OnParseFor("vtctld", registerWatchFlags)
 	servenv.OnParseFor("vtgate", registerWatchFlags)
 	servenv.OnParseFor("vtgr", registerWatchFlags)
-	servenv.OnParseFor("vtorc", registerWatchFlags)
 	servenv.OnParseFor("vttablet", registerWatchFlags)
-	servenv.OnParseFor("vttestserver", registerWatchFlags)
-	servenv.OnParseFor("zk", registerWatchFlags)
+	servenv.OnParseFor("vttablet", registerWatchFlags)
 }
 
 func registerWatchFlags(fs *pflag.FlagSet) {

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -18,9 +18,12 @@ package consultopo
 
 import (
 	"context"
-	"flag"
 	"path"
 	"time"
+
+	"github.com/spf13/pflag"
+
+	"vitess.io/vitess/go/vt/servenv"
 
 	"github.com/hashicorp/consul/api"
 
@@ -28,8 +31,27 @@ import (
 )
 
 var (
-	watchPollDuration = flag.Duration("topo_consul_watch_poll_duration", 30*time.Second, "time of the long poll for watch queries.")
+	// flag vars
+	watchPollDuration = 30 * time.Second
 )
+
+func init() {
+	servenv.OnParseFor("topo2topo", registerWatchFlags)
+	servenv.OnParseFor("vtbackup", registerWatchFlags)
+	servenv.OnParseFor("vtcombo", registerWatchFlags)
+	servenv.OnParseFor("vtctl", registerWatchFlags)
+	servenv.OnParseFor("vtctld", registerWatchFlags)
+	servenv.OnParseFor("vtgate", registerWatchFlags)
+	servenv.OnParseFor("vtgr", registerWatchFlags)
+	servenv.OnParseFor("vtorc", registerWatchFlags)
+	servenv.OnParseFor("vttablet", registerWatchFlags)
+	servenv.OnParseFor("vttestserver", registerWatchFlags)
+	servenv.OnParseFor("zk", registerWatchFlags)
+}
+
+func registerWatchFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&watchPollDuration, "topo_consul_watch_poll_duration", watchPollDuration, "time of the long poll for watch queries.")
+}
 
 // Watch is part of the topo.Conn interface.
 func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, error) {
@@ -75,7 +97,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 			waitIndex := pair.ModifyIndex
 			opts := &api.QueryOptions{
 				WaitIndex: waitIndex,
-				WaitTime:  *watchPollDuration,
+				WaitTime:  watchPollDuration,
 			}
 
 			// Make a new Context for just this one Get() call.


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>

## Description
Updates throttler related flag references specified in https://github.com/vitessio/vitess/issues/10858

Here are the commands registered
go list -f '{{ .ImportPath }}| {{ join .Deps " " }} ' ./go/cmd/... | awk -F"|" '$2 ~ "go/vt/topo/consultopo" {print $1}'
vitess.io/vitess/go/cmd/topo2topo
vitess.io/vitess/go/cmd/vtbackup
vitess.io/vitess/go/cmd/vtcombo
vitess.io/vitess/go/cmd/vtctl
vitess.io/vitess/go/cmd/vtctld
vitess.io/vitess/go/cmd/vtgate
vitess.io/vitess/go/cmd/vtgr
vitess.io/vitess/go/cmd/vtorc
vitess.io/vitess/go/cmd/vttablet
vitess.io/vitess/go/cmd/vttestserver
vitess.io/vitess/go/cmd/zk

## Related Issue(s)

Fixes #10858 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
