### PR TITLE
Add explicit close state to memory topo connection

### DIFF
--- a/go/vt/topo/memorytopo/election.go
+++ b/go/vt/topo/memorytopo/election.go
@@ -26,6 +26,10 @@ import (
 
 // NewLeaderParticipation is part of the topo.Server interface
 func (c *Conn) NewLeaderParticipation(name, id string) (topo.LeaderParticipation, error) {
+	if c.closed {
+		return nil, ErrConnectionClosed
+	}
+
 	c.factory.mu.Lock()
 	defer c.factory.mu.Unlock()
 
@@ -68,6 +72,10 @@ type cLeaderParticipation struct {
 
 // WaitForLeadership is part of the topo.LeaderParticipation interface.
 func (mp *cLeaderParticipation) WaitForLeadership() (context.Context, error) {
+	if mp.c.closed {
+		return nil, ErrConnectionClosed
+	}
+
 	// If Stop was already called, mp.done is closed, so we are interrupted.
 	select {
 	case <-mp.done:
@@ -112,6 +120,10 @@ func (mp *cLeaderParticipation) Stop() {
 
 // GetCurrentLeaderID is part of the topo.LeaderParticipation interface
 func (mp *cLeaderParticipation) GetCurrentLeaderID(ctx context.Context) (string, error) {
+	if mp.c.closed {
+		return "", ErrConnectionClosed
+	}
+
 	electionPath := path.Join(electionsPath, mp.name)
 
 	mp.c.factory.mu.Lock()
@@ -127,6 +139,10 @@ func (mp *cLeaderParticipation) GetCurrentLeaderID(ctx context.Context) (string,
 
 // WaitForNewLeader is part of the topo.LeaderParticipation interface
 func (mp *cLeaderParticipation) WaitForNewLeader(ctx context.Context) (<-chan string, error) {
+	if mp.c.closed {
+		return nil, ErrConnectionClosed
+	}
+
 	mp.c.factory.mu.Lock()
 	defer mp.c.factory.mu.Unlock()
 

--- a/go/vt/topo/memorytopo/lock.go
+++ b/go/vt/topo/memorytopo/lock.go
@@ -102,6 +102,10 @@ func (ld *memoryTopoLockDescriptor) Unlock(ctx context.Context) error {
 }
 
 func (c *Conn) unlock(ctx context.Context, dirPath string) error {
+	if c.closed {
+		return ErrConnectionClosed
+	}
+
 	c.factory.mu.Lock()
 	defer c.factory.mu.Unlock()
 

--- a/go/vt/topo/memorytopo/watch.go
+++ b/go/vt/topo/memorytopo/watch.go
@@ -25,6 +25,10 @@ import (
 
 // Watch is part of the topo.Conn interface.
 func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, error) {
+	if c.closed {
+		return nil, nil, ErrConnectionClosed
+	}
+
 	c.factory.Lock()
 	defer c.factory.Unlock()
 
@@ -55,10 +59,9 @@ func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-c
 		// This function can be called at any point, so we first need
 		// to make sure the watch is still valid.
 		c.factory.Lock()
-		f := c.factory
-		defer f.Unlock()
+		defer c.factory.Unlock()
 
-		n := f.nodeByPath(c.cell, filePath)
+		n := c.factory.nodeByPath(c.cell, filePath)
 		if n == nil {
 			return
 		}
@@ -74,6 +77,10 @@ func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-c
 
 // WatchRecursive is part of the topo.Conn interface.
 func (c *Conn) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.WatchDataRecursive, <-chan *topo.WatchDataRecursive, error) {
+	if c.closed {
+		return nil, nil, ErrConnectionClosed
+	}
+
 	c.factory.Lock()
 	defer c.factory.Unlock()
 

--- a/go/vt/topo/test/file.go
+++ b/go/vt/topo/test/file.go
@@ -210,6 +210,12 @@ func checkList(t *testing.T, ts *topo.Server) {
 	if err != nil {
 		t.Fatalf("ConnForCell(LocalCellName) failed: %v", err)
 	}
+
+	_, err = conn.Create(ctx, "/some/arbitrary/file", []byte{'a'})
+	if err != nil {
+		t.Fatalf("Create('/myfile') failed: %v", err)
+	}
+
 	_, err = conn.List(ctx, "/")
 	if topo.IsErrType(err, topo.NoImplementation) {
 		// If this is not supported, skip the test

--- a/go/vt/topo/test/testing.go
+++ b/go/vt/topo/test/testing.go
@@ -114,14 +114,20 @@ func TopoServerTestSuite(t *testing.T, factory func() *topo.Server) {
 	t.Log("=== checkWatch")
 	ts = factory()
 	checkWatch(t, ts)
+	ts.Close()
+
+	ts = factory()
 	t.Log("=== checkWatchInterrupt")
 	checkWatchInterrupt(t, ts)
+	ts.Close()
 
+	ts = factory()
 	t.Log("=== checkList")
 	checkList(t, ts)
+	ts.Close()
 
+	ts = factory()
 	t.Log("=== checkWatchRecursive")
 	checkWatchRecursive(t, ts)
-
 	ts.Close()
 }


### PR DESCRIPTION
The model of where we clear out the factory instance to nil is not really tenable since it always by definition races with `Watch` shutdown and there's no way to resolve that without explicit communication.

This introduces an explicit closed state flag instead and we error out if we're already closed to avoid issues around usage after close. This resolves all the issues.

The tests here are also updated to essentially always trigger the previous problem and it's gone with the changes applied here.

## Related Issue(s)

Previous attempts like https://github.com/vitessio/vitess/pull/11065, https://github.com/vitessio/vitess/pull/10954 & https://github.com/vitessio/vitess/pull/10906 tried to improve this but don't solve the more fundamental issue. Tried to avoid this change before but I think we have to make it.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
