### PR TITLE
Treat `IN` operations on single value tuples as `Equal` operations.

### DIFF
--- a/go/vt/vtgate/planbuilder/physical/route.go
+++ b/go/vt/vtgate/planbuilder/physical/route.go
@@ -498,6 +498,12 @@ func (r *Route) planInOp(ctx *plancontext.PlanningContext, cmp *sqlparser.Compar
 	switch left := cmp.Left.(type) {
 	case *sqlparser.ColName:
 		vdValue := cmp.Right
+
+		valTuple, isTuple := vdValue.(sqlparser.ValTuple)
+		if isTuple && len(valTuple) == 1 {
+			return r.planEqualOp(ctx, &sqlparser.ComparisonExpr{Left: left, Right: valTuple[0], Operator: sqlparser.EqualOp})
+		}
+
 		value := r.makeEvalEngineExpr(ctx, vdValue)
 		if value == nil {
 			return false

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -5542,3 +5542,72 @@ Gen4 plan same as above
     "user.user"
   ]
 }
+
+# Treating single value tuples as `EqualUnique` routes
+"SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.user_id IN (5)) AND music.user_id = 5"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.user_id IN (5)) AND music.user_id = 5",
+  "Instructions": {
+    "OperatorType": "Subquery",
+    "Variant": "PulloutIn",
+    "PulloutVars": [
+      "__sq_has_values1",
+      "__sq1"
+    ],
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "IN",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select music.id from music where 1 != 1",
+        "Query": "select music.id from music where music.user_id in ::__vals",
+        "Table": "music",
+        "Values": [
+          "(INT64(5))"
+        ],
+        "Vindex": "user_index"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select music.id from music where 1 != 1",
+        "Query": "select music.id from music where music.user_id = 5 and :__sq_has_values1 = 1 and music.id in ::__sq1",
+        "Table": "music",
+        "Values": [
+          "INT64(5)"
+        ],
+        "Vindex": "user_index"
+      }
+    ]
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT music.id FROM music WHERE music.id IN (SELECT music.id FROM music WHERE music.user_id IN (5)) AND music.user_id = 5",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select music.id from music where 1 != 1",
+    "Query": "select music.id from music where music.id in (select music.id from music where music.user_id in (5)) and music.user_id = 5",
+    "Table": "music",
+    "Values": [
+      "INT64(5)"
+    ],
+    "Vindex": "user_index"
+  },
+  "TablesUsed": [
+    "user.music"
+  ]
+}


### PR DESCRIPTION
## Description

This improves routing mergeability and vindex selection by treating `IN` operations with single value tuples like `Equal` operations.

A query like this:

```sql
SELECT music.id FROM music WHERE music.user_id IN (5)
```

Will now have a plan like this:

```json
{
  "QueryType": "SELECT",
  "Original": "SELECT music.id FROM music WHERE music.user_id IN (5)",
  "Instructions": {
    "OperatorType": "Route",
    "Variant": "EqualUnique",
    "Keyspace": {
      "Name": "user",
      "Sharded": true
    },
    "FieldQuery": "select music.id from music where 1 != 1",
    "Query": "select music.id from music where music.user_id in (5)",
    "Table": "music",
    "Values": [
      "INT64(5)"
    ],
    "Vindex": "user_index"
  },
  "TablesUsed": [
    "user.music"
  ]
}
```

---

This is a very simple fix for this issue, and it does not handle the following edge cases:

* Multiple repeated values: `music.user_id IN (5, 5, 5)` will not be treated as a single value tuple, although it essentially is equivalent to `music.user_id IN (5)`. Can we use the evaluation engine to perform a "distinct" operation on the tuple values?
* Values using different types. `music.user_id IN (5,  '5')` will not be treated as a single value tuple, although MySQLs type conversion rules will essentially perform comparisons with types that don't match after conversion to floating point values. Can we again use the evaluation engine to take the column type into account when performing the "distinct" operation?

## Related Issue(s)

Fixes: https://github.com/vitessio/vitess/issues/11112

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
