### PR TITLE
CLI Pflag migration work: Fix regression caused by pflag-vreplication PR

### DIFF
--- a/go/internal/flag/flag.go
+++ b/go/internal/flag/flag.go
@@ -69,7 +69,7 @@ func Parse(fs *flag.FlagSet) {
 
 // filterTestFlags returns two slices: the second one has just the flags for `go test` and the first one contains
 // the rest of the flags.
-const goTestFlagSuffix = "=test"
+const goTestFlagSuffix = "-test"
 
 func filterTestFlags() ([]string, []string) {
 	args := os.Args

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	_flag "vitess.io/vitess/go/internal/flag"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
@@ -111,6 +112,7 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
+	_flag.ParseFlagsForTest()
 	exitCode := func() int {
 		var err error
 		env, err = testenv.Init()


### PR DESCRIPTION
## Description

Previous PR https://github.com/vitessio/vitess/pull/11095 had introduced  a bug which related to running the tests manually on the command line. It would ignore all passed test flags due to two bugs: one a typo in the parsing of test flags and another, a missing call to perform the parsing in `TestMain` in `tabletmanager/vreplication`

## Related Issue(s)

#11095 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

