### PR TITLE
Port time zone handling from vdiff1 to vdiff2

### DIFF
--- a/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
@@ -113,6 +113,7 @@ func (td *tableDiffer) buildTablePlan() (*tablePlan, error) {
 		fields[strings.ToLower(field.Name)] = field.Type
 	}
 
+	targetSelect.SelectExprs = td.adjustForSourceTimeZone(targetSelect.SelectExprs, fields)
 	// Start with adding all columns for comparison.
 	tp.compareCols = make([]compareColInfo, len(sourceSelect.SelectExprs))
 	for i := range tp.compareCols {


### PR DESCRIPTION
## Description

This ports the timezone handling added to VDiff as part of https://github.com/vitessio/vitess/pull/10102 over to VDiff2.

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/10102

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required