### PR TITLE
Include the compose examples in the `do_release` script

### DIFF
--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -77,14 +77,19 @@ function updateJava () {
 
 # First argument is the Release Version (for instance: v12.0.0)
 # Second argument is the Vitess Operator version
-function updateVitessOperatorExample () {
+function updateVitessExamples () {
+  compose_example_files=$(find -E $ROOT/examples/compose/* -regex ".*.(go|yml)")
+  compose_example_sub_files=$(find -E $ROOT/examples/compose/**/* -regex ".*.(go|yml)")
   vtop_example_files=$(find -E $ROOT/examples/operator -name "*.yaml")
-  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:v$1/g" $vtop_example_files
+  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:v$1/g" $compose_example_files $compose_example_sub_files $vtop_example_files
+  sed -i.bak -E "s/vitess\/lite:\${VITESS_TAG:-latest}/vitess\/lite:v$1/g" $compose_example_sub_files $vtop_example_files
   sed -i.bak -E "s/vitess\/lite:(.*)-mysql80/vitess\/lite:v$1-mysql80/g" $(find -E $ROOT/examples/operator -name "*.md")
   if [ "$2" != "" ]; then
   		sed -i.bak -E "s/planetscale\/vitess-operator:(.*)/planetscale\/vitess-operator:v$2/g" $vtop_example_files
   fi
   rm -f $(find -E $ROOT/examples/operator -regex ".*.(md|yaml).bak")
+  rm -f $(find -E $ROOT/examples/compose/* -regex ".*.(go|yml).bak")
+  rm -f $(find -E $ROOT/examples/compose/**/* -regex ".*.(go|yml).bak")
 }
 
 git_status_output=$(git status --porcelain)


### PR DESCRIPTION
## Description

This pull request modifies the do_release script to modify the compose example files to use the proper docker image tag. Now, when doing a release, the compose example will be changed to use the release' image.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
