### PR TITLE
Upgrade go version to `1.17.13` on `release-13.0`

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -20,7 +20,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/check_imports.yml
+++ b/.github/workflows/check_imports.yml
@@ -20,7 +20,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Check out code
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -20,7 +20,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/check_make_sizegen.yml
+++ b/.github/workflows/check_make_sizegen.yml
@@ -20,7 +20,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -20,7 +20,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -23,7 +23,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -23,7 +23,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -16,7 +16,7 @@
      - name: Set up Go
        uses: actions/setup-go@v2
        with:
-         go-version: 1.17.12
+         go-version: 1.17.13
 
      - name: Tune the OS
        run: |
@@ -107,7 +107,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -31,7 +31,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -20,7 +20,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       run: |

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -21,7 +21,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -21,7 +21,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -20,7 +20,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -20,7 +20,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/ensure_bootstrap_updated.yml
+++ b/.github/workflows/ensure_bootstrap_updated.yml
@@ -20,7 +20,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -19,7 +19,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
       id: go
 
     - name: Tune the OS

--- a/.github/workflows/gomod-tidy.yml
+++ b/.github/workflows/gomod-tidy.yml
@@ -19,7 +19,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
       id: go
 
     - name: Tune the OS

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -25,7 +25,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -25,7 +25,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -25,7 +25,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -24,7 +24,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -25,7 +25,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -25,7 +25,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -25,7 +25,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -70,7 +70,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -78,7 +78,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -95,7 +95,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -80,7 +80,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -70,7 +70,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -80,7 +80,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -80,7 +80,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -80,7 +80,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -80,7 +80,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -71,7 +71,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -69,7 +69,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.18.5
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ $(PROTO_GO_OUTS): minimaltools install_protoc-gen-go proto/*.proto
 # This rule builds the bootstrap images for all flavors.
 DOCKER_IMAGES_FOR_TEST = mariadb mariadb103 mysql56 mysql57 mysql80 percona percona57 percona80
 DOCKER_IMAGES = common $(DOCKER_IMAGES_FOR_TEST)
-BOOTSTRAP_VERSION=4.3
+BOOTSTRAP_VERSION=4.4
 ensure_bootstrap_version:
 	find docker/ -type f -exec sed -i "s/^\(ARG bootstrap_version\)=.*/\1=${BOOTSTRAP_VERSION}/" {} \;
 	sed -i 's/\(^.*flag.String(\"bootstrap-version\",\) *\"[^\"]\+\"/\1 \"${BOOTSTRAP_VERSION}\"/' test.go

--- a/build.env
+++ b/build.env
@@ -17,7 +17,7 @@
 source ./tools/shell_functions.inc
 
 go version >/dev/null 2>&1 || fail "Go is not installed or is not in \$PATH. See https://vitess.io/contributing/build-from-source for install instructions."
-goversion_min 1.17.12 || fail "Go version reported: `go version`. Version 1.17.12+ required. See https://vitess.io/contributing/build-from-source for install instructions."
+goversion_min 1.17.13 || fail "Go version reported: `go version`. Version 1.17.13+ required. See https://vitess.io/contributing/build-from-source for install instructions."
 
 mkdir -p dist
 mkdir -p bin

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -21,7 +21,7 @@
 # TODO(mberlin): Remove the symlink and this note once
 # https://github.com/docker/hub-feedback/issues/292 is fixed.
 
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mariadb
+++ b/docker/base/Dockerfile.mariadb
@@ -1,4 +1,4 @@
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mariadb103
+++ b/docker/base/Dockerfile.mariadb103
@@ -1,4 +1,4 @@
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb103"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mysql56
+++ b/docker/base/Dockerfile.mysql56
@@ -1,4 +1,4 @@
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql56"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mysql80
+++ b/docker/base/Dockerfile.mysql80
@@ -1,4 +1,4 @@
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.percona
+++ b/docker/base/Dockerfile.percona
@@ -1,4 +1,4 @@
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-percona"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.percona57
+++ b/docker/base/Dockerfile.percona57
@@ -1,4 +1,4 @@
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-percona57"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.percona80
+++ b/docker/base/Dockerfile.percona80
@@ -1,4 +1,4 @@
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-percona80"
 
 FROM "${image}"

--- a/docker/bootstrap/CHANGELOG.md
+++ b/docker/bootstrap/CHANGELOG.md
@@ -9,5 +9,7 @@ List of changes between bootstrap image versions.
 ## [2] - 2022-07-15
 ### Changes
 - Upgrade golang version to 1.17.12
-    
 
+## [3] - 2022-08-31
+### Changes
+- Upgrade golang version to 1.17.13

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.17.12-buster
+FROM --platform=linux/amd64 golang:1.17.13-buster
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/docker/lite/Dockerfile.alpine
+++ b/docker/lite/Dockerfile.alpine
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb103"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mariadb
+++ b/docker/lite/Dockerfile.mariadb
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mariadb103
+++ b/docker/lite/Dockerfile.mariadb103
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb103"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mysql56
+++ b/docker/lite/Dockerfile.mysql56
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql56"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mysql57
+++ b/docker/lite/Dockerfile.mysql57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mysql80
+++ b/docker/lite/Dockerfile.mysql80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.percona
+++ b/docker/lite/Dockerfile.percona
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-percona"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.percona57
+++ b/docker/lite/Dockerfile.percona57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-percona57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-percona80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.testing
+++ b/docker/lite/Dockerfile.testing
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.mysql57
+++ b/docker/lite/Dockerfile.ubi7.mysql57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.mysql80
+++ b/docker/lite/Dockerfile.ubi7.mysql80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.percona57
+++ b/docker/lite/Dockerfile.ubi7.percona57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-percona57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.percona80
+++ b/docker/lite/Dockerfile.ubi7.percona80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-percona80"
 
 FROM "${image}" AS builder

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,4 +1,4 @@
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM "${image}"

--- a/docker/vttestserver/Dockerfile.mysql57
+++ b/docker/vttestserver/Dockerfile.mysql57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder

--- a/go/vt/servenv/buildinfo_test.go
+++ b/go/vt/servenv/buildinfo_test.go
@@ -33,17 +33,17 @@ func TestVersionString(t *testing.T) {
 		buildTimePretty: "time is now",
 		buildGitRev:     "d54b87c",
 		buildGitBranch:  "gitBranch",
-		goVersion:       "1.17.12",
+		goVersion:       "1.17.13",
 		goOS:            "amiga",
 		goArch:          "amd64",
 		version:         "v1.2.3-SNAPSHOT",
 	}
 
-	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Git revision d54b87c branch 'gitBranch') built on time is now by user@host using 1.17.12 amiga/amd64", v.String())
+	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Git revision d54b87c branch 'gitBranch') built on time is now by user@host using 1.17.13 amiga/amd64", v.String())
 
 	v.jenkinsBuildNumber = 422
 
-	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Jenkins build 422) (Git revision d54b87c branch 'gitBranch') built on time is now by user@host using 1.17.12 amiga/amd64", v.String())
+	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Jenkins build 422) (Git revision d54b87c branch 'gitBranch') built on time is now by user@host using 1.17.13 amiga/amd64", v.String())
 
 	assert.Equal(t, "5.7.9-vitess-v1.2.3-SNAPSHOT", v.MySQLVersion())
 }

--- a/test.go
+++ b/test.go
@@ -74,7 +74,7 @@ For example:
 // Flags
 var (
 	flavor           = flag.String("flavor", "mysql57", "comma-separated bootstrap flavor(s) to run against (when using Docker mode). Available flavors: all,"+flavors)
-	bootstrapVersion = flag.String("bootstrap-version", "4.3", "the version identifier to use for the docker images")
+	bootstrapVersion = flag.String("bootstrap-version", "4.4", "the version identifier to use for the docker images")
 	runCount         = flag.Int("runs", 1, "run each test this many times")
 	retryMax         = flag.Int("retry", 3, "max number of retries, to detect flaky tests")
 	logPass          = flag.Bool("log-pass", false, "log test output even if it passes")

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -29,7 +29,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -21,7 +21,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/test/templates/cluster_endtoend_test_mysql80.tpl
+++ b/test/templates/cluster_endtoend_test_mysql80.tpl
@@ -29,7 +29,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Set up python
       if: steps.skip-workflow.outputs.skip-workflow == 'false'

--- a/test/templates/dockerfile.tpl
+++ b/test/templates/dockerfile.tpl
@@ -1,4 +1,4 @@
-ARG bootstrap_version=4.3
+ARG bootstrap_version=4.4
 ARG image="vitess/bootstrap:${bootstrap_version}-{{.Platform}}"
 
 FROM "${image}"

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -23,7 +23,7 @@ jobs:
       if: steps.skip-workflow.outputs.skip-workflow == 'false'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     - name: Tune the OS
       if: steps.skip-workflow.outputs.skip-workflow == 'false'


### PR DESCRIPTION
## Description

This Pull Request upgrades the golang version used in `release-13.0` from `go1.17.12` to `go1.17.13`. There has been a recent patch release in go `1.17` to fix a vulnerability.

```
go1.17.13 (released 2022-08-01) includes security fixes to the encoding/gob and math/big packages, as well as bug fixes to the compiler and the runtime. 
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
