### PR TITLE
[cli] [servenv] Migrate grpc auth server flags within `servenv` to `pflag`

### DIFF
--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -51,6 +51,7 @@ var (
 func init() {
 	servenv.RegisterDefaultFlags()
 	servenv.RegisterDefaultSocketFileFlags()
+	servenv.RegisterGRPCServerAuthFlags()
 }
 
 func main() {

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -76,6 +76,7 @@ func init() {
 	flags.Var(vttest.JSONTopoData(&tpb), "json_topo", "vttest proto definition of the topology, encoded in json format. See vttest.proto for more information.")
 
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerAuthFlags()
 }
 
 func startMysqld(uid uint32) (*mysqlctl.Mysqld, *mysqlctl.Mycnf) {

--- a/go/cmd/vtctld/main.go
+++ b/go/cmd/vtctld/main.go
@@ -25,6 +25,7 @@ import (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerAuthFlags()
 }
 
 // used at runtime by plug-ins

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -53,6 +53,7 @@ var resilientServer *srvtopo.ResilientServer
 func init() {
 	rand.Seed(time.Now().UnixNano())
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerAuthFlags()
 }
 
 // CheckCellFlags will check validation of cell and cells_to_watch flag

--- a/go/cmd/vtgateclienttest/main.go
+++ b/go/cmd/vtgateclienttest/main.go
@@ -28,6 +28,7 @@ import (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerAuthFlags()
 }
 
 func main() {

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -57,6 +57,7 @@ var (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerAuthFlags()
 }
 
 func main() {

--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -66,8 +66,6 @@ Usage of vtexplain:
       --gate_query_cache_lfu                                             gate server cache algorithm. when set to true, a new cache algorithm based on a TinyLFU admission policy will be used to improve cache behavior and prevent pollution from sparse queries (default true)
       --gate_query_cache_memory int                                      gate server query cache size in bytes, maximum amount of memory to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
       --gate_query_cache_size int                                        gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a cache. This config controls the expected amount of unique entries in the cache. (default 5000)
-      --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
-      --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             when using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -12,8 +12,6 @@ Usage of vtgr:
       --enable_heartbeat_check                                           Enable heartbeat checking, set together with --group_heartbeat_threshold.
       --gr_port int                                                      Port to bootstrap a MySQL group. (default 33061)
       --group_heartbeat_threshold int                                    VTGR will trigger backoff on inconsistent state if the group heartbeat staleness exceeds this threshold (in seconds). Should be used along with --enable_heartbeat_check.
-      --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
-      --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             when using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check

--- a/go/vt/servenv/grpc_auth.go
+++ b/go/vt/servenv/grpc_auth.go
@@ -19,6 +19,7 @@ package servenv
 import (
 	"context"
 
+	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -26,6 +27,28 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 )
+
+var grpcAuthServerFlagHooks []func(*pflag.FlagSet)
+
+// RegisterGRPCServerAuthFlags registers flags required to enable server-side
+// authentication in vitess gRPC services.
+//
+// `go/cmd/*`` entrypoints should call this function before
+// ParseFlags(WithArgs)? if they wish to expose Authenticator functionality.
+func RegisterGRPCServerAuthFlags() {
+	OnParse(func(fs *pflag.FlagSet) {
+		fs.StringVar(&gRPCAuth, "grpc_auth_mode", gRPCAuth, "Which auth plugin implementation to use (eg: static)")
+
+		for _, fn := range grpcAuthServerFlagHooks {
+			fn(fs)
+		}
+	})
+}
+
+// GRPCAuth returns the value of the `--grpc_auth_mode` flag.
+func GRPCAuth() string {
+	return gRPCAuth
+}
 
 // Authenticator provides an interface to implement auth in Vitess in
 // grpc server

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -75,8 +75,11 @@ var (
 	// GRPCServerCA if specified will combine server cert and server CA
 	GRPCServerCA = flag.String("grpc_server_ca", "", "path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients")
 
-	// GRPCAuth which auth plugin to use (at the moment now only static is supported)
-	GRPCAuth = flag.String("grpc_auth_mode", "", "Which auth plugin implementation to use (eg: static)")
+	// GRPCAuth specifies which auth plugin to use. Currently only "static" and
+	// "mtls" are supported.
+	//
+	// To expose this flag, call RegisterGRPCAuthServerFlags before ParseFlags.
+	gRPCAuth string
 
 	// GRPCServer is the global server to serve gRPC.
 	GRPCServer *grpc.Server
@@ -196,9 +199,9 @@ func createGRPCServer() {
 func interceptors() []grpc.ServerOption {
 	interceptors := &serverInterceptorBuilder{}
 
-	if *GRPCAuth != "" {
-		log.Infof("enabling auth plugin %v", *GRPCAuth)
-		pluginInitializer := GetAuthenticator(*GRPCAuth)
+	if gRPCAuth != "" {
+		log.Infof("enabling auth plugin %v", gRPCAuth)
+		pluginInitializer := GetAuthenticator(gRPCAuth)
 		authPluginImpl, err := pluginInitializer()
 		if err != nil {
 			log.Fatalf("Failed to load auth plugin: %v", err)

--- a/go/vt/servenv/grpc_server_auth_mtls.go
+++ b/go/vt/servenv/grpc_server_auth_mtls.go
@@ -17,26 +17,28 @@ limitations under the License.
 package servenv
 
 import (
-	"flag"
+	"context"
 	"strings"
 
+	"github.com/spf13/pflag"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
-
-	"context"
-
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"vitess.io/vitess/go/vt/log"
 )
 
 var (
-	// ClientCertSubstrings list of substrings of at least one of the client certificate names to use during authorization
-	ClientCertSubstrings = flag.String("grpc_auth_mtls_allowed_substrings", "", "List of substrings of at least one of the client certificate names (separated by colon).")
+	// lientCertSubstrings list of substrings of at least one of the client certificate names to use during authorization
+	clientCertSubstrings string
 	// MtlsAuthPlugin implements AuthPlugin interface
 	_ Authenticator = (*MtlsAuthPlugin)(nil)
 )
+
+func registerGRPCServerAuthMTLSFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&clientCertSubstrings, "grpc_auth_mtls_allowed_substrings", clientCertSubstrings, "List of substrings of at least one of the client certificate names (separated by colon).")
+}
 
 // MtlsAuthPlugin  implements static username/password authentication for grpc. It contains an array of username/passwords
 // that will be authorized to connect to the grpc server.
@@ -67,12 +69,19 @@ func (ma *MtlsAuthPlugin) Authenticate(ctx context.Context, fullMethod string) (
 
 func mtlsAuthPluginInitializer() (Authenticator, error) {
 	mtlsAuthPlugin := &MtlsAuthPlugin{
-		clientCertSubstrings: strings.Split(*ClientCertSubstrings, ":"),
+		clientCertSubstrings: strings.Split(clientCertSubstrings, ":"),
 	}
-	log.Infof("mtls auth plugin have initialized successfully with allowed client cert name substrings of %v", *ClientCertSubstrings)
+	log.Infof("mtls auth plugin have initialized successfully with allowed client cert name substrings of %v", clientCertSubstrings)
 	return mtlsAuthPlugin, nil
+}
+
+// ClientCertSubstrings returns the value of the
+// `--grpc_auth_mtls_allowed_substrings` flag.
+func ClientCertSubstrings() string {
+	return clientCertSubstrings
 }
 
 func init() {
 	RegisterAuthPlugin("mtls", mtlsAuthPluginInitializer)
+	grpcAuthServerFlagHooks = append(grpcAuthServerFlagHooks, registerGRPCServerAuthMTLSFlags)
 }

--- a/go/vt/throttler/demo/throttler_demo.go
+++ b/go/vt/throttler/demo/throttler_demo.go
@@ -289,7 +289,7 @@ func (c *client) StatsUpdate(ts *discovery.TabletHealth) {
 }
 
 func main() {
-	flag.Parse()
+	servenv.ParseFlags("throttler_demo")
 
 	go servenv.RunDefault()
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -310,4 +310,5 @@ func main() {
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerAuthFlags()
 }

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -250,8 +250,8 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 	if args.TabletHostName != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--tablet_hostname", args.TabletHostName}...)
 	}
-	if *servenv.GRPCAuth == "mtls" {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--grpc_auth_mode", *servenv.GRPCAuth, "--grpc_key", *servenv.GRPCKey, "--grpc_cert", *servenv.GRPCCert, "--grpc_ca", *servenv.GRPCCA, "--grpc_auth_mtls_allowed_substrings", *servenv.ClientCertSubstrings}...)
+	if servenv.GRPCAuth() == "mtls" {
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--grpc_auth_mode", servenv.GRPCAuth(), "--grpc_key", *servenv.GRPCKey, "--grpc_cert", *servenv.GRPCCert, "--grpc_ca", *servenv.GRPCCA, "--grpc_auth_mtls_allowed_substrings", servenv.ClientCertSubstrings()}...)
 	}
 	if args.InitWorkflowManager {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--workflow_manager_init"}...)


### PR DESCRIPTION


<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

The only codepath that uses these is via `createGRPCServer`, which is called by `Run` (which no one calls externally??) and `RunDefault` (which calls `Run` under the hood)

## Related Issue(s)

Relates to #11144.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
