### PR TITLE
Use Ubuntu 20 for vtgate and tabletmanager workflows

### DIFF
--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -162,6 +162,10 @@ type selfHostedTest struct {
 	MakeTools, InstallXtraBackup, Docker                        bool
 }
 
+func needsUbuntu20(clusterName string, mysqlVersion mysqlVersion) bool {
+	return mysqlVersion == mysql80 || strings.HasPrefix(clusterName, "vtgate") || strings.HasPrefix(clusterName, "tabletmanager")
+}
+
 // clusterMySQLVersions return list of mysql versions (one or more) that this cluster needs to test against
 func clusterMySQLVersions(clusterName string) mysqlVersions {
 	switch {
@@ -345,8 +349,10 @@ func generateClusterWorkflows(list []string, tpl string) {
 					break
 				}
 			}
-			if mysqlVersion == mysql80 {
+			if needsUbuntu20(cluster, mysqlVersion) {
 				test.Ubuntu20 = true
+			}
+			if mysqlVersion == mysql80 {
 				test.Platform = string(mysql80)
 			}
 			if strings.HasPrefix(cluster, "vreplication") || strings.HasSuffix(cluster, "heavy") {


### PR DESCRIPTION
## Description

We recently changed the vtgate (https://github.com/vitessio/vitess/pull/11118) and tablet manager (https://github.com/vitessio/vitess/pull/11116) CI jobs to run on Ubuntu20, however, the CI generation script did not change. This Pull Request updates the script to generate the same workflows as the ones currently on `main`.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
