### PR TITLE
Nil-check errors before printing them in VTOrc

### DIFF
--- a/go/vt/orchestrator/app/cli.go
+++ b/go/vt/orchestrator/app/cli.go
@@ -187,7 +187,9 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatal(err)
 			} else {
 				for _, e := range errs {
-					log.Error(e)
+					if e != nil {
+						log.Error(e)
+					}
 				}
 				for _, replica := range replicas {
 					fmt.Println(replica.Key.DisplayString())
@@ -250,7 +252,9 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatal(err)
 			} else {
 				for _, e := range errs {
-					log.Error(e)
+					if e != nil {
+						log.Error(e)
+					}
 				}
 				for _, replica := range movedReplicas {
 					fmt.Println(replica.Key.DisplayString())
@@ -287,7 +291,9 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatal(err)
 			} else {
 				for _, e := range errs {
-					log.Error(e)
+					if e != nil {
+						log.Error(e)
+					}
 				}
 				for _, replica := range repointedReplicas {
 					fmt.Printf("%s<%s\n", replica.Key.DisplayString(), instanceKey.DisplayString())
@@ -370,7 +376,9 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatal(err)
 			} else {
 				for _, e := range errs {
-					log.Error(e)
+					if e != nil {
+						log.Error(e)
+					}
 				}
 				for _, replica := range movedReplicas {
 					fmt.Println(replica.Key.DisplayString())

--- a/go/vt/orchestrator/inst/analysis_dao.go
+++ b/go/vt/orchestrator/inst/analysis_dao.go
@@ -773,8 +773,9 @@ func auditInstanceAnalysisInChangelog(instanceKey *InstanceKey, analysisCode Ana
 	)
 	if err == nil {
 		analysisChangeWriteCounter.Inc(1)
+	} else {
+		log.Error(err)
 	}
-	log.Error(err)
 	return err
 }
 
@@ -788,7 +789,9 @@ func ExpireInstanceAnalysisChangelog() error {
 			`,
 		config.Config.UnseenInstanceForgetHours,
 	)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 

--- a/go/vt/orchestrator/inst/candidate_database_instance_dao.go
+++ b/go/vt/orchestrator/inst/candidate_database_instance_dao.go
@@ -46,7 +46,9 @@ func RegisterCandidateInstance(candidate *CandidateDatabaseInstance) error {
 			`
 	writeFunc := func() error {
 		_, err := db.ExecOrchestrator(query, args...)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)
@@ -60,7 +62,9 @@ func ExpireCandidateInstances() error {
 				where last_suggested < NOW() - INTERVAL ? MINUTE
 				`, config.Config.CandidateInstanceExpireMinutes,
 		)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)

--- a/go/vt/orchestrator/inst/cluster_alias_dao.go
+++ b/go/vt/orchestrator/inst/cluster_alias_dao.go
@@ -90,7 +90,9 @@ func writeClusterAlias(clusterName string, alias string) error {
 					(?, ?, now())
 			`,
 			clusterName, alias)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)
@@ -106,7 +108,9 @@ func writeClusterAliasManualOverride(clusterName string, alias string) error {
 					(?, ?)
 			`,
 			clusterName, alias)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)
@@ -139,7 +143,9 @@ func UpdateClusterAliases() error {
 						read_only desc,
 						num_replica_hosts asc
 			`, DowntimeLostInRecoveryMessage)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	if err := ExecDBWriteFunc(writeFunc); err != nil {
@@ -159,7 +165,9 @@ func UpdateClusterAliases() error {
 					having
 						sum(suggested_cluster_alias = '') = count(*)
 			`)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	if err := ExecDBWriteFunc(writeFunc); err != nil {
@@ -179,7 +187,9 @@ func ReplaceAliasClusterName(oldClusterName string, newClusterName string) (err 
 				where cluster_name = ?
 			`,
 				newClusterName, oldClusterName)
-			log.Error(err)
+			if err != nil {
+				log.Error(err)
+			}
 			return err
 		}
 		err = ExecDBWriteFunc(writeFunc)
@@ -192,7 +202,9 @@ func ReplaceAliasClusterName(oldClusterName string, newClusterName string) (err 
 				where cluster_name = ?
 			`,
 				newClusterName, oldClusterName)
-			log.Error(err)
+			if err != nil {
+				log.Error(err)
+			}
 			return err
 		}
 		if ferr := ExecDBWriteFunc(writeFunc); ferr != nil {

--- a/go/vt/orchestrator/inst/cluster_domain_dao.go
+++ b/go/vt/orchestrator/inst/cluster_domain_dao.go
@@ -35,7 +35,9 @@ func WriteClusterDomainName(clusterName string, domainName string) error {
 					last_registered=values(last_registered)
 			`,
 			clusterName, domainName)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)
@@ -49,7 +51,9 @@ func ExpireClusterDomainName() error {
 				where last_registered < NOW() - INTERVAL ? MINUTE
 				`, config.Config.ExpiryHostnameResolvesMinutes,
 		)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)

--- a/go/vt/orchestrator/inst/instance_dao.go
+++ b/go/vt/orchestrator/inst/instance_dao.go
@@ -1884,7 +1884,9 @@ func GetClusterName(instanceKey *InstanceKey) (clusterName string, err error) {
 		instanceKeyInformativeClusterName.Set(instanceKey.StringCode(), clusterName, cache.DefaultExpiration)
 		return nil
 	})
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return clusterName, err
 }
 
@@ -2427,7 +2429,9 @@ func UpdateInstanceLastChecked(instanceKey *InstanceKey, partialSuccess bool) er
 			instanceKey.Hostname,
 			instanceKey.Port,
 		)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)
@@ -2454,7 +2458,9 @@ func UpdateInstanceLastAttemptedCheck(instanceKey *InstanceKey) error {
 			instanceKey.Hostname,
 			instanceKey.Port,
 		)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)
@@ -2635,7 +2641,9 @@ func RecordStaleInstanceBinlogCoordinates(instanceKey *InstanceKey, binlogCoordi
 					?, ?, ?, ?, NOW()
 				)`,
 		args...)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 
@@ -2650,7 +2658,9 @@ func ExpireStaleInstanceBinlogCoordinates() error {
 					where first_seen < NOW() - INTERVAL ? SECOND
 					`, expireSeconds,
 		)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)
@@ -2668,7 +2678,9 @@ func ResetInstanceRelaylogCoordinatesHistory(instanceKey *InstanceKey) error {
 				hostname=? and port=?
 				`, instanceKey.Hostname, instanceKey.Port,
 		)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)

--- a/go/vt/orchestrator/inst/instance_topology.go
+++ b/go/vt/orchestrator/inst/instance_topology.go
@@ -1831,7 +1831,9 @@ func RegroupReplicasGTID(
 
 		movedReplicas, unmovedReplicas, _, err = MoveReplicasViaGTID(replicasToMove, candidateReplica, postponedFunctionsContainer)
 		unmovedReplicas = append(unmovedReplicas, aheadReplicas...)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	if postponedFunctionsContainer != nil && postponeAllMatchOperations != nil && postponeAllMatchOperations(candidateReplica, hasBestPromotionRule) {

--- a/go/vt/orchestrator/inst/instance_topology_dao.go
+++ b/go/vt/orchestrator/inst/instance_topology_dao.go
@@ -404,7 +404,9 @@ func RestartReplication(instanceKey *InstanceKey) (instance *Instance, err error
 		return instance, err
 	}
 	instance, err = StartReplication(instanceKey)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return instance, err
 }
 

--- a/go/vt/orchestrator/inst/maintenance_dao.go
+++ b/go/vt/orchestrator/inst/maintenance_dao.go
@@ -163,7 +163,9 @@ func InMaintenance(instanceKey *InstanceKey) (inMaintenance bool, err error) {
 		return nil
 	})
 
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return inMaintenance, err
 }
 
@@ -189,7 +191,9 @@ func ReadMaintenanceInstanceKey(maintenanceToken int64) (*InstanceKey, error) {
 		return nil
 	})
 
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return res, err
 }
 

--- a/go/vt/orchestrator/inst/pool_dao.go
+++ b/go/vt/orchestrator/inst/pool_dao.go
@@ -131,6 +131,8 @@ func ExpirePoolInstances() error {
 			`,
 		config.Config.InstancePoolExpiryMinutes,
 	)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }

--- a/go/vt/orchestrator/inst/resolve_dao.go
+++ b/go/vt/orchestrator/inst/resolve_dao.go
@@ -143,7 +143,9 @@ func ReadAllHostnameUnresolves() ([]HostnameUnresolve, error) {
 		return nil
 	})
 
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return unres, err
 }
 
@@ -213,7 +215,9 @@ func DeleteHostnameUnresolve(instanceKey *InstanceKey) error {
 				where hostname=?
 				`, instanceKey.Hostname,
 		)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)
@@ -227,7 +231,9 @@ func ExpireHostnameUnresolve() error {
 				where last_registered < NOW() - INTERVAL ? MINUTE
 				`, config.Config.ExpiryHostnameResolvesMinutes,
 		)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)
@@ -277,7 +283,9 @@ func DeleteInvalidHostnameResolves() error {
 				hostname = ?`,
 			invalidHostname,
 		)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 	}
 	return err
 }
@@ -308,7 +316,9 @@ func writeHostnameIPs(hostname string, ipv4String string, ipv6String string) err
 			ipv4String,
 			ipv6String,
 		)
-		log.Error(err)
+		if err != nil {
+			log.Error(err)
+		}
 		return err
 	}
 	return ExecDBWriteFunc(writeFunc)

--- a/go/vt/orchestrator/inst/tag_dao.go
+++ b/go/vt/orchestrator/inst/tag_dao.go
@@ -125,7 +125,9 @@ func ReadInstanceTag(instanceKey *InstanceKey, tag *Tag) (tagExists bool, err er
 		return nil
 	})
 
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return tagExists, err
 }
 
@@ -151,7 +153,9 @@ func ReadInstanceTags(instanceKey *InstanceKey) (tags [](*Tag), err error) {
 		return nil
 	})
 
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return tags, err
 }
 
@@ -196,6 +200,8 @@ func GetInstanceKeysByTag(tag *Tag) (tagged *InstanceKeyMap, err error) {
 		tagged.AddKey(*key)
 		return nil
 	})
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return tagged, err
 }

--- a/go/vt/orchestrator/logic/topology_recovery.go
+++ b/go/vt/orchestrator/logic/topology_recovery.go
@@ -801,7 +801,9 @@ func emergentlyRestartReplicationOnTopologyInstanceReplicas(instanceKey *inst.In
 
 func emergentlyRecordStaleBinlogCoordinates(instanceKey *inst.InstanceKey, binlogCoordinates *inst.BinlogCoordinates) {
 	err := inst.RecordStaleInstanceBinlogCoordinates(instanceKey, binlogCoordinates)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 // checkAndExecuteFailureDetectionProcesses tries to register for failure detection and potentially executes
@@ -1071,14 +1073,18 @@ func CheckAndRecover(specificInstance *inst.InstanceKey, candidateInstanceKey *i
 			// force mode. Keep it synchronuous
 			var topologyRecovery *TopologyRecovery
 			recoveryAttempted, topologyRecovery, err = executeCheckAndRecoverFunction(analysisEntry, candidateInstanceKey, true, skipProcesses)
-			log.Error(err)
+			if err != nil {
+				log.Error(err)
+			}
 			if topologyRecovery != nil {
 				promotedReplicaKey = topologyRecovery.SuccessorKey
 			}
 		} else {
 			go func() {
 				_, _, err := executeCheckAndRecoverFunction(analysisEntry, candidateInstanceKey, false, skipProcesses)
-				log.Error(err)
+				if err != nil {
+					log.Error(err)
+				}
 			}()
 		}
 	}

--- a/go/vt/orchestrator/logic/topology_recovery_dao.go
+++ b/go/vt/orchestrator/logic/topology_recovery_dao.go
@@ -109,7 +109,9 @@ func ClearActiveFailureDetections() error {
 			`,
 		config.Config.FailureDetectionPeriodBlockMinutes,
 	)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 
@@ -125,7 +127,9 @@ func clearAcknowledgedFailureDetections(whereClause string, args []any) error {
 				and %s
 			`, whereClause)
 	_, err := db.ExecOrchestrator(query, args...)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 
@@ -257,7 +261,9 @@ func ClearActiveRecoveries() error {
 			`,
 		config.Config.RecoveryPeriodBlockSeconds,
 	)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 
@@ -353,7 +359,9 @@ func ExpireBlockedRecoveries() error {
 					last_blocked_timestamp < NOW() - interval ? second
 			`, (config.RecoveryPollSeconds * 2),
 	)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 
@@ -386,7 +394,9 @@ func acknowledgeRecoveries(owner string, comment string, markEndRecovery bool, w
 		return 0, err
 	}
 	rows, err := sqlResult.RowsAffected()
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return rows, err
 }
 
@@ -498,7 +508,9 @@ func writeResolveRecovery(topologyRecovery *TopologyRecovery) error {
 		strings.Join(topologyRecovery.AllErrors, "\n"),
 		topologyRecovery.UID,
 	)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 
@@ -583,7 +595,9 @@ func readRecoveries(whereCondition string, limit string, args []any) ([]*Topolog
 		return nil
 	})
 
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return res, err
 }
 
@@ -726,7 +740,9 @@ func readFailureDetections(whereCondition string, limit string, args []any) ([]*
 		return nil
 	})
 
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return res, err
 }
 
@@ -787,7 +803,9 @@ func ReadBlockedRecoveries(clusterName string) ([]BlockedTopologyRecovery, error
 		return nil
 	})
 
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return res, err
 }
 
@@ -805,7 +823,9 @@ func writeTopologyRecoveryStep(topologyRecoveryStep *TopologyRecoveryStep) error
 		return err
 	}
 	topologyRecoveryStep.ID, err = sqlResult.LastInsertId()
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 
@@ -832,7 +852,9 @@ func ReadTopologyRecoverySteps(recoveryUID string) ([]TopologyRecoveryStep, erro
 		res = append(res, recoveryStep)
 		return nil
 	})
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return res, err
 }
 

--- a/go/vt/orchestrator/process/access_token_dao.go
+++ b/go/vt/orchestrator/process/access_token_dao.go
@@ -91,7 +91,9 @@ func AcquireAccessToken(publicToken string) (secretToken string, err error) {
 		secretToken = m.GetString("secret_token")
 		return nil
 	})
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return secretToken, err
 }
 
@@ -114,7 +116,9 @@ func TokenIsValid(publicToken string, secretToken string) (result bool, err erro
 		result = m.GetInt("valid_token") > 0
 		return nil
 	})
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return result, err
 }
 
@@ -129,6 +133,8 @@ func ExpireAccessTokens() error {
 			`,
 		config.Config.AccessTokenExpiryMinutes,
 	)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }

--- a/go/vt/orchestrator/process/election_dao.go
+++ b/go/vt/orchestrator/process/election_dao.go
@@ -118,14 +118,18 @@ func GrabElection() error {
 			`,
 		ThisHostname, util.ProcessToken.Hash,
 	)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 
 // Reelect clears the way for re-elections. Active node is immediately demoted.
 func Reelect() error {
 	_, err := db.ExecOrchestrator(`delete from active_node where anchor = 1`)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 
@@ -153,6 +157,8 @@ func ElectedNode() (node *NodeHealth, isElected bool, err error) {
 	})
 
 	isElected = (node.Hostname == ThisHostname && node.Token == util.ProcessToken.Hash)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return node, isElected, err //nolint copylocks: return copies lock value
 }

--- a/go/vt/orchestrator/process/health_dao.go
+++ b/go/vt/orchestrator/process/health_dao.go
@@ -143,7 +143,9 @@ func ExpireNodesHistory() error {
 			`,
 		config.Config.UnseenInstanceForgetHours,
 	)
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return err
 }
 
@@ -176,6 +178,8 @@ func ReadAvailableNodes(onlyHTTPNodes bool) (nodes [](*NodeHealth), err error) {
 		nodes = append(nodes, nodeHealth)
 		return nil
 	})
-	log.Error(err)
+	if err != nil {
+		log.Error(err)
+	}
 	return nodes, err
 }


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

After moving away from external logging in https://github.com/vitessio/vitess/pull/11085, we started seeing error messages like 
```
E0901 16:38:28.412132   63266 topology_recovery_dao.go:112] <nil>
E0901 16:38:28.412186   63266 topology_recovery_dao.go:356] <nil>
E0901 16:38:28.412247   63266 topology_recovery_dao.go:260] <nil>
E0901 16:38:28.412352   63266 cluster_alias_dao.go:142] <nil>
```

The problem was traced to not doing a nil-check before printing the error message. The previous implementation of `log.Errore` used to do the nil-check before printing the error, so it wasn't required in the codebase.
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
