### PR TITLE
On demand heartbeats: fix race condition closing the writer

### DIFF
--- a/go/vt/vttablet/tabletserver/repltracker/writer.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer.go
@@ -238,9 +238,20 @@ func (w *heartbeatWriter) enableWrites(enable bool) {
 	if w.ticks == nil {
 		return
 	}
-	if enable {
-		w.ticks.Start(w.writeHeartbeat)
-	} else {
+	switch enable {
+	case true:
+		// We must combat a potential race condition: the writer is Open, and a request comes
+		// to enableWrites(true), but simultaneously the writes gets Close()d.
+		// We must not send any more ticks while the writer is closed.
+		go func() {
+			w.mu.Lock()
+			defer w.mu.Unlock()
+			if !w.isOpen {
+				return
+			}
+			w.ticks.Start(w.writeHeartbeat)
+		}()
+	case false:
 		w.ticks.Stop()
 		if w.onDemandDuration > 0 {
 			// Let the next RequestHeartbeats() go through


### PR DESCRIPTION

## Description

Fixing a race condition scenario where on-demand heartbeats are requested (e.g. by a running VReplication workflow) while the writer is also closing, e.g. being demoted in a PRS.

The fix is to use the writer's mutex before enabling writes; this now takes place in a `goroutine` because the call can be made by `Open()` itself as well as by `EnableWrites()`.


## Related Issue(s)

https://github.com/vitessio/vitess/issues/10196

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
