### PR TITLE
[cli] [servenv] Migrate flags used by grpc servers to `pflag`

### DIFF
--- a/doc/releasenotes/15_0_0_summary.md
+++ b/doc/releasenotes/15_0_0_summary.md
@@ -17,6 +17,8 @@
 
 ### Breaking Changes
 
+- The deprecated `--cpu_profile` flag has been removed. Please use the `--pprof` flag instead.
+
 #### Vindex Interface
 
 All the vindex interface methods are changed by adding `context.Context` as an input parameter.

--- a/doc/releasenotes/15_0_0_summary.md
+++ b/doc/releasenotes/15_0_0_summary.md
@@ -17,7 +17,11 @@
 
 ### Breaking Changes
 
+#### Flags
+
 - The deprecated `--cpu_profile` flag has been removed. Please use the `--pprof` flag instead.
+- The deprecated `--mem-profile-rate` flag has been removed. Please use `--pprof=mem` instead.
+- The deprecated `--mutex-profile-fraction` flag has been removed. Please use `--pprof=mutex` instead.
 
 #### Vindex Interface
 

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -50,6 +50,7 @@ var (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
 	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterDefaultSocketFileFlags()
 	servenv.RegisterGRPCServerAuthFlags()

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -50,6 +50,7 @@ var (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterDefaultSocketFileFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -74,6 +74,7 @@ func init() {
 	flags.Var(vttest.JSONTopoData(&tpb), "json_topo", "vttest proto definition of the topology, encoded in json format. See vttest.proto for more information.")
 
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
 	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"vitess.io/vitess/go/vt/log"
-
 	"github.com/spf13/pflag"
 	"google.golang.org/protobuf/proto"
 
@@ -36,7 +34,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/env"
-
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/servenv"
@@ -76,6 +74,7 @@ func init() {
 	flags.Var(vttest.JSONTopoData(&tpb), "json_topo", "vttest proto definition of the topology, encoded in json format. See vttest.proto for more information.")
 
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }
 

--- a/go/cmd/vtctld/main.go
+++ b/go/cmd/vtctld/main.go
@@ -25,6 +25,7 @@ import (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
 	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }

--- a/go/cmd/vtctld/main.go
+++ b/go/cmd/vtctld/main.go
@@ -25,6 +25,7 @@ import (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }
 

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -23,22 +23,20 @@ import (
 	"strings"
 	"time"
 
-	"vitess.io/vitess/go/vt/env"
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-
-	"vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/vterrors"
-
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/discovery"
+	"vitess.io/vitess/go/vt/env"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 var (
@@ -53,6 +51,7 @@ var resilientServer *srvtopo.ResilientServer
 func init() {
 	rand.Seed(time.Now().UnixNano())
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }
 

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -51,6 +51,7 @@ var resilientServer *srvtopo.ResilientServer
 func init() {
 	rand.Seed(time.Now().UnixNano())
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
 	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }

--- a/go/cmd/vtgateclienttest/main.go
+++ b/go/cmd/vtgateclienttest/main.go
@@ -28,6 +28,7 @@ import (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }
 

--- a/go/cmd/vtgateclienttest/main.go
+++ b/go/cmd/vtgateclienttest/main.go
@@ -28,6 +28,7 @@ import (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
 	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -23,9 +23,6 @@ import (
 	"flag"
 	"os"
 
-	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
-	"vitess.io/vitess/resources"
-
 	"vitess.io/vitess/go/vt/binlog"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
@@ -37,10 +34,12 @@ import (
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vttablet/onlineddl"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager"
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/yaml2"
+	"vitess.io/vitess/resources"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
@@ -57,6 +56,7 @@ var (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }
 
@@ -90,8 +90,8 @@ func main() {
 
 	// Initialize and start tm.
 	gRPCPort := int32(0)
-	if servenv.GRPCPort != nil {
-		gRPCPort = int32(*servenv.GRPCPort)
+	if servenv.GRPCPort() != 0 {
+		gRPCPort = int32(servenv.GRPCPort())
 	}
 	tablet, err := tabletmanager.BuildTabletFromInput(tabletAlias, int32(*servenv.Port), gRPCPort, mysqld.GetVersionString(), config.DB)
 	if err != nil {

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -94,7 +94,7 @@ func main() {
 	if servenv.GRPCPort() != 0 {
 		gRPCPort = int32(servenv.GRPCPort())
 	}
-	tablet, err := tabletmanager.BuildTabletFromInput(tabletAlias, int32(*servenv.Port), gRPCPort, mysqld.GetVersionString(), config.DB)
+	tablet, err := tabletmanager.BuildTabletFromInput(tabletAlias, int32(servenv.Port()), gRPCPort, mysqld.GetVersionString(), config.DB)
 	if err != nil {
 		log.Exitf("failed to parse --tablet-path: %v", err)
 	}

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -56,6 +56,7 @@ var (
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
 	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }

--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// vttestserver is a native Go implementation of `run_local_server.py`.
-// It allows users to spawn a self-contained Vitess server for local testing/CI
+// vttestserver allows users to spawn a self-contained Vitess server for local testing/CI.
 package main
 
 import (

--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -205,16 +205,18 @@ func (t *topoFlags) buildTopology() (*vttestpb.VTTestTopology, error) {
 
 // Annoying, but in unit tests, parseFlags gets called multiple times per process
 // (anytime startCluster is called), so we need to guard against the second test
-// to run failing with:
+// to run failing with, for example:
 //	flag redefined: log_rotate_max_size
-var logFlagsOnce sync.Once
+var flagsOnce sync.Once
 
 func parseFlags() (env vttest.Environment, err error) {
-	logFlagsOnce.Do(func() {
+	flagsOnce.Do(func() {
 		var tmp []string
 		tmp, os.Args = os.Args[1:], os.Args[0:1]
 		defer func() { os.Args = append(os.Args, tmp...) }()
 
+		servenv.RegisterFlags()
+		servenv.RegisterGRPCServerFlags()
 		servenv.RegisterGRPCServerAuthFlags()
 		servenv.ParseFlags("vttestserver")
 

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -88,7 +88,7 @@ Usage of vtctld:
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
       --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
-      --grpc_port int                                                    Port to listen on for gRPC calls
+      --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
       --grpc_server_initial_conn_window_size int                         gRPC server initial connection window size

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -26,7 +26,6 @@ Usage of vtctld:
       --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
       --consolidator-stream-total-size int                               Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)
       --consul_auth_static_file string                                   JSON File to read the topos/tokens from.
-      --cpu_profile string                                               deprecated: use '-pprof=cpu' instead
       --datadog-agent-host string                                        host to send spans to. if empty, no tracing will be done
       --datadog-agent-port string                                        port to send spans to. if empty, no tracing will be done
       --db-credentials-file string                                       db credentials file; send SIGHUP to reload this file
@@ -114,8 +113,6 @@ Usage of vtctld:
       --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                      log to standard error instead of files
       --master_connect_retry duration                                    Deprecated, use -replication_connect_retry (default 10s)
-      --mem-profile-rate int                                             deprecated: use '-pprof=mem' instead (default 524288)
-      --mutex-profile-fraction int                                       deprecated: use '-pprof=mutex' instead
       --mysql_server_flush_delay duration                                Delay after which buffered response will be flushed to the client. (default 100ms)
       --mysql_server_version string                                      MySQL server version to advertise.
       --mysqlctl_client_protocol string                                  the protocol to use to talk to the mysqlctl server (default "grpc")

--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -16,7 +16,6 @@ Usage of vtexplain:
       --compression-level int                                        what level to pass to the compressor (default 1)
       --consolidator-stream-query-size int                           Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
       --consolidator-stream-total-size int                           Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)
-      --cpu_profile string                                           deprecated: use '-pprof=cpu' instead
       --db-credentials-file string                                   db credentials file; send SIGHUP to reload this file
       --db-credentials-server string                                 db credentials server type ('file' - file implementation; 'vault' - HashiCorp Vault implementation) (default "file")
       --db-credentials-vault-addr string                             URL to Vault server
@@ -92,9 +91,7 @@ Usage of vtexplain:
       --master_connect_retry duration                                Deprecated, use -replication_connect_retry (default 10s)
       --max_memory_rows int                                          Maximum number of rows that will be held in memory for intermediate results as well as the final result. (default 300000)
       --max_payload_size int                                         The threshold for query payloads in bytes. A payload greater than this threshold will result in a failure to handle the query.
-      --mem-profile-rate int                                         deprecated: use '-pprof=mem' instead (default 524288)
       --message_stream_grace_period duration                         the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent. (default 30s)
-      --mutex-profile-fraction int                                   deprecated: use '-pprof=mutex' instead
       --mysql_allow_clear_text_without_tls                           If set, the server will allow the use of a clear text password over non-SSL connections.
       --mysql_auth_server_impl string                                Which auth server implementation to use. Options: none, ldap, clientcert, static, vault. (default "static")
       --mysql_default_workload string                                Default session workload (OLTP, OLAP, DBA) (default "OLTP")

--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -11,7 +11,6 @@ Usage of vtexplain:
       --binlog_player_protocol string                                the protocol to download binlogs from a vttablet (default "grpc")
       --builtinbackup_mysqld_timeout duration                        how long to wait for mysqld to shutdown at the start of the backup (default 10m0s)
       --builtinbackup_progress duration                              how often to send progress updates when backing up large files (default 5s)
-      --catch-sigpipe                                                catch and ignore SIGPIPE on stdout and stderr if specified
       --compression-engine-name string                               compressor engine used for compression. (default "pargzip")
       --compression-level int                                        what level to pass to the compressor (default 1)
       --consolidator-stream-query-size int                           Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
@@ -80,7 +79,6 @@ Usage of vtexplain:
       --keep_logs_by_mtime duration                                  keep logs for this long (using mtime) (zero to keep forever)
       --ks-shard-map string                                          JSON map of keyspace name -> shard name -> ShardReference object. The inner map is the same as the output of FindAllShardsInKeyspace
       --ks-shard-map-file string                                     File containing json blob of keyspace name -> shard name -> ShardReference object
-      --lameduck-period duration                                     keep running at least this long after SIGTERM before stopping (default 50ms)
       --lock_heartbeat_time duration                                 If there is lock function used. This will keep the lock connection active by using this heartbeat (default 5s)
       --log_backtrace_at traceLocation                               when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                                               If non-empty, write log files in this directory
@@ -118,8 +116,6 @@ Usage of vtexplain:
       --no_scatter                                                   when set to true, the planner will fail instead of producing a plan that includes scatter queries
       --normalize                                                    Whether to enable vtgate normalization
       --normalize_queries                                            Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars. (default true)
-      --onclose_timeout duration                                     wait no more than this for OnClose handlers before stopping (default 1ns)
-      --onterm_timeout duration                                      wait no more than this for OnTermSync handlers before stopping (default 10s)
       --output-mode string                                           Output in human-friendly text or json (default "text")
       --pid_file string                                              If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --planner-version string                                       Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4

--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -1,251 +1,238 @@
 Usage of vtexplain:
-      --alsologtostderr                                                  log to standard error as well as files
-      --app_idle_timeout duration                                        Idle timeout for app connections (default 1m0s)
-      --app_pool_size int                                                Size of the connection pool for app connections (default 40)
-      --backup_engine_implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
-      --backup_storage_block_size int                                    if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)
-      --backup_storage_compress                                          if set, the backup files will be compressed (default is true). Set to false for instance if a backup_storage_hook is specified and it compresses the data. (default true)
-      --backup_storage_hook string                                       if set, we send the contents of the backup files through this hook.
-      --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, at once, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression (default 2)
-      --batch-interval duration                                          Interval between logical time slots. (default 10ms)
-      --binlog_player_protocol string                                    the protocol to download binlogs from a vttablet (default "grpc")
-      --builtinbackup_mysqld_timeout duration                            how long to wait for mysqld to shutdown at the start of the backup (default 10m0s)
-      --builtinbackup_progress duration                                  how often to send progress updates when backing up large files (default 5s)
-      --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
-      --compression-engine-name string                                   compressor engine used for compression. (default "pargzip")
-      --compression-level int                                            what level to pass to the compressor (default 1)
-      --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
-      --consolidator-stream-total-size int                               Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)
-      --cpu_profile string                                               deprecated: use '-pprof=cpu' instead
-      --db-credentials-file string                                       db credentials file; send SIGHUP to reload this file
-      --db-credentials-server string                                     db credentials server type ('file' - file implementation; 'vault' - HashiCorp Vault implementation) (default "file")
-      --db-credentials-vault-addr string                                 URL to Vault server
-      --db-credentials-vault-path string                                 Vault path to credentials JSON blob, e.g.: secret/data/prod/dbcreds
-      --db-credentials-vault-role-mountpoint string                      Vault AppRole mountpoint; can also be passed using VAULT_MOUNTPOINT environment variable (default "approle")
-      --db-credentials-vault-role-secretidfile string                    Path to file containing Vault AppRole secret_id; can also be passed using VAULT_SECRETID environment variable
-      --db-credentials-vault-roleid string                               Vault AppRole id; can also be passed using VAULT_ROLEID environment variable
-      --db-credentials-vault-timeout duration                            Timeout for vault API operations (default 10s)
-      --db-credentials-vault-tls-ca string                               Path to CA PEM for validating Vault server certificate
-      --db-credentials-vault-tokenfile string                            Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
-      --db-credentials-vault-ttl duration                                How long to cache DB credentials from the Vault server (default 30m0s)
-      --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
-      --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
-      --dbddl_plugin string                                              controls how to handle CREATE/DROP DATABASE. use it if you are using your own database provisioning service (default "fail")
-      --dbname string                                                    Optional database target to override normal routing
-      --ddl_strategy string                                              Set default strategy for DDL statements. Override with @@ddl_strategy session variable (default "direct")
-      --default_tablet_type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
-      --degraded_threshold duration                                      replication lag after which a replica is considered degraded (default 30s)
-      --disable_active_reparents                                         if set, do not allow active reparents. Use this to protect a cluster using external reparents.
-      --disable_local_gateway                                            deprecated: if specified, this process will not route any queries to local tablets in the local cell
-      --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
-      --enable-consolidator                                              Synonym to -enable_consolidator (default true)
-      --enable-consolidator-replicas                                     Synonym to -enable_consolidator_replicas
-      --enable-lag-throttler                                             Synonym to -enable_lag_throttler
-      --enable-query-plan-field-caching                                  Synonym to -enable_query_plan_field_caching (default true)
-      --enable-tx-throttler                                              Synonym to -enable_tx_throttler
-      --enable_consolidator                                              This option enables the query consolidator. (default true)
-      --enable_consolidator_replicas                                     This option enables the query consolidator only on replicas.
-      --enable_direct_ddl                                                Allow users to submit direct DDL statements (default true)
-      --enable_hot_row_protection                                        If true, incoming transactions for the same row (range) will be queued and cannot consume all txpool slots.
-      --enable_hot_row_protection_dry_run                                If true, hot row protection is not enforced but logs if transactions would have been queued.
-      --enable_lag_throttler                                             If true, vttablet will run a throttler service, and will implicitly enable heartbeats
-      --enable_online_ddl                                                Allow users to submit, review and control Online DDL (default true)
-      --enable_query_plan_field_caching                                  (DEPRECATED) This option fetches & caches fields (columns) when storing query plans (default true)
-      --enable_replication_reporter                                      Use polling to track replication lag.
-      --enable_set_var                                                   This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections (default true)
-      --enable_system_settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
-      --enable_transaction_limit                                         If true, limit on number of transactions open at the same time will be enforced for all users. User trying to open a new transaction after exhausting their limit will receive an error immediately, regardless of whether there are available slots or not.
-      --enable_transaction_limit_dry_run                                 If true, limit on number of transactions open at the same time will be tracked for all users, but not enforced.
-      --enable_tx_throttler                                              If true replication-lag-based throttling on transactions will be enabled.
-      --enforce_strict_trans_tables                                      If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database. (default true)
-      --execution-mode string                                            The execution mode to simulate -- must be set to multi, legacy-autocommit, or twopc (default "multi")
-      --external-compressor string                                       command with arguments to use when compressing a backup
-      --external-compressor-extension string                             extension to use when using an external compressor
-      --external-decompressor string                                     command with arguments to use when decompressing a backup
-      --foreign_key_mode string                                          This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow (default "allow")
-      --gate_query_cache_lfu                                             gate server cache algorithm. when set to true, a new cache algorithm based on a TinyLFU admission policy will be used to improve cache behavior and prevent pollution from sparse queries (default true)
-      --gate_query_cache_memory int                                      gate server query cache size in bytes, maximum amount of memory to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
-      --gate_query_cache_size int                                        gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a cache. This config controls the expected amount of unique entries in the cache. (default 5000)
-      --grpc_auth_static_client_creds string                             when using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server
-      --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
-      --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
-      --grpc_crl string                                                  path to a certificate revocation list in PEM format, client certificates will be further verified against this file during TLS handshake
-      --grpc_enable_optional_tls                                         enable optional TLS mode when a server accepts both TLS and plain-text connections on the same port
-      --grpc_key string                                                  server private key to use for gRPC connections, requires grpc_cert, enables TLS
-      --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
-      --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
-      --grpc_port int                                                    Port to listen on for gRPC calls
-      --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
-      --grpc_server_initial_conn_window_size int                         gRPC server initial connection window size
-      --grpc_server_initial_window_size int                              gRPC server initial window size
-      --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
-      --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
-      --health_check_interval duration                                   Interval between health checks (default 20s)
-      --healthcheck_retry_delay duration                                 health check retry delay (default 2ms)
-      --healthcheck_timeout duration                                     the health check timeout period (default 1m0s)
-      --heartbeat_enable                                                 If true, vttablet records (if master) or checks (if replica) the current time of a replication heartbeat in the table _vt.heartbeat. The result is used to inform the serving state of the vttablet via healthchecks.
-      --heartbeat_interval duration                                      How frequently to read and write replication heartbeat. (default 1s)
-      --heartbeat_on_demand_duration duration                            If non-zero, heartbeats are only written upon consumer request, and only run for up to given duration following the request. Frequent requests can keep the heartbeat running consistently; when requests are infrequent heartbeat may completely stop between requests (default 0s)
-  -h, --help                                                             display usage and exit
-      --hot_row_protection_concurrent_transactions int                   Number of concurrent transactions let through to the txpool/MySQL for the same hot row. Should be > 1 to have enough 'ready' transactions in MySQL and benefit from a pipelining effect. (default 5)
-      --hot_row_protection_max_global_queue_size int                     Global queue limit across all row (ranges). Useful to prevent that the queue can grow unbounded. (default 1000)
-      --hot_row_protection_max_queue_size int                            Maximum number of BeginExecute RPCs which will be queued for the same row (range). (default 20)
-      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
-      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
-      --ks-shard-map string                                              JSON map of keyspace name -> shard name -> ShardReference object. The inner map is the same as the output of FindAllShardsInKeyspace
-      --ks-shard-map-file string                                         File containing json blob of keyspace name -> shard name -> ShardReference object
-      --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
-      --lock_heartbeat_time duration                                     If there is lock function used. This will keep the lock connection active by using this heartbeat (default 5s)
-      --log_backtrace_at traceLocation                                   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                                                   If non-empty, write log files in this directory
-      --log_err_stacks                                                   log stack traces for errors
-      --log_queries_to_file string                                       Enable query logging to the specified file
-      --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
-      --logtostderr                                                      log to standard error instead of files
-      --master_connect_retry duration                                    Deprecated, use -replication_connect_retry (default 10s)
-      --max_memory_rows int                                              Maximum number of rows that will be held in memory for intermediate results as well as the final result. (default 300000)
-      --max_payload_size int                                             The threshold for query payloads in bytes. A payload greater than this threshold will result in a failure to handle the query.
-      --mem-profile-rate int                                             deprecated: use '-pprof=mem' instead (default 524288)
-      --message_stream_grace_period duration                             the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent. (default 30s)
-      --mutex-profile-fraction int                                       deprecated: use '-pprof=mutex' instead
-      --mysql_allow_clear_text_without_tls                               If set, the server will allow the use of a clear text password over non-SSL connections.
-      --mysql_auth_server_impl string                                    Which auth server implementation to use. Options: none, ldap, clientcert, static, vault. (default "static")
-      --mysql_default_workload string                                    Default session workload (OLTP, OLAP, DBA) (default "OLTP")
-      --mysql_server_bind_address string                                 Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.
-      --mysql_server_flush_delay duration                                Delay after which buffered response will be flushed to the client. (default 100ms)
-      --mysql_server_port int                                            If set, also listen for MySQL binary protocol connections on this port. (default -1)
-      --mysql_server_query_timeout duration                              mysql query timeout (default 0s)
-      --mysql_server_read_timeout duration                               connection read timeout (default 0s)
-      --mysql_server_require_secure_transport                            Reject insecure connections but only if mysql_server_ssl_cert and mysql_server_ssl_key are provided
-      --mysql_server_socket_path string                                  This option specifies the Unix socket file to use when listening for local connections. By default it will be empty and it won't listen to a unix socket
-      --mysql_server_ssl_ca string                                       Path to ssl CA for mysql server plugin SSL. If specified, server will require and validate client certs.
-      --mysql_server_ssl_cert string                                     Path to the ssl cert for mysql server plugin SSL
-      --mysql_server_ssl_crl string                                      Path to ssl CRL for mysql server plugin SSL
-      --mysql_server_ssl_key string                                      Path to ssl key for mysql server plugin SSL
-      --mysql_server_ssl_server_ca string                                path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
-      --mysql_server_tls_min_version string                              Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
-      --mysql_server_version string                                      MySQL server version to advertise.
-      --mysql_server_write_timeout duration                              connection write timeout (default 0s)
-      --mysql_slow_connect_warn_threshold duration                       Warn if it takes more than the given threshold for a mysql connection to establish (default 0s)
-      --mysql_tcp_version string                                         Select tcp, tcp4, or tcp6 to control the socket type. (default "tcp")
-      --mysqlctl_client_protocol string                                  the protocol to use to talk to the mysqlctl server (default "grpc")
-      --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
-      --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
-      --no_scatter                                                       when set to true, the planner will fail instead of producing a plan that includes scatter queries
-      --normalize                                                        Whether to enable vtgate normalization
-      --normalize_queries                                                Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars. (default true)
-      --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 1ns)
-      --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
-      --output-mode string                                               Output in human-friendly text or json (default "text")
-      --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
-      --planner-version string                                           Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4
-      --planner_version string                                           Deprecated flag. Use planner-version instead
-      --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled) (default 0s)
-      --pprof string                                                     enable profiling
-      --proxy_protocol                                                   Enable HAProxy PROXY protocol on MySQL listener socket
-      --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
-      --query-log-stream-handler string                                  URL handler for streaming queries log (default "/debug/querylog")
-      --querylog-buffer-size int                                         Maximum number of buffered query logs before throttling log output (default 10)
-      --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
-      --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
-      --queryserver-config-enable-table-acl-dry-run                      If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results
-      --queryserver-config-idle-timeout float                            query server idle timeout (in seconds), vttablet manages various mysql connection pools. This config means if a connection has not been used in given idle timeout, this connection will be removed from pool. This effectively manages number of connection objects and optimize the pool performance. (default 1800)
-      --queryserver-config-max-result-size int                           query server max result size, maximum number of rows allowed to return from vttablet for non-streaming queries. (default 10000)
-      --queryserver-config-message-postpone-cap int                      query server message postpone cap is the maximum number of messages that can be postponed at any given time. Set this number to substantially lower than transaction cap, so that the transaction pool isn't exhausted by the message subsystem. (default 4)
-      --queryserver-config-passthrough-dmls                              query server pass through all dml statements without rewriting
-      --queryserver-config-pool-prefill-parallelism int                  (DEPRECATED) query server read pool prefill parallelism, a non-zero value will prefill the pool using the specified parallism.
-      --queryserver-config-pool-size int                                 query server read pool size, connection pool is used by regular queries (non streaming, not in a transaction) (default 16)
-      --queryserver-config-query-cache-lfu                               query server cache algorithm. when set to true, a new cache algorithm based on a TinyLFU admission policy will be used to improve cache behavior and prevent pollution from sparse queries (default true)
-      --queryserver-config-query-cache-memory int                        query server query cache size in bytes, maximum amount of memory to be used for caching. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
-      --queryserver-config-query-cache-size int                          query server query cache size, maximum number of queries to be cached. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 5000)
-      --queryserver-config-query-pool-timeout float                      query server query pool timeout (in seconds), it is how long vttablet waits for a connection from the query pool. If set to 0 (default) then the overall query timeout is used instead.
-      --queryserver-config-query-pool-waiter-cap int                     query server query pool waiter limit, this is the maximum number of queries that can be queued waiting to get a connection (default 5000)
-      --queryserver-config-query-timeout float                           query server query timeout (in seconds), this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed. (default 30)
-      --queryserver-config-schema-change-signal                          query server schema signal, will signal connected vtgates that schema has changed whenever this is detected. VTGates will need to have -schema_change_signal enabled for this to work (default true)
-      --queryserver-config-schema-change-signal-interval float           query server schema change signal interval defines at which interval the query server shall send schema updates to vtgate. (default 5)
-      --queryserver-config-schema-reload-time float                      query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance in seconds. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time. (default 1800)
-      --queryserver-config-stream-buffer-size int                        query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size. (default 32768)
-      --queryserver-config-stream-pool-prefill-parallelism int           (DEPRECATED) query server stream pool prefill parallelism, a non-zero value will prefill the pool using the specified parallelism
-      --queryserver-config-stream-pool-size int                          query server stream connection pool size, stream pool is used by stream queries: queries that return results to client in a streaming fashion (default 200)
-      --queryserver-config-stream-pool-timeout float                     query server stream pool timeout (in seconds), it is how long vttablet waits for a connection from the stream pool. If set to 0 (default) then there is no timeout.
-      --queryserver-config-stream-pool-waiter-cap int                    query server stream pool waiter limit, this is the maximum number of streaming queries that can be queued waiting to get a connection
-      --queryserver-config-strict-table-acl                              only allow queries that pass table acl checks
-      --queryserver-config-terse-errors                                  prevent bind vars from escaping in client error messages
-      --queryserver-config-transaction-cap int                           query server transaction cap is the maximum number of transactions allowed to happen at any given point of a time for a single vttablet. E.g. by setting transaction cap to 100, there are at most 100 transactions will be processed by a vttablet and the 101th transaction will be blocked (and fail if it cannot get connection within specified timeout) (default 20)
-      --queryserver-config-transaction-prefill-parallelism int           (DEPRECATED) query server transaction prefill parallelism, a non-zero value will prefill the pool using the specified parallism.
-      --queryserver-config-transaction-timeout float                     query server transaction timeout (in seconds), a transaction will be killed if it takes longer than this value (default 30)
-      --queryserver-config-txpool-timeout float                          query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1)
-      --queryserver-config-txpool-waiter-cap int                         query server transaction pool waiter limit, this is the maximum number of transactions that can be queued waiting to get a connection (default 5000)
-      --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
-      --queryserver_enable_online_ddl                                    Enable online DDL. (default true)
-      --queryserver_enable_settings_pool                                 Enable pooling of connections with modified system settings
-      --remote_operation_timeout duration                                time to wait for a remote operation (default 30s)
-      --replication-mode string                                          The replication mode to simulate -- must be set to either ROW or STATEMENT (default "ROW")
-      --replication_connect_retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
-      --sanitize_log_messages                                            Remove potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.
-      --schema string                                                    The SQL table schema
-      --schema-file string                                               Identifies the file that contains the SQL table schema
-      --schema_change_signal                                             Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work (default true)
-      --schema_change_signal_user string                                 User to be used to send down query to vttablet to retrieve schema changes
-      --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
-      --service_map StringList                                           comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
-      --serving_state_grace_period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state (default 0s)
-      --shards int                                                       Number of shards per keyspace. Passing --ks-shard-map/--ks-shard-map-file causes this flag to be ignored. (default 2)
-      --shutdown_grace_period float                                      how long to wait (in seconds) for queries and transactions to complete during graceful shutdown.
-      --sql string                                                       A list of semicolon-delimited SQL commands to analyze
-      --sql-file string                                                  Identifies the file that contains the SQL commands to analyze
-      --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
-      --sql-max-length-ui int                                            truncate queries in debug UIs to the given length (default 512) (default 512)
-      --srv_topo_cache_refresh duration                                  how frequently to refresh the topology for cached entries (default 1s)
-      --srv_topo_cache_ttl duration                                      how long to use cached entries for topology (default 1s)
-      --srv_topo_timeout duration                                        topo server timeout (default 5s)
-      --stats_backend string                                             The name of the registered push-based monitoring/stats backend to use
-      --stats_combine_dimensions string                                  List of dimensions to be combined into a single "all" value in exported stats vars
-      --stats_common_tags string                                         Comma-separated list of common tags for the stats backend. It provides both label and values. Example: label1:value1,label2:value2
-      --stats_drop_variables string                                      Variables to be dropped from the list of exported variables.
-      --stats_emit_period duration                                       Interval between emitting stats to all registered backends (default 1m0s)
-      --stderrthreshold severity                                         logs at or above this threshold go to stderr (default 1)
-      --stream_buffer_size int                                           the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size. (default 32768)
-      --stream_health_buffer_size uint                                   max streaming health entries to buffer per streaming health client (default 20)
-      --tablet_dir string                                                The directory within the vtdataroot to store vttablet/mysql files. Defaults to being generated by the tablet uid.
-      --topo_global_root string                                          the path of the global topology data in the global topology server
-      --topo_global_server_address string                                the address of the global topology server
-      --topo_implementation string                                       the topology implementation to use
-      --track_schema_versions                                            When enabled, vttablet will store versions of schemas at each position that a DDL is applied and allow retrieval of the schema corresponding to a position
-      --transaction-log-stream-handler string                            URL handler for streaming transactions log (default "/debug/txlog")
-      --transaction_limit_by_component                                   Include CallerID.component when considering who the user is for the purpose of transaction limit.
-      --transaction_limit_by_principal                                   Include CallerID.principal when considering who the user is for the purpose of transaction limit. (default true)
-      --transaction_limit_by_subcomponent                                Include CallerID.subcomponent when considering who the user is for the purpose of transaction limit.
-      --transaction_limit_by_username                                    Include VTGateCallerID.username when considering who the user is for the purpose of transaction limit. (default true)
-      --transaction_limit_per_user float                                 Maximum number of transactions a single user is allowed to use at any time, represented as fraction of -transaction_cap. (default 0.4)
-      --transaction_mode string                                          SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
-      --twopc_abandon_age float                                          time in seconds. Any unresolved transaction older than this time will be sent to the coordinator to be resolved.
-      --twopc_coordinator_address string                                 address of the (VTGate) process(es) that will be used to notify of abandoned transactions.
-      --twopc_enable                                                     if the flag is on, 2pc is enabled. Other 2pc flags must be supplied.
-      --tx-throttler-config string                                       Synonym to -tx_throttler_config (default "target_replication_lag_sec: 2\nmax_replication_lag_sec: 10\ninitial_rate: 100\nmax_increase: 1\nemergency_decrease: 0.5\nmin_duration_between_increases_sec: 40\nmax_duration_between_increases_sec: 62\nmin_duration_between_decreases_sec: 20\nspread_backlog_across_sec: 20\nage_bad_rate_after_sec: 180\nbad_rate_increase: 0.1\nmax_rate_approach_threshold: 0.9\n")
-      --tx-throttler-healthcheck-cells StringList                        Synonym to -tx_throttler_healthcheck_cells
-      --tx_throttler_config string                                       The configuration of the transaction throttler as a text formatted throttlerdata.Configuration protocol buffer message (default "target_replication_lag_sec: 2\nmax_replication_lag_sec: 10\ninitial_rate: 100\nmax_increase: 1\nemergency_decrease: 0.5\nmin_duration_between_increases_sec: 40\nmax_duration_between_increases_sec: 62\nmin_duration_between_decreases_sec: 20\nspread_backlog_across_sec: 20\nage_bad_rate_after_sec: 180\nbad_rate_increase: 0.1\nmax_rate_approach_threshold: 0.9\n")
-      --tx_throttler_healthcheck_cells StringList                        A comma-separated list of cells. Only tabletservers running in these cells will be monitored for replication lag by the transaction throttler.
-      --unhealthy_threshold duration                                     replication lag after which a replica is considered unhealthy (default 2h0m0s)
-  -v, --v Level                                                          log level for V logs
-      --version                                                          print binary version
-      --vmodule moduleSpec                                               comma-separated list of pattern=N settings for file-filtered logging
-      --vreplication_copy_phase_max_innodb_history_list_length int       The maximum InnoDB transaction history that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet. (default 1000000)
-      --vreplication_copy_phase_max_mysql_replication_lag int            The maximum MySQL replication lag (in seconds) that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet. (default 43200)
-      --vschema string                                                   Identifies the VTGate routing schema
-      --vschema-file string                                              Identifies the VTGate routing schema file
-      --vschema_ddl_authorized_users string                              List of users authorized to execute vschema ddl operations, or '%' to allow all users.
-      --vtgate-config-terse-errors                                       prevent bind vars from escaping in returned errors
-      --vtgate_protocol string                                           how to talk to vtgate (default "grpc")
-      --warn_memory_rows int                                             Warning threshold for in-memory results. A row count higher than this amount will cause the VtGateWarnings.ResultsExceeded counter to be incremented. (default 30000)
-      --warn_payload_size int                                            The warning threshold for query payloads in bytes. A payload greater than this threshold will cause the VtGateWarnings.WarnPayloadSizeExceeded counter to be incremented.
-      --warn_sharded_only                                                If any features that are only available in unsharded mode are used, query execution warnings will be added to the session
-      --watch_replication_stream                                         When enabled, vttablet will stream the MySQL replication stream from the local server, and use it to update schema when it sees a DDL.
-      --xbstream_restore_flags string                                    flags to pass to xbstream command during restore. These should be space separated and will be added to the end of the command. These need to match the ones used for backup e.g. --compress / --decompress, --encrypt / --decrypt
-      --xtrabackup_backup_flags string                                   flags to pass to backup command. These should be space separated and will be added to the end of the command
-      --xtrabackup_prepare_flags string                                  flags to pass to prepare command. These should be space separated and will be added to the end of the command
-      --xtrabackup_root_path string                                      directory location of the xtrabackup and xbstream executables, e.g., /usr/bin
-      --xtrabackup_stream_mode string                                    which mode to use if streaming, valid values are tar and xbstream (default "tar")
-      --xtrabackup_stripe_block_size uint                                Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe (default 102400)
-      --xtrabackup_stripes uint                                          If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression
-      --xtrabackup_user string                                           User that xtrabackup will use to connect to the database server. This user must have all necessary privileges. For details, please refer to xtrabackup documentation.
+      --alsologtostderr                                              log to standard error as well as files
+      --app_idle_timeout duration                                    Idle timeout for app connections (default 1m0s)
+      --app_pool_size int                                            Size of the connection pool for app connections (default 40)
+      --backup_engine_implementation string                          Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
+      --backup_storage_block_size int                                if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)
+      --backup_storage_compress                                      if set, the backup files will be compressed (default is true). Set to false for instance if a backup_storage_hook is specified and it compresses the data. (default true)
+      --backup_storage_hook string                                   if set, we send the contents of the backup files through this hook.
+      --backup_storage_number_blocks int                             if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, at once, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression (default 2)
+      --batch-interval duration                                      Interval between logical time slots. (default 10ms)
+      --binlog_player_protocol string                                the protocol to download binlogs from a vttablet (default "grpc")
+      --builtinbackup_mysqld_timeout duration                        how long to wait for mysqld to shutdown at the start of the backup (default 10m0s)
+      --builtinbackup_progress duration                              how often to send progress updates when backing up large files (default 5s)
+      --catch-sigpipe                                                catch and ignore SIGPIPE on stdout and stderr if specified
+      --compression-engine-name string                               compressor engine used for compression. (default "pargzip")
+      --compression-level int                                        what level to pass to the compressor (default 1)
+      --consolidator-stream-query-size int                           Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
+      --consolidator-stream-total-size int                           Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)
+      --cpu_profile string                                           deprecated: use '-pprof=cpu' instead
+      --db-credentials-file string                                   db credentials file; send SIGHUP to reload this file
+      --db-credentials-server string                                 db credentials server type ('file' - file implementation; 'vault' - HashiCorp Vault implementation) (default "file")
+      --db-credentials-vault-addr string                             URL to Vault server
+      --db-credentials-vault-path string                             Vault path to credentials JSON blob, e.g.: secret/data/prod/dbcreds
+      --db-credentials-vault-role-mountpoint string                  Vault AppRole mountpoint; can also be passed using VAULT_MOUNTPOINT environment variable (default "approle")
+      --db-credentials-vault-role-secretidfile string                Path to file containing Vault AppRole secret_id; can also be passed using VAULT_SECRETID environment variable
+      --db-credentials-vault-roleid string                           Vault AppRole id; can also be passed using VAULT_ROLEID environment variable
+      --db-credentials-vault-timeout duration                        Timeout for vault API operations (default 10s)
+      --db-credentials-vault-tls-ca string                           Path to CA PEM for validating Vault server certificate
+      --db-credentials-vault-tokenfile string                        Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
+      --db-credentials-vault-ttl duration                            How long to cache DB credentials from the Vault server (default 30m0s)
+      --dba_idle_timeout duration                                    Idle timeout for dba connections (default 1m0s)
+      --dba_pool_size int                                            Size of the connection pool for dba connections (default 20)
+      --dbddl_plugin string                                          controls how to handle CREATE/DROP DATABASE. use it if you are using your own database provisioning service (default "fail")
+      --dbname string                                                Optional database target to override normal routing
+      --ddl_strategy string                                          Set default strategy for DDL statements. Override with @@ddl_strategy session variable (default "direct")
+      --default_tablet_type topodatapb.TabletType                    The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
+      --degraded_threshold duration                                  replication lag after which a replica is considered degraded (default 30s)
+      --disable_active_reparents                                     if set, do not allow active reparents. Use this to protect a cluster using external reparents.
+      --disable_local_gateway                                        deprecated: if specified, this process will not route any queries to local tablets in the local cell
+      --emit_stats                                                   If set, emit stats to push-based monitoring and stats backends
+      --enable-consolidator                                          Synonym to -enable_consolidator (default true)
+      --enable-consolidator-replicas                                 Synonym to -enable_consolidator_replicas
+      --enable-lag-throttler                                         Synonym to -enable_lag_throttler
+      --enable-query-plan-field-caching                              Synonym to -enable_query_plan_field_caching (default true)
+      --enable-tx-throttler                                          Synonym to -enable_tx_throttler
+      --enable_consolidator                                          This option enables the query consolidator. (default true)
+      --enable_consolidator_replicas                                 This option enables the query consolidator only on replicas.
+      --enable_direct_ddl                                            Allow users to submit direct DDL statements (default true)
+      --enable_hot_row_protection                                    If true, incoming transactions for the same row (range) will be queued and cannot consume all txpool slots.
+      --enable_hot_row_protection_dry_run                            If true, hot row protection is not enforced but logs if transactions would have been queued.
+      --enable_lag_throttler                                         If true, vttablet will run a throttler service, and will implicitly enable heartbeats
+      --enable_online_ddl                                            Allow users to submit, review and control Online DDL (default true)
+      --enable_query_plan_field_caching                              (DEPRECATED) This option fetches & caches fields (columns) when storing query plans (default true)
+      --enable_replication_reporter                                  Use polling to track replication lag.
+      --enable_set_var                                               This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections (default true)
+      --enable_system_settings                                       This will enable the system settings to be changed per session at the database connection level (default true)
+      --enable_transaction_limit                                     If true, limit on number of transactions open at the same time will be enforced for all users. User trying to open a new transaction after exhausting their limit will receive an error immediately, regardless of whether there are available slots or not.
+      --enable_transaction_limit_dry_run                             If true, limit on number of transactions open at the same time will be tracked for all users, but not enforced.
+      --enable_tx_throttler                                          If true replication-lag-based throttling on transactions will be enabled.
+      --enforce_strict_trans_tables                                  If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database. (default true)
+      --execution-mode string                                        The execution mode to simulate -- must be set to multi, legacy-autocommit, or twopc (default "multi")
+      --external-compressor string                                   command with arguments to use when compressing a backup
+      --external-compressor-extension string                         extension to use when using an external compressor
+      --external-decompressor string                                 command with arguments to use when decompressing a backup
+      --foreign_key_mode string                                      This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow (default "allow")
+      --gate_query_cache_lfu                                         gate server cache algorithm. when set to true, a new cache algorithm based on a TinyLFU admission policy will be used to improve cache behavior and prevent pollution from sparse queries (default true)
+      --gate_query_cache_memory int                                  gate server query cache size in bytes, maximum amount of memory to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
+      --gate_query_cache_size int                                    gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a cache. This config controls the expected amount of unique entries in the cache. (default 5000)
+      --grpc_auth_static_client_creds string                         when using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server
+      --health_check_interval duration                               Interval between health checks (default 20s)
+      --healthcheck_retry_delay duration                             health check retry delay (default 2ms)
+      --healthcheck_timeout duration                                 the health check timeout period (default 1m0s)
+      --heartbeat_enable                                             If true, vttablet records (if master) or checks (if replica) the current time of a replication heartbeat in the table _vt.heartbeat. The result is used to inform the serving state of the vttablet via healthchecks.
+      --heartbeat_interval duration                                  How frequently to read and write replication heartbeat. (default 1s)
+      --heartbeat_on_demand_duration duration                        If non-zero, heartbeats are only written upon consumer request, and only run for up to given duration following the request. Frequent requests can keep the heartbeat running consistently; when requests are infrequent heartbeat may completely stop between requests (default 0s)
+  -h, --help                                                         display usage and exit
+      --hot_row_protection_concurrent_transactions int               Number of concurrent transactions let through to the txpool/MySQL for the same hot row. Should be > 1 to have enough 'ready' transactions in MySQL and benefit from a pipelining effect. (default 5)
+      --hot_row_protection_max_global_queue_size int                 Global queue limit across all row (ranges). Useful to prevent that the queue can grow unbounded. (default 1000)
+      --hot_row_protection_max_queue_size int                        Maximum number of BeginExecute RPCs which will be queued for the same row (range). (default 20)
+      --keep_logs duration                                           keep logs for this long (using ctime) (zero to keep forever)
+      --keep_logs_by_mtime duration                                  keep logs for this long (using mtime) (zero to keep forever)
+      --ks-shard-map string                                          JSON map of keyspace name -> shard name -> ShardReference object. The inner map is the same as the output of FindAllShardsInKeyspace
+      --ks-shard-map-file string                                     File containing json blob of keyspace name -> shard name -> ShardReference object
+      --lameduck-period duration                                     keep running at least this long after SIGTERM before stopping (default 50ms)
+      --lock_heartbeat_time duration                                 If there is lock function used. This will keep the lock connection active by using this heartbeat (default 5s)
+      --log_backtrace_at traceLocation                               when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                                               If non-empty, write log files in this directory
+      --log_err_stacks                                               log stack traces for errors
+      --log_queries_to_file string                                   Enable query logging to the specified file
+      --log_rotate_max_size uint                                     size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
+      --logtostderr                                                  log to standard error instead of files
+      --master_connect_retry duration                                Deprecated, use -replication_connect_retry (default 10s)
+      --max_memory_rows int                                          Maximum number of rows that will be held in memory for intermediate results as well as the final result. (default 300000)
+      --max_payload_size int                                         The threshold for query payloads in bytes. A payload greater than this threshold will result in a failure to handle the query.
+      --mem-profile-rate int                                         deprecated: use '-pprof=mem' instead (default 524288)
+      --message_stream_grace_period duration                         the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent. (default 30s)
+      --mutex-profile-fraction int                                   deprecated: use '-pprof=mutex' instead
+      --mysql_allow_clear_text_without_tls                           If set, the server will allow the use of a clear text password over non-SSL connections.
+      --mysql_auth_server_impl string                                Which auth server implementation to use. Options: none, ldap, clientcert, static, vault. (default "static")
+      --mysql_default_workload string                                Default session workload (OLTP, OLAP, DBA) (default "OLTP")
+      --mysql_server_bind_address string                             Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.
+      --mysql_server_flush_delay duration                            Delay after which buffered response will be flushed to the client. (default 100ms)
+      --mysql_server_port int                                        If set, also listen for MySQL binary protocol connections on this port. (default -1)
+      --mysql_server_query_timeout duration                          mysql query timeout (default 0s)
+      --mysql_server_read_timeout duration                           connection read timeout (default 0s)
+      --mysql_server_require_secure_transport                        Reject insecure connections but only if mysql_server_ssl_cert and mysql_server_ssl_key are provided
+      --mysql_server_socket_path string                              This option specifies the Unix socket file to use when listening for local connections. By default it will be empty and it won't listen to a unix socket
+      --mysql_server_ssl_ca string                                   Path to ssl CA for mysql server plugin SSL. If specified, server will require and validate client certs.
+      --mysql_server_ssl_cert string                                 Path to the ssl cert for mysql server plugin SSL
+      --mysql_server_ssl_crl string                                  Path to ssl CRL for mysql server plugin SSL
+      --mysql_server_ssl_key string                                  Path to ssl key for mysql server plugin SSL
+      --mysql_server_ssl_server_ca string                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
+      --mysql_server_tls_min_version string                          Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
+      --mysql_server_version string                                  MySQL server version to advertise.
+      --mysql_server_write_timeout duration                          connection write timeout (default 0s)
+      --mysql_slow_connect_warn_threshold duration                   Warn if it takes more than the given threshold for a mysql connection to establish (default 0s)
+      --mysql_tcp_version string                                     Select tcp, tcp4, or tcp6 to control the socket type. (default "tcp")
+      --mysqlctl_client_protocol string                              the protocol to use to talk to the mysqlctl server (default "grpc")
+      --mysqlctl_mycnf_template string                               template file to use for generating the my.cnf file during server init
+      --mysqlctl_socket string                                       socket file to use for remote mysqlctl actions (empty for local actions)
+      --no_scatter                                                   when set to true, the planner will fail instead of producing a plan that includes scatter queries
+      --normalize                                                    Whether to enable vtgate normalization
+      --normalize_queries                                            Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars. (default true)
+      --onclose_timeout duration                                     wait no more than this for OnClose handlers before stopping (default 1ns)
+      --onterm_timeout duration                                      wait no more than this for OnTermSync handlers before stopping (default 10s)
+      --output-mode string                                           Output in human-friendly text or json (default "text")
+      --pid_file string                                              If set, the process will write its pid to the named file, and delete it on graceful shutdown.
+      --planner-version string                                       Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4
+      --planner_version string                                       Deprecated flag. Use planner-version instead
+      --pool_hostname_resolve_interval duration                      if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled) (default 0s)
+      --pprof string                                                 enable profiling
+      --proxy_protocol                                               Enable HAProxy PROXY protocol on MySQL listener socket
+      --purge_logs_interval duration                                 how often try to remove old logs (default 1h0m0s)
+      --query-log-stream-handler string                              URL handler for streaming queries log (default "/debug/querylog")
+      --querylog-buffer-size int                                     Maximum number of buffered query logs before throttling log output (default 10)
+      --queryserver-config-acl-exempt-acl string                     an acl that exempt from table acl checking (this acl is free to access any vitess tables).
+      --queryserver-config-annotate-queries                          prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
+      --queryserver-config-enable-table-acl-dry-run                  If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results
+      --queryserver-config-idle-timeout float                        query server idle timeout (in seconds), vttablet manages various mysql connection pools. This config means if a connection has not been used in given idle timeout, this connection will be removed from pool. This effectively manages number of connection objects and optimize the pool performance. (default 1800)
+      --queryserver-config-max-result-size int                       query server max result size, maximum number of rows allowed to return from vttablet for non-streaming queries. (default 10000)
+      --queryserver-config-message-postpone-cap int                  query server message postpone cap is the maximum number of messages that can be postponed at any given time. Set this number to substantially lower than transaction cap, so that the transaction pool isn't exhausted by the message subsystem. (default 4)
+      --queryserver-config-passthrough-dmls                          query server pass through all dml statements without rewriting
+      --queryserver-config-pool-prefill-parallelism int              (DEPRECATED) query server read pool prefill parallelism, a non-zero value will prefill the pool using the specified parallism.
+      --queryserver-config-pool-size int                             query server read pool size, connection pool is used by regular queries (non streaming, not in a transaction) (default 16)
+      --queryserver-config-query-cache-lfu                           query server cache algorithm. when set to true, a new cache algorithm based on a TinyLFU admission policy will be used to improve cache behavior and prevent pollution from sparse queries (default true)
+      --queryserver-config-query-cache-memory int                    query server query cache size in bytes, maximum amount of memory to be used for caching. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
+      --queryserver-config-query-cache-size int                      query server query cache size, maximum number of queries to be cached. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 5000)
+      --queryserver-config-query-pool-timeout float                  query server query pool timeout (in seconds), it is how long vttablet waits for a connection from the query pool. If set to 0 (default) then the overall query timeout is used instead.
+      --queryserver-config-query-pool-waiter-cap int                 query server query pool waiter limit, this is the maximum number of queries that can be queued waiting to get a connection (default 5000)
+      --queryserver-config-query-timeout float                       query server query timeout (in seconds), this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed. (default 30)
+      --queryserver-config-schema-change-signal                      query server schema signal, will signal connected vtgates that schema has changed whenever this is detected. VTGates will need to have -schema_change_signal enabled for this to work (default true)
+      --queryserver-config-schema-change-signal-interval float       query server schema change signal interval defines at which interval the query server shall send schema updates to vtgate. (default 5)
+      --queryserver-config-schema-reload-time float                  query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance in seconds. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time. (default 1800)
+      --queryserver-config-stream-buffer-size int                    query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size. (default 32768)
+      --queryserver-config-stream-pool-prefill-parallelism int       (DEPRECATED) query server stream pool prefill parallelism, a non-zero value will prefill the pool using the specified parallelism
+      --queryserver-config-stream-pool-size int                      query server stream connection pool size, stream pool is used by stream queries: queries that return results to client in a streaming fashion (default 200)
+      --queryserver-config-stream-pool-timeout float                 query server stream pool timeout (in seconds), it is how long vttablet waits for a connection from the stream pool. If set to 0 (default) then there is no timeout.
+      --queryserver-config-stream-pool-waiter-cap int                query server stream pool waiter limit, this is the maximum number of streaming queries that can be queued waiting to get a connection
+      --queryserver-config-strict-table-acl                          only allow queries that pass table acl checks
+      --queryserver-config-terse-errors                              prevent bind vars from escaping in client error messages
+      --queryserver-config-transaction-cap int                       query server transaction cap is the maximum number of transactions allowed to happen at any given point of a time for a single vttablet. E.g. by setting transaction cap to 100, there are at most 100 transactions will be processed by a vttablet and the 101th transaction will be blocked (and fail if it cannot get connection within specified timeout) (default 20)
+      --queryserver-config-transaction-prefill-parallelism int       (DEPRECATED) query server transaction prefill parallelism, a non-zero value will prefill the pool using the specified parallism.
+      --queryserver-config-transaction-timeout float                 query server transaction timeout (in seconds), a transaction will be killed if it takes longer than this value (default 30)
+      --queryserver-config-txpool-timeout float                      query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1)
+      --queryserver-config-txpool-waiter-cap int                     query server transaction pool waiter limit, this is the maximum number of transactions that can be queued waiting to get a connection (default 5000)
+      --queryserver-config-warn-result-size int                      query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
+      --queryserver_enable_online_ddl                                Enable online DDL. (default true)
+      --queryserver_enable_settings_pool                             Enable pooling of connections with modified system settings
+      --remote_operation_timeout duration                            time to wait for a remote operation (default 30s)
+      --replication-mode string                                      The replication mode to simulate -- must be set to either ROW or STATEMENT (default "ROW")
+      --replication_connect_retry duration                           how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
+      --sanitize_log_messages                                        Remove potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.
+      --schema string                                                The SQL table schema
+      --schema-file string                                           Identifies the file that contains the SQL table schema
+      --schema_change_signal                                         Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work (default true)
+      --schema_change_signal_user string                             User to be used to send down query to vttablet to retrieve schema changes
+      --security_policy string                                       the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
+      --service_map StringList                                       comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
+      --serving_state_grace_period duration                          how long to pause after broadcasting health to vtgate, before enforcing a new serving state (default 0s)
+      --shards int                                                   Number of shards per keyspace. Passing --ks-shard-map/--ks-shard-map-file causes this flag to be ignored. (default 2)
+      --shutdown_grace_period float                                  how long to wait (in seconds) for queries and transactions to complete during graceful shutdown.
+      --sql string                                                   A list of semicolon-delimited SQL commands to analyze
+      --sql-file string                                              Identifies the file that contains the SQL commands to analyze
+      --sql-max-length-errors int                                    truncate queries in error logs to the given length (default unlimited)
+      --sql-max-length-ui int                                        truncate queries in debug UIs to the given length (default 512) (default 512)
+      --srv_topo_cache_refresh duration                              how frequently to refresh the topology for cached entries (default 1s)
+      --srv_topo_cache_ttl duration                                  how long to use cached entries for topology (default 1s)
+      --srv_topo_timeout duration                                    topo server timeout (default 5s)
+      --stats_backend string                                         The name of the registered push-based monitoring/stats backend to use
+      --stats_combine_dimensions string                              List of dimensions to be combined into a single "all" value in exported stats vars
+      --stats_common_tags string                                     Comma-separated list of common tags for the stats backend. It provides both label and values. Example: label1:value1,label2:value2
+      --stats_drop_variables string                                  Variables to be dropped from the list of exported variables.
+      --stats_emit_period duration                                   Interval between emitting stats to all registered backends (default 1m0s)
+      --stderrthreshold severity                                     logs at or above this threshold go to stderr (default 1)
+      --stream_buffer_size int                                       the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size. (default 32768)
+      --stream_health_buffer_size uint                               max streaming health entries to buffer per streaming health client (default 20)
+      --tablet_dir string                                            The directory within the vtdataroot to store vttablet/mysql files. Defaults to being generated by the tablet uid.
+      --topo_global_root string                                      the path of the global topology data in the global topology server
+      --topo_global_server_address string                            the address of the global topology server
+      --topo_implementation string                                   the topology implementation to use
+      --track_schema_versions                                        When enabled, vttablet will store versions of schemas at each position that a DDL is applied and allow retrieval of the schema corresponding to a position
+      --transaction-log-stream-handler string                        URL handler for streaming transactions log (default "/debug/txlog")
+      --transaction_limit_by_component                               Include CallerID.component when considering who the user is for the purpose of transaction limit.
+      --transaction_limit_by_principal                               Include CallerID.principal when considering who the user is for the purpose of transaction limit. (default true)
+      --transaction_limit_by_subcomponent                            Include CallerID.subcomponent when considering who the user is for the purpose of transaction limit.
+      --transaction_limit_by_username                                Include VTGateCallerID.username when considering who the user is for the purpose of transaction limit. (default true)
+      --transaction_limit_per_user float                             Maximum number of transactions a single user is allowed to use at any time, represented as fraction of -transaction_cap. (default 0.4)
+      --transaction_mode string                                      SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
+      --twopc_abandon_age float                                      time in seconds. Any unresolved transaction older than this time will be sent to the coordinator to be resolved.
+      --twopc_coordinator_address string                             address of the (VTGate) process(es) that will be used to notify of abandoned transactions.
+      --twopc_enable                                                 if the flag is on, 2pc is enabled. Other 2pc flags must be supplied.
+      --tx-throttler-config string                                   Synonym to -tx_throttler_config (default "target_replication_lag_sec: 2\nmax_replication_lag_sec: 10\ninitial_rate: 100\nmax_increase: 1\nemergency_decrease: 0.5\nmin_duration_between_increases_sec: 40\nmax_duration_between_increases_sec: 62\nmin_duration_between_decreases_sec: 20\nspread_backlog_across_sec: 20\nage_bad_rate_after_sec: 180\nbad_rate_increase: 0.1\nmax_rate_approach_threshold: 0.9\n")
+      --tx-throttler-healthcheck-cells StringList                    Synonym to -tx_throttler_healthcheck_cells
+      --tx_throttler_config string                                   The configuration of the transaction throttler as a text formatted throttlerdata.Configuration protocol buffer message (default "target_replication_lag_sec: 2\nmax_replication_lag_sec: 10\ninitial_rate: 100\nmax_increase: 1\nemergency_decrease: 0.5\nmin_duration_between_increases_sec: 40\nmax_duration_between_increases_sec: 62\nmin_duration_between_decreases_sec: 20\nspread_backlog_across_sec: 20\nage_bad_rate_after_sec: 180\nbad_rate_increase: 0.1\nmax_rate_approach_threshold: 0.9\n")
+      --tx_throttler_healthcheck_cells StringList                    A comma-separated list of cells. Only tabletservers running in these cells will be monitored for replication lag by the transaction throttler.
+      --unhealthy_threshold duration                                 replication lag after which a replica is considered unhealthy (default 2h0m0s)
+  -v, --v Level                                                      log level for V logs
+      --version                                                      print binary version
+      --vmodule moduleSpec                                           comma-separated list of pattern=N settings for file-filtered logging
+      --vreplication_copy_phase_max_innodb_history_list_length int   The maximum InnoDB transaction history that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet. (default 1000000)
+      --vreplication_copy_phase_max_mysql_replication_lag int        The maximum MySQL replication lag (in seconds) that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet. (default 43200)
+      --vschema string                                               Identifies the VTGate routing schema
+      --vschema-file string                                          Identifies the VTGate routing schema file
+      --vschema_ddl_authorized_users string                          List of users authorized to execute vschema ddl operations, or '%' to allow all users.
+      --vtgate-config-terse-errors                                   prevent bind vars from escaping in returned errors
+      --vtgate_protocol string                                       how to talk to vtgate (default "grpc")
+      --warn_memory_rows int                                         Warning threshold for in-memory results. A row count higher than this amount will cause the VtGateWarnings.ResultsExceeded counter to be incremented. (default 30000)
+      --warn_payload_size int                                        The warning threshold for query payloads in bytes. A payload greater than this threshold will cause the VtGateWarnings.WarnPayloadSizeExceeded counter to be incremented.
+      --warn_sharded_only                                            If any features that are only available in unsharded mode are used, query execution warnings will be added to the session
+      --watch_replication_stream                                     When enabled, vttablet will stream the MySQL replication stream from the local server, and use it to update schema when it sees a DDL.
+      --xbstream_restore_flags string                                flags to pass to xbstream command during restore. These should be space separated and will be added to the end of the command. These need to match the ones used for backup e.g. --compress / --decompress, --encrypt / --decrypt
+      --xtrabackup_backup_flags string                               flags to pass to backup command. These should be space separated and will be added to the end of the command
+      --xtrabackup_prepare_flags string                              flags to pass to prepare command. These should be space separated and will be added to the end of the command
+      --xtrabackup_root_path string                                  directory location of the xtrabackup and xbstream executables, e.g., /usr/bin
+      --xtrabackup_stream_mode string                                which mode to use if streaming, valid values are tar and xbstream (default "tar")
+      --xtrabackup_stripe_block_size uint                            Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe (default 102400)
+      --xtrabackup_stripes uint                                      If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression
+      --xtrabackup_user string                                       User that xtrabackup will use to connect to the database server. This user must have all necessary privileges. For details, please refer to xtrabackup documentation.

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -51,7 +51,7 @@ Usage of vtgate:
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
       --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
-      --grpc_port int                                                    Port to listen on for gRPC calls
+      --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
       --grpc_server_initial_conn_window_size int                         gRPC server initial connection window size

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -12,7 +12,6 @@ Usage of vtgate:
       --cell string                                                      cell to use (default "test_nj")
       --cells_to_watch string                                            comma-separated list of cells for watching tablets
       --consul_auth_static_file string                                   JSON File to read the topos/tokens from.
-      --cpu_profile string                                               deprecated: use '-pprof=cpu' instead
       --datadog-agent-host string                                        host to send spans to. if empty, no tracing will be done
       --datadog-agent-port string                                        port to send spans to. if empty, no tracing will be done
       --dbddl_plugin string                                              controls how to handle CREATE/DROP DATABASE. use it if you are using your own database provisioning service (default "fail")
@@ -77,10 +76,8 @@ Usage of vtgate:
       --logtostderr                                                      log to standard error instead of files
       --max_memory_rows int                                              Maximum number of rows that will be held in memory for intermediate results as well as the final result. (default 300000)
       --max_payload_size int                                             The threshold for query payloads in bytes. A payload greater than this threshold will result in a failure to handle the query.
-      --mem-profile-rate int                                             deprecated: use '-pprof=mem' instead (default 524288)
       --message_stream_grace_period duration                             the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent. (default 30s)
       --min_number_serving_vttablets int                                 The minimum number of vttablets for each replicating tablet_type (e.g. replica, rdonly) that will be continue to be used even with replication lag above discovery_low_replication_lag, but still below discovery_high_replication_lag_minimum_serving. (default 2)
-      --mutex-profile-fraction int                                       deprecated: use '-pprof=mutex' instead
       --mysql_allow_clear_text_without_tls                               If set, the server will allow the use of a clear text password over non-SSL connections.
       --mysql_auth_server_impl string                                    Which auth server implementation to use. Options: none, ldap, clientcert, static, vault. (default "static")
       --mysql_auth_server_static_file string                             JSON File to read the users/passwords from.

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -1,96 +1,83 @@
 Usage of vtgr:
-      --abort_rebootstrap                                                Don't allow vtgr to rebootstrap an existing group.
-      --alsologtostderr                                                  log to standard error as well as files
-      --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
-      --clusters_to_watch strings                                        Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"
-      --consul_auth_static_file string                                   JSON File to read the topos/tokens from.
-      --cpu_profile string                                               deprecated: use '-pprof=cpu' instead
-      --db_config string                                                 Full path to db config file that will be used by VTGR.
-      --db_flavor string                                                 MySQL flavor override. (default "MySQL56")
-      --db_port int                                                      Local mysql port, set this to enable local fast check.
-      --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
-      --enable_heartbeat_check                                           Enable heartbeat checking, set together with --group_heartbeat_threshold.
-      --gr_port int                                                      Port to bootstrap a MySQL group. (default 33061)
-      --group_heartbeat_threshold int                                    VTGR will trigger backoff on inconsistent state if the group heartbeat staleness exceeds this threshold (in seconds). Should be used along with --enable_heartbeat_check.
-      --grpc_auth_static_client_creds string                             when using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server
-      --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
-      --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
-      --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
-      --grpc_crl string                                                  path to a certificate revocation list in PEM format, client certificates will be further verified against this file during TLS handshake
-      --grpc_enable_optional_tls                                         enable optional TLS mode when a server accepts both TLS and plain-text connections on the same port
-      --grpc_enable_tracing                                              Enable gRPC tracing.
-      --grpc_initial_conn_window_size int                                gRPC initial connection window size
-      --grpc_initial_window_size int                                     gRPC initial window size
-      --grpc_keepalive_time duration                                     After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
-      --grpc_keepalive_timeout duration                                  After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
-      --grpc_key string                                                  server private key to use for gRPC connections, requires grpc_cert, enables TLS
-      --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
-      --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
-      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
-      --grpc_port int                                                    Port to listen on for gRPC calls
-      --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
-      --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
-      --grpc_server_initial_conn_window_size int                         gRPC server initial connection window size
-      --grpc_server_initial_window_size int                              gRPC server initial window size
-      --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
-      --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
-  -h, --help                                                             display usage and exit
-      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
-      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
-      --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
-      --log_backtrace_at traceLocation                                   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                                                   If non-empty, write log files in this directory
-      --log_err_stacks                                                   log stack traces for errors
-      --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
-      --logtostderr                                                      log to standard error instead of files
-      --mem-profile-rate int                                             deprecated: use '-pprof=mem' instead (default 524288)
-      --mutex-profile-fraction int                                       deprecated: use '-pprof=mutex' instead
-      --mysql_server_flush_delay duration                                Delay after which buffered response will be flushed to the client. (default 100ms)
-      --mysql_server_version string                                      MySQL server version to advertise.
-      --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 1ns)
-      --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
-      --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
-      --ping_tablet_timeout duration                                     time to wait when we ping a tablet (default 2s)
-      --pprof string                                                     enable profiling
-      --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
-      --refresh_interval duration                                        Refresh interval to load tablets. (default 10s)
-      --remote_operation_timeout duration                                time to wait for a remote operation (default 30s)
-      --scan_interval duration                                           Scan interval to diagnose and repair. (default 3s)
-      --scan_repair_timeout duration                                     Time to wait for a Diagnose and repair operation. (default 3s)
-      --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
-      --service_map StringList                                           comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
-      --stats_backend string                                             The name of the registered push-based monitoring/stats backend to use
-      --stats_combine_dimensions string                                  List of dimensions to be combined into a single "all" value in exported stats vars
-      --stats_common_tags string                                         Comma-separated list of common tags for the stats backend. It provides both label and values. Example: label1:value1,label2:value2
-      --stats_drop_variables string                                      Variables to be dropped from the list of exported variables.
-      --stats_emit_period duration                                       Interval between emitting stats to all registered backends (default 1m0s)
-      --stderrthreshold severity                                         logs at or above this threshold go to stderr (default 1)
-      --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
-      --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
-      --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
-      --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
-      --tablet_manager_grpc_key string                                   the key to use to connect
-      --tablet_manager_grpc_server_name string                           the server name to use to validate server certificate
-      --tablet_manager_protocol string                                   Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
-      --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
-      --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
-      --topo_consul_lock_session_ttl string                              TTL for consul session.
-      --topo_consul_watch_poll_duration duration                         time of the long poll for watch queries. (default 30s)
-      --topo_etcd_lease_ttl int                                          Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
-      --topo_etcd_tls_ca string                                          path to the ca to use to validate the server cert when connecting to the etcd topo server
-      --topo_etcd_tls_cert string                                        path to the client cert to use to connect to the etcd topo server, requires topo_etcd_tls_key, enables TLS
-      --topo_etcd_tls_key string                                         path to the client key to use to connect to the etcd topo server, enables TLS
-      --topo_global_root string                                          the path of the global topology data in the global topology server
-      --topo_global_server_address string                                the address of the global topology server
-      --topo_implementation string                                       the topology implementation to use
-      --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
-      --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)
-      --topo_zk_max_concurrency int                                      maximum number of pending requests to send to a Zookeeper server. (default 64)
-      --topo_zk_tls_ca string                                            the server ca to use to validate servers when connecting to the zk topo server
-      --topo_zk_tls_cert string                                          the cert to use to connect to the zk topo server, requires topo_zk_tls_key, enables TLS
-      --topo_zk_tls_key string                                           the key to use to connect to the zk topo server, enables TLS
-  -v, --v Level                                                          log level for V logs
-      --version                                                          print binary version
-      --vmodule moduleSpec                                               comma-separated list of pattern=N settings for file-filtered logging
-      --vtgr_config string                                               Config file for vtgr.
+      --abort_rebootstrap                          Don't allow vtgr to rebootstrap an existing group.
+      --alsologtostderr                            log to standard error as well as files
+      --catch-sigpipe                              catch and ignore SIGPIPE on stdout and stderr if specified
+      --clusters_to_watch strings                  Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"
+      --consul_auth_static_file string             JSON File to read the topos/tokens from.
+      --cpu_profile string                         deprecated: use '-pprof=cpu' instead
+      --db_config string                           Full path to db config file that will be used by VTGR.
+      --db_flavor string                           MySQL flavor override. (default "MySQL56")
+      --db_port int                                Local mysql port, set this to enable local fast check.
+      --emit_stats                                 If set, emit stats to push-based monitoring and stats backends
+      --enable_heartbeat_check                     Enable heartbeat checking, set together with --group_heartbeat_threshold.
+      --gr_port int                                Port to bootstrap a MySQL group. (default 33061)
+      --group_heartbeat_threshold int              VTGR will trigger backoff on inconsistent state if the group heartbeat staleness exceeds this threshold (in seconds). Should be used along with --enable_heartbeat_check.
+      --grpc_auth_static_client_creds string       when using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server
+      --grpc_compression string                    Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
+      --grpc_enable_tracing                        Enable gRPC tracing.
+      --grpc_initial_conn_window_size int          gRPC initial connection window size
+      --grpc_initial_window_size int               gRPC initial window size
+      --grpc_keepalive_time duration               After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
+      --grpc_keepalive_timeout duration            After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
+      --grpc_max_message_size int                  Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_prometheus                            Enable gRPC monitoring with Prometheus.
+  -h, --help                                       display usage and exit
+      --keep_logs duration                         keep logs for this long (using ctime) (zero to keep forever)
+      --keep_logs_by_mtime duration                keep logs for this long (using mtime) (zero to keep forever)
+      --lameduck-period duration                   keep running at least this long after SIGTERM before stopping (default 50ms)
+      --log_backtrace_at traceLocation             when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                             If non-empty, write log files in this directory
+      --log_err_stacks                             log stack traces for errors
+      --log_rotate_max_size uint                   size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
+      --logtostderr                                log to standard error instead of files
+      --mem-profile-rate int                       deprecated: use '-pprof=mem' instead (default 524288)
+      --mutex-profile-fraction int                 deprecated: use '-pprof=mutex' instead
+      --mysql_server_flush_delay duration          Delay after which buffered response will be flushed to the client. (default 100ms)
+      --mysql_server_version string                MySQL server version to advertise.
+      --onclose_timeout duration                   wait no more than this for OnClose handlers before stopping (default 1ns)
+      --onterm_timeout duration                    wait no more than this for OnTermSync handlers before stopping (default 10s)
+      --pid_file string                            If set, the process will write its pid to the named file, and delete it on graceful shutdown.
+      --ping_tablet_timeout duration               time to wait when we ping a tablet (default 2s)
+      --pprof string                               enable profiling
+      --purge_logs_interval duration               how often try to remove old logs (default 1h0m0s)
+      --refresh_interval duration                  Refresh interval to load tablets. (default 10s)
+      --remote_operation_timeout duration          time to wait for a remote operation (default 30s)
+      --scan_interval duration                     Scan interval to diagnose and repair. (default 3s)
+      --scan_repair_timeout duration               Time to wait for a Diagnose and repair operation. (default 3s)
+      --security_policy string                     the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
+      --service_map StringList                     comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
+      --stats_backend string                       The name of the registered push-based monitoring/stats backend to use
+      --stats_combine_dimensions string            List of dimensions to be combined into a single "all" value in exported stats vars
+      --stats_common_tags string                   Comma-separated list of common tags for the stats backend. It provides both label and values. Example: label1:value1,label2:value2
+      --stats_drop_variables string                Variables to be dropped from the list of exported variables.
+      --stats_emit_period duration                 Interval between emitting stats to all registered backends (default 1m0s)
+      --stderrthreshold severity                   logs at or above this threshold go to stderr (default 1)
+      --tablet_manager_grpc_ca string              the server ca to use to validate servers when connecting
+      --tablet_manager_grpc_cert string            the cert to use to connect
+      --tablet_manager_grpc_concurrency int        concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_connpool_size int      number of tablets to keep tmclient connections open to (default 100)
+      --tablet_manager_grpc_crl string             the server crl to use to validate server certificates when connecting
+      --tablet_manager_grpc_key string             the key to use to connect
+      --tablet_manager_grpc_server_name string     the server name to use to validate server certificate
+      --tablet_manager_protocol string             Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
+      --topo_consul_lock_delay duration            LockDelay for consul session. (default 15s)
+      --topo_consul_lock_session_checks string     List of checks for consul session. (default "serfHealth")
+      --topo_consul_lock_session_ttl string        TTL for consul session.
+      --topo_consul_watch_poll_duration duration   time of the long poll for watch queries. (default 30s)
+      --topo_etcd_lease_ttl int                    Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
+      --topo_etcd_tls_ca string                    path to the ca to use to validate the server cert when connecting to the etcd topo server
+      --topo_etcd_tls_cert string                  path to the client cert to use to connect to the etcd topo server, requires topo_etcd_tls_key, enables TLS
+      --topo_etcd_tls_key string                   path to the client key to use to connect to the etcd topo server, enables TLS
+      --topo_global_root string                    the path of the global topology data in the global topology server
+      --topo_global_server_address string          the address of the global topology server
+      --topo_implementation string                 the topology implementation to use
+      --topo_zk_auth_file string                   auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
+      --topo_zk_base_timeout duration              zk base timeout (see zk.Connect) (default 30s)
+      --topo_zk_max_concurrency int                maximum number of pending requests to send to a Zookeeper server. (default 64)
+      --topo_zk_tls_ca string                      the server ca to use to validate servers when connecting to the zk topo server
+      --topo_zk_tls_cert string                    the cert to use to connect to the zk topo server, requires topo_zk_tls_key, enables TLS
+      --topo_zk_tls_key string                     the key to use to connect to the zk topo server, enables TLS
+  -v, --v Level                                    log level for V logs
+      --version                                    print binary version
+      --vmodule moduleSpec                         comma-separated list of pattern=N settings for file-filtered logging
+      --vtgr_config string                         Config file for vtgr.

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -1,7 +1,6 @@
 Usage of vtgr:
       --abort_rebootstrap                          Don't allow vtgr to rebootstrap an existing group.
       --alsologtostderr                            log to standard error as well as files
-      --catch-sigpipe                              catch and ignore SIGPIPE on stdout and stderr if specified
       --clusters_to_watch strings                  Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"
       --consul_auth_static_file string             JSON File to read the topos/tokens from.
       --db_config string                           Full path to db config file that will be used by VTGR.
@@ -23,7 +22,6 @@ Usage of vtgr:
   -h, --help                                       display usage and exit
       --keep_logs duration                         keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                keep logs for this long (using mtime) (zero to keep forever)
-      --lameduck-period duration                   keep running at least this long after SIGTERM before stopping (default 50ms)
       --log_backtrace_at traceLocation             when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                             If non-empty, write log files in this directory
       --log_err_stacks                             log stack traces for errors
@@ -31,8 +29,6 @@ Usage of vtgr:
       --logtostderr                                log to standard error instead of files
       --mysql_server_flush_delay duration          Delay after which buffered response will be flushed to the client. (default 100ms)
       --mysql_server_version string                MySQL server version to advertise.
-      --onclose_timeout duration                   wait no more than this for OnClose handlers before stopping (default 1ns)
-      --onterm_timeout duration                    wait no more than this for OnTermSync handlers before stopping (default 10s)
       --pid_file string                            If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --ping_tablet_timeout duration               time to wait when we ping a tablet (default 2s)
       --pprof string                               enable profiling

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -4,7 +4,6 @@ Usage of vtgr:
       --catch-sigpipe                              catch and ignore SIGPIPE on stdout and stderr if specified
       --clusters_to_watch strings                  Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"
       --consul_auth_static_file string             JSON File to read the topos/tokens from.
-      --cpu_profile string                         deprecated: use '-pprof=cpu' instead
       --db_config string                           Full path to db config file that will be used by VTGR.
       --db_flavor string                           MySQL flavor override. (default "MySQL56")
       --db_port int                                Local mysql port, set this to enable local fast check.
@@ -30,8 +29,6 @@ Usage of vtgr:
       --log_err_stacks                             log stack traces for errors
       --log_rotate_max_size uint                   size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                log to standard error instead of files
-      --mem-profile-rate int                       deprecated: use '-pprof=mem' instead (default 524288)
-      --mutex-profile-fraction int                 deprecated: use '-pprof=mutex' instead
       --mysql_server_flush_delay duration          Delay after which buffered response will be flushed to the client. (default 100ms)
       --mysql_server_version string                MySQL server version to advertise.
       --onclose_timeout duration                   wait no more than this for OnClose handlers before stopping (default 1ns)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -229,7 +229,7 @@ Usage of vttablet:
       --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
       --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
       --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
-      --grpc_port int                                                    Port to listen on for gRPC calls
+      --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
       --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus.
       --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
       --grpc_server_initial_conn_window_size int                         gRPC server initial connection window size

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -36,7 +36,6 @@ Usage of vttablet:
       --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
       --consolidator-stream-total-size int                               Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)
       --consul_auth_static_file string                                   JSON File to read the topos/tokens from.
-      --cpu_profile string                                               deprecated: use '-pprof=cpu' instead
       --datadog-agent-host string                                        host to send spans to. if empty, no tracing will be done
       --datadog-agent-port string                                        port to send spans to. if empty, no tracing will be done
       --db-config-allprivs-charset string                                deprecated: use db_charset (default "utf8mb4")
@@ -265,9 +264,7 @@ Usage of vttablet:
       --logtostderr                                                      log to standard error instead of files
       --master_connect_retry duration                                    Deprecated, use -replication_connect_retry (default 10s)
       --max_concurrent_online_ddl int                                    Maximum number of online DDL changes that may run concurrently (default 256)
-      --mem-profile-rate int                                             deprecated: use '-pprof=mem' instead (default 524288)
       --migration_check_interval duration                                Interval between migration checks (default 1m0s)
-      --mutex-profile-fraction int                                       deprecated: use '-pprof=mutex' instead
       --mycnf-file string                                                path to my.cnf, if reading all config params from there
       --mycnf_bin_log_path string                                        mysql binlog path
       --mycnf_data_dir string                                            data directory for mysql

--- a/go/flagutil/optional.go
+++ b/go/flagutil/optional.go
@@ -29,6 +29,9 @@ import (
 // Though not part of the interface, because the return type would be different
 // for each implementation, by convention, each implementation should define a
 // Get() method to access the underlying value.
+//
+// TODO (ajm188) - replace this interface with a generic type.
+// c.f. https://github.com/vitessio/vitess/issues/11154.
 type OptionalFlag interface {
 	pflag.Value
 	IsSet() bool

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -19,7 +19,6 @@ package servenv
 import (
 	"context"
 	"crypto/tls"
-	"flag"
 	"fmt"
 	"math"
 	"net"
@@ -27,6 +26,7 @@ import (
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health"
@@ -55,27 +55,7 @@ import (
 // Note servenv.GRPCServer can only be used in servenv.OnRun,
 // and not before, as it is initialized right before calling OnRun.
 var (
-	// GRPCPort is the port to listen on for gRPC. If not set or zero, don't listen.
-	GRPCPort = flag.Int("grpc_port", 0, "Port to listen on for gRPC calls")
-
-	// GRPCCert is the cert to use if TLS is enabled
-	GRPCCert = flag.String("grpc_cert", "", "server certificate to use for gRPC connections, requires grpc_key, enables TLS")
-
-	// GRPCKey is the key to use if TLS is enabled
-	GRPCKey = flag.String("grpc_key", "", "server private key to use for gRPC connections, requires grpc_cert, enables TLS")
-
-	// GRPCCA is the CA to use if TLS is enabled
-	GRPCCA = flag.String("grpc_ca", "", "server CA to use for gRPC connections, requires TLS, and enforces client certificate check")
-
-	// GRPCCRL is the CRL (Certificate Revocation List) to use if TLS is enabled
-	GRPCCRL = flag.String("grpc_crl", "", "path to a certificate revocation list in PEM format, client certificates will be further verified against this file during TLS handshake")
-
-	GRPCEnableOptionalTLS = flag.Bool("grpc_enable_optional_tls", false, "enable optional TLS mode when a server accepts both TLS and plain-text connections on the same port")
-
-	// GRPCServerCA if specified will combine server cert and server CA
-	GRPCServerCA = flag.String("grpc_server_ca", "", "path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients")
-
-	// GRPCAuth specifies which auth plugin to use. Currently only "static" and
+	// gRPCAuth specifies which auth plugin to use. Currently only "static" and
 	// "mtls" are supported.
 	//
 	// To expose this flag, call RegisterGRPCAuthServerFlags before ParseFlags.
@@ -84,37 +64,105 @@ var (
 	// GRPCServer is the global server to serve gRPC.
 	GRPCServer *grpc.Server
 
-	// GRPCMaxConnectionAge is the maximum age of a client connection, before GoAway is sent.
-	// This is useful for L4 loadbalancing to ensure rebalancing after scaling.
-	GRPCMaxConnectionAge = flag.Duration("grpc_max_connection_age", time.Duration(math.MaxInt64), "Maximum age of a client connection before GoAway is sent.")
-
-	// GRPCMaxConnectionAgeGrace is an additional grace period after GRPCMaxConnectionAge, after which
-	// connections are forcibly closed.
-	GRPCMaxConnectionAgeGrace = flag.Duration("grpc_max_connection_age_grace", time.Duration(math.MaxInt64), "Additional grace period after grpc_max_connection_age, after which connections are forcibly closed.")
-
-	// GRPCInitialConnWindowSize ServerOption that sets window size for a connection.
-	// The lower bound for window size is 64K and any value smaller than that will be ignored.
-	GRPCInitialConnWindowSize = flag.Int("grpc_server_initial_conn_window_size", 0, "gRPC server initial connection window size")
-
-	// GRPCInitialWindowSize ServerOption that sets window size for stream.
-	// The lower bound for window size is 64K and any value smaller than that will be ignored.
-	GRPCInitialWindowSize = flag.Int("grpc_server_initial_window_size", 0, "gRPC server initial window size")
-
-	// EnforcementPolicy MinTime that sets the keepalive enforcement policy on the server.
-	// This is the minimum amount of time a client should wait before sending a keepalive ping.
-	GRPCKeepAliveEnforcementPolicyMinTime = flag.Duration("grpc_server_keepalive_enforcement_policy_min_time", 10*time.Second, "gRPC server minimum keepalive time")
-
-	// EnforcementPolicy PermitWithoutStream - If true, server allows keepalive pings
-	// even when there are no active streams (RPCs). If false, and client sends ping when
-	// there are no active streams, server will send GOAWAY and close the connection.
-	GRPCKeepAliveEnforcementPolicyPermitWithoutStream = flag.Bool("grpc_server_keepalive_enforcement_policy_permit_without_stream", false, "gRPC server permit client keepalive pings even when there are no active streams (RPCs)")
-
 	authPlugin Authenticator
 )
 
+// Misc. server variables.
+var (
+	// gRPCPort is the port to listen on for gRPC. If zero, don't listen.
+	gRPCPort int
+
+	// gRPCMaxConnectionAge is the maximum age of a client connection, before GoAway is sent.
+	// This is useful for L4 loadbalancing to ensure rebalancing after scaling.
+	gRPCMaxConnectionAge = time.Duration(math.MaxInt64)
+
+	// gRPCMaxConnectionAgeGrace is an additional grace period after GRPCMaxConnectionAge, after which
+	// connections are forcibly closed.
+	gRPCMaxConnectionAgeGrace = time.Duration(math.MaxInt64)
+
+	// gRPCInitialConnWindowSize ServerOption that sets window size for a connection.
+	// The lower bound for window size is 64K and any value smaller than that will be ignored.
+	gRPCInitialConnWindowSize int
+
+	// gRPCInitialWindowSize ServerOption that sets window size for stream.
+	// The lower bound for window size is 64K and any value smaller than that will be ignored.
+	gRPCInitialWindowSize int
+
+	// gRPCKeepAliveEnforcementPolicyMinTime sets the keepalive enforcement policy on the server.
+	// This is the minimum amount of time a client should wait before sending a keepalive ping.
+	gRPCKeepAliveEnforcementPolicyMinTime = 10 * time.Second
+
+	// gRPCKeepAliveEnforcementPolicyPermitWithoutStream, if true, instructs the server to allow keepalive pings
+	// even when there are no active streams (RPCs). If false, and client sends ping when
+	// there are no active streams, server will send GOAWAY and close the connection.
+	gRPCKeepAliveEnforcementPolicyPermitWithoutStream bool
+)
+
+// TLS variables.
+var (
+	// gRPCCert is the cert to use if TLS is enabled.
+	gRPCCert string
+	// gRPCKey is the key to use if TLS is enabled.
+	gRPCKey string
+	// gRPCCA is the CA to use if TLS is enabled.
+	gRPCCA string
+	// gRPCCRL is the CRL (Certificate Revocation List) to use if TLS is
+	// enabled.
+	gRPCCRL string
+	// gRPCEnableOptionalTLS enables an optional TLS mode when a server accepts
+	// both TLS and plain-text connections on the same port.
+	gRPCEnableOptionalTLS bool
+	// gRPCServerCA if specified will combine server cert and server CA.
+	gRPCServerCA string
+)
+
+// RegisterGRPCServerFlags registers flags required to run a gRPC server via Run
+// or RunDefault.
+//
+// `go/cmd/*`` entrypoints should call this function before
+// ParseFlags(WithArgs)? if they wish to expose run a gRPC server.
+func RegisterGRPCServerFlags() {
+	OnParse(func(fs *pflag.FlagSet) {
+		fs.IntVar(&gRPCPort, "grpc_port", gRPCPort, "Port to listen on for gRPC calls. If zero, do not listen.")
+		fs.DurationVar(&gRPCMaxConnectionAge, "grpc_max_connection_age", gRPCMaxConnectionAge, "Maximum age of a client connection before GoAway is sent.")
+		fs.DurationVar(&gRPCMaxConnectionAgeGrace, "grpc_max_connection_age_grace", gRPCMaxConnectionAgeGrace, "Additional grace period after grpc_max_connection_age, after which connections are forcibly closed.")
+		fs.IntVar(&gRPCInitialConnWindowSize, "grpc_server_initial_conn_window_size", gRPCInitialConnWindowSize, "gRPC server initial connection window size")
+		fs.IntVar(&gRPCInitialWindowSize, "grpc_server_initial_window_size", gRPCInitialWindowSize, "gRPC server initial window size")
+		fs.DurationVar(&gRPCKeepAliveEnforcementPolicyMinTime, "grpc_server_keepalive_enforcement_policy_min_time", gRPCKeepAliveEnforcementPolicyMinTime, "gRPC server minimum keepalive time")
+		fs.BoolVar(&gRPCKeepAliveEnforcementPolicyPermitWithoutStream, "grpc_server_keepalive_enforcement_policy_permit_without_stream", gRPCKeepAliveEnforcementPolicyPermitWithoutStream, "gRPC server permit client keepalive pings even when there are no active streams (RPCs)")
+
+		fs.StringVar(&gRPCCert, "grpc_cert", gRPCCert, "server certificate to use for gRPC connections, requires grpc_key, enables TLS")
+		fs.StringVar(&gRPCKey, "grpc_key", gRPCKey, "server private key to use for gRPC connections, requires grpc_cert, enables TLS")
+		fs.StringVar(&gRPCCA, "grpc_ca", gRPCCA, "server CA to use for gRPC connections, requires TLS, and enforces client certificate check")
+		fs.StringVar(&gRPCCRL, "grpc_crl", gRPCCRL, "path to a certificate revocation list in PEM format, client certificates will be further verified against this file during TLS handshake")
+		fs.BoolVar(&gRPCEnableOptionalTLS, "grpc_enable_optional_tls", gRPCEnableOptionalTLS, "enable optional TLS mode when a server accepts both TLS and plain-text connections on the same port")
+		fs.StringVar(&gRPCServerCA, "grpc_server_ca", gRPCServerCA, "path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients")
+	})
+}
+
+// GRPCCert returns the value of the `--grpc_cert` flag.
+func GRPCCert() string {
+	return gRPCCert
+}
+
+// GRPCCertificateAuthority returns the value of the `--grpc_ca` flag.
+func GRPCCertificateAuthority() string {
+	return gRPCCA
+}
+
+// GRPCKey returns the value of the `--grpc_key` flag.
+func GRPCKey() string {
+	return gRPCKey
+}
+
+// GRPCPort returns the value of the `--grpc_port` flag.
+func GRPCPort() int {
+	return gRPCPort
+}
+
 // isGRPCEnabled returns true if gRPC server is set
 func isGRPCEnabled() bool {
-	if GRPCPort != nil && *GRPCPort != 0 {
+	if gRPCPort != 0 {
 		return true
 	}
 
@@ -138,15 +186,15 @@ func createGRPCServer() {
 	grpccommon.EnableTracingOpt()
 
 	var opts []grpc.ServerOption
-	if GRPCPort != nil && *GRPCCert != "" && *GRPCKey != "" {
-		config, err := vttls.ServerConfig(*GRPCCert, *GRPCKey, *GRPCCA, *GRPCCRL, *GRPCServerCA, tls.VersionTLS12)
+	if gRPCCert != "" && gRPCKey != "" {
+		config, err := vttls.ServerConfig(gRPCCert, gRPCKey, gRPCCA, gRPCCRL, gRPCServerCA, tls.VersionTLS12)
 		if err != nil {
 			log.Exitf("Failed to log gRPC cert/key/ca: %v", err)
 		}
 
 		// create the creds server options
 		creds := credentials.NewTLS(config)
-		if *GRPCEnableOptionalTLS {
+		if gRPCEnableOptionalTLS {
 			log.Warning("Optional TLS is active. Plain-text connections will be accepted")
 			creds = grpcoptionaltls.New(creds)
 		}
@@ -164,31 +212,27 @@ func createGRPCServer() {
 	opts = append(opts, grpc.MaxRecvMsgSize(msgSize))
 	opts = append(opts, grpc.MaxSendMsgSize(msgSize))
 
-	if *GRPCInitialConnWindowSize != 0 {
-		log.Infof("Setting grpc server initial conn window size to %d", int32(*GRPCInitialConnWindowSize))
-		opts = append(opts, grpc.InitialConnWindowSize(int32(*GRPCInitialConnWindowSize)))
+	if gRPCInitialConnWindowSize != 0 {
+		log.Infof("Setting grpc server initial conn window size to %d", int32(gRPCInitialConnWindowSize))
+		opts = append(opts, grpc.InitialConnWindowSize(int32(gRPCInitialConnWindowSize)))
 	}
 
-	if *GRPCInitialWindowSize != 0 {
-		log.Infof("Setting grpc server initial window size to %d", int32(*GRPCInitialWindowSize))
-		opts = append(opts, grpc.InitialWindowSize(int32(*GRPCInitialWindowSize)))
+	if gRPCInitialWindowSize != 0 {
+		log.Infof("Setting grpc server initial window size to %d", int32(gRPCInitialWindowSize))
+		opts = append(opts, grpc.InitialWindowSize(int32(gRPCInitialWindowSize)))
 	}
 
 	ep := keepalive.EnforcementPolicy{
-		MinTime:             *GRPCKeepAliveEnforcementPolicyMinTime,
-		PermitWithoutStream: *GRPCKeepAliveEnforcementPolicyPermitWithoutStream,
+		MinTime:             gRPCKeepAliveEnforcementPolicyMinTime,
+		PermitWithoutStream: gRPCKeepAliveEnforcementPolicyPermitWithoutStream,
 	}
 	opts = append(opts, grpc.KeepaliveEnforcementPolicy(ep))
 
-	if GRPCMaxConnectionAge != nil {
-		ka := keepalive.ServerParameters{
-			MaxConnectionAge: *GRPCMaxConnectionAge,
-		}
-		if GRPCMaxConnectionAgeGrace != nil {
-			ka.MaxConnectionAgeGrace = *GRPCMaxConnectionAgeGrace
-		}
-		opts = append(opts, grpc.KeepaliveParams(ka))
+	ka := keepalive.ServerParameters{
+		MaxConnectionAge:      gRPCMaxConnectionAge,
+		MaxConnectionAgeGrace: gRPCMaxConnectionAgeGrace,
 	}
+	opts = append(opts, grpc.KeepaliveParams(ka))
 
 	opts = append(opts, interceptors()...)
 
@@ -225,7 +269,7 @@ func serveGRPC() {
 		grpc_prometheus.EnableHandlingTimeHistogram()
 	}
 	// skip if not registered
-	if GRPCPort == nil || *GRPCPort == 0 {
+	if gRPCPort == 0 {
 		return
 	}
 
@@ -241,10 +285,10 @@ func serveGRPC() {
 	}
 
 	// listen on the port
-	log.Infof("Listening for gRPC calls on port %v", *GRPCPort)
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", *GRPCPort))
+	log.Infof("Listening for gRPC calls on port %v", gRPCPort)
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", gRPCPort))
 	if err != nil {
-		log.Exitf("Cannot listen on port %v for gRPC: %v", *GRPCPort, err)
+		log.Exitf("Cannot listen on port %v for gRPC: %v", gRPCPort, err)
 	}
 
 	// and serve on it

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -120,7 +120,7 @@ var (
 // or RunDefault.
 //
 // `go/cmd/*`` entrypoints should call this function before
-// ParseFlags(WithArgs)? if they wish to expose run a gRPC server.
+// ParseFlags(WithArgs)? if they wish to run a gRPC server.
 func RegisterGRPCServerFlags() {
 	OnParse(func(fs *pflag.FlagSet) {
 		fs.IntVar(&gRPCPort, "grpc_port", gRPCPort, "Port to listen on for gRPC calls. If zero, do not listen.")

--- a/go/vt/servenv/pprof.go
+++ b/go/vt/servenv/pprof.go
@@ -35,7 +35,6 @@ import (
 )
 
 var (
-	_         = flag.String("cpu_profile", "", "deprecated: use '-pprof=cpu' instead")
 	pprofFlag = flag.String("pprof", "", "enable profiling")
 )
 

--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -58,18 +58,18 @@ func Run(port int) {
 	l.Close()
 
 	startTime := time.Now()
-	log.Infof("Entering lameduck mode for at least %v", *lameduckPeriod)
+	log.Infof("Entering lameduck mode for at least %v", lameduckPeriod)
 	log.Infof("Firing asynchronous OnTerm hooks")
 	go onTermHooks.Fire()
 
-	fireOnTermSyncHooks(*onTermTimeout)
-	if remain := *lameduckPeriod - time.Since(startTime); remain > 0 {
+	fireOnTermSyncHooks(onTermTimeout)
+	if remain := lameduckPeriod - time.Since(startTime); remain > 0 {
 		log.Infof("Sleeping an extra %v after OnTermSync to finish lameduck period", remain)
 		time.Sleep(remain)
 	}
 
 	log.Info("Shutting down gracefully")
-	fireOnCloseHooks(*onCloseTimeout)
+	fireOnCloseHooks(onCloseTimeout)
 }
 
 // Close runs any registered exit hooks in parallel.

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -67,8 +67,6 @@ var (
 	lameduckPeriod = flag.Duration("lameduck-period", 50*time.Millisecond, "keep running at least this long after SIGTERM before stopping")
 	onTermTimeout  = flag.Duration("onterm_timeout", 10*time.Second, "wait no more than this for OnTermSync handlers before stopping")
 	onCloseTimeout = flag.Duration("onclose_timeout", time.Nanosecond, "wait no more than this for OnClose handlers before stopping")
-	_              = flag.Int("mem-profile-rate", 512*1024, "deprecated: use '-pprof=mem' instead")
-	_              = flag.Int("mutex-profile-fraction", 0, "deprecated: use '-pprof=mutex' instead")
 	catchSigpipe   = flag.Bool("catch-sigpipe", false, "catch and ignore SIGPIPE on stdout and stderr if specified")
 
 	// mutex used to protect the Init function

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -60,8 +60,8 @@ import (
 )
 
 var (
-	// Port is part of the flags used when calling RegisterDefaultFlags.
-	Port *int
+	// port is part of the flags used when calling RegisterDefaultFlags.
+	port int
 
 	// mutex used to protect the Init function
 	mu sync.Mutex
@@ -240,12 +240,19 @@ func FireRunHooks() {
 // listening to a given port for standard connections.
 // If calling this, then call RunDefault()
 func RegisterDefaultFlags() {
-	Port = flag.Int("port", 0, "port for the server")
+	OnParse(func(fs *pflag.FlagSet) {
+		fs.IntVar(&port, "port", port, "port for the server")
+	})
+}
+
+// Port returns the value of the `--port` flag.
+func Port() int {
+	return port
 }
 
 // RunDefault calls Run() with the parameters from the flags.
 func RunDefault() {
-	Run(*Port)
+	Run(port)
 }
 
 var (

--- a/go/vt/servenv/servenv_test.go
+++ b/go/vt/servenv/servenv_test.go
@@ -67,7 +67,7 @@ func TestFireOnCloseHooksTimeout(t *testing.T) {
 
 	// we deliberatly test the flag to make sure it's not accidently set to a
 	// high value.
-	if finished, want := fireOnCloseHooks(*onCloseTimeout), false; finished != want {
+	if finished, want := fireOnCloseHooks(onCloseTimeout), false; finished != want {
 		t.Errorf("finished = %v, want %v", finished, want)
 	}
 }

--- a/go/vt/throttler/demo/throttler_demo.go
+++ b/go/vt/throttler/demo/throttler_demo.go
@@ -310,6 +310,7 @@ func main() {
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
 	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }

--- a/go/vt/throttler/demo/throttler_demo.go
+++ b/go/vt/throttler/demo/throttler_demo.go
@@ -310,5 +310,6 @@ func main() {
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	servenv.RegisterGRPCServerFlags()
 	servenv.RegisterGRPCServerAuthFlags()
 }

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1344,7 +1344,7 @@ exit $exit_code
 	onHookContent := func(status schema.OnlineDDLStatus, hint string) string {
 		return fmt.Sprintf(`#!/bin/bash
 	curl --max-time 10 -s 'http://localhost:%d/schema-migration/report-status?uuid=%s&status=%s&hint=%s&dryrun='"$GH_OST_DRY_RUN"'&progress='"$GH_OST_PROGRESS"'&eta='"$GH_OST_ETA_SECONDS"'&rowscopied='"$GH_OST_COPIED_ROWS"
-			`, *servenv.Port, onlineDDL.UUID, string(status), hint)
+			`, servenv.Port(), onlineDDL.UUID, string(status), hint)
 	}
 	if _, err := createTempScript(tempDir, "gh-ost-on-startup", onHookContent(schema.OnlineDDLStatusRunning, emptyHint)); err != nil {
 		log.Errorf("Error creating script: %+v", err)
@@ -1431,7 +1431,7 @@ exit $exit_code
 			fmt.Sprintf("--serve-socket-file=%s", serveSocketFile),
 			fmt.Sprintf("--hooks-path=%s", tempDir),
 			fmt.Sprintf(`--hooks-hint-token=%s`, onlineDDL.UUID),
-			fmt.Sprintf(`--throttle-http=http://localhost:%d/throttler/check?app=%s:gh-ost:%s&p=low`, *servenv.Port, throttlerOnlineDDLApp, onlineDDL.UUID),
+			fmt.Sprintf(`--throttle-http=http://localhost:%d/throttler/check?app=%s:gh-ost:%s&p=low`, servenv.Port(), throttlerOnlineDDLApp, onlineDDL.UUID),
 			fmt.Sprintf(`--database=%s`, e.dbName),
 			fmt.Sprintf(`--table=%s`, onlineDDL.Table),
 			fmt.Sprintf(`--alter=%s`, alterOptions),
@@ -1594,7 +1594,7 @@ export MYSQL_PWD
 
 	1;
 	`
-	pluginCode = strings.ReplaceAll(pluginCode, "{{VTTABLET_PORT}}", fmt.Sprintf("%d", *servenv.Port))
+	pluginCode = strings.ReplaceAll(pluginCode, "{{VTTABLET_PORT}}", fmt.Sprintf("%d", servenv.Port()))
 	pluginCode = strings.ReplaceAll(pluginCode, "{{MIGRATION_UUID}}", onlineDDL.UUID)
 	pluginCode = strings.ReplaceAll(pluginCode, "{{THROTTLER_ONLINE_DDL_APP}}", throttlerOnlineDDLApp)
 

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -251,7 +251,7 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--tablet_hostname", args.TabletHostName}...)
 	}
 	if servenv.GRPCAuth() == "mtls" {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--grpc_auth_mode", servenv.GRPCAuth(), "--grpc_key", *servenv.GRPCKey, "--grpc_cert", *servenv.GRPCCert, "--grpc_ca", *servenv.GRPCCA, "--grpc_auth_mtls_allowed_substrings", servenv.ClientCertSubstrings()}...)
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--grpc_auth_mode", servenv.GRPCAuth(), "--grpc_key", servenv.GRPCKey(), "--grpc_cert", servenv.GRPCCert(), "--grpc_ca", servenv.GRPCCertificateAuthority(), "--grpc_auth_mtls_allowed_substrings", servenv.ClientCertSubstrings()}...)
 	}
 	if args.InitWorkflowManager {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--workflow_manager_init"}...)


### PR DESCRIPTION


## Description

This migrates the flags used by the grpc servers calling into `servenv.Init`, `servenv.Run`, and `servenv.RunDefault`.

⚠️ it also removes the deprecated profliing flags, which were deprecated approximately 18 months ago ⚠️ 

## Related Issue(s)

- #11146 
- #11144 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
