### PR TITLE
evalengine: Support built-in MySQL function LOWER() 

### DIFF
--- a/go/vt/vtgate/evalengine/func.go
+++ b/go/vt/vtgate/evalengine/func.go
@@ -36,6 +36,7 @@ var builtinFunctions = map[string]builtin{
 	"collation": builtinCollation{},
 	"bit_count": builtinBitCount{},
 	"hex":       builtinHex{},
+	"lower":     builtinLower{},
 }
 
 var builtinFunctionsRewrite = map[string]builtinRewrite{

--- a/go/vt/vtgate/evalengine/func.go
+++ b/go/vt/vtgate/evalengine/func.go
@@ -37,6 +37,7 @@ var builtinFunctions = map[string]builtin{
 	"bit_count": builtinBitCount{},
 	"hex":       builtinHex{},
 	"lower":     builtinLower{},
+	"lcase":     builtinLcase{},
 }
 
 var builtinFunctionsRewrite = map[string]builtinRewrite{

--- a/go/vt/vtgate/evalengine/integration/string_fun_test.go
+++ b/go/vt/vtgate/evalengine/integration/string_fun_test.go
@@ -38,22 +38,15 @@ var cases = []string{
 	"-999999999999999999999999",
 }
 
-func TestBuiltinLower(t *testing.T) {
+func TestBuiltinLowerandLcase(t *testing.T) {
 	var conn = mysqlconn(t)
 	defer conn.Close()
 
 	for _, str := range cases {
 		query := fmt.Sprintf("LOWER(%s)", str)
 		compareRemoteExpr(t, conn, query)
-	}
-}
 
-func TestBuiltinLcase(t *testing.T) {
-	var conn = mysqlconn(t)
-	defer conn.Close()
-
-	for _, str := range cases {
-		query := fmt.Sprintf("LCASE(%s)", str)
+		query = fmt.Sprintf("LCASE(%s)", str)
 		compareRemoteExpr(t, conn, query)
 	}
 }

--- a/go/vt/vtgate/evalengine/integration/string_fun_test.go
+++ b/go/vt/vtgate/evalengine/integration/string_fun_test.go
@@ -18,32 +18,42 @@ import (
 	"testing"
 )
 
-func TestBuiltinLower(t *testing.T) {
-	var cases = []string{
-		"NULL",
-		"\"\"",
-		"\"a\"",
-		"\"abc\"",
-		"1",
-		"-1",
-		"0123",
-		"0xAACC",
-		"3.1415926",
-		"\"中文测试\"",
-		"\"日本語テスト\"",
-		"\"한국어 시험\"",
-		"\"😊😂🤢\"",
-		"9223372036854775807",
-		"-9223372036854775808",
-		"999999999999999999999999",
-		"-999999999999999999999999",
-	}
+var cases = []string{
+	"NULL",
+	"\"\"",
+	"\"a\"",
+	"\"abc\"",
+	"1",
+	"-1",
+	"0123",
+	"0xAACC",
+	"3.1415926",
+	"\"中文测试\"",
+	"\"日本語テスト\"",
+	"\"한국어 시험\"",
+	"\"😊😂🤢\"",
+	"9223372036854775807",
+	"-9223372036854775808",
+	"999999999999999999999999",
+	"-999999999999999999999999",
+}
 
+func TestBuiltinLower(t *testing.T) {
 	var conn = mysqlconn(t)
 	defer conn.Close()
 
 	for _, str := range cases {
 		query := fmt.Sprintf("LOWER(%s)", str)
+		compareRemoteExpr(t, conn, query)
+	}
+}
+
+func TestBuiltinLcase(t *testing.T) {
+	var conn = mysqlconn(t)
+	defer conn.Close()
+
+	for _, str := range cases {
+		query := fmt.Sprintf("LCASE(%s)", str)
 		compareRemoteExpr(t, conn, query)
 	}
 }

--- a/go/vt/vtgate/evalengine/integration/string_fun_test.go
+++ b/go/vt/vtgate/evalengine/integration/string_fun_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBuiltinLower(t *testing.T) {
+	var cases = []string{
+		"NULL",
+		"\"\"",
+		"\"a\"",
+		"\"abc\"",
+		"1",
+		"-1",
+		"0123",
+		"0xAACC",
+		"3.1415926",
+		"\"中文测试\"",
+		"\"日本語テスト\"",
+		"\"한국어 시험\"",
+		"\"😊😂🤢\"",
+		"9223372036854775807",
+		"-9223372036854775808",
+		"999999999999999999999999",
+		"-999999999999999999999999",
+	}
+
+	var conn = mysqlconn(t)
+	defer conn.Close()
+
+	for _, str := range cases {
+		query := fmt.Sprintf("LOWER(%s)", str)
+		compareRemoteExpr(t, conn, query)
+	}
+}

--- a/go/vt/vtgate/evalengine/string.go
+++ b/go/vt/vtgate/evalengine/string.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evalengine
+
+import (
+	"strings"
+
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+)
+
+type (
+	builtinLower struct{}
+)
+
+func (builtinLower) call(_ *ExpressionEnv, args []EvalResult, result *EvalResult) {
+	inarg := &args[0]
+	t := inarg.typeof()
+	if inarg.isNull() {
+		result.setNull()
+		return
+	}
+
+	if sqltypes.IsText(t) {
+		tolower := strings.ToLower(inarg.value().RawStr())
+		result.setString(tolower, inarg.collation())
+	} else {
+		tolower := inarg.value().RawStr()
+		inarg.makeTextualAndConvert(collations.CollationUtf8mb4ID)
+		result.setString(tolower, inarg.collation())
+	}
+}
+
+func (builtinLower) typeof(env *ExpressionEnv, args []Expr) (sqltypes.Type, flag) {
+	if len(args) != 1 {
+		throwArgError("LOWER")
+	}
+	_, f := args[0].typeof(env)
+	return sqltypes.VarChar, f
+}

--- a/go/vt/vtgate/evalengine/string.go
+++ b/go/vt/vtgate/evalengine/string.go
@@ -19,7 +19,6 @@ package evalengine
 import (
 	"strings"
 
-	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 )
 
@@ -28,7 +27,7 @@ type (
 	builtinLcase struct{}
 )
 
-func (builtinLower) call(_ *ExpressionEnv, args []EvalResult, result *EvalResult) {
+func (builtinLower) call(env *ExpressionEnv, args []EvalResult, result *EvalResult) {
 	inarg := &args[0]
 	t := inarg.typeof()
 	if inarg.isNull() {
@@ -41,7 +40,7 @@ func (builtinLower) call(_ *ExpressionEnv, args []EvalResult, result *EvalResult
 		result.setString(tolower, inarg.collation())
 	} else {
 		tolower := inarg.value().RawStr()
-		inarg.makeTextualAndConvert(collations.CollationUtf8mb4ID)
+		inarg.makeTextualAndConvert(env.DefaultCollation,)
 		result.setString(tolower, inarg.collation())
 	}
 }
@@ -54,7 +53,7 @@ func (builtinLower) typeof(env *ExpressionEnv, args []Expr) (sqltypes.Type, flag
 	return sqltypes.VarChar, f
 }
 
-func (builtinLcase) call(_ *ExpressionEnv, args []EvalResult, result *EvalResult) {
+func (builtinLcase) call(env *ExpressionEnv, args []EvalResult, result *EvalResult) {
 	inarg := &args[0]
 	t := inarg.typeof()
 	if inarg.isNull() {
@@ -67,7 +66,7 @@ func (builtinLcase) call(_ *ExpressionEnv, args []EvalResult, result *EvalResult
 		result.setString(tolower, inarg.collation())
 	} else {
 		tolower := inarg.value().RawStr()
-		inarg.makeTextualAndConvert(collations.CollationUtf8mb4ID)
+		inarg.makeTextualAndConvert(env.DefaultCollation,)
 		result.setString(tolower, inarg.collation())
 	}
 }


### PR DESCRIPTION
Signed-off-by: Weijun-H <huangweijun1001@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Implement support LOWER()
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- #9647 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
