### PR TITLE
Prevent martini from logging in VTOrc

### DIFF
--- a/go/vt/orchestrator/app/http.go
+++ b/go/vt/orchestrator/app/http.go
@@ -18,6 +18,8 @@ package app
 
 import (
 	"flag"
+	"io/ioutil"
+	golog "log"
 	"net"
 	nethttp "net/http"
 	"path"
@@ -76,6 +78,8 @@ func promptForSSLPasswords() {
 // standardHTTP starts serving HTTP or HTTPS (api/web) requests, to be used by normal clients
 func standardHTTP(continuousDiscovery bool) {
 	m := martini.Classic()
+	// Make martini silent by setting its logger to a discard endpoint
+	m.Logger(golog.New(ioutil.Discard, "", 0))
 
 	switch strings.ToLower(config.Config.AuthenticationMethod) {
 	case "basic":


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

It has been observed that `martini` code does excessive logging on each HTTP request served in VTOrc. This causes logs to fill up quickly and also makes it harder to find logs that are actually worth looking at.

This PR removes the logging from `martini` by setting its logger to a discard endpoint.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
