### PR TITLE
Adds delete planning to Gen4

### DIFF
--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -62,7 +62,7 @@ func (del *Delete) TryExecute(ctx context.Context, vcursor VCursor, bindVars map
 	switch del.Opcode {
 	case Unsharded:
 		return del.execUnsharded(ctx, vcursor, bindVars, rss)
-	case Equal, IN, Scatter, ByDestination, SubShard:
+	case Equal, IN, Scatter, ByDestination, SubShard, EqualUnique:
 		return del.execMultiDestination(ctx, vcursor, bindVars, rss, del.deleteVindexEntries)
 	default:
 		// Unreachable.

--- a/go/vt/vtgate/planbuilder/abstract/delete.go
+++ b/go/vt/vtgate/planbuilder/abstract/delete.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package abstract
+
+import (
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/semantics"
+)
+
+type Delete struct {
+	Table     *QueryTable
+	TableInfo semantics.TableInfo
+	AST       *sqlparser.Delete
+}
+
+var _ LogicalOperator = (*Delete)(nil)
+
+// TableID implements the LogicalOperator interface
+func (d *Delete) TableID() semantics.TableSet {
+	return d.Table.ID
+}
+
+// UnsolvedPredicates implements the LogicalOperator interface
+func (d *Delete) UnsolvedPredicates(semTable *semantics.SemTable) []sqlparser.Expr {
+	return nil
+}
+
+// CheckValid implements the LogicalOperator interface
+func (d *Delete) CheckValid() error {
+	return nil
+}
+
+// iLogical implements the LogicalOperator interface
+func (d *Delete) iLogical() {}
+
+// PushPredicate implements the LogicalOperator interface
+func (d *Delete) PushPredicate(expr sqlparser.Expr, semTable *semantics.SemTable) (LogicalOperator, error) {
+	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "can't accept predicates")
+}
+
+// Compact implements the LogicalOperator interface
+func (d *Delete) Compact(semTable *semantics.SemTable) (LogicalOperator, error) {
+	return d, nil
+}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -221,7 +221,11 @@ func createInstructionFor(query string, stmt sqlparser.Statement, reservedVars *
 		}
 		return buildRoutePlan(stmt, reservedVars, vschema, configuredPlanner)
 	case *sqlparser.Delete:
-		return buildRoutePlan(stmt, reservedVars, vschema, buildDeletePlan)
+		configuredPlanner, err := getConfiguredPlanner(vschema, buildDeletePlan, stmt, query)
+		if err != nil {
+			return nil, err
+		}
+		return buildRoutePlan(stmt, reservedVars, vschema, configuredPlanner)
 	case *sqlparser.Union:
 		configuredPlanner, err := getConfiguredPlanner(vschema, buildUnionPlan, stmt, query)
 		if err != nil {

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -25,51 +25,53 @@ import (
 )
 
 // buildDeletePlan builds the instructions for a DELETE statement.
-func buildDeletePlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, vschema plancontext.VSchema) (*planResult, error) {
-	del := stmt.(*sqlparser.Delete)
-	if del.With != nil {
-		return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: with expression in delete statement")
-	}
-	var err error
-	if len(del.TableExprs) == 1 && len(del.Targets) == 1 {
-		del, err = rewriteSingleTbl(del)
+func buildDeletePlan(string) stmtPlanner {
+	return func(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, vschema plancontext.VSchema) (*planResult, error) {
+		del := stmt.(*sqlparser.Delete)
+		if del.With != nil {
+			return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: with expression in delete statement")
+		}
+		var err error
+		if len(del.TableExprs) == 1 && len(del.Targets) == 1 {
+			del, err = rewriteSingleTbl(del)
+			if err != nil {
+				return nil, err
+			}
+		}
+		dml, tables, ksidVindex, err := buildDMLPlan(vschema, "delete", del, reservedVars, del.TableExprs, del.Where, del.OrderBy, del.Limit, del.Comments, del.Targets)
 		if err != nil {
 			return nil, err
 		}
-	}
-	dml, tables, ksidVindex, err := buildDMLPlan(vschema, "delete", del, reservedVars, del.TableExprs, del.Where, del.OrderBy, del.Limit, del.Comments, del.Targets)
-	if err != nil {
-		return nil, err
-	}
-	edel := &engine.Delete{DML: dml}
-	if dml.Opcode == engine.Unsharded {
+		edel := &engine.Delete{DML: dml}
+		if dml.Opcode == engine.Unsharded {
+			return newPlanResult(edel, tables...), nil
+		}
+
+		if len(del.Targets) > 1 {
+			return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "multi-table delete statement in not supported in sharded database")
+		}
+
+		edelTable, err := edel.GetSingleTable()
+		if err != nil {
+			return nil, err
+		}
+		if len(del.Targets) == 1 && del.Targets[0].Name != edelTable.Name {
+			return nil, vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.UnknownTable, "Unknown table '%s' in MULTI DELETE", del.Targets[0].Name.String())
+		}
+
+		if len(edelTable.Owned) > 0 {
+			aTblExpr, ok := del.TableExprs[0].(*sqlparser.AliasedTableExpr)
+			if !ok {
+				return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: delete on complex table expression")
+			}
+			tblExpr := &sqlparser.AliasedTableExpr{Expr: sqlparser.TableName{Name: edelTable.Name}, As: aTblExpr.As}
+			edel.OwnedVindexQuery = generateDMLSubquery(tblExpr, del.Where, del.OrderBy, del.Limit, edelTable, ksidVindex.Columns)
+			edel.KsidVindex = ksidVindex.Vindex
+			edel.KsidLength = len(ksidVindex.Columns)
+		}
+
 		return newPlanResult(edel, tables...), nil
 	}
-
-	if len(del.Targets) > 1 {
-		return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "multi-table delete statement in not supported in sharded database")
-	}
-
-	edelTable, err := edel.GetSingleTable()
-	if err != nil {
-		return nil, err
-	}
-	if len(del.Targets) == 1 && del.Targets[0].Name != edelTable.Name {
-		return nil, vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.UnknownTable, "Unknown table '%s' in MULTI DELETE", del.Targets[0].Name.String())
-	}
-
-	if len(edelTable.Owned) > 0 {
-		aTblExpr, ok := del.TableExprs[0].(*sqlparser.AliasedTableExpr)
-		if !ok {
-			return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: delete on complex table expression")
-		}
-		tblExpr := &sqlparser.AliasedTableExpr{Expr: sqlparser.TableName{Name: edelTable.Name}, As: aTblExpr.As}
-		edel.OwnedVindexQuery = generateDMLSubquery(tblExpr, del.Where, del.OrderBy, del.Limit, edelTable, ksidVindex.Columns)
-		edel.KsidVindex = ksidVindex.Vindex
-		edel.KsidLength = len(ksidVindex.Columns)
-	}
-
-	return newPlanResult(edel, tables...), nil
 }
 
 func rewriteSingleTbl(del *sqlparser.Delete) (*sqlparser.Delete, error) {

--- a/go/vt/vtgate/planbuilder/physical/delete.go
+++ b/go/vt/vtgate/planbuilder/physical/delete.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package physical
+
+import (
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/abstract"
+	"vitess.io/vitess/go/vt/vtgate/semantics"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+type Delete struct {
+	QTable           *abstract.QueryTable
+	VTable           *vindexes.Table
+	OwnedVindexQuery string
+	AST              *sqlparser.Delete
+}
+
+var _ abstract.PhysicalOperator = (*Delete)(nil)
+var _ abstract.IntroducesTable = (*Delete)(nil)
+
+// TableID implements the PhysicalOperator interface
+func (d *Delete) TableID() semantics.TableSet {
+	return d.QTable.ID
+}
+
+// UnsolvedPredicates implements the PhysicalOperator interface
+func (d *Delete) UnsolvedPredicates(semTable *semantics.SemTable) []sqlparser.Expr {
+	return nil
+}
+
+// CheckValid implements the PhysicalOperator interface
+func (d *Delete) CheckValid() error {
+	return nil
+}
+
+// IPhysical implements the PhysicalOperator interface
+func (d *Delete) IPhysical() {}
+
+// Cost implements the PhysicalOperator interface
+func (d *Delete) Cost() int {
+	return 1
+}
+
+// Clone implements the PhysicalOperator interface
+func (d *Delete) Clone() abstract.PhysicalOperator {
+	return &Delete{
+		QTable:           d.QTable,
+		VTable:           d.VTable,
+		OwnedVindexQuery: d.OwnedVindexQuery,
+		AST:              d.AST,
+	}
+}
+
+// GetQTable implements the IntroducesTable interface
+func (d *Delete) GetQTable() *abstract.QueryTable {
+	return d.QTable
+}
+
+// GetVTable implements the IntroducesTable interface
+func (d *Delete) GetVTable() *vindexes.Table {
+	return d.VTable
+}

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -833,7 +833,32 @@ Gen4 plan same as above
     "user.user"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from user where id = 1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where id = 1 for update",
+    "Query": "delete from `user` where id = 1",
+    "Table": "user",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "user_index"
+  },
+  "TablesUsed": [
+    "user.user"
+  ]
+}
 
 # multi-table delete with comma join
 "delete a from unsharded_a a, unsharded_b b where a.id = b.id and b.val = 1"
@@ -934,7 +959,32 @@ Gen4 plan same as above
     "user.user"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from route1 where id = 1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select Id, `Name`, Costly from `user` as route1 where id = 1 for update",
+    "Query": "delete from `user` as route1 where id = 1",
+    "Table": "user",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "user_index"
+  },
+  "TablesUsed": [
+    "user.user"
+  ]
+}
 
 # delete: routing rules for subquery
 "delete from  unsharded_a where a=(select a from route2)"
@@ -957,7 +1007,26 @@ Gen4 plan same as above
     "main.unsharded_a"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from  unsharded_a where a=(select a from route2)",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Unsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from unsharded_a where a = (select a from unsharded as route2)",
+    "Table": "unsharded, unsharded_a"
+  },
+  "TablesUsed": [
+    "main.unsharded",
+    "main.unsharded_a"
+  ]
+}
 
 # update by lookup
 "update music set val = 1 where id = 1"
@@ -1084,7 +1153,32 @@ Gen4 plan same as above
     "user.music"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from music where id = 1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select user_id, id from music where id = 1 for update",
+    "Query": "delete from music where id = 1",
+    "Table": "music",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "music_user_map"
+  },
+  "TablesUsed": [
+    "user.music"
+  ]
+}
 
 # delete from, no owned vindexes
 "delete from music_extra where user_id = 1"
@@ -1111,7 +1205,29 @@ Gen4 plan same as above
     "user.music_extra"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from music_extra where user_id = 1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from music_extra where user_id = 1",
+    "Table": "music_extra",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "user_index"
+  },
+  "TablesUsed": [
+    "user.music_extra"
+  ]
+}
 
 # simple insert, no values
 "insert into unsharded values()"
@@ -2344,7 +2460,32 @@ Gen4 plan same as above
     "user.multicolvin"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicolvin where kid=1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
+    "KsidVindex": "kid_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select kid, column_a, column_b, column_c from multicolvin where kid = 1 for update",
+    "Query": "delete from multicolvin where kid = 1",
+    "Table": "multicolvin",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "kid_index"
+  },
+  "TablesUsed": [
+    "user.multicolvin"
+  ]
+}
 
 # update columns of multi column vindex
 "update multicolvin set column_b = 1, column_c = 2 where kid = 1"
@@ -2912,7 +3053,26 @@ Gen4 plan same as above
     "main.unsharded"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from unsharded where col = (select id from unsharded_a where id = unsharded.col)",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Unsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from unsharded where col = (select id from unsharded_a where id = unsharded.col)",
+    "Table": "unsharded, unsharded_a"
+  },
+  "TablesUsed": [
+    "main.unsharded",
+    "main.unsharded_a"
+  ]
+}
 
 # update vindex value to null
 "update user set name = null where id = 1"
@@ -3199,7 +3359,32 @@ Gen4 plan same as above
     "user.music"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete music from music where id = 1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select user_id, id from music where id = 1 for update",
+    "Query": "delete from music where id = 1",
+    "Table": "music",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "music_user_map"
+  },
+  "TablesUsed": [
+    "user.music"
+  ]
+}
 
 # scatter update table with owned vindexes without changing lookup vindex
 "update user set val = 1"
@@ -3396,7 +3581,32 @@ Gen4 plan same as above
     "user.user"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from user where name = _binary 'abc'",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `name` = _binary 'abc' for update",
+    "Query": "delete from `user` where `name` = _binary 'abc'",
+    "Table": "user",
+    "Values": [
+      "VARBINARY(\"abc\")"
+    ],
+    "Vindex": "name_user_map"
+  },
+  "TablesUsed": [
+    "user.user"
+  ]
+}
 
 # delete with shard targeting
 "delete from `user[-]`.user"
@@ -3622,7 +3832,32 @@ Gen4 plan same as above
     "zlookup_unique.t1"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from zlookup_unique.t1 where c2 = 10 and c3 = 20",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "zlookup_unique",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
+    "KsidVindex": "xxhash",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select c1, c2, c3 from t1 where c2 = 10 and c3 = 20 for update",
+    "Query": "delete from t1 where c2 = 10 and c3 = 20",
+    "Table": "t1",
+    "Values": [
+      "INT64(20)"
+    ],
+    "Vindex": "lookup_t1_2"
+  },
+  "TablesUsed": [
+    "zlookup_unique.t1"
+  ]
+}
 
 # Update on backfilling and non-backfilling unique lookup vindexes should be an equal
 "update zlookup_unique.t1 set c2 = 1 where c2 = 10 and c3 = 20"
@@ -3990,7 +4225,33 @@ Gen4 plan same as above
     "user.multicol_tbl"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where cola = 1 and colb = 2",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where cola = 1 and colb = 2 for update",
+    "Query": "delete from multicol_tbl where cola = 1 and colb = 2",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  },
+  "TablesUsed": [
+    "user.multicol_tbl"
+  ]
+}
 
 # delete with a multicol vindex - reverse order
 "delete from multicol_tbl where colb = 2 and cola = 1"
@@ -4021,7 +4282,33 @@ Gen4 plan same as above
     "user.multicol_tbl"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where colb = 2 and cola = 1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where colb = 2 and cola = 1 for update",
+    "Query": "delete from multicol_tbl where colb = 2 and cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  },
+  "TablesUsed": [
+    "user.multicol_tbl"
+  ]
+}
 
 # delete with a multicol vindex using an IN clause
 "delete from multicol_tbl where colb IN (1,2) and cola = 1"
@@ -4425,7 +4712,32 @@ Gen4 plan same as above
     "user.multicol_tbl"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where cola = 1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "SubShard",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where cola = 1 for update",
+    "Query": "delete from multicol_tbl where cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "multicolIdx"
+  },
+  "TablesUsed": [
+    "user.multicol_tbl"
+  ]
+}
 
 # delete with routing using subsharding column with in query
 "delete from multicol_tbl where cola in (1,2)"
@@ -4485,7 +4797,32 @@ Gen4 plan same as above
     "user.multicol_tbl"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where name = 'foo' and cola = 2",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, `name` from multicol_tbl where `name` = 'foo' and cola = 2 for update",
+    "Query": "delete from multicol_tbl where `name` = 'foo' and cola = 2",
+    "Table": "multicol_tbl",
+    "Values": [
+      "VARCHAR(\"foo\")"
+    ],
+    "Vindex": "name_muticoltbl_map"
+  },
+  "TablesUsed": [
+    "user.multicol_tbl"
+  ]
+}
 
 # insert using select with simple table.
 "insert into music(id, user_id) select * from user"
@@ -5545,7 +5882,6 @@ Gen4 plan same as above
 }
 Gen4 plan same as above
 
-
 # explain dml without any directive should fail
 "explain format=vtexplain delete from user"
 "explain format = vtexplain will actually run queries. `/*vt+ EXECUTE_DML_QUERIES */` must be set to run DML queries in vtexplain. Example: `explain /*vt+ EXECUTE_DML_QUERIES */ format = vtexplain delete from t1`"
@@ -5613,3 +5949,46 @@ Gen4 plan same as above
 }
 Gen4 plan same as above
 
+# Here V3 populates the TablesUsed incorrectly
+# delete with join from multi table join subquery.
+"delete foo from unsharded as foo join (select id from unsharded a join unsharded_b b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000"
+{
+  "QueryType": "DELETE",
+  "Original": "delete foo from unsharded as foo join (select id from unsharded a join unsharded_b b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Unsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete foo from unsharded as foo join (select id from unsharded as a join unsharded_b as b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000",
+    "Table": "unsharded, unsharded, unsharded_b"
+  },
+  "TablesUsed": [
+    "main.unsharded",
+    "main.unsharded, unsharded_b"
+  ]
+}
+{
+  "QueryType": "DELETE",
+  "Original": "delete foo from unsharded as foo join (select id from unsharded a join unsharded_b b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Unsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete foo from unsharded as foo join (select id from unsharded as a join unsharded_b as b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000",
+    "Table": "unsharded, unsharded_b"
+  },
+  "TablesUsed": [
+    "main.unsharded",
+    "main.unsharded_b"
+  ]
+}

--- a/go/vt/vtgate/planbuilder/testdata/oltp_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/oltp_cases.txt
@@ -345,7 +345,29 @@
     "main.sbtest15"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "DELETE FROM sbtest15 WHERE id=7525",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from sbtest15 where id = 7525",
+    "Table": "sbtest15",
+    "Values": [
+      "INT64(7525)"
+    ],
+    "Vindex": "hash"
+  },
+  "TablesUsed": [
+    "main.sbtest15"
+  ]
+}
 
 # OLTP insert
 "INSERT INTO sbtest16 (id, k, c, pad) VALUES (42, 1, 2, 50)"

--- a/go/vt/vtgate/planbuilder/testdata/tpcc_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/tpcc_cases.txt
@@ -1126,7 +1126,29 @@ Gen4 plan same as above
     "main.new_orders1"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "DELETE FROM new_orders1 WHERE no_o_id = 2218 AND no_d_id = 358 AND no_w_id = 98465",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from new_orders1 where no_o_id = 2218 and no_d_id = 358 and no_w_id = 98465",
+    "Table": "new_orders1",
+    "Values": [
+      "INT64(98465)"
+    ],
+    "Vindex": "hash"
+  },
+  "TablesUsed": [
+    "main.new_orders1"
+  ]
+}
 
 # TPC-C select unique orders1
 "SELECT o_c_id FROM orders1 WHERE o_id = 6 AND o_d_id = 1983 AND o_w_id = 894605"
@@ -1639,7 +1661,29 @@ Gen4 plan same as above
     "main.order_line1"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "DELETE FROM order_line1 where ol_w_id=178 AND ol_d_id=1 AND ol_o_id=84",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from order_line1 where ol_w_id = 178 and ol_d_id = 1 and ol_o_id = 84",
+    "Table": "order_line1",
+    "Values": [
+      "INT64(178)"
+    ],
+    "Vindex": "hash"
+  },
+  "TablesUsed": [
+    "main.order_line1"
+  ]
+}
 
 # TPC-C delete orders1
 "DELETE FROM orders1 where o_w_id=1 AND o_d_id=3 and o_id=384"
@@ -1666,7 +1710,29 @@ Gen4 plan same as above
     "main.orders1"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "DELETE FROM orders1 where o_w_id=1 AND o_d_id=3 and o_id=384",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from orders1 where o_w_id = 1 and o_d_id = 3 and o_id = 384",
+    "Table": "orders1",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "hash"
+  },
+  "TablesUsed": [
+    "main.orders1"
+  ]
+}
 
 # TPC-C delete history1
 "DELETE FROM history1 where h_w_id=75 AND h_d_id=102 LIMIT 10"
@@ -1693,4 +1759,26 @@ Gen4 plan same as above
     "main.history1"
   ]
 }
-Gen4 plan same as above
+{
+  "QueryType": "DELETE",
+  "Original": "DELETE FROM history1 where h_w_id=75 AND h_d_id=102 LIMIT 10",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from history1 where h_w_id = 75 and h_d_id = 102 limit 10",
+    "Table": "history1",
+    "Values": [
+      "INT64(75)"
+    ],
+    "Vindex": "hash"
+  },
+  "TablesUsed": [
+    "main.history1"
+  ]
+}

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -60,11 +60,11 @@ func newScoper() *scoper {
 func (s *scoper) down(cursor *sqlparser.Cursor) error {
 	node := cursor.Node()
 	switch node := node.(type) {
-	case *sqlparser.Update:
+	case *sqlparser.Update, *sqlparser.Delete:
 		currScope := newScope(s.currentScope())
 		s.push(currScope)
 
-		currScope.stmt = node
+		currScope.stmt = node.(sqlparser.Statement)
 	case *sqlparser.Select:
 		currScope := newScope(s.currentScope())
 		s.push(currScope)


### PR DESCRIPTION


<!--  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds delete planning to Gen4 planner. This was required specifically for the following types of queries leads to incorrect tables used populated by v3 - 
```json
# delete with join from multi table join subquery.
"delete foo from unsharded as foo join (select id from unsharded a join unsharded_b b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000"
{
  "QueryType": "DELETE",
  "Original": "delete foo from unsharded as foo join (select id from unsharded a join unsharded_b b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000",
  "Instructions": {
    "OperatorType": "Delete",
    "Variant": "Unsharded",
    "Keyspace": {
      "Name": "main",
      "Sharded": false
    },
    "TargetTabletType": "PRIMARY",
    "MultiShardAutocommit": false,
    "Query": "delete foo from unsharded as foo join (select id from unsharded as a join unsharded_b as b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000",
    "Table": "unsharded, unsharded, unsharded_b"
  },
  "TablesUsed": [
    "main.unsharded",
    "main.unsharded, unsharded_b"
  ]
}
{
  "QueryType": "DELETE",
  "Original": "delete foo from unsharded as foo join (select id from unsharded a join unsharded_b b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000",
  "Instructions": {
    "OperatorType": "Delete",
    "Variant": "Unsharded",
    "Keyspace": {
      "Name": "main",
      "Sharded": false
    },
    "TargetTabletType": "PRIMARY",
    "MultiShardAutocommit": false,
    "Query": "delete foo from unsharded as foo join (select id from unsharded as a join unsharded_b as b on a.user_id = b.user_id) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000",
    "Table": "unsharded, unsharded_b"
  },
  "TablesUsed": [
    "main.unsharded",
    "main.unsharded_b"
  ]
}

```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
