### PR TITLE
Simple code freeze script and workflow

### DIFF
--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -1,0 +1,12 @@
+name: Code Freeze
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Code Freeze
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fail if Code Freeze is enabled
+      run: |
+        exit 0

--- a/tools/code_freeze.sh
+++ b/tools/code_freeze.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright 2022 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+freeze=$1
+branch=$2
+code_freeze_workflow="./.github/workflows/code_freeze.yml"
+
+if [ "$freeze" != "freeze" && "$freeze" != "unfreeze" ]; then
+    echo "the first argument must be either 'freeze' or 'unfreeze'"
+    exit 1
+fi
+
+git checkout -b $branch-code-freeze-1 $branch
+for (( i = 2; $? != 0; i++ )); do
+  git checkout -b $branch-code-freeze-$i $branch
+done
+
+if [ "$freeze" == "freeze" ]; then
+    sed -i.bak -E "s/exit (.*)/exit 1/g" $code_freeze_workflow
+elif [ "$freeze" == "unfreeze" ]; then
+    sed -i.bak -E "s/exit (.*)/exit 0/g" $code_freeze_workflow
+fi
+
+rm -f $code_freeze_workflow.bak
+
+git add --all
+git commit -n -s -m "Code $freeze of $branch"


### PR DESCRIPTION
## Description

This PR adds a script that enables us to freeze the code of a branch.

The script can be used as follows:
```
./tools/code_freeze.sh freeze release-14.0     # to freeze
./tools/code_freeze.sh unfreeze release-14.0   # to unfreeze
```

When hitting `freeze`, the script will make the newly introduced workflow fail. And when we use `unfreeze`, the workflow will pass again.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
