### PR TITLE
Install panic handler for all grpcvtctldserver endpoints

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -688,7 +688,7 @@ func (s *VtctldServer) CreateShard(ctx context.Context, req *vtctldatapb.CreateS
 	if req.IncludeParent {
 		log.Infof("Creating empty keyspace for %s", req.Keyspace)
 		if err2 := s.ts.CreateKeyspace(ctx, req.Keyspace, &topodatapb.Keyspace{}); err2 != nil {
-			if req.Force && topo.IsErrType(err, topo.NodeExists) {
+			if req.Force && topo.IsErrType(err2, topo.NodeExists) {
 				log.Infof("keyspace %v already exists; ignoring error because Force = true", req.Keyspace)
 			} else {
 				err = err2

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -703,6 +703,7 @@ func (s *VtctldServer) CreateShard(ctx context.Context, req *vtctldatapb.CreateS
 		if req.Force && topo.IsErrType(err, topo.NodeExists) {
 			log.Infof("shard %v/%v already exists; ignoring error because Force = true", req.Keyspace, req.ShardName)
 			shardExists = true
+			err = nil
 		} else {
 			return nil, err
 		}

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -97,13 +97,22 @@ func NewVtctldServer(ts *topo.Server) *VtctldServer {
 	}
 }
 
+func panicHandler(err *error) {
+	if x := recover(); x != nil {
+		*err = fmt.Errorf("uncaught panic: %v", x)
+	}
+}
+
 // AddCellInfo is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) AddCellInfo(ctx context.Context, req *vtctldatapb.AddCellInfoRequest) (*vtctldatapb.AddCellInfoResponse, error) {
+func (s *VtctldServer) AddCellInfo(ctx context.Context, req *vtctldatapb.AddCellInfoRequest) (resp *vtctldatapb.AddCellInfoResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.AddCellInfo")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	if req.CellInfo.Root == "" {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "CellInfo.Root must be non-empty")
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "CellInfo.Root must be non-empty")
+		return nil, err
 	}
 
 	span.Annotate("cell", req.Name)
@@ -113,7 +122,7 @@ func (s *VtctldServer) AddCellInfo(ctx context.Context, req *vtctldatapb.AddCell
 	ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer cancel()
 
-	if err := s.ts.CreateCellInfo(ctx, req.Name, req.CellInfo); err != nil {
+	if err = s.ts.CreateCellInfo(ctx, req.Name, req.CellInfo); err != nil {
 		return nil, err
 	}
 
@@ -121,9 +130,11 @@ func (s *VtctldServer) AddCellInfo(ctx context.Context, req *vtctldatapb.AddCell
 }
 
 // AddCellsAlias is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) AddCellsAlias(ctx context.Context, req *vtctldatapb.AddCellsAliasRequest) (*vtctldatapb.AddCellsAliasResponse, error) {
+func (s *VtctldServer) AddCellsAlias(ctx context.Context, req *vtctldatapb.AddCellsAliasRequest) (resp *vtctldatapb.AddCellsAliasResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.AddCellsAlias")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("cells_alias", req.Name)
 	span.Annotate("cells", strings.Join(req.Cells, ","))
@@ -131,7 +142,7 @@ func (s *VtctldServer) AddCellsAlias(ctx context.Context, req *vtctldatapb.AddCe
 	ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer cancel()
 
-	if err := s.ts.CreateCellsAlias(ctx, req.Name, &topodatapb.CellsAlias{Cells: req.Cells}); err != nil {
+	if err = s.ts.CreateCellsAlias(ctx, req.Name, &topodatapb.CellsAlias{Cells: req.Cells}); err != nil {
 		return nil, err
 	}
 
@@ -139,26 +150,29 @@ func (s *VtctldServer) AddCellsAlias(ctx context.Context, req *vtctldatapb.AddCe
 }
 
 // ApplyRoutingRules is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ApplyRoutingRules(ctx context.Context, req *vtctldatapb.ApplyRoutingRulesRequest) (*vtctldatapb.ApplyRoutingRulesResponse, error) {
+func (s *VtctldServer) ApplyRoutingRules(ctx context.Context, req *vtctldatapb.ApplyRoutingRulesRequest) (resp *vtctldatapb.ApplyRoutingRulesResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ApplyRoutingRules")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("skip_rebuild", req.SkipRebuild)
 	span.Annotate("rebuild_cells", strings.Join(req.RebuildCells, ","))
 
-	if err := s.ts.SaveRoutingRules(ctx, req.RoutingRules); err != nil {
+	if err = s.ts.SaveRoutingRules(ctx, req.RoutingRules); err != nil {
 		return nil, err
 	}
 
-	resp := &vtctldatapb.ApplyRoutingRulesResponse{}
+	resp = &vtctldatapb.ApplyRoutingRulesResponse{}
 
 	if req.SkipRebuild {
 		log.Warningf("Skipping rebuild of SrvVSchema, will need to run RebuildVSchemaGraph for changes to take effect")
 		return resp, nil
 	}
 
-	if err := s.ts.RebuildSrvVSchema(ctx, req.RebuildCells); err != nil {
-		return nil, vterrors.Wrapf(err, "RebuildSrvVSchema(%v) failed: %v", req.RebuildCells, err)
+	if err = s.ts.RebuildSrvVSchema(ctx, req.RebuildCells); err != nil {
+		err = vterrors.Wrapf(err, "RebuildSrvVSchema(%v) failed: %v", req.RebuildCells, err)
+		return nil, err
 	}
 
 	return resp, nil
@@ -169,12 +183,15 @@ func (s *VtctldServer) ApplySchema(ctx context.Context, req *vtctldatapb.ApplySc
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ApplySchema")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("skip_preflight", req.SkipPreflight)
 	span.Annotate("ddl_strategy", req.DdlStrategy)
 
 	if len(req.Sql) == 0 {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "Sql must be a non-empty array")
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "Sql must be a non-empty array")
+		return nil, err
 	}
 
 	// Attach the callerID as the EffectiveCallerID.
@@ -185,7 +202,8 @@ func (s *VtctldServer) ApplySchema(ctx context.Context, req *vtctldatapb.ApplySc
 
 	executionUUID, err := schema.CreateUUID()
 	if err != nil {
-		return resp, vterrors.Wrapf(err, "unable to create execution UUID")
+		err = vterrors.Wrapf(err, "unable to create execution UUID")
+		return resp, err
 	}
 
 	migrationContext := req.MigrationContext
@@ -195,7 +213,8 @@ func (s *VtctldServer) ApplySchema(ctx context.Context, req *vtctldatapb.ApplySc
 
 	waitReplicasTimeout, ok, err := protoutil.DurationFromProto(req.WaitReplicasTimeout)
 	if err != nil {
-		return nil, vterrors.Wrapf(err, "unable to parse WaitReplicasTimeout into a valid duration")
+		err = vterrors.Wrapf(err, "unable to parse WaitReplicasTimeout into a valid duration")
+		return nil, err
 	} else if !ok {
 		waitReplicasTimeout = time.Second * 30
 	}
@@ -217,13 +236,15 @@ func (s *VtctldServer) ApplySchema(ctx context.Context, req *vtctldatapb.ApplySc
 		executor.SkipPreflight()
 	}
 
-	if err := executor.SetDDLStrategy(req.DdlStrategy); err != nil {
-		return resp, vterrors.Wrapf(err, "invalid DdlStrategy: %s", req.DdlStrategy)
+	if err = executor.SetDDLStrategy(req.DdlStrategy); err != nil {
+		err = vterrors.Wrapf(err, "invalid DdlStrategy: %s", req.DdlStrategy)
+		return resp, err
 	}
 
 	if len(req.UuidList) > 0 {
-		if err := executor.SetUUIDList(req.UuidList); err != nil {
-			return resp, vterrors.Wrapf(err, "invalid UuidList: %s", req.UuidList)
+		if err = executor.SetUUIDList(req.UuidList); err != nil {
+			err = vterrors.Wrapf(err, "invalid UuidList: %s", req.UuidList)
+			return resp, err
 		}
 	}
 
@@ -243,51 +264,59 @@ func (s *VtctldServer) ApplySchema(ctx context.Context, req *vtctldatapb.ApplySc
 }
 
 // ApplyVSchema is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ApplyVSchema(ctx context.Context, req *vtctldatapb.ApplyVSchemaRequest) (*vtctldatapb.ApplyVSchemaResponse, error) {
+func (s *VtctldServer) ApplyVSchema(ctx context.Context, req *vtctldatapb.ApplyVSchemaRequest) (resp *vtctldatapb.ApplyVSchemaResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ApplyVSchema")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("cells", strings.Join(req.Cells, ","))
 	span.Annotate("skip_rebuild", req.SkipRebuild)
 	span.Annotate("dry_run", req.DryRun)
 
-	if _, err := s.ts.GetKeyspace(ctx, req.Keyspace); err != nil {
+	if _, err = s.ts.GetKeyspace(ctx, req.Keyspace); err != nil {
 		if topo.IsErrType(err, topo.NoNode) {
-			return nil, vterrors.Wrapf(err, "keyspace(%s) doesn't exist, check if the keyspace is initialized", req.Keyspace)
+			err = vterrors.Wrapf(err, "keyspace(%s) doesn't exist, check if the keyspace is initialized", req.Keyspace)
+		} else {
+			err = vterrors.Wrapf(err, "GetKeyspace(%s)", req.Keyspace)
 		}
-		return nil, vterrors.Wrapf(err, "GetKeyspace(%s)", req.Keyspace)
+
+		return nil, err
 	}
 
 	if (req.Sql != "" && req.VSchema != nil) || (req.Sql == "" && req.VSchema == nil) {
-		return nil, vterrors.New(vtrpc.Code_INVALID_ARGUMENT, "must pass exactly one of req.VSchema and req.Sql")
+		err = vterrors.New(vtrpc.Code_INVALID_ARGUMENT, "must pass exactly one of req.VSchema and req.Sql")
+		return nil, err
 	}
 
-	var (
-		vs  *vschemapb.Keyspace
-		err error
-	)
+	var vs *vschemapb.Keyspace
 
 	if req.Sql != "" {
 		span.Annotate("sql_mode", true)
 
-		stmt, err := sqlparser.Parse(req.Sql)
+		var stmt sqlparser.Statement
+		stmt, err = sqlparser.Parse(req.Sql)
 		if err != nil {
-			return nil, vterrors.Wrapf(err, "Parse(%s)", req.Sql)
+			err = vterrors.Wrapf(err, "Parse(%s)", req.Sql)
+			return nil, err
 		}
 		ddl, ok := stmt.(*sqlparser.AlterVschema)
 		if !ok {
-			return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "error parsing VSchema DDL statement `%s`", req.Sql)
+			err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "error parsing VSchema DDL statement `%s`", req.Sql)
+			return nil, err
 		}
 
 		vs, err = s.ts.GetVSchema(ctx, req.Keyspace)
 		if err != nil && !topo.IsErrType(err, topo.NoNode) {
-			return nil, vterrors.Wrapf(err, "GetVSchema(%s)", req.Keyspace)
+			err = vterrors.Wrapf(err, "GetVSchema(%s)", req.Keyspace)
+			return nil, err
 		} // otherwise, we keep the empty vschema object from above
 
 		vs, err = topotools.ApplyVSchemaDDL(req.Keyspace, vs, ddl)
 		if err != nil {
-			return nil, vterrors.Wrapf(err, "ApplyVSchemaDDL(%s,%v,%v)", req.Keyspace, vs, ddl)
+			err = vterrors.Wrapf(err, "ApplyVSchemaDDL(%s,%v,%v)", req.Keyspace, vs, ddl)
+			return nil, err
 		}
 	} else { // "jsonMode"
 		span.Annotate("sql_mode", false)
@@ -299,25 +328,30 @@ func (s *VtctldServer) ApplyVSchema(ctx context.Context, req *vtctldatapb.ApplyV
 	}
 
 	if err = s.ts.SaveVSchema(ctx, req.Keyspace, vs); err != nil {
-		return nil, vterrors.Wrapf(err, "SaveVSchema(%s, %v)", req.Keyspace, req.VSchema)
+		err = vterrors.Wrapf(err, "SaveVSchema(%s, %v)", req.Keyspace, req.VSchema)
+		return nil, err
 	}
 
 	if !req.SkipRebuild {
-		if err := s.ts.RebuildSrvVSchema(ctx, req.Cells); err != nil {
-			return nil, vterrors.Wrapf(err, "RebuildSrvVSchema")
+		if err = s.ts.RebuildSrvVSchema(ctx, req.Cells); err != nil {
+			err = vterrors.Wrapf(err, "RebuildSrvVSchema")
+			return nil, err
 		}
 	}
 	updatedVS, err := s.ts.GetVSchema(ctx, req.Keyspace)
 	if err != nil {
-		return nil, vterrors.Wrapf(err, "GetVSchema(%s)", req.Keyspace)
+		err = vterrors.Wrapf(err, "GetVSchema(%s)", req.Keyspace)
+		return nil, err
 	}
 	return &vtctldatapb.ApplyVSchemaResponse{VSchema: updatedVS}, nil
 }
 
 // Backup is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) Backup(req *vtctldatapb.BackupRequest, stream vtctlservicepb.Vtctld_BackupServer) error {
+func (s *VtctldServer) Backup(req *vtctldatapb.BackupRequest, stream vtctlservicepb.Vtctld_BackupServer) (err error) {
 	span, ctx := trace.NewSpan(stream.Context(), "VtctldServer.Backup")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 	span.Annotate("allow_primary", req.AllowPrimary)
@@ -331,13 +365,16 @@ func (s *VtctldServer) Backup(req *vtctldatapb.BackupRequest, stream vtctlservic
 	span.Annotate("keyspace", ti.Keyspace)
 	span.Annotate("shard", ti.Shard)
 
-	return s.backupTablet(ctx, ti.Tablet, req, stream)
+	err = s.backupTablet(ctx, ti.Tablet, req, stream)
+	return err
 }
 
 // BackupShard is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) BackupShard(req *vtctldatapb.BackupShardRequest, stream vtctlservicepb.Vtctld_BackupShardServer) error {
+func (s *VtctldServer) BackupShard(req *vtctldatapb.BackupShardRequest, stream vtctlservicepb.Vtctld_BackupShardServer) (err error) {
 	span, ctx := trace.NewSpan(stream.Context(), "VtctldServer.BackupShard")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
@@ -379,13 +416,15 @@ func (s *VtctldServer) BackupShard(req *vtctldatapb.BackupShardRequest, stream v
 	}
 
 	if backupTablet == nil {
-		return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no tablet available for backup")
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no tablet available for backup")
+		return err
 	}
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(backupTablet.Alias))
 
 	r := &vtctldatapb.BackupRequest{Concurrency: req.Concurrency, AllowPrimary: req.AllowPrimary}
-	return s.backupTablet(ctx, backupTablet, r, stream)
+	err = s.backupTablet(ctx, backupTablet, r, stream)
+	return err
 }
 
 func (s *VtctldServer) backupTablet(ctx context.Context, tablet *topodatapb.Tablet, req *vtctldatapb.BackupRequest, stream interface {
@@ -434,9 +473,11 @@ func (s *VtctldServer) backupTablet(ctx context.Context, tablet *topodatapb.Tabl
 }
 
 // ChangeTabletType is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ChangeTabletType(ctx context.Context, req *vtctldatapb.ChangeTabletTypeRequest) (*vtctldatapb.ChangeTabletTypeResponse, error) {
+func (s *VtctldServer) ChangeTabletType(ctx context.Context, req *vtctldatapb.ChangeTabletTypeRequest) (resp *vtctldatapb.ChangeTabletTypeResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ChangeTabletType")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 	span.Annotate("dry_run", req.DryRun)
@@ -453,7 +494,8 @@ func (s *VtctldServer) ChangeTabletType(ctx context.Context, req *vtctldatapb.Ch
 	span.Annotate("before_tablet_type", topoproto.TabletTypeLString(tablet.Type))
 
 	if !topo.IsTrivialTypeChange(tablet.Type, req.DbType) {
-		return nil, fmt.Errorf("tablet %v type change %v -> %v is not an allowed transition for ChangeTabletType", req.TabletAlias, tablet.Type, req.DbType)
+		err = fmt.Errorf("tablet %v type change %v -> %v is not an allowed transition for ChangeTabletType", req.TabletAlias, tablet.Type, req.DbType)
+		return nil, err
 	}
 
 	if req.DryRun {
@@ -483,20 +525,24 @@ func (s *VtctldServer) ChangeTabletType(ctx context.Context, req *vtctldatapb.Ch
 	}
 
 	if !shard.HasPrimary() {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no primary tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no primary tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
+		return nil, err
 	}
 
 	shardPrimary, err := s.ts.GetTablet(ctx, shard.PrimaryAlias)
 	if err != nil {
-		return nil, fmt.Errorf("cannot lookup primary tablet %v for shard %v/%v: %w", topoproto.TabletAliasString(shard.PrimaryAlias), tablet.Keyspace, tablet.Shard, err)
+		err = fmt.Errorf("cannot lookup primary tablet %v for shard %v/%v: %w", topoproto.TabletAliasString(shard.PrimaryAlias), tablet.Keyspace, tablet.Shard, err)
+		return nil, err
 	}
 
 	if shardPrimary.Type != topodatapb.TabletType_PRIMARY {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "TopologyServer has incosistent state for shard primary %v", topoproto.TabletAliasString(shard.PrimaryAlias))
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "TopologyServer has incosistent state for shard primary %v", topoproto.TabletAliasString(shard.PrimaryAlias))
+		return nil, err
 	}
 
 	if shardPrimary.Keyspace != tablet.Keyspace || shardPrimary.Shard != tablet.Shard {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary %v and potential replica %v not in same keypace shard (%v/%v)", topoproto.TabletAliasString(shard.PrimaryAlias), req.TabletAlias, tablet.Keyspace, tablet.Shard)
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary %v and potential replica %v not in same keypace shard (%v/%v)", topoproto.TabletAliasString(shard.PrimaryAlias), req.TabletAlias, tablet.Keyspace, tablet.Shard)
+		return nil, err
 	}
 
 	// We should clone the tablet and change its type to the expected type before checking the durability rules
@@ -525,9 +571,11 @@ func (s *VtctldServer) ChangeTabletType(ctx context.Context, req *vtctldatapb.Ch
 }
 
 // CreateKeyspace is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) CreateKeyspace(ctx context.Context, req *vtctldatapb.CreateKeyspaceRequest) (*vtctldatapb.CreateKeyspaceResponse, error) {
+func (s *VtctldServer) CreateKeyspace(ctx context.Context, req *vtctldatapb.CreateKeyspaceRequest) (resp *vtctldatapb.CreateKeyspaceResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.CreateKeyspace")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Name)
 	span.Annotate("keyspace_type", topoproto.KeyspaceTypeLString(req.Type))
@@ -539,11 +587,13 @@ func (s *VtctldServer) CreateKeyspace(ctx context.Context, req *vtctldatapb.Crea
 	case topodatapb.KeyspaceType_NORMAL:
 	case topodatapb.KeyspaceType_SNAPSHOT:
 		if req.BaseKeyspace == "" {
-			return nil, errors.New("BaseKeyspace is required for SNAPSHOT keyspaces")
+			err = errors.New("BaseKeyspace is required for SNAPSHOT keyspaces")
+			return nil, err
 		}
 
 		if req.SnapshotTime == nil {
-			return nil, errors.New("SnapshotTime is required for SNAPSHOT keyspaces")
+			err = errors.New("SnapshotTime is required for SNAPSHOT keyspaces")
+			return nil, err
 		}
 
 		span.Annotate("base_keyspace", req.BaseKeyspace)
@@ -560,7 +610,7 @@ func (s *VtctldServer) CreateKeyspace(ctx context.Context, req *vtctldatapb.Crea
 		DurabilityPolicy: req.DurabilityPolicy,
 	}
 
-	err := s.ts.CreateKeyspace(ctx, req.Name, ki)
+	err = s.ts.CreateKeyspace(ctx, req.Name, ki)
 	if req.Force && topo.IsErrType(err, topo.NodeExists) {
 		log.Infof("keyspace %v already exists (ignoring error with Force=true)", req.Name)
 		err = nil
@@ -578,13 +628,14 @@ func (s *VtctldServer) CreateKeyspace(ctx context.Context, req *vtctldatapb.Crea
 	}
 
 	if !req.AllowEmptyVSchema {
-		if err := s.ts.EnsureVSchema(ctx, req.Name); err != nil {
+		if err = s.ts.EnsureVSchema(ctx, req.Name); err != nil {
 			return nil, err
 		}
 	}
 
 	if req.Type == topodatapb.KeyspaceType_SNAPSHOT {
-		vs, err := s.ts.GetVSchema(ctx, req.BaseKeyspace)
+		var vs *vschemapb.Keyspace
+		vs, err = s.ts.GetVSchema(ctx, req.BaseKeyspace)
 		if err != nil {
 			log.Infof("error from GetVSchema(%v) = %v", req.BaseKeyspace, err)
 			if topo.IsErrType(err, topo.NoNode) {
@@ -602,8 +653,9 @@ func (s *VtctldServer) CreateKeyspace(ctx context.Context, req *vtctldatapb.Crea
 		// SNAPSHOT keyspaces are excluded from global routing.
 		vs.RequireExplicitRouting = true
 
-		if err := s.ts.SaveVSchema(ctx, req.Name, vs); err != nil {
-			return nil, fmt.Errorf("SaveVSchema(%v) = %w", vs, err)
+		if err = s.ts.SaveVSchema(ctx, req.Name, vs); err != nil {
+			err = fmt.Errorf("SaveVSchema(%v) = %w", vs, err)
+			return nil, err
 		}
 	}
 
@@ -622,9 +674,11 @@ func (s *VtctldServer) CreateKeyspace(ctx context.Context, req *vtctldatapb.Crea
 }
 
 // CreateShard is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) CreateShard(ctx context.Context, req *vtctldatapb.CreateShardRequest) (*vtctldatapb.CreateShardResponse, error) {
+func (s *VtctldServer) CreateShard(ctx context.Context, req *vtctldatapb.CreateShardRequest) (resp *vtctldatapb.CreateShardResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.CreateShard")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.ShardName)
@@ -633,10 +687,11 @@ func (s *VtctldServer) CreateShard(ctx context.Context, req *vtctldatapb.CreateS
 
 	if req.IncludeParent {
 		log.Infof("Creating empty keyspace for %s", req.Keyspace)
-		if err := s.ts.CreateKeyspace(ctx, req.Keyspace, &topodatapb.Keyspace{}); err != nil {
+		if err2 := s.ts.CreateKeyspace(ctx, req.Keyspace, &topodatapb.Keyspace{}); err2 != nil {
 			if req.Force && topo.IsErrType(err, topo.NodeExists) {
 				log.Infof("keyspace %v already exists; ignoring error because Force = true", req.Keyspace)
 			} else {
+				err = err2
 				return nil, err
 			}
 		}
@@ -644,7 +699,7 @@ func (s *VtctldServer) CreateShard(ctx context.Context, req *vtctldatapb.CreateS
 
 	shardExists := false
 
-	if err := s.ts.CreateShard(ctx, req.Keyspace, req.ShardName); err != nil {
+	if err = s.ts.CreateShard(ctx, req.Keyspace, req.ShardName); err != nil {
 		if req.Force && topo.IsErrType(err, topo.NodeExists) {
 			log.Infof("shard %v/%v already exists; ignoring error because Force = true", req.Keyspace, req.ShardName)
 			shardExists = true
@@ -681,9 +736,11 @@ func (s *VtctldServer) CreateShard(ctx context.Context, req *vtctldatapb.CreateS
 }
 
 // DeleteCellInfo is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) DeleteCellInfo(ctx context.Context, req *vtctldatapb.DeleteCellInfoRequest) (*vtctldatapb.DeleteCellInfoResponse, error) {
+func (s *VtctldServer) DeleteCellInfo(ctx context.Context, req *vtctldatapb.DeleteCellInfoRequest) (resp *vtctldatapb.DeleteCellInfoResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.DeleteCellInfo")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("cell", req.Name)
 	span.Annotate("force", req.Force)
@@ -691,7 +748,7 @@ func (s *VtctldServer) DeleteCellInfo(ctx context.Context, req *vtctldatapb.Dele
 	ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer cancel()
 
-	if err := s.ts.DeleteCellInfo(ctx, req.Name, req.Force); err != nil {
+	if err = s.ts.DeleteCellInfo(ctx, req.Name, req.Force); err != nil {
 		return nil, err
 	}
 
@@ -699,16 +756,18 @@ func (s *VtctldServer) DeleteCellInfo(ctx context.Context, req *vtctldatapb.Dele
 }
 
 // DeleteCellsAlias is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) DeleteCellsAlias(ctx context.Context, req *vtctldatapb.DeleteCellsAliasRequest) (*vtctldatapb.DeleteCellsAliasResponse, error) {
+func (s *VtctldServer) DeleteCellsAlias(ctx context.Context, req *vtctldatapb.DeleteCellsAliasRequest) (resp *vtctldatapb.DeleteCellsAliasResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.DeleteCellsAlias")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("cells_alias", req.Name)
 
 	ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer cancel()
 
-	if err := s.ts.DeleteCellsAlias(ctx, req.Name); err != nil {
+	if err = s.ts.DeleteCellsAlias(ctx, req.Name); err != nil {
 		return nil, err
 	}
 
@@ -716,9 +775,11 @@ func (s *VtctldServer) DeleteCellsAlias(ctx context.Context, req *vtctldatapb.De
 }
 
 // DeleteKeyspace is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) DeleteKeyspace(ctx context.Context, req *vtctldatapb.DeleteKeyspaceRequest) (*vtctldatapb.DeleteKeyspaceResponse, error) {
+func (s *VtctldServer) DeleteKeyspace(ctx context.Context, req *vtctldatapb.DeleteKeyspaceRequest) (resp *vtctldatapb.DeleteKeyspaceResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.DeleteKeyspace")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("recursive", req.Recursive)
@@ -729,12 +790,12 @@ func (s *VtctldServer) DeleteKeyspace(ctx context.Context, req *vtctldatapb.Dele
 	case lerr == nil:
 		ctx = lctx
 	case !req.Force:
-		return nil, fmt.Errorf("failed to lock %s; if you really want to delete this keyspace, re-run with Force=true: %w", req.Keyspace, lerr)
+		err = fmt.Errorf("failed to lock %s; if you really want to delete this keyspace, re-run with Force=true: %w", req.Keyspace, lerr)
+		return nil, err
 	default:
 		log.Warningf("%s: failed to lock keyspace %s for deletion, but force=true, proceeding anyway ...", lerr, req.Keyspace)
 	}
 
-	var err error
 	if unlock != nil {
 		defer func() {
 			// Attempting to unlock a keyspace we successfully deleted results
@@ -758,7 +819,8 @@ func (s *VtctldServer) DeleteKeyspace(ctx context.Context, req *vtctldatapb.Dele
 
 	if len(shards) > 0 {
 		if !req.Recursive {
-			return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "keyspace %v still has %d shards; use Recursive=true or remove them manually", req.Keyspace, len(shards))
+			err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "keyspace %v still has %d shards; use Recursive=true or remove them manually", req.Keyspace, len(shards))
+			return nil, err
 		}
 
 		log.Infof("Deleting all %d shards (and their tablets) in keyspace %v", len(shards), req.Keyspace)
@@ -770,7 +832,8 @@ func (s *VtctldServer) DeleteKeyspace(ctx context.Context, req *vtctldatapb.Dele
 			log.Infof("Recursively deleting shard %v/%v", req.Keyspace, shard)
 			err = deleteShard(ctx, s.ts, req.Keyspace, shard, recursive, evenIfServing, force)
 			if err != nil {
-				return nil, fmt.Errorf("cannot delete shard %v/%v: %w", req.Keyspace, shard, err)
+				err = fmt.Errorf("cannot delete shard %v/%v: %w", req.Keyspace, shard, err)
+				return nil, err
 			}
 		}
 	}
@@ -799,9 +862,11 @@ func (s *VtctldServer) DeleteKeyspace(ctx context.Context, req *vtctldatapb.Dele
 }
 
 // DeleteShards is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) DeleteShards(ctx context.Context, req *vtctldatapb.DeleteShardsRequest) (*vtctldatapb.DeleteShardsResponse, error) {
+func (s *VtctldServer) DeleteShards(ctx context.Context, req *vtctldatapb.DeleteShardsRequest) (resp *vtctldatapb.DeleteShardsResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.DeleteShards")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("num_shards", len(req.Shards))
 	span.Annotate("even_if_serving", req.EvenIfServing)
@@ -809,7 +874,8 @@ func (s *VtctldServer) DeleteShards(ctx context.Context, req *vtctldatapb.Delete
 	span.Annotate("force", req.Force)
 
 	for _, shard := range req.Shards {
-		if err := deleteShard(ctx, s.ts, shard.Keyspace, shard.Name, req.Recursive, req.EvenIfServing, req.Force); err != nil {
+		if err2 := deleteShard(ctx, s.ts, shard.Keyspace, shard.Name, req.Recursive, req.EvenIfServing, req.Force); err2 != nil {
+			err = err2
 			return nil, err
 		}
 	}
@@ -818,15 +884,23 @@ func (s *VtctldServer) DeleteShards(ctx context.Context, req *vtctldatapb.Delete
 }
 
 // DeleteSrvVSchema is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) DeleteSrvVSchema(ctx context.Context, req *vtctldatapb.DeleteSrvVSchemaRequest) (*vtctldatapb.DeleteSrvVSchemaResponse, error) {
+func (s *VtctldServer) DeleteSrvVSchema(ctx context.Context, req *vtctldatapb.DeleteSrvVSchemaRequest) (resp *vtctldatapb.DeleteSrvVSchemaResponse, err error) {
+	span, ctx := trace.NewSpan(ctx, "VtctldServer.DeleteSrvVSchema")
+	defer span.Finish()
+
+	defer panicHandler(&err)
+
 	if req.Cell == "" {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell must be non-empty")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell must be non-empty")
+		return nil, err
 	}
+
+	span.Annotate("cell", req.Cell)
 
 	ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer cancel()
 
-	if err := s.ts.DeleteSrvVSchema(ctx, req.Cell); err != nil {
+	if err = s.ts.DeleteSrvVSchema(ctx, req.Cell); err != nil {
 		return nil, err
 	}
 
@@ -834,15 +908,18 @@ func (s *VtctldServer) DeleteSrvVSchema(ctx context.Context, req *vtctldatapb.De
 }
 
 // DeleteTablets is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) DeleteTablets(ctx context.Context, req *vtctldatapb.DeleteTabletsRequest) (*vtctldatapb.DeleteTabletsResponse, error) {
+func (s *VtctldServer) DeleteTablets(ctx context.Context, req *vtctldatapb.DeleteTabletsRequest) (resp *vtctldatapb.DeleteTabletsResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.DeleteTablets")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("num_tablets", len(req.TabletAliases))
 	span.Annotate("allow_primary", req.AllowPrimary)
 
 	for _, alias := range req.TabletAliases {
-		if err := deleteTablet(ctx, s.ts, alias, req.AllowPrimary); err != nil {
+		if err2 := deleteTablet(ctx, s.ts, alias, req.AllowPrimary); err2 != nil {
+			err = err2
 			return nil, err
 		}
 	}
@@ -851,9 +928,11 @@ func (s *VtctldServer) DeleteTablets(ctx context.Context, req *vtctldatapb.Delet
 }
 
 // EmergencyReparentShard is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) EmergencyReparentShard(ctx context.Context, req *vtctldatapb.EmergencyReparentShardRequest) (*vtctldatapb.EmergencyReparentShardResponse, error) {
+func (s *VtctldServer) EmergencyReparentShard(ctx context.Context, req *vtctldatapb.EmergencyReparentShardRequest) (resp *vtctldatapb.EmergencyReparentShardResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.EmergencyReparentShard")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
@@ -892,7 +971,7 @@ func (s *VtctldServer) EmergencyReparentShard(ctx context.Context, req *vtctldat
 		},
 	)
 
-	resp := &vtctldatapb.EmergencyReparentShardResponse{
+	resp = &vtctldatapb.EmergencyReparentShardResponse{
 		Keyspace: req.Keyspace,
 		Shard:    req.Shard,
 	}
@@ -916,9 +995,11 @@ func (s *VtctldServer) EmergencyReparentShard(ctx context.Context, req *vtctldat
 }
 
 // ExecuteFetchAsApp is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ExecuteFetchAsApp(ctx context.Context, req *vtctldatapb.ExecuteFetchAsAppRequest) (*vtctldatapb.ExecuteFetchAsAppResponse, error) {
+func (s *VtctldServer) ExecuteFetchAsApp(ctx context.Context, req *vtctldatapb.ExecuteFetchAsAppRequest) (resp *vtctldatapb.ExecuteFetchAsAppResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ExecuteFetchAsApp")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 	span.Annotate("max_rows", req.MaxRows)
@@ -941,9 +1022,11 @@ func (s *VtctldServer) ExecuteFetchAsApp(ctx context.Context, req *vtctldatapb.E
 }
 
 // ExecuteFetchAsDBA is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ExecuteFetchAsDBA(ctx context.Context, req *vtctldatapb.ExecuteFetchAsDBARequest) (*vtctldatapb.ExecuteFetchAsDBAResponse, error) {
+func (s *VtctldServer) ExecuteFetchAsDBA(ctx context.Context, req *vtctldatapb.ExecuteFetchAsDBARequest) (resp *vtctldatapb.ExecuteFetchAsDBAResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ExecuteFetchAsDBA")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 	span.Annotate("max_rows", req.MaxRows)
@@ -969,20 +1052,24 @@ func (s *VtctldServer) ExecuteFetchAsDBA(ctx context.Context, req *vtctldatapb.E
 }
 
 // ExecuteHook is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ExecuteHook(ctx context.Context, req *vtctldatapb.ExecuteHookRequest) (*vtctldatapb.ExecuteHookResponse, error) {
+func (s *VtctldServer) ExecuteHook(ctx context.Context, req *vtctldatapb.ExecuteHookRequest) (resp *vtctldatapb.ExecuteHookResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ExecuteHook")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 
 	if req.TabletHookRequest == nil {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "TabletHookRequest cannot be nil")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "TabletHookRequest cannot be nil")
+		return nil, err
 	}
 
 	span.Annotate("hook_name", req.TabletHookRequest.Name)
 
 	if strings.Contains(req.TabletHookRequest.Name, "/") {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "hook name cannot contain a '/'; was %v", req.TabletHookRequest.Name)
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "hook name cannot contain a '/'; was %v", req.TabletHookRequest.Name)
+		return nil, err
 	}
 
 	ti, err := s.ts.GetTablet(ctx, req.TabletAlias)
@@ -1004,9 +1091,11 @@ func (s *VtctldServer) ExecuteHook(ctx context.Context, req *vtctldatapb.Execute
 }
 
 // FindAllShardsInKeyspace is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) FindAllShardsInKeyspace(ctx context.Context, req *vtctldatapb.FindAllShardsInKeyspaceRequest) (*vtctldatapb.FindAllShardsInKeyspaceResponse, error) {
+func (s *VtctldServer) FindAllShardsInKeyspace(ctx context.Context, req *vtctldatapb.FindAllShardsInKeyspaceRequest) (resp *vtctldatapb.FindAllShardsInKeyspaceResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.FindAllShardsInKeyspace")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 
@@ -1030,9 +1119,11 @@ func (s *VtctldServer) FindAllShardsInKeyspace(ctx context.Context, req *vtctlda
 }
 
 // GetBackups is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) GetBackups(ctx context.Context, req *vtctldatapb.GetBackupsRequest) (*vtctldatapb.GetBackupsResponse, error) {
+func (s *VtctldServer) GetBackups(ctx context.Context, req *vtctldatapb.GetBackupsRequest) (resp *vtctldatapb.GetBackupsResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetBackups")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
@@ -1093,9 +1184,11 @@ func (s *VtctldServer) GetBackups(ctx context.Context, req *vtctldatapb.GetBacku
 }
 
 // GetCellInfoNames is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetCellInfoNames(ctx context.Context, req *vtctldatapb.GetCellInfoNamesRequest) (*vtctldatapb.GetCellInfoNamesResponse, error) {
+func (s *VtctldServer) GetCellInfoNames(ctx context.Context, req *vtctldatapb.GetCellInfoNamesRequest) (resp *vtctldatapb.GetCellInfoNamesResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetCellInfoNames")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	names, err := s.ts.GetCellInfoNames(ctx)
 	if err != nil {
@@ -1106,12 +1199,15 @@ func (s *VtctldServer) GetCellInfoNames(ctx context.Context, req *vtctldatapb.Ge
 }
 
 // GetCellInfo is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetCellInfo(ctx context.Context, req *vtctldatapb.GetCellInfoRequest) (*vtctldatapb.GetCellInfoResponse, error) {
+func (s *VtctldServer) GetCellInfo(ctx context.Context, req *vtctldatapb.GetCellInfoRequest) (resp *vtctldatapb.GetCellInfoResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetCellInfo")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	if req.Cell == "" {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell field is required")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell field is required")
+		return nil, err
 	}
 
 	span.Annotate("cell", req.Cell)
@@ -1128,9 +1224,11 @@ func (s *VtctldServer) GetCellInfo(ctx context.Context, req *vtctldatapb.GetCell
 }
 
 // GetCellsAliases is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetCellsAliases(ctx context.Context, req *vtctldatapb.GetCellsAliasesRequest) (*vtctldatapb.GetCellsAliasesResponse, error) {
+func (s *VtctldServer) GetCellsAliases(ctx context.Context, req *vtctldatapb.GetCellsAliasesRequest) (resp *vtctldatapb.GetCellsAliasesResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetCellsAliases")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	strongRead := true
 	aliases, err := s.ts.GetCellsAliases(ctx, strongRead)
@@ -1142,9 +1240,11 @@ func (s *VtctldServer) GetCellsAliases(ctx context.Context, req *vtctldatapb.Get
 }
 
 // GetFullStatus is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetFullStatus(ctx context.Context, req *vtctldatapb.GetFullStatusRequest) (*vtctldatapb.GetFullStatusResponse, error) {
+func (s *VtctldServer) GetFullStatus(ctx context.Context, req *vtctldatapb.GetFullStatusRequest) (resp *vtctldatapb.GetFullStatusResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetFullStatus")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 
@@ -1164,9 +1264,11 @@ func (s *VtctldServer) GetFullStatus(ctx context.Context, req *vtctldatapb.GetFu
 }
 
 // GetKeyspace is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetKeyspace(ctx context.Context, req *vtctldatapb.GetKeyspaceRequest) (*vtctldatapb.GetKeyspaceResponse, error) {
+func (s *VtctldServer) GetKeyspace(ctx context.Context, req *vtctldatapb.GetKeyspaceRequest) (resp *vtctldatapb.GetKeyspaceResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetKeyspace")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 
@@ -1184,9 +1286,11 @@ func (s *VtctldServer) GetKeyspace(ctx context.Context, req *vtctldatapb.GetKeys
 }
 
 // GetKeyspaces is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetKeyspaces(ctx context.Context, req *vtctldatapb.GetKeyspacesRequest) (*vtctldatapb.GetKeyspacesResponse, error) {
+func (s *VtctldServer) GetKeyspaces(ctx context.Context, req *vtctldatapb.GetKeyspacesRequest) (resp *vtctldatapb.GetKeyspacesResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetKeyspaces")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	names, err := s.ts.GetKeyspaces(ctx)
 	if err != nil {
@@ -1196,8 +1300,9 @@ func (s *VtctldServer) GetKeyspaces(ctx context.Context, req *vtctldatapb.GetKey
 	keyspaces := make([]*vtctldatapb.Keyspace, len(names))
 
 	for i, name := range names {
-		ks, err := s.GetKeyspace(ctx, &vtctldatapb.GetKeyspaceRequest{Keyspace: name})
-		if err != nil {
+		ks, err2 := s.GetKeyspace(ctx, &vtctldatapb.GetKeyspaceRequest{Keyspace: name})
+		if err2 != nil {
+			err = err2
 			return nil, err
 		}
 
@@ -1208,14 +1313,17 @@ func (s *VtctldServer) GetKeyspaces(ctx context.Context, req *vtctldatapb.GetKey
 }
 
 // GetPermissions is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetPermissions(ctx context.Context, req *vtctldatapb.GetPermissionsRequest) (*vtctldatapb.GetPermissionsResponse, error) {
+func (s *VtctldServer) GetPermissions(ctx context.Context, req *vtctldatapb.GetPermissionsRequest) (resp *vtctldatapb.GetPermissionsResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetPermissions")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 	ti, err := s.ts.GetTablet(ctx, req.TabletAlias)
 	if err != nil {
-		return nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "Failed to get tablet %v: %v", req.TabletAlias, err)
+		err = vterrors.Errorf(vtrpc.Code_NOT_FOUND, "Failed to get tablet %v: %v", req.TabletAlias, err)
+		return nil, err
 	}
 
 	p, err := s.tmc.GetPermissions(ctx, ti.Tablet)
@@ -1229,9 +1337,11 @@ func (s *VtctldServer) GetPermissions(ctx context.Context, req *vtctldatapb.GetP
 }
 
 // GetRoutingRules is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetRoutingRules(ctx context.Context, req *vtctldatapb.GetRoutingRulesRequest) (*vtctldatapb.GetRoutingRulesResponse, error) {
+func (s *VtctldServer) GetRoutingRules(ctx context.Context, req *vtctldatapb.GetRoutingRulesRequest) (resp *vtctldatapb.GetRoutingRulesResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetRoutingRules")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	rr, err := s.ts.GetRoutingRules(ctx)
 	if err != nil {
@@ -1244,9 +1354,11 @@ func (s *VtctldServer) GetRoutingRules(ctx context.Context, req *vtctldatapb.Get
 }
 
 // GetSchema is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetSchema(ctx context.Context, req *vtctldatapb.GetSchemaRequest) (*vtctldatapb.GetSchemaResponse, error) {
+func (s *VtctldServer) GetSchema(ctx context.Context, req *vtctldatapb.GetSchemaRequest) (resp *vtctldatapb.GetSchemaResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetSchema")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 	span.Annotate("tables", strings.Join(req.Tables, ","))
@@ -1293,9 +1405,11 @@ func (s *VtctldServer) GetSchema(ctx context.Context, req *vtctldatapb.GetSchema
 }
 
 // GetShard is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetShard(ctx context.Context, req *vtctldatapb.GetShardRequest) (*vtctldatapb.GetShardResponse, error) {
+func (s *VtctldServer) GetShard(ctx context.Context, req *vtctldatapb.GetShardRequest) (resp *vtctldatapb.GetShardResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetShard")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.ShardName)
@@ -1315,13 +1429,17 @@ func (s *VtctldServer) GetShard(ctx context.Context, req *vtctldatapb.GetShardRe
 }
 
 // GetSrvKeyspaceNames is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetSrvKeyspaceNames(ctx context.Context, req *vtctldatapb.GetSrvKeyspaceNamesRequest) (*vtctldatapb.GetSrvKeyspaceNamesResponse, error) {
+func (s *VtctldServer) GetSrvKeyspaceNames(ctx context.Context, req *vtctldatapb.GetSrvKeyspaceNamesRequest) (resp *vtctldatapb.GetSrvKeyspaceNamesResponse, err error) {
+	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetSrvKeyspaceNames")
+	defer span.Finish()
+
+	defer panicHandler(&err)
+
 	cells := req.Cells
 	if len(cells) == 0 {
 		ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 		defer cancel()
 
-		var err error
 		cells, err = s.ts.GetCellInfoNames(ctx)
 		if err != nil {
 			return nil, err
@@ -1334,9 +1452,10 @@ func (s *VtctldServer) GetSrvKeyspaceNames(ctx context.Context, req *vtctldatapb
 	// Total runtime is O(len(cells) * topo.RemoteOperationTimeout).
 	for _, cell := range cells {
 		ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
-		names, err := s.ts.GetSrvKeyspaceNames(ctx, cell)
-		if err != nil {
+		names, err2 := s.ts.GetSrvKeyspaceNames(ctx, cell)
+		if err2 != nil {
 			cancel()
+			err = err2
 			return nil, err
 		}
 
@@ -1350,15 +1469,15 @@ func (s *VtctldServer) GetSrvKeyspaceNames(ctx context.Context, req *vtctldatapb
 }
 
 // GetSrvKeyspaces is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetSrvKeyspaces(ctx context.Context, req *vtctldatapb.GetSrvKeyspacesRequest) (*vtctldatapb.GetSrvKeyspacesResponse, error) {
+func (s *VtctldServer) GetSrvKeyspaces(ctx context.Context, req *vtctldatapb.GetSrvKeyspacesRequest) (resp *vtctldatapb.GetSrvKeyspacesResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetSrvKeyspaces")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	cells := req.Cells
 
 	if len(cells) == 0 {
-		var err error
-
 		cells, err = s.ts.GetCellInfoNames(ctx)
 		if err != nil {
 			return nil, err
@@ -1370,7 +1489,8 @@ func (s *VtctldServer) GetSrvKeyspaces(ctx context.Context, req *vtctldatapb.Get
 	srvKeyspaces := make(map[string]*topodatapb.SrvKeyspace, len(cells))
 
 	for _, cell := range cells {
-		srvKeyspace, err := s.ts.GetSrvKeyspace(ctx, cell, req.Keyspace)
+		var srvKeyspace *topodatapb.SrvKeyspace
+		srvKeyspace, err = s.ts.GetSrvKeyspace(ctx, cell, req.Keyspace)
 
 		if err != nil {
 			if !topo.IsErrType(err, topo.NoNode) {
@@ -1391,9 +1511,11 @@ func (s *VtctldServer) GetSrvKeyspaces(ctx context.Context, req *vtctldatapb.Get
 }
 
 // GetSrvVSchema is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetSrvVSchema(ctx context.Context, req *vtctldatapb.GetSrvVSchemaRequest) (*vtctldatapb.GetSrvVSchemaResponse, error) {
+func (s *VtctldServer) GetSrvVSchema(ctx context.Context, req *vtctldatapb.GetSrvVSchemaRequest) (resp *vtctldatapb.GetSrvVSchemaResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetSrvVSchema")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("cell", req.Cell)
 
@@ -1408,9 +1530,11 @@ func (s *VtctldServer) GetSrvVSchema(ctx context.Context, req *vtctldatapb.GetSr
 }
 
 // GetSrvVSchemas is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetSrvVSchemas(ctx context.Context, req *vtctldatapb.GetSrvVSchemasRequest) (*vtctldatapb.GetSrvVSchemasResponse, error) {
+func (s *VtctldServer) GetSrvVSchemas(ctx context.Context, req *vtctldatapb.GetSrvVSchemasRequest) (resp *vtctldatapb.GetSrvVSchemasResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetSrvVSchemas")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	allCells, err := s.ts.GetCellInfoNames(ctx)
 	if err != nil {
@@ -1431,7 +1555,8 @@ func (s *VtctldServer) GetSrvVSchemas(ctx context.Context, req *vtctldatapb.GetS
 	svs := make(map[string]*vschemapb.SrvVSchema, len(cells))
 
 	for _, cell := range cells {
-		sv, err := s.ts.GetSrvVSchema(ctx, cell)
+		var sv *vschemapb.SrvVSchema
+		sv, err = s.ts.GetSrvVSchema(ctx, cell)
 
 		if err != nil {
 			if !topo.IsErrType(err, topo.NoNode) {
@@ -1451,9 +1576,11 @@ func (s *VtctldServer) GetSrvVSchemas(ctx context.Context, req *vtctldatapb.GetS
 }
 
 // GetTablet is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetTablet(ctx context.Context, req *vtctldatapb.GetTabletRequest) (*vtctldatapb.GetTabletResponse, error) {
+func (s *VtctldServer) GetTablet(ctx context.Context, req *vtctldatapb.GetTabletRequest) (resp *vtctldatapb.GetTabletResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetTablet")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 
@@ -1468,9 +1595,11 @@ func (s *VtctldServer) GetTablet(ctx context.Context, req *vtctldatapb.GetTablet
 }
 
 // GetTablets is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetTablets(ctx context.Context, req *vtctldatapb.GetTabletsRequest) (*vtctldatapb.GetTabletsResponse, error) {
+func (s *VtctldServer) GetTablets(ctx context.Context, req *vtctldatapb.GetTabletsRequest) (resp *vtctldatapb.GetTabletsResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetTablets")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("cells", strings.Join(req.Cells, ","))
 	if req.TabletType != topodatapb.TabletType_UNKNOWN {
@@ -1495,10 +1624,7 @@ func (s *VtctldServer) GetTablets(ctx context.Context, req *vtctldatapb.GetTable
 	ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer cancel()
 
-	var (
-		tabletMap map[string]*topo.TabletInfo
-		err       error
-	)
+	var tabletMap map[string]*topo.TabletInfo
 
 	switch {
 	case len(req.TabletAliases) > 0:
@@ -1556,7 +1682,8 @@ func (s *VtctldServer) GetTablets(ctx context.Context, req *vtctldatapb.GetTable
 
 	cells := req.Cells
 	if len(cells) == 0 {
-		c, err := s.ts.GetKnownCells(ctx)
+		var c []string
+		c, err = s.ts.GetKnownCells(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -1597,7 +1724,8 @@ func (s *VtctldServer) GetTablets(ctx context.Context, req *vtctldatapb.GetTable
 
 	if rec.HasErrors() {
 		if req.Strict || len(rec.Errors) == len(cells) {
-			return nil, rec.Error()
+			err = rec.Error()
+			return nil, err
 		}
 	}
 
@@ -1644,7 +1772,12 @@ func (s *VtctldServer) GetTablets(ctx context.Context, req *vtctldatapb.GetTable
 }
 
 // GetVersion returns the version of a tablet from its debug vars
-func (s *VtctldServer) GetVersion(ctx context.Context, req *vtctldatapb.GetVersionRequest) (*vtctldatapb.GetVersionResponse, error) {
+func (s *VtctldServer) GetVersion(ctx context.Context, req *vtctldatapb.GetVersionRequest) (resp *vtctldatapb.GetVersionResponse, err error) {
+	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetVersion")
+	defer span.Finish()
+
+	defer panicHandler(&err)
+
 	tabletAlias := req.TabletAlias
 	tablet, err := s.ts.GetTablet(ctx, tabletAlias)
 	if err != nil {
@@ -1660,9 +1793,11 @@ func (s *VtctldServer) GetVersion(ctx context.Context, req *vtctldatapb.GetVersi
 }
 
 // GetVSchema is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetVSchema(ctx context.Context, req *vtctldatapb.GetVSchemaRequest) (*vtctldatapb.GetVSchemaResponse, error) {
+func (s *VtctldServer) GetVSchema(ctx context.Context, req *vtctldatapb.GetVSchemaRequest) (resp *vtctldatapb.GetVSchemaResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetVSchema")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 
@@ -1677,27 +1812,34 @@ func (s *VtctldServer) GetVSchema(ctx context.Context, req *vtctldatapb.GetVSche
 }
 
 // GetWorkflows is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) GetWorkflows(ctx context.Context, req *vtctldatapb.GetWorkflowsRequest) (*vtctldatapb.GetWorkflowsResponse, error) {
+func (s *VtctldServer) GetWorkflows(ctx context.Context, req *vtctldatapb.GetWorkflowsRequest) (resp *vtctldatapb.GetWorkflowsResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.GetWorkflows")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("active_only", req.ActiveOnly)
 
-	return s.ws.GetWorkflows(ctx, req)
+	resp, err = s.ws.GetWorkflows(ctx, req)
+	return resp, err
 }
 
 // InitShardPrimary is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) InitShardPrimary(ctx context.Context, req *vtctldatapb.InitShardPrimaryRequest) (*vtctldatapb.InitShardPrimaryResponse, error) {
+func (s *VtctldServer) InitShardPrimary(ctx context.Context, req *vtctldatapb.InitShardPrimaryRequest) (resp *vtctldatapb.InitShardPrimaryResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.InitShardPrimary")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	if req.Keyspace == "" {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "keyspace field is required")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "keyspace field is required")
+		return nil, err
 	}
 
 	if req.Shard == "" {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "shard field is required")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "shard field is required")
+		return nil, err
 	}
 
 	waitReplicasTimeout, ok, err := protoutil.DurationFromProto(req.WaitReplicasTimeout)
@@ -1722,7 +1864,7 @@ func (s *VtctldServer) InitShardPrimary(ctx context.Context, req *vtctldatapb.In
 	ev := &events.Reparent{}
 	logstream := []*logutilpb.Event{}
 
-	resp := &vtctldatapb.InitShardPrimaryResponse{}
+	resp = &vtctldatapb.InitShardPrimaryResponse{}
 	err = s.InitShardPrimaryLocked(ctx, ev, req, waitReplicasTimeout, s.tmc, logutil.NewCallbackLogger(func(e *logutilpb.Event) {
 		m.Lock()
 		defer m.Unlock()
@@ -1962,9 +2104,11 @@ func (s *VtctldServer) InitShardPrimaryLocked(
 }
 
 // PingTablet is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) PingTablet(ctx context.Context, req *vtctldatapb.PingTabletRequest) (*vtctldatapb.PingTabletResponse, error) {
+func (s *VtctldServer) PingTablet(ctx context.Context, req *vtctldatapb.PingTabletRequest) (resp *vtctldatapb.PingTabletResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.PingTablet")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 
@@ -1982,9 +2126,11 @@ func (s *VtctldServer) PingTablet(ctx context.Context, req *vtctldatapb.PingTabl
 }
 
 // PlannedReparentShard is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) PlannedReparentShard(ctx context.Context, req *vtctldatapb.PlannedReparentShardRequest) (*vtctldatapb.PlannedReparentShardResponse, error) {
+func (s *VtctldServer) PlannedReparentShard(ctx context.Context, req *vtctldatapb.PlannedReparentShardRequest) (resp *vtctldatapb.PlannedReparentShardResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.PlannedReparentShard")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	waitReplicasTimeout, ok, err := protoutil.DurationFromProto(req.WaitReplicasTimeout)
 	if err != nil {
@@ -2024,7 +2170,7 @@ func (s *VtctldServer) PlannedReparentShard(ctx context.Context, req *vtctldatap
 		},
 	)
 
-	resp := &vtctldatapb.PlannedReparentShardResponse{
+	resp = &vtctldatapb.PlannedReparentShardResponse{
 		Keyspace: req.Keyspace,
 		Shard:    req.Shard,
 	}
@@ -2048,15 +2194,17 @@ func (s *VtctldServer) PlannedReparentShard(ctx context.Context, req *vtctldatap
 }
 
 // RebuildKeyspaceGraph is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) RebuildKeyspaceGraph(ctx context.Context, req *vtctldatapb.RebuildKeyspaceGraphRequest) (*vtctldatapb.RebuildKeyspaceGraphResponse, error) {
+func (s *VtctldServer) RebuildKeyspaceGraph(ctx context.Context, req *vtctldatapb.RebuildKeyspaceGraphRequest) (resp *vtctldatapb.RebuildKeyspaceGraphResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.RebuildKeyspaceGraph")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("cells", strings.Join(req.Cells, ","))
 	span.Annotate("allow_partial", req.AllowPartial)
 
-	if err := topotools.RebuildKeyspace(ctx, logutil.NewCallbackLogger(func(e *logutilpb.Event) {}), s.ts, req.Keyspace, req.Cells, req.AllowPartial); err != nil {
+	if err = topotools.RebuildKeyspace(ctx, logutil.NewCallbackLogger(func(e *logutilpb.Event) {}), s.ts, req.Keyspace, req.Cells, req.AllowPartial); err != nil {
 		return nil, err
 	}
 
@@ -2064,13 +2212,15 @@ func (s *VtctldServer) RebuildKeyspaceGraph(ctx context.Context, req *vtctldatap
 }
 
 // RebuildVSchemaGraph is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) RebuildVSchemaGraph(ctx context.Context, req *vtctldatapb.RebuildVSchemaGraphRequest) (*vtctldatapb.RebuildVSchemaGraphResponse, error) {
+func (s *VtctldServer) RebuildVSchemaGraph(ctx context.Context, req *vtctldatapb.RebuildVSchemaGraphRequest) (resp *vtctldatapb.RebuildVSchemaGraphResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.RebuildVSchemaGraph")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	span.Annotate("cells", strings.Join(req.Cells, ","))
 
-	if err := s.ts.RebuildSrvVSchema(ctx, req.Cells); err != nil {
+	if err = s.ts.RebuildSrvVSchema(ctx, req.Cells); err != nil {
 		return nil, err
 	}
 
@@ -2078,9 +2228,15 @@ func (s *VtctldServer) RebuildVSchemaGraph(ctx context.Context, req *vtctldatapb
 }
 
 // RefreshState is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) RefreshState(ctx context.Context, req *vtctldatapb.RefreshStateRequest) (*vtctldatapb.RefreshStateResponse, error) {
+func (s *VtctldServer) RefreshState(ctx context.Context, req *vtctldatapb.RefreshStateRequest) (resp *vtctldatapb.RefreshStateResponse, err error) {
+	span, ctx := trace.NewSpan(ctx, "VtctldServer.RefreshState")
+	defer span.Finish()
+
+	defer panicHandler(&err)
+
 	if req.TabletAlias == nil {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "RefreshState requires a tablet alias")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "RefreshState requires a tablet alias")
+		return nil, err
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
@@ -2088,10 +2244,11 @@ func (s *VtctldServer) RefreshState(ctx context.Context, req *vtctldatapb.Refres
 
 	tablet, err := s.ts.GetTablet(ctx, req.TabletAlias)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get tablet %s: %w", topoproto.TabletAliasString(req.TabletAlias), err)
+		err = fmt.Errorf("Failed to get tablet %s: %w", topoproto.TabletAliasString(req.TabletAlias), err)
+		return nil, err
 	}
 
-	if err := s.tmc.RefreshState(ctx, tablet.Tablet); err != nil {
+	if err = s.tmc.RefreshState(ctx, tablet.Tablet); err != nil {
 		return nil, err
 	}
 
@@ -2099,13 +2256,20 @@ func (s *VtctldServer) RefreshState(ctx context.Context, req *vtctldatapb.Refres
 }
 
 // RefreshStateByShard is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) RefreshStateByShard(ctx context.Context, req *vtctldatapb.RefreshStateByShardRequest) (*vtctldatapb.RefreshStateByShardResponse, error) {
+func (s *VtctldServer) RefreshStateByShard(ctx context.Context, req *vtctldatapb.RefreshStateByShardRequest) (resp *vtctldatapb.RefreshStateByShardResponse, err error) {
+	span, ctx := trace.NewSpan(ctx, "VtctldServer.RefreshStateByShard")
+	defer span.Finish()
+
+	defer panicHandler(&err)
+
 	if req.Keyspace == "" {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "RefreshStateByShard requires a keyspace")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "RefreshStateByShard requires a keyspace")
+		return nil, err
 	}
 
 	if req.Shard == "" {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "RefreshStateByShard requires a shard")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "RefreshStateByShard requires a shard")
+		return nil, err
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
@@ -2113,7 +2277,8 @@ func (s *VtctldServer) RefreshStateByShard(ctx context.Context, req *vtctldatapb
 
 	si, err := s.ts.GetShard(ctx, req.Keyspace, req.Shard)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get shard %s/%s/: %w", req.Keyspace, req.Shard, err)
+		err = fmt.Errorf("Failed to get shard %s/%s/: %w", req.Keyspace, req.Shard, err)
+		return nil, err
 	}
 
 	isPartial, partialDetails, err := topotools.RefreshTabletsByShard(ctx, s.ts, s.tmc, si, req.Cells, logutil.NewCallbackLogger(func(e *logutilpb.Event) {
@@ -2137,15 +2302,18 @@ func (s *VtctldServer) RefreshStateByShard(ctx context.Context, req *vtctldatapb
 }
 
 // ReloadSchema is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ReloadSchema(ctx context.Context, req *vtctldatapb.ReloadSchemaRequest) (*vtctldatapb.ReloadSchemaResponse, error) {
+func (s *VtctldServer) ReloadSchema(ctx context.Context, req *vtctldatapb.ReloadSchemaRequest) (resp *vtctldatapb.ReloadSchemaResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ReloadSchema")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 
 	ti, err := s.ts.GetTablet(ctx, req.TabletAlias)
 	if err != nil {
-		return nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "GetTablet(%v) failed: %v", req.TabletAlias, err)
+		err = vterrors.Errorf(vtrpc.Code_NOT_FOUND, "GetTablet(%v) failed: %v", req.TabletAlias, err)
+		return nil, err
 	}
 
 	err = s.tmc.ReloadSchema(ctx, ti.Tablet, "")
@@ -2157,7 +2325,9 @@ func (s *VtctldServer) ReloadSchema(ctx context.Context, req *vtctldatapb.Reload
 }
 
 // ReloadSchemaShard is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ReloadSchemaShard(ctx context.Context, req *vtctldatapb.ReloadSchemaShardRequest) (*vtctldatapb.ReloadSchemaShardResponse, error) {
+func (s *VtctldServer) ReloadSchemaShard(ctx context.Context, req *vtctldatapb.ReloadSchemaShardRequest) (resp *vtctldatapb.ReloadSchemaShardResponse, err error) {
+	defer panicHandler(&err)
+
 	logger, getEvents := eventStreamLogger()
 
 	var sema *sync2.Semaphore
@@ -2191,9 +2361,11 @@ func (s *VtctldServer) reloadSchemaShard(ctx context.Context, req *vtctldatapb.R
 }
 
 // ReloadSchemaKeyspace is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ReloadSchemaKeyspace(ctx context.Context, req *vtctldatapb.ReloadSchemaKeyspaceRequest) (*vtctldatapb.ReloadSchemaKeyspaceResponse, error) {
+func (s *VtctldServer) ReloadSchemaKeyspace(ctx context.Context, req *vtctldatapb.ReloadSchemaKeyspaceRequest) (resp *vtctldatapb.ReloadSchemaKeyspaceResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ReloadSchemaKeyspace")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("concurrency", req.Concurrency)
@@ -2202,7 +2374,8 @@ func (s *VtctldServer) ReloadSchemaKeyspace(ctx context.Context, req *vtctldatap
 
 	shards, err := s.ts.GetShardNames(ctx, req.Keyspace)
 	if err != nil {
-		return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "GetShardNames(%v) failed: %v", req.Keyspace, err)
+		err = vterrors.Errorf(vtrpc.Code_INTERNAL, "GetShardNames(%v) failed: %v", req.Keyspace, err)
+		return nil, err
 	}
 
 	var (
@@ -2236,9 +2409,11 @@ func (s *VtctldServer) ReloadSchemaKeyspace(ctx context.Context, req *vtctldatap
 }
 
 // RemoveBackup is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) RemoveBackup(ctx context.Context, req *vtctldatapb.RemoveBackupRequest) (*vtctldatapb.RemoveBackupResponse, error) {
+func (s *VtctldServer) RemoveBackup(ctx context.Context, req *vtctldatapb.RemoveBackupRequest) (resp *vtctldatapb.RemoveBackupResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.RemoveBackup")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	bucket := fmt.Sprintf("%v/%v", req.Keyspace, req.Shard)
 
@@ -2253,7 +2428,7 @@ func (s *VtctldServer) RemoveBackup(ctx context.Context, req *vtctldatapb.Remove
 	}
 	defer bs.Close()
 
-	if err := bs.RemoveBackup(ctx, bucket, req.Name); err != nil {
+	if err = bs.RemoveBackup(ctx, bucket, req.Name); err != nil {
 		return nil, err
 	}
 
@@ -2261,9 +2436,11 @@ func (s *VtctldServer) RemoveBackup(ctx context.Context, req *vtctldatapb.Remove
 }
 
 // RemoveKeyspaceCell is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) RemoveKeyspaceCell(ctx context.Context, req *vtctldatapb.RemoveKeyspaceCellRequest) (*vtctldatapb.RemoveKeyspaceCellResponse, error) {
+func (s *VtctldServer) RemoveKeyspaceCell(ctx context.Context, req *vtctldatapb.RemoveKeyspaceCellRequest) (resp *vtctldatapb.RemoveKeyspaceCellResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.RemoveKeyspaceCell")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("cell", req.Cell)
@@ -2278,24 +2455,28 @@ func (s *VtctldServer) RemoveKeyspaceCell(ctx context.Context, req *vtctldatapb.
 	// Remove all the shards, serially. Stop immediately if any fail.
 	for _, shard := range shards {
 		log.Infof("Removing cell %v from shard %v/%v", req.Cell, req.Keyspace, shard)
-		if err := removeShardCell(ctx, s.ts, req.Cell, req.Keyspace, shard, req.Recursive, req.Force); err != nil {
-			return nil, fmt.Errorf("cannot remove cell %v from shard %v/%v: %w", req.Cell, req.Keyspace, shard, err)
+		if err2 := removeShardCell(ctx, s.ts, req.Cell, req.Keyspace, shard, req.Recursive, req.Force); err2 != nil {
+			err = fmt.Errorf("cannot remove cell %v from shard %v/%v: %w", req.Cell, req.Keyspace, shard, err2)
+			return nil, err
 		}
 	}
 
 	// Last, remove the SrvKeyspace object.
 	log.Infof("Removing cell %v keyspace %v SrvKeyspace object", req.Cell, req.Keyspace)
-	if err := s.ts.DeleteSrvKeyspace(ctx, req.Cell, req.Keyspace); err != nil {
-		return nil, fmt.Errorf("cannot delete SrvKeyspace from cell %v for keyspace %v: %w", req.Cell, req.Keyspace, err)
+	if err = s.ts.DeleteSrvKeyspace(ctx, req.Cell, req.Keyspace); err != nil {
+		err = fmt.Errorf("cannot delete SrvKeyspace from cell %v for keyspace %v: %w", req.Cell, req.Keyspace, err)
+		return nil, err
 	}
 
 	return &vtctldatapb.RemoveKeyspaceCellResponse{}, nil
 }
 
 // RemoveShardCell is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) RemoveShardCell(ctx context.Context, req *vtctldatapb.RemoveShardCellRequest) (*vtctldatapb.RemoveShardCellResponse, error) {
+func (s *VtctldServer) RemoveShardCell(ctx context.Context, req *vtctldatapb.RemoveShardCellRequest) (resp *vtctldatapb.RemoveShardCellResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.RemoveShardCell")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.ShardName)
@@ -2303,7 +2484,7 @@ func (s *VtctldServer) RemoveShardCell(ctx context.Context, req *vtctldatapb.Rem
 	span.Annotate("force", req.Force)
 	span.Annotate("recursive", req.Recursive)
 
-	if err := removeShardCell(ctx, s.ts, req.Cell, req.Keyspace, req.ShardName, req.Recursive, req.Force); err != nil {
+	if err = removeShardCell(ctx, s.ts, req.Cell, req.Keyspace, req.ShardName, req.Recursive, req.Force); err != nil {
 		return nil, err
 	}
 
@@ -2311,12 +2492,15 @@ func (s *VtctldServer) RemoveShardCell(ctx context.Context, req *vtctldatapb.Rem
 }
 
 // ReparentTablet is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) ReparentTablet(ctx context.Context, req *vtctldatapb.ReparentTabletRequest) (*vtctldatapb.ReparentTabletResponse, error) {
+func (s *VtctldServer) ReparentTablet(ctx context.Context, req *vtctldatapb.ReparentTabletRequest) (resp *vtctldatapb.ReparentTabletResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ReparentTablet")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	if req.Tablet == nil {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "tablet alias must not be nil")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "tablet alias must not be nil")
+		return nil, err
 	}
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.Tablet))
@@ -2332,24 +2516,29 @@ func (s *VtctldServer) ReparentTablet(ctx context.Context, req *vtctldatapb.Repa
 	}
 
 	if !shard.HasPrimary() {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no primary tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no primary tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
+		return nil, err
 	}
 
 	shardPrimary, err := s.ts.GetTablet(ctx, shard.PrimaryAlias)
 	if err != nil {
-		return nil, fmt.Errorf("cannot lookup primary tablet %v for shard %v/%v: %w", topoproto.TabletAliasString(shard.PrimaryAlias), tablet.Keyspace, tablet.Shard, err)
+		err = fmt.Errorf("cannot lookup primary tablet %v for shard %v/%v: %w", topoproto.TabletAliasString(shard.PrimaryAlias), tablet.Keyspace, tablet.Shard, err)
+		return nil, err
 	}
 
 	if shardPrimary.Type != topodatapb.TabletType_PRIMARY {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "TopologyServer has incosistent state for shard primary %v", topoproto.TabletAliasString(shard.PrimaryAlias))
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "TopologyServer has incosistent state for shard primary %v", topoproto.TabletAliasString(shard.PrimaryAlias))
+		return nil, err
 	}
 
 	if shardPrimary.Keyspace != tablet.Keyspace || shardPrimary.Shard != tablet.Shard {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary %v and potential replica %v not in same keypace shard (%v/%v)", topoproto.TabletAliasString(shard.PrimaryAlias), topoproto.TabletAliasString(req.Tablet), tablet.Keyspace, tablet.Shard)
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary %v and potential replica %v not in same keypace shard (%v/%v)", topoproto.TabletAliasString(shard.PrimaryAlias), topoproto.TabletAliasString(req.Tablet), tablet.Keyspace, tablet.Shard)
+		return nil, err
 	}
 
 	if topoproto.TabletAliasEqual(req.Tablet, shardPrimary.Alias) {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "cannot ReparentTablet current shard primary (%v) onto itself", topoproto.TabletAliasString(req.Tablet))
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "cannot ReparentTablet current shard primary (%v) onto itself", topoproto.TabletAliasString(req.Tablet))
+		return nil, err
 	}
 
 	durabilityName, err := s.ts.GetKeyspaceDurability(ctx, tablet.Keyspace)
@@ -2362,7 +2551,7 @@ func (s *VtctldServer) ReparentTablet(ctx context.Context, req *vtctldatapb.Repa
 		return nil, err
 	}
 
-	if err := s.tmc.SetReplicationSource(ctx, tablet.Tablet, shard.PrimaryAlias, 0, "", false, reparentutil.IsReplicaSemiSync(durability, shardPrimary.Tablet, tablet.Tablet)); err != nil {
+	if err = s.tmc.SetReplicationSource(ctx, tablet.Tablet, shard.PrimaryAlias, 0, "", false, reparentutil.IsReplicaSemiSync(durability, shardPrimary.Tablet, tablet.Tablet)); err != nil {
 		return nil, err
 	}
 
@@ -2373,9 +2562,11 @@ func (s *VtctldServer) ReparentTablet(ctx context.Context, req *vtctldatapb.Repa
 	}, nil
 }
 
-func (s *VtctldServer) RestoreFromBackup(req *vtctldatapb.RestoreFromBackupRequest, stream vtctlservicepb.Vtctld_RestoreFromBackupServer) error {
+func (s *VtctldServer) RestoreFromBackup(req *vtctldatapb.RestoreFromBackupRequest, stream vtctlservicepb.Vtctld_RestoreFromBackupServer) (err error) {
 	span, ctx := trace.NewSpan(stream.Context(), "VtctldServer.RestoreFromBackup")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 	backupTime := protoutil.TimeFromProto(req.BackupTime)
@@ -2399,7 +2590,8 @@ func (s *VtctldServer) RestoreFromBackup(req *vtctldatapb.RestoreFromBackupReque
 	logger := logutil.NewConsoleLogger()
 
 	for {
-		event, err := logStream.Recv()
+		var event *logutilpb.Event
+		event, err = logStream.Recv()
 		switch err {
 		case nil:
 			logutil.LogEvent(logger, event)
@@ -2409,7 +2601,7 @@ func (s *VtctldServer) RestoreFromBackup(req *vtctldatapb.RestoreFromBackupReque
 				Shard:       ti.Shard,
 				Event:       event,
 			}
-			if err := stream.Send(resp); err != nil {
+			if err = stream.Send(resp); err != nil {
 				logger.Errorf("failed to send stream response %+v: %v", resp, err)
 			}
 		case io.EOF:
@@ -2423,12 +2615,14 @@ func (s *VtctldServer) RestoreFromBackup(req *vtctldatapb.RestoreFromBackupReque
 			// shard primary may have changed while it was restoring.
 			//
 			// This also affects whether or not we want to send semi-sync ACKs.
-			ti, err := s.ts.GetTablet(ctx, req.TabletAlias)
+			var ti *topo.TabletInfo
+			ti, err = s.ts.GetTablet(ctx, req.TabletAlias)
 			if err != nil {
 				return err
 			}
 
-			return reparentutil.SetReplicationSource(ctx, s.ts, s.tmc, ti.Tablet)
+			err = reparentutil.SetReplicationSource(ctx, s.ts, s.tmc, ti.Tablet)
+			return err
 		default:
 			return err
 		}
@@ -2436,9 +2630,11 @@ func (s *VtctldServer) RestoreFromBackup(req *vtctldatapb.RestoreFromBackupReque
 }
 
 // RunHealthCheck is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) RunHealthCheck(ctx context.Context, req *vtctldatapb.RunHealthCheckRequest) (*vtctldatapb.RunHealthCheckResponse, error) {
+func (s *VtctldServer) RunHealthCheck(ctx context.Context, req *vtctldatapb.RunHealthCheckRequest) (resp *vtctldatapb.RunHealthCheckResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.RunHealthCheck")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 
@@ -2456,19 +2652,21 @@ func (s *VtctldServer) RunHealthCheck(ctx context.Context, req *vtctldatapb.RunH
 }
 
 // SetKeyspaceDurabilityPolicy is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) SetKeyspaceDurabilityPolicy(ctx context.Context, req *vtctldatapb.SetKeyspaceDurabilityPolicyRequest) (*vtctldatapb.SetKeyspaceDurabilityPolicyResponse, error) {
+func (s *VtctldServer) SetKeyspaceDurabilityPolicy(ctx context.Context, req *vtctldatapb.SetKeyspaceDurabilityPolicyRequest) (resp *vtctldatapb.SetKeyspaceDurabilityPolicyResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.SetKeyspaceDurabilityPolicy")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("durability_policy", req.DurabilityPolicy)
 
 	ctx, unlock, lockErr := s.ts.LockKeyspace(ctx, req.Keyspace, "SetKeyspaceDurabilityPolicy")
 	if lockErr != nil {
-		return nil, lockErr
+		err = lockErr
+		return nil, err
 	}
 
-	var err error
 	defer unlock(&err)
 
 	ki, err := s.ts.GetKeyspace(ctx, req.Keyspace)
@@ -2478,7 +2676,8 @@ func (s *VtctldServer) SetKeyspaceDurabilityPolicy(ctx context.Context, req *vtc
 
 	policyValid := reparentutil.CheckDurabilityPolicyExists(req.DurabilityPolicy)
 	if !policyValid {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "durability policy <%v> is not a valid policy. Please register it as a policy first", req.DurabilityPolicy)
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "durability policy <%v> is not a valid policy. Please register it as a policy first", req.DurabilityPolicy)
+		return nil, err
 	}
 
 	ki.DurabilityPolicy = req.DurabilityPolicy
@@ -2494,9 +2693,11 @@ func (s *VtctldServer) SetKeyspaceDurabilityPolicy(ctx context.Context, req *vtc
 }
 
 // SetKeyspaceServedFrom is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) SetKeyspaceServedFrom(ctx context.Context, req *vtctldatapb.SetKeyspaceServedFromRequest) (*vtctldatapb.SetKeyspaceServedFromResponse, error) {
+func (s *VtctldServer) SetKeyspaceServedFrom(ctx context.Context, req *vtctldatapb.SetKeyspaceServedFromRequest) (resp *vtctldatapb.SetKeyspaceServedFromResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.SetKeyspaceServedFrom")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("tablet_type", topoproto.TabletTypeLString(req.TabletType))
@@ -2506,10 +2707,10 @@ func (s *VtctldServer) SetKeyspaceServedFrom(ctx context.Context, req *vtctldata
 
 	ctx, unlock, lockErr := s.ts.LockKeyspace(ctx, req.Keyspace, "SetKeyspaceServedFrom")
 	if lockErr != nil {
-		return nil, lockErr
+		err = lockErr
+		return nil, err
 	}
 
-	var err error
 	defer unlock(&err)
 
 	ki, err := s.ts.GetKeyspace(ctx, req.Keyspace)
@@ -2533,9 +2734,11 @@ func (s *VtctldServer) SetKeyspaceServedFrom(ctx context.Context, req *vtctldata
 }
 
 // SetShardIsPrimaryServing is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) SetShardIsPrimaryServing(ctx context.Context, req *vtctldatapb.SetShardIsPrimaryServingRequest) (*vtctldatapb.SetShardIsPrimaryServingResponse, error) {
+func (s *VtctldServer) SetShardIsPrimaryServing(ctx context.Context, req *vtctldatapb.SetShardIsPrimaryServingRequest) (resp *vtctldatapb.SetShardIsPrimaryServingResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.SetShardIsPrimaryServing")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
@@ -2543,10 +2746,10 @@ func (s *VtctldServer) SetShardIsPrimaryServing(ctx context.Context, req *vtctld
 
 	ctx, unlock, lockErr := s.ts.LockKeyspace(ctx, req.Keyspace, fmt.Sprintf("SetShardIsPrimaryServing(%v,%v,%v)", req.Keyspace, req.Shard, req.IsServing))
 	if lockErr != nil {
-		return nil, lockErr
+		err = lockErr
+		return nil, err
 	}
 
-	var err error
 	defer unlock(&err)
 
 	si, err := s.ts.UpdateShardFields(ctx, req.Keyspace, req.Shard, func(si *topo.ShardInfo) error {
@@ -2563,7 +2766,7 @@ func (s *VtctldServer) SetShardIsPrimaryServing(ctx context.Context, req *vtctld
 }
 
 // SetShardTabletControl is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) SetShardTabletControl(ctx context.Context, req *vtctldatapb.SetShardTabletControlRequest) (*vtctldatapb.SetShardTabletControlResponse, error) {
+func (s *VtctldServer) SetShardTabletControl(ctx context.Context, req *vtctldatapb.SetShardTabletControlRequest) (resp *vtctldatapb.SetShardTabletControlResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.SetShardTabletControl")
 	defer span.Finish()
 
@@ -2577,10 +2780,10 @@ func (s *VtctldServer) SetShardTabletControl(ctx context.Context, req *vtctldata
 
 	ctx, unlock, lockErr := s.ts.LockKeyspace(ctx, req.Keyspace, "SetShardTabletControl")
 	if lockErr != nil {
-		return nil, lockErr
+		err = lockErr
+		return nil, err
 	}
 
-	var err error
 	defer unlock(&err)
 
 	si, err := s.ts.UpdateShardFields(ctx, req.Keyspace, req.Shard, func(si *topo.ShardInfo) error {
@@ -2613,12 +2816,15 @@ func (s *VtctldServer) SetShardTabletControl(ctx context.Context, req *vtctldata
 }
 
 // SetWritable is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) SetWritable(ctx context.Context, req *vtctldatapb.SetWritableRequest) (*vtctldatapb.SetWritableResponse, error) {
+func (s *VtctldServer) SetWritable(ctx context.Context, req *vtctldatapb.SetWritableRequest) (resp *vtctldatapb.SetWritableResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.SetWritable")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	if req.TabletAlias == nil {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "SetWritable.TabletAlias is required")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "SetWritable.TabletAlias is required")
+		return nil, err
 	}
 
 	alias := topoproto.TabletAliasString(req.TabletAlias)
@@ -2639,7 +2845,7 @@ func (s *VtctldServer) SetWritable(ctx context.Context, req *vtctldatapb.SetWrit
 		f = s.tmc.SetReadOnly
 	}
 
-	if err := f(ctx, tablet.Tablet); err != nil {
+	if err = f(ctx, tablet.Tablet); err != nil {
 		log.Errorf("SetWritable: failed to set writable=%v on %v: %v", req.Writable, alias, err)
 		return nil, err
 	}
@@ -2648,15 +2854,17 @@ func (s *VtctldServer) SetWritable(ctx context.Context, req *vtctldatapb.SetWrit
 }
 
 // ShardReplicationAdd is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ShardReplicationAdd(ctx context.Context, req *vtctldatapb.ShardReplicationAddRequest) (*vtctldatapb.ShardReplicationAddResponse, error) {
+func (s *VtctldServer) ShardReplicationAdd(ctx context.Context, req *vtctldatapb.ShardReplicationAddRequest) (resp *vtctldatapb.ShardReplicationAddResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ShardReplicationAdd")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
 
-	if err := topo.UpdateShardReplicationRecord(ctx, s.ts, req.Keyspace, req.Shard, req.TabletAlias); err != nil {
+	if err = topo.UpdateShardReplicationRecord(ctx, s.ts, req.Keyspace, req.Shard, req.TabletAlias); err != nil {
 		return nil, err
 	}
 
@@ -2664,9 +2872,11 @@ func (s *VtctldServer) ShardReplicationAdd(ctx context.Context, req *vtctldatapb
 }
 
 // ShardReplicationFix is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ShardReplicationFix(ctx context.Context, req *vtctldatapb.ShardReplicationFixRequest) (*vtctldatapb.ShardReplicationFixResponse, error) {
+func (s *VtctldServer) ShardReplicationFix(ctx context.Context, req *vtctldatapb.ShardReplicationFixRequest) (resp *vtctldatapb.ShardReplicationFixResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ShardReplicationFix")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
@@ -2688,16 +2898,19 @@ func (s *VtctldServer) ShardReplicationFix(ctx context.Context, req *vtctldatapb
 }
 
 // ShardReplicationPositions is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) ShardReplicationPositions(ctx context.Context, req *vtctldatapb.ShardReplicationPositionsRequest) (*vtctldatapb.ShardReplicationPositionsResponse, error) {
+func (s *VtctldServer) ShardReplicationPositions(ctx context.Context, req *vtctldatapb.ShardReplicationPositionsRequest) (resp *vtctldatapb.ShardReplicationPositionsResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ShardReplicationPositions")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
 
 	tabletInfoMap, err := s.ts.GetTabletMapForShard(ctx, req.Keyspace, req.Shard)
 	if err != nil {
-		return nil, fmt.Errorf("GetTabletMapForShard(%s, %s) failed: %w", req.Keyspace, req.Shard, err)
+		err = fmt.Errorf("GetTabletMapForShard(%s, %s) failed: %w", req.Keyspace, req.Shard, err)
+		return nil, err
 	}
 
 	log.Infof("Gathering tablet replication status for: %v", tabletInfoMap)
@@ -2805,7 +3018,8 @@ func (s *VtctldServer) ShardReplicationPositions(ctx context.Context, req *vtctl
 	wg.Wait()
 
 	if rec.HasErrors() {
-		return nil, rec.Error()
+		err = rec.Error()
+		return nil, err
 	}
 
 	return &vtctldatapb.ShardReplicationPositionsResponse{
@@ -2815,15 +3029,17 @@ func (s *VtctldServer) ShardReplicationPositions(ctx context.Context, req *vtctl
 }
 
 // ShardReplicationRemove is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ShardReplicationRemove(ctx context.Context, req *vtctldatapb.ShardReplicationRemoveRequest) (*vtctldatapb.ShardReplicationRemoveResponse, error) {
+func (s *VtctldServer) ShardReplicationRemove(ctx context.Context, req *vtctldatapb.ShardReplicationRemoveRequest) (resp *vtctldatapb.ShardReplicationRemoveResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ShardReplicationRemove")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
 
-	if err := topo.RemoveShardReplicationRecord(ctx, s.ts, req.TabletAlias.Cell, req.Keyspace, req.Shard, req.TabletAlias); err != nil {
+	if err = topo.RemoveShardReplicationRecord(ctx, s.ts, req.TabletAlias.Cell, req.Keyspace, req.Shard, req.TabletAlias); err != nil {
 		return nil, err
 	}
 
@@ -2831,9 +3047,11 @@ func (s *VtctldServer) ShardReplicationRemove(ctx context.Context, req *vtctldat
 }
 
 // SleepTablet is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) SleepTablet(ctx context.Context, req *vtctldatapb.SleepTabletRequest) (*vtctldatapb.SleepTabletResponse, error) {
+func (s *VtctldServer) SleepTablet(ctx context.Context, req *vtctldatapb.SleepTabletRequest) (resp *vtctldatapb.SleepTabletResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.SleepTablet")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.TabletAlias))
 
@@ -2860,9 +3078,11 @@ func (s *VtctldServer) SleepTablet(ctx context.Context, req *vtctldatapb.SleepTa
 }
 
 // SourceShardAdd is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) SourceShardAdd(ctx context.Context, req *vtctldatapb.SourceShardAddRequest) (*vtctldatapb.SourceShardAddResponse, error) {
+func (s *VtctldServer) SourceShardAdd(ctx context.Context, req *vtctldatapb.SourceShardAddRequest) (resp *vtctldatapb.SourceShardAddResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.SourceShardAdd")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
@@ -2872,14 +3092,12 @@ func (s *VtctldServer) SourceShardAdd(ctx context.Context, req *vtctldatapb.Sour
 	span.Annotate("keyrange", key.KeyRangeString(req.KeyRange))
 	span.Annotate("tables", strings.Join(req.Tables, ","))
 
-	var (
-		si  *topo.ShardInfo
-		err error
-	)
+	var si *topo.ShardInfo
 
 	ctx, unlock, lockErr := s.ts.LockKeyspace(ctx, req.Keyspace, fmt.Sprintf("SourceShardAdd(%v)", req.Uid))
 	if lockErr != nil {
-		return nil, lockErr
+		err = lockErr
+		return nil, err
 	}
 	defer unlock(&err)
 
@@ -2903,7 +3121,7 @@ func (s *VtctldServer) SourceShardAdd(ctx context.Context, req *vtctldatapb.Sour
 		return nil, err
 	}
 
-	resp := &vtctldatapb.SourceShardAddResponse{}
+	resp = &vtctldatapb.SourceShardAddResponse{}
 	switch si {
 	case nil:
 		// If we return NoUpdateNeeded from ts.UpdateShardFields, then we don't
@@ -2916,22 +3134,22 @@ func (s *VtctldServer) SourceShardAdd(ctx context.Context, req *vtctldatapb.Sour
 }
 
 // SourceShardDelete is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) SourceShardDelete(ctx context.Context, req *vtctldatapb.SourceShardDeleteRequest) (*vtctldatapb.SourceShardDeleteResponse, error) {
+func (s *VtctldServer) SourceShardDelete(ctx context.Context, req *vtctldatapb.SourceShardDeleteRequest) (resp *vtctldatapb.SourceShardDeleteResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.SourceShardDelete")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
 	span.Annotate("uid", req.Uid)
 
-	var (
-		si  *topo.ShardInfo
-		err error
-	)
+	var si *topo.ShardInfo
 
 	ctx, unlock, lockErr := s.ts.LockKeyspace(ctx, req.Keyspace, fmt.Sprintf("SourceShardDelete(%v)", req.Uid))
 	if lockErr != nil {
-		return nil, lockErr
+		err = lockErr
+		return nil, err
 	}
 	defer unlock(&err)
 
@@ -2954,7 +3172,7 @@ func (s *VtctldServer) SourceShardDelete(ctx context.Context, req *vtctldatapb.S
 		return nil, err
 	}
 
-	resp := &vtctldatapb.SourceShardDeleteResponse{}
+	resp = &vtctldatapb.SourceShardDeleteResponse{}
 	switch si {
 	case nil:
 		// If we return NoUpdateNeeded from ts.UpdateShardFields, then we don't
@@ -2967,12 +3185,15 @@ func (s *VtctldServer) SourceShardDelete(ctx context.Context, req *vtctldatapb.S
 }
 
 // StartReplication is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) StartReplication(ctx context.Context, req *vtctldatapb.StartReplicationRequest) (*vtctldatapb.StartReplicationResponse, error) {
+func (s *VtctldServer) StartReplication(ctx context.Context, req *vtctldatapb.StartReplicationRequest) (resp *vtctldatapb.StartReplicationResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.StartReplication")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	if req.TabletAlias == nil {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "StartReplication.TabletAlias is required")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "StartReplication.TabletAlias is required")
+		return nil, err
 	}
 
 	alias := topoproto.TabletAliasString(req.TabletAlias)
@@ -2990,20 +3211,24 @@ func (s *VtctldServer) StartReplication(ctx context.Context, req *vtctldatapb.St
 	}
 
 	if !shard.HasPrimary() {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no primary tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no primary tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
+		return nil, err
 	}
 
 	shardPrimary, err := s.ts.GetTablet(ctx, shard.PrimaryAlias)
 	if err != nil {
-		return nil, fmt.Errorf("cannot lookup primary tablet %v for shard %v/%v: %w", topoproto.TabletAliasString(shard.PrimaryAlias), tablet.Keyspace, tablet.Shard, err)
+		err = fmt.Errorf("cannot lookup primary tablet %v for shard %v/%v: %w", topoproto.TabletAliasString(shard.PrimaryAlias), tablet.Keyspace, tablet.Shard, err)
+		return nil, err
 	}
 
 	if shardPrimary.Type != topodatapb.TabletType_PRIMARY {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "TopologyServer has incosistent state for shard primary %v", topoproto.TabletAliasString(shard.PrimaryAlias))
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "TopologyServer has incosistent state for shard primary %v", topoproto.TabletAliasString(shard.PrimaryAlias))
+		return nil, err
 	}
 
 	if shardPrimary.Keyspace != tablet.Keyspace || shardPrimary.Shard != tablet.Shard {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary %v and replica %v not in same keypace shard (%v/%v)", topoproto.TabletAliasString(shard.PrimaryAlias), topoproto.TabletAliasString(tablet.Alias), tablet.Keyspace, tablet.Shard)
+		err = vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary %v and replica %v not in same keypace shard (%v/%v)", topoproto.TabletAliasString(shard.PrimaryAlias), topoproto.TabletAliasString(tablet.Alias), tablet.Keyspace, tablet.Shard)
+		return nil, err
 	}
 
 	durabilityName, err := s.ts.GetKeyspaceDurability(ctx, tablet.Keyspace)
@@ -3016,7 +3241,7 @@ func (s *VtctldServer) StartReplication(ctx context.Context, req *vtctldatapb.St
 		return nil, err
 	}
 
-	if err := s.tmc.StartReplication(ctx, tablet.Tablet, reparentutil.IsReplicaSemiSync(durability, shardPrimary.Tablet, tablet.Tablet)); err != nil {
+	if err = s.tmc.StartReplication(ctx, tablet.Tablet, reparentutil.IsReplicaSemiSync(durability, shardPrimary.Tablet, tablet.Tablet)); err != nil {
 		log.Errorf("StartReplication: failed to start replication on %v: %v", alias, err)
 		return nil, err
 	}
@@ -3025,12 +3250,15 @@ func (s *VtctldServer) StartReplication(ctx context.Context, req *vtctldatapb.St
 }
 
 // StopReplication is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) StopReplication(ctx context.Context, req *vtctldatapb.StopReplicationRequest) (*vtctldatapb.StopReplicationResponse, error) {
+func (s *VtctldServer) StopReplication(ctx context.Context, req *vtctldatapb.StopReplicationRequest) (resp *vtctldatapb.StopReplicationResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.StopReplication")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	if req.TabletAlias == nil {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "StopReplication.TabletAlias is required")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "StopReplication.TabletAlias is required")
+		return nil, err
 	}
 
 	alias := topoproto.TabletAliasString(req.TabletAlias)
@@ -3051,12 +3279,15 @@ func (s *VtctldServer) StopReplication(ctx context.Context, req *vtctldatapb.Sto
 }
 
 // TabletExternallyReparented is part of the vtctldservicepb.VtctldServer interface.
-func (s *VtctldServer) TabletExternallyReparented(ctx context.Context, req *vtctldatapb.TabletExternallyReparentedRequest) (*vtctldatapb.TabletExternallyReparentedResponse, error) {
+func (s *VtctldServer) TabletExternallyReparented(ctx context.Context, req *vtctldatapb.TabletExternallyReparentedRequest) (resp *vtctldatapb.TabletExternallyReparentedResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.TabletExternallyReparented")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	if req.Tablet == nil {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "TabletExternallyReparentedRequest.Tablet must not be nil")
+		err = vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "TabletExternallyReparentedRequest.Tablet must not be nil")
+		return nil, err
 	}
 
 	span.Annotate("tablet_alias", topoproto.TabletAliasString(req.Tablet))
@@ -3073,7 +3304,7 @@ func (s *VtctldServer) TabletExternallyReparented(ctx context.Context, req *vtct
 		return nil, err
 	}
 
-	resp := &vtctldatapb.TabletExternallyReparentedResponse{
+	resp = &vtctldatapb.TabletExternallyReparentedResponse{
 		Keyspace:   shard.Keyspace(),
 		Shard:      shard.ShardName(),
 		NewPrimary: req.Tablet,
@@ -3115,7 +3346,7 @@ func (s *VtctldServer) TabletExternallyReparented(ctx context.Context, req *vtct
 		return nil, err
 	}
 
-	if err := s.tmc.ChangeType(ctx, tablet.Tablet, topodatapb.TabletType_PRIMARY, reparentutil.SemiSyncAckers(durability, tablet.Tablet) > 0); err != nil {
+	if err = s.tmc.ChangeType(ctx, tablet.Tablet, topodatapb.TabletType_PRIMARY, reparentutil.SemiSyncAckers(durability, tablet.Tablet) > 0); err != nil {
 		log.Warningf("ChangeType(%v, PRIMARY): %v", topoproto.TabletAliasString(req.Tablet), err)
 		return nil, err
 	}
@@ -3126,9 +3357,11 @@ func (s *VtctldServer) TabletExternallyReparented(ctx context.Context, req *vtct
 }
 
 // UpdateCellInfo is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) UpdateCellInfo(ctx context.Context, req *vtctldatapb.UpdateCellInfoRequest) (*vtctldatapb.UpdateCellInfoResponse, error) {
+func (s *VtctldServer) UpdateCellInfo(ctx context.Context, req *vtctldatapb.UpdateCellInfoRequest) (resp *vtctldatapb.UpdateCellInfoResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.UpdateCellInfo")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("cell", req.Name)
 	span.Annotate("cell_server_address", req.CellInfo.ServerAddress)
@@ -3138,7 +3371,7 @@ func (s *VtctldServer) UpdateCellInfo(ctx context.Context, req *vtctldatapb.Upda
 	defer cancel()
 
 	var updatedCi *topodatapb.CellInfo
-	err := s.ts.UpdateCellInfoFields(ctx, req.Name, func(ci *topodatapb.CellInfo) error {
+	err = s.ts.UpdateCellInfoFields(ctx, req.Name, func(ci *topodatapb.CellInfo) error {
 		defer func() {
 			updatedCi = proto.Clone(ci).(*topodatapb.CellInfo)
 		}()
@@ -3173,9 +3406,11 @@ func (s *VtctldServer) UpdateCellInfo(ctx context.Context, req *vtctldatapb.Upda
 }
 
 // UpdateCellsAlias is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) UpdateCellsAlias(ctx context.Context, req *vtctldatapb.UpdateCellsAliasRequest) (*vtctldatapb.UpdateCellsAliasResponse, error) {
+func (s *VtctldServer) UpdateCellsAlias(ctx context.Context, req *vtctldatapb.UpdateCellsAliasRequest) (resp *vtctldatapb.UpdateCellsAliasResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.UpdateCellsAlias")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("cells_alias", req.Name)
 	span.Annotate("cells_alias_cells", strings.Join(req.CellsAlias.Cells, ","))
@@ -3184,7 +3419,7 @@ func (s *VtctldServer) UpdateCellsAlias(ctx context.Context, req *vtctldatapb.Up
 	defer cancel()
 
 	var updatedCa *topodatapb.CellsAlias
-	err := s.ts.UpdateCellsAlias(ctx, req.Name, func(ca *topodatapb.CellsAlias) error {
+	err = s.ts.UpdateCellsAlias(ctx, req.Name, func(ca *topodatapb.CellsAlias) error {
 		defer func() {
 			updatedCa = proto.Clone(ca).(*topodatapb.CellsAlias)
 		}()
@@ -3204,20 +3439,22 @@ func (s *VtctldServer) UpdateCellsAlias(ctx context.Context, req *vtctldatapb.Up
 }
 
 // Validate is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) Validate(ctx context.Context, req *vtctldatapb.ValidateRequest) (*vtctldatapb.ValidateResponse, error) {
+func (s *VtctldServer) Validate(ctx context.Context, req *vtctldatapb.ValidateRequest) (resp *vtctldatapb.ValidateResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.Validate")
 	defer span.Finish()
 
+	defer panicHandler(&err)
+
 	span.Annotate("ping_tablets", req.PingTablets)
 
-	resp := vtctldatapb.ValidateResponse{}
+	resp = &vtctldatapb.ValidateResponse{}
 	getKeyspacesCtx, getKeyspacesCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer getKeyspacesCancel()
 
 	keyspaces, err := s.ts.GetKeyspaces(getKeyspacesCtx)
 	if err != nil {
 		resp.Results = append(resp.Results, fmt.Sprintf("GetKeyspaces failed: %v", err))
-		return &resp, nil
+		return resp, nil
 	}
 
 	var (
@@ -3332,25 +3569,28 @@ func (s *VtctldServer) Validate(ctx context.Context, req *vtctldatapb.ValidateRe
 	}
 
 	wg.Wait()
-	return &resp, nil
+	return resp, err
 }
 
 // ValidateKeyspace is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ValidateKeyspace(ctx context.Context, req *vtctldatapb.ValidateKeyspaceRequest) (*vtctldatapb.ValidateKeyspaceResponse, error) {
+func (s *VtctldServer) ValidateKeyspace(ctx context.Context, req *vtctldatapb.ValidateKeyspaceRequest) (resp *vtctldatapb.ValidateKeyspaceResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ValidateKeyspace")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("ping_tablets", req.PingTablets)
 
-	resp := vtctldatapb.ValidateKeyspaceResponse{}
+	resp = &vtctldatapb.ValidateKeyspaceResponse{}
 	getShardNamesCtx, getShardNamesCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer getShardNamesCancel()
 
 	shards, err := s.ts.GetShardNames(getShardNamesCtx, req.Keyspace)
 	if err != nil {
 		resp.Results = append(resp.Results, fmt.Sprintf("TopologyServer.GetShardNames(%v) failed: %v", req.Keyspace, err))
-		return &resp, nil
+		err = nil
+		return resp, err
 	}
 
 	resp.ResultsByShard = make(map[string]*vtctldatapb.ValidateShardResponse, len(shards))
@@ -3382,26 +3622,29 @@ func (s *VtctldServer) ValidateKeyspace(ctx context.Context, req *vtctldatapb.Va
 	}
 
 	wg.Wait()
-	return &resp, nil
+	return resp, err
 }
 
 // ValidateSchemaKeyspace is a part of the vtctlservicepb.VtctldServer interface.
 // It will diff the schema from all the tablets in the keyspace.
-func (s *VtctldServer) ValidateSchemaKeyspace(ctx context.Context, req *vtctldatapb.ValidateSchemaKeyspaceRequest) (*vtctldatapb.ValidateSchemaKeyspaceResponse, error) {
+func (s *VtctldServer) ValidateSchemaKeyspace(ctx context.Context, req *vtctldatapb.ValidateSchemaKeyspaceRequest) (resp *vtctldatapb.ValidateSchemaKeyspaceResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ValidateSchemaKeyspace")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	keyspace := req.Keyspace
 
-	resp := vtctldatapb.ValidateSchemaKeyspaceResponse{
+	resp = &vtctldatapb.ValidateSchemaKeyspaceResponse{
 		Results: []string{},
 	}
 
 	shards, err := s.ts.GetShardNames(ctx, keyspace)
 	if err != nil {
 		resp.Results = append(resp.Results, fmt.Sprintf("TopologyServer.GetShardNames(%v) failed: %v", req.Keyspace, err))
-		return &resp, nil
+		err = nil
+		return resp, err
 	}
 
 	resp.ResultsByShard = make(map[string]*vtctldatapb.ValidateShardResponse, len(shards))
@@ -3414,13 +3657,14 @@ func (s *VtctldServer) ValidateSchemaKeyspace(ctx context.Context, req *vtctldat
 	}
 
 	if req.IncludeVschema {
-		results, err := s.ValidateVSchema(ctx, &vtctldatapb.ValidateVSchemaRequest{
+		results, err2 := s.ValidateVSchema(ctx, &vtctldatapb.ValidateVSchemaRequest{
 			Keyspace:      keyspace,
 			Shards:        shards,
 			ExcludeTables: req.ExcludeTables,
 			IncludeViews:  req.IncludeViews,
 		})
-		if err != nil {
+		if err2 != nil {
+			err = err2
 			return nil, err
 		}
 
@@ -3429,7 +3673,7 @@ func (s *VtctldServer) ValidateSchemaKeyspace(ctx context.Context, req *vtctldat
 			for shard, shardResults := range resp.ResultsByShard {
 				resp.ResultsByShard[shard].Results = append(resp.ResultsByShard[shard].Results, shardResults.Results...)
 			}
-			return &resp, nil
+			return resp, err
 		}
 	}
 
@@ -3518,26 +3762,29 @@ func (s *VtctldServer) ValidateSchemaKeyspace(ctx context.Context, req *vtctldat
 
 	wg.Wait()
 
-	return &resp, nil
+	return resp, err
 }
 
 // ValidateShard is part of the vtctlservicepb.VtctldServer interface.
-func (s *VtctldServer) ValidateShard(ctx context.Context, req *vtctldatapb.ValidateShardRequest) (*vtctldatapb.ValidateShardResponse, error) {
+func (s *VtctldServer) ValidateShard(ctx context.Context, req *vtctldatapb.ValidateShardRequest) (resp *vtctldatapb.ValidateShardResponse, err error) {
 	span, ctx := trace.NewSpan(ctx, "VtctldServer.ValidateShard")
 	defer span.Finish()
+
+	defer panicHandler(&err)
 
 	span.Annotate("keyspace", req.Keyspace)
 	span.Annotate("shard", req.Shard)
 	span.Annotate("ping_tablets", req.PingTablets)
 
-	resp := vtctldatapb.ValidateShardResponse{}
+	resp = &vtctldatapb.ValidateShardResponse{}
 	getShardCtx, getShardCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer getShardCancel()
 
 	si, err := s.ts.GetShard(getShardCtx, req.Keyspace, req.Shard)
 	if err != nil {
 		resp.Results = append(resp.Results, fmt.Sprintf("TopologyServer.GetShard(%v, %v) failed: %v", req.Keyspace, req.Shard, err))
-		return &resp, nil
+		err = nil
+		return resp, err
 	}
 
 	findAllTabletAliasesCtx, findAllTabletAliasesCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
@@ -3546,7 +3793,8 @@ func (s *VtctldServer) ValidateShard(ctx context.Context, req *vtctldatapb.Valid
 	aliases, err := s.ts.FindAllTabletAliasesInShard(findAllTabletAliasesCtx, req.Keyspace, req.Shard)
 	if err != nil {
 		resp.Results = append(resp.Results, fmt.Sprintf("TopologyServer.FindAllTabletAliasesInShard(%v, %v) failed: %v", req.Keyspace, req.Shard, err))
-		return &resp, nil
+		err = nil
+		return resp, err
 	}
 
 	getTabletMapCtx, getTabletMapCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
@@ -3698,44 +3946,52 @@ func (s *VtctldServer) ValidateShard(ctx context.Context, req *vtctldatapb.Valid
 	close(results)
 	<-done
 
-	return &resp, nil
+	return resp, err
 }
 
 // ValidateVersionKeyspace validates all versions are the same in all
 // tablets in a keyspace
-func (s *VtctldServer) ValidateVersionKeyspace(ctx context.Context, req *vtctldatapb.ValidateVersionKeyspaceRequest) (*vtctldatapb.ValidateVersionKeyspaceResponse, error) {
+func (s *VtctldServer) ValidateVersionKeyspace(ctx context.Context, req *vtctldatapb.ValidateVersionKeyspaceRequest) (resp *vtctldatapb.ValidateVersionKeyspaceResponse, err error) {
+	span, ctx := trace.NewSpan(ctx, "VtctldServer.ValidateVersionKeyspace")
+	defer span.Finish()
+
+	defer panicHandler(&err)
+
 	keyspace := req.Keyspace
 	shards, err := s.ts.GetShardNames(ctx, keyspace)
-	resp := vtctldatapb.ValidateVersionKeyspaceResponse{
+	resp = &vtctldatapb.ValidateVersionKeyspaceResponse{
 		Results:        []string{},
 		ResultsByShard: make(map[string]*vtctldatapb.ValidateShardResponse, len(shards)),
 	}
 
 	if err != nil {
 		resp.Results = append(resp.Results, fmt.Sprintf("TopologyServer.GetShardNames(%v) failed: %v", keyspace, err))
-		return &resp, nil
+		err = nil
+		return
 	}
 
 	if len(shards) == 0 {
 		resp.Results = append(resp.Results, fmt.Sprintf("no shards in keyspace %v", keyspace))
-		return &resp, nil
+		return
 	}
 
 	si, err := s.ts.GetShard(ctx, keyspace, shards[0])
 	if err != nil {
 		resp.Results = append(resp.Results, fmt.Sprintf("unable to find primary shard %v/%v", keyspace, shards[0]))
-		return &resp, nil
+		err = nil
+		return
 	}
 	if !si.HasPrimary() {
 		resp.Results = append(resp.Results, fmt.Sprintf("no primary in shard %v/%v", keyspace, shards[0]))
-		return &resp, nil
+		return
 	}
 
 	referenceAlias := si.PrimaryAlias
 	referenceVersion, err := s.GetVersion(ctx, &vtctldatapb.GetVersionRequest{TabletAlias: referenceAlias})
 	if err != nil {
 		resp.Results = append(resp.Results, fmt.Sprintf("unable to get reference version of first shard's primary tablet: %v", err))
-		return &resp, nil
+		err = nil
+		return
 	}
 
 	var validateVersionKeyspaceResponseMutex sync.Mutex
@@ -3792,11 +4048,15 @@ func (s *VtctldServer) ValidateVersionKeyspace(ctx context.Context, req *vtctlda
 		validateVersionKeyspaceResponseMutex.Unlock()
 	}
 
-	return &resp, nil
+	return resp, err
 }
 
 // ValidateVSchema compares the schema of each primary tablet in "keyspace/shards..." to the vschema and errs if there are differences
-func (s *VtctldServer) ValidateVSchema(ctx context.Context, req *vtctldatapb.ValidateVSchemaRequest) (*vtctldatapb.ValidateVSchemaResponse, error) {
+func (s *VtctldServer) ValidateVSchema(ctx context.Context, req *vtctldatapb.ValidateVSchemaRequest) (resp *vtctldatapb.ValidateVSchemaResponse, err error) {
+	span, ctx := trace.NewSpan(ctx, "VtctldServer.ValidateVSchema")
+	defer span.Finish()
+
+	defer panicHandler(&err)
 	keyspace := req.Keyspace
 	shards := req.Shards
 	excludeTables := req.ExcludeTables
@@ -3804,10 +4064,11 @@ func (s *VtctldServer) ValidateVSchema(ctx context.Context, req *vtctldatapb.Val
 
 	vschm, err := s.ts.GetVSchema(ctx, keyspace)
 	if err != nil {
-		return nil, fmt.Errorf("GetVSchema(%s) failed: %v", keyspace, err)
+		err = fmt.Errorf("GetVSchema(%s) failed: %v", keyspace, err)
+		return nil, err
 	}
 
-	resp := vtctldatapb.ValidateVSchemaResponse{
+	resp = &vtctldatapb.ValidateVSchemaResponse{
 		Results:        []string{},
 		ResultsByShard: make(map[string]*vtctldatapb.ValidateShardResponse, len(shards)),
 	}
@@ -3872,7 +4133,7 @@ func (s *VtctldServer) ValidateVSchema(ctx context.Context, req *vtctldatapb.Val
 		}(shard)
 	}
 	wg.Wait()
-	return &resp, nil
+	return resp, err
 }
 
 // StartServer registers a VtctldServer for RPCs on the given gRPC server.

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -72,6 +72,22 @@ func init() {
 	})
 }
 
+func TestPanicHandler(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		err := recover()
+		assert.Nil(t, err, "bad request should catch panic")
+	}()
+
+	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, nil, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
+		return NewVtctldServer(ts)
+	})
+
+	_, err := vtctld.AddCellInfo(context.Background(), nil)
+	assert.Error(t, err)
+}
+
 func TestAddCellInfo(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


## Description

What it says in the title.

After:

```
$ grpcurl -plaintext localhost:15999 vtctlservice.Vtctld.ReloadSchema
ERROR:
  Code: Unknown
  Message: uncaught panic: runtime error: invalid memory address or nil pointer dereference
$ ps aux | grep vtctld
andrew           79727   0.0  0.3 408764896  44272 s000  S     3:19PM   0:00.07 vtctld --topo_implementation etcd2 --topo_global_server_address localhost:2379 --topo_global_root /vitess/global --cell test --workflow_manager_init --workflow_manager_use_election --service_map grpc-vtctl,grpc-vtctld --backup_storage_implementation file --file_backup_storage_root /Users/andrew/dev/vitess/examples/local/vtdataroot/backups --log_dir /Users/andrew/dev/vitess/examples/local/vtdataroot/tmp --port 15000 --grpc_port 15999 --pid_file /Users/andrew/dev/vitess/examples/local/vtdataroot/tmp/vtctld.pid
```

## Related Issue(s)

Fixes #11183.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
