### PR TITLE
[cli] [servenv] Migrate miscellaneous flags to `pflag`

### DIFF
--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -117,7 +117,6 @@ Usage of vtexplain:
       --normalize                                                    Whether to enable vtgate normalization
       --normalize_queries                                            Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars. (default true)
       --output-mode string                                           Output in human-friendly text or json (default "text")
-      --pid_file string                                              If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --planner-version string                                       Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4
       --planner_version string                                       Deprecated flag. Use planner-version instead
       --pool_hostname_resolve_interval duration                      if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled) (default 0s)

--- a/go/flags/endtoend/vtgr.txt
+++ b/go/flags/endtoend/vtgr.txt
@@ -29,7 +29,6 @@ Usage of vtgr:
       --logtostderr                                log to standard error instead of files
       --mysql_server_flush_delay duration          Delay after which buffered response will be flushed to the client. (default 100ms)
       --mysql_server_version string                MySQL server version to advertise.
-      --pid_file string                            If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --ping_tablet_timeout duration               time to wait when we ping a tablet (default 2s)
       --pprof strings                              enable profiling
       --purge_logs_interval duration               how often try to remove old logs (default 1h0m0s)

--- a/go/internal/flag/flag.go
+++ b/go/internal/flag/flag.go
@@ -57,7 +57,7 @@ func Parse(fs *flag.FlagSet) {
 
 		defer func() {
 			if help {
-				flag.Usage()
+				Usage()
 				os.Exit(0)
 			}
 		}()
@@ -65,6 +65,12 @@ func Parse(fs *flag.FlagSet) {
 
 	flag.CommandLine = fs
 	flag.Parse()
+}
+
+// Usage invokes the current CommandLine's Usage func, or if not overridden,
+// "prints a simple header and calls PrintDefaults".
+func Usage() {
+	flag.Usage()
 }
 
 // filterTestFlags returns two slices: the second one has just the flags for `go test` and the first one contains

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -166,7 +166,7 @@ func isGRPCEnabled() bool {
 		return true
 	}
 
-	if SocketFile != nil && *SocketFile != "" {
+	if socketFile != "" {
 		return true
 	}
 

--- a/go/vt/servenv/pid_file.go
+++ b/go/vt/servenv/pid_file.go
@@ -17,27 +17,26 @@ limitations under the License.
 package servenv
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
 	"vitess.io/vitess/go/vt/log"
 )
 
-var pidFile = flag.String("pid_file", "", "If set, the process will write its pid to the named file, and delete it on graceful shutdown.")
+var pidFile string // registered in RegisterFlags as --pid_file
 
 func init() {
 	pidFileCreated := false
 
 	// Create pid file after flags are parsed.
 	OnInit(func() {
-		if *pidFile == "" {
+		if pidFile == "" {
 			return
 		}
 
-		file, err := os.OpenFile(*pidFile, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+		file, err := os.OpenFile(pidFile, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 		if err != nil {
-			log.Errorf("Unable to create pid file '%s': %v", *pidFile, err)
+			log.Errorf("Unable to create pid file '%s': %v", pidFile, err)
 			return
 		}
 		pidFileCreated = true
@@ -47,15 +46,15 @@ func init() {
 
 	// Remove pid file on graceful shutdown.
 	OnClose(func() {
-		if *pidFile == "" {
+		if pidFile == "" {
 			return
 		}
 		if !pidFileCreated {
 			return
 		}
 
-		if err := os.Remove(*pidFile); err != nil {
-			log.Errorf("Unable to remove pid file '%s': %v", *pidFile, err)
+		if err := os.Remove(pidFile); err != nil {
+			log.Errorf("Unable to remove pid file '%s': %v", pidFile, err)
 		}
 	})
 }

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -94,6 +94,9 @@ func RegisterFlags() {
 		fs.DurationVar(&onTermTimeout, "onterm_timeout", onTermTimeout, "wait no more than this for OnTermSync handlers before stopping")
 		fs.DurationVar(&onCloseTimeout, "onclose_timeout", onCloseTimeout, "wait no more than this for OnClose handlers before stopping")
 		fs.BoolVar(&catchSigpipe, "catch-sigpipe", catchSigpipe, "catch and ignore SIGPIPE on stdout and stderr if specified")
+
+		// pid_file.go
+		fs.StringVar(&pidFile, "pid_file", pidFile, "If set, the process will write its pid to the named file, and delete it on graceful shutdown.")
 	})
 }
 

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -29,7 +29,6 @@ limitations under the License.
 package servenv
 
 import (
-	"flag"
 	"net/url"
 	"os"
 	"os/signal"
@@ -321,7 +320,7 @@ func ParseFlags(cmd string) {
 
 	args := fs.Args()
 	if len(args) > 0 {
-		flag.Usage()
+		_flag.Usage()
 		log.Exitf("%s doesn't take any positional arguments, got '%s'", cmd, strings.Join(args, " "))
 	}
 }

--- a/go/vt/servenv/unix_socket.go
+++ b/go/vt/servenv/unix_socket.go
@@ -17,26 +17,27 @@ limitations under the License.
 package servenv
 
 import (
-	"flag"
 	"net"
 	"os"
+
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/log"
 )
 
 var (
-	// SocketFile has the flag used when calling
+	// socketFile has the flag used when calling
 	// RegisterDefaultSocketFileFlags.
-	SocketFile *string
+	socketFile string
 )
 
 // serveSocketFile listen to the named socket and serves RPCs on it.
 func serveSocketFile() {
-	if SocketFile == nil || *SocketFile == "" {
+	if socketFile == "" {
 		log.Infof("Not listening on socket file")
 		return
 	}
-	name := *SocketFile
+	name := socketFile
 
 	// try to delete if file exists
 	if _, err := os.Stat(name); err == nil {
@@ -57,5 +58,7 @@ func serveSocketFile() {
 // RegisterDefaultSocketFileFlags registers the default flags for listening
 // to a socket. This needs to be called before flags are parsed.
 func RegisterDefaultSocketFileFlags() {
-	SocketFile = flag.String("socket_file", "", "Local unix socket file to listen on")
+	OnParse(func(fs *pflag.FlagSet) {
+		fs.StringVar(&socketFile, "socket_file", socketFile, "Local unix socket file to listen on")
+	})
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This one covers `--pid_file` and `--socket_file`, leaving only MySQLVersion and `--version`, which I'll tackle separately.

## Related Issue(s)

Relates to #11144 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
