### PR TITLE
Fix vtcompose and docker-compose examples

### DIFF
--- a/examples/compose/.env
+++ b/examples/compose/.env
@@ -1,4 +1,4 @@
-TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500 -topo_global_root vitess/global
+TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500 --topo_global_root vitess/global
 GRPC_PORT=15999
 WEB_PORT=8080
 MYSQL_PORT=15306

--- a/examples/compose/client.go
+++ b/examples/compose/client.go
@@ -22,25 +22,26 @@
 // Then run:
 // vitess$ . dev.env
 // vitess$ cd examples/local
-// vitess/examples/local$ go run client.go -server=localhost:15991
+// vitess/examples/local$ go run client.go --server=localhost:15991
 package main
 
 import (
-	"flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	"vitess.io/vitess/go/vt/vitessdriver"
 )
 
 var (
-	server = flag.String("server", "", "vtgate server to connect to")
+	server = pflag.String("server", "", "vtgate server to connect to")
 )
 
 func main() {
-	flag.Parse()
+	pflag.Parse()
 	rand.Seed(time.Now().UnixNano())
 
 	// Connect to vtgate.

--- a/examples/compose/client.sh
+++ b/examples/compose/client.sh
@@ -25,4 +25,4 @@ if [[ "$OSTYPE" == "msys" ]]; then
 fi
 
 # This is a convenience script to run the client.go script
-exec $tty docker-compose exec -u root "${CS:-vtgate}" go run "${script:-/script/client.go}" -server=vtgate:15999
+exec $tty docker-compose exec -u root "${CS:-vtgate}" go run "${script:-/script/client.go}" --server=vtgate:15999

--- a/examples/compose/docker-compose.beginners.yml
+++ b/examples/compose/docker-compose.beginners.yml
@@ -64,15 +64,15 @@ services:
       - "$GRPC_PORT"
     command: ["sh", "-c", " /vt/bin/vtctld \
         $TOPOLOGY_FLAGS \
-        -cell $CELL \
-        -workflow_manager_init \
-        -workflow_manager_use_election \
-        -service_map 'grpc-vtctl,grpc-vtctld' \
-        -backup_storage_implementation file \
-        -file_backup_storage_root /vt/vtdataroot/backups \
-        -logtostderr=true \
-        -port $WEB_PORT \
-        -grpc_port $GRPC_PORT
+        --cell $CELL \
+        --workflow_manager_init \
+        --workflow_manager_use_election \
+        --service_map 'grpc-vtctl,grpc-vtctld' \
+        --backup_storage_implementation file \
+        --file_backup_storage_root /vt/vtdataroot/backups \
+        --logtostderr=true \
+        --port $WEB_PORT \
+        --grpc_port $GRPC_PORT
         "]
     depends_on:
       - consul1
@@ -90,16 +90,16 @@ services:
       - "15306:$MYSQL_PORT"
     command: ["sh", "-c", "/vt/bin/vtgate \
         $TOPOLOGY_FLAGS \
-        -logtostderr=true \
-        -port $WEB_PORT \
-        -grpc_port $GRPC_PORT \
-        -mysql_server_port $MYSQL_PORT \
-        -mysql_auth_server_impl none \
-        -cell $CELL \
-        -cells_to_watch $CELL \
-        -tablet_types_to_wait PRIMARY,REPLICA \
-        -service_map 'grpc-vtgateservice' \
-        -enable_system_settings=true \
+        --logtostderr=true \
+        --port $WEB_PORT \
+        --grpc_port $GRPC_PORT \
+        --mysql_server_port $MYSQL_PORT \
+        --mysql_auth_server_impl none \
+        --cell $CELL \
+        --cells_to_watch $CELL \
+        --tablet_types_to_wait PRIMARY,REPLICA \
+        --service_map 'grpc-vtgateservice' \
+        --enable_system_settings=true \
         "]
     volumes:
       - ".:/script"

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -63,8 +63,8 @@ services:
       vttablet301:
         condition: service_healthy
     environment:
-    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global
+    - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global
     - WEB_PORT=8080
     - GRPC_PORT=15999
     - CELL=test
@@ -89,8 +89,8 @@ services:
       vttablet201:
         condition: service_healthy
     environment:
-    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global
+    - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global
     - WEB_PORT=8080
     - GRPC_PORT=15999
     - CELL=test
@@ -126,8 +126,8 @@ services:
     depends_on:
     - vtctld
     environment:
-    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global
+    - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global
     - EXTERNAL_DB=0
     image: vitess/lite:${VITESS_TAG:-latest}
     volumes:
@@ -136,10 +136,10 @@ services:
     command:
     - sh
     - -c
-    - ' /vt/bin/vtctld -topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global -cell test -workflow_manager_init -workflow_manager_use_election
-      -service_map ''grpc-vtctl,grpc-vtctld'' -backup_storage_implementation file -file_backup_storage_root
-      /vt/vtdataroot/backups -logtostderr=true -port 8080 -grpc_port 15999 '
+    - ' /vt/bin/vtctld --topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global --cell test --workflow_manager_init --workflow_manager_use_election
+      --service_map ''grpc-vtctl,grpc-vtctld'' --backup_storage_implementation file --file_backup_storage_root
+      /vt/vtdataroot/backups --logtostderr=true --port 8080 --grpc_port 15999 '
     depends_on:
       external_db_host:
         condition: service_healthy
@@ -153,11 +153,11 @@ services:
     command:
     - sh
     - -c
-    - '/script/run-forever.sh /vt/bin/vtgate -topo_implementation consul -topo_global_server_address
-      consul1:8500 -topo_global_root vitess/global -logtostderr=true -port 8080 -grpc_port
-      15999 -mysql_server_port 15306 -mysql_auth_server_impl none -cell test -cells_to_watch
-      test -tablet_types_to_wait PRIMARY,REPLICA,RDONLY -service_map ''grpc-vtgateservice''
-      -normalize_queries=true '
+    - '/script/run-forever.sh /vt/bin/vtgate --topo_implementation consul --topo_global_server_address
+      consul1:8500 --topo_global_root vitess/global --logtostderr=true --port 8080 --grpc_port
+      15999 --mysql_server_port 15306 --mysql_auth_server_impl none --cell test --cells_to_watch
+      test --tablet_types_to_wait PRIMARY,REPLICA,RDONLY --service_map ''grpc-vtgateservice''
+      --normalize_queries=true '
     depends_on:
     - vtctld
     image: vitess/lite:${VITESS_TAG:-latest}
@@ -176,8 +176,8 @@ services:
     - vtctld
     - set_keyspace_durability_policy
     environment:
-    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global
+    - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global
     - EXTERNAL_DB=0
     - DB_USER=
     - DB_PASS=
@@ -194,8 +194,8 @@ services:
     depends_on:
     - vtctld
     environment:
-    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global
+    - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global
     - WEB_PORT=8080
     - GRPC_PORT=15999
     - CELL=test
@@ -231,8 +231,8 @@ services:
     depends_on:
     - vtctld
     environment:
-    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global
+    - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global
     - WEB_PORT=8080
     - GRPC_PORT=15999
     - CELL=test
@@ -268,8 +268,8 @@ services:
     depends_on:
     - vtctld
     environment:
-    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global
+    - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global
     - WEB_PORT=8080
     - GRPC_PORT=15999
     - CELL=test
@@ -305,8 +305,8 @@ services:
     depends_on:
     - vtctld
     environment:
-    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global
+    - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global
     - WEB_PORT=8080
     - GRPC_PORT=15999
     - CELL=test
@@ -342,8 +342,8 @@ services:
     depends_on:
     - vtctld
     environment:
-    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global
+    - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global
     - WEB_PORT=8080
     - GRPC_PORT=15999
     - CELL=test
@@ -379,8 +379,8 @@ services:
     depends_on:
     - vtctld
     environment:
-    - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-      -topo_global_root vitess/global
+    - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global
     - WEB_PORT=8080
     - GRPC_PORT=15999
     - CELL=test

--- a/examples/compose/lvtctl.sh
+++ b/examples/compose/lvtctl.sh
@@ -21,4 +21,4 @@ if [[ "$OSTYPE" == "msys" ]]; then
 fi
 
 # This is a convenience script to run vtctlclient against the local example.
-exec $tty docker-compose exec ${CS:-vtctld} vtctlclient --server vtctld:15999 "$@"
+exec $tty docker-compose exec ${CS:-vtctld} /vt/bin/vtctlclient --server vtctld:15999 "$@"

--- a/examples/compose/schemaload.sh
+++ b/examples/compose/schemaload.sh
@@ -26,23 +26,23 @@ sleep $sleeptime
 
 if [ ! -f schema_run ]; then
   while true; do
-    vtctlclient -server vtctld:$GRPC_PORT GetTablet $targettab && break
+    vtctlclient --server vtctld:$GRPC_PORT GetTablet $targettab && break
     sleep 1
   done
   if [ "$external_db" = "0" ]; then
     for schema_file in $schema_files; do
       echo "Applying Schema ${schema_file} to ${KEYSPACE}"
-      vtctlclient -server vtctld:$GRPC_PORT ApplySchema -sql-file /script/tables/${schema_file} $KEYSPACE || \
-      vtctlclient -server vtctld:$GRPC_PORT ApplySchema -sql "$(cat /script/tables/${schema_file})" $KEYSPACE || true
+      vtctlclient --server vtctld:$GRPC_PORT -- ApplySchema --sql-file /script/tables/${schema_file} $KEYSPACE || \
+      vtctlclient --server vtctld:$GRPC_PORT -- ApplySchema --sql "$(cat /script/tables/${schema_file})" $KEYSPACE || true
     done
   fi
   echo "Applying VSchema ${vschema_file} to ${KEYSPACE}"
   
-  vtctlclient -server vtctld:$GRPC_PORT ApplyVSchema -vschema_file /script/${vschema_file} $KEYSPACE || \
-  vtctlclient -server vtctld:$GRPC_PORT ApplyVSchema -vschema "$(cat /script/${vschema_file})" $KEYSPACE
+  vtctlclient --server vtctld:$GRPC_PORT -- ApplyVSchema --vschema_file /script/${vschema_file} $KEYSPACE || \
+  vtctlclient --server vtctld:$GRPC_PORT -- ApplyVSchema --vschema "$(cat /script/${vschema_file})" $KEYSPACE
   
   echo "List All Tablets"
-  vtctlclient -server vtctld:$GRPC_PORT ListAllTablets
+  vtctlclient --server vtctld:$GRPC_PORT ListAllTablets
     
   if [ -n "$load_file" ]; then
     # vtgate can take a REALLY long time to come up fully

--- a/examples/compose/template.env
+++ b/examples/compose/template.env
@@ -1,4 +1,4 @@
-TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500 -topo_global_root vitess/global
+TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500 --topo_global_root vitess/global
 GRPC_PORT=15999
 WEB_PORT=8080
 MYSQL_PORT=15306

--- a/examples/compose/vtcompose/docker-compose.test.yml
+++ b/examples/compose/vtcompose/docker-compose.test.yml
@@ -29,6 +29,33 @@ services:
       - "8600"
     hostname: consul3
     image: consul:latest
+  external_db_host:
+    build:
+      context: ./external_db/mysql
+      dockerfile: Dockerfile
+    command:
+      - --server-id=1
+      - --log-bin=mysql-bin
+      - --gtid_mode=ON
+      - --enforce_gtid_consistency
+      - --general_log=1
+      - --slow_query_log=1
+    environment:
+      MYSQL_DATABASE: ${DB:-commerce}
+      MYSQL_PASSWORD: ${DB_PASS:-external_db_password}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-pass}
+      MYSQL_USER: ${DB_USER:-external_db_user}
+    healthcheck:
+      retries: 10
+      test: /usr/bin/mysql --user=root --password=$${MYSQL_ROOT_PASSWORD} --execute
+        "SHOW DATABASES;"
+      timeout: 10s
+    ports:
+      - "3306"
+    restart: always
+    volumes:
+      - ./external_db/mysql/:/docker-entrypoint-initdb.d/
+      - ./external_db/mysql/log:/var/log/mysql
   schemaload_test_keyspace:
     command:
       - sh
@@ -40,8 +67,8 @@ services:
       vttablet201:
         condition: service_healthy
     environment:
-      - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-        -topo_global_root vitess/global
+      - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+        --topo_global_root vitess/global
       - WEB_PORT=8080
       - GRPC_PORT=15999
       - CELL=test
@@ -52,7 +79,7 @@ services:
       - SCHEMA_FILES=test_keyspace_schema_file.sql
       - POST_LOAD_FILE=
       - EXTERNAL_DB=0
-    image: vitess/base
+    image: vitess/lite:${VITESS_TAG:-latest}
     volumes:
       - .:/script
   schemaload_unsharded_keyspace:
@@ -64,8 +91,8 @@ services:
       vttablet301:
         condition: service_healthy
     environment:
-      - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-        -topo_global_root vitess/global
+      - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+        --topo_global_root vitess/global
       - WEB_PORT=8080
       - GRPC_PORT=15999
       - CELL=test
@@ -76,23 +103,63 @@ services:
       - SCHEMA_FILES=unsharded_keyspace_schema_file.sql
       - POST_LOAD_FILE=
       - EXTERNAL_DB=0
-    image: vitess/base
+    image: vitess/lite:${VITESS_TAG:-latest}
+    volumes:
+      - .:/script
+  set_keyspace_durability_policy_test_keyspace:
+    command:
+      - sh
+      - -c
+      - /script/set_keyspace_durability_policy.sh
+    depends_on:
+      - vttablet101
+      - vttablet201
+    environment:
+      - GRPC_PORT=15999
+      - KEYSPACES=test_keyspace
+    image: vitess/lite:${VITESS_TAG:-latest}
+    volumes:
+      - .:/script
+  set_keyspace_durability_policy_unsharded_keyspace:
+    command:
+      - sh
+      - -c
+      - /script/set_keyspace_durability_policy.sh
+    depends_on:
+      - vttablet301
+    environment:
+      - GRPC_PORT=15999
+      - KEYSPACES=unsharded_keyspace
+    image: vitess/lite:${VITESS_TAG:-latest}
+    volumes:
+      - .:/script
+  vreplication:
+    command:
+      - sh
+      - -c
+      - '[ $$EXTERNAL_DB -eq 1 ] && /script/externaldb_vreplication.sh || exit 0'
+    depends_on:
+      - vtctld
+    environment:
+      - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+        --topo_global_root vitess/global
+      - EXTERNAL_DB=0
+    image: vitess/lite:${VITESS_TAG:-latest}
     volumes:
       - .:/script
   vtctld:
     command:
       - sh
       - -c
-      - ' $$VTROOT/bin/vtctld -topo_implementation consul -topo_global_server_address
-      consul1:8500 -topo_global_root vitess/global -cell test -workflow_manager_init
-      -workflow_manager_use_election -service_map ''grpc-vtctl'' -backup_storage_implementation
-      file -file_backup_storage_root $$VTDATAROOT/backups -logtostderr=true -port
-      8080 -grpc_port 15999 -pid_file $$VTDATAROOT/tmp/vtctld.pid '
+      - ' /vt/bin/vtctld --topo_implementation consul --topo_global_server_address consul1:8500
+      --topo_global_root vitess/global --cell test --workflow_manager_init --workflow_manager_use_election
+      --service_map ''grpc-vtctl,grpc-vtctld'' --backup_storage_implementation file
+      --file_backup_storage_root /vt/vtdataroot/backups --logtostderr=true --port
+      8080 --grpc_port 15999 '
     depends_on:
-      - consul1
-      - consul2
-      - consul3
-    image: vitess/base
+      external_db_host:
+        condition: service_healthy
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - 15000:8080
       - "15999"
@@ -102,18 +169,38 @@ services:
     command:
       - sh
       - -c
-      - '/script/run-forever.sh $$VTROOT/bin/vtgate -topo_implementation consul -topo_global_server_address
-      consul1:8500 -topo_global_root vitess/global -logtostderr=true -port 8080 -grpc_port
-      15999 -mysql_server_port 15306 -mysql_auth_server_impl none -cell test -cells_to_watch
-      test -tablet_types_to_wait PRIMARY,REPLICA,RDONLY -service_map ''grpc-vtgateservice''
-      -pid_file $$VTDATAROOT/tmp/vtgate.pid -normalize_queries=true '
+      - '/script/run-forever.sh /vt/bin/vtgate --topo_implementation consul --topo_global_server_address
+      consul1:8500 --topo_global_root vitess/global --logtostderr=true --port 8080
+      --grpc_port 15999 --mysql_server_port 15306 --mysql_auth_server_impl none --cell
+      test --cells_to_watch test --tablet_types_to_wait PRIMARY,REPLICA,RDONLY --service_map
+      ''grpc-vtgateservice'' --normalize_queries=true '
     depends_on:
       - vtctld
-    image: vitess/base
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - 15099:8080
       - "15999"
       - 15306:15306
+    volumes:
+      - .:/script
+  vtorc:
+    command:
+      - sh
+      - -c
+      - /script/vtorc-up.sh
+    depends_on:
+      - set_keyspace_durability_policy_unsharded_keyspace
+      - set_keyspace_durability_policy_test_keyspace
+      - vtctld
+    environment:
+      - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+        --topo_global_root vitess/global
+      - EXTERNAL_DB=0
+      - DB_USER=
+      - DB_PASS=
+    image: vitess/lite:${VITESS_TAG:-latest}
+    ports:
+      - 13000:3000
     volumes:
       - .:/script
   vttablet101:
@@ -124,8 +211,8 @@ services:
     depends_on:
       - vtctld
     environment:
-      - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-        -topo_global_root vitess/global
+      - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+        --topo_global_root vitess/global
       - WEB_PORT=8080
       - GRPC_PORT=15999
       - CELL=test
@@ -144,9 +231,9 @@ services:
       retries: 15
       test:
         - CMD-SHELL
-        - curl localhost:8080/debug/health
+        - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/base
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - 15101:8080
       - "15999"
@@ -161,8 +248,8 @@ services:
     depends_on:
       - vtctld
     environment:
-      - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-        -topo_global_root vitess/global
+      - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+        --topo_global_root vitess/global
       - WEB_PORT=8080
       - GRPC_PORT=15999
       - CELL=test
@@ -181,9 +268,9 @@ services:
       retries: 15
       test:
         - CMD-SHELL
-        - curl localhost:8080/debug/health
+        - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/base
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - 15102:8080
       - "15999"
@@ -198,8 +285,8 @@ services:
     depends_on:
       - vtctld
     environment:
-      - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-        -topo_global_root vitess/global
+      - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+        --topo_global_root vitess/global
       - WEB_PORT=8080
       - GRPC_PORT=15999
       - CELL=test
@@ -218,9 +305,9 @@ services:
       retries: 15
       test:
         - CMD-SHELL
-        - curl localhost:8080/debug/health
+        - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/base
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - 15201:8080
       - "15999"
@@ -235,8 +322,8 @@ services:
     depends_on:
       - vtctld
     environment:
-      - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-        -topo_global_root vitess/global
+      - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+        --topo_global_root vitess/global
       - WEB_PORT=8080
       - GRPC_PORT=15999
       - CELL=test
@@ -255,9 +342,9 @@ services:
       retries: 15
       test:
         - CMD-SHELL
-        - curl localhost:8080/debug/health
+        - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/base
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - 15202:8080
       - "15999"
@@ -272,8 +359,8 @@ services:
     depends_on:
       - vtctld
     environment:
-      - TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500
-        -topo_global_root vitess/global
+      - TOPOLOGY_FLAGS=--topo_implementation consul --topo_global_server_address consul1:8500
+        --topo_global_root vitess/global
       - WEB_PORT=8080
       - GRPC_PORT=15999
       - CELL=test
@@ -292,9 +379,9 @@ services:
       retries: 15
       test:
         - CMD-SHELL
-        - curl localhost:8080/debug/health
+        - curl -s --fail --show-error localhost:8080/debug/health
       timeout: 10s
-    image: vitess/base
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - 15301:8080
       - "15999"

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"math"
 	"os"
@@ -29,6 +28,7 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	yamlpatch "github.com/krishicks/yaml-patch"
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/log"
 )
@@ -46,23 +46,23 @@ const (
 	cellUsage             = "Vitess Cell name"
 	DefaultExternalDbData = ""
 	externalDbDataUsage   = "List of Data corresponding to external DBs. List of <external_db_name>,<DB_HOST>,<DB_PORT>,<DB_USER>,<DB_PASS>,<DB_CHARSET> separated by ';'"
-	DefaultTopologyFlags  = "-topo_implementation consul -topo_global_server_address consul1:8500 -topo_global_root vitess/global"
+	DefaultTopologyFlags  = "--topo_implementation consul --topo_global_server_address consul1:8500 --topo_global_root vitess/global"
 	topologyFlagsUsage    = "Vitess Topology Flags config"
 )
 
 var (
 	tabletsUsed           = 0
 	tablesPath            = "tables/"
-	baseDockerComposeFile = flag.String("base_yaml", "vtcompose/docker-compose.base.yml", "Starting docker-compose yaml")
-	baseVschemaFile       = flag.String("base_vschema", "vtcompose/base_vschema.json", "Starting vschema json")
+	baseDockerComposeFile = pflag.String("base_yaml", "vtcompose/docker-compose.base.yml", "Starting docker-compose yaml")
+	baseVschemaFile       = pflag.String("base_vschema", "vtcompose/base_vschema.json", "Starting vschema json")
 
-	topologyFlags  = flag.String("topologyFlags", DefaultTopologyFlags, topologyFlagsUsage)
-	webPort        = flag.Int("webPort", DefaultWebPort, webPortUsage)
-	gRpcPort       = flag.Int("gRpcPort", DefaultGrpcPort, gRpcPortUsage)
-	mySqlPort      = flag.Int("mySqlPort", DefaultMysqlPort, mySqlPortUsage)
-	cell           = flag.String("cell", DefaultCell, cellUsage)
-	keyspaceData   = flag.String("keyspaceData", DefaultKeyspaceData, keyspaceDataUsage)
-	externalDbData = flag.String("externalDbData", DefaultExternalDbData, externalDbDataUsage)
+	topologyFlags  = pflag.String("topologyFlags", DefaultTopologyFlags, topologyFlagsUsage)
+	webPort        = pflag.Int("webPort", DefaultWebPort, webPortUsage)
+	gRpcPort       = pflag.Int("gRpcPort", DefaultGrpcPort, gRpcPortUsage)
+	mySqlPort      = pflag.Int("mySqlPort", DefaultMysqlPort, mySqlPortUsage)
+	cell           = pflag.String("cell", DefaultCell, cellUsage)
+	keyspaceData   = pflag.String("keyspaceData", DefaultKeyspaceData, keyspaceDataUsage)
+	externalDbData = pflag.String("externalDbData", DefaultExternalDbData, externalDbDataUsage)
 )
 
 type vtOptions struct {
@@ -167,7 +167,7 @@ func parseExternalDbData(externalDbData string) map[string]externalDbInfo {
 }
 
 func main() {
-	flag.Parse()
+	pflag.Parse()
 	keyspaceInfoMap := parseKeyspaceInfo(*keyspaceData)
 	externalDbInfoMap := parseExternalDbData(*externalDbData)
 	vtOpts := vtOptions{
@@ -671,15 +671,15 @@ func generateVtctld(opts vtOptions) string {
       - "%[2]d"
     command: ["sh", "-c", " /vt/bin/vtctld \
         %[3]s \
-        -cell %[4]s \
-        -workflow_manager_init \
-        -workflow_manager_use_election \
-        -service_map 'grpc-vtctl,grpc-vtctld' \
-        -backup_storage_implementation file \
-        -file_backup_storage_root /vt/vtdataroot/backups \
-        -logtostderr=true \
-        -port %[1]d \
-        -grpc_port %[2]d \
+        --cell %[4]s \
+        --workflow_manager_init \
+        --workflow_manager_use_election \
+        --service_map 'grpc-vtctl,grpc-vtctld' \
+        --backup_storage_implementation file \
+        --file_backup_storage_root /vt/vtdataroot/backups \
+        --logtostderr=true \
+        --port %[1]d \
+        --grpc_port %[2]d \
         "]
     volumes:
       - .:/script
@@ -705,16 +705,16 @@ func generateVtgate(opts vtOptions) string {
       - "15306:%[3]d"
     command: ["sh", "-c", "/script/run-forever.sh /vt/bin/vtgate \
         %[4]s \
-        -logtostderr=true \
-        -port %[1]d \
-        -grpc_port %[2]d \
-        -mysql_server_port %[3]d \
-        -mysql_auth_server_impl none \
-        -cell %[5]s \
-        -cells_to_watch %[5]s \
-        -tablet_types_to_wait PRIMARY,REPLICA,RDONLY \
-        -service_map 'grpc-vtgateservice' \
-        -normalize_queries=true \
+        --logtostderr=true \
+        --port %[1]d \
+        --grpc_port %[2]d \
+        --mysql_server_port %[3]d \
+        --mysql_auth_server_impl none \
+        --cell %[5]s \
+        --cells_to_watch %[5]s \
+        --tablet_types_to_wait PRIMARY,REPLICA,RDONLY \
+        --service_map 'grpc-vtgateservice' \
+        --normalize_queries=true \
         "]
     volumes:
       - .:/script

--- a/examples/compose/vtorc-up.sh
+++ b/examples/compose/vtorc-up.sh
@@ -39,6 +39,6 @@ fi
 echo "Starting vtorc..."
 exec /vt/bin/vtorc \
 $TOPOLOGY_FLAGS \
--logtostderr=true \
--orc_web_dir=/vt/web/orchestrator \
--config $config
+--logtostderr=true \
+--orc_web_dir=/vt/web/orchestrator \
+--config $config

--- a/test/client.go
+++ b/test/client.go
@@ -26,21 +26,22 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	"vitess.io/vitess/go/vt/vitessdriver"
 )
 
 var (
-	server = flag.String("server", "", "vtgate server to connect to")
+	server = pflag.String("server", "", "vtgate server to connect to")
 )
 
 func main() {
-	flag.Parse()
+	pflag.Parse()
 	rand.Seed(time.Now().UnixNano())
 
 	// Connect to vtgate.

--- a/test/client_test.sh
+++ b/test/client_test.sh
@@ -38,7 +38,7 @@ vtctlclient --server localhost:15999 RebuildVSchemaGraph
 CELL=test ./scripts/vtgate-up.sh
 
 echo "Run Go client script..."
-go run $VTROOT/test/client.go -server=localhost:15991
+go run $VTROOT/test/client.go --server=localhost:15991
 
 echo "Run Java client script..."
 $VTROOT/test/client_java.sh


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the docker-compose examples and the `vtcompose` binary used to generate docker-compose files. 
The example was noticed to be broken and issue filed at #11187 

On further investigation of the `vtctld` container which fails to start leads to - 
```bash
docker-compose logs vtctld   
Attaching to compose_vtctld_1
vtctld_1                          | ERROR: logging before flag.Parse: E0908 07:54:24.363388       9 syslogger.go:149] can't connect to syslog
vtctld_1                          | unknown shorthand flag: 't' in -topo_implementation
```

The issue is arising from the flag being set in vtctld binary. We aren't using the double-dashed arguments. This PR fixes this issue.

After this PR all the docker-compose examples have been tested manually, `docker-compose.yml`, `docker-compose.beginner.yml` and the file generated from `vtcompose.go`

```bash
 ~/vitess/examples/compose   docker-compose-example  docker-compose ps
               Name                             Command                  State                                                                     Ports                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
compose_consul1_1                    docker-entrypoint.sh agent ...   Up             8300/tcp, 8301/tcp, 8301/udp, 8302/tcp, 8302/udp, 0.0.0.0:8400->8400/tcp, 0.0.0.0:8500->8500/tcp, 0.0.0.0:8600->8600/tcp, 8600/udp
compose_consul2_1                    docker-entrypoint.sh agent ...   Up             8300/tcp, 8301/tcp, 8301/udp, 8302/tcp, 8302/udp, 8400/tcp, 8500/tcp, 8600/tcp, 8600/udp                                          
compose_consul3_1                    docker-entrypoint.sh agent ...   Up             8300/tcp, 8301/tcp, 8301/udp, 8302/tcp, 8302/udp, 8400/tcp, 8500/tcp, 8600/tcp, 8600/udp                                          
compose_external_db_host_1           docker-entrypoint.sh --ser ...   Up (healthy)   0.0.0.0:64014->3306/tcp, 33060/tcp                                                                                                
compose_schemaload_test_keyspace_1   sh -c /script/schemaload.sh      Exit 0                                                                                                                                           
compose_vreplication_1               sh -c [ $EXTERNAL_DB -eq 1 ...   Exit 0                                                                                                                                           
compose_vtctld_1                     sh -c  /vt/bin/vtctld --to ...   Up             0.0.0.0:64061->15999/tcp, 0.0.0.0:15000->8080/tcp                                                                                 
compose_vtgate_1                     sh -c /script/run-forever. ...   Up             0.0.0.0:15306->15306/tcp, 0.0.0.0:64065->15999/tcp, 0.0.0.0:15099->8080/tcp                                                       
compose_vtorc_1                      sh -c /script/vtorc-up.sh        Up             0.0.0.0:13000->3000/tcp                                                                                                           
compose_vttablet101_1                sh -c /script/vttablet-up. ...   Up (healthy)   0.0.0.0:64073->15999/tcp, 0.0.0.0:64074->3306/tcp, 0.0.0.0:15101->8080/tcp                                                        
compose_vttablet102_1                sh -c /script/vttablet-up. ...   Up (healthy)   0.0.0.0:64069->15999/tcp, 0.0.0.0:64070->3306/tcp, 0.0.0.0:15102->8080/tcp                                                        
compose_vttablet201_1                sh -c /script/vttablet-up. ...   Up (healthy)   0.0.0.0:64071->15999/tcp, 0.0.0.0:64072->3306/tcp, 0.0.0.0:15201->8080/tcp                                                        
compose_vttablet202_1                sh -c /script/vttablet-up. ...   Up (healthy)   0.0.0.0:64063->15999/tcp, 0.0.0.0:64064->3306/tcp, 0.0.0.0:15202->8080/tcp                                                        
compose_vttablet301_1                sh -c /script/vttablet-up. ...   Up (healthy)   0.0.0.0:64067->15999/tcp, 0.0.0.0:64068->3306/tcp, 0.0.0.0:15301->8080/tcp   
```

Notice everything is healthy.

As part of this endeavour, some shell scripts also had to be fixed. While at it, I have also ported over the `vtcompose` and `client` binaries to pflags architecture.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Fixes #11187 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
