### PR TITLE
Replication Manager Improvements

### DIFF
--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -181,8 +181,8 @@ Usage of vttablet:
       --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
       --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
       --degraded_threshold duration                                      replication lag after which a replica is considered degraded (default 30s)
+      --disable-replication-manager                                      Disable replication manager to prevent replication repairs.
       --disable_active_reparents                                         if set, do not allow active reparents. Use this to protect a cluster using external reparents.
-      --disable_replication_manager                                      Disable replication manager to prevent replication repairs.
       --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
       --enable-consolidator                                              Synonym to -enable_consolidator (default true)
       --enable-consolidator-replicas                                     Synonym to -enable_consolidator_replicas

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -182,6 +182,7 @@ Usage of vttablet:
       --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
       --degraded_threshold duration                                      replication lag after which a replica is considered degraded (default 30s)
       --disable_active_reparents                                         if set, do not allow active reparents. Use this to protect a cluster using external reparents.
+      --disable_replication_manager                                      Disable replication manager to prevent replication repairs.
       --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
       --enable-consolidator                                              Synonym to -enable_consolidator (default true)
       --enable-consolidator-replicas                                     Synonym to -enable_consolidator_replicas

--- a/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletmanager
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
+	tabletpb "vitess.io/vitess/go/vt/proto/topodata"
+	tmc "vitess.io/vitess/go/vt/vttablet/grpctmclient"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	tmClient        *tmc.Client
+	primaryTablet   cluster.Vttablet
+	replicaTablet   cluster.Vttablet
+	hostname        = "localhost"
+	keyspaceName    = "ks"
+	cell            = "zone1"
+	sqlSchema       = `
+	create table t1(
+		id bigint,
+		value varchar(16),
+		primary key(id)
+	) Engine=InnoDB DEFAULT CHARSET=utf8;
+	CREATE VIEW v1 AS SELECT id, value FROM t1;
+`
+
+	vSchema = `
+	{
+    "sharded": false,
+    "vindexes": {
+      "hash": {
+        "type": "hash"
+      }
+    },
+    "tables": {
+      "t1": {
+        "column_vindexes": [
+          {
+            "column": "id",
+            "name": "hash"
+          }
+        ]
+      }
+    }
+  }`
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		err := clusterInstance.StartTopo()
+		if err != nil {
+			return 1
+		}
+
+		// We do not need semiSync for this test case.
+		clusterInstance.EnableSemiSync = false
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      keyspaceName,
+			SchemaSQL: sqlSchema,
+			VSchema:   vSchema,
+		}
+
+		if err = clusterInstance.StartUnshardedKeyspace(*keyspace, 1, false); err != nil {
+			return 1
+		}
+
+		// Collect table paths and ports
+		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
+		for _, tablet := range tablets {
+			if tablet.Type == "primary" {
+				primaryTablet = *tablet
+			} else {
+				replicaTablet = *tablet
+			}
+		}
+
+		// create tablet manager client
+		tmClient = tmc.NewClient()
+
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func tmcGetReplicationStatus(ctx context.Context, tabletGrpcPort int) (*replicationdatapb.Status, error) {
+	vtablet := getTablet(tabletGrpcPort)
+	return tmClient.ReplicationStatus(ctx, vtablet)
+}
+
+func getTablet(tabletGrpcPort int) *tabletpb.Tablet {
+	portMap := make(map[string]int32)
+	portMap["grpc"] = int32(tabletGrpcPort)
+	return &tabletpb.Tablet{Hostname: hostname, PortMap: portMap}
+}
+
+// resurrectTablet is used to resurrect the given tablet
+func resurrectTablet(t *testing.T, tab cluster.Vttablet) {
+	// initialize config again to regenerate the my.cnf file which has the port to use
+	_, err := tab.MysqlctlProcess.ExecuteCommandWithOutput("--log_dir", tab.MysqlctlProcess.LogDirectory,
+		"--tablet_uid", fmt.Sprintf("%d", tab.MysqlctlProcess.TabletUID),
+		"--mysql_port", fmt.Sprintf("%d", tab.MysqlctlProcess.MySQLPort),
+		"init_config")
+	require.NoError(t, err)
+
+	tab.MysqlctlProcess.InitMysql = false
+	err = tab.MysqlctlProcess.Start()
+	require.NoError(t, err)
+
+	// Start the tablet
+	tab.VttabletProcess.ServingStatus = "SERVING"
+	err = tab.VttabletProcess.Setup()
+	require.NoError(t, err)
+}
+
+// stopTablet stops the tablet
+func stopTablet(t *testing.T, tab cluster.Vttablet) {
+	err := tab.VttabletProcess.TearDownWithTimeout(30 * time.Second)
+	require.NoError(t, err)
+	err = tab.MysqlctlProcess.Stop()
+	require.NoError(t, err)
+}
+
+func waitForSourcePort(ctx context.Context, t *testing.T, tablet cluster.Vttablet, expectedPort int32) error {
+	timeout := time.Now().Add(15 * time.Second)
+	for time.Now().Before(timeout) {
+		// Check that initially replication is setup correctly on the replica tablet
+		replicaStatus, err := tmcGetReplicationStatus(ctx, tablet.GrpcPort)
+		require.NoError(t, err)
+		if replicaStatus.SourcePort == expectedPort {
+			return nil
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return fmt.Errorf("time out before source port became %v for %v", expectedPort, tablet.Alias)
+}
+
+func TestReplicationRepairAfterPrimaryTabletChange(t *testing.T) {
+	ctx := context.Background()
+	// Check that initially replication is setup correctly on the replica tablet
+	err := waitForSourcePort(ctx, t, replicaTablet, int32(primaryTablet.MySQLPort))
+	require.NoError(t, err)
+
+	// Stop the primary tablet
+	stopTablet(t, primaryTablet)
+
+	// Change the MySQL port of the primary tablet
+	newMysqlPort := clusterInstance.GetAndReservePort()
+	primaryTablet.MySQLPort = newMysqlPort
+	primaryTablet.MysqlctlProcess.MySQLPort = newMysqlPort
+
+	// Start the primary tablet again
+	resurrectTablet(t, primaryTablet)
+
+	// Let replication manager repair replication
+	err = waitForSourcePort(ctx, t, replicaTablet, int32(newMysqlPort))
+	require.NoError(t, err)
+}

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -109,9 +109,14 @@ func (rm *replManager) checkActionLocked() {
 			return
 		}
 	} else {
-		// If only one of the threads is stopped, it's probably
-		// intentional. So, we don't repair replication.
-		if status.SQLHealthy() || status.IOHealthy() {
+		if status.SQLHealthy() && status.IOState == mysql.ReplicationStateConnecting && status.LastIOError != "" {
+			// SQL thread is healthy, but IO thread is in Connecting state with an IO Error,
+			// then we know that no Vitess operation stopped the IO thread and it is having trouble connecting to the primary
+			// Maybe the primary host-port changed, or something else happened. This could be an ephemeral error, so we should
+			// try and fix it.
+		} else if status.SQLHealthy() || status.IOHealthy() {
+			// If only one of the threads is stopped, it's probably
+			// intentional. So, we don't repair replication.
 			return
 		}
 	}

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -68,7 +68,7 @@ func newReplManager(ctx context.Context, tm *TabletManager, interval time.Durati
 // SetTabletType starts/stops the replication manager ticks based on the tablet type provided.
 // It stops the ticks if the tablet type is not a replica type, starts the ticks otherwise.
 func (rm *replManager) SetTabletType(tabletType topodatapb.TabletType) {
-	if *mysqlctl.DisableActiveReparents {
+	if *mysqlctl.DisableActiveReparents || disableReplicationManager {
 		return
 	}
 	if !topo.IsReplicaType(tabletType) {
@@ -135,7 +135,7 @@ func (rm *replManager) checkActionLocked() {
 // reset the replication manager state and deleting the marker-file.
 // it does not start or stop the ticks. Use setReplicationStopped instead to change that.
 func (rm *replManager) reset() {
-	if *mysqlctl.DisableActiveReparents {
+	if *mysqlctl.DisableActiveReparents || disableReplicationManager {
 		return
 	}
 
@@ -152,7 +152,7 @@ func (rm *replManager) reset() {
 // setReplicationStopped performs a best effort attempt of
 // remembering a decision to stop replication.
 func (rm *replManager) setReplicationStopped(stopped bool) {
-	if *mysqlctl.DisableActiveReparents {
+	if *mysqlctl.DisableActiveReparents || disableReplicationManager {
 		return
 	}
 

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -115,8 +115,9 @@ func (rm *replManager) checkActionLocked() {
 			// Maybe the primary host-port changed, or something else happened. This could be an ephemeral error, so we should
 			// try and fix it.
 		} else if status.SQLHealthy() || status.IOHealthy() {
+			// If both threads are fine then there is no need to repair.
 			// If only one of the threads is stopped, it's probably
-			// intentional. So, we don't repair replication.
+			// intentional. So, we don't repair replication if either thread is healthy.
 			return
 		}
 	}

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -46,7 +46,7 @@ func registerReplicationFlags(fs *pflag.FlagSet) {
 	fs.MarkDeprecated("enable_semi_sync", "--enable_semi_sync is deprecated; please set the correct durability policy on the keyspace instead.")
 
 	fs.BoolVar(&setSuperReadOnly, "use_super_read_only", setSuperReadOnly, "Set super_read_only flag when performing planned failover.")
-	fs.BoolVar(&disableReplicationManager, "disable_replication_manager", disableReplicationManager, "Disable replication manager to prevent replication repairs from VTTablet")
+	fs.BoolVar(&disableReplicationManager, "disable_replication_manager", disableReplicationManager, "Disable replication manager to prevent replication repairs.")
 }
 
 func init() {

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -39,12 +39,14 @@ import (
 )
 
 var setSuperReadOnly bool
+var disableReplicationManager bool
 
 func registerReplicationFlags(fs *pflag.FlagSet) {
 	fs.Bool("enable_semi_sync", false, "")
 	fs.MarkDeprecated("enable_semi_sync", "--enable_semi_sync is deprecated; please set the correct durability policy on the keyspace instead.")
 
 	fs.BoolVar(&setSuperReadOnly, "use_super_read_only", setSuperReadOnly, "Set super_read_only flag when performing planned failover.")
+	fs.BoolVar(&disableReplicationManager, "disable_replication_manager", disableReplicationManager, "Disable replication manager to prevent replication repairs from VTTablet")
 }
 
 func init() {

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -46,7 +46,7 @@ func registerReplicationFlags(fs *pflag.FlagSet) {
 	fs.MarkDeprecated("enable_semi_sync", "--enable_semi_sync is deprecated; please set the correct durability policy on the keyspace instead.")
 
 	fs.BoolVar(&setSuperReadOnly, "use_super_read_only", setSuperReadOnly, "Set super_read_only flag when performing planned failover.")
-	fs.BoolVar(&disableReplicationManager, "disable_replication_manager", disableReplicationManager, "Disable replication manager to prevent replication repairs.")
+	fs.BoolVar(&disableReplicationManager, "disable-replication-manager", disableReplicationManager, "Disable replication manager to prevent replication repairs.")
 }
 
 func init() {

--- a/go/vt/vttablet/tabletmanager/rpc_replication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication_test.go
@@ -74,3 +74,19 @@ func TestPromoteReplicaReplicationManagerFailure(t *testing.T) {
 	// At the end we expect the replication manager to be stopped.
 	require.True(t, tm.replManager.ticks.Running())
 }
+
+// TestDisableReplicationManager checks that the replication manager doesn't start if it is disabled
+func TestDisableReplicationManager(t *testing.T) {
+	ts := memorytopo.NewServer("cell1")
+	statsTabletTypeCount.ResetAll()
+	prevDisableReplicationManager := disableReplicationManager
+	disableReplicationManager = true
+	defer func() {
+		disableReplicationManager = prevDisableReplicationManager
+	}()
+
+	tm := newTestTM(t, ts, 100, keyspace, shard)
+	defer tm.Stop()
+
+	require.False(t, tm.replManager.ticks.Running())
+}

--- a/test/config.json
+++ b/test/config.json
@@ -463,6 +463,15 @@
 				"site_test"
 			]
 		},
+		"tabletmanager_replication_manager": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/tabletmanager/replication_manager"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "18",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"tabletmanager_consul": {
 			"File": "unused.go",
 			"Args": [


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR improves the replication manager. The proposed improvements are two-fold - 
1. The first is that the replication manager should be able to catch the case where the replication is broken because the primary's hostname and port changed due to kubernetes pod reschedule or some other reason. 
2. The second improvement is the addition of a flag that allows the replication manager to be turned off, if so desired.

Tests of both these changes have been added. An end to end test for the first one and a unit test for the other.

## Related Issue(s)
#9809 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
