### PR TITLE
VDiff2: Add support for Mount+Migrate

### DIFF
--- a/go/test/endtoend/vreplication/migrate_test.go
+++ b/go/test/endtoend/vreplication/migrate_test.go
@@ -48,15 +48,6 @@ func TestMigrate(t *testing.T) {
 	allCellNames = "zone1"
 	vc = NewVitessCluster(t, "TestMigrate", cells, mainClusterConfig)
 
-	// VDiff2 does not support this mount+migrate use case today
-	// TODO: add support for this in the tablet picker phase
-	if runVDiffsSideBySide {
-		runVDiffsSideBySide = false
-		defer func() {
-			runVDiffsSideBySide = true
-		}()
-	}
-
 	require.NotNil(t, vc)
 	defaultReplicas = 0
 	defaultRdonly = 0

--- a/go/vt/discovery/tablet_picker.go
+++ b/go/vt/discovery/tablet_picker.go
@@ -102,9 +102,9 @@ func NewTabletPicker(ts *topo.Server, cells []string, keyspace, shard, tabletTyp
 	}, nil
 }
 
-// PickForStreaming picks an available tablet
+// PickForStreaming picks an available tablet.
 // All tablets that belong to tp.cells are evaluated and one is
-// chosen at random
+// chosen at random.
 func (tp *TabletPicker) PickForStreaming(ctx context.Context) (*topodatapb.Tablet, error) {
 	rand.Seed(time.Now().UnixNano())
 	// keep trying at intervals (tabletPickerRetryDelay) until a tablet is found

--- a/go/vt/vttablet/tabletmanager/vdiff/action.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/action.go
@@ -115,28 +115,36 @@ func (vde *Engine) fixupOptions(options *tabletmanagerdatapb.VDiffOptions) (*tab
 	// Assign defaults to sourceCell and targetCell if not specified.
 	sourceCell := options.PickerOptions.SourceCell
 	targetCell := options.PickerOptions.TargetCell
-	if sourceCell == "" && targetCell == "" {
-		cells, err := vde.ts.GetCellInfoNames(vde.ctx)
+	var defaultCell string
+	var err error
+	if sourceCell == "" || targetCell == "" {
+		defaultCell, err = vde.getDefaultCell()
 		if err != nil {
 			return nil, err
 		}
-		if len(cells) == 0 {
-			// Unreachable
-			return nil, fmt.Errorf("there are no cells in the topo")
-		}
-		sourceCell = cells[0]
-		targetCell = sourceCell
 	}
 	if sourceCell == "" {
-		sourceCell = targetCell
+		sourceCell = defaultCell
 	}
 	if targetCell == "" {
-		targetCell = sourceCell
+		targetCell = defaultCell
 	}
 	options.PickerOptions.SourceCell = sourceCell
 	options.PickerOptions.TargetCell = targetCell
 
 	return options, nil
+}
+
+func (vde *Engine) getDefaultCell() (string, error) {
+	cells, err := vde.ts.GetCellInfoNames(vde.ctx)
+	if err != nil {
+		return "", err
+	}
+	if len(cells) == 0 {
+		// Unreachable
+		return "", fmt.Errorf("there are no cells in the topo")
+	}
+	return cells[0], nil
 }
 
 func (vde *Engine) handleCreateResumeAction(ctx context.Context, dbClient binlogplayer.DBClient, action VDiffAction, req *tabletmanagerdatapb.VDiffRequest, resp *tabletmanagerdatapb.VDiffResponse) error {

--- a/go/vt/vttablet/tabletmanager/vdiff/controller.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/controller.go
@@ -72,6 +72,8 @@ type controller struct {
 	options             *tabletmanagerdata.VDiffOptions // options initially from vtctld command and later from _vt.vdiff
 
 	sourceTimeZone, targetTimeZone string // named time zones if conversions are necessary for datetime values
+
+	externalCluster string // for mount+migrate
 }
 
 func newController(ctx context.Context, row sqltypes.RowNamedValues, dbClientFactory func() binlogplayer.DBClient,
@@ -201,6 +203,10 @@ func (ct *controller) start(ctx context.Context, dbClient binlogplayer.DBClient)
 		source.vrID, _ = row["id"].ToInt64()
 		ct.sourceTimeZone = bls.SourceTimeZone
 		ct.targetTimeZone = bls.TargetTimeZone
+
+		if bls.ExternalCluster != "" {
+			ct.externalCluster = bls.ExternalCluster
+		}
 
 		ct.sources[source.shard] = source
 		if i == 0 {

--- a/go/vt/vttablet/tabletmanager/vdiff/controller.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/controller.go
@@ -73,7 +73,7 @@ type controller struct {
 
 	sourceTimeZone, targetTimeZone string // named time zones if conversions are necessary for datetime values
 
-	externalCluster string // for mount+migrate
+	externalCluster string // for Mount+Migrate
 }
 
 func newController(ctx context.Context, row sqltypes.RowNamedValues, dbClientFactory func() binlogplayer.DBClient,

--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
@@ -194,20 +194,22 @@ func (td *tableDiffer) selectTablets(ctx context.Context, cell, tabletTypes stri
 	var wg sync.WaitGroup
 	ct := td.wd.ct
 	var err1, err2 error
+
+	// For Mount+Migrate, the source tablets will be in a different
+	// Vitess cluster with its own TopoServer.
+	sourceTopoServer := ct.ts
+	if ct.externalCluster != "" {
+		extTS, err := ct.ts.OpenExternalVitessClusterServer(ctx, ct.externalCluster)
+		if err != nil {
+			return err
+		}
+		sourceTopoServer = extTS
+	}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		err1 = td.forEachSource(func(source *migrationSource) error {
-			tabletTopoServer := ct.ts
-			// For mount+migrate
-			if ct.externalCluster != "" {
-				extTs, err := ct.ts.OpenExternalVitessClusterServer(ctx, ct.externalCluster)
-				if err != nil {
-					return err
-				}
-				tabletTopoServer = extTs
-			}
-			tablet, err := pickTablet(ctx, tabletTopoServer, cell, ct.sourceKeyspace, source.shard, tabletTypes)
+			tablet, err := pickTablet(ctx, sourceTopoServer, cell, ct.sourceKeyspace, source.shard, tabletTypes)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

This adds support for doing VDiffs — using [VDiff2](https://vitess.io/docs/15.0/reference/vreplication/vdiff2/) — against intercluster VReplication workflows created using the [Mount](https://vitess.io/docs/15.0/reference/vreplication/mount/) and [Migrate](https://vitess.io/docs/15.0/reference/vreplication/migrate/) commands.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/11182

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were enabled
-   [x] Documentation is not required (it was expected to work)