### PR TITLE
Add Metric For Time Elapsed In Getting Connection In Pools

### DIFF
--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -98,7 +98,7 @@ func NewPool(env tabletenv.Env, name string, cfg tabletenv.ConnPoolConfig) *Pool
 	env.Exporter().NewCounterFunc(name+"GetSetting", "Tablet server conn pool get with setting count", cp.GetSettingCount)
 	env.Exporter().NewCounterFunc(name+"DiffSetting", "Number of times pool applied different setting", cp.DiffSettingCount)
 	env.Exporter().NewCounterFunc(name+"ResetSetting", "Number of times pool reset the setting", cp.ResetSettingCount)
-	cp.getConnTime = env.Exporter().NewGaugesWithSingleLabel("GetConnTime", "Tracks the amount of time it takes to get a connection", "Settings")
+	cp.getConnTime = env.Exporter().NewGaugesWithSingleLabel(name+"GetConnTime", "Tracks the amount of time it takes to get a connection", "Settings")
 
 	return cp
 }

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -17,6 +17,7 @@ limitations under the License.
 package connpool
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -24,11 +25,8 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/netutil"
-	"vitess.io/vitess/go/stats"
-
-	"context"
-
 	"vitess.io/vitess/go/pools"
+	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/callerid"

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -366,19 +366,19 @@ func TestPoolGetConnTime(t *testing.T) {
 	connPool := newPool()
 	connPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 	defer connPool.Close()
-	connPool.getConnTime.ResetAll()
+	connPool.getConnTime.Reset()
 
 	getTimeMap := connPool.getConnTime.Counts()
-	assert.Zero(t, getTimeMap["with"])
-	assert.Zero(t, getTimeMap["without"])
+	assert.Zero(t, getTimeMap["PoolTest.GetWithSettings"])
+	assert.Zero(t, getTimeMap["PoolTest.GetWithoutSettings"])
 
 	dbConn, err := connPool.Get(context.Background(), nil)
 	require.NoError(t, err)
 	defer dbConn.Recycle()
 
 	getTimeMap = connPool.getConnTime.Counts()
-	assert.Zero(t, getTimeMap["with"])
-	assert.NotZero(t, getTimeMap["without"])
+	assert.EqualValues(t, 1, getTimeMap["PoolTest.GetWithoutSettings"])
+	assert.Zero(t, getTimeMap["PoolTest.GetWithSettings"])
 
 	db.AddQuery("b", &sqltypes.Result{})
 	sb := pools.NewSetting("b", "")
@@ -387,7 +387,7 @@ func TestPoolGetConnTime(t *testing.T) {
 	defer dbConn.Recycle()
 
 	getTimeMap = connPool.getConnTime.Counts()
-	assert.NotZero(t, getTimeMap["with"])
+	assert.EqualValues(t, 1, getTimeMap["PoolTest.GetWithSettings"])
 }
 
 func newPool() *Pool {


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR added a metric called `GetConnTime` with labels `with` and `without` for `settings`, that publishes the amount of time it took to get a connection with and without having settings respectively.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- #9706 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
