### PR TITLE
Add getNumOfRows() in Java client to get result size for select queries

### DIFF
--- a/java/client/src/main/java/io/vitess/client/cursor/Cursor.java
+++ b/java/client/src/main/java/io/vitess/client/cursor/Cursor.java
@@ -67,6 +67,14 @@ public abstract class Cursor implements AutoCloseable {
   public abstract long getRowsAffected() throws SQLException;
 
   /**
+   * Returns the number of rows in the result.
+   *
+   * @throws SQLException if the server returns an error.
+   * @throws SQLFeatureNotSupportedException if the cursor type doesn't support this.
+   */
+  public abstract int getNumOfRows() throws SQLException;
+
+  /**
    * Returns the ID of the last insert.
    *
    * @throws SQLException if the server returns an error.

--- a/java/client/src/main/java/io/vitess/client/cursor/SimpleCursor.java
+++ b/java/client/src/main/java/io/vitess/client/cursor/SimpleCursor.java
@@ -46,6 +46,11 @@ public class SimpleCursor extends Cursor {
   }
 
   @Override
+  public int getNumOfRows() throws SQLException {
+    return queryResult.getRowsCount();
+  }
+
+  @Override
   public long getInsertId() throws SQLException {
     return queryResult.getInsertId();
   }

--- a/java/client/src/main/java/io/vitess/client/cursor/StreamCursor.java
+++ b/java/client/src/main/java/io/vitess/client/cursor/StreamCursor.java
@@ -51,6 +51,11 @@ public class StreamCursor extends Cursor {
   }
 
   @Override
+  public int getNumOfRows() throws SQLException {
+    throw new SQLFeatureNotSupportedException("getNumOfRows() is not supported on StreamCursor");
+  }
+
+  @Override
   public long getInsertId() throws SQLException {
     throw new SQLFeatureNotSupportedException("getInsertId() is not supported on StreamCursor");
   }


### PR DESCRIPTION
## Description
Add a getNumOfRows() method in Java client to return the number of rows query got. Currently there is only one method to return the number of affected rows. But it is not useful for SELECT queries. 

## Checklist

-   [X] "Backport me!" label has been added if this change should be backported
-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes
Only affecting the java client. Not impact to vitess. 
