### PR TITLE
Online DDL: more info in a conflicting migration message

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -423,20 +423,19 @@ func (e *Executor) proposedMigrationConflictsWithRunningMigration(runningMigrati
 
 // isAnyConflictingMigrationRunning checks if there's any running migration that conflicts with the
 // given migration, such that they can't both run concurrently.
-func (e *Executor) isAnyConflictingMigrationRunning(onlineDDL *schema.OnlineDDL) bool {
-	conflictFound := false
+func (e *Executor) isAnyConflictingMigrationRunning(onlineDDL *schema.OnlineDDL) (conflictFound bool, conflictingMigration *schema.OnlineDDL) {
 	e.ownedRunningMigrations.Range(func(_, val any) bool {
 		runningMigration, ok := val.(*schema.OnlineDDL)
 		if !ok {
 			return true // continue iteration
 		}
 		if e.proposedMigrationConflictsWithRunningMigration(runningMigration, onlineDDL) {
-			conflictFound = true
+			conflictingMigration = runningMigration
 			return false // stop iteration, no need to review other migrations
 		}
 		return true // continue iteration
 	})
-	return conflictFound
+	return (conflictingMigration != nil), conflictingMigration
 }
 
 func (e *Executor) ghostPanicFlagFileName(uuid string) string {
@@ -1177,8 +1176,8 @@ func (e *Executor) ExecuteWithVReplication(ctx context.Context, onlineDDL *schem
 	// make sure there's no vreplication workflow running under same name
 	_ = e.terminateVReplMigration(ctx, onlineDDL.UUID)
 
-	if e.isAnyConflictingMigrationRunning(onlineDDL) {
-		return ErrExecutorMigrationAlreadyRunning
+	if conflictFound, conflictingMigration := e.isAnyConflictingMigrationRunning(onlineDDL); conflictFound {
+		return vterrors.Wrapf(ErrExecutorMigrationAlreadyRunning, "conflicting migration: %v over table: %v", conflictingMigration.UUID, conflictingMigration.Table)
 	}
 
 	if e.tabletTypeFunc() != topodatapb.TabletType_PRIMARY {
@@ -1284,8 +1283,8 @@ func (e *Executor) ExecuteWithVReplication(ctx context.Context, onlineDDL *schem
 // Validation included testing the backend MySQL server and the gh-ost binary itself
 // Execution runs first a dry run, then an actual migration
 func (e *Executor) ExecuteWithGhost(ctx context.Context, onlineDDL *schema.OnlineDDL) error {
-	if e.isAnyConflictingMigrationRunning(onlineDDL) {
-		return ErrExecutorMigrationAlreadyRunning
+	if conflictFound, conflictingMigration := e.isAnyConflictingMigrationRunning(onlineDDL); conflictFound {
+		return vterrors.Wrapf(ErrExecutorMigrationAlreadyRunning, "conflicting migration: %v over table: %v", conflictingMigration.UUID, conflictingMigration.Table)
 	}
 
 	if e.tabletTypeFunc() != topodatapb.TabletType_PRIMARY {
@@ -1502,8 +1501,8 @@ exit $exit_code
 // Validation included testing the backend MySQL server and the pt-online-schema-change binary itself
 // Execution runs first a dry run, then an actual migration
 func (e *Executor) ExecuteWithPTOSC(ctx context.Context, onlineDDL *schema.OnlineDDL) error {
-	if e.isAnyConflictingMigrationRunning(onlineDDL) {
-		return ErrExecutorMigrationAlreadyRunning
+	if conflictFound, conflictingMigration := e.isAnyConflictingMigrationRunning(onlineDDL); conflictFound {
+		return vterrors.Wrapf(ErrExecutorMigrationAlreadyRunning, "conflicting migration: %v over table: %v", conflictingMigration.UUID, conflictingMigration.Table)
 	}
 
 	if e.tabletTypeFunc() != topodatapb.TabletType_PRIMARY {
@@ -2981,7 +2980,7 @@ func (e *Executor) runNextMigration(ctx context.Context) error {
 			if err != nil {
 				return nil, err
 			}
-			if !e.isAnyConflictingMigrationRunning(onlineDDL) {
+			if conflictFound, _ := e.isAnyConflictingMigrationRunning(onlineDDL); !conflictFound {
 				if e.countOwnedRunningMigrations() < maxConcurrentOnlineDDLs {
 					// This migration seems good to go
 					return onlineDDL, err


### PR DESCRIPTION

## Description

Today, when the Online DDL executor attempts to run a migration that has a conflict, vitess returns a generic error message: 

> cannot run migration since a migration is already running

As of this PR, the message indicates the UUID and table name that cause the conflict. UUID is enough, but table name is added for more clarity.

## Related Issue(s)

#6926

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
