### PR TITLE
Only refresh required tablet's information in VTOrc

### DIFF
--- a/go/vt/orchestrator/inst/analysis.go
+++ b/go/vt/orchestrator/inst/analysis.go
@@ -122,6 +122,7 @@ type ReplicationAnalysis struct {
 	AnalyzedInstanceDataCenter                string
 	AnalyzedInstanceRegion                    string
 	AnalyzedKeyspace                          string
+	AnalyzedShard                             string
 	AnalyzedInstancePhysicalEnvironment       string
 	AnalyzedInstanceBinlogCoordinates         BinlogCoordinates
 	IsPrimary                                 bool

--- a/go/vt/orchestrator/inst/analysis_dao.go
+++ b/go/vt/orchestrator/inst/analysis_dao.go
@@ -76,6 +76,7 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		vitess_tablet.port,
 		vitess_tablet.tablet_type,
 		vitess_tablet.primary_timestamp,
+		vitess_tablet.shard AS shard,
 		vitess_keyspace.keyspace AS keyspace,
 		vitess_keyspace.keyspace_type AS keyspace_type,
 		vitess_keyspace.durability_policy AS durability_policy,
@@ -377,6 +378,7 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 
 		a.TabletType = tablet.Type
 		a.AnalyzedKeyspace = m.GetString("keyspace")
+		a.AnalyzedShard = m.GetString("shard")
 		a.PrimaryTimeStamp = m.GetTime("primary_timestamp")
 
 		if keyspaceType := topodatapb.KeyspaceType(m.GetInt("keyspace_type")); keyspaceType == topodatapb.KeyspaceType_SNAPSHOT {

--- a/go/vt/orchestrator/inst/analysis_dao_test.go
+++ b/go/vt/orchestrator/inst/analysis_dao_test.go
@@ -29,10 +29,12 @@ import (
 
 func TestGetReplicationAnalysis(t *testing.T) {
 	tests := []struct {
-		name       string
-		info       []*test.InfoForRecoveryAnalysis
-		codeWanted AnalysisCode
-		wantErr    string
+		name           string
+		info           []*test.InfoForRecoveryAnalysis
+		codeWanted     AnalysisCode
+		shardWanted    string
+		keyspaceWanted string
+		wantErr        string
 	}{
 		{
 			name: "ClusterHasNoPrimary",
@@ -49,7 +51,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				DurabilityPolicy: "none",
 				LastCheckValid:   1,
 			}},
-			codeWanted: ClusterHasNoPrimary,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     ClusterHasNoPrimary,
 		}, {
 			name: "DeadPrimary",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -69,7 +73,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				CountValidReplicatingReplicas: 0,
 				IsPrimary:                     1,
 			}},
-			codeWanted: DeadPrimary,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     DeadPrimary,
 		}, {
 			name: "DeadPrimaryWithoutReplicas",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -87,7 +93,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				CountReplicas:    0,
 				IsPrimary:        1,
 			}},
-			codeWanted: DeadPrimaryWithoutReplicas,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     DeadPrimaryWithoutReplicas,
 		}, {
 			name: "DeadPrimaryAndReplicas",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -105,7 +113,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				CountReplicas:    3,
 				IsPrimary:        1,
 			}},
-			codeWanted: DeadPrimaryAndReplicas,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     DeadPrimaryAndReplicas,
 		}, {
 			name: "DeadPrimaryAndSomeReplicas",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -125,7 +135,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				CountValidReplicatingReplicas: 0,
 				IsPrimary:                     1,
 			}},
-			codeWanted: DeadPrimaryAndSomeReplicas,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     DeadPrimaryAndSomeReplicas,
 		}, {
 			name: "PrimaryHasPrimary",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -144,7 +156,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				CountValidReplicas: 4,
 				IsPrimary:          0,
 			}},
-			codeWanted: PrimaryHasPrimary,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     PrimaryHasPrimary,
 		}, {
 			name: "PrimaryIsReadOnly",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -164,7 +178,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				IsPrimary:          1,
 				ReadOnly:           1,
 			}},
-			codeWanted: PrimaryIsReadOnly,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     PrimaryIsReadOnly,
 		}, {
 			name: "PrimarySemiSyncMustNotBeSet",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -184,7 +200,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				IsPrimary:              1,
 				SemiSyncPrimaryEnabled: 1,
 			}},
-			codeWanted: PrimarySemiSyncMustNotBeSet,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     PrimarySemiSyncMustNotBeSet,
 		}, {
 			name: "PrimarySemiSyncMustBeSet",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -204,7 +222,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				IsPrimary:              1,
 				SemiSyncPrimaryEnabled: 0,
 			}},
-			codeWanted: PrimarySemiSyncMustBeSet,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     PrimarySemiSyncMustBeSet,
 		}, {
 			name: "NotConnectedToPrimary",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -239,7 +259,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				ReadOnly:       1,
 				IsPrimary:      1,
 			}},
-			codeWanted: NotConnectedToPrimary,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     NotConnectedToPrimary,
 		}, {
 			name: "ReplicaIsWritable",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -276,7 +298,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				LastCheckValid:   1,
 				ReadOnly:         0,
 			}},
-			codeWanted: ReplicaIsWritable,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     ReplicaIsWritable,
 		}, {
 			name: "ConnectedToWrongPrimary",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -313,7 +337,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				LastCheckValid:   1,
 				ReadOnly:         1,
 			}},
-			codeWanted: ConnectedToWrongPrimary,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     ConnectedToWrongPrimary,
 		}, {
 			name: "ReplicationStopped",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -351,7 +377,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				ReadOnly:           1,
 				ReplicationStopped: 1,
 			}},
-			codeWanted: ReplicationStopped,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     ReplicationStopped,
 		},
 		{
 			name: "ReplicaSemiSyncMustBeSet",
@@ -400,7 +428,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				ReadOnly:               1,
 				SemiSyncReplicaEnabled: 0,
 			}},
-			codeWanted: ReplicaSemiSyncMustBeSet,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     ReplicaSemiSyncMustBeSet,
 		}, {
 			name: "ReplicaSemiSyncMustNotBeSet",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -447,7 +477,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				ReadOnly:               1,
 				SemiSyncReplicaEnabled: 1,
 			}},
-			codeWanted: ReplicaSemiSyncMustNotBeSet,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     ReplicaSemiSyncMustNotBeSet,
 		}, {
 			name: "SnapshotKeyspace",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -465,7 +497,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				DurabilityPolicy: "none",
 				LastCheckValid:   1,
 			}},
-			codeWanted: NoProblem,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     NoProblem,
 		}, {
 			name: "EmptyDurabilityPolicy",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -481,7 +515,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 				LastCheckValid: 1,
 			}},
 			// We will ignore these keyspaces too until the durability policy is set in the topo server
-			codeWanted: NoProblem,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     NoProblem,
 		},
 	}
 	for _, tt := range tests {
@@ -505,6 +541,8 @@ func TestGetReplicationAnalysis(t *testing.T) {
 			}
 			require.Len(t, got, 1)
 			require.Equal(t, tt.codeWanted, got[0].Analysis)
+			require.Equal(t, tt.keyspaceWanted, got[0].AnalyzedKeyspace)
+			require.Equal(t, tt.shardWanted, got[0].AnalyzedShard)
 		})
 	}
 }

--- a/go/vt/orchestrator/logic/orchestrator.go
+++ b/go/vt/orchestrator/logic/orchestrator.go
@@ -452,7 +452,7 @@ func ContinuousDiscovery() {
 			}()
 		case <-tabletTopoTick:
 			go RefreshAllKeyspaces()
-			go RefreshTablets(false /* forceRefresh */)
+			go refreshAllTablets()
 		}
 	}
 }

--- a/go/vt/orchestrator/logic/orchestrator.go
+++ b/go/vt/orchestrator/logic/orchestrator.go
@@ -256,6 +256,10 @@ func DiscoverInstance(instanceKey inst.InstanceKey, forceDiscovery bool) {
 		return
 	}
 
+	if forceDiscovery {
+		log.Infof("Force discovered - %+v", instance)
+	}
+
 	discoveryMetrics.Append(&discovery.Metric{
 		Timestamp:       time.Now(),
 		InstanceKey:     instanceKey,

--- a/go/vt/orchestrator/logic/topology_recovery.go
+++ b/go/vt/orchestrator/logic/topology_recovery.go
@@ -1079,6 +1079,11 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 	// Instead we create a new context. The call forceRefreshAllTabletsInShard handles this for us.
 	if isClusterWideRecovery(checkAndRecoverFunctionCode) {
 		forceRefreshAllTabletsInShard(nil, analysisEntry.AnalyzedKeyspace, analysisEntry.AnalyzedShard)
+	} else {
+		// For all other recoveries, we would have changed the replication status of the analyzed tablet
+		// so it doesn't hurt to re-read the information of this tablet, otherwise we'll requeue the same recovery
+		// that we just completed because we would be using stale data.
+		DiscoverInstance(analysisEntry.AnalyzedInstanceKey, true)
 	}
 	if !skipProcesses {
 		if topologyRecovery.SuccessorKey == nil {

--- a/go/vt/orchestrator/logic/topology_recovery.go
+++ b/go/vt/orchestrator/logic/topology_recovery.go
@@ -1056,10 +1056,7 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 // checkIfAlreadyFixed checks whether the problem that the analysis entry represents has already been fixed by another agent or not
 func checkIfAlreadyFixed(analysisEntry inst.ReplicationAnalysis) (bool, error) {
 	// Run a replication analysis again. We will check if the problem persisted
-	// TODO (@GuptaManan100): Use specific cluster name to filter the scope of replication analysis.
-	// Can't do this now since SuggestedClusterAlias, ClusterName, ClusterAlias aren't consistent
-	// and passing any one causes issues in some failures
-	analysisEntries, err := inst.GetReplicationAnalysis("", &inst.ReplicationAnalysisHints{})
+	analysisEntries, err := inst.GetReplicationAnalysis(analysisEntry.ClusterDetails.ClusterName, &inst.ReplicationAnalysisHints{})
 	if err != nil {
 		return false, err
 	}

--- a/go/vt/orchestrator/test/recovery_analysis.go
+++ b/go/vt/orchestrator/test/recovery_analysis.go
@@ -32,6 +32,7 @@ type InfoForRecoveryAnalysis struct {
 	PrimaryTabletInfo                         *topodatapb.Tablet
 	PrimaryTimestamp                          *time.Time
 	Keyspace                                  string
+	Shard                                     string
 	KeyspaceType                              int
 	DurabilityPolicy                          string
 	IsPrimary                                 int
@@ -126,6 +127,8 @@ func (info *InfoForRecoveryAnalysis) ConvertToRowMap() sqlutils.RowMap {
 	rowMap["is_primary"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsPrimary), Valid: true}
 	rowMap["is_stale_binlog_coordinates"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsStaleBinlogCoordinates), Valid: true}
 	rowMap["keyspace_type"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.KeyspaceType), Valid: true}
+	rowMap["keyspace"] = sqlutils.CellData{String: info.Keyspace, Valid: true}
+	rowMap["shard"] = sqlutils.CellData{String: info.Shard, Valid: true}
 	rowMap["last_check_partial_success"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.LastCheckPartialSuccess), Valid: true}
 	rowMap["max_replica_gtid_errant"] = sqlutils.CellData{String: info.MaxReplicaGTIDErrant, Valid: true}
 	rowMap["max_replica_gtid_mode"] = sqlutils.CellData{String: info.MaxReplicaGTIDMode, Valid: true}
@@ -161,6 +164,7 @@ func (info *InfoForRecoveryAnalysis) SetValuesFromTabletInfo() {
 	info.Port = int(info.TabletInfo.MysqlPort)
 	info.DataCenter = info.TabletInfo.Alias.Cell
 	info.Keyspace = info.TabletInfo.Keyspace
+	info.Shard = info.TabletInfo.Shard
 	info.ClusterName = fmt.Sprintf("%v:%v", info.TabletInfo.Keyspace, info.TabletInfo.Shard)
 	info.ClusterDomain = fmt.Sprintf("%v:%d", info.TabletInfo.MysqlHostname, info.TabletInfo.MysqlPort)
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

In #10115 and #10150 we added the capability of refreshing VTOrc's ephemeral information before it ran any fix. This was required to help us guarantee safety however, the first iteration of this change was inefficient.

We used to refresh all the tablets that are in the VTOrc instance's purview for each and every recovery.  As part of the PRs a TODO for fixing this was also added - 
```golang
// TODO (@GuptaManan100): Refresh only the shard tablet information instead of all the tablets
```

This change couldn't be immediately accomplished because we first required the cleanup of `cluster_alias`, `cluster_name`, and `suggested_cluster_alias`. This cleanup was addressed in #11193.

This PR addresses this `TODO` that was introduced then in order to make the recoveries more efficient and faster. Instead of the proposed refreshing all tablets in a shard in the TODO, this PR takes it a step further and only refreshes the tablets that are required.

To this end, all the recoveries have been categorized into two types, the ones that are cluster-wide recoveries and the ones that aren't.

If we are about to run a cluster-wide recovery like `electNewPrimary` or `recoverDeadPrimary`, then it is imperative to first refresh all the tablets of a shard because a new tablet could have been promoted, and we need to have this visibility before we run a cluster operation of our own.

Non-cluster-wide recoveries are only concerned with the specific tablet on which the failure occurred and the primary instance of the shard. For example, ConnectedToWrongPrimary analysis only cares for whom the current primary tablet is and the host-port set on the tablet in question. So, we only need to refresh the tablet info records (to know if the primary tablet has changed), and the replication data of the new primary and this tablet.

These changes make VTOrc recoveries much faster, while still guaranteeing correctness like they used to 🧞 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
 - #8975

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
