### PR TITLE
vtcombo mutates options, make a copy to avoid this

### DIFF
--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -437,7 +437,7 @@ type internalTabletConn struct {
 var _ queryservice.QueryService = (*internalTabletConn)(nil)
 
 // Execute is part of queryservice.QueryService
-// We need to copy the bind variables and options as tablet server will change them.
+// We need to copy the bind variables as tablet server will change them.
 func (itc *internalTabletConn) Execute(
 	ctx context.Context,
 	target *querypb.Target,

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -447,20 +447,7 @@ func (itc *internalTabletConn) Execute(
 	options *querypb.ExecuteOptions,
 ) (*sqltypes.Result, error) {
 	bindVars = sqltypes.CopyBindVariables(bindVars)
-	optionsCopy := options
-	if options != nil {
-		optionsCopy = &querypb.ExecuteOptions{
-			IncludedFields:       options.IncludedFields,
-			ClientFoundRows:      options.ClientFoundRows,
-			Workload:             options.Workload,
-			SqlSelectLimit:       options.SqlSelectLimit,
-			TransactionIsolation: options.TransactionIsolation,
-			SkipQueryPlanCache:   options.SkipQueryPlanCache,
-			PlannerVersion:       options.PlannerVersion,
-			HasCreatedTempTables: options.HasCreatedTempTables,
-		}
-	}
-	reply, err := itc.tablet.qsc.QueryService().Execute(ctx, target, query, bindVars, transactionID, reservedID, optionsCopy)
+	reply, err := itc.tablet.qsc.QueryService().Execute(ctx, target, query, bindVars, transactionID, reservedID, options)
 	if err != nil {
 		return nil, tabletconn.ErrorFromGRPC(vterrors.ToGRPC(err))
 	}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -19,11 +19,12 @@ package tabletserver
 import (
 	"context"
 	"fmt"
-	"google.golang.org/protobuf/proto"
 	"io"
 	"strings"
 	"sync"
 	"time"
+
+	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations"

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -19,6 +19,7 @@ package tabletserver
 import (
 	"context"
 	"fmt"
+	"google.golang.org/protobuf/proto"
 	"io"
 	"strings"
 	"sync"
@@ -195,6 +196,8 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 func (qre *QueryExecutor) execAutocommit(f func(conn *StatefulConnection) (*sqltypes.Result, error)) (reply *sqltypes.Result, err error) {
 	if qre.options == nil {
 		qre.options = &querypb.ExecuteOptions{}
+	} else {
+		qre.options = proto.Clone(qre.options).(*querypb.ExecuteOptions)
 	}
 	qre.options.TransactionIsolation = querypb.ExecuteOptions_AUTOCOMMIT
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

When using vtcombo to run unit tests, we noticed that for transactional tests, transactions didn't seem to be obeyed. Upon further inspection, statements inside of a transaction would always get autocommitted. We could not reproduce this with actual vtgates/vttablets, so it had to be isolated to vtcombo. Turns out, the `options` [here](https://github.com/vitessio/vitess/blob/b277bcb871e847c6fb280431d6cf8e62aa455ff7/go/vt/vtcombo/tablet_map.go#L441-L454) would get mutated [here](https://github.com/vitessio/vitess/blob/1487772f3d59c5fc6fb221402a5100f90c69857f/go/vt/vttablet/tabletserver/query_executor.go#L199), so any previous query that was indeed autocommit=true and not in a transaction would cause future queries to have `qre.options.TransactionIsolation = querypb.ExecuteOptions_AUTOCOMMIT` set

Slack conversation: https://vitess.slack.com/archives/C0PQY0PTK/p1662725270016499

Example:

1. Create table
2. Insert 3 rows with ids 1,2,3..100
3. In one thread, in a transaction update rows with ids 1,2,3..100
4. In another thread, in a transaction update rows with ids 100, 99, 98...1 (in reverse of step 3)
5. Expect a deadlock, but since in step 2 we were not in transaction and it did autocommit, the other statements inherit this and do not deadlock as each one autocommits

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Fixes https://github.com/vitessio/vitess/issues/11222
- Fixes https://github.com/vitessio/vitess/issues/10398

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
None, only concerns vtcombo
