### PR TITLE
Flakes: Correct TestVReplicationCopyThrottling Logic

### DIFF
--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -468,7 +468,7 @@ func getDebugVar(t *testing.T, port int, varPath []string) (string, error) {
 	return string(val), nil
 }
 
-func confirmStreamHasCopiedNoData(t *testing.T, targetKS, workflow string) {
+func confirmWorkflowHasCopiedNoData(t *testing.T, targetKS, workflow string) {
 	timer := time.NewTimer(defaultTimeout)
 	defer timer.Stop()
 	ksWorkflow := fmt.Sprintf("%s.%s", targetKS, workflow)

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -47,7 +47,11 @@ import (
 const (
 	defaultTick          = 1 * time.Second
 	defaultTimeout       = 30 * time.Second
-	workflowStartTimeout = 5 * time.Second
+	workflowStateTimeout = 90 * time.Second
+	workflowStateCopying = "Copying" // nolint
+	workflowStateRunning = "Running" // nolint
+	workflowStateStopped = "Stopped" // nolint
+	workflowStateError   = "Error"   // nolint
 )
 
 func execMultipleQueries(t *testing.T, conn *mysql.Conn, database string, lines string) {
@@ -234,10 +238,10 @@ func validateThatQueryExecutesOnTablet(t *testing.T, conn *mysql.Conn, tablet *c
 	return newCount == count+1
 }
 
-func waitForWorkflowToStart(t *testing.T, vc *VitessCluster, ksWorkflow string) {
+func waitForWorkflowState(t *testing.T, vc *VitessCluster, ksWorkflow string, wantState string) {
 	done := false
-	timer := time.NewTimer(workflowStartTimeout)
-	log.Infof("Waiting for workflow %s to start", ksWorkflow)
+	timer := time.NewTimer(workflowStateTimeout)
+	log.Infof("Waiting for workflow %q to fully reach %q state", ksWorkflow, wantState)
 	for {
 		output, err := vc.VtctlClient.ExecuteCommandWithOutput("Workflow", ksWorkflow, "show")
 		require.NoError(t, err)
@@ -249,8 +253,8 @@ func waitForWorkflowToStart(t *testing.T, vc *VitessCluster, ksWorkflow string) 
 				if streamId.String() == "PrimaryReplicationStatuses" {
 					streamInfos.ForEach(func(attributeKey, attributeValue gjson.Result) bool { // for each attribute in the stream
 						state = attributeValue.Get("State").String()
-						if state != "Running" {
-							done = false // we need to wait for all streams to start
+						if state != wantState {
+							done = false // we need to wait for all streams to have the desired state
 						}
 						return true
 					})
@@ -260,13 +264,13 @@ func waitForWorkflowToStart(t *testing.T, vc *VitessCluster, ksWorkflow string) 
 			return true
 		})
 		if done {
-			log.Infof("Workflow %s has started", ksWorkflow)
+			log.Infof("Workflow %q has fully reached the desired state of %q", ksWorkflow, wantState)
 			return
 		}
 		select {
 		case <-timer.C:
-			require.FailNowf(t, "workflow %q did not fully start before the timeout of %s",
-				ksWorkflow, workflowStartTimeout)
+			require.FailNowf(t, "workflow %q did not fully reach the expected state of %q before the timeout of %s; last seen output: %s",
+				ksWorkflow, wantState, workflowStateTimeout, output)
 		default:
 			time.Sleep(defaultTick)
 		}
@@ -462,4 +466,40 @@ func getDebugVar(t *testing.T, port int, varPath []string) (string, error) {
 	val, _, _, err = jsonparser.Get([]byte(body), varPath...)
 	require.NoError(t, err)
 	return string(val), nil
+}
+
+func confirmStreamHasCopiedNoData(t *testing.T, targetKS, workflow string) {
+	timer := time.NewTimer(defaultTimeout)
+	defer timer.Stop()
+	ksWorkflow := fmt.Sprintf("%s.%s", targetKS, workflow)
+	for {
+		output, err := vc.VtctlClient.ExecuteCommandWithOutput("Workflow", ksWorkflow, "show")
+		require.NoError(t, err)
+		result := gjson.Get(output, "ShardStatuses")
+		result.ForEach(func(tabletId, tabletStreams gjson.Result) bool { // for each source tablet
+			tabletStreams.ForEach(func(streamId, streamInfos gjson.Result) bool { // for each stream
+				if streamId.String() == "PrimaryReplicationStatuses" {
+					streamInfos.ForEach(func(attributeKey, attributeValue gjson.Result) bool { // for each attribute in the stream
+						state := attributeValue.Get("State").String()
+						pos := attributeValue.Get("Pos").String()
+						// If we've actually copied anything then we'll have a position in the stream
+						if (state == workflowStateRunning || state == workflowStateCopying) && pos != "" {
+							require.FailNowf(t, "Unexpected data copied in workflow",
+								"The MoveTables workflow %q copied data in less than %s when it should have been waiting. Show output: %s",
+								ksWorkflow, defaultTimeout, output)
+						}
+						return true // end attribute loop
+					})
+				}
+				return true // end stream loop
+			})
+			return true // end tablet loop
+		})
+		select {
+		case <-timer.C:
+			return
+		default:
+			time.Sleep(defaultTick)
+		}
+	}
 }

--- a/go/test/endtoend/vreplication/migrate_test.go
+++ b/go/test/endtoend/vreplication/migrate_test.go
@@ -107,7 +107,7 @@ func TestMigrate(t *testing.T) {
 			"--source=ext1.rating", "create", ksWorkflow); err != nil {
 			t.Fatalf("Migrate command failed with %+v : %s\n", err, output)
 		}
-		waitForWorkflowToStart(t, vc, ksWorkflow)
+		waitForWorkflowState(t, vc, ksWorkflow, workflowStateRunning)
 		expectNumberOfStreams(t, vtgateConn, "migrate", "e1", "product:0", 1)
 		waitForRowCount(t, vtgateConn, "product:0", "rating", 2)
 		waitForRowCount(t, vtgateConn, "product:0", "review", 3)

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -60,7 +60,7 @@ func createReshardWorkflow(t *testing.T, sourceShards, targetShards string) erro
 	err := tstWorkflowExec(t, defaultCellName, workflowName, targetKs, targetKs,
 		"", workflowActionCreate, "", sourceShards, targetShards)
 	require.NoError(t, err)
-	waitForWorkflowToStart(t, vc, ksWorkflow)
+	waitForWorkflowState(t, vc, ksWorkflow, workflowStateRunning)
 	catchup(t, targetTab1, workflowName, "Reshard")
 	catchup(t, targetTab2, workflowName, "Reshard")
 	vdiff1(t, ksWorkflow, "")
@@ -74,7 +74,7 @@ func createMoveTablesWorkflow(t *testing.T, tables string) error {
 	err := tstWorkflowExec(t, defaultCellName, workflowName, sourceKs, targetKs,
 		tables, workflowActionCreate, "", "", "")
 	require.NoError(t, err)
-	waitForWorkflowToStart(t, vc, ksWorkflow)
+	waitForWorkflowState(t, vc, ksWorkflow, workflowStateRunning)
 	catchup(t, targetTab1, workflowName, "MoveTables")
 	catchup(t, targetTab2, workflowName, "MoveTables")
 	vdiff1(t, ksWorkflow, "")
@@ -267,7 +267,7 @@ func testVSchemaForSequenceAfterMoveTables(t *testing.T) {
 		"customer2", workflowActionCreate, "", "", "")
 	require.NoError(t, err)
 
-	waitForWorkflowToStart(t, vc, "customer.wf2")
+	waitForWorkflowState(t, vc, "customer.wf2", workflowStateRunning)
 	waitForLowLag(t, "customer", "wf2")
 
 	err = tstWorkflowExec(t, defaultCellName, "wf2", sourceKs, targetKs,
@@ -301,7 +301,7 @@ func testVSchemaForSequenceAfterMoveTables(t *testing.T) {
 	err = tstWorkflowExec(t, defaultCellName, "wf3", targetKs, sourceKs,
 		"customer2", workflowActionCreate, "", "", "")
 	require.NoError(t, err)
-	waitForWorkflowToStart(t, vc, "product.wf3")
+	waitForWorkflowState(t, vc, "product.wf3", workflowStateRunning)
 
 	waitForLowLag(t, "product", "wf3")
 	err = tstWorkflowExec(t, defaultCellName, "wf3", targetKs, sourceKs,

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -151,7 +151,7 @@ func TestVreplicationCopyThrottling(t *testing.T) {
 	// Wait for the copy phase to start
 	waitForWorkflowState(t, vc, fmt.Sprintf("%s.%s", targetKs, workflow), workflowStateCopying)
 	// The initial copy phase should be blocking on the history list
-	confirmStreamHasCopiedNoData(t, targetKs, workflow)
+	confirmWorkflowHasCopiedNoData(t, targetKs, workflow)
 	releaseInnoDBRowHistory(t, trxConn)
 	trxConn.Close()
 }


### PR DESCRIPTION
## Description

The `TestVReplicationCopyThrottling` test — which is included in the `vreplication_basic` GitHub Actions workflow — continued to be flaky (especially with 8.0) after https://github.com/vitessio/vitess/pull/11208.

The primary issue was that there was a race condition that the test was not accounting for. That is, during the period of time between when the VReplication workflow starts and sets the state to `Running`, and where it finishes the initial setup of the copy phase before finally setting the state to `Copying` here: https://github.com/vitessio/vitess/blob/b277bcb871e847c6fb280431d6cf8e62aa455ff7/go/vt/vttablet/tabletmanager/vreplication/vcopier.go#L81

If we looked at the `vtctlclient Workflow show` output during that time, the state would be `Running` which in the test we _incorrectly_ assumed to mean that the copy phase had completed. In reality what this state really means, **where [the `Pos` is also empty](https://github.com/vitessio/vitess/blob/b277bcb871e847c6fb280431d6cf8e62aa455ff7/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go#L236) because we haven't copied anything in the stream**, is that we're still in the process of initializing/setting up the copy phase.

The test logic has been corrected to avoid race conditions related to the expected workflow states.

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/11208

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were updated
-   [x] Documentation is not required