### PR TITLE
Don't run VDiff on frozen workflows

### DIFF
--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -186,6 +186,10 @@ func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflowName, sou
 		wr.Logger().Errorf("buildTrafficSwitcher: %v", err)
 		return nil, err
 	}
+	if ts.frozen {
+		return nil, fmt.Errorf("invalid VDiff run: writes have been already been switched for workflow %s.%s",
+			targetKeyspace, workflowName)
+	}
 	if err := ts.validate(ctx); err != nil {
 		ts.Logger().Errorf("validate: %v", err)
 		return nil, err

--- a/go/vt/wrangler/vdiff2.go
+++ b/go/vt/wrangler/vdiff2.go
@@ -18,6 +18,7 @@ package wrangler
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"vitess.io/vitess/go/vt/vtctl/workflow"
@@ -58,6 +59,10 @@ func (wr *Wrangler) VDiff2(ctx context.Context, keyspace, workflowName string, a
 	ts, err := wr.buildTrafficSwitcher(ctx, keyspace, workflowName)
 	if err != nil {
 		return nil, err
+	}
+	if action == vdiff2.CreateAction && ts.frozen {
+		return nil, fmt.Errorf("invalid VDiff run: writes have been already been switched for workflow %s.%s",
+			keyspace, workflowName)
 	}
 
 	output.Err = ts.ForAllTargets(func(target *workflow.MigrationTarget) error {


### PR DESCRIPTION
## Description

https://github.com/vitessio/vitess/issues/11233 has details on the issue this PR is trying to fix. 

The root cause is that `SwitchWrites` will `Stop` the workflows on the target since writes have now been switched to them. However `vdiff` restarts workflows once it is done irrespective of the previous status of the workflow. 

As part of `SwitchWrites` all streams in a workflow are marked as `frozen`.  This PR adds a check in `VDiff` (both v1 and v2) and does not start it in case the workflow is found to be frozen.

This is the most common issue that has been reported related to VDiff starting stopped workflows. Another use-case would be if the user had stopped a workflow for some reason.  That requires some more discussion: on the one hand we can look for Stopped workflow and not restart them. However, VDiff will temporarily restart all workflows while syncing up the source and target, which will mean that workflows will be running for a while and writing to the target. If the user had stopped the workflow to prevent that, for some reason, we will be overriding that. At this time we don't have a reasonable justification for this use-case and also it will take a bit longer to implement it. So we only fix the specific bug referred to in #11233  

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/11233

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [X] Tests were added or are not required
-   [ ] Documentation was added or is not required
