### PR TITLE
Backport to release-14: Fix VTOrc Discovery to also retry discovering tablets which aren't present in database_instance table

### DIFF
--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -802,9 +802,12 @@ func SetupNewClusterSemiSync(t *testing.T) *VtOrcClusterInfo {
 	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, fmt.Sprintf("--durability-policy=semi_sync"))
 	require.NoError(t, err, out)
 
+	// create topo server connection
+	ts, err := topo.OpenServer(*clusterInstance.TopoFlavorString(), clusterInstance.VtctlProcess.TopoGlobalAddress, clusterInstance.VtctlProcess.TopoGlobalRoot)
+	require.NoError(t, err)
 	clusterInfo := &VtOrcClusterInfo{
 		ClusterInstance:     clusterInstance,
-		Ts:                  nil,
+		Ts:                  ts,
 		CellInfos:           nil,
 		lastUsedValue:       100,
 		VtctldClientProcess: vtctldClientProcess,


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR is a backport of https://github.com/vitessio/vitess/pull/10662 to releaes-14.0

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #10650 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
