### PR TITLE
Add hyperlink in the release changelog

### DIFF
--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -116,7 +116,7 @@ The entire changelog for this release can be found [here]({{ .PathToChangeLogFil
 {{- range $component := $type.Components }} 
 #### {{ $component.Name }}
 {{- range $prInfo := $component.PrInfos }}
- * {{ $prInfo.Title }} #{{ $prInfo.Number }}
+ * {{ $prInfo.Title }} [#{{ $prInfo.Number }}](https://github.com/vitessio/vitess/pull/{{ $prInfo.Number }})
 {{- end }}
 {{- end }}
 {{- end }}
@@ -495,7 +495,7 @@ func main() {
 	flag.Parse()
 
 	// The -version flag must be of a valid format.
-	rx := regexp.MustCompile(`v(\d+)\.(\d+)\.(\d+)`)
+	rx := regexp.MustCompile(`v([0-9]+)\.([0-9]+)\.([0-9]+)`)
 	// There should be 4 sub-matches, input: "v14.0.0", output: ["v14.0.0", "14", "0", "0"].
 	versionMatch := rx.FindStringSubmatch(*versionName)
 	if len(versionMatch) != 4 {


### PR DESCRIPTION
## Description

This Pull Request changes the release notes generation script to natively include a link for each Pull Request in the change log. This way, the users reading the change log can quickly click and see the Pull Request associated with a change.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/11240

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
