### PR TITLE
Fix: Insert using select streaming bug

### DIFF
--- a/go/test/endtoend/vtgate/queries/insert/insert_test.go
+++ b/go/test/endtoend/vtgate/queries/insert/insert_test.go
@@ -207,9 +207,11 @@ func TestUnownedVindexInsertSelect(t *testing.T) {
 	assert.EqualValues(t, 4, qr.RowsAffected)
 
 	utils.Exec(t, mcmp.VtConn, "use `sks/-80`")
-	utils.AssertMatches(t, mcmp.VtConn, `select count(*) from order_tbl o join oevent_tbl oe on o.oid = oe.oid`, `[[INT64(3)]]`)
+	qr = utils.Exec(t, mcmp.VtConn, `select count(*) from order_tbl o join oevent_tbl oe on o.oid = oe.oid`)
+	assert.Equal(t, `[[INT64(3)]]`, fmt.Sprintf("%v", qr.Rows))
 	utils.Exec(t, mcmp.VtConn, "use `sks/80-`")
-	utils.AssertMatches(t, mcmp.VtConn, `select count(*) from order_tbl o join oevent_tbl oe on o.oid = oe.oid`, `[[INT64(1)]]`)
+	qr = utils.Exec(t, mcmp.VtConn, `select count(*) from order_tbl o join oevent_tbl oe on o.oid = oe.oid`)
+	assert.Equal(t, `[[INT64(1)]]`, fmt.Sprintf("%v", qr.Rows))
 
 	// resetting the target
 	utils.Exec(t, mcmp.VtConn, "use `sks`")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the bug in insert using select streaming. The fix is to serialize the processing of streaming select.
The underlying issue was causing re-use of same transaction on vttablet in parallel and causing in an error,

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
 - Fixes https://github.com/vitessio/vitess/issues/11247

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported - The feature itself exists only on main.
-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
