### PR TITLE
Parameterize VTOrc constants

### DIFF
--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -86,20 +86,34 @@ type Configuration struct {
 	DefaultRaftPort                             int      // if a RaftNodes entry does not specify port, use this one
 	RaftNodes                                   []string // Raft nodes to make initial connection with
 	ExpectFailureAnalysisConcensus              bool
-	MySQLOrchestratorHost                       string
-	MySQLOrchestratorMaxPoolConnections         int // The maximum size of the connection pool to the VTOrc backend.
-	MySQLOrchestratorPort                       uint
-	MySQLOrchestratorDatabase                   string
-	MySQLOrchestratorUser                       string
-	MySQLOrchestratorPassword                   string
-	MySQLOrchestratorCredentialsConfigFile      string   // my.cnf style configuration file from where to pick credentials. Expecting `user`, `password` under `[client]` section
-	MySQLOrchestratorSSLPrivateKeyFile          string   // Private key file used to authenticate with the VTOrc mysql instance with TLS
-	MySQLOrchestratorSSLCertFile                string   // Certificate PEM file used to authenticate with the VTOrc mysql instance with TLS
-	MySQLOrchestratorSSLCAFile                  string   // Certificate Authority PEM file used to authenticate with the VTOrc mysql instance with TLS
-	MySQLOrchestratorSSLSkipVerify              bool     // If true, do not strictly validate mutual TLS certs for the VTOrc mysql instances
-	MySQLOrchestratorUseMutualTLS               bool     // Turn on TLS authentication with the VTOrc MySQL instance
-	MySQLOrchestratorReadTimeoutSeconds         int      // Number of seconds before backend mysql read operation is aborted (driver-side)
-	MySQLOrchestratorRejectReadOnly             bool     // Reject read only connections https://github.com/go-sql-driver/mysql#rejectreadonly
+	MySQLVTOrcHost                              string
+	MySQLOrchestratorHost                       string // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcMaxPoolConnections                int    // The maximum size of the connection pool to the VTOrc backend.
+	MySQLOrchestratorMaxPoolConnections         int    // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcPort                              uint
+	MySQLOrchestratorPort                       uint // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcDatabase                          string
+	MySQLOrchestratorDatabase                   string // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcUser                              string
+	MySQLOrchestratorUser                       string // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcPassword                          string
+	MySQLOrchestratorPassword                   string   // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcCredentialsConfigFile             string   // my.cnf style configuration file from where to pick credentials. Expecting `user`, `password` under `[client]` section
+	MySQLOrchestratorCredentialsConfigFile      string   // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcSSLPrivateKeyFile                 string   // Private key file used to authenticate with the VTOrc mysql instance with TLS
+	MySQLOrchestratorSSLPrivateKeyFile          string   // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcSSLCertFile                       string   // Certificate PEM file used to authenticate with the VTOrc mysql instance with TLS
+	MySQLOrchestratorSSLCertFile                string   // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcSSLCAFile                         string   // Certificate Authority PEM file used to authenticate with the VTOrc mysql instance with TLS
+	MySQLOrchestratorSSLCAFile                  string   // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcSSLSkipVerify                     bool     // If true, do not strictly validate mutual TLS certs for the VTOrc mysql instances
+	MySQLOrchestratorSSLSkipVerify              bool     // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcUseMutualTLS                      bool     // Turn on TLS authentication with the VTOrc MySQL instance
+	MySQLOrchestratorUseMutualTLS               bool     // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcReadTimeoutSeconds                int      // Number of seconds before backend mysql read operation is aborted (driver-side)
+	MySQLOrchestratorReadTimeoutSeconds         int      // This field is present for backward compatibility, liable to be removed in v16+
+	MySQLVTOrcRejectReadOnly                    bool     // Reject read only connections https://github.com/go-sql-driver/mysql#rejectreadonly
+	MySQLOrchestratorRejectReadOnly             bool     // This field is present for backward compatibility, liable to be removed in v16+
 	MySQLConnectTimeoutSeconds                  int      // Number of seconds before connection is aborted (driver-side)
 	MySQLDiscoveryReadTimeoutSeconds            int      // Number of seconds before topology mysql read operation is aborted (driver-side). Used for discovery queries.
 	MySQLTopologyReadTimeoutSeconds             int      // Number of seconds before topology mysql read operation is aborted (driver-side). Used for all but discovery queries.
@@ -256,14 +270,14 @@ func newConfiguration() *Configuration {
 		DefaultRaftPort:                             10008,
 		RaftNodes:                                   []string{},
 		ExpectFailureAnalysisConcensus:              true,
-		MySQLOrchestratorMaxPoolConnections:         128, // limit concurrent conns to backend DB
-		MySQLOrchestratorPort:                       3306,
+		MySQLVTOrcMaxPoolConnections:                128, // limit concurrent conns to backend DB
+		MySQLVTOrcPort:                              3306,
 		MySQLTopologyUseMutualTLS:                   false,
 		MySQLTopologyUseMixedTLS:                    true,
-		MySQLOrchestratorUseMutualTLS:               false,
+		MySQLVTOrcUseMutualTLS:                      false,
 		MySQLConnectTimeoutSeconds:                  2,
-		MySQLOrchestratorReadTimeoutSeconds:         30,
-		MySQLOrchestratorRejectReadOnly:             false,
+		MySQLVTOrcReadTimeoutSeconds:                30,
+		MySQLVTOrcRejectReadOnly:                    false,
 		MySQLDiscoveryReadTimeoutSeconds:            10,
 		MySQLTopologyReadTimeoutSeconds:             600,
 		MySQLConnectionLifetimeSeconds:              0,
@@ -381,28 +395,71 @@ func newConfiguration() *Configuration {
 }
 
 func (config *Configuration) postReadAdjustments() error {
+	if config.MySQLOrchestratorHost != "" {
+		config.MySQLVTOrcHost = config.MySQLOrchestratorHost
+	}
+	if config.MySQLOrchestratorMaxPoolConnections != 0 {
+		config.MySQLVTOrcMaxPoolConnections = config.MySQLOrchestratorMaxPoolConnections
+	}
+	if config.MySQLOrchestratorPort != 0 {
+		config.MySQLVTOrcPort = config.MySQLOrchestratorPort
+	}
+	if config.MySQLOrchestratorDatabase != "" {
+		config.MySQLVTOrcDatabase = config.MySQLOrchestratorDatabase
+	}
+	if config.MySQLOrchestratorUser != "" {
+		config.MySQLVTOrcUser = config.MySQLOrchestratorUser
+	}
+	if config.MySQLOrchestratorPassword != "" {
+		config.MySQLVTOrcPassword = config.MySQLOrchestratorPassword
+	}
 	if config.MySQLOrchestratorCredentialsConfigFile != "" {
+		config.MySQLVTOrcCredentialsConfigFile = config.MySQLOrchestratorCredentialsConfigFile
+	}
+	if config.MySQLOrchestratorSSLPrivateKeyFile != "" {
+		config.MySQLVTOrcSSLPrivateKeyFile = config.MySQLOrchestratorSSLPrivateKeyFile
+	}
+	if config.MySQLOrchestratorSSLCertFile != "" {
+		config.MySQLVTOrcSSLCertFile = config.MySQLOrchestratorSSLCertFile
+	}
+	if config.MySQLOrchestratorSSLCAFile != "" {
+		config.MySQLVTOrcSSLCAFile = config.MySQLOrchestratorSSLCAFile
+	}
+	if config.MySQLOrchestratorSSLSkipVerify != false {
+		config.MySQLVTOrcSSLSkipVerify = config.MySQLOrchestratorSSLSkipVerify
+	}
+	if config.MySQLOrchestratorUseMutualTLS != false {
+		config.MySQLVTOrcUseMutualTLS = config.MySQLOrchestratorUseMutualTLS
+	}
+	if config.MySQLOrchestratorReadTimeoutSeconds != 0 {
+		config.MySQLVTOrcReadTimeoutSeconds = config.MySQLOrchestratorReadTimeoutSeconds
+	}
+	if config.MySQLOrchestratorRejectReadOnly != false {
+		config.MySQLVTOrcRejectReadOnly = config.MySQLOrchestratorRejectReadOnly
+	}
+
+	if config.MySQLVTOrcCredentialsConfigFile != "" {
 		mySQLConfig := struct {
 			Client struct {
 				User     string
 				Password string
 			}
 		}{}
-		err := gcfg.ReadFileInto(&mySQLConfig, config.MySQLOrchestratorCredentialsConfigFile)
+		err := gcfg.ReadFileInto(&mySQLConfig, config.MySQLVTOrcCredentialsConfigFile)
 		if err != nil {
 			log.Fatalf("Failed to parse gcfg data from file: %+v", err)
 		} else {
-			log.Infof("Parsed vtorc credentials from %s", config.MySQLOrchestratorCredentialsConfigFile)
-			config.MySQLOrchestratorUser = mySQLConfig.Client.User
-			config.MySQLOrchestratorPassword = mySQLConfig.Client.Password
+			log.Infof("Parsed vtorc credentials from %s", config.MySQLVTOrcCredentialsConfigFile)
+			config.MySQLVTOrcUser = mySQLConfig.Client.User
+			config.MySQLVTOrcPassword = mySQLConfig.Client.Password
 		}
 	}
 	{
 		// We accept password in the form "${SOME_ENV_VARIABLE}" in which case we pull
 		// the given variable from os env
-		submatch := envVariableRegexp.FindStringSubmatch(config.MySQLOrchestratorPassword)
+		submatch := envVariableRegexp.FindStringSubmatch(config.MySQLVTOrcPassword)
 		if len(submatch) > 1 {
-			config.MySQLOrchestratorPassword = os.Getenv(submatch[1])
+			config.MySQLVTOrcPassword = os.Getenv(submatch[1])
 		}
 	}
 	if config.MySQLTopologyCredentialsConfigFile != "" {

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -42,19 +42,14 @@ var configurationLoaded = make(chan bool)
 
 const (
 	HealthPollSeconds                     = 1
-	RaftHealthPollSeconds                 = 10
-	RecoveryPollSeconds                   = 1
 	ActiveNodeExpireSeconds               = 5
-	BinlogFileHistoryDays                 = 1
 	MaintenanceOwner                      = "vtorc"
 	AuditPageSize                         = 20
 	MaintenancePurgeDays                  = 7
 	MySQLTopologyMaxPoolConnections       = 3
 	MaintenanceExpireMinutes              = 10
-	AgentHTTPTimeoutSeconds               = 60
 	DebugMetricsIntervalSeconds           = 10
 	StaleInstanceCoordinatesExpireSeconds = 60
-	SelectTrueQuery                       = "select 1"
 )
 
 // Configuration makes for vtorc configuration input, which can be provided by user via JSON formatted file.
@@ -227,6 +222,8 @@ type Configuration struct {
 	InstanceDBExecContextTimeoutSeconds         int               // Timeout on context used while calling ExecContext on instance database
 	LockShardTimeoutSeconds                     int               // Timeout on context used to lock shard. Should be a small value because we should fail-fast
 	WaitReplicasTimeoutSeconds                  int               // Timeout on amount of time to wait for the replicas in case of ERS. Should be a small value because we should fail-fast. Should not be larger than LockShardTimeoutSeconds since that is the total time we use for an ERS.
+	TopoInformationRefreshSeconds               int               // Timer duration on which VTOrc refreshes the keyspace and vttablet records from the topo-server.
+	RecoveryPollSeconds                         int               // Timer duration on which VTOrc recovery analysis runs
 }
 
 // ToJSONString will marshal this configuration as JSON
@@ -378,6 +375,8 @@ func newConfiguration() *Configuration {
 		InstanceDBExecContextTimeoutSeconds:         30,
 		LockShardTimeoutSeconds:                     30,
 		WaitReplicasTimeoutSeconds:                  30,
+		TopoInformationRefreshSeconds:               15,
+		RecoveryPollSeconds:                         1,
 	}
 }
 

--- a/go/vt/vtorc/config/config_test.go
+++ b/go/vt/vtorc/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	test "vitess.io/vitess/go/vt/vtorc/external/golib/tests"
 )
 
@@ -108,4 +110,112 @@ func TestHttpAdvertise(t *testing.T) {
 		err := c.postReadAdjustments()
 		test.S(t).ExpectNotNil(err)
 	}
+}
+
+// TestOrchestratorToVTOrcBackwardCompatibility tests that the VTOrc configurations
+// that are introduced dur to Orchestrator to VTOrc rename are backward compatibility
+func TestOrchestratorToVTOrcBackwardCompatibility(t *testing.T) {
+	t.Run("MySQLOrchestratorHost", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorHost = "config val"
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorHost, c.MySQLVTOrcHost)
+	})
+
+	t.Run("MySQLOrchestratorMaxPoolConnections", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorMaxPoolConnections = 19
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorMaxPoolConnections, c.MySQLVTOrcMaxPoolConnections)
+	})
+
+	t.Run("MySQLOrchestratorPort", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorPort = 17
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorPort, c.MySQLVTOrcPort)
+	})
+
+	t.Run("MySQLOrchestratorDatabase", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorDatabase = "config val"
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorDatabase, c.MySQLVTOrcDatabase)
+	})
+
+	t.Run("MySQLOrchestratorUser", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorUser = "config val"
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorUser, c.MySQLVTOrcUser)
+	})
+
+	t.Run("MySQLOrchestratorPassword", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorPassword = "config val"
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorPassword, c.MySQLVTOrcPassword)
+	})
+
+	t.Run("MySQLOrchestratorSSLPrivateKeyFile", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorSSLPrivateKeyFile = "config val"
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorSSLPrivateKeyFile, c.MySQLVTOrcSSLPrivateKeyFile)
+	})
+
+	t.Run("MySQLOrchestratorSSLCertFile", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorSSLCertFile = "config val"
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorSSLCertFile, c.MySQLVTOrcSSLCertFile)
+	})
+
+	t.Run("MySQLOrchestratorSSLCAFile", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorSSLCAFile = "config val"
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorSSLCAFile, c.MySQLVTOrcSSLCAFile)
+	})
+
+	t.Run("MySQLOrchestratorSSLSkipVerify", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorSSLSkipVerify = true
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorSSLSkipVerify, c.MySQLVTOrcSSLSkipVerify)
+	})
+
+	t.Run("MySQLOrchestratorUseMutualTLS", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorUseMutualTLS = true
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorUseMutualTLS, c.MySQLVTOrcUseMutualTLS)
+	})
+
+	t.Run("MySQLOrchestratorReadTimeoutSeconds", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorReadTimeoutSeconds = 37
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorReadTimeoutSeconds, c.MySQLVTOrcReadTimeoutSeconds)
+	})
+
+	t.Run("MySQLOrchestratorRejectReadOnly", func(t *testing.T) {
+		c := newConfiguration()
+		c.MySQLOrchestratorRejectReadOnly = true
+		err := c.postReadAdjustments()
+		require.NoError(t, err)
+		require.Equal(t, c.MySQLOrchestratorRejectReadOnly, c.MySQLVTOrcRejectReadOnly)
+	})
 }

--- a/go/vt/vtorc/config/config_test.go
+++ b/go/vt/vtorc/config/config_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	test "vitess.io/vitess/go/vt/vtorc/external/golib/tests"
 )
 
 func init() {
@@ -18,32 +16,32 @@ func TestRecoveryPeriodBlock(t *testing.T) {
 		c.RecoveryPeriodBlockSeconds = 0
 		c.RecoveryPeriodBlockMinutes = 0
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNil(err)
-		test.S(t).ExpectEquals(c.RecoveryPeriodBlockSeconds, 0)
+		require.NoError(t, err)
+		require.EqualValues(t, 0, c.RecoveryPeriodBlockSeconds)
 	}
 	{
 		c := newConfiguration()
 		c.RecoveryPeriodBlockSeconds = 30
 		c.RecoveryPeriodBlockMinutes = 1
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNil(err)
-		test.S(t).ExpectEquals(c.RecoveryPeriodBlockSeconds, 30)
+		require.NoError(t, err)
+		require.EqualValues(t, 30, c.RecoveryPeriodBlockSeconds)
 	}
 	{
 		c := newConfiguration()
 		c.RecoveryPeriodBlockSeconds = 0
 		c.RecoveryPeriodBlockMinutes = 2
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNil(err)
-		test.S(t).ExpectEquals(c.RecoveryPeriodBlockSeconds, 120)
+		require.NoError(t, err)
+		require.EqualValues(t, 120, c.RecoveryPeriodBlockSeconds)
 	}
 	{
 		c := newConfiguration()
 		c.RecoveryPeriodBlockSeconds = 15
 		c.RecoveryPeriodBlockMinutes = 0
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNil(err)
-		test.S(t).ExpectEquals(c.RecoveryPeriodBlockSeconds, 15)
+		require.NoError(t, err)
+		require.EqualValues(t, 15, c.RecoveryPeriodBlockSeconds)
 	}
 }
 
@@ -53,21 +51,21 @@ func TestRaft(t *testing.T) {
 		c.RaftBind = "1.2.3.4:1008"
 		c.RaftDataDir = "/path/to/somewhere"
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNil(err)
-		test.S(t).ExpectEquals(c.RaftAdvertise, c.RaftBind)
+		require.NoError(t, err)
+		require.EqualValues(t, c.RaftAdvertise, c.RaftBind)
 	}
 	{
 		c := newConfiguration()
 		c.RaftEnabled = true
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNotNil(err)
+		require.Error(t, err)
 	}
 	{
 		c := newConfiguration()
 		c.RaftEnabled = true
 		c.RaftDataDir = "/path/to/somewhere"
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNil(err)
+		require.NoError(t, err)
 	}
 	{
 		c := newConfiguration()
@@ -75,7 +73,7 @@ func TestRaft(t *testing.T) {
 		c.RaftDataDir = "/path/to/somewhere"
 		c.RaftBind = ""
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNotNil(err)
+		require.Error(t, err)
 	}
 }
 
@@ -84,31 +82,31 @@ func TestHttpAdvertise(t *testing.T) {
 		c := newConfiguration()
 		c.HTTPAdvertise = ""
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNil(err)
+		require.NoError(t, err)
 	}
 	{
 		c := newConfiguration()
 		c.HTTPAdvertise = "http://127.0.0.1:1234"
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNil(err)
+		require.NoError(t, err)
 	}
 	{
 		c := newConfiguration()
 		c.HTTPAdvertise = "http://127.0.0.1"
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNotNil(err)
+		require.Error(t, err)
 	}
 	{
 		c := newConfiguration()
 		c.HTTPAdvertise = "127.0.0.1:1234"
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNotNil(err)
+		require.Error(t, err)
 	}
 	{
 		c := newConfiguration()
 		c.HTTPAdvertise = "http://127.0.0.1:1234/mypath"
 		err := c.postReadAdjustments()
-		test.S(t).ExpectNotNil(err)
+		require.Error(t, err)
 	}
 }
 

--- a/go/vt/vtorc/db/tls.go
+++ b/go/vt/vtorc/db/tls.go
@@ -128,18 +128,18 @@ func SetupMySQLTopologyTLS(uri string) (string, error) {
 // Modify the supplied URI to call the TLS config
 func SetupMySQLVTOrcTLS(uri string) (string, error) {
 	if !vtorcTLSConfigured {
-		tlsConfig, err := ssl.NewTLSConfig(config.Config.MySQLOrchestratorSSLCAFile, !config.Config.MySQLOrchestratorSSLSkipVerify)
+		tlsConfig, err := ssl.NewTLSConfig(config.Config.MySQLVTOrcSSLCAFile, !config.Config.MySQLVTOrcSSLSkipVerify)
 		// Drop to TLS 1.0 for talking to MySQL
 		tlsConfig.MinVersion = tls.VersionTLS10
 		if err != nil {
 			log.Fatalf("Can't create TLS configuration for VTOrc connection %s: %s", uri, err)
 			return "", err
 		}
-		tlsConfig.InsecureSkipVerify = config.Config.MySQLOrchestratorSSLSkipVerify
-		if (!config.Config.MySQLOrchestratorSSLSkipVerify) &&
-			config.Config.MySQLOrchestratorSSLCertFile != "" &&
-			config.Config.MySQLOrchestratorSSLPrivateKeyFile != "" {
-			if err = ssl.AppendKeyPair(tlsConfig, config.Config.MySQLOrchestratorSSLCertFile, config.Config.MySQLOrchestratorSSLPrivateKeyFile); err != nil {
+		tlsConfig.InsecureSkipVerify = config.Config.MySQLVTOrcSSLSkipVerify
+		if (!config.Config.MySQLVTOrcSSLSkipVerify) &&
+			config.Config.MySQLVTOrcSSLCertFile != "" &&
+			config.Config.MySQLVTOrcSSLPrivateKeyFile != "" {
+			if err = ssl.AppendKeyPair(tlsConfig, config.Config.MySQLVTOrcSSLCertFile, config.Config.MySQLVTOrcSSLPrivateKeyFile); err != nil {
 				log.Fatalf("Can't setup TLS key pairs for %s: %s", uri, err)
 				return "", err
 			}

--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -54,7 +54,7 @@ func init() {
 func initializeAnalysisDaoPostConfiguration() {
 	config.WaitForConfigurationToBeLoaded()
 
-	recentInstantAnalysis = cache.New(time.Duration(config.RecoveryPollSeconds*2)*time.Second, time.Second)
+	recentInstantAnalysis = cache.New(time.Duration(config.Config.RecoveryPollSeconds*2)*time.Second, time.Second)
 }
 
 type clusterAnalysis struct {

--- a/go/vt/vtorc/logic/orchestrator.go
+++ b/go/vt/vtorc/logic/orchestrator.go
@@ -360,7 +360,7 @@ func ContinuousDiscovery() {
 	healthTick := time.Tick(config.HealthPollSeconds * time.Second)
 	instancePollTick := time.Tick(instancePollSecondsDuration())
 	caretakingTick := time.Tick(time.Minute)
-	recoveryTick := time.Tick(time.Duration(config.RecoveryPollSeconds) * time.Second)
+	recoveryTick := time.Tick(time.Duration(config.Config.RecoveryPollSeconds) * time.Second)
 	tabletTopoTick := OpenTabletDiscovery()
 	var recoveryEntrance int64
 	var snapshotTopologiesTick <-chan time.Time

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -66,8 +66,7 @@ func OpenTabletDiscovery() <-chan time.Time {
 	refreshTabletsUsing(func(instanceKey *inst.InstanceKey) {
 		_ = inst.InjectSeed(instanceKey)
 	}, false /* forceRefresh */)
-	// TODO(sougou): parameterize poll interval.
-	return time.Tick(15 * time.Second) //nolint SA1015: using time.Tick leaks the underlying ticker
+	return time.Tick(time.Second * time.Duration(config.Config.TopoInformationRefreshSeconds)) //nolint SA1015: using time.Tick leaks the underlying ticker
 }
 
 // refreshAllTablets reloads the tablets from topo and discovers the ones which haven't been refreshed in a while

--- a/go/vt/vtorc/logic/topology_recovery_dao.go
+++ b/go/vt/vtorc/logic/topology_recovery_dao.go
@@ -351,7 +351,7 @@ func ExpireBlockedRecoveries() error {
 				from blocked_topology_recovery
 				where
 					last_blocked_timestamp < NOW() - interval ? second
-			`, (config.RecoveryPollSeconds * 2),
+			`, config.Config.RecoveryPollSeconds*2,
 	)
 	if err != nil {
 		log.Error(err)

--- a/go/vt/vtorc/process/health_dao.go
+++ b/go/vt/vtorc/process/health_dao.go
@@ -84,8 +84,8 @@ func WriteRegisterNode(nodeHealth *NodeHealth) (healthy bool, err error) {
 		if config.Config.IsSQLite() {
 			dbBackend = config.Config.SQLite3DataFile
 		} else {
-			dbBackend = fmt.Sprintf("%s:%d", config.Config.MySQLOrchestratorHost,
-				config.Config.MySQLOrchestratorPort)
+			dbBackend = fmt.Sprintf("%s:%d", config.Config.MySQLVTOrcHost,
+				config.Config.MySQLVTOrcPort)
 		}
 		sqlResult, err := db.ExecVTOrc(`
 			insert ignore into node_health


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR parameterizes some of the VTOrc constants that make sense to be configurable. Also as part of this PR, the configurations that have `Orchestrator` in their name have been changed to `VTOrc` while maintaining backward compatibility. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
