### PR TITLE
Prevent VStreamer engine deadlocks during state transitions

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -45,6 +46,7 @@ import (
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 const (
@@ -67,7 +69,7 @@ type Engine struct {
 	wg sync.WaitGroup
 
 	mu              sync.Mutex
-	isOpen          bool
+	isOpen          int32 // 0 or 1 in place of atomic.Bool added in go 1.19
 	streamIdx       int
 	streamers       map[int]*uvstreamer
 	rowStreamers    map[int]*rowStreamer
@@ -148,30 +150,24 @@ func (vse *Engine) InitDBConfig(keyspace, shard string) {
 
 // Open starts the Engine service.
 func (vse *Engine) Open() {
-	vse.mu.Lock()
-	defer vse.mu.Unlock()
-	if vse.isOpen {
-		return
-	}
 	log.Info("VStreamer: opening")
-	vse.isOpen = true
+	// If it's not already open, then open it now.
+	atomic.CompareAndSwapInt32(&vse.isOpen, 0, 1)
 }
 
 // IsOpen checks if the engine is opened
 func (vse *Engine) IsOpen() bool {
-	vse.mu.Lock()
-	defer vse.mu.Unlock()
-	return vse.isOpen
+	return atomic.LoadInt32(&vse.isOpen) == 1
 }
 
 // Close closes the Engine service.
 func (vse *Engine) Close() {
 	func() {
-		vse.mu.Lock()
-		defer vse.mu.Unlock()
-		if !vse.isOpen {
+		if atomic.LoadInt32(&vse.isOpen) == 0 {
 			return
 		}
+		vse.mu.Lock()
+		defer vse.mu.Unlock()
 		// cancels are non-blocking.
 		for _, s := range vse.streamers {
 			s.Cancel()
@@ -182,7 +178,7 @@ func (vse *Engine) Close() {
 		for _, s := range vse.resultStreamers {
 			s.Cancel()
 		}
-		vse.isOpen = false
+		atomic.StoreInt32(&vse.isOpen, 0)
 	}()
 
 	// Wait only after releasing the lock because the end of every
@@ -207,11 +203,11 @@ func (vse *Engine) Stream(ctx context.Context, startPos string, tablePKs []*binl
 
 	// Create stream and add it to the map.
 	streamer, idx, err := func() (*uvstreamer, int, error) {
-		vse.mu.Lock()
-		defer vse.mu.Unlock()
-		if !vse.isOpen {
+		if atomic.LoadInt32(&vse.isOpen) == 0 {
 			return nil, 0, errors.New("VStreamer is not open")
 		}
+		vse.mu.Lock()
+		defer vse.mu.Unlock()
 		streamer := newUVStreamer(ctx, vse, vse.env.Config().DB.FilteredWithDB(), vse.se, startPos, tablePKs, filter, vse.lvschema, send)
 		idx := vse.streamIdx
 		vse.streamers[idx] = streamer
@@ -248,11 +244,11 @@ func (vse *Engine) StreamRows(ctx context.Context, query string, lastpk []sqltyp
 
 	// Create stream and add it to the map.
 	rowStreamer, idx, err := func() (*rowStreamer, int, error) {
-		vse.mu.Lock()
-		defer vse.mu.Unlock()
-		if !vse.isOpen {
+		if atomic.LoadInt32(&vse.isOpen) == 0 {
 			return nil, 0, errors.New("VStreamer is not open")
 		}
+		vse.mu.Lock()
+		defer vse.mu.Unlock()
 
 		rowStreamer := newRowStreamer(ctx, vse.env.Config().DB.FilteredWithDB(), vse.se, query, lastpk, vse.lvschema, send, vse)
 		idx := vse.streamIdx
@@ -283,11 +279,11 @@ func (vse *Engine) StreamRows(ctx context.Context, query string, lastpk []sqltyp
 func (vse *Engine) StreamResults(ctx context.Context, query string, send func(*binlogdatapb.VStreamResultsResponse) error) error {
 	// Create stream and add it to the map.
 	resultStreamer, idx, err := func() (*resultStreamer, int, error) {
-		vse.mu.Lock()
-		defer vse.mu.Unlock()
-		if !vse.isOpen {
+		if atomic.LoadInt32(&vse.isOpen) == 0 {
 			return nil, 0, errors.New("VStreamer is not open")
 		}
+		vse.mu.Lock()
+		defer vse.mu.Unlock()
 		resultStreamer := newResultStreamer(ctx, vse.env.Config().DB.FilteredWithDB(), query, send, vse)
 		idx := vse.streamIdx
 		vse.resultStreamers[idx] = resultStreamer
@@ -441,7 +437,7 @@ func (vse *Engine) waitForMySQL(ctx context.Context, db dbconfigs.Connector, tab
 			}
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return vterrors.Errorf(vtrpcpb.Code_CANCELED, "context has expired")
 			case <-time.After(backoff):
 				// Exponential backoff with 1.5 as a factor
 				if backoff != backoffLimit {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -28,6 +28,7 @@ import (
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/timer"
 	vtschema "vitess.io/vitess/go/vt/schema"
+	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
@@ -40,6 +41,7 @@ import (
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 const (
@@ -278,13 +280,18 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 
 	injectHeartbeat := func(throttled bool) error {
 		now := time.Now().UnixNano()
-		err := bufferAndTransmit(&binlogdatapb.VEvent{
-			Type:        binlogdatapb.VEventType_HEARTBEAT,
-			Timestamp:   now / 1e9,
-			CurrentTime: now,
-			Throttled:   throttled,
-		})
-		return err
+		select {
+		case <-ctx.Done():
+			return vterrors.Errorf(vtrpcpb.Code_CANCELED, "context has expired")
+		default:
+			err := bufferAndTransmit(&binlogdatapb.VEvent{
+				Type:        binlogdatapb.VEventType_HEARTBEAT,
+				Timestamp:   now / 1e9,
+				CurrentTime: now,
+				Throttled:   throttled,
+			})
+			return err
+		}
 	}
 
 	throttleEvents := func(throttledEvents chan mysql.BinlogEvent) {
@@ -361,11 +368,16 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 				}
 			}
 		case vs.vschema = <-vs.vevents:
-			if err := vs.rebuildPlans(); err != nil {
-				return err
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				if err := vs.rebuildPlans(); err != nil {
+					return err
+				}
+				// Increment this counter for testing.
+				vschemaUpdateCount.Add(1)
 			}
-			// Increment this counter for testing.
-			vschemaUpdateCount.Add(1)
 		case <-ctx.Done():
 			return nil
 		case <-hbTimer.C:


### PR DESCRIPTION
## Description

The VStreamer engine is somewhat unusual in two ways:
  1. It is open and running on replica tablets rather than only running on primary tablets.
  2. It has no controllers -- but instead has a list of uvstreamers -- so the main engine mutex is widely shared.

Because of this, when a tablet has open vstreams (direct binary log streams) performing work which require RPCs (such as when handling VSchema updates), and a state transition starts, it can deadlock between the VStreamerEngine mutex, the UVStreamer mutex, and the TabletManager mutex when checking if the engine is open or not as part of the TabletManager's [`ChangeType`](https://github.com/vitessio/vitess/blob/a1f1f12be8e1f8c568bf550f74f25c8051548de1/go/vt/vttablet/tabletmanager/rpc_actions.go#L80) RPC call. More specifically, the deadlock seems to be (still trying to figure this out) this as seen using [the repro test here](https://github.com/vitessio/vitess/issues/11169):
  1. TabletManager’s (RPC) mutex is held while performing the [`ChangeType`](https://github.com/vitessio/vitess/blob/a1f1f12be8e1f8c568bf550f74f25c8051548de1/go/vt/vttablet/tabletmanager/rpc_actions.go#L80) RPC call. It blocks on the VStreamerEngine mutex when opening (or closing) the engine.
  2. VStreamer is streaming and holding the engine mutex, but then needs to handle the `ApplyVSchema` RPC calls because of [VSchema changes](https://github.com/vitessio/vitess/blob/e35a118344e79e17833450c7833aab27c3d4ee52/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go#L140). While it's broadcasting these changes the UVStreamer lock is held. It then blocks on the TabletManager’s (RPC) mutex??? Another key factor here is that we can block on the vschema channel when handling the vschema changes. Another workaround was to increase the message buffering well beyond 1 for that channel.
  3. We have a deadlock until we cancel the VSchema RPC call???

The blocking factors involved are:
  1. TabletManager's mutex 
  2. VStreamerEngine's mutex
  3. Each UVStreamer's mutex
  4. The VStreamerEngine's vschema channel

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/11169

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required