### PR TITLE
feat: rewrite column names in HAVING

### DIFF
--- a/go/vt/vtgate/planbuilder/rewrite_test.go
+++ b/go/vt/vtgate/planbuilder/rewrite_test.go
@@ -120,10 +120,10 @@ func TestHavingRewrite(t *testing.T) {
 		output: "select 1 from t1 where (x = 1 or y = 2) and a = 1 having count(*) = 1",
 	}, {
 		input:  "select count(*) k from t1 where x = 1 or y = 2 having a = 1 and k = 1",
-		output: "select count(*) as k from t1 where (x = 1 or y = 2) and a = 1 having k = 1",
+		output: "select count(*) as k from t1 where (x = 1 or y = 2) and a = 1 having count(*) = 1",
 	}, {
 		input:  "select count(*) k from t1 having k = 10",
-		output: "select count(*) as k from t1 having k = 10",
+		output: "select count(*) as k from t1 having count(*) = 10",
 	}, {
 		input:  "select 1 from t1 where x in (select 1 from t2 having a = 1)",
 		output: "select 1 from t1 where :__sq_has_values1 = 1 and x in ::__sq1",

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -1073,7 +1073,7 @@ Gen4 error: unsupported: '*' expression in cross-shard query
       "Sharded": true
     },
     "FieldQuery": "select id, count(*) as c from `user` where 1 != 1 group by id",
-    "Query": "select id, count(*) as c from `user` where id = 1 group by id having c = 10",
+    "Query": "select id, count(*) as c from `user` where id = 1 group by id having count(*) = 10",
     "Table": "`user`",
     "Values": [
       "INT64(1)"
@@ -3388,7 +3388,7 @@ Gen4 plan same as above
   "Original": "select count(*) a from user having a = 10",
   "Instructions": {
     "OperatorType": "Filter",
-    "Predicate": "a = 10",
+    "Predicate": ":0 = 10",
     "Inputs": [
       {
         "OperatorType": "Aggregate",
@@ -3423,7 +3423,7 @@ Gen4 plan same as above
   "Original": "select count(*) a from user having a = '1'",
   "Instructions": {
     "OperatorType": "Filter",
-    "Predicate": "a = '1'",
+    "Predicate": ":0 = '1'",
     "Inputs": [
       {
         "OperatorType": "Aggregate",
@@ -3458,7 +3458,7 @@ Gen4 plan same as above
   "Original": "select count(*) a from user having a != 10",
   "Instructions": {
     "OperatorType": "Filter",
-    "Predicate": "a != 10",
+    "Predicate": ":0 != 10",
     "Inputs": [
       {
         "OperatorType": "Aggregate",
@@ -3493,7 +3493,7 @@ Gen4 plan same as above
   "Original": "select count(*) a from user having a != '1'",
   "Instructions": {
     "OperatorType": "Filter",
-    "Predicate": "a != '1'",
+    "Predicate": ":0 != '1'",
     "Inputs": [
       {
         "OperatorType": "Aggregate",
@@ -3528,7 +3528,7 @@ Gen4 plan same as above
   "Original": "select count(*) a from user having a \u003e 10",
   "Instructions": {
     "OperatorType": "Filter",
-    "Predicate": "a \u003e 10",
+    "Predicate": ":0 \u003e 10",
     "Inputs": [
       {
         "OperatorType": "Aggregate",
@@ -3563,7 +3563,7 @@ Gen4 plan same as above
   "Original": "select count(*) a from user having a \u003e= 10",
   "Instructions": {
     "OperatorType": "Filter",
-    "Predicate": "a \u003e= 10",
+    "Predicate": ":0 \u003e= 10",
     "Inputs": [
       {
         "OperatorType": "Aggregate",
@@ -3598,7 +3598,7 @@ Gen4 plan same as above
   "Original": "select count(*) a from user having a \u003c 10",
   "Instructions": {
     "OperatorType": "Filter",
-    "Predicate": "a \u003c 10",
+    "Predicate": ":0 \u003c 10",
     "Inputs": [
       {
         "OperatorType": "Aggregate",
@@ -3633,7 +3633,7 @@ Gen4 plan same as above
   "Original": "select count(*) a from user having a \u003c= 10",
   "Instructions": {
     "OperatorType": "Filter",
-    "Predicate": "a \u003c= 10",
+    "Predicate": ":0 \u003c= 10",
     "Inputs": [
       {
         "OperatorType": "Aggregate",
@@ -3668,7 +3668,7 @@ Gen4 plan same as above
   "Original": "select col, count(*) a from user group by col having a \u003c= 10",
   "Instructions": {
     "OperatorType": "Filter",
-    "Predicate": "a \u003c= 10",
+    "Predicate": ":1 \u003c= 10",
     "Inputs": [
       {
         "OperatorType": "Aggregate",
@@ -3712,7 +3712,7 @@ Gen4 plan same as above
     "Inputs": [
       {
         "OperatorType": "Filter",
-        "Predicate": "a = 1.00",
+        "Predicate": ":0 = 1.00",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -4913,7 +4913,7 @@ Gen4 error: aggregate functions take a single argument 'count(distinct user_id, 
     "Inputs": [
       {
         "OperatorType": "Filter",
-        "Predicate": "fooSum + :2 = 42",
+        "Predicate": ":1 + :2 = 42",
         "Inputs": [
           {
             "OperatorType": "Aggregate",

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -3027,7 +3027,7 @@ Gen4 plan same as above
   "Original": "select count(*) a from user having a = 0x01",
   "Instructions": {
     "OperatorType": "Filter",
-    "Predicate": "a = 0x01",
+    "Predicate": ":0 = 0x01",
     "Inputs": [
       {
         "OperatorType": "Aggregate",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -4366,7 +4366,7 @@ Gen4 plan same as above
       "Sharded": false
     },
     "FieldQuery": "select 1 from (select col, count(*) as a from unsharded where 1 != 1 group by col) as f left join unsharded as u on f.col = u.id where 1 != 1",
-    "Query": "select 1 from (select col, count(*) as a from unsharded group by col having a \u003e 0 limit 0, 12) as f left join unsharded as u on f.col = u.id",
+    "Query": "select 1 from (select col, count(*) as a from unsharded group by col having count(*) \u003e 0 limit 0, 12) as f left join unsharded as u on f.col = u.id",
     "Table": "unsharded"
   },
   "TablesUsed": [

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -813,6 +813,9 @@ func TestHavingBinding(t *testing.T) {
 		"select t.id, count(*) as a from t, t1 group by t.id having a = 1",
 		MergeTableSets(T1, T2),
 	}, {
+		"select t.id, sum(t2.name) as a from t, t2 group by t.id having a = 1",
+		T2,
+	}, {
 		sql:  "select u2.a, u1.a from u1, u2 having u2.a = 2",
 		deps: T2,
 	}}

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -33,33 +33,19 @@ type earlyRewriter struct {
 
 func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 	switch node := cursor.Node().(type) {
+	case *sqlparser.Where:
+		if node.Type != sqlparser.HavingClause {
+			return nil
+		}
+		rewriteHavingAndOrderBy(cursor, node)
 	case sqlparser.SelectExprs:
 		_, isSel := cursor.Parent().(*sqlparser.Select)
 		if !isSel {
 			return nil
 		}
-		currentScope := r.scoper.currentScope()
-		var selExprs sqlparser.SelectExprs
-		changed := false
-		for _, selectExpr := range node {
-			starExpr, isStarExpr := selectExpr.(*sqlparser.StarExpr)
-			if !isStarExpr {
-				selExprs = append(selExprs, selectExpr)
-				continue
-			}
-			starExpanded, colNames, err := expandTableColumns(starExpr, currentScope.tables, r.binder.usingJoinInfo, r.scoper.org)
-			if err != nil {
-				return err
-			}
-			if !starExpanded || colNames == nil {
-				selExprs = append(selExprs, selectExpr)
-				continue
-			}
-			selExprs = append(selExprs, colNames...)
-			changed = true
-		}
-		if changed {
-			cursor.ReplaceAndRevisit(selExprs)
+		err := r.expandStar(cursor, node)
+		if err != nil {
+			return err
 		}
 	case *sqlparser.JoinTableExpr:
 		if node.Join == sqlparser.StraightJoinType {
@@ -68,6 +54,7 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 		}
 	case *sqlparser.Order:
 		r.clause = "order clause"
+		rewriteHavingAndOrderBy(cursor, node)
 	case sqlparser.GroupBy:
 		r.clause = "group statement"
 
@@ -93,6 +80,60 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 		}
 	}
 	return nil
+}
+
+func (r *earlyRewriter) expandStar(cursor *sqlparser.Cursor, node sqlparser.SelectExprs) error {
+	currentScope := r.scoper.currentScope()
+	var selExprs sqlparser.SelectExprs
+	changed := false
+	for _, selectExpr := range node {
+		starExpr, isStarExpr := selectExpr.(*sqlparser.StarExpr)
+		if !isStarExpr {
+			selExprs = append(selExprs, selectExpr)
+			continue
+		}
+		starExpanded, colNames, err := expandTableColumns(starExpr, currentScope.tables, r.binder.usingJoinInfo, r.scoper.org)
+		if err != nil {
+			return err
+		}
+		if !starExpanded || colNames == nil {
+			selExprs = append(selExprs, selectExpr)
+			continue
+		}
+		selExprs = append(selExprs, colNames...)
+		changed = true
+	}
+	if changed {
+		cursor.ReplaceAndRevisit(selExprs)
+	}
+	return nil
+}
+
+func rewriteHavingAndOrderBy(cursor *sqlparser.Cursor, node sqlparser.SQLNode) {
+	sel, isSel := cursor.Parent().(*sqlparser.Select)
+	if !isSel {
+		return
+	}
+	sqlparser.Rewrite(node, func(inner *sqlparser.Cursor) bool {
+		switch col := inner.Node().(type) {
+		case *sqlparser.Subquery:
+			return false
+		case *sqlparser.ColName:
+			if !col.Qualifier.IsEmpty() {
+				return false
+			}
+			for _, e := range sel.SelectExprs {
+				ae, ok := e.(*sqlparser.AliasedExpr)
+				if !ok {
+					continue
+				}
+				if ae.As.Equal(col.Name) {
+					inner.Replace(ae.Expr)
+				}
+			}
+		}
+		return true
+	}, nil)
 }
 
 func (r *earlyRewriter) rewriteOrderByExpr(node *sqlparser.Literal) (sqlparser.Expr, error) {

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -145,7 +145,7 @@ func TestExpandStar(t *testing.T) {
 		expSQL: "select t1.b as b, t1.a as a, t1.c as c, t5.a as a from t1 join t5 where t1.b = t5.b",
 	}, {
 		sql:    "select * from t1 join t5 using (b) having b = 12",
-		expSQL: "select t1.b as b, t1.a as a, t1.c as c, t5.a as a from t1 join t5 where t1.b = t5.b having b = 12",
+		expSQL: "select t1.b as b, t1.a as a, t1.c as c, t5.a as a from t1 join t5 where t1.b = t5.b having t1.b = 12",
 	}, {
 		sql:    "select 1 from t1 join t5 using (b) having b = 12",
 		expSQL: "select 1 from t1 join t5 where t1.b = t5.b having t1.b = 12",


### PR DESCRIPTION
## Description
When trying to figure out the offsets for some HAVING and ORDER BY expression, it's much easier for the planner if we have the real aggregation function and not the column alias introduced. This PR rewrites these queries, so later phases of the planner don't have to take this possibility into account.

Example:

```sql
select id, sum(foo) as sumOfFoo from tbl group by id having sumOfFoo > 10
```

will get rewritten to:

```sql
select id, sum(foo) as sumOfFoo from tbl group by id having sum(foo) > 10
```
