### PR TITLE
[cli] Misc pflag binary migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,11 +187,11 @@ asthelpergen:
 
 sizegen:
 	go run ./go/tools/sizegen/sizegen.go \
-		-in ./go/... \
-	  	-gen vitess.io/vitess/go/pools.Setting \
-	  	-gen vitess.io/vitess/go/vt/vtgate/engine.Plan \
-	  	-gen vitess.io/vitess/go/vt/vttablet/tabletserver.TabletPlan \
-	  	-gen vitess.io/vitess/go/sqltypes.Result
+		--in ./go/... \
+		--gen vitess.io/vitess/go/pools.Setting \
+		--gen vitess.io/vitess/go/vt/vtgate/engine.Plan \
+		--gen vitess.io/vitess/go/vt/vttablet/tabletserver.TabletPlan \
+		--gen vitess.io/vitess/go/sqltypes.Result
 
 astfmtgen:
 	go run ./go/tools/astfmtgen/main.go vitess.io/vitess/go/vt/sqlparser/...

--- a/go/tools/sizegen/sizegen.go
+++ b/go/tools/sizegen/sizegen.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"go/types"
 	"log"
@@ -27,12 +26,13 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/dave/jennifer/jen"
+	"github.com/spf13/pflag"
+	"golang.org/x/tools/go/packages"
+
 	"vitess.io/vitess/go/hack"
 	"vitess.io/vitess/go/tools/common"
 	"vitess.io/vitess/go/tools/goimports"
-
-	"github.com/dave/jennifer/jen"
-	"golang.org/x/tools/go/packages"
 )
 
 const licenseFileHeader = `Copyright 2021 The Vitess Authors.
@@ -495,14 +495,15 @@ func (t *typePaths) Set(path string) error {
 }
 
 func main() {
-	var patterns typePaths
-	var generate typePaths
-	var verify bool
+	var (
+		patterns, generate []string
+		verify             bool
+	)
 
-	flag.Var(&patterns, "in", "Go packages to load the generator")
-	flag.Var(&generate, "gen", "Typename of the Go struct to generate size info for")
-	flag.BoolVar(&verify, "verify", false, "ensure that the generated files are correct")
-	flag.Parse()
+	pflag.StringSliceVar(&patterns, "in", nil, "Go packages to load the generator")
+	pflag.StringSliceVar(&generate, "gen", nil, "Typename of the Go struct to generate size info for")
+	pflag.BoolVar(&verify, "verify", false, "ensure that the generated files are correct")
+	pflag.Parse()
 
 	result, err := GenerateSizeHelpers(patterns, generate)
 	if err != nil {

--- a/go/vt/vtctl/grpcvtctldclient/client.go
+++ b/go/vt/vtctl/grpcvtctldclient/client.go
@@ -46,7 +46,7 @@ type gRPCVtctldClient struct {
 }
 
 //go:generate -command grpcvtctldclient go run ../vtctldclient/codegen
-//go:generate grpcvtctldclient -out client_gen.go
+//go:generate grpcvtctldclient --out client_gen.go
 
 func gRPCVtctldClientFactory(addr string) (vtctldclient.VtctldClient, error) {
 	opt, err := grpcclientcommon.SecureDialOption()

--- a/go/vt/vtctl/localvtctldclient/client.go
+++ b/go/vt/vtctl/localvtctldclient/client.go
@@ -38,7 +38,7 @@ type localVtctldClient struct {
 func (client *localVtctldClient) Close() error { return nil }
 
 //go:generate -command localvtctldclient go run ../vtctldclient/codegen
-//go:generate localvtctldclient -targetpkg localvtctldclient -impl localVtctldClient -out client_gen.go -local
+//go:generate localvtctldclient --targetpkg localvtctldclient --impl localVtctldClient --out client_gen.go --local
 
 // New returns a local vtctldclient.VtctldClient that makes method calls on the
 // provided VtctldServer implementation. No network traffic takes place between

--- a/go/vt/vtctl/vtctldclient/codegen/main.go
+++ b/go/vt/vtctl/vtctldclient/codegen/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"go/types"
 	"io"
@@ -27,33 +26,34 @@ import (
 	"regexp"
 	"sort"
 
+	"github.com/spf13/pflag"
 	"golang.org/x/tools/go/packages"
 )
 
 func main() { // nolint:funlen
-	source := flag.String("source", "../../proto/vtctlservice", "source package")
-	typeName := flag.String("type", "VtctldClient", "interface type to implement")
-	implType := flag.String("impl", "gRPCVtctldClient", "type implementing the interface")
-	pkgName := flag.String("targetpkg", "grpcvtctldclient", "package name to generate code for")
-	local := flag.Bool("local", false, "generate a local, in-process client rather than a grpcclient")
-	out := flag.String("out", "", "output destination. leave empty to use stdout")
+	source := pflag.String("source", "../../proto/vtctlservice", "source package")
+	typeName := pflag.String("type", "VtctldClient", "interface type to implement")
+	implType := pflag.String("impl", "gRPCVtctldClient", "type implementing the interface")
+	pkgName := pflag.String("targetpkg", "grpcvtctldclient", "package name to generate code for")
+	local := pflag.Bool("local", false, "generate a local, in-process client rather than a grpcclient")
+	out := pflag.String("out", "", "output destination. leave empty to use stdout")
 
-	flag.Parse()
+	pflag.Parse()
 
 	if *source == "" {
-		panic("-source cannot be empty")
+		panic("--source cannot be empty")
 	}
 
 	if *typeName == "" {
-		panic("-type cannot be empty")
+		panic("--type cannot be empty")
 	}
 
 	if *implType == "" {
-		panic("-impl cannot be empty")
+		panic("--impl cannot be empty")
 	}
 
 	if *pkgName == "" {
-		panic("-targetpkg cannot be empty")
+		panic("--targetpkg cannot be empty")
 	}
 
 	var output io.Writer = os.Stdout


### PR DESCRIPTION
## Description

This migrates the following tools to pflag:

- `go/vt/vtctl/vtctldclient/codegen`
- `go/tools/sizegen`

Running both make targets (`make vtctldclient sizegen`) works with no diffs.

## Related Issue(s)

- Closes #11300 
- Closes #11305 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
