### PR TITLE
Fix conditions after `<=>` operator on left joined table columns being ignored for routing purposes.

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -5938,6 +5938,33 @@ Gen4 plan same as above
 }
 Gen4 plan same as above
 
+# conditions following a null safe comparison operator can be used for routing
+"SELECT music.id FROM music LEFT OUTER JOIN user ON music.user_id = user.id WHERE user.id <=> NULL AND music.user_id = 10"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT music.id FROM music LEFT OUTER JOIN user ON music.user_id = user.id WHERE user.id \u003c=\u003e NULL AND music.user_id = 10",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select music.id from music left join `user` on music.user_id = `user`.id where 1 != 1",
+    "Query": "select music.id from music left join `user` on music.user_id = `user`.id where music.user_id = 10 and `user`.id \u003c=\u003e null",
+    "Table": "`user`, music",
+    "Values": [
+      "INT64(10)"
+    ],
+    "Vindex": "user_index"
+  },
+  "TablesUsed": [
+    "user.music",
+    "user.user"
+  ]
+}
+Gen4 plan same as above
+
 # optimize ORs to IN route op codes #1
 "select col from user where id = 1 or id = 2"
 {


### PR DESCRIPTION
## Description

This fixes an edge case where a comparison using the `<=>` operator would prevent the use of any following predicates after for routing purposes (only on left joins).

Here's an example query:

```sql
SELECT music.id FROM music LEFT OUTER JOIN user ON music.user_id = user.id WHERE user.id <=> NULL AND music.user_id = 10
```

This would generate the following plan:

```json
{
  "QueryType": "SELECT",
  "Original": "SELECT music.id FROM music LEFT OUTER JOIN user ON music.user_id = user.id WHERE user.id \u003c=\u003e NULL AND music.user_id = 10",
  "Instructions": {
    "OperatorType": "Route",
    "Variant": "Scatter",
    "Keyspace": {
      "Name": "user",
      "Sharded": true
    },
    "FieldQuery": "select music.id from music left join `user` on music.user_id = `user`.id where 1 != 1",
    "Query": "select music.id from music left join `user` on music.user_id = `user`.id where `user`.id \u003c=\u003e null and music.user_id = 10",
    "Table": "`user`, music"
  },
  "TablesUsed": [
    "user.music",
    "user.user"
  ]
}
```

With this fix in place, this plan is generated instead:

```json
{
  "QueryType": "SELECT",
  "Original": "SELECT music.id FROM music LEFT OUTER JOIN user ON music.user_id = user.id WHERE user.id \u003c=\u003e NULL AND music.user_id = 10",
  "Instructions": {
    "OperatorType": "Route",
    "Variant": "EqualUnique",
    "Keyspace": {
      "Name": "user",
      "Sharded": true
    },
    "FieldQuery": "select music.id from music left join `user` on music.user_id = `user`.id where 1 != 1",
    "Query": "select music.id from music left join `user` on music.user_id = `user`.id where music.user_id = 10 and `user`.id \u003c=\u003e null",
    "Table": "`user`, music",
    "Values": [
      "INT64(10)"
    ],
    "Vindex": "user_index"
  },
  "TablesUsed": [
    "user.music",
    "user.user"
  ]
}
```

## Related Issue(s)

I stumbled upon this issue while working on a fix for https://github.com/vitessio/vitess/issues/11275.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
