### PR TITLE
Fix local example scripts

### DIFF
--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -46,14 +46,14 @@ vtctldclient --server localhost:15999 SetKeyspaceDurabilityPolicy --durability-p
 ./scripts/vtorc-up.sh
 
 # Wait for all the tablets to be up and registered in the topology server
-for i in $(seq 0 200); do
+for _ in $(seq 0 200); do
 	vtctldclient GetTablets --keyspace commerce --shard 0 | wc -l | grep -q "3" && break
 	sleep 1
 done;
 vtctldclient GetTablets --keyspace commerce --shard 0 | wc -l | grep -q "3" || (echo "Timed out waiting for tablets to be up in commerce/0" && exit 1)
 
 # Wait for a primary tablet to be elected in the shard
-for i in $(seq 0 200); do
+for _ in $(seq 0 200); do
 	vtctldclient GetTablets --keyspace commerce --shard 0 | grep -q "primary" && break
 	sleep 1
 done;

--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -42,8 +42,22 @@ done
 # set the correct durability policy for the keyspace
 vtctldclient --server localhost:15999 SetKeyspaceDurabilityPolicy --durability-policy=semi_sync commerce
 
-# set one of the replicas to primary
-vtctldclient PlannedReparentShard commerce/0 --new-primary zone1-100
+# start vtorc
+./scripts/vtorc-up.sh
+
+# Wait for all the tablets to be up and registered in the topology server
+for i in $(seq 0 200); do
+	vtctldclient GetTablets --keyspace commerce --shard 0 | wc -l | grep -q "3" && break
+	sleep 1
+done;
+vtctldclient GetTablets --keyspace commerce --shard 0 | wc -l | grep -q "3" || (echo "Timed out waiting for tablets to be up in commerce/0" && exit 1)
+
+# Wait for a primary tablet to be elected in the shard
+for i in $(seq 0 200); do
+	vtctldclient GetTablets --keyspace commerce --shard 0 | grep -q "primary" && break
+	sleep 1
+done;
+vtctldclient GetTablets --keyspace commerce --shard 0 | grep "primary" || (echo "Timed out waiting for primary to be elected in commerce/0" && exit 1)
 
 # create the schema
 vtctldclient ApplySchema --sql-file create_commerce_schema.sql commerce
@@ -57,5 +71,3 @@ CELL=zone1 ./scripts/vtgate-up.sh
 # start vtadmin
 ./scripts/vtadmin-up.sh
 
-# start vtorc
-./scripts/vtorc-up.sh

--- a/examples/local/201_customer_tablets.sh
+++ b/examples/local/201_customer_tablets.sh
@@ -29,14 +29,14 @@ done
 vtctldclient --server localhost:15999 SetKeyspaceDurabilityPolicy --durability-policy=semi_sync customer
 
 # Wait for all the tablets to be up and registered in the topology server
-for i in $(seq 0 200); do
+for _ in $(seq 0 200); do
 	vtctldclient GetTablets --keyspace customer --shard 0 | wc -l | grep -q "3" && break
 	sleep 1
 done;
 vtctldclient GetTablets --keyspace customer --shard 0 | wc -l | grep -q "3" || (echo "Timed out waiting for tablets to be up in customer/0" && exit 1)
 
 # Wait for a primary tablet to be elected in the shard
-for i in $(seq 0 200); do
+for _ in $(seq 0 200); do
 	vtctldclient GetTablets --keyspace customer --shard 0 | grep -q "primary" && break
 	sleep 1
 done;

--- a/examples/local/201_customer_tablets.sh
+++ b/examples/local/201_customer_tablets.sh
@@ -28,4 +28,16 @@ done
 # set the correct durability policy for the keyspace
 vtctldclient --server localhost:15999 SetKeyspaceDurabilityPolicy --durability-policy=semi_sync customer
 
-vtctldclient InitShardPrimary --force customer/0 zone1-200
+# Wait for all the tablets to be up and registered in the topology server
+for i in $(seq 0 200); do
+	vtctldclient GetTablets --keyspace customer --shard 0 | wc -l | grep -q "3" && break
+	sleep 1
+done;
+vtctldclient GetTablets --keyspace customer --shard 0 | wc -l | grep -q "3" || (echo "Timed out waiting for tablets to be up in customer/0" && exit 1)
+
+# Wait for a primary tablet to be elected in the shard
+for i in $(seq 0 200); do
+	vtctldclient GetTablets --keyspace customer --shard 0 | grep -q "primary" && break
+	sleep 1
+done;
+vtctldclient GetTablets --keyspace customer --shard 0 | grep "primary" || (echo "Timed out waiting for primary to be elected in customer/0" && exit 1)

--- a/examples/local/201_newkeyspace_tablets.sh
+++ b/examples/local/201_newkeyspace_tablets.sh
@@ -33,14 +33,14 @@ for i in ${BASETABLETNUM}00 ${BASETABLETNUM}01 ${BASETABLETNUM}02; do
 done
 
 # Wait for all the tablets to be up and registered in the topology server
-for i in $(seq 0 200); do
+for _ in $(seq 0 200); do
 	vtctldclient GetTablets --keyspace "${KEYSPACE}" --shard "${SHARD}" | wc -l | grep -q "3" && break
 	sleep 1
 done;
 vtctldclient GetTablets --keyspace "${KEYSPACE}" --shard "${SHARD}" | wc -l | grep -q "3" || (echo "Timed out waiting for tablets to be up in ${KEYSPACE}/${SHARD}" && exit 1)
 
 # Wait for a primary tablet to be elected in the shard
-for i in $(seq 0 200); do
+for _ in $(seq 0 200); do
 	vtctldclient GetTablets --keyspace "${KEYSPACE}" --shard "${SHARD}" | grep -q "primary" && break
 	sleep 1
 done;

--- a/examples/local/201_newkeyspace_tablets.sh
+++ b/examples/local/201_newkeyspace_tablets.sh
@@ -32,7 +32,19 @@ for i in ${BASETABLETNUM}00 ${BASETABLETNUM}01 ${BASETABLETNUM}02; do
         SHARD=${SHARD} CELL=zone1 KEYSPACE=${KEYSPACE} TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
-vtctldclient InitShardPrimary --force "${KEYSPACE}/${SHARD}" "zone1-${BASETABLETNUM}00"
+# Wait for all the tablets to be up and registered in the topology server
+for i in $(seq 0 200); do
+	vtctldclient GetTablets --keyspace "${KEYSPACE}" --shard "${SHARD}" | wc -l | grep -q "3" && break
+	sleep 1
+done;
+vtctldclient GetTablets --keyspace "${KEYSPACE}" --shard "${SHARD}" | wc -l | grep -q "3" || (echo "Timed out waiting for tablets to be up in ${KEYSPACE}/${SHARD}" && exit 1)
+
+# Wait for a primary tablet to be elected in the shard
+for i in $(seq 0 200); do
+	vtctldclient GetTablets --keyspace "${KEYSPACE}" --shard "${SHARD}" | grep -q "primary" && break
+	sleep 1
+done;
+vtctldclient GetTablets --keyspace "${KEYSPACE}" --shard "${SHARD}" | grep "primary" || (echo "Timed out waiting for primary to be elected in ${KEYSPACE}/${SHARD}" && exit 1)
 
 # Go back to the original ${PWD} in the parent shell
 popd >/dev/null

--- a/examples/local/302_new_shards.sh
+++ b/examples/local/302_new_shards.sh
@@ -29,5 +29,18 @@ for i in 400 401 402; do
 	SHARD=80- CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
-vtctldclient InitShardPrimary --force customer/-80 zone1-300
-vtctldclient InitShardPrimary --force customer/80- zone1-400
+for shard in "-80" "80-"; do
+  # Wait for all the tablets to be up and registered in the topology server
+  for i in $(seq 0 200); do
+  	vtctldclient GetTablets --keyspace customer --shard $shard | wc -l | grep -q "3" && break
+  	sleep 1
+  done;
+  vtctldclient GetTablets --keyspace customer --shard $shard | wc -l | grep -q "3" || (echo "Timed out waiting for tablets to be up in customer/$shard" && exit 1)
+
+  # Wait for a primary tablet to be elected in the shard
+  for i in $(seq 0 200); do
+  	vtctldclient GetTablets --keyspace customer --shard $shard | grep -q "primary" && break
+  	sleep 1
+  done;
+  vtctldclient GetTablets --keyspace customer --shard $shard | grep "primary" || (echo "Timed out waiting for primary to be elected in customer/$shard" && exit 1)
+done;

--- a/examples/local/302_new_shards.sh
+++ b/examples/local/302_new_shards.sh
@@ -31,14 +31,14 @@ done
 
 for shard in "-80" "80-"; do
   # Wait for all the tablets to be up and registered in the topology server
-  for i in $(seq 0 200); do
+  for _ in $(seq 0 200); do
   	vtctldclient GetTablets --keyspace customer --shard $shard | wc -l | grep -q "3" && break
   	sleep 1
   done;
   vtctldclient GetTablets --keyspace customer --shard $shard | wc -l | grep -q "3" || (echo "Timed out waiting for tablets to be up in customer/$shard" && exit 1)
 
   # Wait for a primary tablet to be elected in the shard
-  for i in $(seq 0 200); do
+  for _ in $(seq 0 200); do
   	vtctldclient GetTablets --keyspace customer --shard $shard | grep -q "primary" && break
   	sleep 1
   done;

--- a/examples/region_sharding/101_initial_cluster.sh
+++ b/examples/region_sharding/101_initial_cluster.sh
@@ -38,7 +38,15 @@ SHARD=0 CELL=zone1 KEYSPACE=main TABLET_UID=100 ./scripts/vttablet-up.sh
 # set the correct durability policy for the keyspace
 vtctldclient --server localhost:15999 SetKeyspaceDurabilityPolicy --durability-policy=none main
 
-vtctldclient InitShardPrimary --force main/0 zone1-100
+# start vtorc
+./scripts/vtorc-up.sh
+
+# Wait for a primary tablet to be elected in the shard
+for _ in $(seq 0 200); do
+	vtctldclient GetTablets --keyspace main --shard 0 | grep -q "primary" && break
+	sleep 1
+done;
+vtctldclient GetTablets --keyspace main --shard 0 | grep "primary" || (echo "Timed out waiting for primary to be elected in main/0" && exit 1)
 
 # create the schema
 vtctldclient ApplySchema --sql-file create_main_schema.sql main
@@ -52,5 +60,3 @@ CELL=zone1 ./scripts/vtgate-up.sh
 # start vtadmin
 ./scripts/vtadmin-up.sh
 
-# start vtorc
-./scripts/vtorc-up.sh


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Since we introduced VTOrc to also be part of the local and region sharding examples, the tests have been flaky as pointed out in https://github.com/vitessio/vitess/issues/11295. 

This PR fixes the second problem mentioned in https://github.com/vitessio/vitess/issues/11295#issuecomment-1253910772. The problem was arising from the part where we were calling `InitShardPrimary` after VTOrc already initialized the shard. The fix is really simple, just not calling `InitShardPrimary`.

Instead, the call to `ISP` is replaced by code to wait until VTOrc has elected a primary.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #11295 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
