### PR TITLE
make MySQL56-flavor schema queries forward-compatible

### DIFF
--- a/go/mysql/endtoend/client_test.go
+++ b/go/mysql/endtoend/client_test.go
@@ -377,3 +377,32 @@ func TestClientInfo(t *testing.T) {
 		t.Fatalf("expected result.Info=%q, got=%q", infoPrepared, result.Info)
 	}
 }
+
+func TestBaseShowTables(t *testing.T) {
+	params := connParams
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &params)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	sql := conn.BaseShowTables()
+	// An improved test would make assertions about the results. This test just
+	// makes sure there aren't any errors.
+	_, err = conn.ExecuteFetch(sql, -1, true)
+	require.NoError(t, err)
+}
+
+func TestBaseShowTablesFilePos(t *testing.T) {
+	params := connParams
+	params.Flavor = "FilePos"
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &params)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	sql := conn.BaseShowTables()
+	// An improved test would make assertions about the results. This test just
+	// makes sure there aren't any errors.
+	_, err = conn.ExecuteFetch(sql, -1, true)
+	require.NoError(t, err)
+}

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -309,8 +309,18 @@ func (mysqlFlavor) disableBinlogPlaybackCommand() string {
 }
 
 // TablesWithSize56 is a query to select table along with size for mysql 5.6
-const TablesWithSize56 = `SELECT table_name, table_type, unix_timestamp(create_time), table_comment, SUM( data_length + index_length), SUM( data_length + index_length)
-		FROM information_schema.tables WHERE table_schema = database() group by table_name`
+const TablesWithSize56 = `SELECT table_name,
+	table_type,
+	UNIX_TIMESTAMP(create_time) AS uts_create_time,
+	table_comment,
+	SUM(data_length + index_length),
+	SUM(data_length + index_length)
+FROM information_schema.tables
+WHERE table_schema = database()
+GROUP BY table_name,
+	table_type,
+	uts_create_time,
+	table_comment`
 
 // TablesWithSize57 is a query to select table along with size for mysql 5.7.
 //


### PR DESCRIPTION
## Description

The various SQL flavors (56, 57, 80, MariaDB, FilePos) use different queries for schema inspection. The FilePos flavor is using a 56 flavor query which isn't forward compatible with MySQL 80.
## Related Issue(s)

This commit updates the 56 flavor to be forward-compatible with 57, 80. s/o @mattlord for the suggested fix.

Fixes #11312.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
