### PR TITLE
VStreamer: fix deadlock when there are a lot of vschema changes at the same time as binlog events

### DIFF
--- a/go/test/endtoend/vreplication/vschema_load_test.go
+++ b/go/test/endtoend/vreplication/vschema_load_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/log"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+)
+
+func TestVSchemaChangesUnderLoad(t *testing.T) {
+
+	extendedTimeout := defaultTimeout * 4
+
+	defaultCellName := "zone1"
+	allCells := []string{"zone1"}
+	allCellNames = "zone1"
+	vc = NewVitessCluster(t, "TestVSchemaChanges", allCells, mainClusterConfig)
+
+	require.NotNil(t, vc)
+	defaultReplicas = 1
+	defaultRdonly = 0
+
+	defer vc.TearDown(t)
+
+	defaultCell = vc.Cells[defaultCellName]
+	vc.AddKeyspace(t, []*Cell{defaultCell}, "product", "0", initialProductVSchema, initialProductSchema, defaultReplicas, defaultRdonly, 100, sourceKsOpts)
+	vtgate = defaultCell.Vtgates[0]
+	require.NotNil(t, vtgate)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", "product", "0"), 1)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", "product", "0"), 1)
+	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+	defer vtgateConn.Close()
+	ch1 := make(chan bool, 1)
+	ctx := context.Background()
+	b := false
+	startCid := 100
+	warmupRowCount := startCid + 2000
+	insertData := func() {
+		timer := time.NewTimer(extendedTimeout)
+		log.Infof("Inserting data into customer")
+		cid := startCid
+		for {
+			if !b && cid > warmupRowCount {
+				log.Infof("Done inserting initial data into customer")
+				b = true
+				ch1 <- true
+			}
+			query := fmt.Sprintf("insert into customer(cid, name) values (%d, 'a')", cid)
+			_, _ = vtgateConn.ExecuteFetch(query, 1, false)
+			cid++
+			query = "update customer set name = concat(name, 'a')"
+			_, _ = vtgateConn.ExecuteFetch(query, 10000, false)
+			select {
+			case <-timer.C:
+				log.Infof("Done inserting data into customer")
+				return
+			default:
+			}
+		}
+	}
+	go func() {
+		log.Infof("Starting to vstream from replica")
+		vgtid := &binlogdatapb.VGtid{
+			ShardGtids: []*binlogdatapb.ShardGtid{{
+				Keyspace: "product",
+				Shard:    "0",
+				Gtid:     "",
+			}}}
+
+		filter := &binlogdatapb.Filter{
+			Rules: []*binlogdatapb.Rule{{
+				Match:  "customer",
+				Filter: "select * from customer",
+			}},
+		}
+		conn, err := vtgateconn.Dial(ctx, fmt.Sprintf("localhost:%d", vc.ClusterConfig.vtgateGrpcPort))
+		require.NoError(t, err)
+		defer conn.Close()
+
+		flags := &vtgatepb.VStreamFlags{}
+
+		ctx2, cancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer cancel()
+		reader, err := conn.VStream(ctx2, topodatapb.TabletType_REPLICA, vgtid, filter, flags)
+		require.NoError(t, err)
+		_, err = reader.Recv()
+		require.NoError(t, err)
+		log.Infof("About to sleep in vstreaming to block the vstream Recv() channel")
+		time.Sleep(extendedTimeout)
+		log.Infof("Done vstreaming")
+	}()
+
+	go insertData()
+	<-ch1 // wait for enough data to be inserted before ApplyVSchema
+	go func() {
+		timer := time.NewTimer(extendedTimeout)
+		log.Infof("Started ApplyVSchema")
+		for {
+			if err := vc.VtctlClient.ExecuteCommand("ApplyVSchema", "--", "--vschema={}", "product"); err != nil {
+				log.Errorf("ApplyVSchema command failed with %+v\n", err)
+				return
+			}
+			select {
+			case <-timer.C:
+				log.Infof("Done ApplyVSchema")
+				return
+			default:
+				time.Sleep(defaultTick)
+			}
+		}
+	}()
+
+	time.Sleep(defaultTimeout) // wait for enough ApplyVSchema calls before doing a PRS
+	if err := vc.VtctlClient.ExecuteCommand("PlannedReparentShard", "--", "--keyspace_shard", "product/0",
+		"--new_primary", "zone1-101", "--wait_replicas_timeout", defaultTimeout.String()); err != nil {
+		t.Fatalf("PlannedReparentShard command failed with %+v\n", err)
+	}
+}

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -45,6 +46,7 @@ import (
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 const (
@@ -67,7 +69,7 @@ type Engine struct {
 	wg sync.WaitGroup
 
 	mu              sync.Mutex
-	isOpen          bool
+	isOpen          int32 // 0 or 1 in place of atomic.Bool added in go 1.19
 	streamIdx       int
 	streamers       map[int]*uvstreamer
 	rowStreamers    map[int]*rowStreamer
@@ -148,30 +150,24 @@ func (vse *Engine) InitDBConfig(keyspace, shard string) {
 
 // Open starts the Engine service.
 func (vse *Engine) Open() {
-	vse.mu.Lock()
-	defer vse.mu.Unlock()
-	if vse.isOpen {
-		return
-	}
 	log.Info("VStreamer: opening")
-	vse.isOpen = true
+	// If it's not already open, then open it now.
+	atomic.CompareAndSwapInt32(&vse.isOpen, 0, 1)
 }
 
 // IsOpen checks if the engine is opened
 func (vse *Engine) IsOpen() bool {
-	vse.mu.Lock()
-	defer vse.mu.Unlock()
-	return vse.isOpen
+	return atomic.LoadInt32(&vse.isOpen) == 1
 }
 
 // Close closes the Engine service.
 func (vse *Engine) Close() {
 	func() {
-		vse.mu.Lock()
-		defer vse.mu.Unlock()
-		if !vse.isOpen {
+		if atomic.LoadInt32(&vse.isOpen) == 0 {
 			return
 		}
+		vse.mu.Lock()
+		defer vse.mu.Unlock()
 		// cancels are non-blocking.
 		for _, s := range vse.streamers {
 			s.Cancel()
@@ -182,7 +178,7 @@ func (vse *Engine) Close() {
 		for _, s := range vse.resultStreamers {
 			s.Cancel()
 		}
-		vse.isOpen = false
+		atomic.StoreInt32(&vse.isOpen, 0)
 	}()
 
 	// Wait only after releasing the lock because the end of every
@@ -207,11 +203,11 @@ func (vse *Engine) Stream(ctx context.Context, startPos string, tablePKs []*binl
 
 	// Create stream and add it to the map.
 	streamer, idx, err := func() (*uvstreamer, int, error) {
-		vse.mu.Lock()
-		defer vse.mu.Unlock()
-		if !vse.isOpen {
+		if atomic.LoadInt32(&vse.isOpen) == 0 {
 			return nil, 0, errors.New("VStreamer is not open")
 		}
+		vse.mu.Lock()
+		defer vse.mu.Unlock()
 		streamer := newUVStreamer(ctx, vse, vse.env.Config().DB.FilteredWithDB(), vse.se, startPos, tablePKs, filter, vse.lvschema, send)
 		idx := vse.streamIdx
 		vse.streamers[idx] = streamer
@@ -248,11 +244,11 @@ func (vse *Engine) StreamRows(ctx context.Context, query string, lastpk []sqltyp
 
 	// Create stream and add it to the map.
 	rowStreamer, idx, err := func() (*rowStreamer, int, error) {
-		vse.mu.Lock()
-		defer vse.mu.Unlock()
-		if !vse.isOpen {
+		if atomic.LoadInt32(&vse.isOpen) == 0 {
 			return nil, 0, errors.New("VStreamer is not open")
 		}
+		vse.mu.Lock()
+		defer vse.mu.Unlock()
 
 		rowStreamer := newRowStreamer(ctx, vse.env.Config().DB.FilteredWithDB(), vse.se, query, lastpk, vse.lvschema, send, vse)
 		idx := vse.streamIdx
@@ -283,11 +279,11 @@ func (vse *Engine) StreamRows(ctx context.Context, query string, lastpk []sqltyp
 func (vse *Engine) StreamResults(ctx context.Context, query string, send func(*binlogdatapb.VStreamResultsResponse) error) error {
 	// Create stream and add it to the map.
 	resultStreamer, idx, err := func() (*resultStreamer, int, error) {
-		vse.mu.Lock()
-		defer vse.mu.Unlock()
-		if !vse.isOpen {
+		if atomic.LoadInt32(&vse.isOpen) == 0 {
 			return nil, 0, errors.New("VStreamer is not open")
 		}
+		vse.mu.Lock()
+		defer vse.mu.Unlock()
 		resultStreamer := newResultStreamer(ctx, vse.env.Config().DB.FilteredWithDB(), query, send, vse)
 		idx := vse.streamIdx
 		vse.resultStreamers[idx] = resultStreamer
@@ -441,7 +437,7 @@ func (vse *Engine) waitForMySQL(ctx context.Context, db dbconfigs.Connector, tab
 			}
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return vterrors.Errorf(vtrpcpb.Code_CANCELED, "context has expired")
 			case <-time.After(backoff):
 				// Exponential backoff with 1.5 as a factor
 				if backoff != backoffLimit {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -143,6 +143,12 @@ func (vs *vstreamer) SetVSchema(vschema *localVSchema) {
 	select {
 	case vs.vevents <- vschema:
 	case <-vs.ctx.Done():
+	default: // if there is a pending vschema in the channel, drain it and update it with the latest one
+		select {
+		case <-vs.vevents:
+			vs.vevents <- vschema
+		default:
+		}
 	}
 }
 

--- a/test/config.json
+++ b/test/config.json
@@ -1008,6 +1008,15 @@
 			"RetryMax": 2,
 			"Tags": []
 		},
+		"vreplication_vschema_load": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestVSchemaChangesUnderLoad"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vreplication_cellalias",
+			"RetryMax": 2,
+			"Tags": []
+		},
 		"vreplication_basic": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestBasicVreplicationWorkflow"],


### PR DESCRIPTION
## Description

This fixes the bug reported in  https://github.com/vitessio/vitess/issues/11169

Pre-conditions for bug:
1. There is a vstreamer client that is subscribed to, but not reading events fast enough, from a Replica
2. There are a lot of VSchema changes at this time
3. A PRS happens at this time, switching this Replica to a Primary

Bug cause:
1. In `vstreamer.SetVSchema()`  the new vschema is written to a single message buffered channel for each active vstreamer. This is read by the vstreamer event processor, holding the vstreamer engine mutex.
2. In the vstreamer event processor there are two parallel `case` statements: one reads from the vschema channel and other reads the binlog events. The binlog events are streamed to the receiver. If the receiver is not reading them then the send will block. This means that the other `case` which polls the vschema change channel will not get called. This results in the vstreamer engine lock being held until all events are streamed
4. The PRS results in the vttablet state manager trying to shut down the vstreamer engine for which it needs the vstreamer engine mutex. This can cause the PRS to get blocked.

This PR drains the vschema channel so that only the latest vschema update is sent. So it no longer holds the vstreamer lock for an extended time allowing the PRS to proceed.

This PR also incorporates the changes made in https://github.com/vitessio/vitess/pull/11268 which also solves the same issue in a different way:  the vschema update no longer holds a lock (since it uses `atomic.int32` to signal whether the vstreamer engine is open, rather than the mutex). #11268 also adds checks for cancelled contexts.

## Related Issue(s)

fixes #11169

## Checklist

-   [X] "Backport me!" label has been added if this change should be backported
-   [X] Tests were added or are not required
-   [x] Documentation was added or is not required

