### PR TITLE
[cli] [vtctld] Migrate vtctld flags to pflags

### DIFF
--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -93,7 +93,7 @@ Usage of vtctld:
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 1ns)
-      --online_ddl_check_interval duration                               deprecated. Will be removed in next Vitess version (default 0s)
+      --online_ddl_check_interval duration                               deprecated. Will be removed in next Vitess version
       --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
       --opentsdb_uri string                                              URI of opentsdb /api/put method
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -93,7 +93,6 @@ Usage of vtctld:
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 1ns)
-      --online_ddl_check_interval duration                               deprecated. Will be removed in next Vitess version
       --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
       --opentsdb_uri string                                              URI of opentsdb /api/put method
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
@@ -192,7 +191,7 @@ Usage of vtctld:
       --vtgate_protocol string                                           how to talk to vtgate (default "grpc")
       --web_dir string                                                   NOT USED, here for backward compatibility
       --web_dir2 string                                                  NOT USED, here for backward compatibility
-      --workflow_manager_disable StringList                              comma separated list of workflow types to disable
+      --workflow_manager_disable strings                                 comma separated list of workflow types to disable
       --workflow_manager_init                                            Initialize the workflow manager in this vtctld instance.
       --workflow_manager_use_election                                    if specified, will use a topology server-based master election to ensure only one workflow manager is active at a time.
       --xbstream_restore_flags string                                    flags to pass to xbstream command during restore. These should be space separated and will be added to the end of the command. These need to match the ones used for backup e.g. --compress / --decompress, --encrypt / --decrypt

--- a/go/vt/vtctld/action_repository.go
+++ b/go/vt/vtctld/action_repository.go
@@ -17,17 +17,15 @@ limitations under the License.
 package vtctld
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	"github.com/spf13/pflag"
 
-	"vitess.io/vitess/go/vt/servenv"
-
-	"context"
-
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtctld
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,10 +28,6 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"vitess.io/vitess/go/vt/servenv"
-
-	"context"
-
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/discovery"
@@ -40,6 +37,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/vttime"
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/schemamanager"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl"
@@ -55,7 +53,7 @@ import (
 var (
 	localCell        string
 	showTopologyCRUD = true
-	proxyTablets     = false
+	proxyTablets     bool
 )
 
 // This file implements a REST-style API for the vtctld web interface.

--- a/go/vt/vtctld/tablet_data.go
+++ b/go/vt/vtctld/tablet_data.go
@@ -17,10 +17,13 @@ limitations under the License.
 package vtctld
 
 import (
-	"flag"
 	"io"
 	"sync"
 	"time"
+
+	"github.com/spf13/pflag"
+
+	"vitess.io/vitess/go/vt/servenv"
 
 	"context"
 
@@ -39,7 +42,7 @@ import (
 // result.
 
 var (
-	tabletHealthKeepAlive = flag.Duration("tablet_health_keep_alive", 5*time.Minute, "close streaming tablet health connection if there are no requests for this long")
+	tabletHealthKeepAlive = 5 * time.Minute
 )
 
 type tabletHealth struct {
@@ -56,6 +59,16 @@ type tabletHealth struct {
 	done chan struct{}
 	// ready is closed when there is at least one result to read.
 	ready chan struct{}
+}
+
+func init() {
+	for _, cmd := range []string{"vtcombo", "vtctld"} {
+		servenv.OnParseFor(cmd, registerVtctlTabletFlags)
+	}
+}
+
+func registerVtctlTabletFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&tabletHealthKeepAlive, "tablet_health_keep_alive", tabletHealthKeepAlive, "close streaming tablet health connection if there are no requests for this long")
 }
 
 func newTabletHealth() *tabletHealth {
@@ -119,7 +132,7 @@ func (th *tabletHealth) stream(ctx context.Context, ts *topo.Server, tabletAlias
 			close(th.ready)
 			first = false
 		}
-		if time.Since(th.lastAccessed()) >= *tabletHealthKeepAlive {
+		if time.Since(th.lastAccessed()) >= tabletHealthKeepAlive {
 			return io.EOF
 		}
 		return nil

--- a/go/vt/vtctld/tablet_data.go
+++ b/go/vt/vtctld/tablet_data.go
@@ -17,18 +17,16 @@ limitations under the License.
 package vtctld
 
 import (
+	"context"
 	"io"
 	"sync"
 	"time"
 
 	"github.com/spf13/pflag"
 
-	"vitess.io/vitess/go/vt/servenv"
-
-	"context"
-
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vttablet/tabletconn"

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/spf13/pflag"
 
@@ -47,8 +46,6 @@ var (
 	sanitizeLogMessages = false
 	webDir              string
 	webDir2             string
-	// deprecated, only here for backwards compatibility:
-	deprecatedOnlineDDLCheckInterval = time.Duration(0)
 )
 
 const (
@@ -68,16 +65,10 @@ func registerVtctldFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&sanitizeLogMessages, "vtctld_sanitize_log_messages", sanitizeLogMessages, "When true, vtctld sanitizes logging.")
 	fs.StringVar(&webDir, "web_dir", webDir, "NOT USED, here for backward compatibility")
 	fs.StringVar(&webDir2, "web_dir2", webDir2, "NOT USED, here for backward compatibility")
-	// deprecated, only here for backwards compatibility:
-	fs.DurationVar(&deprecatedOnlineDDLCheckInterval, "online_ddl_check_interval", deprecatedOnlineDDLCheckInterval, "deprecated. Will be removed in next Vitess version")
 }
 
 // InitVtctld initializes all the vtctld functionality.
 func InitVtctld(ts *topo.Server) error {
-	if deprecatedOnlineDDLCheckInterval != 0 {
-		log.Warningf("the flag '--online_ddl_check_interval' is deprecated and will be removed in future versions. It is currently unused.")
-	}
-
 	actionRepo := NewActionRepository(ts)
 
 	// keyspace actions

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -20,9 +20,13 @@ package vtctld
 
 import (
 	"context"
-	"flag"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"vitess.io/vitess/go/vt/servenv"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/discovery"
@@ -37,25 +41,40 @@ import (
 )
 
 var (
-	enableRealtimeStats = flag.Bool("enable_realtime_stats", false, "Required for the Realtime Stats view. If set, vtctld will maintain a streaming RPC to each tablet (in all cells) to gather the realtime health stats.")
-	enableUI            = flag.Bool("enable_vtctld_ui", true, "If true, the vtctld web interface will be enabled. Default is true.")
-	_                   = flag.String("durability_policy", "none", "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
-	sanitizeLogMessages = flag.Bool("vtctld_sanitize_log_messages", false, "When true, vtctld sanitizes logging.")
-
-	_ = flag.String("web_dir", "", "NOT USED, here for backward compatibility")
-	_ = flag.String("web_dir2", "", "NOT USED, here for backward compatibility")
-
+	enableRealtimeStats = false
+	enableUI            = true
+	durabilityPolicy    = "none"
+	sanitizeLogMessages = false
+	webDir              string
+	webDir2             string
 	// deprecated, only here for backwards compatibility:
-	deprecatedOnlineDDLCheckInterval = flag.Duration("online_ddl_check_interval", 0, "deprecated. Will be removed in next Vitess version")
+	deprecatedOnlineDDLCheckInterval = time.Duration(0)
 )
 
 const (
 	appPrefix = "/app/"
 )
 
+func init() {
+	for _, cmd := range []string{"vtcombo", "vtctld"} {
+		servenv.OnParseFor(cmd, registerVtctldFlags)
+	}
+}
+
+func registerVtctldFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&enableRealtimeStats, "enable_realtime_stats", enableRealtimeStats, "Required for the Realtime Stats view. If set, vtctld will maintain a streaming RPC to each tablet (in all cells) to gather the realtime health stats.")
+	fs.BoolVar(&enableUI, "enable_vtctld_ui", enableUI, "If true, the vtctld web interface will be enabled. Default is true.")
+	fs.StringVar(&durabilityPolicy, "durability_policy", durabilityPolicy, "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
+	fs.BoolVar(&sanitizeLogMessages, "vtctld_sanitize_log_messages", sanitizeLogMessages, "When true, vtctld sanitizes logging.")
+	fs.StringVar(&webDir, "web_dir", webDir, "NOT USED, here for backward compatibility")
+	fs.StringVar(&webDir2, "web_dir2", webDir2, "NOT USED, here for backward compatibility")
+	// deprecated, only here for backwards compatibility:
+	fs.DurationVar(&deprecatedOnlineDDLCheckInterval, "online_ddl_check_interval", deprecatedOnlineDDLCheckInterval, "deprecated. Will be removed in next Vitess version")
+}
+
 // InitVtctld initializes all the vtctld functionality.
 func InitVtctld(ts *topo.Server) error {
-	if *deprecatedOnlineDDLCheckInterval != 0 {
+	if deprecatedOnlineDDLCheckInterval != 0 {
 		log.Warningf("the flag '--online_ddl_check_interval' is deprecated and will be removed in future versions. It is currently unused.")
 	}
 
@@ -140,16 +159,16 @@ func InitVtctld(ts *topo.Server) error {
 		http.Redirect(w, r, appPrefix, http.StatusFound)
 	})
 
-	http.Handle(appPrefix, staticContentHandler(*enableUI))
+	http.Handle(appPrefix, staticContentHandler(enableUI))
 
 	var healthCheck discovery.HealthCheck
-	if *enableRealtimeStats {
+	if enableRealtimeStats {
 		ctx := context.Background()
 		cells, err := ts.GetKnownCells(ctx)
 		if err != nil {
 			log.Errorf("Failed to get the list of known cells, failed to instantiate the healthcheck at startup: %v", err)
 		} else {
-			healthCheck = discovery.NewHealthCheck(ctx, *vtctl.HealthcheckRetryDelay, *vtctl.HealthCheckTimeout, ts, *localCell, strings.Join(cells, ","))
+			healthCheck = discovery.NewHealthCheck(ctx, *vtctl.HealthcheckRetryDelay, *vtctl.HealthCheckTimeout, ts, localCell, strings.Join(cells, ","))
 		}
 	}
 

--- a/go/vt/vtctld/workflow.go
+++ b/go/vt/vtctld/workflow.go
@@ -18,14 +18,12 @@ package vtctld
 
 import (
 	"context"
-	"flag"
 	"time"
 
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/trace"
 
-	"vitess.io/vitess/go/flagutil"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
@@ -35,22 +33,23 @@ import (
 )
 
 var (
-	workflowManagerInit        = false
-	workflowManagerUseElection = false
+	workflowManagerInit        bool
+	workflowManagerUseElection bool
 
-	workflowManagerDisable flagutil.StringListValue
+	workflowManagerDisable []string
 )
 
 func registerVtctldWorkflowFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&workflowManagerInit, "workflow_manager_init", workflowManagerInit, "Initialize the workflow manager in this vtctld instance.")
 	fs.BoolVar(&workflowManagerUseElection, "workflow_manager_use_election", workflowManagerUseElection, "if specified, will use a topology server-based master election to ensure only one workflow manager is active at a time.")
+	fs.StringSliceVar(&workflowManagerDisable, "workflow_manager_disable", workflowManagerDisable, "comma separated list of workflow types to disable")
 }
 
 func init() {
 	for _, cmd := range []string{"vtcombo", "vtctld"} {
 		servenv.OnParseFor(cmd, registerVtctldWorkflowFlags)
 	}
-	flag.Var(&workflowManagerDisable, "workflow_manager_disable", "comma separated list of workflow types to disable")
+
 }
 
 func initWorkflowManager(ts *topo.Server) {


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>


## Description

Updates vtctld related flag references specified in https://github.com/vitessio/vitess/issues/10893

Modules for flag registration

go list -f '{{ .ImportPath }}| {{ join .Deps " " }} ' ./go/cmd/... | awk -F"|" '$2 ~ "vitess.io/vitess/go/vt/vtctld" {print $1}'
vitess.io/vitess/go/cmd/vtcombo
vitess.io/vitess/go/cmd/vtctld

## Related Issue(s)

fixes #10893

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
