### PR TITLE
[cli] [topo] Migrate topo2topo flags to pflags

### DIFF
--- a/go/cmd/topo2topo/topo2topo.go
+++ b/go/cmd/topo2topo/topo2topo.go
@@ -40,7 +40,7 @@ func main() {
 	grpccommon.RegisterFlags(fs)
 	log.RegisterFlags(fs)
 	logutil.RegisterFlags(fs)
-	fromImplementation := fs.String("from_implementation", "abc", "topology implementation to copy data from")
+	fromImplementation := fs.String("from_implementation", "", "topology implementation to copy data from")
 	fromServerAddress := fs.String("from_server", "", "topology server address to copy data from")
 	fromRoot := fs.String("from_root", "", "topology server root to copy data from")
 	toImplementation := fs.String("to_implementation", "", "topology implementation to copy data to")

--- a/go/cmd/topo2topo/topo2topo.go
+++ b/go/cmd/topo2topo/topo2topo.go
@@ -18,11 +18,8 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
-
-	"vitess.io/vitess/go/vt/servenv"
 
 	"github.com/spf13/pflag"
 
@@ -30,11 +27,9 @@ import (
 	"vitess.io/vitess/go/vt/grpccommon"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/helpers"
-
-	// Include deprecation warnings for soon-to-be-unsupported flag invocations.
-	_flag "vitess.io/vitess/go/internal/flag"
 )
 
 func main() {
@@ -42,11 +37,10 @@ func main() {
 	defer logutil.Flush()
 
 	fs := pflag.NewFlagSet("topo2topo", pflag.ExitOnError)
-	servenv.ParseFlags("topo2topo")
 	grpccommon.RegisterFlags(fs)
 	log.RegisterFlags(fs)
 	logutil.RegisterFlags(fs)
-	fromImplementation := fs.String("from_implementation", "", "topology implementation to copy data from")
+	fromImplementation := fs.String("from_implementation", "abc", "topology implementation to copy data from")
 	fromServerAddress := fs.String("from_server", "", "topology server address to copy data from")
 	fromRoot := fs.String("from_root", "", "topology server root to copy data from")
 	toImplementation := fs.String("to_implementation", "", "topology implementation to copy data to")
@@ -58,13 +52,7 @@ func main() {
 	doShardReplications := fs.Bool("do-shard-replications", false, "copies the shard replication information")
 	doTablets := fs.Bool("do-tablets", false, "copies the tablet information")
 	doRoutingRules := fs.Bool("do-routing-rules", false, "copies the routing rules")
-
-	_flag.Parse(fs)
-	args := _flag.Args()
-	if len(args) != 0 {
-		flag.Usage()
-		log.Exitf("topo2topo doesn't take any parameter.")
-	}
+	servenv.ParseFlags("topo2topo")
 
 	fromTS, err := topo.OpenServer(*fromImplementation, *fromServerAddress, *fromRoot)
 	if err != nil {

--- a/go/cmd/topo2topo/topo2topo.go
+++ b/go/cmd/topo2topo/topo2topo.go
@@ -32,6 +32,38 @@ import (
 	"vitess.io/vitess/go/vt/topo/helpers"
 )
 
+var (
+	fromImplementation  string
+	fromServerAddress   string
+	fromRoot            string
+	toImplementation    string
+	toServerAddress     string
+	toRoot              string
+	compare             bool
+	doKeyspaces         bool
+	doShards            bool
+	doShardReplications bool
+	doTablets           bool
+	doRoutingRules      bool
+)
+
+func init() {
+	servenv.OnParseFor("topo2topo", func(fs *pflag.FlagSet) {
+		fs.StringVar(&fromImplementation, "from_implementation", fromImplementation, "topology implementation to copy data from")
+		fs.StringVar(&fromServerAddress, "from_server", fromServerAddress, "topology server address to copy data from")
+		fs.StringVar(&fromRoot, "from_root", fromRoot, "topology server root to copy data from")
+		fs.StringVar(&toImplementation, "to_implementation", toImplementation, "topology implementation to copy data to")
+		fs.StringVar(&toServerAddress, "to_server", toServerAddress, "topology server address to copy data to")
+		fs.StringVar(&toRoot, "to_root", toRoot, "topology server root to copy data to")
+		fs.BoolVar(&compare, "compare", compare, "compares data between topologies")
+		fs.BoolVar(&doKeyspaces, "do-keyspaces", doKeyspaces, "copies the keyspace information")
+		fs.BoolVar(&doShards, "do-shards", doShards, "copies the shard information")
+		fs.BoolVar(&doShardReplications, "do-shard-replications", doShardReplications, "copies the shard replication information")
+		fs.BoolVar(&doTablets, "do-tablets", doTablets, "copies the tablet information")
+		fs.BoolVar(&doRoutingRules, "do-routing-rules", doRoutingRules, "copies the routing rules")
+	})
+}
+
 func main() {
 	defer exit.RecoverAll()
 	defer logutil.Flush()
@@ -40,36 +72,25 @@ func main() {
 	grpccommon.RegisterFlags(fs)
 	log.RegisterFlags(fs)
 	logutil.RegisterFlags(fs)
-	fromImplementation := fs.String("from_implementation", "", "topology implementation to copy data from")
-	fromServerAddress := fs.String("from_server", "", "topology server address to copy data from")
-	fromRoot := fs.String("from_root", "", "topology server root to copy data from")
-	toImplementation := fs.String("to_implementation", "", "topology implementation to copy data to")
-	toServerAddress := fs.String("to_server", "", "topology server address to copy data to")
-	toRoot := fs.String("to_root", "", "topology server root to copy data to")
-	compare := fs.Bool("compare", false, "compares data between topologies")
-	doKeyspaces := fs.Bool("do-keyspaces", false, "copies the keyspace information")
-	doShards := fs.Bool("do-shards", false, "copies the shard information")
-	doShardReplications := fs.Bool("do-shard-replications", false, "copies the shard replication information")
-	doTablets := fs.Bool("do-tablets", false, "copies the tablet information")
-	doRoutingRules := fs.Bool("do-routing-rules", false, "copies the routing rules")
+
 	servenv.ParseFlags("topo2topo")
 
-	fromTS, err := topo.OpenServer(*fromImplementation, *fromServerAddress, *fromRoot)
+	fromTS, err := topo.OpenServer(fromImplementation, fromServerAddress, fromRoot)
 	if err != nil {
 		log.Exitf("Cannot open 'from' topo %v: %v", fromImplementation, err)
 	}
-	toTS, err := topo.OpenServer(*toImplementation, *toServerAddress, *toRoot)
+	toTS, err := topo.OpenServer(toImplementation, toServerAddress, toRoot)
 	if err != nil {
 		log.Exitf("Cannot open 'to' topo %v: %v", toImplementation, err)
 	}
 
 	ctx := context.Background()
 
-	if *compare {
-		compareTopos(ctx, fromTS, toTS, *doKeyspaces, *doShards, *doShardReplications, *doTablets)
+	if compare {
+		compareTopos(ctx, fromTS, toTS, doKeyspaces, doShards, doShardReplications, doTablets)
 		return
 	}
-	copyTopos(ctx, fromTS, toTS, *doKeyspaces, *doShards, *doShardReplications, *doTablets, *doRoutingRules)
+	copyTopos(ctx, fromTS, toTS, doKeyspaces, doShards, doShardReplications, doTablets, doRoutingRules)
 }
 
 func copyTopos(ctx context.Context, fromTS, toTS *topo.Server, doKeyspaces bool, doShards bool, doShardReplications bool, doTablets bool, doRoutingRules bool) {

--- a/go/cmd/topo2topo/topo2topo.go
+++ b/go/cmd/topo2topo/topo2topo.go
@@ -48,7 +48,7 @@ var (
 )
 
 func init() {
-	servenv.OnParseFor("topo2topo", func(fs *pflag.FlagSet) {
+	servenv.OnParse(func(fs *pflag.FlagSet) {
 		fs.StringVar(&fromImplementation, "from_implementation", fromImplementation, "topology implementation to copy data from")
 		fs.StringVar(&fromServerAddress, "from_server", fromServerAddress, "topology server address to copy data from")
 		fs.StringVar(&fromRoot, "from_root", fromRoot, "topology server root to copy data from")
@@ -87,13 +87,13 @@ func main() {
 	ctx := context.Background()
 
 	if compare {
-		compareTopos(ctx, fromTS, toTS, doKeyspaces, doShards, doShardReplications, doTablets)
+		compareTopos(ctx, fromTS, toTS)
 		return
 	}
-	copyTopos(ctx, fromTS, toTS, doKeyspaces, doShards, doShardReplications, doTablets, doRoutingRules)
+	copyTopos(ctx, fromTS, toTS)
 }
 
-func copyTopos(ctx context.Context, fromTS, toTS *topo.Server, doKeyspaces bool, doShards bool, doShardReplications bool, doTablets bool, doRoutingRules bool) {
+func copyTopos(ctx context.Context, fromTS, toTS *topo.Server) {
 	if doKeyspaces {
 		helpers.CopyKeyspaces(ctx, fromTS, toTS)
 	}
@@ -111,7 +111,7 @@ func copyTopos(ctx context.Context, fromTS, toTS *topo.Server, doKeyspaces bool,
 	}
 }
 
-func compareTopos(ctx context.Context, fromTS, toTS *topo.Server, doKeyspaces bool, doShards bool, doShardReplications bool, doTablets bool) {
+func compareTopos(ctx context.Context, fromTS, toTS *topo.Server) {
 	var err error
 	if doKeyspaces {
 		err = helpers.CompareKeyspaces(ctx, fromTS, toTS)


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>

## Description

Updates mysqlctl related flag references specified in https://github.com/vitessio/vitess/issues/11106

possible package using this flags.

go list -f '{{ .ImportPath }}| {{ join .Deps " " }} ' ./go/cmd/... | awk -F"|" '$2 ~ "vitess.io/vitess/go/cmd" {print $1}'
vitess.io/vitess/go/cmd/mysqlctl
vitess.io/vitess/go/cmd/rulesctl
vitess.io/vitess/go/cmd/rulesctl/cmd
vitess.io/vitess/go/cmd/vtbackup
vitess.io/vitess/go/cmd/vtcombo
vitess.io/vitess/go/cmd/vtctl
vitess.io/vitess/go/cmd/vtctld
vitess.io/vitess/go/cmd/vtctldclient
vitess.io/vitess/go/cmd/vtctldclient/command
vitess.io/vitess/go/cmd/vtctldclient/docgen
vitess.io/vitess/go/cmd/vtgateclienttest
vitess.io/vitess/go/cmd/zk

## Related Issue(s)

#11106

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
