### PR TITLE
customrule pflags migration

### DIFF
--- a/go/vt/vttablet/customrule/filecustomrule/filecustomrule.go
+++ b/go/vt/vttablet/customrule/filecustomrule/filecustomrule.go
@@ -18,12 +18,12 @@ limitations under the License.
 package filecustomrule
 
 import (
-	"flag"
 	"os"
 	"path"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
@@ -34,11 +34,21 @@ import (
 var (
 	// Actual FileCustomRule object in charge of rule updates
 	fileCustomRule = NewFileCustomRule()
-	// Commandline flag to specify rule path
-	fileRulePath = flag.String("filecustomrules", "", "file based custom rule path")
 
-	fileRuleShouldWatch = flag.Bool("filecustomrules_watch", false, "set up a watch on the target file and reload query rules when it changes")
+	// Commandline flag to specify rule path
+	fileRulePath        string
+	fileRuleShouldWatch bool
 )
+
+func registerFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&fileRulePath, "filecustomrules", fileRulePath, "file based custom rule path")
+	fs.BoolVar(&fileRuleShouldWatch, "filecustomrules_watch", fileRuleShouldWatch, "set up a watch on the target file and reload query rules when it changes")
+}
+
+func init() {
+	servenv.OnParseFor("rulesctl", registerFlags)
+	servenv.OnParseFor("vttablet", registerFlags)
+}
 
 // FileCustomRule is an implementation of CustomRuleManager, it reads custom query
 // rules from local file for once and push it to vttablet
@@ -105,16 +115,16 @@ func (fcr *FileCustomRule) GetRules() (qrs *rules.Rules, version int64, err erro
 
 // ActivateFileCustomRules activates this static file based custom rule mechanism
 func ActivateFileCustomRules(qsc tabletserver.Controller) {
-	if *fileRulePath != "" {
+	if fileRulePath != "" {
 		qsc.RegisterQueryRuleSource(FileCustomRuleSource)
-		fileCustomRule.Open(qsc, *fileRulePath)
+		fileCustomRule.Open(qsc, fileRulePath)
 
-		if !*fileRuleShouldWatch {
+		if !fileRuleShouldWatch {
 			return
 		}
 
-		baseDir := path.Dir(*fileRulePath)
-		ruleFileName := path.Base(*fileRulePath)
+		baseDir := path.Dir(fileRulePath)
+		ruleFileName := path.Base(fileRulePath)
 
 		watcher, err := fsnotify.NewWatcher()
 		if err != nil {
@@ -132,16 +142,16 @@ func ActivateFileCustomRules(qsc tabletserver.Controller) {
 					if path.Base(evt.Name) != ruleFileName {
 						continue
 					}
-					if err := fileCustomRule.Open(tsc, *fileRulePath); err != nil {
-						log.Infof("Failed to load custom rules from %q: %v", *fileRulePath, err)
+					if err := fileCustomRule.Open(tsc, fileRulePath); err != nil {
+						log.Infof("Failed to load custom rules from %q: %v", fileRulePath, err)
 					} else {
-						log.Infof("Loaded custom rules from %q", *fileRulePath)
+						log.Infof("Loaded custom rules from %q", fileRulePath)
 					}
 				case err, ok := <-watcher.Errors:
 					if !ok {
 						return
 					}
-					log.Errorf("Error watching %v: %v", *fileRulePath, err)
+					log.Errorf("Error watching %v: %v", fileRulePath, err)
 				}
 			}
 		}(qsc)

--- a/go/vt/vttablet/customrule/filecustomrule/filecustomrule.go
+++ b/go/vt/vttablet/customrule/filecustomrule/filecustomrule.go
@@ -46,7 +46,6 @@ func registerFlags(fs *pflag.FlagSet) {
 }
 
 func init() {
-	servenv.OnParseFor("rulesctl", registerFlags)
 	servenv.OnParseFor("vttablet", registerFlags)
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This migrates the following tools to pflag:
* `go/vt/vttablet/customrule/filecustomrule`
* `go/vt/vttablet/customrule/topocustomrule`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Closes https://github.com/vitessio/vitess/issues/10971
- Closes https://github.com/vitessio/vitess/issues/10972

## Checklist

-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required