### PR TITLE
Fix frouioui in the MAINTAINERS.md file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,7 @@ The following is the full list, alphabetically ordered.
 * David Weitzman ([dweitzman](https://github.com/dweitzman)) dweitzman@pinterest.com
 * Deepthi Sigireddi ([deepthi](https://github.com/deepthi)) deepthi@planetscale.com
 * Derek Perkins ([derekperkins](https://github.com/derekperkins)) derek@nozzle.io
-* Florent Poinsard ([frouioui](https://github.com/frouioui)) frouioui@planetscale.com
+* Florent Poinsard ([frouioui](https://github.com/frouioui)) florent@planetscale.com
 * Harshit Gangal ([harshit-gangal](https://github.com/harshit-gangal)) harshit.gangal@gmail.com
 * Jon Tirsen ([tirsen](https://github.com/tirsen)) jontirsen@squareup.com
 * Mali Akmanalp ([makmanalp](https://github.com/makmanalp) makmanalp@hubspot.com
@@ -29,7 +29,7 @@ The following is the full list, alphabetically ordered.
 sougou, deepthi, demmer, rafael, dweitzman, tirsen, enisoc
 
 ### Builds
-dkhenry, shlomi-noach, ajm188, vmg, GuptaManan100
+dkhenry, shlomi-noach, ajm188, vmg, GuptaManan100, frouioui
 
 ### Resharding
 sougou, rafael, tirsen, dweitzman, systay, rohit-nayak-ps, deepthi, mattlord


### PR DESCRIPTION
## Description

This PR fixes a typo in the MAINTAINERS.md file regarding my work email address and adds me to the `build` section.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
