### PR TITLE
VStreams: Rotate Binary Log For Snapshot Connections

### DIFF
--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -465,6 +465,7 @@ Usage of vttablet:
       --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
       --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of _vt.vreplication
       --vreplication_tablet_type string                                  comma separated list of tablet types used as a source (default "in_order:REPLICA,PRIMARY")
+      --vstream_binlog_rotation_threshold int                            Byte size at which a VStreamer will attempt to rotate the source's open binary log before starting a GTID snapshot based stream (e.g. a ResultStreamer or RowStreamer) (default 67108864)
       --vstream_dynamic_packet_size                                      Enable dynamic packet sizing for VReplication. This will adjust the packet size during replication to improve performance. (default true)
       --vstream_packet_size int                                          Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount. (default 250000)
       --vtctld_addr string                                               address of a vtctld instance

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -465,7 +465,7 @@ Usage of vttablet:
       --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
       --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of _vt.vreplication
       --vreplication_tablet_type string                                  comma separated list of tablet types used as a source (default "in_order:REPLICA,PRIMARY")
-      --vstream_binlog_rotation_threshold int                            Byte size at which a VStreamer will attempt to rotate the source's open binary log before starting a GTID snapshot based stream (e.g. a ResultStreamer or RowStreamer) (default 67108864)
+      --vstream-binlog-rotation-threshold int                            Byte size at which a VStreamer will attempt to rotate the source's open binary log before starting a GTID snapshot based stream (e.g. a ResultStreamer or RowStreamer) (default 67108864)
       --vstream_dynamic_packet_size                                      Enable dynamic packet sizing for VReplication. This will adjust the packet size during replication to improve performance. (default true)
       --vstream_packet_size int                                          Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount. (default 250000)
       --vtctld_addr string                                               address of a vtctld instance

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -44,6 +44,7 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	throttlebase "vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/base"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer"
 )
 
 var (
@@ -292,9 +293,8 @@ func TestVStreamFlushBinlog(t *testing.T) {
 	flushCount := int64(sourceTab.GetVars()["VStreamerFlushBinlogs"].(float64))
 	require.Equal(t, flushCount, int64(0), "VStreamerFlushBinlogs should be 0")
 
-	// Generate a lot of binlog events; target size should be
-	// > vstreamer.binlogRotateSize (64MiB).
-	targetBinlogSize := int64(64 * 1024 * 1024)
+	// Generate a lot of binlog event bytes
+	targetBinlogSize := vstreamer.GetBinlogRotationThreshold() + 16
 	vtgateConn := getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
 	queryF := "insert into db_order_test (c_uuid, dbstuff, created_at) values ('%d', repeat('A', 65000), now())"
 	for i := 100; i < 5000; i++ {

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -250,6 +250,89 @@ func TestMultiCellVreplicationWorkflow(t *testing.T) {
 	testVStreamCellFlag(t)
 }
 
+func TestVStreamFlushBinlog(t *testing.T) {
+	defaultCellName := "zone1"
+	allCells := []string{defaultCellName}
+	allCellNames = defaultCellName
+	workflow := "test_vstream_p2c"
+	shard := "0"
+	vc = NewVitessCluster(t, "TestVStreamBinlogFlush", allCells, mainClusterConfig)
+	defaultCell = vc.Cells[defaultCellName]
+
+	require.NotNil(t, vc)
+	// Keep the cluster processes minimal to deal with CI resource constraints.
+	// This also makes it easier to confirm the behavior as we know exactly
+	// what tablets will be involved.
+	defaultReplicas = 0
+	defaultRdonly = 0
+	defer func() { defaultReplicas = 1 }()
+
+	defer vc.TearDown(t)
+
+	if _, err := vc.AddKeyspace(t, []*Cell{defaultCell}, sourceKs, shard, initialProductVSchema, initialProductSchema, 0, 0, 100, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vc.AddKeyspace(t, []*Cell{defaultCell}, targetKs, shard, "", "", 0, 0, 200, nil); err != nil {
+		t.Fatal(err)
+	}
+	vtgate = defaultCell.Vtgates[0]
+	require.NotNil(t, vtgate)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", sourceKs, shard), 1)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", targetKs, shard), 1)
+
+	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+	sourceTab = vc.getPrimaryTablet(t, sourceKs, shard)
+	defer vtgateConn.Close()
+	verifyClusterHealth(t, vc)
+
+	insertInitialData(t)
+
+	tables := "product,customer,merchant,orders"
+	moveTables(t, defaultCellName, workflow, sourceKs, targetKs, tables)
+	catchup(t, vc.getPrimaryTablet(t, targetKs, shard), workflow, "MoveTables")
+
+	// So far, we should not have rotated any binlogs
+	flushCount := int64(sourceTab.GetVars()["VStreamerFlushBinlogs"].(float64))
+	require.Equal(t, flushCount, int64(0), "VStreamerFlushBinlogs should be 0")
+
+	// Generate a lot of binlog events; target size should be
+	// > vstreamer.binlogRotateSize (64MiB).
+	targetBinlogSize := int64(1024 * 1024 * 64)
+	vtgateConn := getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+	queryF := "insert into db_order_test (c_uuid, dbstuff, created_at) values ('%d', repeat('A', 65000), now())"
+	for i := 100; i < 5000; i++ {
+		res, err := vtgateConn.ExecuteFetch(fmt.Sprintf(queryF, i), -1, false)
+		require.NoError(t, err)
+		require.Greater(t, res.RowsAffected, uint64(0))
+
+		if i%100 == 0 {
+			res, err := sourceTab.QueryTablet("show binary logs", sourceKs, false)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.Greater(t, len(res.Rows), 0)
+			lastRow := res.Rows[len(res.Rows)-1]
+			size, err := lastRow[1].ToInt64()
+			require.NoError(t, err)
+			if size > targetBinlogSize {
+				break
+			}
+		}
+	}
+
+	// Now we should rotate the binary logs ONE time on the source, even
+	// though we're opening up multiple result streams (1 per table).
+	runVDiffsSideBySide = false
+	vdiff(t, targetKs, workflow, defaultCellName, true, false, nil)
+	flushCount = int64(sourceTab.GetVars()["VStreamerFlushBinlogs"].(float64))
+	require.Equal(t, flushCount, int64(1), "VStreamerFlushBinlogs should now be 1")
+
+	// Now if we do another vdiff, we should NOT rotate the binlogs again
+	// as we haven't been generating a lot of new binlog events.
+	vdiff(t, targetKs, workflow, defaultCellName, true, false, nil)
+	flushCount = int64(sourceTab.GetVars()["VStreamerFlushBinlogs"].(float64))
+	require.Equal(t, flushCount, int64(1), "VStreamerFlushBinlogs should still be 1")
+}
+
 func testVStreamCellFlag(t *testing.T) {
 	vgtid := &binlogdatapb.VGtid{
 		ShardGtids: []*binlogdatapb.ShardGtid{{

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -290,8 +290,8 @@ func TestVStreamFlushBinlog(t *testing.T) {
 	catchup(t, vc.getPrimaryTablet(t, targetKs, shard), workflow, "MoveTables")
 
 	// So far, we should not have rotated any binlogs
-	flushCount := int64(sourceTab.GetVars()["VStreamerFlushBinlogs"].(float64))
-	require.Equal(t, flushCount, int64(0), "VStreamerFlushBinlogs should be 0")
+	flushCount := int64(sourceTab.GetVars()["VStreamerFlushedBinlogs"].(float64))
+	require.Equal(t, flushCount, int64(0), "VStreamerFlushedBinlogs should be 0")
 
 	// Generate a lot of binlog event bytes
 	targetBinlogSize := vstreamer.GetBinlogRotationThreshold() + 16
@@ -320,14 +320,14 @@ func TestVStreamFlushBinlog(t *testing.T) {
 	// though we're opening up multiple result streams (1 per table).
 	runVDiffsSideBySide = false
 	vdiff(t, targetKs, workflow, defaultCellName, true, false, nil)
-	flushCount = int64(sourceTab.GetVars()["VStreamerFlushBinlogs"].(float64))
-	require.Equal(t, flushCount, int64(1), "VStreamerFlushBinlogs should now be 1")
+	flushCount = int64(sourceTab.GetVars()["VStreamerFlushedBinlogs"].(float64))
+	require.Equal(t, flushCount, int64(1), "VStreamerFlushedBinlogs should now be 1")
 
 	// Now if we do another vdiff, we should NOT rotate the binlogs again
 	// as we haven't been generating a lot of new binlog events.
 	vdiff(t, targetKs, workflow, defaultCellName, true, false, nil)
-	flushCount = int64(sourceTab.GetVars()["VStreamerFlushBinlogs"].(float64))
-	require.Equal(t, flushCount, int64(1), "VStreamerFlushBinlogs should still be 1")
+	flushCount = int64(sourceTab.GetVars()["VStreamerFlushedBinlogs"].(float64))
+	require.Equal(t, flushCount, int64(1), "VStreamerFlushedBinlogs should still be 1")
 }
 
 func testVStreamCellFlag(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -97,6 +97,7 @@ type Engine struct {
 	errorCounts               *stats.CountersWithSingleLabel
 	vstreamersCreated         *stats.Counter
 	vstreamersEndedWithErrors *stats.Counter
+	vstreamerFlushBinlogs     *stats.Counter
 
 	throttlerClient *throttle.Client
 }
@@ -133,6 +134,7 @@ func NewEngine(env tabletenv.Env, ts srvtopo.Server, se *schema.Engine, lagThrot
 		vstreamersCreated:         env.Exporter().NewCounter("VStreamersCreated", "Count of vstreamers created"),
 		vstreamersEndedWithErrors: env.Exporter().NewCounter("VStreamersEndedWithErrors", "Count of vstreamers that ended with errors"),
 		errorCounts:               env.Exporter().NewCountersWithSingleLabel("VStreamerErrors", "Tracks errors in vstreamer", "type", "Catchup", "Copy", "Send", "TablePlan"),
+		vstreamerFlushBinlogs:     env.Exporter().NewCounter("VStreamerFlushBinlogs", "Number of times we've issued a FLUSH BINARY LOGS when starting a vstream"),
 	}
 	env.Exporter().NewGaugeFunc("RowStreamerMaxInnoDBTrxHistLen", "", func() int64 { return env.Config().RowStreamer.MaxInnoDBTrxHistLen })
 	env.Exporter().NewGaugeFunc("RowStreamerMaxMySQLReplLagSecs", "", func() int64 { return env.Config().RowStreamer.MaxMySQLReplLagSecs })

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -97,7 +97,7 @@ type Engine struct {
 	errorCounts               *stats.CountersWithSingleLabel
 	vstreamersCreated         *stats.Counter
 	vstreamersEndedWithErrors *stats.Counter
-	vstreamerFlushBinlogs     *stats.Counter
+	vstreamerFlushedBinlogs   *stats.Counter
 
 	throttlerClient *throttle.Client
 }
@@ -134,7 +134,7 @@ func NewEngine(env tabletenv.Env, ts srvtopo.Server, se *schema.Engine, lagThrot
 		vstreamersCreated:         env.Exporter().NewCounter("VStreamersCreated", "Count of vstreamers created"),
 		vstreamersEndedWithErrors: env.Exporter().NewCounter("VStreamersEndedWithErrors", "Count of vstreamers that ended with errors"),
 		errorCounts:               env.Exporter().NewCountersWithSingleLabel("VStreamerErrors", "Tracks errors in vstreamer", "type", "Catchup", "Copy", "Send", "TablePlan"),
-		vstreamerFlushBinlogs:     env.Exporter().NewCounter("VStreamerFlushBinlogs", "Number of times we've issued a FLUSH BINARY LOGS when starting a vstream"),
+		vstreamerFlushedBinlogs:   env.Exporter().NewCounter("VStreamerFlushedBinlogs", "Number of times we've successfully executed a FLUSH BINARY LOGS statement when starting a vstream"),
 	}
 	env.Exporter().NewGaugeFunc("RowStreamerMaxInnoDBTrxHistLen", "", func() int64 { return env.Config().RowStreamer.MaxInnoDBTrxHistLen })
 	env.Exporter().NewGaugeFunc("RowStreamerMaxMySQLReplLagSecs", "", func() int64 { return env.Config().RowStreamer.MaxMySQLReplLagSecs })

--- a/go/vt/vttablet/tabletserver/vstreamer/resultstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/resultstreamer.go
@@ -72,8 +72,8 @@ func (rs *resultStreamer) Stream() error {
 		return err
 	}
 	defer conn.Close()
-	gtid, flushedLog, err := conn.streamWithSnapshot(rs.ctx, rs.tableName.String(), rs.query)
-	if flushedLog {
+	gtid, rotatedLog, err := conn.streamWithSnapshot(rs.ctx, rs.tableName.String(), rs.query)
+	if rotatedLog {
 		rs.vse.vstreamerFlushBinlogs.Add(1)
 	}
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/resultstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/resultstreamer.go
@@ -72,7 +72,10 @@ func (rs *resultStreamer) Stream() error {
 		return err
 	}
 	defer conn.Close()
-	gtid, err := conn.streamWithSnapshot(rs.ctx, rs.tableName.String(), rs.query)
+	gtid, flushedLog, err := conn.streamWithSnapshot(rs.ctx, rs.tableName.String(), rs.query)
+	if flushedLog {
+		rs.vse.vstreamerFlushBinlogs.Add(1)
+	}
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/resultstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/resultstreamer.go
@@ -74,7 +74,7 @@ func (rs *resultStreamer) Stream() error {
 	defer conn.Close()
 	gtid, rotatedLog, err := conn.streamWithSnapshot(rs.ctx, rs.tableName.String(), rs.query)
 	if rotatedLog {
-		rs.vse.vstreamerFlushBinlogs.Add(1)
+		rs.vse.vstreamerFlushedBinlogs.Add(1)
 	}
 	if err != nil {
 		return err

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -291,7 +291,10 @@ func (rs *rowStreamer) streamQuery(conn *snapshotConn, send func(*binlogdatapb.V
 	}
 
 	log.Infof("Streaming query: %v\n", rs.sendQuery)
-	gtid, err := conn.streamWithSnapshot(rs.ctx, rs.plan.Table.Name, rs.sendQuery)
+	gtid, flushedLog, err := conn.streamWithSnapshot(rs.ctx, rs.plan.Table.Name, rs.sendQuery)
+	if flushedLog {
+		rs.vse.vstreamerFlushBinlogs.Add(1)
+	}
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -293,7 +293,7 @@ func (rs *rowStreamer) streamQuery(conn *snapshotConn, send func(*binlogdatapb.V
 	log.Infof("Streaming query: %v\n", rs.sendQuery)
 	gtid, rotatedLog, err := conn.streamWithSnapshot(rs.ctx, rs.plan.Table.Name, rs.sendQuery)
 	if rotatedLog {
-		rs.vse.vstreamerFlushBinlogs.Add(1)
+		rs.vse.vstreamerFlushedBinlogs.Add(1)
 	}
 	if err != nil {
 		return err

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -291,8 +291,8 @@ func (rs *rowStreamer) streamQuery(conn *snapshotConn, send func(*binlogdatapb.V
 	}
 
 	log.Infof("Streaming query: %v\n", rs.sendQuery)
-	gtid, flushedLog, err := conn.streamWithSnapshot(rs.ctx, rs.plan.Table.Name, rs.sendQuery)
-	if flushedLog {
+	gtid, rotatedLog, err := conn.streamWithSnapshot(rs.ctx, rs.plan.Table.Name, rs.sendQuery)
+	if rotatedLog {
 		rs.vse.vstreamerFlushBinlogs.Add(1)
 	}
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 func registerSnapshotConnFlags(fs *pflag.FlagSet) {
-	fs.Int64Var(&binlogRotationThreshold, "vstream_binlog_rotation_threshold", binlogRotationThreshold, "Byte size at which a VStreamer will attempt to rotate the source's open binary log before starting a GTID snapshot based stream (e.g. a ResultStreamer or RowStreamer)")
+	fs.Int64Var(&binlogRotationThreshold, "vstream-binlog-rotation-threshold", binlogRotationThreshold, "Byte size at which a VStreamer will attempt to rotate the source's open binary log before starting a GTID snapshot based stream (e.g. a ResultStreamer or RowStreamer)")
 }
 
 func snapshotConnect(ctx context.Context, cp dbconfigs.Connector) (*snapshotConn, error) {

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -28,7 +28,7 @@ import (
 
 // byte size for the current binary log at which point we should
 // attempt to rotate it before starting the snapshot query.
-const binlogRotateSize = int64(1024 * 1024 * 64) // 64MiB
+const binlogRotateSize = int64(64 * 1024 * 1024) // 64MiB
 
 // snapshotConn is wrapper on mysql.Conn capable of
 // reading a table along with a gtid snapshot.
@@ -51,9 +51,9 @@ func snapshotConnect(ctx context.Context, cp dbconfigs.Connector) (*snapshotConn
 // startSnapshot starts a streaming query with a snapshot view of the specified table.
 // It returns the gtid of the time when the snapshot was taken.
 func (conn *snapshotConn) streamWithSnapshot(ctx context.Context, table, query string) (gtid string, flushedLog bool, err error) {
-	// Rotate the binary logs if needed to limit the GTID auto positioning overhead.
-	// This may be needed as the currently open binary log (which can be up to 1G in size
-	// by default) will need to be scanned and empty GTID events will be streamed for
+	// Rotate the binary log if needed to limit the GTID auto positioning overhead.
+	// This may be needed as the currently open binary log (which can be up to 1G in
+	// size by default) will need to be scanned and empty events will be streamed for
 	// those GTIDs in the log that we are skipping. In total, this can add a lot of
 	// overhead on both the mysqld instance and the tablet.
 	// Rotating the log when it's above a certain size ensures that we are processing

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -55,7 +55,10 @@ func (conn *snapshotConn) streamWithSnapshot(ctx context.Context, table, query s
 	// Rotating the log ensures that we are processing a fresh binary log that will
 	// be minimal in size and GTID events.
 	if _, err = conn.ExecuteFetch("FLUSH BINARY LOGS", 1, false); err != nil {
-		return "", err
+		// This is a best effort operation meant to lower overhead and improve performance.
+		// Thus it should not be required, nor cause the vstream operation to fail.
+		log.Warningf("Failed to flush binary logs in order to lessen overhead and improve performance of a VStream using query %q: %v",
+			query, err)
 	}
 
 	_, err = conn.ExecuteFetch("set session session_track_gtids = START_GTID", 1, false)

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -19,22 +19,37 @@ package vstreamer
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
+
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-// byte size for the current binary log at which point we should
-// attempt to rotate it before starting the snapshot query.
-const binlogRotateSize = int64(64 * 1024 * 1024) // 64MiB
+// If the current binary log is greater than this byte size, we
+// will attempt to rotate it before starting a GTID snapshot
+// based stream.
+// Default is 64MiB.
+var binlogRotationThreshold = int64(64 * 1024 * 1024) // 64MiB
 
 // snapshotConn is wrapper on mysql.Conn capable of
-// reading a table along with a gtid snapshot.
+// reading a table along with a GTID snapshot.
 type snapshotConn struct {
 	*mysql.Conn
 	cp dbconfigs.Connector
+}
+
+func init() {
+	servenv.OnParseFor("vtcombo", registerSnapshotConnFlags)
+	servenv.OnParseFor("vttablet", registerSnapshotConnFlags)
+}
+
+func registerSnapshotConnFlags(fs *pflag.FlagSet) {
+	fs.Int64Var(&binlogRotationThreshold, "vstream_binlog_rotation_threshold", binlogRotationThreshold, "Byte size at which a VStreamer will attempt to rotate the source's open binary log before starting a GTID snapshot based stream (e.g. a ResultStreamer or RowStreamer)")
 }
 
 func snapshotConnect(ctx context.Context, cp dbconfigs.Connector) (*snapshotConn, error) {
@@ -49,8 +64,8 @@ func snapshotConnect(ctx context.Context, cp dbconfigs.Connector) (*snapshotConn
 }
 
 // startSnapshot starts a streaming query with a snapshot view of the specified table.
-// It returns the gtid of the time when the snapshot was taken.
-func (conn *snapshotConn) streamWithSnapshot(ctx context.Context, table, query string) (gtid string, flushedLog bool, err error) {
+// It returns the GTID set from the time when the snapshot was taken.
+func (conn *snapshotConn) streamWithSnapshot(ctx context.Context, table, query string) (gtid string, rotatedLog bool, err error) {
 	// Rotate the binary log if needed to limit the GTID auto positioning overhead.
 	// This may be needed as the currently open binary log (which can be up to 1G in
 	// size by default) will need to be scanned and empty events will be streamed for
@@ -60,7 +75,7 @@ func (conn *snapshotConn) streamWithSnapshot(ctx context.Context, table, query s
 	// a relatively small binary log that will be minimal in size and GTID events.
 	// We only attempt to rotate it if the current log is of any significant size to
 	// avoid too many unecessary rotations.
-	if flushedLog, err = conn.limitOpenBinlogSize(binlogRotateSize); err != nil {
+	if rotatedLog, err = conn.limitOpenBinlogSize(); err != nil {
 		// This is a best effort operation meant to lower overhead and improve performance.
 		// Thus it should not be required, nor cause the operation to fail.
 		log.Warningf("Failed in attempt to potentially flush binary logs in order to lessen overhead and improve performance of a VStream using query %q: %v",
@@ -76,12 +91,12 @@ func (conn *snapshotConn) streamWithSnapshot(ctx context.Context, table, query s
 		gtid, err = conn.startSnapshotWithConsistentGTID(ctx)
 	}
 	if err != nil {
-		return "", flushedLog, err
+		return "", rotatedLog, err
 	}
 	if err := conn.ExecuteStreamFetch(query); err != nil {
-		return "", flushedLog, err
+		return "", rotatedLog, err
 	}
-	return gtid, flushedLog, nil
+	return gtid, rotatedLog, nil
 }
 
 // snapshot performs the snapshotting.
@@ -161,28 +176,42 @@ func mysqlConnect(ctx context.Context, cp dbconfigs.Connector) (*mysql.Conn, err
 }
 
 // limitOpenBinlogSize will rotate the binary log if the current binary
-// log is greater than the specified max size in bytes.
-func (conn *snapshotConn) limitOpenBinlogSize(maxBinlogSize int64) (bool, error) {
-	flushedLog := false
+// log is greater than binlogRotationThreshold.
+func (conn *snapshotConn) limitOpenBinlogSize() (bool, error) {
+	rotatedLog := false
 	// Output: https://dev.mysql.com/doc/refman/en/show-binary-logs.html
 	res, err := conn.ExecuteFetch("SHOW BINARY LOGS", -1, false)
 	if err != nil {
-		return flushedLog, err
+		return rotatedLog, err
 	}
 	if res == nil || len(res.Rows) == 0 {
-		return flushedLog, fmt.Errorf("SHOW BINARY LOGS returned no rows")
+		return rotatedLog, fmt.Errorf("SHOW BINARY LOGS returned no rows")
 	}
 	// the current log will be the last one in the results
 	curLogIdx := len(res.Rows) - 1
 	curLogSize, err := res.Rows[curLogIdx][1].ToInt64()
 	if err != nil {
-		return flushedLog, err
+		return rotatedLog, err
 	}
-	if curLogSize > maxBinlogSize {
+	if curLogSize > atomic.LoadInt64(&binlogRotationThreshold) {
 		if _, err = conn.ExecuteFetch("FLUSH BINARY LOGS", 0, false); err != nil {
-			return flushedLog, err
+			return rotatedLog, err
 		}
-		flushedLog = true
+		rotatedLog = true
 	}
-	return flushedLog, nil
+	return rotatedLog, nil
+}
+
+// GetBinlogRotationThreshold returns the current byte size at which a VStreamer
+// will attempt to rotate the binary log before starting a GTID snapshot based
+// stream (e.g. a ResultStreamer or RowStreamer).
+func GetBinlogRotationThreshold() int64 {
+	return atomic.LoadInt64(&binlogRotationThreshold)
+}
+
+// SetBinlogRotationThreshold sets the byte size at which a VStreamer will
+// attempt to rotate the binary log before starting a GTID snapshot based
+// stream (e.g. a ResultStreamer or RowStreamer).
+func SetBinlogRotationThreshold(threshold int64) {
+	atomic.StoreInt64(&binlogRotationThreshold, threshold)
 }

--- a/test/config.json
+++ b/test/config.json
@@ -1026,6 +1026,15 @@
 			"RetryMax": 2,
 			"Tags": []
 		},
+		"vstream_flush_binlog": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestVStreamFlushBinlog"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vreplication_basic",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"vstream_failover": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "VStreamFailover"],


### PR DESCRIPTION
## Description

Rotate the binary logs as needed in order to limit the GTID auto positioning overhead when starting a results/row stream from a given GTID set/position in VStreams. This is needed as the currently open binary log (which can be up to 1G in size by default) will need to be scanned and empty GTID events will be streamed for those GTIDs in the log that we are skipping. In total, this can add a lot of overhead on both the mysqld instance and the tablet. It can also cause a significant delay — particularly on connections with higher latency such as when the source and target are communicating over the internet with TLS — for otherwise fast actions such as VDiff on relatively small tables. Rotating the log ensures that we are processing a fresh binary log that will be minimal in size and GTID events.

> **Note**
>  We only rotate the binary log if it's > 64MiB in size by default. This avoids unnecessary flushes when there are many vstreams running  concurrently and/or there's very little write activity happening.

We had previously discovered this behavior during other events which require syncing with a GTID position/set, specifically during reparents, and used the same solution. See related issue and its links below.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/11345
  - Related to: https://github.com/vitessio/vitess/issues/4161

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added
-   [x] Documentation: https://github.com/vitessio/website/pull/1153