### PR TITLE
[cli] Migrate cmd/vtclient and cmd/vttablet from flag to pflag 

### DIFF
--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -64,18 +64,19 @@ Examples:
   $ vtclient --server vtgate:15991 --target '@primary' --bind_variables '[ 12345, 1, "msg 12345" ]' "INSERT INTO messages (page,time_created_ns,message) VALUES (:v1, :v2, :v3)"
 
 `
-	server        = flag.String("server", "", "vtgate server to connect to")
-	timeout       = flag.Duration("timeout", 30*time.Second, "timeout for queries")
-	streaming     = flag.Bool("streaming", false, "use a streaming query")
-	bindVariables = newBindvars("bind_variables", "bind variables as a json list")
-	targetString  = flag.String("target", "", "keyspace:shard@tablet_type")
-	jsonOutput    = flag.Bool("json", false, "Output JSON instead of human-readable table")
-	parallel      = flag.Int("parallel", 1, "DMLs only: Number of threads executing the same query in parallel. Useful for simple load testing.")
-	count         = flag.Int("count", 1, "DMLs only: Number of times each thread executes the query. Useful for simple, sustained load testing.")
-	minSeqID      = flag.Int("min_sequence_id", 0, "min sequence ID to generate. When max_sequence_id > min_sequence_id, for each query, a number is generated in [min_sequence_id, max_sequence_id) and attached to the end of the bind variables.")
-	maxSeqID      = flag.Int("max_sequence_id", 0, "max sequence ID.")
-	useRandom     = flag.Bool("use_random_sequence", false, "use random sequence for generating [min_sequence_id, max_sequence_id)")
-	qps           = flag.Int("qps", 0, "queries per second to throttle each thread at.")
+	server        string
+	streaming     bool
+	targetString  string
+	jsonOutput    bool
+	useRandom     bool
+	bindVariables *bindvars
+
+	timeout  = 30 * time.Second
+	parallel = 1
+	count    = 1
+	minSeqID = 0
+	maxSeqID = 0
+	qps      = 0
 )
 
 var (
@@ -86,6 +87,22 @@ func init() {
 	_flag.SetUsage(flag.CommandLine, _flag.UsageOptions{
 		Epilogue: func(w io.Writer) { fmt.Fprint(w, usage) },
 	})
+}
+
+func registerFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&server, "server", server, "vtgate server to connect to")
+	fs.DurationVar(&timeout, "timeout", timeout, "timeout for queries")
+	fs.BoolVar(&streaming, "streaming", streaming, "use a streaming query")
+	fs.StringVar(&targetString, "target", targetString, "keyspace:shard@tablet_type")
+	fs.BoolVar(&jsonOutput, "json", jsonOutput, "Output JSON instead of human-readable table")
+	fs.IntVar(&parallel, "parallel", parallel, "DMLs only: Number of threads executing the same query in parallel. Useful for simple load testing.")
+	fs.IntVar(&count, "count", count, "DMLs only: Number of times each thread executes the query. Useful for simple, sustained load testing.")
+	fs.IntVar(&minSeqID, "min_sequence_id", minSeqID, "min sequence ID to generate. When max_sequence_id > min_sequence_id, for each query, a number is generated in [min_sequence_id, max_sequence_id) and attached to the end of the bind variables.")
+	fs.IntVar(&maxSeqID, "max_sequence_id", maxSeqID, "max sequence ID.")
+	fs.BoolVar(&useRandom, "use_random_sequence", useRandom, "use random sequence for generating [min_sequence_id, max_sequence_id)")
+	fs.IntVar(&qps, "qps", qps, "queries per second to throttle each thread at.")
+
+	bindVariables = newBindvars(fs, "bind_variables", "bind variables as a json list")
 }
 
 type bindvars []any
@@ -123,9 +140,14 @@ func (bv *bindvars) Get() any {
 	return bv
 }
 
-func newBindvars(name, usage string) *bindvars {
+// Type is part of the pflag.Value interface. bindvars.Set() expects all numbers as float64.
+func (bv *bindvars) Type() string {
+	return "float64"
+}
+
+func newBindvars(fs *pflag.FlagSet, name, usage string) *bindvars {
 	var bv bindvars
-	flag.Var(&bv, name, usage)
+	fs.Var(&bv, name, usage)
 	return &bv
 }
 
@@ -133,7 +155,7 @@ func main() {
 	defer logutil.Flush()
 
 	qr, err := run()
-	if *jsonOutput && qr != nil {
+	if jsonOutput && qr != nil {
 		data, err := json.MarshalIndent(qr, "", "  ")
 		if err != nil {
 			log.Exitf("cannot marshal data: %v", err)
@@ -155,26 +177,27 @@ func run() (*results, error) {
 	log.RegisterFlags(fs)
 	logutil.RegisterFlags(fs)
 	servenv.RegisterMySQLServerFlags(fs)
+	registerFlags(fs)
 	_flag.Parse(fs)
 	args := _flag.Args()
 
 	if len(args) == 0 {
-		flag.Usage()
+		pflag.Usage()
 		return nil, errors.New("no arguments provided. See usage above")
 	}
 	if len(args) > 1 {
 		return nil, errors.New("no additional arguments after the query allowed")
 	}
 
-	if *maxSeqID > *minSeqID {
+	if maxSeqID > minSeqID {
 		go func() {
-			if *useRandom {
+			if useRandom {
 				rand.Seed(time.Now().UnixNano())
 				for {
-					seqChan <- rand.Intn(*maxSeqID-*minSeqID) + *minSeqID
+					seqChan <- rand.Intn(maxSeqID-minSeqID) + minSeqID
 				}
 			} else {
-				for i := *minSeqID; i < *maxSeqID; i++ {
+				for i := minSeqID; i < maxSeqID; i++ {
 					seqChan <- i
 				}
 			}
@@ -183,9 +206,9 @@ func run() (*results, error) {
 
 	c := vitessdriver.Configuration{
 		Protocol:  *vtgateconn.VtgateProtocol,
-		Address:   *server,
-		Target:    *targetString,
-		Streaming: *streaming,
+		Address:   server,
+		Target:    targetString,
+		Streaming: streaming,
 	}
 	db, err := vitessdriver.OpenWithConfiguration(c)
 	if err != nil {
@@ -194,7 +217,7 @@ func run() (*results, error) {
 
 	log.Infof("Sending the query...")
 
-	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	return execMulti(ctx, db, args[0])
 }
@@ -202,7 +225,7 @@ func run() (*results, error) {
 func prepareBindVariables() []any {
 	bv := make([]any, 0, len(*bindVariables)+1)
 	bv = append(bv, (*bindVariables)...)
-	if *maxSeqID > *minSeqID {
+	if maxSeqID > minSeqID {
 		bv = append(bv, <-seqChan)
 	}
 	return bv
@@ -214,10 +237,10 @@ func execMulti(ctx context.Context, db *sql.DB, sql string) (*results, error) {
 	wg := sync.WaitGroup{}
 	isDML := sqlparser.IsDML(sql)
 
-	isThrottled := *qps > 0
+	isThrottled := qps > 0
 
 	start := time.Now()
-	for i := 0; i < *parallel; i++ {
+	for i := 0; i < parallel; i++ {
 		wg.Add(1)
 
 		go func() {
@@ -225,11 +248,11 @@ func execMulti(ctx context.Context, db *sql.DB, sql string) (*results, error) {
 
 			var ticker *time.Ticker
 			if isThrottled {
-				tickDuration := time.Second / time.Duration(*qps)
+				tickDuration := time.Second / time.Duration(qps)
 				ticker = time.NewTicker(tickDuration)
 			}
 
-			for j := 0; j < *count; j++ {
+			for j := 0; j < count; j++ {
 				var qr *results
 				var err error
 				if isDML {
@@ -237,7 +260,7 @@ func execMulti(ctx context.Context, db *sql.DB, sql string) (*results, error) {
 				} else {
 					qr, err = execNonDml(ctx, db, sql)
 				}
-				if *count == 1 && *parallel == 1 {
+				if count == 1 && parallel == 1 {
 					all = qr
 				} else {
 					all.merge(qr)

--- a/go/cmd/vtclient/vtclient_test.go
+++ b/go/cmd/vtclient/vtclient_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/vttest"
 
@@ -120,10 +121,10 @@ func TestVtclient(t *testing.T) {
 	}
 
 	// Change ErrorHandling from ExitOnError to panicking.
-	flag.CommandLine.Init("vtclient_test.go", flag.PanicOnError)
+	pflag.CommandLine.Init("vtclient_test.go", pflag.PanicOnError)
 	for _, q := range queries {
 		// Run main function directly and not as external process. To achieve this,
-		// overwrite os.Args which is used by flag.Parse().
+		// overwrite os.Args which is used by pflag.Parse().
 		os.Args = []string{"vtclient_test.go", "--server", vtgateAddr}
 		os.Args = append(os.Args, q.args...)
 

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -381,7 +381,7 @@ Usage of vttablet:
       --stderrthreshold severity                                         logs at or above this threshold go to stderr (default 1)
       --stream_health_buffer_size uint                                   max streaming health entries to buffer per streaming health client (default 20)
       --table-acl-config string                                          path to table access checker config file; send SIGHUP to reload this file
-      --table-acl-config-reload-interval duration                        Ticker to reload ACLs. Duration flag, format e.g.: 30s. Default: do not reload (default 0s)
+      --table-acl-config-reload-interval duration                        Ticker to reload ACLs. Duration flag, format e.g.: 30s. Default: do not reload
       --table_gc_lifecycle string                                        States for a DROP TABLE garbage collection cycle. Default is 'hold,purge,evac,drop', use any subset ('drop' implcitly always included) (default "hold,purge,evac,drop")
       --tablet-path string                                               tablet alias
       --tablet_config string                                             YAML file config for tablet


### PR DESCRIPTION

## Description

Migrate the vtclient and vttablet cmds to pflag

## Related Issue(s)
Fixes #11288
Fixes #11289

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
