### PR TITLE
[cli] Migrate cmd/vtctld to pflag

### DIFF
--- a/go/cmd/vtctld/schema.go
+++ b/go/cmd/vtctld/schema.go
@@ -17,10 +17,10 @@ limitations under the License.
 package main
 
 import (
-	"flag"
+	"context"
 	"time"
 
-	"context"
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"
@@ -32,31 +32,42 @@ import (
 )
 
 var (
-	schemaChangeDir             = flag.String("schema_change_dir", "", "directory contains schema changes for all keyspaces. Each keyspace has its own directory and schema changes are expected to live in '$KEYSPACE/input' dir. e.g. test_keyspace/input/*sql, each sql file represents a schema change")
-	schemaChangeController      = flag.String("schema_change_controller", "", "schema change controller is responsible for finding schema changes and responding to schema change events")
-	schemaChangeCheckInterval   = flag.Int("schema_change_check_interval", 60, "this value decides how often we check schema change dir, in seconds")
-	schemaChangeUser            = flag.String("schema_change_user", "", "The user who submits this schema change.")
-	schemaChangeReplicasTimeout = flag.Duration("schema_change_replicas_timeout", wrangler.DefaultWaitReplicasTimeout, "how long to wait for replicas to receive the schema change")
+	schemaChangeDir             string
+	schemaChangeController      string
+	schemaChangeUser            string
+	schemaChangeCheckInterval   = 60
+	schemaChangeReplicasTimeout = wrangler.DefaultWaitReplicasTimeout
 )
+
+func init() {
+	servenv.OnParse(func(fs *pflag.FlagSet) {
+		fs.StringVar(&schemaChangeDir, "schema_change_dir", schemaChangeDir, "Directory containing schema changes for all keyspaces. Each keyspace has its own directory, and schema changes are expected to live in '$KEYSPACE/input' dir. (e.g. 'test_keyspace/input/*sql'). Each sql file represents a schema change.")
+		fs.StringVar(&schemaChangeController, "schema_change_controller", schemaChangeController, "Schema change controller is responsible for finding schema changes and responding to schema change events.")
+		fs.StringVar(&schemaChangeUser, "schema_change_user", schemaChangeUser, "The user who schema changes are submitted on behalf of.")
+
+		fs.IntVar(&schemaChangeCheckInterval, "schema_change_check_interval", schemaChangeCheckInterval, "How often the schema change dir is checked for schema changes, in seconds.")
+		fs.DurationVar(&schemaChangeReplicasTimeout, "schema_change_replicas_timeout", schemaChangeReplicasTimeout, "How long to wait for replicas to receive a schema change.")
+	})
+}
 
 func initSchema() {
 	// Start schema manager service if needed.
-	if *schemaChangeDir != "" {
+	if schemaChangeDir != "" {
 		interval := 60
-		if *schemaChangeCheckInterval > 0 {
-			interval = *schemaChangeCheckInterval
+		if schemaChangeCheckInterval > 0 {
+			interval = schemaChangeCheckInterval
 		}
 		timer := timer.NewTimer(time.Duration(interval) * time.Second)
 		controllerFactory, err :=
-			schemamanager.GetControllerFactory(*schemaChangeController)
+			schemamanager.GetControllerFactory(schemaChangeController)
 		if err != nil {
 			log.Fatalf("unable to get a controller factory, error: %v", err)
 		}
 
 		timer.Start(func() {
 			controller, err := controllerFactory(map[string]string{
-				schemamanager.SchemaChangeDirName: *schemaChangeDir,
-				schemamanager.SchemaChangeUser:    *schemaChangeUser,
+				schemamanager.SchemaChangeDirName: schemaChangeDir,
+				schemamanager.SchemaChangeUser:    schemaChangeUser,
 			})
 			if err != nil {
 				log.Errorf("failed to get controller, error: %v", err)
@@ -67,7 +78,7 @@ func initSchema() {
 			_, err = schemamanager.Run(
 				ctx,
 				controller,
-				schemamanager.NewTabletExecutor("vtctld/schema", wr.TopoServer(), wr.TabletManagerClient(), wr.Logger(), *schemaChangeReplicasTimeout),
+				schemamanager.NewTabletExecutor("vtctld/schema", wr.TopoServer(), wr.TabletManagerClient(), wr.Logger(), schemaChangeReplicasTimeout),
 			)
 			if err != nil {
 				log.Errorf("Schema change failed, error: %v", err)

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -112,11 +112,11 @@ Usage of vtctld:
       --s3_backup_storage_bucket string                                  S3 bucket to use for backups.
       --s3_backup_storage_root string                                    root prefix for all backup-related object names.
       --s3_backup_tls_skip_verify_cert                                   skip the 'certificate is valid' check for SSL connections.
-      --schema_change_check_interval int                                 this value decides how often we check schema change dir, in seconds (default 60)
-      --schema_change_controller string                                  schema change controller is responsible for finding schema changes and responding to schema change events
-      --schema_change_dir string                                         directory contains schema changes for all keyspaces. Each keyspace has its own directory and schema changes are expected to live in '$KEYSPACE/input' dir. e.g. test_keyspace/input/*sql, each sql file represents a schema change
-      --schema_change_replicas_timeout duration                          how long to wait for replicas to receive the schema change (default 10s)
-      --schema_change_user string                                        The user who submits this schema change.
+      --schema_change_check_interval int                                 How often the schema change dir is checked for schema changes, in seconds. (default 60)
+      --schema_change_controller string                                  Schema change controller is responsible for finding schema changes and responding to schema change events.
+      --schema_change_dir string                                         Directory containing schema changes for all keyspaces. Each keyspace has its own directory, and schema changes are expected to live in '$KEYSPACE/input' dir. (e.g. 'test_keyspace/input/*sql'). Each sql file represents a schema change.
+      --schema_change_replicas_timeout duration                          How long to wait for replicas to receive a schema change. (default 10s)
+      --schema_change_user string                                        The user who schema changes are submitted on behalf of.
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service_map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
       --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -112,7 +112,7 @@ Usage of vtctld:
       --s3_backup_storage_bucket string                                  S3 bucket to use for backups.
       --s3_backup_storage_root string                                    root prefix for all backup-related object names.
       --s3_backup_tls_skip_verify_cert                                   skip the 'certificate is valid' check for SSL connections.
-      --schema_change_check_interval int                                 How often the schema change dir is checked for schema changes, in seconds. (default 60)
+      --schema_change_check_interval duration                            How often the schema change dir is checked for schema changes (deprecated: if passed as a bare integer, the duration will be in seconds). (default 1m0s)
       --schema_change_controller string                                  Schema change controller is responsible for finding schema changes and responding to schema change events.
       --schema_change_dir string                                         Directory containing schema changes for all keyspaces. Each keyspace has its own directory, and schema changes are expected to live in '$KEYSPACE/input' dir. (e.g. 'test_keyspace/input/*sql'). Each sql file represents a schema change.
       --schema_change_replicas_timeout duration                          How long to wait for replicas to receive a schema change. (default 10s)

--- a/go/flagutil/flagutil.go
+++ b/go/flagutil/flagutil.go
@@ -23,9 +23,13 @@ import (
 	"flag"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/pflag"
+
+	"vitess.io/vitess/go/vt/log"
 )
 
 var (
@@ -188,3 +192,63 @@ func DualFormatBoolVar(fs *pflag.FlagSet, p *bool, name string, value bool, usag
 		flag.BoolVar(p, dashes, *p, fmt.Sprintf("Synonym to -%s", underscores))
 	}
 }
+
+// DurationOrIntVar implements pflag.Value for flags that have historically been
+// of type IntVar (and then converted to seconds or some other unit) but are
+// now transitioning to a proper DurationVar type.
+//
+// When parsing a command-line argument, it will first attempt to parse the
+// argument using time.ParseDuration; if this fails, it will fallback to
+// strconv.ParseInt and multiply that value by the `fallback` unit value to get
+// a duration. If the initial ParseDuration fails, it will also log a
+// deprecation warning.
+type DurationOrIntVar struct {
+	name     string
+	val      time.Duration
+	fallback time.Duration
+}
+
+// NewDurationOrIntVar returns a new DurationOrIntVar struct with the given name,
+// default value, and fallback unit.
+//
+// The name is used only when issuing a deprecation warning (so the user knows
+// which flag needs its argument format updated).
+//
+// The `fallback` argument is used when parsing an argument as an int (legacy behavior) as the multiplier
+// to get a time.Duration value. As an example, if a flag used to be "the amount
+// of time to wait in seconds" with a default of 60, you would do:
+//
+//	myFlag := flagutil.NewDurationOrIntVar("my-flag", time.Minute /* 60 second default */, time.Second /* fallback unit to multiply by */)
+func NewDurationOrIntVar(name string, val time.Duration, fallback time.Duration) *DurationOrIntVar {
+	return &DurationOrIntVar{name: name, val: val, fallback: fallback}
+}
+
+// Set is part of the pflag.Value interface.
+func (v *DurationOrIntVar) Set(s string) error {
+	d, derr := time.ParseDuration(s)
+	if derr != nil {
+		msg := &strings.Builder{}
+		fmt.Fprintf(msg, "non-duration value passed to %s (error: %s)", v.name, derr)
+
+		i, ierr := strconv.ParseInt(s, 10, 64)
+		if ierr != nil {
+			log.Warningf("%s; attempted to parse as int in %s, which failed with %s", msg.String(), v.fallback, ierr)
+			return ierr
+		}
+
+		d = time.Duration(i) * v.fallback
+		log.Warningf("%s; parsed as int to %s, which is deprecated behavior", d)
+	}
+
+	v.val = d
+	return nil
+}
+
+// String is part of the pflag.Value interface.
+func (v *DurationOrIntVar) String() string { return v.val.String() }
+
+// Type is part of the pflag.Type interface.
+func (v *DurationOrIntVar) Type() string { return "duration" }
+
+// Value returns the underlying Duration value passed to the flag.
+func (v *DurationOrIntVar) Value() time.Duration { return v.val }


### PR DESCRIPTION


## Description

As a bonus, introduces a new flag type so I could move the `schemaChangeCheckInterval` flag from "give us an int and we'll force it into seconds" to "we will accept an actual time.Duration argument" without breaking anyone.

## Related Issue(s)

- Closes #11282 

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
