### PR TITLE
Flakes: Fix Backup Transform Test Flakiness

### DIFF
--- a/go/test/endtoend/backup/transform/backup_transform_utils.go
+++ b/go/test/endtoend/backup/transform/backup_transform_utils.go
@@ -31,6 +31,7 @@ import (
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/vt/log"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 // test main part of the testcase
@@ -38,6 +39,7 @@ var (
 	primary          *cluster.Vttablet
 	replica1         *cluster.Vttablet
 	replica2         *cluster.Vttablet
+	testTablets      []*cluster.Vttablet
 	localCluster     *cluster.LocalProcessCluster
 	newInitDBFile    string
 	cell             = cluster.DefaultCell
@@ -142,8 +144,9 @@ func TestMainSetup(m *testing.M, useMysqlctld bool) {
 		primary = shard.Vttablets[0]
 		replica1 = shard.Vttablets[1]
 		replica2 = shard.Vttablets[2]
+		testTablets = []*cluster.Vttablet{primary, replica1, replica2}
 
-		for _, tablet := range []*cluster.Vttablet{primary, replica1} {
+		for _, tablet := range testTablets {
 			if err := localCluster.VtctlclientProcess.InitTablet(tablet, cell, keyspaceName, hostname, shard.Name); err != nil {
 				return 1, err
 			}
@@ -154,8 +157,8 @@ func TestMainSetup(m *testing.M, useMysqlctld bool) {
 			return 1, err
 		}
 
-		// create database for primary and replica
-		for _, tablet := range []cluster.Vttablet{*primary, *replica1} {
+		// create database for primary and replicas
+		for _, tablet := range testTablets {
 			if err := tablet.VttabletProcess.CreateDB(keyspaceName); err != nil {
 				return 1, err
 			}
@@ -168,6 +171,7 @@ func TestMainSetup(m *testing.M, useMysqlctld bool) {
 		if err := localCluster.VtctlclientProcess.InitShardPrimary(keyspaceName, shard.Name, cell, primary.TabletUID); err != nil {
 			return 1, err
 		}
+		primary.Type = topodatapb.TabletType_PRIMARY.String()
 		return m.Run(), nil
 	}()
 
@@ -177,7 +181,6 @@ func TestMainSetup(m *testing.M, useMysqlctld bool) {
 	} else {
 		os.Exit(exitCode)
 	}
-
 }
 
 // create query for test table creation
@@ -193,7 +196,7 @@ func TestBackupTransformImpl(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	verifyInitialReplication(t)
 
-	// restart the replica with transform hook parameter
+	// restart the replica1 tablet with transform hook parameter
 	replica1.VttabletProcess.TearDown()
 	replica1.VttabletProcess.ExtraArgs = []string{
 		"--db-credentials-file", dbCredentialFile,
@@ -214,15 +217,18 @@ func TestBackupTransformImpl(t *testing.T) {
 	err = localCluster.VtctlclientProcess.ExecuteCommand("Backup", replica1.Alias)
 	require.Nil(t, err)
 
+	log.Errorf("Inserting data...")
 	// insert data in primary
 	_, err = primary.VttabletProcess.QueryTablet("insert into vt_insert_test (msg) values ('test2')", keyspaceName, true)
 	require.Nil(t, err)
 
+	log.Errorf("Verifying backup...")
 	// validate backup_list, expecting 1 backup available
 	backups := localCluster.VerifyBackupCount(t, shardKsName, 1)
 
 	backupLocation := localCluster.CurrentVTDATAROOT + "/backups/" + shardKsName + "/" + backups[0]
 
+	log.Errorf("Validating manifest...")
 	// validate that MANIFEST has TransformHook
 	// every file should start with 'header'
 	validateManifestFile(t, backupLocation)
@@ -232,23 +238,27 @@ func TestBackupTransformImpl(t *testing.T) {
 	// as it is read from the MANIFEST.
 	// clear replica2
 
+	// Stop the tablet
+	replica2.VttabletProcess.TearDown()
+	// Remove the data
 	if replica2.MysqlctlProcess.TabletUID > 0 {
-		replica2.MysqlctlProcess.Stop()
-		os.RemoveAll(replica2.VttabletProcess.Directory)
-		// start replica2 from backup
+		err = replica2.MysqlctlProcess.Stop()
+		require.NoError(t, err)
+		replica2.MysqlctlProcess.CleanupFiles(replica2.TabletUID)
 		err = replica2.MysqlctlProcess.Start()
 		require.Nil(t, err)
 	} else {
-		replica2.MysqlctldProcess.Stop()
-		os.RemoveAll(replica2.VttabletProcess.Directory)
-		// start replica2 from backup
+		err = replica2.MysqlctldProcess.Stop()
+		require.NoError(t, err)
+		replica2.MysqlctldProcess.CleanupFiles(replica2.TabletUID)
+		require.NoError(t, err)
 		err = replica2.MysqlctldProcess.Start()
 		require.Nil(t, err)
 	}
 
+	// Start from the backup
 	err = localCluster.VtctlclientProcess.InitTablet(replica2, cell, keyspaceName, hostname, shardName)
 	require.Nil(t, err)
-	replica2.VttabletProcess.CreateDB(keyspaceName)
 	replica2.VttabletProcess.ExtraArgs = []string{
 		"--db-credentials-file", dbCredentialFile,
 		"--restore_from_backup",
@@ -257,7 +267,7 @@ func TestBackupTransformImpl(t *testing.T) {
 	replica2.VttabletProcess.ServingStatus = ""
 	err = replica2.VttabletProcess.Setup()
 	require.Nil(t, err)
-	err = replica2.VttabletProcess.WaitForTabletStatusesForTimeout([]string{"SERVING"}, 25*time.Second)
+	err = replica2.VttabletProcess.WaitForTabletStatusesForTimeout([]string{"SERVING"}, 30*time.Second)
 	require.Nil(t, err)
 	defer replica2.VttabletProcess.TearDown()
 	// We restart replication here because semi-sync will not be set correctly on tablet startup since
@@ -358,11 +368,33 @@ func verifySemiSyncStatus(t *testing.T, vttablet *cluster.Vttablet, expectedStat
 	assert.Equal(t, expectedStatus, status)
 }
 
-// verifyInitialReplication creates schema in primary, insert some data to primary and verify the same data in replica
+// verifyInitialReplication generates a record on the primary and verifies that the record
+// exists on all tablets in the shard. We also check the PRIMARY as with lossless semi-sync
+// it's possible that a GTID is applied on a replica but not the source.
 func verifyInitialReplication(t *testing.T) {
+	// confirm that semi-sync is enabled for the replica tablets
+	healthyReplicaCount := 0
+	for _, tablet := range testTablets {
+		if tablet.Type == "replica" {
+			t.Logf("verifying replica semi-sync status on %s tablet...", tablet.Alias)
+			verifySemiSyncStatus(t, tablet, "ON")
+			healthyReplicaCount++
+		}
+	}
+
+	if healthyReplicaCount < 2 {
+		log.Errorf("Not enough healthy replicas to guarantee safe backups when semi-sync is enabled! Should have at least two, currently have %d",
+			healthyReplicaCount)
+	}
+
 	_, err := primary.VttabletProcess.QueryTablet(vtInsertTest, keyspaceName, true)
 	require.Nil(t, err)
+	t.Logf("Inserting test record on primary tablet...")
 	_, err = primary.VttabletProcess.QueryTablet("insert into vt_insert_test (msg) values ('test1')", keyspaceName, true)
 	require.Nil(t, err)
-	cluster.VerifyRowsInTablet(t, replica1, keyspaceName, 1)
+
+	for _, tablet := range testTablets {
+		t.Logf("Verifying that test record exists on the %s tablet's mysqld...", tablet.Alias)
+		cluster.VerifyRowsInTablet(t, tablet, keyspaceName, 1)
+	}
 }

--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -271,9 +271,8 @@ func resetTabletDirectory(t *testing.T, tablet cluster.Vttablet, initMysql bool)
 	err = tablet.VttabletProcess.TearDown()
 	require.Nil(t, err)
 
-	// Empty the dir
-	err = os.RemoveAll(tablet.VttabletProcess.Directory)
-	require.Nil(t, err)
+	// Clear out the previous data
+	tablet.MysqlctlProcess.CleanupFiles(tablet.TabletUID)
 
 	if initMysql {
 		// Init the Mysql

--- a/test/config.json
+++ b/test/config.json
@@ -120,7 +120,7 @@
 		},
 		"backup_transform": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/backup/transform", "-timeout", "30m"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/backup/transform", "-timeout", "15m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "vtbackup_transform",

--- a/test/config.json
+++ b/test/config.json
@@ -111,7 +111,7 @@
 		},
 		"backup_only": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/backup/vtbackup", "-timeout", "30m"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/backup/vtbackup", "-timeout", "20m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "vtbackup_transform",


### PR DESCRIPTION
## Description

The `TestBackupTransform` test was not fully adjusted for MySQL Semi-Sync replication when we enabled it for all tests. I say that because the test only initially setup a single PRIMARY and a single REPLICA tablet. With [lossless semi-sync](http://my-replication-life.blogspot.com/2013/09/loss-less-semi-synchronous-replication.html) — which is [the default ](https://dev.mysql.com/doc/refman/en/replication-options-source.html#sysvar_rpl_semi_sync_master_wait_point)— this means that we only have a single ACKer and if that ACKer / REPLICA tablet is shutdown after receiving the GTID but before ACKing it, the GTID will exist on the REPLICA (will be applied from the local relay log by the time it starts up again) but will NOT exist on the PRIMARY. At this point the PRIMARY is also left indefinitely waiting for an ACK and is blocked from making further changes.

In the built-in backup engine, we enter this for loop because the REPLICA's GTID position will not equal the PRIMARY's, and we do not exit the for loop until we hit the 1 hour timeout for the Backup RPC call because the REPLICA's position will never change/advance because we don't execute any more statements on the PRIMARY (and if we tried, the PRIMARY will block it anyway as it's still waiting for an ACK on the previous GTID): https://github.com/vitessio/vitess/blob/d281e580a15b777208adf44ed2d584f4647ba917/go/vt/mysqlctl/builtinbackupengine.go#L262-L283

This PR addresses the problems by:
1. Initially setting up 2 REPLICA tablets so that we have 2 ACKers and the `replica2` will also ACK the GTID even if `replica1` does not due to being shutdown for the backup
2. Confirming that semi-sync replication is setup properly on both REPLICAs
3. Confirming that the test data exists on the PRIMARY and both REPLICAs before proceeding with the Backup

For whatever reasons, the test when run in the CI would trigger this race condition regularly. Before this PR, I would guess that the `TestBackupTransform` test was anecdotally failing over 50% of the time based on my personal experience. With these fixes, it successfully ran 20 times in a row:
  - https://github.com/vitessio/vitess/actions/runs/3131716643 (failed workflow runs were NOT due to the transform test)
  - https://github.com/vitessio/vitess/actions/runs/3132595831 (after the fix for reliably clearing out existing tablet data noted below, BOTH tests in the workflow passed every time — 12 times in a row)

> **Note**
> The workflow was still pretty flaky because of the `TestBackup` test. That needed to be investigated and fixed separately. In those failures I saw this sequence:
>   - `Error:      	Expected nil, but got: &fs.PathError{Op:"unlinkat", Path:"/tmp/vt_685235216/vtroot_16001/vt_0000002723", Err:0x27}` (0x27 is decimal 39 which is OS error `ENOTEMPTY`) followed by:
>   - `vttablet.go:170] mycnf read failed: open /tmp/vt_784732455/vtroot_16001/vt_0000005331/my.cnf: no such file or directory` followed by:
>   - `Expected nil, but got: &errors.errorString{s:"process 'vttablet' timed out after 10s (err: process 'vttablet' exited prematurely (err: exit status 1))"}`

So in order to fix that remaining flakiness due to the sequence of errors (successful runs did not have the `unlinkat` errors while all of the failed ones did) this PR also [uses a more reliable method for clearing out existing vttablet/mysql data](https://github.com/vitessio/vitess/pull/11352/commits/351e1b698909cbac493783f30bc3cf998e6cc986).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were updated
-   [x] Documentation is not required