### PR TITLE
Fix flags in vttestserver run script used in the docker image

### DIFF
--- a/docker/vttestserver/run.sh
+++ b/docker/vttestserver/run.sh
@@ -31,16 +31,16 @@ rm -vf "$VTDATAROOT"/"$tablet_dir"/{mysql.sock,mysql.sock.lock}
 
 # Run the vttestserver binary
 /vt/bin/vttestserver \
-	-port "$PORT" \
-	-keyspaces "$KEYSPACES" \
-	-num_shards "$NUM_SHARDS" \
-	-mysql_bind_host "${MYSQL_BIND_HOST:-127.0.0.1}" \
-	-mysql_server_version "${MYSQL_SERVER_VERSION:-$1}" \
-	-charset "${CHARSET:-utf8mb4}" \
-	-foreign_key_mode "${FOREIGN_KEY_MODE:-allow}" \
-	-enable_online_ddl="${ENABLE_ONLINE_DDL:-true}" \
-	-enable_direct_ddl="${ENABLE_DIRECT_DDL:-true}" \
-	-planner-version="${PLANNER_VERSION:-v3}" \
-	-vschema_ddl_authorized_users=% \
-	-schema_dir="/vt/schema/"
+	--port "$PORT" \
+	--keyspaces "$KEYSPACES" \
+	--num_shards "$NUM_SHARDS" \
+	--mysql_bind_host "${MYSQL_BIND_HOST:-127.0.0.1}" \
+	--mysql_server_version "${MYSQL_SERVER_VERSION:-$1}" \
+	--charset "${CHARSET:-utf8mb4}" \
+	--foreign_key_mode "${FOREIGN_KEY_MODE:-allow}" \
+	--enable_online_ddl="${ENABLE_ONLINE_DDL:-true}" \
+	--enable_direct_ddl="${ENABLE_DIRECT_DDL:-true}" \
+	--planner-version="${PLANNER_VERSION:-v3}" \
+	--vschema_ddl_authorized_users=% \
+	--schema_dir="/vt/schema/"
 


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the vttestserver docker image by fixing the flags passed to the vttestserver binary by it. This change is required since we moved to the `pflag` package to parse flags which required double-dashed arguments.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #11353 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
