### PR TITLE
advisory lock to acquire reserve connection only for get_lock

### DIFF
--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -2928,6 +2928,33 @@ func TestSelectLock(t *testing.T) {
 	utils.MustMatch(t, wantSession, session.Session, "")
 }
 
+func TestLockReserve(t *testing.T) {
+	// no connection should be reserved for these queries.
+	tcases := []string{
+		"select is_free_lock('lock name') from dual",
+		"select is_used_lock('lock name') from dual",
+		"select release_all_locks() from dual",
+		"select release_lock('lock name') from dual",
+	}
+
+	executor, _, _, _ := createExecutorEnv()
+	session := NewAutocommitSession(&vtgatepb.Session{})
+
+	for _, sql := range tcases {
+		t.Run(sql, func(t *testing.T) {
+			_, err := exec(executor, session, sql)
+			require.NoError(t, err)
+			require.Nil(t, session.LockSession)
+		})
+	}
+
+	// get_lock should reserve a connection.
+	_, err := exec(executor, session, "select get_lock('lock name', 10) from dual")
+	require.NoError(t, err)
+	require.NotNil(t, session.LockSession)
+
+}
+
 func TestSelectFromInformationSchema(t *testing.T) {
 	executor, sbc1, _, _ := createExecutorEnv()
 	session := NewSafeSession(nil)

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -839,12 +839,12 @@ func lockInfo(target *querypb.Target, session *SafeSession, lockFuncType sqlpars
 		info.reservedID = session.LockSession.ReservedId
 		info.alias = session.LockSession.TabletAlias
 	}
-	// TODO: after release 14.0, uncomment this line.
-	// This commented for backward compatiblity as there is a specific check in vttablet for lock functions,
-	// to always be on reserved connection.
-	// if lockFuncType != sqlparser.GetLock {
-	//	return info, nil
-	// }
+	// Only GetLock needs to start a reserved connection.
+	// Once in reserved connection, it will be used for other calls as well.
+	// But, we don't want to start a reserved connection for other calls like IsFreeLock, IsUsedLock, etc.
+	if lockFuncType != sqlparser.GetLock {
+		return info, nil
+	}
 	if info.reservedID == 0 {
 		info.actionNeeded = reserve
 	}


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR ensures that connection is only reserved when a get_lock advisory function is present in the query.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Closes https://github.com/vitessio/vitess/issues/10436

## Checklist

-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
