### PR TITLE
fix: store the output of the rewrite

### DIFF
--- a/go/vt/vtgate/planbuilder/abstract/derived.go
+++ b/go/vt/vtgate/planbuilder/abstract/derived.go
@@ -50,7 +50,7 @@ func (d *Derived) PushPredicate(expr sqlparser.Expr, semTable *semantics.SemTabl
 		return nil, err
 	}
 
-	newExpr, err := semantics.RewriteDerivedExpression(expr, tableInfo)
+	newExpr, err := semantics.RewriteDerivedTableExpression(expr, tableInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/physical/operator_funcs.go
+++ b/go/vt/vtgate/planbuilder/physical/operator_funcs.go
@@ -130,7 +130,7 @@ func PushPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr, op abs
 			}
 			return nil, err
 		}
-		newExpr, err := semantics.RewriteDerivedExpression(expr, tableInfo)
+		newExpr, err := semantics.RewriteDerivedTableExpression(expr, tableInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -220,7 +220,7 @@ func PushOutputColumns(ctx *plancontext.PlanningContext, op abstract.PhysicalOpe
 		if len(columns) == 0 {
 			return op, nil, nil
 		}
-		for _, col := range columns { ///select 1 from (select * from user join user_extra) t join unsharded on t.id = unsharded.apa
+		for _, col := range columns { // /select 1 from (select * from user join user_extra) t join unsharded on t.id = unsharded.apa
 			i, err := op.findOutputColumn(col)
 			if err != nil {
 				return nil, nil, err

--- a/go/vt/vtgate/planbuilder/physical/route_planning.go
+++ b/go/vt/vtgate/planbuilder/physical/route_planning.go
@@ -1193,7 +1193,7 @@ func pushJoinPredicateOnDerived(ctx *plancontext.PlanningContext, exprs []sqlpar
 		if err != nil {
 			return nil, err
 		}
-		rewritten, err := semantics.RewriteDerivedExpression(expr, tblInfo)
+		rewritten, err := semantics.RewriteDerivedTableExpression(expr, tblInfo)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/planbuilder/projection_pushing.go
+++ b/go/vt/vtgate/planbuilder/projection_pushing.go
@@ -327,7 +327,7 @@ func rewriteProjectionOfDerivedTable(expr *sqlparser.AliasedExpr, semTable *sema
 	}
 	_, isDerivedTable := ti.(*semantics.DerivedTable)
 	if isDerivedTable {
-		expr.Expr, err = semantics.RewriteDerivedExpression(expr.Expr, ti)
+		expr.Expr, err = semantics.RewriteDerivedTableExpression(expr.Expr, ti)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -6066,3 +6066,47 @@ Gen4 plan same as above
     "user.authoritative"
   ]
 }
+
+
+"select * from (select bar as push_it from (select foo as bar from (select id as foo from user) as t1) as t2) as t3 where push_it = 12"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from (select bar as push_it from (select foo as bar from (select id as foo from user) as t1) as t2) as t3 where push_it = 12",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from (select bar as push_it from (select foo as bar from (select id as foo from `user` where 1 != 1) as t1 where 1 != 1) as t2 where 1 != 1) as t3 where 1 != 1",
+    "Query": "select * from (select bar as push_it from (select foo as bar from (select id as foo from `user`) as t1) as t2) as t3 where push_it = 12",
+    "Table": "`user`",
+    "Values": [
+      "INT64(12)"
+    ],
+    "Vindex": "user_index"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from (select bar as push_it from (select foo as bar from (select id as foo from user) as t1) as t2) as t3 where push_it = 12",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "EqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select t3.push_it from (select bar as push_it from (select foo as bar from (select id as foo from `user` where 1 != 1) as t1 where 1 != 1) as t2 where 1 != 1) as t3 where 1 != 1",
+    "Query": "select t3.push_it from (select bar as push_it from (select foo as bar from (select id as foo from `user` where id = 12) as t1) as t2) as t3",
+    "Table": "`user`",
+    "Values": [
+      "INT64(12)"
+    ],
+    "Vindex": "user_index"
+  },
+  "TablesUsed": [
+    "user.user"
+  ]
+}


### PR DESCRIPTION
## Description
When pushing predicates and projections into derived tables, we were not catching the outer rewrite.

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
