### PR TITLE
Migrates `release-notes` to pflag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -491,7 +491,7 @@ generate_ci_workflows:
 	cd test && go run ci_workflow_gen.go && cd ..
 
 release-notes:
-	go run ./go/tools/release-notes -from "$(FROM)" -to "$(TO)" -version "$(VERSION)" -summary "$(SUMMARY)"
+	go run ./go/tools/release-notes --from "$(FROM)" --to "$(TO)" --version "$(VERSION)" --summary "$(SUMMARY)"
 
 install_kubectl_kind:
 	./tools/get_kubectl_kind.sh

--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -490,12 +490,13 @@ func groupAndStringifyPullRequest(pr []prInfo) (string, error) {
 
 func main() {
 	var (
-		from, to, versionName, summaryFile string
+		from, versionName, summaryFile string
+		to                             = "HEAD"
 	)
-	pflag.StringVar(&from, "from", "", "from sha/tag/branch")
-	pflag.StringVar(&to, "to", "HEAD", "to sha/tag/branch")
-	pflag.StringVar(&versionName, "version", "", "name of the version (has to be the following format: v11.0.0)")
-	pflag.StringVar(&summaryFile, "summary", "", "readme file on which there is a summary of the release")
+	pflag.StringVarP(&from, "from", "f", "", "from sha/tag/branch")
+	pflag.StringVarP(&to, "to", to, "t", "to sha/tag/branch")
+	pflag.StringVarP(&versionName, "version", "v", "", "name of the version (has to be the following format: v11.0.0)")
+	pflag.StringVarP(&summaryFile, "summary", "s", "", "readme file on which there is a summary of the release")
 	pflag.Parse()
 
 	// The -version flag must be of a valid format.


### PR DESCRIPTION
## Description

This PR changes the `release-notes` package to use pflag instead of the old flag system.

## Related Issue(s)

- Closes #11299
- Part of https://github.com/vitessio/vitess/issues/10697

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
