### PR TITLE
[vtctlclient] Migrate `vtctl_client_protocol` to pflag

### DIFF
--- a/go/cmd/vtctldclient/main.go
+++ b/go/cmd/vtctldclient/main.go
@@ -28,6 +28,7 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtctl/grpcclientcommon"
+	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
 )
 
 func main() {
@@ -41,6 +42,7 @@ func main() {
 	grpccommon.RegisterFlags(command.Root.PersistentFlags())
 	grpcclientcommon.RegisterFlags(command.Root.PersistentFlags())
 	servenv.RegisterMySQLServerFlags(command.Root.PersistentFlags())
+	vtctlclient.RegisterFlags(command.Root.PersistentFlags())
 
 	// hack to get rid of an "ERROR: logging before flag.Parse"
 	args := os.Args[:]

--- a/go/flags/endtoend/vtctlclient.txt
+++ b/go/flags/endtoend/vtctlclient.txt
@@ -33,7 +33,7 @@ Usage of vtctlclient:
   -v, --v Level                                log level for V logs
       --version                                print binary version
       --vmodule moduleSpec                     comma-separated list of pattern=N settings for file-filtered logging
-      --vtctl_client_protocol string           the protocol to use to talk to the vtctl server (default "grpc")
+      --vtctl_client_protocol string           Protocol to use to talk to the vtctl server. (default "grpc")
       --vtctld_grpc_ca string                  the server ca to use to validate servers when connecting
       --vtctld_grpc_cert string                the cert to use to connect
       --vtctld_grpc_crl string                 the server crl to use to validate server certificates when connecting

--- a/go/flags/endtoend/vtctldclient.txt
+++ b/go/flags/endtoend/vtctldclient.txt
@@ -154,7 +154,7 @@ Flags:
   -v, --v Level                                         log level for V logs
       --version                                         print binary version
       --vmodule moduleSpec                              comma-separated list of pattern=N settings for file-filtered logging
-      --vtctl_client_protocol string                    the protocol to use to talk to the vtctl server (default "grpc")
+      --vtctl_client_protocol string                    Protocol to use to talk to the vtctl server. (default "grpc")
       --vtctld_grpc_ca string                           the server ca to use to validate servers when connecting
       --vtctld_grpc_cert string                         the cert to use to connect
       --vtctld_grpc_crl string                          the server crl to use to validate server certificates when connecting

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -142,7 +142,7 @@ Usage of vttestserver:
       --version                                                          print binary version
       --vmodule moduleSpec                                               comma-separated list of pattern=N settings for file-filtered logging
       --vschema_ddl_authorized_users string                              Comma separated list of users authorized to execute vschema ddl operations via vtgate
-      --vtctl_client_protocol string                                     the protocol to use to talk to the vtctl server (default "grpc")
+      --vtctl_client_protocol string                                     Protocol to use to talk to the vtctl server. (default "grpc")
       --vtctld_grpc_ca string                                            the server ca to use to validate servers when connecting
       --vtctld_grpc_cert string                                          the cert to use to connect
       --vtctld_grpc_crl string                                           the server crl to use to validate server certificates when connecting

--- a/go/vt/vtctl/vtctlclient/interface.go
+++ b/go/vt/vtctl/vtctlclient/interface.go
@@ -18,18 +18,32 @@ limitations under the License.
 package vtctlclient
 
 import (
-	"flag"
+	"context"
 	"fmt"
 	"time"
 
-	"context"
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 // vtctlClientProtocol specifics which RPC client implementation should be used.
-var vtctlClientProtocol = flag.String("vtctl_client_protocol", "grpc", "the protocol to use to talk to the vtctl server")
+var vtctlClientProtocol = "grpc"
+
+func RegisterFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&vtctlClientProtocol, "vtctl_client_protocol", vtctlClientProtocol, "Protocol to use to talk to the vtctl server.")
+}
+
+func init() {
+	for _, cmd := range []string{
+		"vtctlclient",
+		"vttestserver",
+	} {
+		servenv.OnParseFor(cmd, RegisterFlags)
+	}
+}
 
 // VtctlClient defines the interface used to send remote vtctl commands
 type VtctlClient interface {
@@ -67,9 +81,9 @@ func UnregisterFactoryForTest(name string) {
 
 // New allows a user of the client library to get its implementation.
 func New(addr string) (VtctlClient, error) {
-	factory, ok := factories[*vtctlClientProtocol]
+	factory, ok := factories[vtctlClientProtocol]
 	if !ok {
-		return nil, fmt.Errorf("unknown vtctl client protocol: %v", *vtctlClientProtocol)
+		return nil, fmt.Errorf("unknown vtctl client protocol: %v", vtctlClientProtocol)
 	}
 	return factory(addr)
 }

--- a/go/vt/wrangler/testlib/vtctl_pipe.go
+++ b/go/vt/wrangler/testlib/vtctl_pipe.go
@@ -18,7 +18,7 @@ package testlib
 
 import (
 	"bytes"
-	"flag"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -26,9 +26,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
@@ -56,7 +56,14 @@ func NewVtctlPipe(t *testing.T, ts *topo.Server) *VtctlPipe {
 	// Register all vtctl commands
 	servenvInitialized.Do(func() {
 		// make sure we use the right protocol
-		flag.Set("vtctl_client_protocol", "grpc")
+		fs := pflag.NewFlagSet("", pflag.ContinueOnError)
+		vtctlclient.RegisterFlags(fs)
+
+		err := fs.Parse([]string{
+			"--vtctl_client_protocol",
+			"grpc",
+		})
+		require.NoError(t, err, "failed to set `--vtctl_client_protocol=%s`", "grpc")
 
 		servenv.FireRunHooks()
 	})


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Title says it all.

## Related Issue(s)

- Closes #10892.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
