### PR TITLE
Move vtaclcheck command to pflags

### DIFF
--- a/go/cmd/vtaclcheck/vtaclcheck.go
+++ b/go/cmd/vtaclcheck/vtaclcheck.go
@@ -17,44 +17,26 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"fmt"
+
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtaclcheck"
-
-	// Include deprecation warnings for soon-to-be-unsupported flag invocations.
-	_flag "vitess.io/vitess/go/internal/flag"
 )
 
-var (
-	aclFileFlag        = flag.String("acl_file", "", "The path of the JSON ACL file to check")
-	staticAuthFileFlag = flag.String("static_auth_file", "", "The path of the auth_server_static JSON file to check")
-
-	// vtaclcheckFlags lists all the flags that should show in usage
-	vtaclcheckFlags = []string{
-		"acl_file",
-		"static_auth_file",
-	}
-)
+var aclFile, staticAuthFile string
 
 func init() {
 	logger := logutil.NewConsoleLogger()
-	flag.CommandLine.SetOutput(logutil.NewLoggerWriter(logger))
-	_flag.SetUsage(flag.CommandLine, _flag.UsageOptions{
-		FlagFilter: func(f *flag.Flag) bool {
-			for _, name := range vtaclcheckFlags {
-				if f.Name == name {
-					return true
-				}
-			}
-
-			return false
-		},
+	servenv.OnParse(func(fs *pflag.FlagSet) {
+		fs.StringVar(&aclFile, "acl-file", aclFile, "The path of the JSON ACL file to check")
+		fs.StringVar(&staticAuthFile, "static-auth-file", staticAuthFile, "The path of the auth_server_static JSON file to check")
 	})
+	pflag.CommandLine.SetOutput(logutil.NewLoggerWriter(logger))
 }
 
 func main() {
@@ -63,20 +45,20 @@ func main() {
 
 	servenv.ParseFlags("vtaclcheck")
 
-	err := parseAndRun()
+	err := run()
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err)
 		exit.Return(1)
 	}
 }
 
-func parseAndRun() error {
+func run() error {
 	opts := &vtaclcheck.Options{
-		ACLFile:        *aclFileFlag,
-		StaticAuthFile: *staticAuthFileFlag,
+		ACLFile:        aclFile,
+		StaticAuthFile: staticAuthFile,
 	}
 
-	log.V(100).Infof("acl_file %s\nstatic_auth_file %s\n", *aclFileFlag, *staticAuthFileFlag)
+	log.V(100).Infof("acl_file %s\nstatic_auth_file %s\n", aclFile, staticAuthFile)
 
 	if err := vtaclcheck.Init(opts); err != nil {
 		return err

--- a/go/cmd/vtaclcheck/vtaclcheck.go
+++ b/go/cmd/vtaclcheck/vtaclcheck.go
@@ -35,8 +35,9 @@ func init() {
 	servenv.OnParse(func(fs *pflag.FlagSet) {
 		fs.StringVar(&aclFile, "acl-file", aclFile, "The path of the JSON ACL file to check")
 		fs.StringVar(&staticAuthFile, "static-auth-file", staticAuthFile, "The path of the auth_server_static JSON file to check")
+		
+		fs.SetOutput(logutil.NewLoggerWriter(logger))
 	})
-	pflag.CommandLine.SetOutput(logutil.NewLoggerWriter(logger))
 }
 
 func main() {

--- a/go/cmd/vtaclcheck/vtaclcheck.go
+++ b/go/cmd/vtaclcheck/vtaclcheck.go
@@ -35,7 +35,7 @@ func init() {
 	servenv.OnParse(func(fs *pflag.FlagSet) {
 		fs.StringVar(&aclFile, "acl-file", aclFile, "The path of the JSON ACL file to check")
 		fs.StringVar(&staticAuthFile, "static-auth-file", staticAuthFile, "The path of the auth_server_static JSON file to check")
-		
+
 		fs.SetOutput(logutil.NewLoggerWriter(logger))
 	})
 }

--- a/go/flags/endtoend/flags_test.go
+++ b/go/flags/endtoend/flags_test.go
@@ -32,6 +32,9 @@ import (
 )
 
 var (
+	//go:embed vtaclcheck.txt
+	vtaclcheckTxt string
+
 	//go:embed vtexplain.txt
 	vtexplainTxt string
 
@@ -60,6 +63,7 @@ var (
 	vttestserverTxt string
 
 	helpOutput = map[string]string{
+		"vtaclcheck":   vtaclcheckTxt,
 		"vtexplain":    vtexplainTxt,
 		"vtgate":       vtgateTxt,
 		"vtgr":         vtgrTxt,

--- a/go/flags/endtoend/vtaclcheck.txt
+++ b/go/flags/endtoend/vtaclcheck.txt
@@ -1,0 +1,19 @@
+Usage of vtaclcheck:
+      --acl-file string                  The path of the JSON ACL file to check
+      --alsologtostderr                  log to standard error as well as files
+  -h, --help                             display usage and exit
+      --keep_logs duration               keep logs for this long (using ctime) (zero to keep forever)
+      --keep_logs_by_mtime duration      keep logs for this long (using mtime) (zero to keep forever)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --log_err_stacks                   log stack traces for errors
+      --log_rotate_max_size uint         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
+      --logtostderr                      log to standard error instead of files
+      --pprof strings                    enable profiling
+      --purge_logs_interval duration     how often try to remove old logs (default 1h0m0s)
+      --security_policy string           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
+      --static-auth-file string          The path of the auth_server_static JSON file to check
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 1)
+  -v, --v Level                          log level for V logs
+      --version                          print binary version
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging


### PR DESCRIPTION
## Description

Switches flag definitions to be on pflag instead of flag for `go/cmd/vtaclcheck`.

This is a stand-alone binary that uses a dedicated `vtaclcheck` package:
```
$ go list -f '{{ .ImportPath }}| {{ join .Deps " " }} ' ./go/cmd/... | awk -F"|" '$2 ~ " vitess.io/vitess/go/vt/vtaclcheck " {print $1}'
vitess.io/vitess/go/cmd/vtaclcheck
```

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/11278

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required