### PR TITLE
Remove deprecated IsSkipTopo() function

### DIFF
--- a/go/vt/schema/ddl_strategy.go
+++ b/go/vt/schema/ddl_strategy.go
@@ -173,12 +173,6 @@ func (setting *DDLStrategySetting) IsVreplicationTestSuite() bool {
 	return setting.hasFlag(vreplicationTestSuite)
 }
 
-// IsSkipTopoFlag returns 'true' if strategy options include `-skip-topo`. This flag is deprecated,
-// and this function is temporary in v14 so that we can print a deprecation message.
-func (setting *DDLStrategySetting) IsSkipTopoFlag() bool {
-	return setting.hasFlag(skipTopoFlag)
-}
-
 // RuntimeOptions returns the options used as runtime flags for given strategy, removing any internal hint options
 func (setting *DDLStrategySetting) RuntimeOptions() []string {
 	opts, _ := shlex.Split(setting.Options)

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3081,12 +3081,6 @@ func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		return fmt.Errorf("the <keyspace> argument is required for the commandApplySchema command")
 	}
 
-	// v14 deprecates `--skip-topo` flag. This check will be removed in v15
-	if settings, _ := schema.ParseDDLStrategy(*ddlStrategy); settings != nil && settings.IsSkipTopoFlag() {
-		deprecationMessage := `--skip-topo flag is deprecated and will be removed in v15`
-		log.Warningf(deprecationMessage)
-	}
-
 	keyspace := subFlags.Arg(0)
 	change, err := getFileParam(*sql, *sqlFile, "sql")
 	if err != nil {


### PR DESCRIPTION

## Description

Followup to #8450 and #9816, this PR removes a deprecated function from the code.

## Related Issue(s)

#6926

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
