### PR TITLE
Move evalengine integration tests to use pflags

### DIFF
--- a/go/internal/flag/flag.go
+++ b/go/internal/flag/flag.go
@@ -106,8 +106,8 @@ func ParseFlagsForTest() {
 	}
 
 	// parse remaining flags including the log-related ones like --alsologtostderr
-	fs := flag.NewFlagSet("test", flag.ExitOnError)
-	Parse(fs)
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	flag.Parse()
 }
 
 // Parsed returns true if the command-line flags have been parsed.

--- a/go/mysql/collations/integration/main_test.go
+++ b/go/mysql/collations/integration/main_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"vitess.io/vitess/go/internal/flag"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/vttest"
 
@@ -34,9 +35,12 @@ import (
 
 var (
 	connParams mysql.ConnParams
+	waitmysql  bool
 )
 
-var waitmysql = pflag.Bool("waitmysql", false, "")
+func init() {
+	pflag.BoolVar(&waitmysql, "waitmysql", waitmysql, "")
+}
 
 func mysqlconn(t *testing.T) *mysql.Conn {
 	conn, err := mysql.Connect(context.Background(), &connParams)
@@ -56,7 +60,7 @@ func mysqlconn(t *testing.T) *mysql.Conn {
 }
 
 func TestMain(m *testing.M) {
-	pflag.Parse()
+	flag.ParseFlagsForTest()
 
 	exitCode := func() int {
 		// Launch MySQL.
@@ -90,7 +94,7 @@ func TestMain(m *testing.M) {
 
 		connParams = cluster.MySQLConnParams()
 
-		if *waitmysql {
+		if waitmysql {
 			debugMysql()
 		}
 		return m.Run()


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR moves the evalengine integration tests package to use pflags instead of flags.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/10933

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
