### PR TITLE
Migrate mysqlctl command and package to pflag

### DIFF
--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -19,9 +19,7 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -31,31 +29,40 @@ import (
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/flagutil"
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
-
-	// Include deprecation warnings for soon-to-be-unsupported flag invocations.
-	_flag "vitess.io/vitess/go/internal/flag"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 var (
-	port        = flag.Int("port", 6612, "vttablet port")
-	mysqlPort   = flag.Int("mysql_port", 3306, "mysql port")
-	tabletUID   = flag.Uint("tablet_uid", 41983, "tablet uid")
-	mysqlSocket = flag.String("mysql_socket", "", "path to the mysql socket")
-
-	// Reason for nolint : Being used in line 246 (tabletAddr = netutil.JoinHostPort("localhost", int32(*port))
-	tabletAddr string //nolint
+	mysqlPort   = 3306
+	tabletUID   = uint(41983)
+	mysqlSocket string
 )
 
-func initConfigCmd(subFlags *flag.FlagSet, args []string) error {
-	subFlags.Parse(args)
+func init() {
+	servenv.RegisterDefaultFlags()
+	servenv.RegisterDefaultSocketFileFlags()
+	servenv.RegisterFlags()
+	servenv.RegisterGRPCServerFlags()
+	servenv.RegisterGRPCServerAuthFlags()
+	servenv.RegisterServiceMapFlag()
+	// mysqlctl only starts and stops mysql, only needs dba.
+	dbconfigs.RegisterFlags(dbconfigs.Dba)
+	servenv.OnParse(func(fs *pflag.FlagSet) {
+		fs.IntVar(&mysqlPort, "mysql_port", mysqlPort, "MySQL port")
+		fs.UintVar(&tabletUID, "tablet_uid", tabletUID, "Tablet UID")
+		fs.StringVar(&mysqlSocket, "mysql_socket", mysqlSocket, "Path to the mysqld socket file")
+	})
+}
+
+func initConfigCmd(subFlags *pflag.FlagSet, args []string) error {
+	_ = subFlags.Parse(args)
 
 	// Generate my.cnf from scratch and use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(uint32(*tabletUID), *mysqlSocket, int32(*mysqlPort))
+	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(uint32(tabletUID), mysqlSocket, int32(mysqlPort))
 	if err != nil {
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}
@@ -66,13 +73,13 @@ func initConfigCmd(subFlags *flag.FlagSet, args []string) error {
 	return nil
 }
 
-func initCmd(subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for startup")
-	initDBSQLFile := subFlags.String("init_db_sql_file", "", "path to .sql file to run after mysql_install_db")
-	subFlags.Parse(args)
+func initCmd(subFlags *pflag.FlagSet, args []string) error {
+	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "How long to wait for mysqld startup")
+	initDBSQLFile := subFlags.String("init_db_sql_file", "", "Path to .sql file to run after mysqld initiliaztion")
+	_ = subFlags.Parse(args)
 
 	// Generate my.cnf from scratch and use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(uint32(*tabletUID), *mysqlSocket, int32(*mysqlPort))
+	mysqld, cnf, err := mysqlctl.CreateMysqldAndMycnf(uint32(tabletUID), mysqlSocket, int32(mysqlPort))
 	if err != nil {
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}
@@ -86,11 +93,11 @@ func initCmd(subFlags *flag.FlagSet, args []string) error {
 	return nil
 }
 
-func reinitConfigCmd(subFlags *flag.FlagSet, args []string) error {
-	subFlags.Parse(args)
+func reinitConfigCmd(subFlags *pflag.FlagSet, args []string) error {
+	_ = subFlags.Parse(args)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(*tabletUID))
+	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(tabletUID))
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
@@ -102,12 +109,12 @@ func reinitConfigCmd(subFlags *flag.FlagSet, args []string) error {
 	return nil
 }
 
-func shutdownCmd(subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for shutdown")
-	subFlags.Parse(args)
+func shutdownCmd(subFlags *pflag.FlagSet, args []string) error {
+	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "How long to wait for mysqld shutdown")
+	_ = subFlags.Parse(args)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(*tabletUID))
+	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(tabletUID))
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
@@ -121,14 +128,14 @@ func shutdownCmd(subFlags *flag.FlagSet, args []string) error {
 	return nil
 }
 
-func startCmd(subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for startup")
+func startCmd(subFlags *pflag.FlagSet, args []string) error {
+	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "How long to wait for mysqld startup")
 	var mysqldArgs flagutil.StringListValue
 	subFlags.Var(&mysqldArgs, "mysqld_args", "List of comma-separated flags to pass additionally to mysqld")
-	subFlags.Parse(args)
+	_ = subFlags.Parse(args)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(*tabletUID))
+	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(tabletUID))
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
@@ -142,13 +149,13 @@ func startCmd(subFlags *flag.FlagSet, args []string) error {
 	return nil
 }
 
-func teardownCmd(subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for shutdown")
-	force := subFlags.Bool("force", false, "will remove the root directory even if mysqld shutdown fails")
-	subFlags.Parse(args)
+func teardownCmd(subFlags *pflag.FlagSet, args []string) error {
+	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "How long to wait for mysqld shutdown")
+	force := subFlags.Bool("force", false, "Remove the root directory even if mysqld shutdown fails")
+	_ = subFlags.Parse(args)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(*tabletUID))
+	mysqld, cnf, err := mysqlctl.OpenMysqldAndMycnf(uint32(tabletUID))
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
@@ -162,8 +169,8 @@ func teardownCmd(subFlags *flag.FlagSet, args []string) error {
 	return nil
 }
 
-func positionCmd(subFlags *flag.FlagSet, args []string) error {
-	subFlags.Parse(args)
+func positionCmd(subFlags *pflag.FlagSet, args []string) error {
+	_ = subFlags.Parse(args)
 	if len(args) < 3 {
 		return fmt.Errorf("not enough arguments for position operation")
 	}
@@ -199,7 +206,7 @@ func positionCmd(subFlags *flag.FlagSet, args []string) error {
 
 type command struct {
 	name   string
-	method func(*flag.FlagSet, []string) error
+	method func(*pflag.FlagSet, []string) error
 	params string
 	help   string
 }
@@ -227,54 +234,52 @@ func main() {
 	defer exit.Recover()
 	defer logutil.Flush()
 
-	_flag.SetUsage(flag.CommandLine, _flag.UsageOptions{
-		Preface: func(w io.Writer) {
-			fmt.Fprintf(w, "Usage: %s [global parameters] command [command parameters]\n", os.Args[0])
-			fmt.Fprintf(w, "\nThe global optional parameters are:\n")
-		},
-		Epilogue: func(w io.Writer) {
-			fmt.Fprintf(w, "\nThe commands are listed below. Use '%s <command> -h' for more help.\n\n", os.Args[0])
-			for _, cmd := range commands {
-				fmt.Fprintf(w, "  %s", cmd.name)
-				if cmd.params != "" {
-					fmt.Fprintf(w, " %s", cmd.params)
-				}
-				fmt.Fprintf(w, "\n")
+	fs := pflag.NewFlagSet("mysqlctl", pflag.ExitOnError)
+	log.RegisterFlags(fs)
+	logutil.RegisterFlags(fs)
+	pflag.Usage = func() {
+		w := os.Stderr
+		fmt.Fprintf(w, "Usage: %s [global-flags] <command> -- [command-flags]\n", os.Args[0])
+		fmt.Fprintf(w, "\nThe commands are listed below. Use '%s <command> -- {-h, --help}' for command help.\n\n", os.Args[0])
+		for _, cmd := range commands {
+			fmt.Fprintf(w, "  %s", cmd.name)
+			if cmd.params != "" {
+				fmt.Fprintf(w, " %s", cmd.params)
 			}
 			fmt.Fprintf(w, "\n")
-		},
-	})
+		}
+		fmt.Fprintf(w, "\nGlobal flags:\n")
+		pflag.PrintDefaults()
+	}
+	args := servenv.ParseFlagsWithArgs("mysqlctl")
 
 	if cmd.IsRunningAsRoot() {
 		fmt.Fprintln(os.Stderr, "mysqlctl cannot be ran as root. Please run as a different user")
 		exit.Return(1)
 	}
-	dbconfigs.RegisterFlags(dbconfigs.Dba)
-	fs := pflag.NewFlagSet("mysqlctl", pflag.ExitOnError)
-	log.RegisterFlags(fs)
-	logutil.RegisterFlags(fs)
-	_flag.Parse(fs)
 
-	tabletAddr = netutil.JoinHostPort("localhost", int32(*port))
-
-	action := _flag.Arg(0)
+	action := args[0]
 	for _, cmd := range commands {
 		if cmd.name == action {
-			subFlags := flag.NewFlagSet(action, flag.ExitOnError)
-			_flag.SetUsage(subFlags, _flag.UsageOptions{
-				Preface: func(w io.Writer) {
-					fmt.Fprintf(w, "Usage: %s %s %s\n\n", os.Args[0], cmd.name, cmd.params)
-					fmt.Fprintf(w, "%s\n\n", cmd.help)
-				},
-			})
-
-			if err := cmd.method(subFlags, _flag.Args()[1:]); err != nil {
-				log.Error(err)
+			subFlags := pflag.NewFlagSet(action, pflag.ExitOnError)
+			subFlags.Usage = func() {
+				w := os.Stderr
+				fmt.Fprintf(w, "Usage: %s %s %s\n\n", os.Args[0], cmd.name, cmd.params)
+				fmt.Fprintf(w, cmd.help)
+				fmt.Fprintf(w, "\n\n")
+				subFlags.PrintDefaults()
+			}
+			// This is logged and we want sentence capitalization and punctuation.
+			pflag.ErrHelp = fmt.Errorf("\nSee %s --help for more information.", os.Args[0]) // nolint:revive
+			if err := cmd.method(subFlags, args[1:]); err != nil {
+				log.Errorf("%v\n", err)
+				subFlags.Usage()
 				exit.Return(1)
 			}
 			return
 		}
 	}
-	log.Errorf("invalid action: %v", action)
+	log.Errorf("invalid action: %v\n\n", action)
+	pflag.Usage()
 	exit.Return(1)
 }

--- a/go/flags/endtoend/flags_test.go
+++ b/go/flags/endtoend/flags_test.go
@@ -32,6 +32,9 @@ import (
 )
 
 var (
+	//go:embed mysqlctl.txt
+	mysqlctlTxt string
+
 	//go:embed mysqlctld.txt
 	mysqlctldTxt string
 
@@ -72,6 +75,7 @@ var (
 	zkctldTxt string
 
 	helpOutput = map[string]string{
+		"mysqlctl":     mysqlctlTxt,
 		"mysqlctld":    mysqlctldTxt,
 		"vtaclcheck":   vtaclcheckTxt,
 		"vtexplain":    vtexplainTxt,

--- a/go/flags/endtoend/mysqlctl.txt
+++ b/go/flags/endtoend/mysqlctl.txt
@@ -1,0 +1,140 @@
+Usage: mysqlctl [global-flags] <command> -- [command-flags]
+
+The commands are listed below. Use 'mysqlctl <command> -- {-h, --help}' for command help.
+
+  init [--wait_time=5m] [--init_db_sql_file=]
+  init_config
+  reinit_config
+  teardown [--wait_time=5m] [--force]
+  start [--wait_time=5m]
+  shutdown [--wait_time=5m]
+  position <operation> <pos1> <pos2 | gtid>
+
+Global flags:
+      --alsologtostderr                                                  log to standard error as well as files
+      --app_idle_timeout duration                                        Idle timeout for app connections (default 1m0s)
+      --app_pool_size int                                                Size of the connection pool for app connections (default 40)
+      --backup_engine_implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
+      --backup_storage_block_size int                                    if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)
+      --backup_storage_compress                                          if set, the backup files will be compressed (default is true). Set to false for instance if a backup_storage_hook is specified and it compresses the data. (default true)
+      --backup_storage_hook string                                       if set, we send the contents of the backup files through this hook.
+      --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, at once, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --builtinbackup_mysqld_timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
+      --builtinbackup_progress duration                                  how often to send progress updates when backing up large files. (default 5s)
+      --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
+      --compression-engine-name string                                   compressor engine used for compression. (default "pargzip")
+      --compression-level int                                            what level to pass to the compressor. (default 1)
+      --db-config-dba-charset string                                     deprecated: use db_charset (default "utf8mb4")
+      --db-config-dba-flags uint                                         deprecated: use db_flags
+      --db-config-dba-flavor string                                      deprecated: use db_flavor
+      --db-config-dba-host string                                        deprecated: use db_host
+      --db-config-dba-pass string                                        db dba deprecated: use db_dba_password
+      --db-config-dba-port int                                           deprecated: use db_port
+      --db-config-dba-server_name string                                 deprecated: use db_server_name
+      --db-config-dba-ssl-ca string                                      deprecated: use db_ssl_ca
+      --db-config-dba-ssl-ca-path string                                 deprecated: use db_ssl_ca_path
+      --db-config-dba-ssl-cert string                                    deprecated: use db_ssl_cert
+      --db-config-dba-ssl-key string                                     deprecated: use db_ssl_key
+      --db-config-dba-uname string                                       deprecated: use db_dba_user (default "vt_dba")
+      --db-config-dba-unixsocket string                                  deprecated: use db_socket
+      --db-credentials-file string                                       db credentials file; send SIGHUP to reload this file
+      --db-credentials-server string                                     db credentials server type ('file' - file implementation; 'vault' - HashiCorp Vault implementation) (default "file")
+      --db-credentials-vault-addr string                                 URL to Vault server
+      --db-credentials-vault-path string                                 Vault path to credentials JSON blob, e.g.: secret/data/prod/dbcreds
+      --db-credentials-vault-role-mountpoint string                      Vault AppRole mountpoint; can also be passed using VAULT_MOUNTPOINT environment variable (default "approle")
+      --db-credentials-vault-role-secretidfile string                    Path to file containing Vault AppRole secret_id; can also be passed using VAULT_SECRETID environment variable
+      --db-credentials-vault-roleid string                               Vault AppRole id; can also be passed using VAULT_ROLEID environment variable
+      --db-credentials-vault-timeout duration                            Timeout for vault API operations (default 10s)
+      --db-credentials-vault-tls-ca string                               Path to CA PEM for validating Vault server certificate
+      --db-credentials-vault-tokenfile string                            Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
+      --db-credentials-vault-ttl duration                                How long to cache DB credentials from the Vault server (default 30m0s)
+      --db_charset string                                                Character set used for this tablet. (default "utf8mb4")
+      --db_conn_query_info                                               enable parsing and processing of QUERY_OK info fields
+      --db_connect_timeout_ms int                                        connection timeout to mysqld in milliseconds (0 for no timeout)
+      --db_dba_password string                                           db dba password
+      --db_dba_use_ssl                                                   Set this flag to false to make the dba connection to not use ssl (default true)
+      --db_dba_user string                                               db dba user userKey (default "vt_dba")
+      --db_flags uint                                                    Flag values as defined by MySQL.
+      --db_flavor string                                                 Flavor overrid. Valid value is FilePos.
+      --db_host string                                                   The host name for the tcp connection.
+      --db_port int                                                      tcp port
+      --db_server_name string                                            server name of the DB we are connecting to.
+      --db_socket string                                                 The unix socket to connect on. If this is specified, host and port will not be used.
+      --db_ssl_ca string                                                 connection ssl ca
+      --db_ssl_ca_path string                                            connection ssl ca path
+      --db_ssl_cert string                                               connection ssl certificate
+      --db_ssl_key string                                                connection ssl key
+      --db_ssl_mode SslMode                                              SSL mode to connect with. One of disabled, preferred, required, verify_ca & verify_identity.
+      --db_tls_min_version string                                        Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
+      --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
+      --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
+      --disable_active_reparents                                         if set, do not allow active reparents. Use this to protect a cluster using external reparents.
+      --external-compressor string                                       command with arguments to use when compressing a backup.
+      --external-compressor-extension string                             extension to use when using an external compressor.
+      --external-decompressor string                                     command with arguments to use when decompressing a backup.
+      --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
+      --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
+      --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
+      --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
+      --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
+      --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
+      --grpc_crl string                                                  path to a certificate revocation list in PEM format, client certificates will be further verified against this file during TLS handshake
+      --grpc_enable_optional_tls                                         enable optional TLS mode when a server accepts both TLS and plain-text connections on the same port
+      --grpc_initial_conn_window_size int                                gRPC initial connection window size
+      --grpc_initial_window_size int                                     gRPC initial window size
+      --grpc_keepalive_time duration                                     After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
+      --grpc_keepalive_timeout duration                                  After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
+      --grpc_key string                                                  server private key to use for gRPC connections, requires grpc_cert, enables TLS
+      --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
+      --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
+      --grpc_port int                                                    Port to listen on for gRPC calls. If zero, do not listen.
+      --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
+      --grpc_server_initial_conn_window_size int                         gRPC server initial connection window size
+      --grpc_server_initial_window_size int                              gRPC server initial window size
+      --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
+      --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
+  -h, --help                                                             display usage and exit
+      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
+      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
+      --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
+      --log_backtrace_at traceLocation                                   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                                                   If non-empty, write log files in this directory
+      --log_err_stacks                                                   log stack traces for errors
+      --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
+      --logtostderr                                                      log to standard error instead of files
+      --mysql_port int                                                   MySQL port (default 3306)
+      --mysql_server_version string                                      MySQL server version to advertise.
+      --mysql_socket string                                              Path to the mysqld socket file
+      --mysqlctl_client_protocol string                                  the protocol to use to talk to the mysqlctl server (default "grpc")
+      --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
+      --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
+      --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 1ns)
+      --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
+      --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
+      --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
+      --port int                                                         port for the server
+      --pprof strings                                                    enable profiling
+      --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
+      --remote_operation_timeout duration                                time to wait for a remote operation (default 30s)
+      --replication_connect_retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
+      --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
+      --service_map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
+      --socket_file string                                               Local unix socket file to listen on
+      --stderrthreshold severity                                         logs at or above this threshold go to stderr (default 1)
+      --tablet_dir string                                                The directory within the vtdataroot to store vttablet/mysql files. Defaults to being generated by the tablet uid.
+      --tablet_uid uint                                                  Tablet UID (default 41983)
+      --topo_global_root string                                          the path of the global topology data in the global topology server
+      --topo_global_server_address string                                the address of the global topology server
+      --topo_implementation string                                       the topology implementation to use
+  -v, --v Level                                                          log level for V logs
+      --version                                                          print binary version
+      --vmodule moduleSpec                                               comma-separated list of pattern=N settings for file-filtered logging
+      --xbstream_restore_flags string                                    flags to pass to xbstream command during restore. These should be space separated and will be added to the end of the command. These need to match the ones used for backup e.g. --compress / --decompress, --encrypt / --decrypt
+      --xtrabackup_backup_flags string                                   flags to pass to backup command. These should be space separated and will be added to the end of the command
+      --xtrabackup_prepare_flags string                                  flags to pass to prepare command. These should be space separated and will be added to the end of the command
+      --xtrabackup_root_path string                                      directory location of the xtrabackup and xbstream executables, e.g., /usr/bin
+      --xtrabackup_stream_mode string                                    which mode to use if streaming, valid values are tar and xbstream (default "tar")
+      --xtrabackup_stripe_block_size uint                                Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe (default 102400)
+      --xtrabackup_stripes uint                                          If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression
+      --xtrabackup_user string                                           User that xtrabackup will use to connect to the database server. This user must have all necessary privileges. For details, please refer to xtrabackup documentation.

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -46,6 +46,7 @@ var (
 
 	// every vitess binary that makes grpc client-side calls.
 	grpcclientBinaries = []string{
+		"mysqlctl",
 		"mysqlctld",
 		"vtadmin",
 		"vtbackup",

--- a/go/vt/mysqlctl/mycnf_flag.go
+++ b/go/vt/mysqlctl/mycnf_flag.go
@@ -17,9 +17,10 @@ limitations under the License.
 package mysqlctl
 
 import (
-	"flag"
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 // This file handles using command line flags to create a Mycnf object.
@@ -28,51 +29,53 @@ import (
 
 var (
 	// the individual command line parameters
-	flagServerID              *int
-	flagMysqlPort             *int
-	flagDataDir               *string
-	flagInnodbDataHomeDir     *string
-	flagInnodbLogGroupHomeDir *string
-	flagSocketFile            *string
-	flagGeneralLogPath        *string
-	flagErrorLogPath          *string
-	flagSlowLogPath           *string
-	flagRelayLogPath          *string
-	flagRelayLogIndexPath     *string
-	flagRelayLogInfoPath      *string
-	flagBinLogPath            *string
-	flagMasterInfoFile        *string
-	flagPidFile               *string
-	flagTmpDir                *string
-	flagSecureFilePriv        *string
+	flagServerID              int
+	flagMysqlPort             int
+	flagDataDir               string
+	flagInnodbDataHomeDir     string
+	flagInnodbLogGroupHomeDir string
+	flagSocketFile            string
+	flagGeneralLogPath        string
+	flagErrorLogPath          string
+	flagSlowLogPath           string
+	flagRelayLogPath          string
+	flagRelayLogIndexPath     string
+	flagRelayLogInfoPath      string
+	flagBinLogPath            string
+	flagMasterInfoFile        string
+	flagPidFile               string
+	flagTmpDir                string
+	flagSecureFilePriv        string
 
 	// the file to use to specify them all
-	flagMycnfFile *string
+	flagMycnfFile string
 )
 
 // RegisterFlags registers the command line flags for
 // specifying the values of a mycnf config file. See NewMycnfFromFlags
 // to get the supported modes.
 func RegisterFlags() {
-	flagServerID = flag.Int("mycnf_server_id", 0, "mysql server id of the server (if specified, mycnf-file will be ignored)")
-	flagMysqlPort = flag.Int("mycnf_mysql_port", 0, "port mysql is listening on")
-	flagDataDir = flag.String("mycnf_data_dir", "", "data directory for mysql")
-	flagInnodbDataHomeDir = flag.String("mycnf_innodb_data_home_dir", "", "Innodb data home directory")
-	flagInnodbLogGroupHomeDir = flag.String("mycnf_innodb_log_group_home_dir", "", "Innodb log group home directory")
-	flagSocketFile = flag.String("mycnf_socket_file", "", "mysql socket file")
-	flagGeneralLogPath = flag.String("mycnf_general_log_path", "", "mysql general log path")
-	flagErrorLogPath = flag.String("mycnf_error_log_path", "", "mysql error log path")
-	flagSlowLogPath = flag.String("mycnf_slow_log_path", "", "mysql slow query log path")
-	flagRelayLogPath = flag.String("mycnf_relay_log_path", "", "mysql relay log path")
-	flagRelayLogIndexPath = flag.String("mycnf_relay_log_index_path", "", "mysql relay log index path")
-	flagRelayLogInfoPath = flag.String("mycnf_relay_log_info_path", "", "mysql relay log info path")
-	flagBinLogPath = flag.String("mycnf_bin_log_path", "", "mysql binlog path")
-	flagMasterInfoFile = flag.String("mycnf_master_info_file", "", "mysql master.info file")
-	flagPidFile = flag.String("mycnf_pid_file", "", "mysql pid file")
-	flagTmpDir = flag.String("mycnf_tmp_dir", "", "mysql tmp directory")
-	flagSecureFilePriv = flag.String("mycnf_secure_file_priv", "", "mysql path for loading secure files")
+	servenv.OnParse(func(fs *pflag.FlagSet) {
+		fs.IntVar(&flagServerID, "mycnf_server_id", flagServerID, "mysql server id of the server (if specified, mycnf-file will be ignored)")
+		fs.IntVar(&flagMysqlPort, "mycnf_mysql_port", flagMysqlPort, "port mysql is listening on")
+		fs.StringVar(&flagDataDir, "mycnf_data_dir", flagDataDir, "data directory for mysql")
+		fs.StringVar(&flagInnodbDataHomeDir, "mycnf_innodb_data_home_dir", flagInnodbDataHomeDir, "Innodb data home directory")
+		fs.StringVar(&flagInnodbLogGroupHomeDir, "mycnf_innodb_log_group_home_dir", flagInnodbLogGroupHomeDir, "Innodb log group home directory")
+		fs.StringVar(&flagSocketFile, "mycnf_socket_file", flagSocketFile, "mysql socket file")
+		fs.StringVar(&flagGeneralLogPath, "mycnf_general_log_path", flagGeneralLogPath, "mysql general log path")
+		fs.StringVar(&flagErrorLogPath, "mycnf_error_log_path", flagErrorLogPath, "mysql error log path")
+		fs.StringVar(&flagSlowLogPath, "mycnf_slow_log_path", flagSlowLogPath, "mysql slow query log path")
+		fs.StringVar(&flagRelayLogPath, "mycnf_relay_log_path", flagRelayLogPath, "mysql relay log path")
+		fs.StringVar(&flagRelayLogIndexPath, "mycnf_relay_log_index_path", flagRelayLogIndexPath, "mysql relay log index path")
+		fs.StringVar(&flagRelayLogInfoPath, "mycnf_relay_log_info_path", flagRelayLogInfoPath, "mysql relay log info path")
+		fs.StringVar(&flagBinLogPath, "mycnf_bin_log_path", flagBinLogPath, "mysql binlog path")
+		fs.StringVar(&flagMasterInfoFile, "mycnf_master_info_file", flagMasterInfoFile, "mysql master.info file")
+		fs.StringVar(&flagPidFile, "mycnf_pid_file", flagPidFile, "mysql pid file")
+		fs.StringVar(&flagTmpDir, "mycnf_tmp_dir", flagTmpDir, "mysql tmp directory")
+		fs.StringVar(&flagSecureFilePriv, "mycnf_secure_file_priv", flagSecureFilePriv, "mysql path for loading secure files")
 
-	flagMycnfFile = flag.String("mycnf-file", "", "path to my.cnf, if reading all config params from there")
+		fs.StringVar(&flagMycnfFile, "mycnf-file", flagMycnfFile, "path to my.cnf, if reading all config params from there")
+	})
 }
 
 // NewMycnfFromFlags creates a Mycnf object from the command line flags.
@@ -90,41 +93,41 @@ func RegisterFlags() {
 // RegisterCommandLineFlags should have been called before calling
 // this, otherwise we'll panic.
 func NewMycnfFromFlags(uid uint32) (mycnf *Mycnf, err error) {
-	if *flagServerID != 0 {
+	if flagServerID != 0 {
 		log.Info("mycnf_server_id is specified, using command line parameters for mysql config")
 		return &Mycnf{
-			ServerID:              uint32(*flagServerID),
-			MysqlPort:             int32(*flagMysqlPort),
-			DataDir:               *flagDataDir,
-			InnodbDataHomeDir:     *flagInnodbDataHomeDir,
-			InnodbLogGroupHomeDir: *flagInnodbLogGroupHomeDir,
-			SocketFile:            *flagSocketFile,
-			GeneralLogPath:        *flagGeneralLogPath,
-			ErrorLogPath:          *flagErrorLogPath,
-			SlowLogPath:           *flagSlowLogPath,
-			RelayLogPath:          *flagRelayLogPath,
-			RelayLogIndexPath:     *flagRelayLogIndexPath,
-			RelayLogInfoPath:      *flagRelayLogInfoPath,
-			BinLogPath:            *flagBinLogPath,
-			MasterInfoFile:        *flagMasterInfoFile,
-			PidFile:               *flagPidFile,
-			TmpDir:                *flagTmpDir,
-			SecureFilePriv:        *flagSecureFilePriv,
+			ServerID:              uint32(flagServerID),
+			MysqlPort:             int32(flagMysqlPort),
+			DataDir:               flagDataDir,
+			InnodbDataHomeDir:     flagInnodbDataHomeDir,
+			InnodbLogGroupHomeDir: flagInnodbLogGroupHomeDir,
+			SocketFile:            flagSocketFile,
+			GeneralLogPath:        flagGeneralLogPath,
+			ErrorLogPath:          flagErrorLogPath,
+			SlowLogPath:           flagSlowLogPath,
+			RelayLogPath:          flagRelayLogPath,
+			RelayLogIndexPath:     flagRelayLogIndexPath,
+			RelayLogInfoPath:      flagRelayLogInfoPath,
+			BinLogPath:            flagBinLogPath,
+			MasterInfoFile:        flagMasterInfoFile,
+			PidFile:               flagPidFile,
+			TmpDir:                flagTmpDir,
+			SecureFilePriv:        flagSecureFilePriv,
 
 			// This is probably not going to be used by anybody,
 			// but fill in a default value. (Note it's used by
 			// mysqld.Start, in which case it is correct).
-			Path: MycnfFile(uint32(*flagServerID)),
+			Path: MycnfFile(uint32(flagServerID)),
 		}, nil
 	}
 
-	if *flagMycnfFile == "" {
-		*flagMycnfFile = MycnfFile(uid)
-		log.Infof("No mycnf_server_id, no mycnf-file specified, using default config for server id %v: %v", uid, *flagMycnfFile)
+	if flagMycnfFile == "" {
+		flagMycnfFile = MycnfFile(uid)
+		log.Infof("No mycnf_server_id, no mycnf-file specified, using default config for server id %v: %v", uid, flagMycnfFile)
 	} else {
-		log.Infof("No mycnf_server_id specified, using mycnf-file file %v", *flagMycnfFile)
+		log.Infof("No mycnf_server_id specified, using mycnf-file file %v", flagMycnfFile)
 	}
 	mycnf = NewMycnf(uid, 0)
-	mycnf.Path = *flagMycnfFile
+	mycnf.Path = flagMycnfFile
 	return ReadMycnf(mycnf)
 }


### PR DESCRIPTION
## Description

This migrates the `mysqlctl` command/binary and the `mysqlctl` package from go flag to pflag.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/11266

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required