### PR TITLE
[cli] [etcd2] Migrate etcd2topo flags to pflags

### DIFF
--- a/go/vt/topo/etcd2topo/lock.go
+++ b/go/vt/topo/etcd2topo/lock.go
@@ -17,25 +17,38 @@ limitations under the License.
 package etcd2topo
 
 import (
-	"flag"
+	"context"
 	"fmt"
 	"path"
 
-	"context"
+	"github.com/spf13/pflag"
+
+	"vitess.io/vitess/go/vt/servenv"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
-	"vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/vterrors"
-
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 var (
-	leaseTTL = flag.Int("topo_etcd_lease_ttl", 30, "Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going.")
+	leaseTTL = 30
 )
+
+func init() {
+	topo.RegisterFactory("etcd2", Factory{})
+	for _, cmd := range []string{"vttablet", "vtctl", "vtctld", "mysqlctl", "mysqlctld", "vttestserver", "vtcombo", "vtctldclient", "vtexplain", "vtgate",
+		"vtgr", "vtorc", "vtbackup"} {
+		servenv.OnParseFor(cmd, registerEtcd2TopoLockFlags)
+	}
+}
+
+func registerEtcd2TopoLockFlags(fs *pflag.FlagSet) {
+	fs.IntVar(&leaseTTL, "topo_etcd_lease_ttl", leaseTTL, "Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going.")
+}
 
 // newUniqueEphemeralKV creates a new file in the provided directory.
 // It is linked to the Lease.
@@ -141,7 +154,7 @@ func (s *Server) lock(ctx context.Context, nodePath, contents string) (topo.Lock
 	nodePath = path.Join(s.root, nodePath, locksPath)
 
 	// Get a lease, set its KeepAlive.
-	lease, err := s.cli.Grant(ctx, int64(*leaseTTL))
+	lease, err := s.cli.Grant(ctx, int64(leaseTTL))
 	if err != nil {
 		return nil, convertError(err, nodePath)
 	}

--- a/go/vt/topo/etcd2topo/lock.go
+++ b/go/vt/topo/etcd2topo/lock.go
@@ -39,7 +39,6 @@ var (
 )
 
 func init() {
-	topo.RegisterFactory("etcd2", Factory{})
 	for _, cmd := range []string{"vttablet", "vtctl", "vtctld", "mysqlctl", "mysqlctld", "vttestserver", "vtcombo", "vtctldclient", "vtexplain", "vtgate",
 		"vtgr", "vtorc", "vtbackup"} {
 		servenv.OnParseFor(cmd, registerEtcd2TopoLockFlags)

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -82,11 +82,11 @@ type Server struct {
 }
 
 func init() {
-	topo.RegisterFactory("etcd2", Factory{})
 	for _, cmd := range []string{"vttablet", "vtctl", "vtctld", "mysqlctl", "mysqlctld", "vttestserver", "vtcombo", "vtctldclient", "vtexplain", "vtgate",
 		"vtgr", "vtorc", "vtbackup"} {
 		servenv.OnParseFor(cmd, registerEtcd2TopoFlags)
 	}
+	topo.RegisterFactory("etcd2", Factory{})
 }
 
 func registerEtcd2TopoFlags(fs *pflag.FlagSet) {

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -36,22 +36,25 @@ package etcd2topo
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"flag"
 	"strings"
 	"time"
 
-	"google.golang.org/grpc"
+	"github.com/spf13/pflag"
+
+	"vitess.io/vitess/go/vt/servenv"
 
 	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
+	"google.golang.org/grpc"
+
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"vitess.io/vitess/go/vt/topo"
 )
 
 var (
-	clientCertPath = flag.String("topo_etcd_tls_cert", "", "path to the client cert to use to connect to the etcd topo server, requires topo_etcd_tls_key, enables TLS")
-	clientKeyPath  = flag.String("topo_etcd_tls_key", "", "path to the client key to use to connect to the etcd topo server, enables TLS")
-	serverCaPath   = flag.String("topo_etcd_tls_ca", "", "path to the ca to use to validate the server cert when connecting to the etcd topo server")
+	clientCertPath string
+	clientKeyPath  string
+	serverCaPath   string
 )
 
 // Factory is the consul topo.Factory implementation.
@@ -76,6 +79,20 @@ type Server struct {
 	root string
 
 	running chan struct{}
+}
+
+func init() {
+	topo.RegisterFactory("etcd2", Factory{})
+	for _, cmd := range []string{"vttablet", "vtctl", "vtctld", "mysqlctl", "mysqlctld", "vttestserver", "vtcombo", "vtctldclient", "vtexplain", "vtgate",
+		"vtgr", "vtorc", "vtbackup"} {
+		servenv.OnParseFor(cmd, registerEtcd2TopoFlags)
+	}
+}
+
+func registerEtcd2TopoFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&clientCertPath, "topo_etcd_tls_cert", clientCertPath, "path to the client cert to use to connect to the etcd topo server, requires topo_etcd_tls_key, enables TLS")
+	fs.StringVar(&clientKeyPath, "topo_etcd_tls_key", clientKeyPath, "path to the client key to use to connect to the etcd topo server, enables TLS")
+	fs.StringVar(&serverCaPath, "topo_etcd_tls_ca", serverCaPath, "path to the ca to use to validate the server cert when connecting to the etcd topo server")
 }
 
 // Close implements topo.Server.Close.
@@ -153,9 +170,5 @@ func NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath string) (*Ser
 func NewServer(serverAddr, root string) (*Server, error) {
 	// TODO: Rename this to a name to signifies this function uses the process-wide TLS settings.
 
-	return NewServerWithOpts(serverAddr, root, *clientCertPath, *clientKeyPath, *serverCaPath)
-}
-
-func init() {
-	topo.RegisterFactory("etcd2", Factory{})
+	return NewServerWithOpts(serverAddr, root, clientCertPath, clientKeyPath, serverCaPath)
 }

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -271,7 +271,7 @@ func testKeyspaceLock(t *testing.T, ts *topo.Server) {
 	}
 
 	// Long TTL, unlock before lease runs out.
-	*leaseTTL = 1000
+	leaseTTL = 1000
 	lockDescriptor, err := conn.Lock(ctx, keyspacePath, "ttl")
 	if err != nil {
 		t.Fatalf("Lock failed: %v", err)
@@ -281,7 +281,7 @@ func testKeyspaceLock(t *testing.T, ts *topo.Server) {
 	}
 
 	// Short TTL, make sure it doesn't expire.
-	*leaseTTL = 1
+	leaseTTL = 1
 	lockDescriptor, err = conn.Lock(ctx, keyspacePath, "short ttl")
 	if err != nil {
 		t.Fatalf("Lock failed: %v", err)


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>

## Description

Updates topo related flag references specified in #10859 
```
$ go list -f '{{ .ImportPath }}| {{ join .Deps " " }} ' ./go/cmd/... | awk -F"|" '$2 ~ "vitess.io/vitess/go/vt/topo/etcd2topo" {print $1}'
vitess.io/vitess/go/cmd/topo2topo
vitess.io/vitess/go/cmd/vtbackup
vitess.io/vitess/go/cmd/vtcombo
vitess.io/vitess/go/cmd/vtctl
vitess.io/vitess/go/cmd/vtctld
vitess.io/vitess/go/cmd/vtgate
vitess.io/vitess/go/cmd/vtgr
vitess.io/vitess/go/cmd/vtorc
vitess.io/vitess/go/cmd/vttablet
vitess.io/vitess/go/cmd/vttestserver
vitess.io/vitess/go/cmd/zk
```
## Related Issue(s)

closes #10859

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
