### PR TITLE
[cli] Use pflag/flag interop function in vtctldclient legacy shim

### DIFF
--- a/go/cmd/vtctldclient/command/legacy_shim.go
+++ b/go/cmd/vtctldclient/command/legacy_shim.go
@@ -18,13 +18,13 @@ package command
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"vitess.io/vitess/go/cmd/vtctldclient/cli"
+	"vitess.io/vitess/go/internal/flag"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/vtctl/vtctlclient"


### PR DESCRIPTION
## Description

Moving from the standard library to our custom interoperability function.

## Related Issue(s)

Closes #11284.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
