### PR TITLE
flags etc: delete old flags and stats, add deprecation notice to release notes

### DIFF
--- a/doc/releasenotes/15_0_0_summary.md
+++ b/doc/releasenotes/15_0_0_summary.md
@@ -67,6 +67,7 @@ The following VTTablet flags were deprecated in 7.0. They have now been deleted
 #### vttablet startup flag deprecations
 - --enable-query-plan-field-caching is now deprecated. It will be removed in v16.
 - --enable_semi_sync is now deprecated. It will be removed in v16. Instead, set the correct durability policy using `SetKeyspaceDurabilityPolicy`
+- --queryserver-config-pool-prefill-parallelism, --queryserver-config-stream-pool-prefill-parallelism and --queryserver-config-transaction-prefill-parallelism have all been deprecated. They will be removed in v16.
 
 ### New command line flags and behavior
 

--- a/go/cmd/vtctlclient/main.go
+++ b/go/cmd/vtctlclient/main.go
@@ -57,20 +57,14 @@ func init() {
 // VEP-4 will replace the need for this function. See https://github.com/vitessio/enhancements/blob/main/veps/vep-4.md
 func checkDeprecations(args []string) {
 	// utility:
-	findSubstring := func(s string) (arg string, ok bool) {
+	// name this to findSubstring if you need to use it
+	_ = func(s string) (arg string, ok bool) {
 		for _, arg := range args {
 			if strings.Contains(arg, s) {
 				return arg, true
 			}
 		}
 		return "", false
-	}
-	if _, ok := findSubstring("ApplySchema"); ok {
-		if arg, ok := findSubstring("ddl_strategy"); ok {
-			if strings.Contains(arg, "-skip-topo") {
-				log.Warning("-skip-topo is deprecated and will be removed in future versions")
-			}
-		}
 	}
 }
 

--- a/go/test/endtoend/recovery/pitr/shardedpitr_test.go
+++ b/go/test/endtoend/recovery/pitr/shardedpitr_test.go
@@ -302,10 +302,10 @@ func performResharding(t *testing.T) {
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("Reshard", "--", "--v1", "ks.reshardWorkflow", "0", "-80,80-")
 	require.NoError(t, err)
 
-	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SwitchReads", "--", "--tablet_type=rdonly", "ks.reshardWorkflow")
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SwitchReads", "--", "--tablet_types=rdonly", "ks.reshardWorkflow")
 	require.NoError(t, err)
 
-	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SwitchReads", "--", "--tablet_type=replica", "ks.reshardWorkflow")
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SwitchReads", "--", "--tablet_types=replica", "ks.reshardWorkflow")
 	require.NoError(t, err)
 
 	// then serve primary from the split shards

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -1191,7 +1191,7 @@ func applyVSchema(t *testing.T, vschema, keyspace string) {
 }
 
 func switchReadsDryRun(t *testing.T, cells, ksWorkflow string, dryRunResults []string) {
-	output, err := vc.VtctlClient.ExecuteCommandWithOutput("SwitchReads", "--", "--cells="+cells, "--tablet_type=replica", "--dry_run", ksWorkflow)
+	output, err := vc.VtctlClient.ExecuteCommandWithOutput("SwitchReads", "--", "--cells="+cells, "--tablet_types=replica", "--dry_run", ksWorkflow)
 	require.NoError(t, err, fmt.Sprintf("SwitchReads DryRun Error: %s: %s", err, output))
 	validateDryRunResults(t, output, dryRunResults)
 }
@@ -1199,9 +1199,9 @@ func switchReadsDryRun(t *testing.T, cells, ksWorkflow string, dryRunResults []s
 func switchReads(t *testing.T, cells, ksWorkflow string) {
 	var output string
 	var err error
-	output, err = vc.VtctlClient.ExecuteCommandWithOutput("SwitchReads", "--", "--cells="+cells, "--tablet_type=rdonly", ksWorkflow)
+	output, err = vc.VtctlClient.ExecuteCommandWithOutput("SwitchReads", "--", "--cells="+cells, "--tablet_types=rdonly", ksWorkflow)
 	require.NoError(t, err, fmt.Sprintf("SwitchReads Error: %s: %s", err, output))
-	output, err = vc.VtctlClient.ExecuteCommandWithOutput("SwitchReads", "--", "--cells="+cells, "--tablet_type=replica", ksWorkflow)
+	output, err = vc.VtctlClient.ExecuteCommandWithOutput("SwitchReads", "--", "--cells="+cells, "--tablet_types=replica", ksWorkflow)
 	require.NoError(t, err, fmt.Sprintf("SwitchReads Error: %s: %s", err, output))
 }
 

--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -178,15 +178,10 @@ func (st *StatsConn) WatchRecursive(ctx context.Context, path string) ([]*WatchD
 // NewLeaderParticipation is part of the Conn interface
 func (st *StatsConn) NewLeaderParticipation(name, id string) (LeaderParticipation, error) {
 	startTime := time.Now()
-	// TODO(deepthi): delete after v13.0
-	deprecatedKey := []string{"NewMasterParticipation", st.cell}
-	defer topoStatsConnTimings.Record(deprecatedKey, startTime)
-
 	statsKey := []string{"NewLeaderParticipation", st.cell}
 	defer topoStatsConnTimings.Record(statsKey, startTime)
 	res, err := st.conn.NewLeaderParticipation(name, id)
 	if err != nil {
-		topoStatsConnErrors.Add(deprecatedKey, int64(1))
 		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}

--- a/go/vt/topo/stats_conn_test.go
+++ b/go/vt/topo/stats_conn_test.go
@@ -319,34 +319,18 @@ func TestStatsConnTopoNewLeaderParticipation(t *testing.T) {
 	statsConn := NewStatsConn("global", conn)
 
 	_, _ = statsConn.NewLeaderParticipation("", "")
-	// TODO(deepthi): delete "Master" stats after v13.0
-	timingCounts := topoStatsConnTimings.Counts()["NewMasterParticipation.global"]
-	if got, want := timingCounts, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
-	timingCounts = topoStatsConnTimings.Counts()["NewLeaderParticipation.global"]
+	timingCounts := topoStatsConnTimings.Counts()["NewLeaderParticipation.global"]
 	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
 	// error is zero before getting an error
-	errorCount := topoStatsConnErrors.Counts()["NewMasterParticipation.global"]
-	if got, want := errorCount, int64(0); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
-	// error is zero before getting an error
-	errorCount = topoStatsConnErrors.Counts()["NewLeaderParticipation.global"]
+	errorCount := topoStatsConnErrors.Counts()["NewLeaderParticipation.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
 	_, _ = statsConn.NewLeaderParticipation("error", "")
-
-	// error stats gets emitted
-	errorCount = topoStatsConnErrors.Counts()["NewMasterParticipation.global"]
-	if got, want := errorCount, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
 
 	// error stats gets emitted
 	errorCount = topoStatsConnErrors.Counts()["NewLeaderParticipation.global"]

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -249,13 +249,6 @@ var commands = []commandGroup{
 				help:   "Runs a health check on a remote tablet.",
 			},
 			{
-				name:       "IgnoreHealthError",
-				method:     commandIgnoreHealthError,
-				params:     "<tablet alias> <ignore regexp>",
-				help:       "Sets the regexp for health check errors to ignore on the specified tablet. The pattern has implicit ^$ anchors. Set to empty string or restart vttablet to stop ignoring anything.",
-				deprecated: true,
-			},
-			{
 				name:   "Sleep",
 				method: commandSleep,
 				params: "<tablet alias> <duration>",
@@ -464,7 +457,7 @@ var commands = []commandGroup{
 			{
 				name:   "CreateLookupVindex",
 				method: commandCreateLookupVindex,
-				params: "[--cell=<source_cells> DEPRECATED] [--cells=<source_cells>] [--tablet_types=<source_tablet_types>] <keyspace> <json_spec>",
+				params: "[--cells=<source_cells>] [--tablet_types=<source_tablet_types>] <keyspace> <json_spec>",
 				help:   `Create and backfill a lookup vindex. the json_spec must contain the vindex and colvindex specs for the new lookup.`,
 			},
 			{
@@ -488,7 +481,7 @@ var commands = []commandGroup{
 			{
 				name:   "SwitchReads",
 				method: commandSwitchReads,
-				params: "[--cells=c1,c2,...] [--reverse] --tablet_type={replica|rdonly} [--dry_run] <keyspace.workflow>",
+				params: "[--cells=c1,c2,...] [--reverse] [--tablet_types=REPLICA,RDONLY] [--dry_run] <keyspace.workflow>",
 				help:   "Switch read traffic for the specified workflow.",
 			},
 			{
@@ -1257,10 +1250,6 @@ func commandRunHealthCheck(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		TabletAlias: tabletAlias,
 	})
 	return err
-}
-
-func commandIgnoreHealthError(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	return fmt.Errorf("this command is no longer relevant and has been deprecated")
 }
 
 func commandSleep(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
@@ -2527,8 +2516,6 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 
 func commandCreateLookupVindex(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	cells := subFlags.String("cells", "", "Source cells to replicate from.")
-	// TODO: keep --cell around for backward compatibility and remove it in a future version
-	cell := subFlags.String("cell", "", "Cell to replicate from.")
 	tabletTypes := subFlags.String("tablet_types", "", "Source tablet types to replicate from.")
 	continueAfterCopyWithOwner := subFlags.Bool("continue_after_copy_with_owner", false, "Vindex will continue materialization after copy when an owner is provided")
 	if err := subFlags.Parse(args); err != nil {
@@ -2536,9 +2523,6 @@ func commandCreateLookupVindex(ctx context.Context, wr *wrangler.Wrangler, subFl
 	}
 	if subFlags.NArg() != 2 {
 		return fmt.Errorf("two arguments are required: keyspace and json_spec")
-	}
-	if *cells == "" && *cell != "" {
-		*cells = *cell
 	}
 	keyspace := subFlags.Arg(0)
 	specs := &vschemapb.Keyspace{}
@@ -2681,19 +2665,10 @@ func commandSwitchReads(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 
 	reverse := subFlags.Bool("reverse", false, "Moves the served tablet type backward instead of forward.")
 	cellsStr := subFlags.String("cells", "", "Specifies a comma-separated list of cells to update")
-	tabletTypes := subFlags.String("tablet_types", "rdonly,replica", "Tablet types to switch one or both or rdonly/replica")
-	deprecatedTabletType := subFlags.String("tablet_type", "", "(DEPRECATED) one of rdonly/replica")
+	tabletTypes := subFlags.String("tablet_types", "rdonly,replica", "Tablet types to switch one or both of rdonly/replica")
 	dryRun := subFlags.Bool("dry_run", false, "Does a dry run of SwitchReads and only reports the actions to be taken")
 	if err := subFlags.Parse(args); err != nil {
 		return err
-	}
-
-	if !(*deprecatedTabletType == "" || *deprecatedTabletType == "replica" || *deprecatedTabletType == "rdonly") {
-		return fmt.Errorf("invalid value specified for --tablet_type: %s", *deprecatedTabletType)
-	}
-
-	if *deprecatedTabletType != "" {
-		*tabletTypes = *deprecatedTabletType
 	}
 
 	tabletTypesArr := strings.Split(*tabletTypes, ",")
@@ -3079,12 +3054,6 @@ func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 	}
 	if subFlags.NArg() != 1 {
 		return fmt.Errorf("the <keyspace> argument is required for the commandApplySchema command")
-	}
-
-	// v14 deprecates `--skip-topo` flag. This check will be removed in v15
-	if settings, _ := schema.ParseDDLStrategy(*ddlStrategy); settings != nil && settings.IsSkipTopoFlag() {
-		deprecationMessage := `--skip-topo flag is deprecated and will be removed in v15`
-		log.Warningf(deprecationMessage)
 	}
 
 	keyspace := subFlags.Arg(0)


### PR DESCRIPTION
## Description
- remove `master` stats
- remove deprecated vtctl command sub flags
- add deprecation notice for `prefill` flags

## Related Issue(s)
#5960
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
