### PR TITLE
VTop: Adds a function to get the flag set for a given command

### DIFF
--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -305,10 +305,7 @@ func getFlagHooksFor(cmd string) (hooks []func(fs *pflag.FlagSet)) {
 // ParseFlags initializes flags and handles the common case when no positional
 // arguments are expected.
 func ParseFlags(cmd string) {
-	fs := pflag.NewFlagSet(cmd, pflag.ExitOnError)
-	for _, hook := range getFlagHooksFor(cmd) {
-		hook(fs)
-	}
+	fs := GetFlagSetFor(cmd)
 
 	_flag.Parse(fs)
 
@@ -324,12 +321,20 @@ func ParseFlags(cmd string) {
 	}
 }
 
-// ParseFlagsWithArgs initializes flags and returns the positional arguments
-func ParseFlagsWithArgs(cmd string) []string {
+// GetFlagSetFor returns the flag set for a given command.
+// This has to exported for the Vitess-operator to use
+func GetFlagSetFor(cmd string) *pflag.FlagSet {
 	fs := pflag.NewFlagSet(cmd, pflag.ExitOnError)
 	for _, hook := range getFlagHooksFor(cmd) {
 		hook(fs)
 	}
+
+	return fs
+}
+
+// ParseFlagsWithArgs initializes flags and returns the positional arguments
+func ParseFlagsWithArgs(cmd string) []string {
+	fs := GetFlagSetFor(cmd)
 
 	_flag.Parse(fs)
 


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

With the recent flag changes, we discovered that VTop binary broke. The Vitess-operator requires the backup flags like `bakcup_storage_implementation`, `ceph_backup_storage_config` among others. Previously, when we used the `flag` package these got implicitly imported when we imported the packages that defined these flags. Now that we have moved to the `pflag` package, we register the flags only for the binaries that require it. This leads to the flags not being registered in the vitess-operator binary. 

One possible solution would have been to add the `vitess-operator` binary to the list of the binaries where we register certain flags, but that doesn't seem the best approach because it adds a cross-repository code-base dependency. Instead, an alternate fix is proposed in this PR.

This PR refactors some part of the `servenv.ParseFlags` function to return the flagSet of the given command without parsing it. On the VTop side we can ask for the flag set of the `vtbackup` binary and add the flags that we require from it to the VTop binary.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/10697

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
