### PR TITLE
Update flag parsing for tests to work with "go tool test2json", used by GoLand to run unit tests

### DIFF
--- a/go/internal/flag/flag.go
+++ b/go/internal/flag/flag.go
@@ -105,14 +105,20 @@ func Usage() {
 // filterTestFlags returns two slices: the second one has just the flags for `go test` and the first one contains
 // the rest of the flags.
 const goTestFlagSuffix = "-test"
+const goTestRunFlag = "-test.run"
 
 func filterTestFlags() ([]string, []string) {
 	args := os.Args
 	var testFlags []string
 	var otherArgs []string
+	isRunFlag := false
 	for i := 0; 0 < len(args) && i < len(args); i++ {
-		if strings.HasPrefix(args[i], goTestFlagSuffix) {
+		if strings.HasPrefix(args[i], goTestFlagSuffix) || isRunFlag {
+			isRunFlag = false
 			testFlags = append(testFlags, args[i])
+			if args[i] == goTestRunFlag {
+				isRunFlag = true
+			}
 			continue
 		}
 		otherArgs = append(otherArgs, args[i])


### PR DESCRIPTION
## Description

The flag parsing logic in `go/internal/flag/flag.go` to handle `go test` flags using `ParseFlagsForTest()`, worked on the CLI with `go test`, but not from within GoLand. The latter uses `go tool test2json`.

I am not entirely sure why this change works, but including the parameter passed to `-run` in the test arguments works both with the CLI and GoLand. 

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
