### PR TITLE
[R14 fix]: do not rewrite single columns in derived tables

### DIFF
--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -538,6 +538,14 @@ func (er *astRewriter) unnestSubQueries(cursor *Cursor, subquery *Subquery) {
 	if !ok {
 		return
 	}
+	_, isColName := expr.Expr.(*ColName)
+	if isColName {
+		// If we find a single col-name in a `dual` subquery, we can be pretty sure the user is returning a column
+		// already projected.
+		// `select 1 as x, (select x)`
+		// is perfectly valid - any aliased columns to the left are available inside subquery scopes
+		return
+	}
 	er.bindVars.NoteRewrite()
 	// we need to make sure that the inner expression also gets rewritten,
 	// so we fire off another rewriter traversal here

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -97,6 +97,10 @@ func TestRewrites(in *testing.T) {
 		expected: "select :__vtdbname as `(select database() from dual)` from dual",
 		db:       true,
 	}, {
+		// don't unnest solo columns
+		in:       "select 1 as foobar, (select foobar)",
+		expected: "select 1 as foobar, (select foobar from dual) from dual",
+	}, {
 		in:       "select id from user where database()",
 		expected: "select id from user where database()",
 		// no bindvar needs

--- a/go/vt/vtgate/planbuilder/physical/filter.go
+++ b/go/vt/vtgate/planbuilder/physical/filter.go
@@ -37,11 +37,6 @@ func (f *Filter) TableID() semantics.TableSet {
 	return f.Source.TableID()
 }
 
-// PushPredicate implements the PhysicalOperator interface
-func (f *Filter) PushPredicate(expr sqlparser.Expr, semTable *semantics.SemTable) error {
-	panic("unimplemented")
-}
-
 // UnsolvedPredicates implements the PhysicalOperator interface
 func (f *Filter) UnsolvedPredicates(semTable *semantics.SemTable) []sqlparser.Expr {
 	panic("implement me")

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5397,5 +5397,24 @@
         ]
       }
     }
+  },
+  {
+    "comment": "Earlier columns are in scope in subqueries https://github.com/vitessio/vitess/issues/11246",
+    "query": "SELECT 1 as x, (SELECT x)",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "SELECT 1 as x, (SELECT x)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 as x, (select x from dual where 1 != 1) from dual where 1 != 1",
+        "Query": "select 1 as x, (select x from dual) from dual",
+        "Table": "dual"
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Description
The Vitess vtgate planner was doing an bad query rewrite. A query such as this:

```sql
select 1 as x, (select x)
```

would get rewritten to:

```sql
select 1 as x, x as `(select x)`
```

This PR stops these rewrites from being performed.

## Related Issue(s)
Fixes #11246
Backport of #11419

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required