### PR TITLE
Add a PRIMARY KEY to the aggregation E2E tests

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/schema.sql
+++ b/go/test/endtoend/vtgate/queries/aggregation/schema.sql
@@ -60,6 +60,7 @@ CREATE TABLE t1 (
     `name` varchar(20) NOT NULL,
     `value` varchar(50),
     shardKey bigint,
+    PRIMARY KEY t1_id,
     UNIQUE KEY `t1id_name` (t1_id, `name`),
     KEY `IDX_TA_ValueName` (`value`(20), `name`(10))
 ) ENGINE InnoDB;


### PR DESCRIPTION
## Description

This PR adds a primary key to the E2E aggregation tests. The PK was missing from one of the tables.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
