### PR TITLE
Fix #11455 - skip vindex operations for `DELETE` statements against unsharded tables

### DIFF
--- a/go/test/endtoend/vtgate/sequence/seq_test.go
+++ b/go/test/endtoend/vtgate/sequence/seq_test.go
@@ -47,9 +47,9 @@ var (
 	)Engine=InnoDB;
 
 	create table sequence_test_seq (
-		id int default 0, 
-		next_id bigint default null, 
-		cache bigint default null, 
+		id int default 0,
+		next_id bigint default null,
+		cache bigint default null,
 		primary key(id)
 	) comment 'vitess_sequence' Engine=InnoDB;
 
@@ -60,13 +60,13 @@ INSERT INTO id_seq (id, next_id, cache) values (0, 1, 1000);
 	`
 
 	unshardedVSchema = `
-		{	
+		{
 			"sharded":false,
 			"vindexes": {
 				"hash_index": {
 					"type": "hash"
 				}
-			},	
+			},
 			"tables": {
 				"sequence_test":{
 					"auto_increment":{
@@ -147,7 +147,7 @@ CREATE TABLE allDefaults (
 				"column": "id",
 				"sequence": "id_seq"
 			  }
-			},			
+			},
 			"allDefaults": {
 			  "columnVindexes": [
 				{
@@ -263,6 +263,12 @@ func TestSeq(t *testing.T) {
 	want := "Duplicate entry"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("wrong insert: %v, must contain %s", err, want)
+	}
+
+	utils.Exec(t, conn, "DELETE FROM sequence_test_seq")
+	qr = utils.Exec(t, conn, "select * from sequence_test_seq")
+	if got, want := fmt.Sprintf("%v", qr.Rows), `[]`; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/physical/route_planning.go
+++ b/go/vt/vtgate/planbuilder/physical/route_planning.go
@@ -226,7 +226,7 @@ func createPhysicalOperatorFromDelete(ctx *plancontext.PlanningContext, op *abst
 		return nil, err
 	}
 
-	if opCode == engine.Unsharded {
+	if !vindexTable.Keyspace.Sharded {
 		return &Route{
 			Source: &Delete{
 				QTable: op.Table,

--- a/go/vt/vtgate/planbuilder/physical/route_planning.go
+++ b/go/vt/vtgate/planbuilder/physical/route_planning.go
@@ -226,6 +226,19 @@ func createPhysicalOperatorFromDelete(ctx *plancontext.PlanningContext, op *abst
 		return nil, err
 	}
 
+	if opCode == engine.Unsharded {
+		return &Route{
+			Source: &Delete{
+				QTable: op.Table,
+				VTable: vindexTable,
+				AST:    op.AST,
+			},
+			RouteOpCode:       opCode,
+			Keyspace:          vindexTable.Keyspace,
+			TargetDestination: dest,
+		}, nil
+	}
+
 	primaryVindex, vindexAndPredicates, err := getVindexInformation(op.TableID(), op.Table.Predicates, vindexTable)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -264,6 +264,29 @@
     }
   },
   {
+    "comment": "delete from sequence",
+    "query": "DELETE FROM seq",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "DELETE FROM seq",
+      "Instructions": {
+        "OperatorType": "Delete",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "TargetTabletType": "PRIMARY",
+        "MultiShardAutocommit": false,
+        "Query": "delete from seq",
+        "Table": "seq"
+      },
+      "TablesUsed": [
+        "main.seq"
+      ]
+    }
+  },
+  {
     "comment": "update by primary keyspace id",
     "query": "update user set val = 1 where id = 1",
     "v3-plan": {

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -287,6 +287,29 @@
     }
   },
   {
+    "comment": "delete from reference table in unsharded keyspace",
+    "query": "DELETE FROM unsharded_ref",
+    "plan": {
+      "QueryType": "DELETE",
+      "Original": "DELETE FROM unsharded_ref",
+      "Instructions": {
+        "OperatorType": "Delete",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "TargetTabletType": "PRIMARY",
+        "MultiShardAutocommit": false,
+        "Query": "delete from unsharded_ref",
+        "Table": "unsharded_ref"
+      },
+      "TablesUsed": [
+        "main.unsharded_ref"
+      ]
+    }
+  },
+  {
     "comment": "update by primary keyspace id",
     "query": "update user set val = 1 where id = 1",
     "v3-plan": {

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
@@ -459,6 +459,9 @@
         },
         "seq": {
           "type": "sequence"
+        },
+        "unsharded_ref": {
+          "type": "reference"
         }
       }
     },


### PR DESCRIPTION
## Description

Executing a `DELETE FROM` query against a sequence table would fail with:

```
table '<sequence table>' does not have a primary vindex (errno 1173) (sqlstate 42000) during query: DELETE FROM <sequence table>
```

This PR fixes that error by skipping all vindex routing logic for unsharded queries.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/11455.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
