### PR TITLE
Give all permissions in rbac in examples

### DIFF
--- a/examples/local/vtadmin/rbac.yaml
+++ b/examples/local/vtadmin/rbac.yaml
@@ -1,17 +1,5 @@
 rules:
   - resource: "*"
-    actions:
-    - "get"
-    - "create"
-    - "delete"
-    - "put"
-    - "ping"
+    actions: ["*"]
     subjects: ["*"]
     clusters: ["*"]
-  - resource: "Shard"
-    actions:
-    - "emergency_reparent_shard"
-    - "planned_reparent_shard"
-    subjects: ["*"]
-    clusters:
-    - "local"

--- a/examples/region_sharding/vtadmin/rbac.yaml
+++ b/examples/region_sharding/vtadmin/rbac.yaml
@@ -1,17 +1,5 @@
 rules:
   - resource: "*"
-    actions:
-    - "get"
-    - "create"
-    - "delete"
-    - "put"
-    - "ping"
+    actions: ["*"]
     subjects: ["*"]
     clusters: ["*"]
-  - resource: "Shard"
-    actions:
-    - "emergency_reparent_shard"
-    - "planned_reparent_shard"
-    subjects: ["*"]
-    clusters:
-    - "local"


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Today while running the local example I noticed that we don't give all the permissions to the users when we run the local-examples. This leads to the user not being able to manage the tablets' replication from the vtadmin page. This is a little counter-intuitive and not easy to debug. For first time users of Vitess, all the vtadmin operations should work without any issues. Rbac is a more of advanced thing that is of more importance when going into production.

This PR fixes the examples to give all the users all the accesses available so that everything works without any issues.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
