### PR TITLE
[vtadmin] Do not backtick binary name

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -168,7 +168,7 @@ func main() {
 	rootCmd.Flags().BoolVar(&httpOpts.EnableTracing, "http-tracing", false, "whether to enable tracing on the HTTP server")
 
 	// gRPC server flags
-	rootCmd.Flags().BoolVar(&opts.AllowReflection, "grpc-allow-reflection", false, "whether to register the gRPC server for reflection; this is required to use tools like `grpc_cli`")
+	rootCmd.Flags().BoolVar(&opts.AllowReflection, "grpc-allow-reflection", false, "whether to register the gRPC server for reflection; this is required to use tools like grpc_cli")
 	rootCmd.Flags().BoolVar(&opts.EnableChannelz, "grpc-enable-channelz", false, "whether to enable the channelz service on the gRPC server")
 
 	// HTTP server flags


### PR DESCRIPTION
## Description

I accidentally stumbled over the behavior outlined in `flag.PrintDefaults` [1], which `pflag` replicates, specifically:

> The listed type, here int, can be changed by placing a back-quoted
> name in the flag's usage string; the first such item in the message is
> taken to be a parameter name to show in the message and the back quotes
> are stripped from the message when displayed.

[1]: https://pkg.go.dev/flag#PrintDefaults.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

https://github.com/rohit-nayak-ps/vreplication-docs/pull/2#pullrequestreview-1137468150

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
