### PR TITLE
Full Status tab improvements for VTAdmin

### DIFF
--- a/web/vtadmin/src/components/routes/tablet/FullStatus.tsx
+++ b/web/vtadmin/src/components/routes/tablet/FullStatus.tsx
@@ -1,24 +1,24 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useGetFullStatus } from '../../../hooks/api';
-import {topodata, vtadmin} from '../../../proto/vtadmin';
+import { topodata, vtadmin } from '../../../proto/vtadmin';
 import { formatAlias } from '../../../util/tablets';
 import { Code } from '../../Code';
 import style from './Tablet.module.scss';
-import {isNil} from "lodash-es";
+import { isNil } from 'lodash-es';
 
 interface Props {
     tablet: vtadmin.Tablet;
 }
 
 function stateReplacer(key: any, val: any) {
-    if ( key === 'io_state' || key == 'sql_state' ) {
+    if (key === 'io_state' || key === 'sql_state') {
         if (val === 3) {
-            return "Replication Running"
+            return 'Replication Running';
         } else if (val === 2) {
-            return "Replication Connected"
+            return 'Replication Connected';
         } else if (val === 1) {
-            return "Replication Stopped"
+            return 'Replication Stopped';
         }
     }
     return val;
@@ -46,16 +46,16 @@ const FullStatus: React.FC<Props> = ({ tablet }) => {
     }
     if (!isNil(data) && !isNil(data.status)) {
         if (data.status.semi_sync_primary_enabled !== true) {
-            data.status.semi_sync_primary_enabled = false
+            data.status.semi_sync_primary_enabled = false;
         }
         if (data.status.semi_sync_replica_enabled !== true) {
-            data.status.semi_sync_replica_enabled = false
+            data.status.semi_sync_replica_enabled = false;
         }
         if (data.status.semi_sync_primary_status !== true) {
-            data.status.semi_sync_primary_status = false
+            data.status.semi_sync_primary_status = false;
         }
         if (data.status.semi_sync_replica_status !== true) {
-            data.status.semi_sync_replica_status = false
+            data.status.semi_sync_replica_status = false;
         }
     }
 

--- a/web/vtadmin/src/components/routes/tablet/FullStatus.tsx
+++ b/web/vtadmin/src/components/routes/tablet/FullStatus.tsx
@@ -1,24 +1,23 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useGetFullStatus } from '../../../hooks/api';
-import { topodata, vtadmin } from '../../../proto/vtadmin';
+import { vtadmin } from '../../../proto/vtadmin';
 import { formatAlias } from '../../../util/tablets';
 import { Code } from '../../Code';
 import style from './Tablet.module.scss';
-import { isNil } from 'lodash-es';
 
 interface Props {
     tablet: vtadmin.Tablet;
 }
 
-function stateReplacer(key: any, val: any) {
+function stateReplacer(key: string, val: number) {
     if (key === 'io_state' || key === 'sql_state') {
         if (val === 3) {
-            return 'Replication Running';
+            return 'Running';
         } else if (val === 2) {
-            return 'Replication Connected';
+            return 'Connecting';
         } else if (val === 1) {
-            return 'Replication Stopped';
+            return 'Stopped';
         }
     }
     return val;
@@ -44,19 +43,12 @@ const FullStatus: React.FC<Props> = ({ tablet }) => {
             </div>
         );
     }
-    if (!isNil(data) && !isNil(data.status)) {
-        if (data.status.semi_sync_primary_enabled !== true) {
-            data.status.semi_sync_primary_enabled = false;
-        }
-        if (data.status.semi_sync_replica_enabled !== true) {
-            data.status.semi_sync_replica_enabled = false;
-        }
-        if (data.status.semi_sync_primary_status !== true) {
-            data.status.semi_sync_primary_status = false;
-        }
-        if (data.status.semi_sync_replica_status !== true) {
-            data.status.semi_sync_replica_status = false;
-        }
+
+    if (data && data.status) {
+        data.status.semi_sync_primary_enabled = !!data.status.semi_sync_primary_enabled;
+        data.status.semi_sync_replica_enabled = !!data.status.semi_sync_replica_enabled;
+        data.status.semi_sync_primary_status = !!data.status.semi_sync_primary_status;
+        data.status.semi_sync_replica_status = !!data.status.semi_sync_replica_status;
     }
 
     return <Code code={JSON.stringify(data, stateReplacer, 2)} />;

--- a/web/vtadmin/src/components/routes/tablet/FullStatus.tsx
+++ b/web/vtadmin/src/components/routes/tablet/FullStatus.tsx
@@ -1,13 +1,27 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useGetFullStatus } from '../../../hooks/api';
-import { vtadmin } from '../../../proto/vtadmin';
+import {topodata, vtadmin} from '../../../proto/vtadmin';
 import { formatAlias } from '../../../util/tablets';
 import { Code } from '../../Code';
 import style from './Tablet.module.scss';
+import {isNil} from "lodash-es";
 
 interface Props {
     tablet: vtadmin.Tablet;
+}
+
+function stateReplacer(key: any, val: any) {
+    if ( key === 'io_state' || key == 'sql_state' ) {
+        if (val === 3) {
+            return "Replication Running"
+        } else if (val === 2) {
+            return "Replication Connected"
+        } else if (val === 1) {
+            return "Replication Stopped"
+        }
+    }
+    return val;
 }
 
 const FullStatus: React.FC<Props> = ({ tablet }) => {
@@ -30,8 +44,22 @@ const FullStatus: React.FC<Props> = ({ tablet }) => {
             </div>
         );
     }
+    if (!isNil(data) && !isNil(data.status)) {
+        if (data.status.semi_sync_primary_enabled !== true) {
+            data.status.semi_sync_primary_enabled = false
+        }
+        if (data.status.semi_sync_replica_enabled !== true) {
+            data.status.semi_sync_replica_enabled = false
+        }
+        if (data.status.semi_sync_primary_status !== true) {
+            data.status.semi_sync_primary_status = false
+        }
+        if (data.status.semi_sync_replica_status !== true) {
+            data.status.semi_sync_replica_status = false
+        }
+    }
 
-    return <Code code={JSON.stringify(data, null, 2)} />;
+    return <Code code={JSON.stringify(data, stateReplacer, 2)} />;
 };
 
 export default FullStatus;


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
The PR https://github.com/vitessio/vitess/pull/11438 introduced the `Full Status` tab in the vttablets in VTAdmin which shows the full replication status of the tablets. 
In this output it was noticed that the IO state and SQL state are printed as integers (because they are stored as an enum), instead of any meaningful output, so it becomes hard for the users to read this data unless they are familiar with Vitess internals on how the enum works.

This PR attempts to improve this situation by decoding these values before printing them using a replacer function in the `json.Stringify`.

Another thing that was noticed was that the semi-sync properties weren't printed if they are false. This is not desirable. We instead always want to print these settings. This PR addresses this too. It checks for these fields being explicitly set to true. If they aren't, then we set them to false.

Here are the images of the Full Status tab after the changes - 

![Screenshot 2022-10-12 at 1 46 11 PM](https://user-images.githubusercontent.com/35839558/195290607-71a0a801-f872-4f5c-9160-c67bc8bfc76d.png)

![Screenshot 2022-10-12 at 1 45 59 PM](https://user-images.githubusercontent.com/35839558/195290403-fc6fddd4-e2a5-4b73-ad79-70904d7ae9c2.png)

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
