### PR TITLE
Skip `TestComparisonSemantics` test

### DIFF
--- a/go/mysql/collations/integration/coercion_test.go
+++ b/go/mysql/collations/integration/coercion_test.go
@@ -135,6 +135,10 @@ func TestComparisonSemantics(t *testing.T) {
 	conn := mysqlconn(t)
 	defer conn.Close()
 
+	if strings.HasPrefix(conn.ServerVersion, "8.0.31") {
+		t.Skipf("Coercion semantics have changed in 8.0.31")
+	}
+
 	for _, coll := range collations.Local().AllCollations() {
 		text := verifyTranscoding(t, coll, remote.NewCollation(conn, coll.Name()), []byte(BaseString))
 		testInputs = append(testInputs, &TextWithCollation{Text: text, Collation: coll})


### PR DESCRIPTION
## Description

The `TestComparisonSemantics` test started failing after a recent release of MySQL. This will unblock the failure on the `Unit Test (mysql80)` workflow. 

> @vmg: Oracle has released a new MySQL minor version that changes some coercion rules. While we figure out what they changed and whether it was intentional, let's skip this test.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
