### PR TITLE
collations: fix coercion semantics according to 8.0.31 changes

### DIFF
--- a/go/mysql/collations/coercion.go
+++ b/go/mysql/collations/coercion.go
@@ -208,8 +208,15 @@ func (env *Environment) MergeCollations(left, right TypedCollation, opt Coercion
 	if leftColl == nil || rightColl == nil {
 		return TypedCollation{}, nil, nil, fmt.Errorf("unsupported TypeCollationID: %v / %v", left.Collation, right.Collation)
 	}
+
 	leftCS := leftColl.Charset()
 	rightCS := rightColl.Charset()
+
+	if left.Coercibility == CoerceExplicit && right.Coercibility == CoerceExplicit {
+		if left.Collation != right.Collation {
+			goto cannotCoerce
+		}
+	}
 
 	if leftCS.Name() == rightCS.Name() {
 		switch {

--- a/go/mysql/collations/integration/coercion_test.go
+++ b/go/mysql/collations/integration/coercion_test.go
@@ -135,8 +135,8 @@ func TestComparisonSemantics(t *testing.T) {
 	conn := mysqlconn(t)
 	defer conn.Close()
 
-	if strings.HasPrefix(conn.ServerVersion, "8.0.31") {
-		t.Skipf("Coercion semantics have changed in 8.0.31")
+	if v, err := conn.ServerVersionAtLeast(8, 0, 31); err != nil || !v {
+		t.Skipf("The behavior of Coercion Semantics is not correct before 8.0.31")
 	}
 
 	for _, coll := range collations.Local().AllCollations() {


### PR DESCRIPTION
## Description

From the MySQL 8.0.31 release notes:

>  When comparing two string values with explicit COLLATE clauses, these should have the same collation, else the comparison should be rejected, but this was not always enforced. 

This was breaking the build.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
