### PR TITLE
Add GenerateShardRanges to vtctldclient

### DIFF
--- a/go/cmd/vtctldclient/command/root.go
+++ b/go/cmd/vtctldclient/command/root.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -49,14 +50,7 @@ var (
 		// command context for every command.
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
 			traceCloser = trace.StartTracing("vtctldclient")
-			if VtctldClientProtocol != "local" {
-				if err := ensureServerArg(); err != nil {
-					return err
-				}
-			}
-
-			client, err = vtctldclient.New(VtctldClientProtocol, server)
-
+			client, err = getClientForCommand(cmd)
 			ctx := cmd.Context()
 			if ctx == nil {
 				ctx = context.Background()
@@ -66,9 +60,11 @@ var (
 		},
 		// Similarly, PersistentPostRun cleans up the resources spawned by
 		// PersistentPreRun.
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) (err error) {
 			commandCancel()
-			err := client.Close()
+			if client != nil {
+				err = client.Close()
+			}
 			trace.LogErrorsWhenClosing(traceCloser)
 			return err
 		},
@@ -87,13 +83,27 @@ var (
 
 var errNoServer = errors.New("please specify --server <vtctld_host:vtctld_port> to specify the vtctld server to connect to")
 
-// ensureServerArg validates that --server was passed to the CLI.
-func ensureServerArg() error {
-	if server == "" {
-		return errNoServer
+const skipClientCreationKey = "skip_client_creation"
+
+// getClientForCommand returns a vtctldclient.VtctldClient for a given command.
+// It validates that --server was passed to the CLI for commands that need it.
+func getClientForCommand(cmd *cobra.Command) (vtctldclient.VtctldClient, error) {
+	if skipStr, ok := cmd.Annotations[skipClientCreationKey]; ok {
+		skipClientCreation, err := strconv.ParseBool(skipStr)
+		if err != nil {
+			skipClientCreation = false
+		}
+
+		if skipClientCreation {
+			return nil, nil
+		}
 	}
 
-	return nil
+	if VtctldClientProtocol != "local" && server == "" {
+		return nil, errNoServer
+	}
+
+	return vtctldclient.New(VtctldClientProtocol, server)
 }
 
 func init() {

--- a/go/flags/endtoend/vtctldclient.txt
+++ b/go/flags/endtoend/vtctldclient.txt
@@ -26,6 +26,7 @@ Available Commands:
   ExecuteFetchAsDBA           Executes the given query as the DBA user on the remote tablet.
   ExecuteHook                 Runs the specified hook on the given tablet.
   FindAllShardsInKeyspace     Returns a map of shard names to shard references for a given keyspace.
+  GenerateShardRanges         Print a set of shard ranges assuming a keyspace with N shards.
   GetBackups                  Lists backups for the given shard.
   GetCellInfo                 Gets the CellInfo object for the given cell.
   GetCellInfoNames            Lists the names of all cells in the cluster.


### PR DESCRIPTION



## Description

I also refactored the `ensureServerArg` to actually create the client (for commands that need it, now that we have one that doesn't), and renamed it accordingly:

```
vtctldclient  GenerateShardRanges 2                 
[
  "-80",
  "80-"
]
```

```
# showing that other commands still need `--server`
vtctldclient  GetCellInfo foo 2>&1 | tail -n 1      
E1013 15:48:33.918217   20963 main.go:56] please specify --server <vtctld_host:vtctld_port> to specify the vtctld server to connect to
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
