### PR TITLE
bug fix: using self-referencing columns in HAVING should not overflow

### DIFF
--- a/go/vt/vtgate/planbuilder/rewrite.go
+++ b/go/vt/vtgate/planbuilder/rewrite.go
@@ -182,12 +182,8 @@ func rewriteHavingClause(node *sqlparser.Select) {
 					return false
 				}
 				originalExpr, isInMap := selectExprMap[x.Name.Lowered()]
-				if isInMap {
-					if sqlparser.ContainsAggregation(originalExpr) {
-						hasAggr = true
-					} else {
-						cursor.Replace(originalExpr)
-					}
+				if isInMap && sqlparser.ContainsAggregation(originalExpr) {
+					hasAggr = true
 				}
 				return false
 			default:

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -4128,6 +4128,7 @@
     }
   },
   {
+    "comment": "select * from samecolvin where col = :col",
     "query": "select * from samecolvin where col = :col",
     "v3-plan": {
       "QueryType": "SELECT",
@@ -6340,6 +6341,43 @@
       },
       "TablesUsed": [
         "user.music"
+      ]
+    }
+  },
+  {
+    "comment": "Self referencing columns in HAVING should work",
+    "query": "select a+2 as a from user having a = 42",
+    "v3-plan": {
+      "QueryType": "SELECT",
+      "Original": "select a+2 as a from user having a = 42",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select a + 2 as a from `user` where 1 != 1",
+        "Query": "select a + 2 as a from `user` having a = 42",
+        "Table": "`user`"
+      }
+    },
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select a+2 as a from user having a = 42",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select a + 2 as a from `user` where 1 != 1",
+        "Query": "select a + 2 as a from `user` where a + 2 = 42",
+        "Table": "`user`"
+      },
+      "TablesUsed": [
+        "user.user"
       ]
     }
   }


### PR DESCRIPTION
## Description
The planner rewrites the HAVING clause in two steps, and in the second part, we were doing the the wrong rewrite, which lead to a cycle in the expression tree. When we then tried to turn the expression back to SQL, we ran into a stack overflow.

Example query that was failing:

```sql
select a+2 as a from user having a = 42
```


## Related Issue(s)

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
