### PR TITLE
Skip CI with the `Skip CI` label

### DIFF
--- a/.github/workflows/check_make_vtadmin_authz_testgen.yml
+++ b/.github/workflows/check_make_vtadmin_authz_testgen.yml
@@ -6,6 +6,13 @@ jobs:
     name: Check Make vtadmin_authz_testgen
     runs-on: ubuntu-latest
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -6,6 +6,13 @@ jobs:
     name: Check Make VTAdmin Web Proto
     runs-on: ubuntu-latest
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_mysql_server_vault.yml
+++ b/.github/workflows/cluster_endtoend_mysql_server_vault.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_mysql_server_vault.yml
+++ b/.github/workflows/cluster_endtoend_mysql_server_vault.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revertible_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate_vdiff2_convert_tz.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vstream_failover.yml
+++ b/.github/workflows/cluster_endtoend_vstream_failover.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_false.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
+++ b/.github/workflows/cluster_endtoend_vstream_stoponreshard_true.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
+++ b/.github/workflows/cluster_endtoend_vstream_with_keyspaces_to_watch.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtbackup_transform.yml
+++ b/.github/workflows/cluster_endtoend_vtbackup_transform.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtbackup_transform.yml
+++ b/.github/workflows/cluster_endtoend_vtbackup_transform.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vtorc_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_mysql57.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_vtorc_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_vtorc_mysql57.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
+++ b/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
@@ -14,9 +14,16 @@ env:
 jobs:
   build:
     name: Run endtoend tests on Cluster (vttablet_prscomplex)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |
@@ -71,8 +78,16 @@ jobs:
     - name: Get dependencies
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
       run: |
+        # Setup Percona Server for MySQL 8.0
         sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+        sudo apt-get install -y lsb-release gnupg2 curl
+        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo percona-release setup ps80
+        sudo apt-get update
+
+        # Install everything else we need, and configure
+        sudo apt-get install -y percona-server-server percona-server-client make unzip g++ etcd git wget eatmydata xz-utils
         sudo service mysql stop
         sudo service etcd stop
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
@@ -96,7 +111,7 @@ jobs:
 
     - name: Run cluster endtoend test
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 30
+      timeout-minutes: 45
       run: |
         # We set the VTDATAROOT to the /tmp folder to reduce the file path of mysql.sock file
         # which musn't be more than 107 characters long.

--- a/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
+++ b/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_xb_backup_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup_mysql57.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_xb_backup_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup_mysql57.yml
@@ -21,6 +21,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery_mysql57.yml
@@ -21,6 +21,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -7,6 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -7,6 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -6,6 +6,13 @@ jobs:
     name: End-to-End Test (Race)
     runs-on: ubuntu-latest
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -6,6 +6,13 @@ jobs:
     name: End-to-End Test
     runs-on: ubuntu-20.04
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -11,6 +11,13 @@ jobs:
         topo: [consul,etcd,k8s]
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -11,6 +11,13 @@ jobs:
         topo: [etcd]
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Skip CI
+        run: |
+          if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+            echo "skipping CI due to the 'Skip CI' label"
+            exit 1
+          fi
+
       - name: Check if workflow needs to be skipped
         id: skip-workflow
         run: |

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -10,6 +10,13 @@ jobs:
     name: Unit Test (Race)
     runs-on: ubuntu-20.04
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -37,6 +37,13 @@ jobs:
       - get_previous_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -37,6 +37,13 @@ jobs:
       - get_next_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -38,6 +38,13 @@ jobs:
       - get_previous_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -38,6 +38,13 @@ jobs:
       - get_next_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -39,6 +39,13 @@ jobs:
       - get_previous_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -39,6 +39,13 @@ jobs:
       - get_next_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -39,6 +39,13 @@ jobs:
       - get_previous_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -39,6 +39,13 @@ jobs:
       - get_next_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -39,6 +39,13 @@ jobs:
       - get_next_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -39,6 +39,13 @@ jobs:
       - get_next_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -39,6 +39,13 @@ jobs:
       - get_previous_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -39,6 +39,13 @@ jobs:
       - get_previous_release
 
     steps:
+    - name: Skip CI
+      run: |
+        if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/.github/workflows/vtadmin_web_build.yml
+++ b/.github/workflows/vtadmin_web_build.yml
@@ -16,6 +16,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip CI
+        run: |
+          if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+            echo "skipping CI due to the 'Skip CI' label"
+            exit 1
+          fi
+
       - name: Check if workflow needs to be skipped
         id: skip-workflow
         run: |

--- a/.github/workflows/vtadmin_web_lint.yml
+++ b/.github/workflows/vtadmin_web_lint.yml
@@ -16,6 +16,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip CI
+        run: |
+          if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+            echo "skipping CI due to the 'Skip CI' label"
+            exit 1
+          fi
+
       - name: Check if workflow needs to be skipped
         id: skip-workflow
         run: |

--- a/.github/workflows/vtadmin_web_unit_tests.yml
+++ b/.github/workflows/vtadmin_web_unit_tests.yml
@@ -16,6 +16,13 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip CI
+        run: |
+          if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+            echo "skipping CI due to the 'Skip CI' label"
+            exit 1
+          fi
+
       - name: Check if workflow needs to be skipped
         id: skip-workflow
         run: |

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -15,6 +15,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -17,10 +17,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -9,10 +9,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -7,6 +7,13 @@ jobs:
     {{if .Ubuntu20}}runs-on: ubuntu-20.04{{else}}runs-on: ubuntu-latest{{end}}
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -20,6 +20,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -22,10 +22,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/test/templates/cluster_endtoend_test_self_hosted.tpl
+++ b/test/templates/cluster_endtoend_test_self_hosted.tpl
@@ -10,6 +10,13 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - name: Skip CI
+        run: |
+          if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
+            echo "skipping CI due to the 'Skip CI' label"
+            exit 1
+          fi
+
       - name: Check if workflow needs to be skipped
         id: skip-workflow
         run: |

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -9,6 +9,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Skip CI
+      run: |
+      if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
+        echo "skipping CI due to the 'Skip CI' label"
+        exit 1
+      fi
+
     - name: Check if workflow needs to be skipped
       id: skip-workflow
       run: |

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -11,10 +11,10 @@ jobs:
     steps:
     - name: Skip CI
       run: |
-      if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
-        echo "skipping CI due to the 'Skip CI' label"
-        exit 1
-      fi
+        if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
+          echo "skipping CI due to the 'Skip CI' label"
+          exit 1
+        fi
 
     - name: Check if workflow needs to be skipped
       id: skip-workflow

--- a/test/templates/unit_test_self_hosted.tpl
+++ b/test/templates/unit_test_self_hosted.tpl
@@ -9,6 +9,13 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - name: Skip CI
+        run: |
+          if [[ "{{"${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}"}}" == "true" ]]; then
+            echo "skipping CI due to the 'Skip CI' label"
+            exit 1
+          fi
+
       - name: Check if workflow needs to be skipped
         id: skip-workflow
         run: |


### PR DESCRIPTION
## Description

This Pull Request uses the newly introduced `Skip CI` label to skip all the workflows. When this label is applied to a Pull Request, all future commits will not be tested through our CI, until someone removes the label and pushes another commit. This is useful when we, for instance, have a draft on which we keep pushing commits but we don't want to overload the CI's queue.

Here, all the workflows will be failed. The workflows complete in ~5 seconds.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
