### PR TITLE
Log which tablet copy_state optimization failed on

### DIFF
--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -739,7 +739,7 @@ func (wr *Wrangler) optimizeCopyStateTable(tablet *topodatapb.Tablet) {
 			if sqlErr, ok := err.(*mysql.SQLError); ok && sqlErr.Num == mysql.ERNoSuchTable { // the table may not exist
 				return
 			}
-			log.Warningf("Failed to optimize the copy_state table: %v", err)
+			log.Warningf("Failed to optimize the copy_state table on %q: %v", tablet.Alias.String(), err)
 		}
 		// This will automatically set the value to 1 or the current max value in the table, whichever is greater
 		sqlResetAutoInc := "alter table _vt.copy_state auto_increment = 1"
@@ -747,7 +747,8 @@ func (wr *Wrangler) optimizeCopyStateTable(tablet *topodatapb.Tablet) {
 			Query:   []byte(sqlResetAutoInc),
 			MaxRows: uint64(0),
 		}); err != nil {
-			log.Warningf("Failed to reset the auto_increment value for the copy_state table: %v", err)
+			log.Warningf("Failed to reset the auto_increment value for the copy_state table on %q: %v",
+				tablet.Alias.String(), err)
 		}
 	}()
 }


### PR DESCRIPTION
## Description

This is a minor follow-up to https://github.com/vitessio/vitess/pull/11451. At the very end of that work I changed the optimizing work so that it's done in a background goroutine for each tablet and the logging of any failures went from the wrangler's logger (vtctl client terminal) to vtctld's warning log. As part of that, however, I should have noted which tablet the work failed on. This PR corrects that.

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/11451

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests are not required
-   [x] Documentation is not required