### PR TITLE
Add Gauge For CheckMySQL Running

### DIFF
--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -122,6 +122,7 @@ type stateManager struct {
 	// checkMySQLThrottler ensures that CheckMysql
 	// doesn't get spammed.
 	checkMySQLThrottler *sync2.Semaphore
+	checkMySQLRunning   bool
 
 	timebombDuration      time.Duration
 	unhealthyThreshold    sync2.AtomicDuration
@@ -301,17 +302,21 @@ func (sm *stateManager) recheckState() bool {
 	return false
 }
 
-// CheckMySQL verifies that we can connect to mysql.
+// checkMySQL verifies that we can connect to mysql.
 // If it fails, then we shutdown the service and initiate
 // the retry loop.
-func (sm *stateManager) CheckMySQL() {
+func (sm *stateManager) checkMySQL() {
 	if !sm.checkMySQLThrottler.TryAcquire() {
 		return
 	}
+	log.Infof("CheckMySQL started")
+	sm.checkMySQLRunning = true
 	go func() {
 		defer func() {
 			time.Sleep(1 * time.Second)
+			sm.checkMySQLRunning = false
 			sm.checkMySQLThrottler.Release()
+			log.Infof("CheckMySQL finished")
 		}()
 
 		err := sm.qe.IsMySQLReachable()
@@ -328,6 +333,14 @@ func (sm *stateManager) CheckMySQL() {
 		sm.closeAll()
 		sm.retryTransition(fmt.Sprintf("Cannot connect to MySQL, shutting down query service: %v", err))
 	}()
+}
+
+// isCheckMySQLRunning returns 1 if CheckMySQL function is in progress
+func (sm *stateManager) isCheckMySQLRunning() int64 {
+	if sm.checkMySQLRunning {
+		return 1
+	}
+	return 0
 }
 
 // StopService shuts down sm. If the shutdown doesn't complete

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -125,6 +125,9 @@ type TabletServer struct {
 
 	// alias is used for identifying this tabletserver in healthcheck responses.
 	alias *topodatapb.TabletAlias
+
+	// This field is only stored for testing
+	checkMysqlGaugeFunc *stats.GaugeFunc
 }
 
 var _ queryservice.QueryService = (*TabletServer)(nil)
@@ -206,6 +209,7 @@ func NewTabletServer(name string, config *tabletenv.TabletConfig, topoServer *to
 	}
 
 	tsv.exporter.NewGaugeFunc("TabletState", "Tablet server state", func() int64 { return int64(tsv.sm.State()) })
+	tsv.checkMysqlGaugeFunc = tsv.exporter.NewGaugeFunc("CheckMySQLRunning", "Check MySQL operation currently in progress", tsv.sm.isCheckMySQLRunning)
 	tsv.exporter.Publish("TabletStateName", stats.StringFunc(tsv.sm.IsServingString))
 
 	// TabletServerState exports the same information as the above two stats (TabletState / TabletStateName),
@@ -1671,7 +1675,7 @@ func (tsv *TabletServer) IsServing() bool {
 // to no more than once per second.
 // The function satisfies tabletenv.Env.
 func (tsv *TabletServer) CheckMySQL() {
-	tsv.sm.CheckMySQL()
+	tsv.sm.checkMySQL()
 }
 
 // TopoServer returns the topo server.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
We have been seeing a failure of `DemotePrimary` wherein it just gets stuck indefinitely. The failure was traced to a call to acquiring a lock which was held by the `CheckMySQL` function which too is stuck indefinitely. This PR aims to add a gauge which tells us if `CheckMySQL` is running or not. If the gauge is constantly 1 for more than 10 minutes, then it is an indication that something is wrong and we can take a look.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
