### PR TITLE
Optimize List Support In Vindex Functions

### DIFF
--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -139,8 +139,8 @@ func (vf *VindexFunc) mapVindex(ctx context.Context, vcursor VCursor, bindVars m
 	result := &sqltypes.Result{
 		Fields: vf.Fields,
 	}
+	var destination key.Destination
 	for i, value := range values {
-		var destination key.Destination
 		if vf.Vindex.IsUnique() {
 			destination = destinations[i]
 		} else {

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -126,6 +126,11 @@ func (vf *VindexFunc) mapVindex(ctx context.Context, vcursor VCursor, bindVars m
 	if err != nil {
 		return nil, err
 	}
+	if len(destinations) != len(values) {
+		// should never happen
+		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Vindex.Map() length mismatch: input values count is %d, output destinations count is %d",
+			len(values), len(destinations))
+	}
 	result := &sqltypes.Result{
 		Fields: vf.Fields,
 	}

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -122,19 +122,19 @@ func (vf *VindexFunc) mapVindex(ctx context.Context, vcursor VCursor, bindVars m
 	} else {
 		values = append(values, k.Value())
 	}
+	destinations, err := vf.Vindex.Map(ctx, vcursor, values)
+	if err != nil {
+		return nil, err
+	}
 	result := &sqltypes.Result{
 		Fields: vf.Fields,
 	}
-	for _, value := range values {
+	for i, value := range values {
 		vkey, err := evalengine.Cast(value, sqltypes.VarBinary)
 		if err != nil {
 			return nil, err
 		}
-		destinations, err := vf.Vindex.Map(ctx, vcursor, []sqltypes.Value{value})
-		if err != nil {
-			return nil, err
-		}
-		switch d := destinations[0].(type) {
+		switch d := destinations[i].(type) {
 		case key.DestinationKeyRange:
 			if d.KeyRange != nil {
 				row, err := vf.buildRow(vkey, nil, d.KeyRange)

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -122,24 +122,41 @@ func (vf *VindexFunc) mapVindex(ctx context.Context, vcursor VCursor, bindVars m
 	} else {
 		values = append(values, k.Value())
 	}
-	destinations, err := vf.Vindex.Map(ctx, vcursor, values)
-	if err != nil {
-		return nil, err
-	}
-	if len(destinations) != len(values) {
-		// should never happen
-		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Vindex.Map() length mismatch: input values count is %d, output destinations count is %d",
-			len(values), len(destinations))
+	var destinations []key.Destination
+	// For unique vindexes we can optimize list handling by making a single
+	// call to Map where we must get a 1 to 1 mapping of values to destinations.
+	if vf.Vindex.IsUnique() {
+		destinations, err = vf.Vindex.Map(ctx, vcursor, values)
+		if err != nil {
+			return nil, err
+		}
+		if len(destinations) != len(values) {
+			// should never happen with a unique vindex
+			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unique Vindex.Map() length mismatch: input values count is %d, output destinations count is %d",
+				len(values), len(destinations))
+		}
 	}
 	result := &sqltypes.Result{
 		Fields: vf.Fields,
 	}
 	for i, value := range values {
+		var destination key.Destination
+		if vf.Vindex.IsUnique() {
+			destination = destinations[i]
+		} else {
+			destinations, err = vf.Vindex.Map(ctx, vcursor, []sqltypes.Value{value})
+			if err != nil {
+				return nil, err
+			}
+			// Use the first destination from the non-unique vindex since
+			// the table output only supports 1 to 1 mappings.
+			destination = destinations[0]
+		}
 		vkey, err := evalengine.Cast(value, sqltypes.VarBinary)
 		if err != nil {
 			return nil, err
 		}
-		switch d := destinations[i].(type) {
+		switch d := destination.(type) {
 		case key.DestinationKeyRange:
 			if d.KeyRange != nil {
 				row, err := vf.buildRow(vkey, nil, d.KeyRange)

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -131,7 +131,7 @@ func (vf *VindexFunc) mapVindex(ctx context.Context, vcursor VCursor, bindVars m
 	}
 	if len(destinations) != len(values) {
 		// should never happen
-		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unique Vindex.Map() length mismatch: input values count is %d, output destinations count is %d",
+		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Vindex.Map() length mismatch: input values count is %d, output destinations count is %d",
 			len(values), len(destinations))
 	}
 	for i, value := range values {


### PR DESCRIPTION
## Description

In #9426 we added list support for [Vindex Functions](https://vitess.io/docs/reference/features/vindexes/#query-vindex-functions) using the`IN` operator so that you can get the mappings for N values. When doing so, [we loop over the values in the list and call `Vindex.Map()` for each one](https://github.com/vitessio/vitess/blob/e803ac7255f7a5a6bce74c232a92867e28b4c465/go/vt/vtgate/engine/vindex_func.go#L113-L137). This was fine for the built-in Vindex types like [`hash`](https://github.com/vitessio/vitess/blob/e803ac7255f7a5a6bce74c232a92867e28b4c465/go/vt/vtgate/vindexes/hash.go#L76-L87) as the same amount of work was done either way, but for [Unique (Consistent) Lookup Vindexes](https://vitess.io/docs/user-guides/vschema-guide/unique-lookup/) this is very inefficient because its `Vindex.Map()` implementation [makes a single call to the backing table for all passed values](https://github.com/vitessio/vitess/blob/e803ac7255f7a5a6bce74c232a92867e28b4c465/go/vt/vtgate/vindexes/consistent_lookup.go#L90-L112) and that lookup is also much more expensive than the built-in ones like `hash` as it requires querying the remote backing table.

This PR adds an optimization *for unique vindexes* by moving to a single `Vindex.Map()` call for the list which will cut down dramatically on the work done for Unique Lookup Vindexes and any implementation that directly supports mapping N values at a time.

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/9426

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were are not required (internal optimization, relying on existing tests)
-   [x] Documentation is not required (internal optimization)