### PR TITLE
[main] Fix: concatenate engine in transaction (#11534)

### DIFF
--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -38,10 +38,7 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	deleteAll := func() {
 		_, _ = utils.ExecAllowError(t, mcmp.VtConn, "set workload = oltp")
 
-		tables := []string{
-			"t1", "t1_id2_idx", "vstream_test", "t2", "t2_id4_idx", "t3", "t3_id7_idx", "t4",
-			"t4_id2_idx", "t5_null_vindex", "t6", "t6_id2_idx", "t7_xxhash", "t7_xxhash_idx", "t7_fk", "t8",
-		}
+		tables := []string{"t1", "t1_id2_idx", "t7_xxhash", "t7_xxhash_idx", "t7_fk"}
 		for _, table := range tables {
 			_, _ = mcmp.ExecAndIgnore("delete from " + table)
 		}
@@ -205,4 +202,25 @@ func TestMultipleSchemaPredicates(t *testing.T) {
 	_, err := mcmp.VtConn.ExecuteFetch(query, 1000, true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "specifying two different database in the query is not supported")
+}
+
+func TestInfrSchemaAndUnionAll(t *testing.T) {
+	clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--planner-version=gen4")
+	require.NoError(t,
+		clusterInstance.RestartVtgate())
+
+	vtConnParams := clusterInstance.GetVTParams(keyspaceName)
+	vtConnParams.DbName = keyspaceName
+	conn, err := mysql.Connect(context.Background(), &vtConnParams)
+	require.NoError(t, err)
+
+	for _, workload := range []string{"oltp", "olap"} {
+		t.Run(workload, func(t *testing.T) {
+			utils.Exec(t, conn, fmt.Sprintf("set workload = %s", workload))
+			utils.Exec(t, conn, "start transaction")
+			utils.Exec(t, conn, `select connection_id()`)
+			utils.Exec(t, conn, `(select 'corder' from t1 limit 1) union all (select 'customer' from t7_xxhash limit 1)`)
+			utils.Exec(t, conn, "rollback")
+		})
+	}
 }

--- a/go/test/endtoend/vtgate/queries/informationschema/schema.sql
+++ b/go/test/endtoend/vtgate/queries/informationschema/schema.sql
@@ -12,87 +12,6 @@ create table t1_id2_idx
     primary key (id2)
 ) Engine = InnoDB;
 
-create table vstream_test
-(
-    id  bigint,
-    val bigint,
-    primary key (id)
-) Engine = InnoDB;
-
-create table t2
-(
-    id3 bigint,
-    id4 bigint,
-    primary key (id3)
-) Engine = InnoDB;
-
-create table t2_id4_idx
-(
-    id  bigint not null auto_increment,
-    id4 bigint,
-    id3 bigint,
-    primary key (id),
-    key idx_id4 (id4)
-) Engine = InnoDB;
-
-create table t3
-(
-    id5 bigint,
-    id6 bigint,
-    id7 bigint,
-    primary key (id5)
-) Engine = InnoDB;
-
-create table t3_id7_idx
-(
-    id  bigint not null auto_increment,
-    id7 bigint,
-    id6 bigint,
-    primary key (id)
-) Engine = InnoDB;
-
-create table t4
-(
-    id1 bigint,
-    id2 varchar(10),
-    primary key (id1)
-) ENGINE = InnoDB
-  DEFAULT charset = utf8mb4
-  COLLATE = utf8mb4_general_ci;
-
-create table t4_id2_idx
-(
-    id2         varchar(10),
-    id1         bigint,
-    keyspace_id varbinary(50),
-    primary key (id2, id1)
-) Engine = InnoDB
-  DEFAULT charset = utf8mb4
-  COLLATE = utf8mb4_general_ci;
-
-create table t5_null_vindex
-(
-    id  bigint not null,
-    idx varchar(50),
-    primary key (id)
-) Engine = InnoDB;
-
-create table t6
-(
-    id1 bigint,
-    id2 varchar(10),
-    primary key (id1)
-) Engine = InnoDB;
-
-create table t6_id2_idx
-(
-    id2         varchar(10),
-    id1         bigint,
-    keyspace_id varbinary(50),
-    primary key (id1),
-    key (id2)
-) Engine = InnoDB;
-
 create table t7_xxhash
 (
     uid   varchar(50),
@@ -115,11 +34,4 @@ create table t7_fk
     primary key (id),
     CONSTRAINT t7_fk_ibfk_1 foreign key (t7_uid) references t7_xxhash (uid)
         on delete set null on update cascade
-) Engine = InnoDB;
-
-create table t8
-(
-    id8    bigint,
-    testId bigint,
-    primary key (id8)
 ) Engine = InnoDB;

--- a/go/test/endtoend/vtgate/queries/informationschema/vschema.json
+++ b/go/test/endtoend/vtgate/queries/informationschema/vschema.json
@@ -7,12 +7,12 @@
     "unicode_loose_xxhash" : {
       "type": "unicode_loose_xxhash"
     },
-    "t3_id7_vdx": {
-      "type": "lookup_hash",
+    "t1_id2_idx": {
+      "type": "lookup_unique",
       "params": {
-        "table": "t3_id7_idx",
-        "from": "id7",
-        "to": "id6"
+        "table": "t1_id2_idx",
+        "from": "id2",
+        "to": "keyspace_id"
       },
       "owner": "t3"
     },
@@ -28,15 +28,15 @@
     }
   },
   "tables": {
-    "t3": {
+    "t1": {
       "column_vindexes": [
         {
-          "column": "id6",
+          "column": "id1",
           "name": "hash"
         },
         {
-          "column": "id7",
-          "name": "t3_id7_vdx"
+          "column": "id2",
+          "name": "t1_id2_idx"
         }
       ]
     },
@@ -45,46 +45,6 @@
         {
           "column": "id7",
           "name": "hash"
-        }
-      ]
-    },
-    "t9": {
-      "column_vindexes": [
-        {
-          "column": "id1",
-          "name": "hash"
-        }
-      ]
-    },
-    "aggr_test": {
-      "column_vindexes": [
-        {
-          "column": "id",
-          "name": "hash"
-        }
-      ],
-      "columns": [
-        {
-          "name": "val1",
-          "type": "VARCHAR"
-        }
-      ]
-    },
-    "aggr_test_dates": {
-      "column_vindexes": [
-        {
-          "column": "id",
-          "name": "hash"
-        }
-      ],
-      "columns": [
-        {
-          "name": "val1",
-          "type": "DATETIME"
-        },
-        {
-          "name": "val2",
-          "type": "DATETIME"
         }
       ]
     },

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -50,6 +50,10 @@ var _ SessionActions = (*noopVCursor)(nil)
 type noopVCursor struct {
 }
 
+func (t *noopVCursor) InTransaction() bool {
+	return false
+}
+
 func (t *noopVCursor) SetCommitOrder(co vtgatepb.CommitOrder) {
 	//TODO implement me
 	panic("implement me")

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -186,6 +186,10 @@ type (
 
 		// SetQueryTimeout sets the query timeout
 		SetQueryTimeout(queryTimeout int64)
+
+		// InTransaction returns true if the session has already opened transaction or
+		// will start a transaction on the query execution.
+		InTransaction() bool
 	}
 
 	// Match is used to check if a Primitive matches

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -870,6 +870,10 @@ func (vc *vcursorImpl) SetCommitOrder(co vtgatepb.CommitOrder) {
 	vc.safeSession.SetCommitOrder(co)
 }
 
+func (vc *vcursorImpl) InTransaction() bool {
+	return vc.safeSession.InTransaction()
+}
+
 // GetDBDDLPluginName implements the VCursor interface
 func (vc *vcursorImpl) GetDBDDLPluginName() string {
 	return dbDDLPlugin

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -657,7 +657,8 @@ func getSingleRowResult() *sqltypes.Result {
 		Rows:        SingleRowResult.Rows,
 	}
 
-	for _, field := range SingleRowResult.Fields {
+	fields := SingleRowResult.Fields
+	for _, field := range fields {
 		singleRowResult.Fields = append(singleRowResult.Fields, &querypb.Field{
 			Name: field.Name,
 			Type: field.Type,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Forward port from 15.0 https://github.com/vitessio/vitess/pull/11534

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR forces concatenate engine to do sequential execution of queries when the session is in a transaction.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/11454

## Checklist

-   [X] Tests were added or are not required
