### PR TITLE
Redact bind variables in mysql errors

### DIFF
--- a/go/test/endtoend/vtgate/queries/dml/insert_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/insert_test.go
@@ -384,3 +384,13 @@ func TestInsertSelectUnshardedUsingSharded(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactDupError(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec("insert into order_tbl(region_id, oid, cust_no) values (1,1,100),(1,2,200),(1,3,300)")
+
+	// inserting same rows, throws error.
+	mcmp.AssertContainsError("insert into order_tbl(region_id, oid, cust_no) select region_id, oid, cust_no from order_tbl", `BindVars: {REDACTED}`)
+}

--- a/go/test/endtoend/vtgate/queries/dml/main_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/main_test.go
@@ -98,6 +98,8 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--vtgate-config-terse-errors")
+
 		// Start vtgate
 		clusterInstance.VtGatePlannerVersion = planbuilder.Gen4
 		err = clusterInstance.StartVtgate()

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -20,9 +20,11 @@ package vtgate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -586,6 +588,12 @@ func recordAndAnnotateError(err error, statsKey []string, request map[string]any
 		statsKey[1],
 		statsKey[2],
 		ec.String(),
+	}
+
+	if terseErrors {
+		regexpBv := regexp.MustCompile(`BindVars: \{.*\}`)
+		str := regexpBv.ReplaceAllString(err.Error(), "BindVars: {REDACTED}")
+		err = errors.New(str)
 	}
 
 	// Traverse the request structure and truncate any long values


### PR DESCRIPTION
## Description

This PR redacts the bindvars in the errors that are produced by MySQL. For instance, a duplicate key error coming from MySQL will no longer contain the bind variables.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
