### PR TITLE
[15.0] Add VTGate debug/status page link to VTAdmin

### DIFF
--- a/examples/local/vtadmin/discovery.json
+++ b/examples/local/vtadmin/discovery.json
@@ -10,6 +10,7 @@
     "vtgates": [
         {
             "host": {
+                "fqdn": "localhost:15001",
                 "hostname": "localhost:15991"
             }
         }

--- a/examples/region_sharding/vtadmin/discovery.json
+++ b/examples/region_sharding/vtadmin/discovery.json
@@ -10,6 +10,7 @@
     "vtgates": [
         {
             "host": {
+                "fqdn": "localhost:15001",
                 "hostname": "localhost:15991"
             }
         }

--- a/web/vtadmin/src/components/routes/Gates.tsx
+++ b/web/vtadmin/src/components/routes/Gates.tsx
@@ -55,15 +55,15 @@ export const Gates = () => {
                     <div className="text-sm text-secondary">{gate.cluster}</div>
                 </DataCell>
                 <DataCell className="whitespace-nowrap">
-                        {gate.fqdn ? (
-                            <div className="font-bold">
-                                <a href={`//${gate.fqdn}`} rel="noopener noreferrer" target="_blank">
-                                    {gate.hostname}
-                                </a>
-                            </div>
-                        ) : (
-                            gate.hostname
-                        )}
+                    {gate.fqdn ? (
+                        <div className="font-bold">
+                            <a href={`//${gate.fqdn}`} rel="noopener noreferrer" target="_blank">
+                                {gate.hostname}
+                            </a>
+                        </div>
+                    ) : (
+                        gate.hostname
+                    )}
                 </DataCell>
                 <DataCell className="whitespace-nowrap">{gate.cell}</DataCell>
                 <DataCell>{(gate.keyspaces || []).join(', ')}</DataCell>

--- a/web/vtadmin/src/components/routes/Gates.tsx
+++ b/web/vtadmin/src/components/routes/Gates.tsx
@@ -41,6 +41,7 @@ export const Gates = () => {
             hostname: g.hostname,
             keyspaces: g.keyspaces,
             pool: g.pool,
+            fqdn: g.FQDN,
         }));
         const filtered = filterNouns(filter, mapped);
         return orderBy(filtered, ['cluster', 'pool', 'hostname', 'cell']);
@@ -53,7 +54,17 @@ export const Gates = () => {
                     <div>{gate.pool}</div>
                     <div className="text-sm text-secondary">{gate.cluster}</div>
                 </DataCell>
-                <DataCell className="whitespace-nowrap">{gate.hostname}</DataCell>
+                <DataCell className="whitespace-nowrap">
+                        {gate.fqdn ? (
+                            <div className="font-bold">
+                                <a href={`//${gate.fqdn}`} rel="noopener noreferrer" target="_blank">
+                                    {gate.hostname}
+                                </a>
+                            </div>
+                        ) : (
+                            gate.hostname
+                        )}
+                </DataCell>
                 <DataCell className="whitespace-nowrap">{gate.cell}</DataCell>
                 <DataCell>{(gate.keyspaces || []).join(', ')}</DataCell>
             </tr>


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

In the VTAdmin vtctld page, we link to the vtctld dashboard. For this purpose the `fqdn` field in the discovery configuration. We can do the same for the vtgate page which currently doesn't link to anything.
This PR makes this change. Now adding a `fqdn` field to the vtgate configuration will allow VTAdmin to link to the debug/status page of vtgate.
The page looks like the following with the hyperlink - 
![Screenshot 2022-10-20 at 2 19 19 PM](https://user-images.githubusercontent.com/35839558/196903528-110f8f73-0b28-4dac-aa1b-cb7b789f4646.png)


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
