### PR TITLE
change CreatePhysicalOperator to use the rewriteBottomUp() functionality

### DIFF
--- a/go/vt/vtgate/planbuilder/gen4_planner.go
+++ b/go/vt/vtgate/planbuilder/gen4_planner.go
@@ -215,7 +215,7 @@ func newBuildSelectPlan(
 		return nil, nil, err
 	}
 
-	physOp, err := operators.CreatePhysicalOperator(ctx, logical)
+	physOp, err := operators.TransformToPhysical(ctx, logical)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -329,7 +329,7 @@ func gen4UpdateStmtPlanner(
 		return nil, err
 	}
 
-	physOp, err := operators.CreatePhysicalOperator(ctx, logical)
+	physOp, err := operators.TransformToPhysical(ctx, logical)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ func gen4DeleteStmtPlanner(
 		return nil, err
 	}
 
-	physOp, err := operators.CreatePhysicalOperator(ctx, logical)
+	physOp, err := operators.TransformToPhysical(ctx, logical)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/operator.go
+++ b/go/vt/vtgate/planbuilder/operators/operator.go
@@ -51,6 +51,11 @@ type (
 	unresolved interface {
 		// UnsolvedPredicates returns any predicates that have dependencies on the given Operator and
 		// on the outside of it (a parent Select expression, any other table not used by Operator, etc).
+		// This is used for sub-queries. An example query could be:
+		// SELECT * FROM tbl WHERE EXISTS (SELECT 1 FROM otherTbl WHERE tbl.col = otherTbl.col)
+		// The subquery would have one unsolved predicate: `tbl.col = otherTbl.col`
+		// It's a predicate that belongs to the inner query, but it needs data from the outer query
+		// These predicates dictate which data we have to send from the outer side to the inner
 		UnsolvedPredicates(semTable *semantics.SemTable) []sqlparser.Expr
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/querygraph.go
+++ b/go/vt/vtgate/planbuilder/operators/querygraph.go
@@ -160,7 +160,7 @@ func (qg *QueryGraph) addNoDepsPredicate(predicate sqlparser.Expr) {
 	}
 }
 
-// UnsolvedPredicates implements the Operator interface
+// UnsolvedPredicates implements the unresolved interface
 func (qg *QueryGraph) UnsolvedPredicates(_ *semantics.SemTable) []sqlparser.Expr {
 	var result []sqlparser.Expr
 	tables := TableID(qg)


### PR DESCRIPTION
## Description
Another small refactoring PR that changes how we work with operators.
Changes the physical operator creation from a top down copy, to a bottom up rewrite.

In the new operator model, an operator tree when it's first built can have a mix of physical and non-physical operators. Before we can produce logical plans and engine primitives, we need to turn all parts of the tree into physical operators. This can now be accomplished using rewriting.

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
