### PR TITLE
Remove `EnableTracingOpt` and `--grpc_enable_tracing`

### DIFF
--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -105,7 +105,6 @@ func Dial(target string, failFast FailFast, opts ...grpc.DialOption) (*grpc.Clie
 // failFast is a non-optional parameter because callers are required to specify
 // what that should be.
 func DialContext(ctx context.Context, target string, failFast FailFast, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	grpccommon.EnableTracingOpt()
 	msgSize := grpccommon.MaxMessageSize()
 	newopts := []grpc.DialOption{
 		grpc.WithDefaultCallOptions(

--- a/go/vt/grpccommon/options.go
+++ b/go/vt/grpccommon/options.go
@@ -17,8 +17,6 @@ limitations under the License.
 package grpccommon
 
 import (
-	"sync"
-
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 
@@ -30,8 +28,6 @@ var (
 	// accept. Larger messages will be rejected.
 	// Note: We're using 16 MiB as default value because that's the default in MySQL
 	maxMessageSize = 16 * 1024 * 1024
-	// enableTracing sets a flag to enable grpc client/server tracing.
-	enableTracing bool
 	// enablePrometheus sets a flag to enable grpc client/server grpc monitoring.
 	enablePrometheus bool
 )
@@ -43,21 +39,8 @@ var (
 // command-line arguments.
 func RegisterFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&maxMessageSize, "grpc_max_message_size", maxMessageSize, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
-	fs.BoolVar(&enableTracing, "grpc_enable_tracing", enableTracing, "Enable gRPC tracing.")
+	fs.BoolVar(&grpc.EnableTracing, "grpc_enable_tracing", grpc.EnableTracing, "Enable gRPC tracing.")
 	fs.BoolVar(&enablePrometheus, "grpc_prometheus", enablePrometheus, "Enable gRPC monitoring with Prometheus.")
-}
-
-var (
-	enableTracingOnce sync.Once
-)
-
-// EnableTracingOpt enables grpc tracing if requested.
-// It must be called before any grpc server or client is created but is safe
-// to be called multiple times.
-func EnableTracingOpt() {
-	enableTracingOnce.Do(func() {
-		grpc.EnableTracing = enableTracing
-	})
 }
 
 // EnableGRPCPrometheus returns the value of the --grpc_prometheus flag.

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -183,8 +183,6 @@ func createGRPCServer() {
 		return
 	}
 
-	grpccommon.EnableTracingOpt()
-
 	var opts []grpc.ServerOption
 	if gRPCCert != "" && gRPCKey != "" {
 		config, err := vttls.ServerConfig(gRPCCert, gRPCKey, gRPCCA, gRPCCRL, gRPCServerCA, tls.VersionTLS12)

--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -34,7 +34,6 @@ import (
 
 	_flag "vitess.io/vitess/go/internal/flag"
 	"vitess.io/vitess/go/test/utils"
-	"vitess.io/vitess/go/vt/grpccommon"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -1110,14 +1109,14 @@ func TestGetKeyspaces(t *testing.T) {
 		{
 			name: "multiple clusters, multiple shards",
 			clusterKeyspaces: [][]*vtctldatapb.Keyspace{
-				//cluster0
+				// cluster0
 				{
 					{
 						Name:     "c0-ks0",
 						Keyspace: &topodatapb.Keyspace{},
 					},
 				},
-				//cluster1
+				// cluster1
 				{
 					{
 						Name:     "c1-ks0",
@@ -1126,7 +1125,7 @@ func TestGetKeyspaces(t *testing.T) {
 				},
 			},
 			clusterShards: [][]*vtctldatapb.Shard{
-				//cluster0
+				// cluster0
 				{
 					{
 						Keyspace: "c0-ks0",
@@ -1137,7 +1136,7 @@ func TestGetKeyspaces(t *testing.T) {
 						Name:     "80-",
 					},
 				},
-				//cluster1
+				// cluster1
 				{
 					{
 						Keyspace: "c1-ks0",
@@ -1248,14 +1247,14 @@ func TestGetKeyspaces(t *testing.T) {
 		{
 			name: "filtered by cluster ID",
 			clusterKeyspaces: [][]*vtctldatapb.Keyspace{
-				//cluster0
+				// cluster0
 				{
 					{
 						Name:     "c0-ks0",
 						Keyspace: &topodatapb.Keyspace{},
 					},
 				},
-				//cluster1
+				// cluster1
 				{
 					{
 						Name:     "c1-ks0",
@@ -5143,17 +5142,6 @@ func init() {
 	tmclient.RegisterTabletManagerClientFactory("vtadmin.test", func() tmclient.TabletManagerClient {
 		return nil
 	})
-
-	// This prevents data-race failures in tests involving grpc client or server
-	// creation. For example, vtctldclient.New() eventually ends up calling
-	// grpccommon.EnableTracingOpt() which does a synchronized, one-time
-	// mutation of the global grpc.EnableTracing. This variable is also read,
-	// unguarded, by grpc.NewServer(), which is a function call that appears in
-	// most, if not all, vtadmin.API tests.
-	//
-	// Calling this here ensures that one-time write happens before any test
-	// attempts to read that value by way of grpc.NewServer().
-	grpccommon.EnableTracingOpt()
 }
 
 //go:generate -command authztestgen go run ./testutil/authztestgen


### PR DESCRIPTION
## Description

This PR removes grpc's `EnableTracingOpt` as it is a racy code path. We set the value of `grpc.EnableTracing` directly with the same flag (`--grpc_enable_tracing`) .

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
