### PR TITLE
Upgrade the `release_notes_label` workflow for `v16.0.0`

### DIFF
--- a/.github/workflows/release_notes_label.yml
+++ b/.github/workflows/release_notes_label.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Print helper
         if: failure() && steps.required_label.outcome == 'failure'
         run: |
-          echo The "release notes (needs details)" label is set. The changes made in this Pull Request need to be documented in the release notes summary "('./doc/releasenotes/15_0_0_summary.md')". Once documented, the "release notes (needs details)" label can be removed.
+          echo The "release notes (needs details)" label is set. The changes made in this Pull Request need to be documented in the release notes summary "('./doc/releasenotes/16_0_0_summary.md')". Once documented, the "release notes (needs details)" label can be removed.
           exit 1
 
       - name: Check type and component labels


### PR DESCRIPTION
## Description

This PR changes the output of the `release_notes_label` workflow to mention `16.0.0` instead of `15.0.0`.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
