### PR TITLE
Increase the memory limit of the vitess-operator

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -5619,7 +5619,7 @@ spec:
           name: vitess-operator
           resources:
             limits:
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
## Description

With the previous memory limit of the vitess-operator (`128Mi`) the Operator would often error out with an `OOMKilled` error:
```
vitess-operator-66967b4bc4-r8pk8                             0/1     OOMKilled   3 (37s ago)     5m24s
```

This PR changes the upper limit allocated to the vitess-operator to `512Mi`. 

This change must be ported over to the vitess-operator repository once it is merged.

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
