### PR TITLE
Test flags: Update logic for parsing test flags to run unit tests within GoLand and to parse test flags in vtgate to allow running unit tests

### DIFF
--- a/go/internal/flag/flag.go
+++ b/go/internal/flag/flag.go
@@ -138,15 +138,16 @@ func filterTestFlags() ([]string, []string) {
 	args := os.Args
 	var testFlags []string
 	var otherArgs []string
-	isRunFlag := false
+	hasExtraTestRunArg := false
 	for i := 0; 0 < len(args) && i < len(args); i++ {
-		// This additional logic for the test.run flag is required for running single unit tests in GoLand,
-		// due to the way it uses "go tool test2json" to run the test.
-		if strings.HasPrefix(args[i], goTestFlagSuffix) || isRunFlag {
-			isRunFlag = false
+		// This additional logic to check for the test.run flag is required for running single unit tests in GoLand,
+		// due to the way it uses "go tool test2json" to run the test. The CLI `go test` specifies the test as "-test.run=TestHeartbeat",
+		// but test2json as "-test.run TestHeartbeat". So in the latter case we need to also add the arg following test.run
+		if strings.HasPrefix(args[i], goTestFlagSuffix) || hasExtraTestRunArg {
+			hasExtraTestRunArg = false
 			testFlags = append(testFlags, args[i])
 			if args[i] == goTestRunFlag {
-				isRunFlag = true
+				hasExtraTestRunArg = true
 			}
 			continue
 		}

--- a/go/internal/flag/flag.go
+++ b/go/internal/flag/flag.go
@@ -132,14 +132,22 @@ func Usage() {
 // filterTestFlags returns two slices: the second one has just the flags for `go test` and the first one contains
 // the rest of the flags.
 const goTestFlagSuffix = "-test"
+const goTestRunFlag = "-test.run"
 
 func filterTestFlags() ([]string, []string) {
 	args := os.Args
 	var testFlags []string
 	var otherArgs []string
+	isRunFlag := false
 	for i := 0; 0 < len(args) && i < len(args); i++ {
-		if strings.HasPrefix(args[i], goTestFlagSuffix) {
+		// This additional logic for the test.run flag is required for running single unit tests in GoLand,
+		// due to the way it uses "go tool test2json" to run the test.
+		if strings.HasPrefix(args[i], goTestFlagSuffix) || isRunFlag {
+			isRunFlag = false
 			testFlags = append(testFlags, args[i])
+			if args[i] == goTestRunFlag {
+				isRunFlag = true
+			}
 			continue
 		}
 		otherArgs = append(otherArgs, args[i])

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -19,11 +19,14 @@ package vtgate
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	_flag "vitess.io/vitess/go/internal/flag"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 
@@ -3739,4 +3742,9 @@ func TestSelectHexAndBit(t *testing.T) {
 		"select 1 + 0b1001, 1 + b'1001', 1 + 0x9, 1 + x'09'", nil)
 	require.NoError(t, err)
 	require.Equal(t, `[[UINT64(10) UINT64(10) UINT64(10) UINT64(10)]]`, fmt.Sprintf("%v", qr.Rows))
+}
+
+func TestMain(m *testing.M) {
+	_flag.ParseFlagsForTest()
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
## Description

* Running single unit tests in vtgate was not possible before this PR: all tests would run instead of a single test
* GoLand was erroring out if you tried to run/debug a single unit test. This is because GoLand runs tests using `testjson` like 
`go tool test2json -t /private/var/folders/y4/rmwnvscj62zg5mz1jhz5rlkr0000gn/T/GoLand/___TestWeightStringsComprehensive_in_vitess_io_vitess_go_mysql_collations_integration.test -test.v -test.paniconexit0 -test.run ^\QTestWeightStringsComprehensive\E$`, unlike `go test` which uses `/tmp/go-build898573698/b001/vstreamer.test -test.paniconexit0 -test.timeout=10m0s -test.failfast=true -test.v=true --alsologtostderr -test.run=TestWeightStringsComprehensive`

The PR adds a `TestMain()` to the vtgate unit tests, so that we can parse test flags for all tests. The PR also looks for an additional argument provided to `-test.run` to fix the GoLand issue.

## Related Issue(s)

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
