### PR TITLE
Detect redo log location dynamically based on presence

### DIFF
--- a/go/vt/mysqlctl/backup_test.go
+++ b/go/vt/mysqlctl/backup_test.go
@@ -23,20 +23,11 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"vitess.io/vitess/go/mysql"
 )
 
-func TestFindFilesToBackup(t *testing.T) {
+func TestFindFilesToBackupWithoutRedoLog(t *testing.T) {
 	root := t.TempDir()
-
-	// get the flavor and version to deal with any behavioral differences
-	versionStr, err := GetVersionString()
-	require.NoError(t, err)
-	flavor, version, err := ParseVersionString(versionStr)
-	require.NoError(t, err)
-	features := newCapabilitySet(flavor, version)
 
 	// Initialize the fake mysql root directories
 	innodbDataDir := path.Join(root, "innodb_data")
@@ -54,10 +45,6 @@ func TestFindFilesToBackup(t *testing.T) {
 	}
 
 	innodbLogFile := "innodb_log_1"
-	if features.hasDynamicRedoLogCapacity() {
-		os.Mkdir(path.Join(innodbLogDir, mysql.DynamicRedoLogSubdir), os.ModePerm)
-		innodbLogFile = path.Join(mysql.DynamicRedoLogSubdir, "#ib_redo1")
-	}
 
 	if err := os.WriteFile(path.Join(innodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm); err != nil {
 		t.Fatalf("failed to write file innodb_data_1: %v", err)
@@ -88,6 +75,98 @@ func TestFindFilesToBackup(t *testing.T) {
 		InnodbDataHomeDir:     innodbDataDir,
 		InnodbLogGroupHomeDir: innodbLogDir,
 		DataDir:               dataDir,
+	}
+
+	result, totalSize, err := findFilesToBackup(cnf)
+	if err != nil {
+		t.Fatalf("findFilesToBackup failed: %v", err)
+	}
+	sort.Sort(forTest(result))
+	t.Logf("findFilesToBackup returned: %v", result)
+	expected := []FileEntry{
+		{
+			Base: "Data",
+			Name: ".rocksdb/000011.sst",
+		},
+		{
+			Base: "Data",
+			Name: "sdi_dir/table1.sdi",
+		},
+		{
+			Base: "Data",
+			Name: "vt_db/db.opt",
+		},
+		{
+			Base: "Data",
+			Name: "vt_symlink/table1.frm",
+		},
+		{
+			Base: "InnoDBData",
+			Name: "innodb_data_1",
+		},
+		{
+			Base: "InnoDBLog",
+			Name: innodbLogFile,
+		},
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("got wrong list of FileEntry %v, expected %v", result, expected)
+	}
+	if totalSize <= 0 {
+		t.Fatalf("backup size should be > 0, got %v", totalSize)
+	}
+}
+
+func TestFindFilesToBackupWithRedoLog(t *testing.T) {
+	root := t.TempDir()
+
+	// Initialize the fake mysql root directories
+	innodbDataDir := path.Join(root, "innodb_data")
+	innodbLogDir := path.Join(root, "innodb_log")
+	dataDir := path.Join(root, "data")
+	dataDbDir := path.Join(dataDir, "vt_db")
+	extraDir := path.Join(dataDir, "extra_dir")
+	outsideDbDir := path.Join(root, "outside_db")
+	rocksdbDir := path.Join(dataDir, ".rocksdb")
+	sdiOnlyDir := path.Join(dataDir, "sdi_dir")
+	for _, s := range []string{innodbDataDir, innodbLogDir, dataDbDir, extraDir, outsideDbDir, rocksdbDir, sdiOnlyDir} {
+		if err := os.MkdirAll(s, os.ModePerm); err != nil {
+			t.Fatalf("failed to create directory %v: %v", s, err)
+		}
+	}
+
+	cnf := &Mycnf{
+		InnodbDataHomeDir:     innodbDataDir,
+		InnodbLogGroupHomeDir: innodbLogDir,
+		DataDir:               dataDir,
+	}
+
+	os.Mkdir(path.Join(innodbLogDir, mysql.DynamicRedoLogSubdir), os.ModePerm)
+	innodbLogFile := path.Join(mysql.DynamicRedoLogSubdir, "#ib_redo1")
+
+	if err := os.WriteFile(path.Join(innodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm); err != nil {
+		t.Fatalf("failed to write file innodb_data_1: %v", err)
+	}
+	if err := os.WriteFile(path.Join(innodbLogDir, innodbLogFile), []byte("innodb log 1 contents"), os.ModePerm); err != nil {
+		t.Fatalf("failed to write file %s: %v", innodbLogFile, err)
+	}
+	if err := os.WriteFile(path.Join(dataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm); err != nil {
+		t.Fatalf("failed to write file db.opt: %v", err)
+	}
+	if err := os.WriteFile(path.Join(extraDir, "extra.stuff"), []byte("extra file"), os.ModePerm); err != nil {
+		t.Fatalf("failed to write file extra.stuff: %v", err)
+	}
+	if err := os.WriteFile(path.Join(outsideDbDir, "table1.frm"), []byte("frm file"), os.ModePerm); err != nil {
+		t.Fatalf("failed to write file table1.opt: %v", err)
+	}
+	if err := os.Symlink(outsideDbDir, path.Join(dataDir, "vt_symlink")); err != nil {
+		t.Fatalf("failed to symlink vt_symlink: %v", err)
+	}
+	if err := os.WriteFile(path.Join(rocksdbDir, "000011.sst"), []byte("rocksdb file"), os.ModePerm); err != nil {
+		t.Fatalf("failed to write file 000011.sst: %v", err)
+	}
+	if err := os.WriteFile(path.Join(sdiOnlyDir, "table1.sdi"), []byte("sdi file"), os.ModePerm); err != nil {
+		t.Fatalf("failed to write file table1.sdi: %v", err)
 	}
 
 	result, totalSize, err := findFilesToBackup(cnf)

--- a/go/vt/mysqlctl/capabilityset.go
+++ b/go/vt/mysqlctl/capabilityset.go
@@ -51,17 +51,6 @@ func (c *capabilitySet) hasMaria104InstallDb() bool {
 	return c.isMariaDB() && c.version.atLeast(ServerVersion{Major: 10, Minor: 4, Patch: 0})
 }
 
-// hasDynamicRedoLogCapacity tells you if the version of MySQL in use supports dynamic redo log
-// capacity.
-// Starting with MySQL 8.0.30, the InnoDB redo logs are stored in a subdirectory of the
-// <innodb_log_group_home_dir> (<datadir>/. by default) called "#innodb_redo" and you can
-// dynamically adjust the capacity of redo log space in the running server. See:
-//
-//	https://dev.mysql.com/doc/refman/8.0/en/innodb-redo-log.html#innodb-modifying-redo-log-capacity
-func (c *capabilitySet) hasDynamicRedoLogCapacity() bool {
-	return c.isMySQLLike() && c.version.atLeast(ServerVersion{Major: 8, Minor: 0, Patch: 30})
-}
-
 // IsMySQLLike tests if the server is either MySQL
 // or Percona Server. At least currently, Vitess doesn't
 // make use of any specific Percona Server features.


### PR DESCRIPTION
## Description

Instead of relying on a specific version check, detect if the new redo log location is present or not.

This makes the backup logic independent from the version check against MySQL. With this change, 8.0.30 can be backed up just as well as any other version.

## Related Issue(s)

Solves the backup part of
https://github.com/vitessio/vitess/issues/11554 by removing the dependency on the version check. There might be still other places where that issue can crop up, but it solves the immediate breaking issue with backups.

## Checklist

Marked this for back porting to 14 and 15, also since we back ported the other 8.0.30 fixes to 14 so we need this one as well.

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required