### PR TITLE
[15.0] Deprecate InitShardPrimary command

### DIFF
--- a/doc/releasenotes/15_0_0_summary.md
+++ b/doc/releasenotes/15_0_0_summary.md
@@ -58,6 +58,10 @@ The connection pool with prefilled connections have been removed. The pool now d
 Following flags are deprecated: `queryserver-config-pool-prefill-parallelism`, `queryserver-config-stream-pool-prefill-parallelism`, `queryserver-config-transaction-prefill-parallelism`
 and will be removed in future version.
 
+#### InitShardPrimary Deprecation
+
+The vtcltd command InitShardPrimary has been deprecated. Please use PlannedReparentShard instead.
+
 ### Command-line syntax deprecations
 
 #### vttablet startup flag deletions

--- a/go/cmd/vtctldclient/command/reparents.go
+++ b/go/cmd/vtctldclient/command/reparents.go
@@ -53,6 +53,7 @@ WARNING: this can cause data loss on an already-replicating shard. PlannedRepare
 EmergencyReparentShard should be used instead.
 `,
 		DisableFlagsInUseLine: true,
+		Deprecated:            "Please use PlannedReparentShard instead",
 		Args:                  cobra.ExactArgs(2),
 		RunE:                  commandInitShardPrimary,
 	}

--- a/go/flags/endtoend/vtctldclient.txt
+++ b/go/flags/endtoend/vtctldclient.txt
@@ -48,7 +48,6 @@ Available Commands:
   GetTopologyPath             Gets the file located at the specified path in the topology server.
   GetVSchema                  Prints a JSON representation of a keyspace's topo record.
   GetWorkflows                Gets all vreplication workflows (Reshard, MoveTables, etc) in the given keyspace.
-  InitShardPrimary            Sets the initial primary for the shard.
   LegacyVtctlCommand          Invoke a legacy vtctlclient command. Flag parsing is best effort.
   PingTablet                  Checks that the specified tablet is awake and responding to RPCs. This command can be blocked by other in-flight operations.
   PlannedReparentShard        Reparents the shard to a new primary, or away from an old primary. Both the old and new primaries must be up and running.

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -44,10 +44,12 @@ func init() {
 		help:   "Sets the initial primary for a shard. Will make all other tablets in the shard replicas of the provided tablet. WARNING: this could cause data loss on an already replicating shard. PlannedReparentShard or EmergencyReparentShard should be used instead.",
 	})
 	addCommand("Shards", command{
-		name:   "PlannedReparentShard",
-		method: commandPlannedReparentShard,
-		params: "--keyspace_shard=<keyspace/shard> [--new_primary=<tablet alias>] [--avoid_tablet=<tablet alias>] [--wait_replicas_timeout=<duration>]",
-		help:   "Reparents the shard to the new primary, or away from old primary. Both old and new primary need to be up and running.",
+		name:         "PlannedReparentShard",
+		method:       commandPlannedReparentShard,
+		params:       "--keyspace_shard=<keyspace/shard> [--new_primary=<tablet alias>] [--avoid_tablet=<tablet alias>] [--wait_replicas_timeout=<duration>]",
+		help:         "Reparents the shard to the new primary, or away from old primary. Both old and new primary need to be up and running.",
+		deprecated:   true,
+		deprecatedBy: "PlannedReparentShard",
 	})
 	addCommand("Shards", command{
 		name:   "EmergencyReparentShard",

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -38,18 +38,18 @@ func init() {
 		help:   "Reparent a tablet to the current primary in the shard. This only works if the current replication position matches the last known reparent action.",
 	})
 	addCommand("Shards", command{
-		name:   "InitShardPrimary",
-		method: commandInitShardPrimary,
-		params: "[--force] [--wait_replicas_timeout=<duration>] <keyspace/shard> <tablet alias>",
-		help:   "Sets the initial primary for a shard. Will make all other tablets in the shard replicas of the provided tablet. WARNING: this could cause data loss on an already replicating shard. PlannedReparentShard or EmergencyReparentShard should be used instead.",
-	})
-	addCommand("Shards", command{
-		name:         "PlannedReparentShard",
-		method:       commandPlannedReparentShard,
-		params:       "--keyspace_shard=<keyspace/shard> [--new_primary=<tablet alias>] [--avoid_tablet=<tablet alias>] [--wait_replicas_timeout=<duration>]",
-		help:         "Reparents the shard to the new primary, or away from old primary. Both old and new primary need to be up and running.",
+		name:         "InitShardPrimary",
+		method:       commandInitShardPrimary,
+		params:       "[--force] [--wait_replicas_timeout=<duration>] <keyspace/shard> <tablet alias>",
+		help:         "Sets the initial primary for a shard. Will make all other tablets in the shard replicas of the provided tablet. WARNING: this could cause data loss on an already replicating shard. PlannedReparentShard or EmergencyReparentShard should be used instead.",
 		deprecated:   true,
 		deprecatedBy: "PlannedReparentShard",
+	})
+	addCommand("Shards", command{
+		name:   "PlannedReparentShard",
+		method: commandPlannedReparentShard,
+		params: "--keyspace_shard=<keyspace/shard> [--new_primary=<tablet alias>] [--avoid_tablet=<tablet alias>] [--wait_replicas_timeout=<duration>]",
+		help:   "Reparents the shard to the new primary, or away from old primary. Both old and new primary need to be up and running.",
 	})
 	addCommand("Shards", command{
 		name:   "EmergencyReparentShard",


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Deprecate `InitShardPrimary` command in favour of `PlannedReparentShard`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #6612 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required Webiste PR - https://github.com/vitessio/website/pull/1189

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
