### PR TITLE
removing mysql_server_version from vtctl binaries

### DIFF
--- a/go/cmd/vtctldclient/main.go
+++ b/go/cmd/vtctldclient/main.go
@@ -26,7 +26,6 @@ import (
 	"vitess.io/vitess/go/vt/grpccommon"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtctl/grpcclientcommon"
 	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
 
@@ -44,7 +43,6 @@ func main() {
 	grpcclient.RegisterFlags(command.Root.PersistentFlags())
 	grpccommon.RegisterFlags(command.Root.PersistentFlags())
 	grpcclientcommon.RegisterFlags(command.Root.PersistentFlags())
-	servenv.RegisterMySQLServerFlags(command.Root.PersistentFlags())
 	vtctlclient.RegisterFlags(command.Root.PersistentFlags())
 	acl.RegisterFlags(command.Root.PersistentFlags())
 

--- a/go/flags/endtoend/flags_test.go
+++ b/go/flags/endtoend/flags_test.go
@@ -83,6 +83,9 @@ var (
 	//go:embed zk.txt
 	zkTxt string
 
+	//go:embed vtctl.txt
+	vtctlTxt string
+
 	helpOutput = map[string]string{
 		"mysqlctl":     mysqlctlTxt,
 		"mysqlctld":    mysqlctldTxt,
@@ -101,6 +104,7 @@ var (
 		"vtbackup":     vtbackupTxt,
 		"zk":           zkTxt,
 		"zkctl":        zkctlTxt,
+		"vtctl":        vtctlTxt,
 	}
 )
 

--- a/go/flags/endtoend/vtctl.txt
+++ b/go/flags/endtoend/vtctl.txt
@@ -1,0 +1,100 @@
+Usage of vtctl:
+      --alsologtostderr                               log to standard error as well as files
+      --azblob_backup_account_key_file string         Path to a file containing the Azure Storage account key; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_KEY will be used as the key itself (NOT a file path).
+      --azblob_backup_account_name string             Azure Storage Account name for backups; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_NAME will be used.
+      --azblob_backup_container_name string           Azure Blob Container Name.
+      --azblob_backup_parallelism int                 Azure Blob operation parallelism (requires extra memory when increased). (default 1)
+      --azblob_backup_storage_root string             Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
+      --backup_storage_implementation string          Which backup storage implementation to use for creating and restoring backups.
+      --ceph_backup_storage_config string             Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
+      --consul_auth_static_file string                JSON File to read the topos/tokens from.
+      --datadog-agent-host string                     host to send spans to. if empty, no tracing will be done
+      --datadog-agent-port string                     port to send spans to. if empty, no tracing will be done
+      --detach                                        detached mode - run vtcl detached from the terminal
+      --file_backup_storage_root string               Root directory for the file backup storage.
+      --gcs_backup_storage_bucket string              Google Cloud Storage bucket to use for backups.
+      --gcs_backup_storage_root string                Root prefix for all backup-related object names.
+      --grpc_auth_static_client_creds string          When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
+      --grpc_compression string                       Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
+      --grpc_enable_tracing                           Enable gRPC tracing.
+      --grpc_initial_conn_window_size int             gRPC initial connection window size
+      --grpc_initial_window_size int                  gRPC initial window size
+      --grpc_keepalive_time duration                  After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
+      --grpc_keepalive_timeout duration               After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
+      --grpc_max_message_size int                     Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
+      --grpc_prometheus                               Enable gRPC monitoring with Prometheus.
+  -h, --help                                          display usage and exit
+      --jaeger-agent-host string                      host and port to send spans to. if empty, no tracing will be done
+      --keep_logs duration                            keep logs for this long (using ctime) (zero to keep forever)
+      --keep_logs_by_mtime duration                   keep logs for this long (using mtime) (zero to keep forever)
+      --log_backtrace_at traceLocation                when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                                If non-empty, write log files in this directory
+      --log_err_stacks                                log stack traces for errors
+      --log_rotate_max_size uint                      size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
+      --logtostderr                                   log to standard error instead of files
+      --pprof strings                                 enable profiling
+      --purge_logs_interval duration                  how often try to remove old logs (default 1h0m0s)
+      --remote_operation_timeout duration             time to wait for a remote operation (default 30s)
+      --s3_backup_aws_endpoint string                 endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_region string                   AWS region to use. (default "us-east-1")
+      --s3_backup_aws_retries int                     AWS request retries. (default -1)
+      --s3_backup_force_path_style                    force the s3 path style.
+      --s3_backup_log_level string                    determine the S3 loglevel to use from LogOff, LogDebug, LogDebugWithSigning, LogDebugWithHTTPBody, LogDebugWithRequestRetries, LogDebugWithRequestErrors. (default "LogOff")
+      --s3_backup_server_side_encryption string       server-side encryption algorithm (e.g., AES256, aws:kms, sse_c:/path/to/key/file).
+      --s3_backup_storage_bucket string               S3 bucket to use for backups.
+      --s3_backup_storage_root string                 root prefix for all backup-related object names.
+      --s3_backup_tls_skip_verify_cert                skip the 'certificate is valid' check for SSL connections.
+      --security_policy string                        the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
+      --sql-max-length-errors int                     truncate queries in error logs to the given length (default unlimited)
+      --sql-max-length-ui int                         truncate queries in debug UIs to the given length (default 512) (default 512)
+      --stderrthreshold severity                      logs at or above this threshold go to stderr (default 1)
+      --tablet_grpc_ca string                         the server ca to use to validate servers when connecting
+      --tablet_grpc_cert string                       the cert to use to connect
+      --tablet_grpc_crl string                        the server crl to use to validate server certificates when connecting
+      --tablet_grpc_key string                        the key to use to connect
+      --tablet_grpc_server_name string                the server name to use to validate server certificate
+      --tablet_manager_grpc_ca string                 the server ca to use to validate servers when connecting
+      --tablet_manager_grpc_cert string               the cert to use to connect
+      --tablet_manager_grpc_concurrency int           concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_connpool_size int         number of tablets to keep tmclient connections open to (default 100)
+      --tablet_manager_grpc_crl string                the server crl to use to validate server certificates when connecting
+      --tablet_manager_grpc_key string                the key to use to connect
+      --tablet_manager_grpc_server_name string        the server name to use to validate server certificate
+      --tablet_manager_protocol string                Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
+      --tablet_protocol string                        Protocol to use to make queryservice RPCs to vttablets. (default "grpc")
+      --topo_consul_lock_delay duration               LockDelay for consul session. (default 15s)
+      --topo_consul_lock_session_checks string        List of checks for consul session. (default "serfHealth")
+      --topo_consul_lock_session_ttl string           TTL for consul session.
+      --topo_consul_watch_poll_duration duration      time of the long poll for watch queries. (default 30s)
+      --topo_etcd_lease_ttl int                       Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going. (default 30)
+      --topo_etcd_tls_ca string                       path to the ca to use to validate the server cert when connecting to the etcd topo server
+      --topo_etcd_tls_cert string                     path to the client cert to use to connect to the etcd topo server, requires topo_etcd_tls_key, enables TLS
+      --topo_etcd_tls_key string                      path to the client key to use to connect to the etcd topo server, enables TLS
+      --topo_global_root string                       the path of the global topology data in the global topology server
+      --topo_global_server_address string             the address of the global topology server
+      --topo_implementation string                    the topology implementation to use
+      --topo_k8s_context string                       The kubeconfig context to use, overrides the 'current-context' from the config
+      --topo_k8s_kubeconfig string                    Path to a valid kubeconfig file. When running as a k8s pod inside the same cluster you wish to use as the topo, you may omit this and the below arguments, and Vitess is capable of auto-discovering the correct values. https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+      --topo_k8s_namespace string                     The kubernetes namespace to use for all objects. Default comes from the context or in-cluster config
+      --topo_zk_auth_file string                      auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
+      --topo_zk_base_timeout duration                 zk base timeout (see zk.Connect) (default 30s)
+      --topo_zk_max_concurrency int                   maximum number of pending requests to send to a Zookeeper server. (default 64)
+      --topo_zk_tls_ca string                         the server ca to use to validate servers when connecting to the zk topo server
+      --topo_zk_tls_cert string                       the cert to use to connect to the zk topo server, requires topo_zk_tls_key, enables TLS
+      --topo_zk_tls_key string                        the key to use to connect to the zk topo server, enables TLS
+      --tracer string                                 tracing service to use (default "noop")
+      --tracing-enable-logging                        whether to enable logging in the tracing service
+      --tracing-sampling-rate float                   sampling rate for the probabilistic jaeger sampler (default 0.1)
+      --tracing-sampling-type string                  sampling strategy to use for jaeger. possible values are 'const', 'probabilistic', 'rateLimiting', or 'remote' (default "const")
+      --v Level                                       log level for V logs
+  -v, --version                                       print binary version
+      --vmodule moduleSpec                            comma-separated list of pattern=N settings for file-filtered logging
+      --vtctl_healthcheck_retry_delay duration        delay before retrying a failed healthcheck (default 5s)
+      --vtctl_healthcheck_timeout duration            the health check timeout period (default 1m0s)
+      --vtctl_healthcheck_topology_refresh duration   refresh interval for re-reading the topology (default 30s)
+      --vtgate_grpc_ca string                         the server ca to use to validate servers when connecting
+      --vtgate_grpc_cert string                       the cert to use to connect
+      --vtgate_grpc_crl string                        the server crl to use to validate server certificates when connecting
+      --vtgate_grpc_key string                        the key to use to connect
+      --vtgate_grpc_server_name string                the server name to use to validate server certificate
+      --wait-time duration                            time to wait on an action (default 24h0m0s)

--- a/go/flags/endtoend/vtctldclient.txt
+++ b/go/flags/endtoend/vtctldclient.txt
@@ -106,7 +106,6 @@ Flags:
       --log_dir string                         If non-empty, write log files in this directory
       --log_rotate_max_size uint               size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                            log to standard error instead of files
-      --mysql_server_version string            MySQL server version to advertise.
       --purge_logs_interval duration           how often try to remove old logs (default 1h0m0s)
       --security_policy string                 the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --server string                          server to use for connection (required)

--- a/go/vt/servenv/mysql.go
+++ b/go/vt/servenv/mysql.go
@@ -50,8 +50,6 @@ func init() {
 		"mysqlctld",
 		"vtbackup",
 		"vtcombo",
-		"vtctl",
-		"vtctldclient",
 		"vtexplain",
 		"vtgate",
 		"vtgateclienttest",


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>


## Description

This will remove mysql_server_version from vtctl and vtctldclient binaries. I do see vtctl is using it in sqlparser but I am intentionally trying it out and want to see if our test fails or not. I will bring it back for vtctl once the test fail. If not then I will investigate.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
