### PR TITLE
[V14] Improve route merging for queries that can be merged via join predicates

### DIFF
--- a/go/vt/vtgate/planbuilder/physical/route_planning.go
+++ b/go/vt/vtgate/planbuilder/physical/route_planning.go
@@ -635,7 +635,7 @@ func tryMerge(
 			return merger(aRoute, bRoute)
 		}
 	case engine.EqualUnique:
-		// if they are already both being sent to the same shard, we can merge
+		// If the two routes fully match, they can be merged together.
 		if bRoute.RouteOpCode == engine.EqualUnique {
 			aVdx := aRoute.SelectedVindex()
 			bVdx := bRoute.SelectedVindex()
@@ -644,9 +644,12 @@ func tryMerge(
 			if aVdx == bVdx && gen4ValuesEqual(ctx, aExpr, bExpr) {
 				return merger(aRoute, bRoute)
 			}
-			return nil, nil
 		}
+
+		// If the two routes don't match, fall through to the next case and see if we
+		// can merge via join predicates instead.
 		fallthrough
+
 	case engine.Scatter, engine.IN:
 		if len(joinPredicates) == 0 {
 			// If we are doing two Scatters, we have to make sure that the

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5416,5 +5416,47 @@
         "Table": "dual"
       }
     }
+  },
+  {
+    "comment": "Join across multiple tables, with conditions on different vindexes, but mergeable through join predicates",
+    "query": "SELECT user.id FROM user INNER JOIN music_extra ON user.id = music_extra.user_id INNER JOIN music ON music_extra.user_id = music.user_id WHERE user.id = 123 and music.id = 456",
+    "v3-plan": {
+      "QueryType": "SELECT",
+      "Original": "SELECT user.id FROM user INNER JOIN music_extra ON user.id = music_extra.user_id INNER JOIN music ON music_extra.user_id = music.user_id WHERE user.id = 123 and music.id = 456",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.id from `user` join music_extra on `user`.id = music_extra.user_id join music on music_extra.user_id = music.user_id where 1 != 1",
+        "Query": "select `user`.id from `user` join music_extra on `user`.id = music_extra.user_id join music on music_extra.user_id = music.user_id where `user`.id = 123 and music.id = 456",
+        "Table": "`user`, music_extra, music",
+        "Values": [
+          "INT64(123)"
+        ],
+        "Vindex": "user_index"
+      }
+    },
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "SELECT user.id FROM user INNER JOIN music_extra ON user.id = music_extra.user_id INNER JOIN music ON music_extra.user_id = music.user_id WHERE user.id = 123 and music.id = 456",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.id from `user`, music_extra, music where 1 != 1",
+        "Query": "select `user`.id from `user`, music_extra, music where music.id = 456 and `user`.id = 123 and `user`.id = music_extra.user_id and music_extra.user_id = music.user_id",
+        "Table": "`user`, music, music_extra",
+        "Values": [
+          "INT64(123)"
+        ],
+        "Vindex": "user_index"
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Description

This pull request imrpoves query route merging for queries that consist of multiple joins (via vindex columns), where some of the joined tables also have additional vindex conditions defined.

An example can be found in https://github.com/vitessio/vitess/issues/10819, and in the test case that was added to `go/vt/vtgate/planbuilder/testdata/select_cases.txt`.

Previously, the Gen4 planner would break the query up into multiple pieces, one for each "direct" vindex condition defined, even though the query could be send to a single shard based on the join conditions between all tables.

For the query from the added test case, the plan generated by Gen4 would look like this:

```json
{
  "QueryType": "SELECT",
  "Original": "SELECT user.id FROM user INNER JOIN music_extra ON user.id = music_extra.user_id INNER JOIN music ON music_extra.user_id = music.user_id WHERE user.id = 123 and music.id = 456",
  "Instructions": {
    "OperatorType": "Join",
    "Variant": "Join",
    "JoinColumnIndexes": "R:0",
    "JoinVars": {
      "music_user_id": 0
    },
    "TableName": "music_`user`, music_extra",
    "Inputs": [
      {
        "OperatorType": "Route",
        "Variant": "EqualUnique",
        "Keyspace": {
          "Name": "user",
          "Sharded": true
        },
        "FieldQuery": "select music.user_id from music where 1 != 1",
        "Query": "select music.user_id from music where music.id = 456",
        "Table": "music",
        "Values": [
          "INT64(456)"
        ],
        "Vindex": "music_user_map"
      },
      {
        "OperatorType": "Route",
        "Variant": "EqualUnique",
        "Keyspace": {
          "Name": "user",
          "Sharded": true
        },
        "FieldQuery": "select `user`.id from `user`, music_extra where 1 != 1",
        "Query": "select `user`.id from `user`, music_extra where `user`.id = 123 and music_extra.user_id = :music_user_id and `user`.id = music_extra.user_id",
        "Table": "`user`, music_extra",
        "Values": [
          ":music_user_id"
        ],
        "Vindex": "user_index"
      }
    ]
  },
  "TablesUsed": [
    "user.music",
    "user.music_extra",
    "user.user"
  ]
}
```

The Gen4 planner would only consider merging `EqualUnique` routes if the routes matched completely, and would immediately give up merging the routes if they didn't. Now, we try to also consider join predicates and merge routes based on them instead.

## Related Issue(s)
Backport of #10942
Fixes #11311

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
