### PR TITLE
mysql: Improve MySQL 5.6 GTID parsing performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,6 +118,7 @@ require (
 require (
 	github.com/bndr/gotabulate v1.1.2
 	github.com/openark/golib v0.0.0-20210531070646-355f37940af8
+	golang.org/x/exp v0.0.0-20221023144134-a1e5550cf13e
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -799,6 +799,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221023144134-a1e5550cf13e h1:SkwG94eNiiYJhbeDE018Grw09HIN/KB9NlRmZsrzfWs=
+golang.org/x/exp v0.0.0-20221023144134-a1e5550cf13e/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -53,7 +53,7 @@ func (mysqlFlavor) primaryGTIDSet(c *Conn) (GTIDSet, error) {
 	if len(qr.Rows) != 1 || len(qr.Rows[0]) != 1 {
 		return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "unexpected result format for gtid_executed: %#v", qr)
 	}
-	return parseMysql56GTIDSet(qr.Rows[0][0].ToString())
+	return ParseMysql56GTIDSet(qr.Rows[0][0].ToString())
 }
 
 // purgedGTIDSet is part of the Flavor interface.
@@ -66,7 +66,7 @@ func (mysqlFlavor) purgedGTIDSet(c *Conn) (GTIDSet, error) {
 	if len(qr.Rows) != 1 || len(qr.Rows[0]) != 1 {
 		return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "unexpected result format for gtid_purged: %#v", qr)
 	}
-	return parseMysql56GTIDSet(qr.Rows[0][0].ToString())
+	return ParseMysql56GTIDSet(qr.Rows[0][0].ToString())
 }
 
 // serverUUID is part of the Flavor interface.
@@ -208,11 +208,11 @@ func parseMysqlReplicationStatus(resultMap map[string]string) (ReplicationStatus
 	}
 
 	var err error
-	status.Position.GTIDSet, err = parseMysql56GTIDSet(resultMap["Executed_Gtid_Set"])
+	status.Position.GTIDSet, err = ParseMysql56GTIDSet(resultMap["Executed_Gtid_Set"])
 	if err != nil {
 		return ReplicationStatus{}, vterrors.Wrapf(err, "ReplicationStatus can't parse MySQL 5.6 GTID (Executed_Gtid_Set: %#v)", resultMap["Executed_Gtid_Set"])
 	}
-	relayLogGTIDSet, err := parseMysql56GTIDSet(resultMap["Retrieved_Gtid_Set"])
+	relayLogGTIDSet, err := ParseMysql56GTIDSet(resultMap["Retrieved_Gtid_Set"])
 	if err != nil {
 		return ReplicationStatus{}, vterrors.Wrapf(err, "ReplicationStatus can't parse MySQL 5.6 GTID (Retrieved_Gtid_Set: %#v)", resultMap["Retrieved_Gtid_Set"])
 	}
@@ -247,7 +247,7 @@ func parseMysqlPrimaryStatus(resultMap map[string]string) (PrimaryStatus, error)
 	status := parsePrimaryStatus(resultMap)
 
 	var err error
-	status.Position.GTIDSet, err = parseMysql56GTIDSet(resultMap["Executed_Gtid_Set"])
+	status.Position.GTIDSet, err = ParseMysql56GTIDSet(resultMap["Executed_Gtid_Set"])
 	if err != nil {
 		return PrimaryStatus{}, vterrors.Wrapf(err, "PrimaryStatus can't parse MySQL 5.6 GTID (Executed_Gtid_Set: %#v)", resultMap["Executed_Gtid_Set"])
 	}

--- a/go/mysql/mysql56_gtid.go
+++ b/go/mysql/mysql56_gtid.go
@@ -73,14 +73,14 @@ func ParseSID(s string) (sid SID, err error) {
 	}
 
 	// Drop the dashes so we can just check the error of Decode once.
-	b := make([]byte, 0, 32)
-	b = append(b, s[:8]...)
-	b = append(b, s[9:13]...)
-	b = append(b, s[14:18]...)
-	b = append(b, s[19:23]...)
-	b = append(b, s[24:]...)
+	var b [32]byte
+	copy(b[0:], s[:8])
+	copy(b[8:], s[9:13])
+	copy(b[12:], s[14:18])
+	copy(b[16:], s[19:23])
+	copy(b[20:], s[24:])
 
-	if _, err := hex.Decode(sid[:], b); err != nil {
+	if _, err := hex.Decode(sid[:], b[:]); err != nil {
 		return sid, vterrors.Wrapf(err, "invalid MySQL 5.6 SID %q", s)
 	}
 	return sid, nil

--- a/go/mysql/mysql56_gtid_set.go
+++ b/go/mysql/mysql56_gtid_set.go
@@ -61,8 +61,9 @@ func parseInterval(s string) (interval, error) {
 // ParseMysql56GTIDSet is registered as a GTIDSet parser.
 //
 // https://dev.mysql.com/doc/refman/5.6/en/replication-gtids-concepts.html
-func ParseMysql56GTIDSet(input string) (Mysql56GTIDSet, error) {
+func ParseMysql56GTIDSet(s string) (Mysql56GTIDSet, error) {
 	set := make(Mysql56GTIDSet)
+	input := s
 
 	// gtid_set: uuid_set [, uuid_set] ...
 	for len(input) > 0 {
@@ -83,13 +84,13 @@ func ParseMysql56GTIDSet(input string) (Mysql56GTIDSet, error) {
 		// uuid_set: uuid:interval[:interval]...
 		head, tail, ok := strings.Cut(uuidSet, ":")
 		if !ok {
-			return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "invalid MySQL 5.6 GTID set (%q): expected uuid:interval", input)
+			return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "invalid MySQL 5.6 GTID set (%q): expected uuid:interval", s)
 		}
 
 		// Parse Server ID.
 		sid, err := ParseSID(head)
 		if err != nil {
-			return nil, vterrors.Wrapf(err, "invalid MySQL 5.6 GTID set (%q)", input)
+			return nil, vterrors.Wrapf(err, "invalid MySQL 5.6 GTID set (%q)", s)
 		}
 
 		intervals := make([]interval, 0, strings.Count(tail, ":")+1)
@@ -104,7 +105,7 @@ func ParseMysql56GTIDSet(input string) (Mysql56GTIDSet, error) {
 
 			iv, err := parseInterval(head)
 			if err != nil {
-				return nil, vterrors.Wrapf(err, "invalid MySQL 5.6 GTID set (%q)", input)
+				return nil, vterrors.Wrapf(err, "invalid MySQL 5.6 GTID set (%q)", s)
 			}
 			if iv.end < iv.start {
 				// According to MySQL 5.6 code:

--- a/go/mysql/mysql56_gtid_set.go
+++ b/go/mysql/mysql56_gtid_set.go
@@ -70,10 +70,10 @@ func parseInterval(s string) (interval, error) {
 	}
 }
 
-// parseMysql56GTIDSet is registered as a GTIDSet parser.
+// ParseMysql56GTIDSet is registered as a GTIDSet parser.
 //
 // https://dev.mysql.com/doc/refman/5.6/en/replication-gtids-concepts.html
-func parseMysql56GTIDSet(s string) (Mysql56GTIDSet, error) {
+func ParseMysql56GTIDSet(s string) (Mysql56GTIDSet, error) {
 	set := Mysql56GTIDSet{}
 
 	// gtid_set: uuid_set [, uuid_set] ...
@@ -657,7 +657,7 @@ func popInterval(dst *interval, s1, s2 *[]interval) bool {
 
 func init() {
 	gtidSetParsers[Mysql56FlavorID] = func(s string) (GTIDSet, error) {
-		return parseMysql56GTIDSet(s)
+		return ParseMysql56GTIDSet(s)
 	}
 }
 
@@ -665,11 +665,11 @@ func init() {
 // The result is also a string.
 // An error is thrown if parsing is not possible for either GTIDSets
 func Subtract(lhs, rhs string) (string, error) {
-	lhsSet, err := parseMysql56GTIDSet(lhs)
+	lhsSet, err := ParseMysql56GTIDSet(lhs)
 	if err != nil {
 		return "", err
 	}
-	rhsSet, err := parseMysql56GTIDSet(rhs)
+	rhsSet, err := ParseMysql56GTIDSet(rhs)
 	if err != nil {
 		return "", err
 	}

--- a/go/mysql/mysql56_gtid_set_test.go
+++ b/go/mysql/mysql56_gtid_set_test.go
@@ -19,7 +19,6 @@ package mysql
 import (
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -43,7 +42,7 @@ func TestSortSIDList(t *testing.T) {
 		{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 		{1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 	}
-	sort.Sort(sidList(input))
+	sortSIDs(input)
 	if !reflect.DeepEqual(input, want) {
 		t.Errorf("got %#v, want %#v", input, want)
 	}

--- a/go/mysql/mysql56_gtid_set_test.go
+++ b/go/mysql/mysql56_gtid_set_test.go
@@ -635,3 +635,25 @@ func TestSubtract(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkMySQL56GTIDParsing(b *testing.B) {
+	var Inputs = []string{
+		"00010203-0405-0607-0809-0a0b0c0d0e0f:1-5",
+		"00010203-0405-0607-0809-0a0b0c0d0e0f:12",
+		"00010203-0405-0607-0809-0a0b0c0d0e0f:1-5:10-20",
+		"00010203-0405-0607-0809-0a0b0c0d0e0f:10-20:1-5",
+		"00010203-0405-0607-0809-0a0b0c0d0e0f:8-7",
+		"00010203-0405-0607-0809-0a0b0c0d0e0f:1-5:8-7:10-20",
+		"00010203-0405-0607-0809-0a0b0c0d0e0f:1-5:10-20,00010203-0405-0607-0809-0a0b0c0d0eff:1-5:50",
+		"8aabbf4f-5074-11ed-b225-aa23ce7e3ba2:1-20443,a6f1bf40-5073-11ed-9c0f-12a3889dc912:1-343402",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		for _, input := range Inputs {
+			_, _ = ParseMysql56GTIDSet(input)
+		}
+	}
+}

--- a/go/mysql/mysql56_gtid_set_test.go
+++ b/go/mysql/mysql56_gtid_set_test.go
@@ -94,13 +94,13 @@ func TestParseMysql56GTIDSet(t *testing.T) {
 	}
 
 	for input, want := range table {
-		got, err := parseMysql56GTIDSet(input)
+		got, err := ParseMysql56GTIDSet(input)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			continue
 		}
 		if !got.Equal(want) {
-			t.Errorf("parseMysql56GTIDSet(%#v) = %#v, want %#v", input, got, want)
+			t.Errorf("ParseMysql56GTIDSet(%#v) = %#v, want %#v", input, got, want)
 		}
 	}
 }
@@ -119,9 +119,9 @@ func TestParseMysql56GTIDSetInvalid(t *testing.T) {
 	}
 
 	for _, input := range table {
-		_, err := parseMysql56GTIDSet(input)
+		_, err := ParseMysql56GTIDSet(input)
 		if err == nil {
-			t.Errorf("parseMysql56GTIDSet(%#v) expected error, got none", err)
+			t.Errorf("ParseMysql56GTIDSet(%#v) expected error, got none", err)
 		}
 	}
 }

--- a/go/mysql/replication_position.go
+++ b/go/mysql/replication_position.go
@@ -138,12 +138,12 @@ func DecodePosition(s string) (rp Position, err error) {
 		return rp, nil
 	}
 
-	parts := strings.SplitN(s, "/", 2)
-	if len(parts) != 2 {
+	flav, gtid, ok := strings.Cut(s, "/")
+	if !ok {
 		// There is no flavor. Try looking for a default parser.
 		return ParsePosition("", s)
 	}
-	return ParsePosition(parts[0], parts[1])
+	return ParsePosition(flav, gtid)
 }
 
 // ParsePosition calls the parser for the specified flavor.


### PR DESCRIPTION
## Description

This is a small optimization pass for MySQL 5.6 GTID Set parsing performance. This is something that we do very often during VStreaming and which we were performing quite inefficiently.

Before/after:

```
name                   old time/op    new time/op    delta
MySQL56GTIDParsing-16    13.0µs ± 1%     6.8µs ± 2%  -47.60%  (p=0.000 n=9+10)

name                   old alloc/op   new alloc/op   delta
MySQL56GTIDParsing-16    4.38kB ± 0%    3.10kB ± 0%  -29.07%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
MySQL56GTIDParsing-16      68.0 ± 0%      25.0 ± 0%  -63.24%  (p=0.000 n=10+10)
```

cc @dbussink 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
