### PR TITLE
docker: remove all vtworker references

### DIFF
--- a/docker/release.sh
+++ b/docker/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-vt_base_version='v13.0.0'
+vt_base_version='v15.0.0'
 debian_versions='buster  bullseye'
 default_debian_version='bullseye'
 


### PR DESCRIPTION
## Description

vtworker was already removed, so this eliminates it from the release process

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
