### PR TITLE
vtbackup: add --disable-redo-log flag (default false)

### DIFF
--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -118,6 +118,7 @@ var (
 	initDBSQLFile    string
 	detachedMode     bool
 	keepAliveTimeout = 0 * time.Second
+	disableRedoLog   = false
 )
 
 func registerFlags(fs *pflag.FlagSet) {
@@ -139,6 +140,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&initDBSQLFile, "init_db_sql_file", initDBSQLFile, "path to .sql file to run after mysql_install_db")
 	fs.BoolVar(&detachedMode, "detach", detachedMode, "detached mode - run backups detached from the terminal")
 	fs.DurationVar(&keepAliveTimeout, "keep-alive-timeout", keepAliveTimeout, "Wait until timeout elapses after a successful backup before shutting down.")
+	fs.BoolVar(&disableRedoLog, "disable-redo-log", disableRedoLog, "Disable InnoDB redo log during replication-from-primary phase of backup.")
 
 	acl.RegisterFlags(fs)
 }
@@ -351,10 +353,12 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 
 	// Disable redo logging (if we can) before we start replication.
 	disabledRedoLog := false
-	if err := mysqld.DisableRedoLog(ctx); err != nil {
-		log.Warningf("Error disabling redo logging: %v", err)
-	} else {
-		disabledRedoLog = true
+	if disableRedoLog {
+		if err := mysqld.DisableRedoLog(ctx); err != nil {
+			log.Warningf("Error disabling redo logging: %v", err)
+		} else {
+			disabledRedoLog = true
+		}
 	}
 
 	// We have restored a backup. Now start replication.

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -63,6 +63,7 @@ Usage of vtbackup:
       --db_ssl_mode SslMode                             SSL mode to connect with. One of disabled, preferred, required, verify_ca & verify_identity.
       --db_tls_min_version string                       Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
       --detach                                          detached mode - run backups detached from the terminal
+      --disable-redo-log                                Disable InnoDB redo log during replication-from-primary phase of backup.
       --emit_stats                                      If set, emit stats to push-based monitoring and stats backends
       --file_backup_storage_root string                 Root directory for the file backup storage.
       --gcs_backup_storage_bucket string                Google Cloud Storage bucket to use for backups.


### PR DESCRIPTION
Recently [vtbackup was changed to disable innodb redo log](https://github.com/vitessio/vitess/pull/11330) during the replicate-from-primary stage of vtbackup. The goal was to squeeze out a bit more performance. 

My mental model at the time was that "if mysqld of vtbackup fails, we won't try to restart from where we left off, so if any data gets corrupted the next attempt won't re-use any corrupted data".

It turns out that isn't true. If mysqld OOMs, mysqld_safe will restart it, and the next mysqld process may re-use InnoDB data corrupted in a previous run.

I think it's probably better to put this behind a flag and let users opt in to it, at least until we have a better handle on things like mysqld OOMs.