### PR TITLE
vtgate: route create table statements to vschema keyspace

### DIFF
--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1277,7 +1277,7 @@ func TestExecutorDDL(t *testing.T) {
 	}
 
 	stmts := []string{
-		"create table t1(id bigint primary key)",
+		"create table t2(id bigint primary key)",
 		"alter table t2 add primary key (id)",
 		"rename table t2 to t3",
 		"truncate table t2",
@@ -1301,10 +1301,10 @@ func TestExecutorDDL(t *testing.T) {
 			stmtType := "DDL"
 			_, err := executor.Execute(ctx, "TestExecute", NewSafeSession(&vtgatepb.Session{TargetString: tc.targetStr}), stmt, nil)
 			if tc.hasNoKeyspaceErr {
-				require.EqualError(t, err, errNoKeyspace.Error(), "expect query to fail")
+				require.EqualError(t, err, errNoKeyspace.Error(), "expect query to fail: %q", stmt)
 				stmtType = "" // For error case, plan is not generated to query log will not contain any stmtType.
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, err, "did not expect error for query: %q", stmt)
 			}
 
 			diff := cmp.Diff(tc.wantCnts, cnts{
@@ -1324,6 +1324,7 @@ func TestExecutorDDL(t *testing.T) {
 		input  string
 		hasErr bool
 	}{
+		{input: "create table t1(id bigint primary key)", hasErr: false},
 		{input: "drop table t1", hasErr: false},
 		{input: "drop table t2", hasErr: true},
 		{input: "drop view t1", hasErr: false},


### PR DESCRIPTION
## Description

Whereas untargeted `ALTER` statements for tables defined a vschema are routed to the vschema's keyspace, the same is not true for `CREATE TABLE` statements, which fail with a "no database selected" error.

This change makes it so that if a `CREATE TABLE` statement references a table defined in a vschema, the statement is routed to that vschema's keyspace.

## Use cases

This is useful, for example, when using declarative online DDL together with [global table routing](https://vitess.io/docs/15.0/reference/features/global-routing/).

## Related Issue(s)

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

