### PR TITLE
Cleanup copying of proto results to sqltypes.Result

### DIFF
--- a/go/sqltypes/proto3.go
+++ b/go/sqltypes/proto3.go
@@ -100,11 +100,12 @@ func ResultToProto3(qr *Result) *querypb.QueryResult {
 		return nil
 	}
 	return &querypb.QueryResult{
-		Fields:       qr.Fields,
-		RowsAffected: qr.RowsAffected,
-		InsertId:     qr.InsertID,
-		Rows:         RowsToProto3(qr.Rows),
-		Info:         qr.Info,
+		Fields:              qr.Fields,
+		RowsAffected:        qr.RowsAffected,
+		InsertId:            qr.InsertID,
+		Rows:                RowsToProto3(qr.Rows),
+		Info:                qr.Info,
+		SessionStateChanges: qr.SessionStateChanges,
 	}
 }
 
@@ -115,11 +116,12 @@ func Proto3ToResult(qr *querypb.QueryResult) *Result {
 		return nil
 	}
 	return &Result{
-		Fields:       qr.Fields,
-		RowsAffected: qr.RowsAffected,
-		InsertID:     qr.InsertId,
-		Rows:         proto3ToRows(qr.Fields, qr.Rows),
-		Info:         qr.Info,
+		Fields:              qr.Fields,
+		RowsAffected:        qr.RowsAffected,
+		InsertID:            qr.InsertId,
+		Rows:                proto3ToRows(qr.Fields, qr.Rows),
+		Info:                qr.Info,
+		SessionStateChanges: qr.SessionStateChanges,
 	}
 }
 
@@ -131,10 +133,12 @@ func CustomProto3ToResult(fields []*querypb.Field, qr *querypb.QueryResult) *Res
 		return nil
 	}
 	return &Result{
-		Fields:       qr.Fields,
-		RowsAffected: qr.RowsAffected,
-		InsertID:     qr.InsertId,
-		Rows:         proto3ToRows(fields, qr.Rows),
+		Fields:              qr.Fields,
+		RowsAffected:        qr.RowsAffected,
+		InsertID:            qr.InsertId,
+		Rows:                proto3ToRows(fields, qr.Rows),
+		Info:                qr.Info,
+		SessionStateChanges: qr.SessionStateChanges,
 	}
 }
 

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -90,8 +90,10 @@ func (result *Result) ReplaceKeyspace(keyspace string) {
 // Copy creates a deep copy of Result.
 func (result *Result) Copy() *Result {
 	out := &Result{
-		InsertID:     result.InsertID,
-		RowsAffected: result.RowsAffected,
+		InsertID:            result.InsertID,
+		RowsAffected:        result.RowsAffected,
+		Info:                result.Info,
+		SessionStateChanges: result.SessionStateChanges,
 	}
 	if result.Fields != nil {
 		out.Fields = make([]*querypb.Field, len(result.Fields))
@@ -106,6 +108,30 @@ func (result *Result) Copy() *Result {
 		}
 	}
 	return out
+}
+
+// ShallowCopy creates a shallow copy of Result.
+func (result *Result) ShallowCopy() *Result {
+	return &Result{
+		Fields:              result.Fields,
+		InsertID:            result.InsertID,
+		RowsAffected:        result.RowsAffected,
+		Info:                result.Info,
+		SessionStateChanges: result.SessionStateChanges,
+		Rows:                result.Rows,
+	}
+}
+
+// Metadata creates a shallow copy of Result without the rows useful
+// for sending as a first packet in streaming results.
+func (result *Result) Metadata() *Result {
+	return &Result{
+		Fields:              result.Fields,
+		InsertID:            result.InsertID,
+		RowsAffected:        result.RowsAffected,
+		Info:                result.Info,
+		SessionStateChanges: result.SessionStateChanges,
+	}
 }
 
 // CopyRow makes a copy of the row.
@@ -125,8 +151,10 @@ func (result *Result) Truncate(l int) *Result {
 	}
 
 	out := &Result{
-		InsertID:     result.InsertID,
-		RowsAffected: result.RowsAffected,
+		InsertID:            result.InsertID,
+		RowsAffected:        result.RowsAffected,
+		Info:                result.Info,
+		SessionStateChanges: result.SessionStateChanges,
 	}
 	if result.Fields != nil {
 		out.Fields = result.Fields[:l]

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -408,12 +408,7 @@ func (route *Route) sort(in *sqltypes.Result) (*sqltypes.Result, error) {
 	// Since Result is immutable, we make a copy.
 	// The copy can be shallow because we won't be changing
 	// the contents of any row.
-	out := &sqltypes.Result{
-		Fields:       in.Fields,
-		Rows:         in.Rows,
-		RowsAffected: in.RowsAffected,
-		InsertID:     in.InsertID,
-	}
+	out := in.ShallowCopy()
 
 	comparers := extractSlices(route.OrderBy)
 

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -99,7 +99,7 @@ func (vf *VindexFunc) TryStreamExecute(ctx context.Context, vcursor VCursor, bin
 	if err != nil {
 		return err
 	}
-	if err := callback(&sqltypes.Result{Fields: r.Fields}); err != nil {
+	if err := callback(r.Metadata()); err != nil {
 		return err
 	}
 	return callback(&sqltypes.Result{Rows: r.Rows})

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -268,8 +268,7 @@ func (e *Executor) StreamExecute(
 				// the framework currently sends all results as one packet.
 				byteCount := 0
 				if len(qr.Fields) > 0 {
-					qrfield := &sqltypes.Result{Fields: qr.Fields}
-					if err := callback(qrfield); err != nil {
+					if err := callback(qr.Metadata()); err != nil {
 						return err
 					}
 					seenResults.Set(true)


### PR DESCRIPTION
We don't consistently copy all fields everywhere which is confusing. This adds also a shallow copy helper which can be used in a few places.

Session state change was not copied everywhere and also the streaming API didn't honor having all fields on the first result packet, where it would only show fields but now other metadata like info etc.

This makes it all consistent so we copy all state everywhere where needed.

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required