### PR TITLE
Docker Image Context Fix

### DIFF
--- a/doc/internal/ReleaseInstructions.md
+++ b/doc/internal/ReleaseInstructions.md
@@ -197,6 +197,10 @@ On the release day, there are several things to do:
   > - Two new Pull Requests have to be created.
   > - One against `main`, it will contain only the new release notes.
   > - And another against the release branch, this one contains the release notes and the release commit. (The commit on which we did `git tag`) 
+- **Build k8s Docker images and publish them**
+  > - The docker image for `base`, `lite`, etc are built automatically by DockerHub. The k8s images however are dependent on these images and are required to be built manually.
+  > - These images should be built after the `base` image has been built and available on DockerHub.
+  > - To build and publish these images, run `./release.sh` from the directory `vitess/docker`.
 
 ### Post-Release
 

--- a/docker/k8s/logrotate/Dockerfile
+++ b/docker/k8s/logrotate/Dockerfile
@@ -16,9 +16,9 @@ ARG DEBIAN_VER=stable-slim
 
 FROM debian:${DEBIAN_VER}
 
-COPY docker/k8s/logrotate/logrotate.conf /vt/logrotate.conf
+COPY logrotate.conf /vt/logrotate.conf
 
-COPY docker/k8s/logrotate/rotate.sh /vt/rotate.sh
+COPY rotate.sh /vt/rotate.sh
 
 RUN mkdir -p /vt && \
    apt-get update && \

--- a/docker/k8s/logtail/Dockerfile
+++ b/docker/k8s/logtail/Dockerfile
@@ -18,7 +18,7 @@ FROM debian:${DEBIAN_VER}
 
 ENV TAIL_FILEPATH /dev/null
 
-COPY docker/k8s/logtail/tail.sh /vt/tail.sh
+COPY tail.sh /vt/tail.sh
 
 RUN mkdir -p /vt && \
    apt-get update && \

--- a/docker/k8s/vtadmin/Dockerfile
+++ b/docker/k8s/vtadmin/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=k8s /vt/bin/vtadmin /vt/bin/
 COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY --chown=nginx --from=node /vt/web/vtadmin/build /var/www/
-COPY --chown=nginx docker/k8s/vtadmin/default.conf /etc/nginx/templates/default.conf.template
+COPY --chown=nginx default.conf /etc/nginx/templates/default.conf.template
 
 # command to run nginx is in the base image
 # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/stable/alpine/Dockerfile#L150

--- a/docker/release.sh
+++ b/docker/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-vt_base_version='v13.0.0'
+vt_base_version='v16.0.0'
 debian_versions='buster  bullseye'
 default_debian_version='bullseye'
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
During the release of v15, a failure of the docker release script was noticed. The bug outlining the issue is at https://github.com/vitessio/vitess/issues/11627. 

The issue was tracked to the PR https://github.com/vitessio/vitess/pull/10968 which changed the context that the Dockerfiles were expecting to be run from. So when the `release.sh` script is run, it fails because the file `docker/k8s/logrotate/logrotate.conf` doesn't exits. Instead it should be `logrotate.conf`.

This PR fixes this issue. It also adds the `release.sh` as a step to the release process which was previously missing.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #11627 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
