### PR TITLE
normalize more expressions

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -88,6 +88,11 @@ func (nz *normalizer) WalkStatement(cursor *Cursor) bool {
 func (nz *normalizer) WalkSelect(cursor *Cursor) bool {
 	switch node := cursor.Node().(type) {
 	case *Literal:
+		parent := cursor.Parent()
+		switch parent.(type) {
+		case *Order, GroupBy:
+			return false
+		}
 		nz.convertLiteralDedup(node, cursor)
 	case *ComparisonExpr:
 		nz.convertComparison(node)
@@ -97,9 +102,6 @@ func (nz *normalizer) WalkSelect(cursor *Cursor) bool {
 	case *ColName, TableName:
 		// Common node types that never contain Literals or ListArgs but create a lot of object
 		// allocations.
-		return false
-	case OrderBy, GroupBy:
-		// do not make a bind var for order by column_position
 		return false
 	case *ConvertType:
 		// we should not rewrite the type description

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -185,7 +185,7 @@ func TestNormalize(t *testing.T) {
 		outstmt: "select a, b from t group by 1",
 		outbv:   map[string]*querypb.BindVariable{},
 	}, {
-		// ORDER BY column_position
+		// ORDER BY with literal inside complex expression
 		in:      "select a, b from t order by field(a,1,2,3) asc",
 		outstmt: "select a, b from t order by field(a, :bv1, :bv2, :bv3) asc",
 		outbv: map[string]*querypb.BindVariable{

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -180,6 +180,15 @@ func TestNormalize(t *testing.T) {
 		outstmt: "select a, b from t order by 1 asc",
 		outbv:   map[string]*querypb.BindVariable{},
 	}, {
+		// ORDER BY column_position
+		in:      "select a, b from t order by field(a,1,2,3) asc",
+		outstmt: "select a, b from t order by field(a, :bv1, :bv2, :bv3) asc",
+		outbv: map[string]*querypb.BindVariable{
+			"bv1": sqltypes.Int64BindVariable(1),
+			"bv2": sqltypes.Int64BindVariable(2),
+			"bv3": sqltypes.Int64BindVariable(3),
+		},
+	}, {
 		// ORDER BY variable
 		in:      "select a, b from t order by c asc",
 		outstmt: "select a, b from t order by c asc",


### PR DESCRIPTION
## Description
We were not auto-parameterizing literal values on the `ORDER BY` and `GROUP BY`.

This is because literals can have special meaning when used in these clauses.

For example:

```sql
select name from user order by 1
```

In the query above, `1` does not mean the integer value 1, instead it refers to the first column returned.
On the other hand, in the following query `1` really means integer 1.

```sql
select name from user order by age + 1
```

This PR changes the normalizer to change literals in ORDER BY/GROUP BY as long as they are not directly following the clause.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
