### PR TITLE
deprecate V3 planner

### DIFF
--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -33,3 +33,7 @@ Other aspects of the VReplication copy-phase logic are preserved:
   4. The vstream packets are committed in the order seen in the stream. So for any PK1 and PK2, the write to `_vt.copy_state` and  `commit` steps (steps 2 and 3 above) for PK1 will both precede the `_vt.copy_state` write and commit steps of PK2.
 
  Other phases, catchup, fast-forward, and replicating/"running", are unchanged.
+
+### Deprecations
+
+The V3 planner is deprecated as of the V16 release, and will be removed in the V17 release of Vitess.

--- a/go/vt/vtgate/planbuilder/plancontext/vschema.go
+++ b/go/vt/vtgate/planbuilder/plancontext/vschema.go
@@ -3,6 +3,7 @@ package plancontext
 import (
 	"strings"
 
+	"vitess.io/vitess/go/vt/log"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 
 	"vitess.io/vitess/go/mysql/collations"
@@ -67,8 +68,10 @@ type VSchema interface {
 
 // PlannerNameToVersion returns the numerical representation of the planner
 func PlannerNameToVersion(s string) (PlannerVersion, bool) {
+	deprecationMessage := "The V3 planner is deprecated and will be removed in V17 of Vitess"
 	switch strings.ToLower(s) {
 	case "v3":
+		log.Warning(deprecationMessage)
 		return querypb.ExecuteOptions_V3, true
 	case "gen4":
 		return querypb.ExecuteOptions_Gen4, true
@@ -79,6 +82,7 @@ func PlannerNameToVersion(s string) (PlannerVersion, bool) {
 	case "gen4fallback":
 		return querypb.ExecuteOptions_Gen4WithFallback, true
 	case "gen4comparev3":
+		log.Warning(deprecationMessage)
 		return querypb.ExecuteOptions_Gen4CompareV3, true
 	}
 	return 0, false


### PR DESCRIPTION
## Description
Deprecates the V3 planner so we can remove it in V17.

## Checklist
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required