### PR TITLE
Fix generating invalid alter table for comments

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -814,7 +814,7 @@ func (c *CreateTableEntity) diffOptions(alterTable *sqlparser.AlterTable,
 			case "COLLATE":
 				// skip. the default collation is applied per CHARSET
 			case "COMMENT":
-				tableOption = &sqlparser.TableOption{String: ""}
+				tableOption = &sqlparser.TableOption{Value: sqlparser.NewStrLiteral("")}
 			case "COMPRESSION":
 				tableOption = &sqlparser.TableOption{Value: sqlparser.NewStrLiteral("")}
 			case "CONNECTION":

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -988,6 +988,13 @@ func TestCreateTableDiff(t *testing.T) {
 			diff:  "alter table t1 collate utf8mb3_bin",
 			cdiff: "ALTER TABLE `t1` COLLATE utf8mb3_bin",
 		},
+		{
+			name:  "remove table comment",
+			from:  "create table t1 (id int primary key) comment='foo'",
+			to:    "create table t1 (id int primary key)",
+			diff:  "alter table t1 comment ''",
+			cdiff: "ALTER TABLE `t1` COMMENT ''",
+		},
 	}
 	standardHints := DiffHints{}
 	for _, ts := range tt {


### PR DESCRIPTION
We need to initialize the default comment with an actual string literal. The reason for this is that `opt.String` being `""` is treated special when the AST is generated back into a query. It's treated as not having a string option, resulting in an alter like the following:

```
alter table t1 comment ()
```

By initializing this to an explicitly string literal value we can distinguish between an empty string and not having a value at all, which isn't possible with a plain string.

## Related Issue(s)

Fixes #11644

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required