### PR TITLE
handle leading zeros

### DIFF
--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -501,3 +501,42 @@ func TestHexAndBitToBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestStripLeadingZero(t *testing.T) {
+	tests := []struct{ in, out string }{
+		{
+			in:  "01001900",
+			out: "1001900",
+		}, {
+			in:  "0x1001900",
+			out: "0x1001900",
+		}, {
+			in:  "000000001",
+			out: "1",
+		}, {
+			in:  "00000000",
+			out: "0",
+		}, {
+			in:  "not a number",
+			out: "not a number",
+		}, {
+			in:  "-0001",
+			out: "-1",
+		}, {
+			in:  "",
+			out: "",
+		}, {
+			in:  "00",
+			out: "0",
+		}, {
+			in:  "-0000000",
+			out: "-0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.out, stripUnsignedLeadingZero([]byte(tc.in)))
+		})
+	}
+}

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -311,6 +311,13 @@ func TestNormalize(t *testing.T) {
 			"bv1":                   sqltypes.Int64BindVariable(1),
 			"comms_by_companies_id": sqltypes.StringBindVariable("rjve634shXzaavKHbAH16ql6OrxJ"),
 		},
+	}, {
+		// TimestampVal should also be normalized
+		in:      `select * from t where zipcode = 01001900`,
+		outstmt: `select * from t where zipcode = :zipcode`,
+		outbv: map[string]*querypb.BindVariable{
+			"zipcode": sqltypes.ValueBindVariable(sqltypes.MakeTrusted(sqltypes.Int64, []byte("01001900"))),
+		},
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.in, func(t *testing.T) {


### PR DESCRIPTION
## Description
Help Vitess correctly parse literals that start with `0`.

## Related Issue(s)
Fixes #11648

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
