### PR TITLE
sqltypes: handle leading zeroes

### DIFF
--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -73,12 +73,12 @@ type (
 func NewValue(typ querypb.Type, val []byte) (v Value, err error) {
 	switch {
 	case IsSigned(typ):
-		if _, err := strconv.ParseInt(string(val), 0, 64); err != nil {
+		if _, err := strconv.ParseInt(string(val), 10, 64); err != nil {
 			return NULL, err
 		}
 		return MakeTrusted(typ, val), nil
 	case IsUnsigned(typ):
-		if _, err := strconv.ParseUint(string(val), 0, 64); err != nil {
+		if _, err := strconv.ParseUint(string(val), 10, 64); err != nil {
 			return NULL, err
 		}
 		return MakeTrusted(typ, val), nil

--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -87,6 +87,14 @@ func TestNewValue(t *testing.T) {
 		inVal:  "1",
 		outVal: TestValue(Uint64, "1"),
 	}, {
+		inType: Uint64,
+		inVal:  "01",
+		outVal: TestValue(Uint64, "01"),
+	}, {
+		inType: Int64,
+		inVal:  "01",
+		outVal: TestValue(Int64, "01"),
+	}, {
 		inType: Float32,
 		inVal:  "1.00",
 		outVal: TestValue(Float32, "1.00"),

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -311,6 +311,13 @@ func TestNormalize(t *testing.T) {
 			"bv1":                   sqltypes.Int64BindVariable(1),
 			"comms_by_companies_id": sqltypes.StringBindVariable("rjve634shXzaavKHbAH16ql6OrxJ"),
 		},
+	}, {
+		// Int leading with zero should also be normalized
+		in:      `select * from t where zipcode = 01001900`,
+		outstmt: `select * from t where zipcode = :zipcode`,
+		outbv: map[string]*querypb.BindVariable{
+			"zipcode": sqltypes.ValueBindVariable(sqltypes.MakeTrusted(sqltypes.Int64, []byte("01001900"))),
+		},
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.in, func(t *testing.T) {


### PR DESCRIPTION
## Description

Change the `base` argument to `strconv` methods to enforce base 10, as all signed and unsigned literals in MySQL are in this base. A leading zero in these literals does not trigger octal as a base, and a leading `0x` does not generate a signed/unsigned literal but a `HexValue`.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/11648

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
