### PR TITLE
Send errors in stream instead of a grpc error from streaming rpcs when transaction or reserved connection is acquired

### DIFF
--- a/go/vt/vttablet/grpcqueryservice/server.go
+++ b/go/vt/vttablet/grpcqueryservice/server.go
@@ -272,16 +272,14 @@ func (q *query) BeginStreamExecute(request *querypb.BeginStreamExecuteRequest, s
 			Result: sqltypes.ResultToProto3(reply),
 		})
 	})
-	if err != nil {
-		return vterrors.ToGRPC(err)
-	}
 
-	errInLastPacket := stream.Send(&querypb.BeginStreamExecuteResponse{
+	err = stream.Send(&querypb.BeginStreamExecuteResponse{
+		Error:               vterrors.ToVTRPC(err),
 		TransactionId:       state.TransactionID,
 		TabletAlias:         state.TabletAlias,
 		SessionStateChanges: state.SessionStateChanges,
 	})
-	return vterrors.ToGRPC(errInLastPacket)
+	return vterrors.ToGRPC(err)
 }
 
 // MessageStream is part of the queryservice.QueryServer interface

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -524,6 +524,10 @@ func (conn *gRPCQueryClient) BeginStreamExecute(ctx context.Context, target *que
 			return state, tabletconn.ErrorFromGRPC(err)
 		}
 
+		if ser.Error != nil {
+			return state, tabletconn.ErrorFromVTRPC(ser.Error)
+		}
+
 		// The last stream receive will not have a result, so callback will not be called for it.
 		if ser.Result == nil {
 			return state, nil

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -871,6 +871,10 @@ func (conn *gRPCQueryClient) ReserveBeginStreamExecute(ctx context.Context, targ
 			return state, tabletconn.ErrorFromGRPC(err)
 		}
 
+		if ser.Error != nil {
+			return state, tabletconn.ErrorFromVTRPC(ser.Error)
+		}
+
 		// The last stream receive will not have a result, so callback will not be called for it.
 		if ser.Result == nil {
 			return state, nil
@@ -970,6 +974,10 @@ func (conn *gRPCQueryClient) ReserveStreamExecute(ctx context.Context, target *q
 
 		if err != nil {
 			return state, tabletconn.ErrorFromGRPC(err)
+		}
+
+		if ser.Error != nil {
+			return state, tabletconn.ErrorFromVTRPC(ser.Error)
 		}
 
 		// The last stream receive will not have a result, so callback will not be called for it.

--- a/go/vt/vttablet/tabletconntest/fakequeryservice.go
+++ b/go/vt/vttablet/tabletconntest/fakequeryservice.go
@@ -42,10 +42,11 @@ type FakeQueryService struct {
 	TestingGateway bool
 
 	// these fields are used to simulate and synchronize on errors
-	HasError      bool
-	HasBeginError bool
-	TabletError   error
-	ErrorWait     chan struct{}
+	HasError        bool
+	HasBeginError   bool
+	HasReserveError bool
+	TabletError     error
+	ErrorWait       chan struct{}
 
 	// these fields are used to simulate and synchronize on panics
 	Panics                   bool
@@ -723,7 +724,24 @@ func (f *FakeQueryService) ReserveExecute(ctx context.Context, target *querypb.T
 
 // ReserveStreamExecute satisfies the Gateway interface
 func (f *FakeQueryService) ReserveStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (queryservice.ReservedState, error) {
-	panic("implement me")
+	state, err := f.reserve(transactionID)
+	if err != nil {
+		return state, err
+	}
+	err = f.StreamExecute(ctx, target, sql, bindVariables, transactionID, state.ReservedID, options, callback)
+	return state, err
+}
+
+func (f *FakeQueryService) reserve(transactionID int64) (queryservice.ReservedState, error) {
+	reserveID := transactionID
+	if reserveID == 0 {
+		reserveID = beginTransactionID
+	}
+	if f.HasReserveError {
+		return queryservice.ReservedState{}, f.TabletError
+	}
+	state := queryservice.ReservedState{ReservedID: reserveID, TabletAlias: TestAlias}
+	return state, nil
 }
 
 // Release implements the QueryService interface


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

The old streaming execution that started a transaction or a reserved connection does not propagate the execution error message back. The change done in https://github.com/vitessio/vitess/pull/11592 was to fix the error propagation. The change resulted in missing propagating the open transaction or reserved connection information back in case of failure.

This PR handles those cases and adds additional tests/asserts to ensure it fixes those issues.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/11674

## Checklist

-   [X] "Backport me!" label has been added if this change should be backported 15.0, 14.0, 13.0
-   [X] Tests were added or are not required