### PR TITLE
schemadiff: normalize index option value (string)

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -482,6 +482,7 @@ func (c *CreateTableEntity) normalizeIndexOptions() {
 		idx.Info.Type = strings.ToLower(idx.Info.Type)
 		for _, opt := range idx.Options {
 			opt.Name = strings.ToLower(opt.Name)
+			opt.String = strings.ToLower(opt.String)
 		}
 	}
 }

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -443,7 +443,7 @@ func TestCreateTableDiff(t *testing.T) {
 			from:  "create table t1 (id int primary key, name tinytext not null)",
 			to:    "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
 			diff:  "alter table t1 add fulltext key name_ft (`name`) with parser ngram",
-			cdiff: "ALTER TABLE `t1` ADD FULLTEXT KEY `name_ft` (`name`) WITH PARSER NGRAM",
+			cdiff: "ALTER TABLE `t1` ADD FULLTEXT KEY `name_ft` (`name`) WITH PARSER ngram",
 		},
 		{
 			name:  "add one fulltext key and one normal key",
@@ -1712,7 +1712,7 @@ func TestNormalize(t *testing.T) {
 		{
 			name: "does not drop non-default index type",
 			from: "create table t (id int primary key, i1 int, key i1_idx(i1) using hash)",
-			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i1` int,\n\tKEY `i1_idx` (`i1`) USING HASH\n)",
+			to:   "CREATE TABLE `t` (\n\t`id` int PRIMARY KEY,\n\t`i1` int,\n\tKEY `i1_idx` (`i1`) USING hash\n)",
 		},
 		{
 			name: "drops default index visibility",

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -472,6 +472,16 @@ func TestCreateTableDiff(t *testing.T) {
 			from: "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
 			to:   "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
 		},
+		{
+			name: "no fulltext diff, 2",
+			from: "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
+			to:   "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) WITH PARSER `ngram`)",
+		},
+		{
+			name: "no fulltext diff, 3",
+			from: "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
+			to:   "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) /*!50100 WITH PARSER `ngram` */)",
+		},
 		// CHECK constraints
 		{
 			name: "identical check constraints",

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -482,6 +482,11 @@ func TestCreateTableDiff(t *testing.T) {
 			from: "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
 			to:   "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) /*!50100 WITH PARSER `ngram` */)",
 		},
+		{
+			name: "no fulltext diff",
+			from: "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
+			to:   "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser NGRAM)",
+		},
 		// CHECK constraints
 		{
 			name: "identical check constraints",

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -439,6 +439,20 @@ func TestCreateTableDiff(t *testing.T) {
 			cdiff: "ALTER TABLE `t1` ADD FULLTEXT KEY `name_ft` (`name`)",
 		},
 		{
+			name:  "add one fulltext key with explicit parser",
+			from:  "create table t1 (id int primary key, name tinytext not null)",
+			to:    "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
+			diff:  "alter table t1 add fulltext key name_ft (`name`) with parser ngram",
+			cdiff: "ALTER TABLE `t1` ADD FULLTEXT KEY `name_ft` (`name`) WITH PARSER NGRAM",
+		},
+		{
+			name:  "add one fulltext key and one normal key",
+			from:  "create table t1 (id int primary key, name tinytext not null)",
+			to:    "create table t1 (id int primary key, name tinytext not null, key name_idx(name(32)), fulltext key name_ft(name))",
+			diff:  "alter table t1 add key name_idx (`name`(32)), add fulltext key name_ft (`name`)",
+			cdiff: "ALTER TABLE `t1` ADD KEY `name_idx` (`name`(32)), ADD FULLTEXT KEY `name_ft` (`name`)",
+		},
+		{
 			name:   "add two fulltext keys, distinct statements",
 			from:   "create table t1 (id int primary key, name1 tinytext not null, name2 tinytext not null)",
 			to:     "create table t1 (id int primary key, name1 tinytext not null, name2 tinytext not null, fulltext key name1_ft(name1), fulltext key name2_ft(name2))",
@@ -452,6 +466,11 @@ func TestCreateTableDiff(t *testing.T) {
 			fulltext: FullTextKeyUnifyStatements,
 			diff:     "alter table t1 add fulltext key name1_ft (name1), add fulltext key name2_ft (name2)",
 			cdiff:    "ALTER TABLE `t1` ADD FULLTEXT KEY `name1_ft` (`name1`), ADD FULLTEXT KEY `name2_ft` (`name2`)",
+		},
+		{
+			name: "no fulltext diff",
+			from: "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
+			to:   "create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
 		},
 		// CHECK constraints
 		{

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -826,7 +826,7 @@ func (idx *IndexDefinition) Format(buf *TrackedBuffer) {
 	for _, opt := range idx.Options {
 		buf.astPrintf(idx, " %s", opt.Name)
 		if opt.String != "" {
-			buf.astPrintf(idx, " %s", opt.String)
+			buf.astPrintf(idx, " %#s", opt.String)
 		} else if opt.Value != nil {
 			buf.astPrintf(idx, " %v", opt.Value)
 		}

--- a/go/vt/sqlparser/tracked_buffer_test.go
+++ b/go/vt/sqlparser/tracked_buffer_test.go
@@ -220,6 +220,10 @@ func TestCanonicalOutput(t *testing.T) {
 			"select char(77, 121, 83, 81, '76' using utf8mb4) from dual",
 			"SELECT CHAR(77, 121, 83, 81, '76' USING utf8mb4) FROM `dual`",
 		},
+		{
+			"create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
+			"CREATE TABLE `t1` (\n\t`id` int PRIMARY KEY,\n\t`name` tinytext NOT NULL,\n\tFULLTEXT KEY `name_ft` (`name`) WITH PARSER ngram\n)",
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION

## Description

With this PR `schemadiff` normalizes (to lower case) the value of an index option. For example: 

`fulltext key name_ft(name) WITH PARSER NGRAM` is normalized into
`fulltext key name_ft(name) WITH PARSER ngram`

## Related Issue(s)

Tracking: https://github.com/vitessio/vitess/issues/10203

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes
