### PR TITLE
Leverage pFlag's Changed function to detect user specified flag

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2337,7 +2337,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *pfl
 		vrwp.TabletTypes = *tabletTypes
 	case vReplicationWorkflowActionSwitchTraffic, vReplicationWorkflowActionReverseTraffic:
 		vrwp.Cells = *cells
-		if userPassedFlag(subFlags, "tablet_types") {
+		if subFlags.Changed("tablet_types") {
 			vrwp.TabletTypes = *tabletTypes
 		} else {
 			// When no tablet types are specified we are supposed to switch all traffic so
@@ -4059,16 +4059,4 @@ func PrintAllCommands(logger logutil.Logger) {
 		}
 		logger.Printf("\n")
 	}
-}
-
-// userPassedFlag returns true if the flag name given was provided
-// as a command-line argument by the user.
-func userPassedFlag(flags *pflag.FlagSet, name string) bool {
-	passed := false
-	flags.Visit(func(f *pflag.Flag) {
-		if f.Name == name {
-			passed = true
-		}
-	})
-	return passed
 }


### PR DESCRIPTION
## Description

Now that we've moved to [pFlag](https://github.com/spf13/pflag) we can leverage the [`Changed`](https://pkg.go.dev/github.com/spf13/pflag#FlagSet.Changed) function to see if the user specified the flag on the command-line.

### Example
```
tabletTypes := subFlags.String("tablet_types", "in_order:RDONLY,REPLICA,PRIMARY", "Tablet types for source and target")
```

If the user  does not specify the `--tablet_types` flag on the command-line, then [`AddFlag`](https://github.com/spf13/pflag/blob/v1.0.5/flag.go#L841) is not called on the flagSet and thus the `tabletTypes` variable has the address of the string variable created for the string literal "in_order:RDONLY,REPLICA,PRIMARY" there rather than the address of the normalized flag map value. [`Changed`](https://github.com/spf13/pflag/blob/v1.0.5/flag.go#L508) then just checks whether or not the key exists in the normalized flags map.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests are not required (existing test verifies this behavior)
-   [x] Documentation is not required