### PR TITLE
Add automation to change vitess version in the docker-release script

### DIFF
--- a/tools/do_release.sh
+++ b/tools/do_release.sh
@@ -113,6 +113,12 @@ function updateVitessExamples () {
   rm -f $(find -E $ROOT/examples/compose/**/* -regex ".*.(go|yml).bak")
 }
 
+# First argument is the Release Version the docker release script should be set to (for instance: v15.0.0)
+function updateDockerReleaseScript () {
+  sed -i.bak -E "s/vt_base_version=.*/vt_base_version='$1'/g" $ROOT/docker/release.sh
+  rm -f $ROOT/docker/release.sh.bak
+}
+
 # Preparing and tagging the release
 function doRelease () {
   checkoutNewBranch "tag"
@@ -131,6 +137,7 @@ function doRelease () {
   # Preparing the release commit
   updateVitessExamples $RELEASE_VERSION $VTOP_VERSION
   updateJava $RELEASE_VERSION
+  updateDockerReleaseScript $RELEASE_VERSION
   updateVersionGo $RELEASE_VERSION
 
   ## Create the commit for this release and tag it
@@ -152,6 +159,7 @@ function doBackToDevMode () {
 
   # Preparing the "dev mode" commit
   updateJava $DEV_VERSION
+  updateDockerReleaseScript $DEV_VERSION
   updateVersionGo $DEV_VERSION
 
   git add --all


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds automation to the release script to also update the vitess version in the docker release script. The changes have been tested manually. Calling the function `updateDockerReleaseScript 'v17.0.0'`, changes the release.sh file like 

```
#!/bin/bash
set -ex

vt_base_version='v17.0.0'
debian_versions='buster  bullseye'
default_debian_version='bullseye'
```
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #11681 

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
