### PR TITLE
Add VTAdmin folder to release package

### DIFF
--- a/tools/make-release-packages.sh
+++ b/tools/make-release-packages.sh
@@ -42,6 +42,9 @@ done;
 # Copy remaining files, preserving date/permissions
 # But resolving symlinks
 cp -rpfL examples "${RELEASE_DIR}"
+# copy vtadmin as well
+mkdir -p "${RELEASE_DIR}"/web/vtadmin
+cp -rpfL web/vtadmin "${RELEASE_DIR}"/web
 
 echo "Follow the installation instructions at: https://vitess.io/docs/get-started/local/" > "${RELEASE_DIR}"/examples/README.md
 


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

When we try to install vitess with local method (https://vitess.io/docs/16.0/get-started/local/#install-vitess) for release 15.0, we are getting following error

```
bash
vtadmin-api is running!
  - API: http://localhost:14200/
  - Logs: /home/vitess/my-vitess-example/vtdataroot/tmp/vtadmin-api.out
  - PID: 43498

npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path /home/web/vtadmin/package.json
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '/home/web/vtadmin/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/vitess/.npm/_logs/2022-11-09T08_25_09_328Z-debug.log
vtadmin-web is running!
  - Browser: http://localhost:14201/
  - Logs: /home/vitess/my-vitess-example/vtdataroot/tmp/vtadmin-web.out
  - PID: 43529
```

upon inspection we found out that it is missing vtadmin folder under vitess. The PR fixes the release script to copy vtadmin folder to vitess root folder. It copies all the files under web/vtadmin right now.  

Followed the steps here (https://vitess.io/docs/16.0/get-started/local/#install-vitess) after the fix and vtadmin seems to be working.

```
~/Downloads/vitess-15.0.0-e8c7e27/examples/local: ./101_initial_cluster.sh 
add /vitess/global
add /vitess/zone1
add zone1 CellInfo
Created cell: zone1
etcd start done...
Starting vtctld...
Starting MySQL for tablet zone1-0000000100...
Starting vttablet for zone1-0000000100...
HTTP/1.1 200 OK
Date: Thu, 10 Nov 2022 22:16:14 GMT
Content-Type: text/html; charset=utf-8

Starting MySQL for tablet zone1-0000000101...
Starting vttablet for zone1-0000000101...
HTTP/1.1 200 OK
Date: Thu, 10 Nov 2022 22:16:27 GMT
Content-Type: text/html; charset=utf-8

Starting MySQL for tablet zone1-0000000102...
Starting vttablet for zone1-0000000102...
HTTP/1.1 200 OK
Date: Thu, 10 Nov 2022 22:16:39 GMT
Content-Type: text/html; charset=utf-8

{
  "keyspace": {
    "served_froms": [],
    "keyspace_type": 0,
    "base_keyspace": "",
    "snapshot_time": null,
    "durability_policy": "semi_sync"
  }
}
vtorc is running!
  - UI: http://localhost:16000
  - Logs: /Users/rameezsajwani/Code/fork/vitess/vtdataroot/tmp/vtorc.out
  - PID: 40053

zone1-0000000100 commerce 0 primary localhost:15100 localhost:17100 [] 2022-11-10T22:16:43Z

New VSchema object:
{
  "sharded": false,
  "vindexes": {},
  "tables": {
    "corder": {
      "type": "",
      "column_vindexes": [],
      "auto_increment": null,
      "columns": [],
      "pinned": "",
      "column_list_authoritative": false
    },
    "customer": {
      "type": "",
      "column_vindexes": [],
      "auto_increment": null,
      "columns": [],
      "pinned": "",
      "column_list_authoritative": false
    },
    "product": {
      "type": "",
      "column_vindexes": [],
      "auto_increment": null,
      "columns": [],
      "pinned": "",
      "column_list_authoritative": false
    }
  },
  "require_explicit_routing": false
}
If this is not what you expected, check the input data (as JSON parsing will skip unexpected fields).
Waiting for vtgate to be up...
vtgate is up!
Access vtgate at http://Rameezs-MacBook-Pro.local:15001/debug/status
vtadmin-api is running!
  - API: http://localhost:14200
  - Logs: /Users/rameezsajwani/Code/fork/vitess/vtdataroot/tmp/vtadmin-api.out
  - PID: 40106


> vtadmin@0.1.0 build
> react-scripts build

Creating an optimized production build...
Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
Compiled successfully.

File sizes after gzip:

  440.1 kB (-198 B)  build/static/js/main.94f6ddc2.js
  15.62 kB           build/static/css/main.de7cb128.css

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment

vtadmin-web is running!
  - Browser: http://localhost:14201
  - Logs: /Users/rameezsajwani/Code/fork/vitess/vtdataroot/tmp/vtadmin-web.out
  - PID: 40143
```
```
 ~/Downloads/vitess-15.0.0-e8c7e27/examples/local: ./401_teardown.sh       
Stopping vtadmin-web...
Stopping vtadmin-api...
./scripts/vtadmin-down.sh: line 9: kill: (40106) - No such process
Stopping vtorc.
./scripts/vtorc-down.sh: line 6: kill: (40053) - No such process
Stopping vtgate...
Shutting down tablet zone1-0000000100
Shutting down MySQL for tablet zone1-0000000100...
Shutting down tablet zone1-0000000101
Shutting down MySQL for tablet zone1-0000000101...
Shutting down tablet zone1-0000000102
Shutting down MySQL for tablet zone1-0000000102...
Stopping vtctld...
Stopping etcd...
All good! It looks like every process has shut down
```


## Related Issue(s)

- Fixes #11679

## Checklist

-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
