### PR TITLE
[15.0] Send errors in stream instead of a grpc error from streaming rpcs when transaction or reserved connection is acquired

### DIFF
--- a/go/vt/vttablet/grpcqueryservice/server.go
+++ b/go/vt/vttablet/grpcqueryservice/server.go
@@ -272,15 +272,15 @@ func (q *query) BeginStreamExecute(request *querypb.BeginStreamExecuteRequest, s
 			Result: sqltypes.ResultToProto3(reply),
 		})
 	})
+	if err != nil {
+		return vterrors.ToGRPC(err)
+	}
+
 	errInLastPacket := stream.Send(&querypb.BeginStreamExecuteResponse{
 		TransactionId:       state.TransactionID,
 		TabletAlias:         state.TabletAlias,
 		SessionStateChanges: state.SessionStateChanges,
 	})
-	if err != nil {
-		return vterrors.ToGRPC(err)
-	}
-
 	return vterrors.ToGRPC(errInLastPacket)
 }
 
@@ -399,14 +399,14 @@ func (q *query) ReserveStreamExecute(request *querypb.ReserveStreamExecuteReques
 			Result: sqltypes.ResultToProto3(reply),
 		})
 	})
-	errInLastPacket := stream.Send(&querypb.ReserveStreamExecuteResponse{
-		ReservedId:  state.ReservedID,
-		TabletAlias: state.TabletAlias,
-	})
 	if err != nil {
 		return vterrors.ToGRPC(err)
 	}
 
+	errInLastPacket := stream.Send(&querypb.ReserveStreamExecuteResponse{
+		ReservedId:  state.ReservedID,
+		TabletAlias: state.TabletAlias,
+	})
 	return vterrors.ToGRPC(errInLastPacket)
 }
 
@@ -452,16 +452,16 @@ func (q *query) ReserveBeginStreamExecute(request *querypb.ReserveBeginStreamExe
 			Result: sqltypes.ResultToProto3(reply),
 		})
 	})
+	if err != nil {
+		return vterrors.ToGRPC(err)
+	}
+
 	errInLastPacket := stream.Send(&querypb.ReserveBeginStreamExecuteResponse{
 		ReservedId:          state.ReservedID,
 		TransactionId:       state.TransactionID,
 		TabletAlias:         state.TabletAlias,
 		SessionStateChanges: state.SessionStateChanges,
 	})
-	if err != nil {
-		return vterrors.ToGRPC(err)
-	}
-
 	return vterrors.ToGRPC(errInLastPacket)
 }
 

--- a/go/vt/vttablet/grpcqueryservice/server.go
+++ b/go/vt/vttablet/grpcqueryservice/server.go
@@ -272,16 +272,18 @@ func (q *query) BeginStreamExecute(request *querypb.BeginStreamExecuteRequest, s
 			Result: sqltypes.ResultToProto3(reply),
 		})
 	})
-	if err != nil {
+
+	if err != nil && state.TransactionID == 0 {
 		return vterrors.ToGRPC(err)
 	}
 
-	errInLastPacket := stream.Send(&querypb.BeginStreamExecuteResponse{
+	err = stream.Send(&querypb.BeginStreamExecuteResponse{
+		Error:               vterrors.ToVTRPC(err),
 		TransactionId:       state.TransactionID,
 		TabletAlias:         state.TabletAlias,
 		SessionStateChanges: state.SessionStateChanges,
 	})
-	return vterrors.ToGRPC(errInLastPacket)
+	return vterrors.ToGRPC(err)
 }
 
 // MessageStream is part of the queryservice.QueryServer interface
@@ -399,15 +401,16 @@ func (q *query) ReserveStreamExecute(request *querypb.ReserveStreamExecuteReques
 			Result: sqltypes.ResultToProto3(reply),
 		})
 	})
-	if err != nil {
+	if err != nil && state.ReservedID == 0 {
 		return vterrors.ToGRPC(err)
 	}
 
-	errInLastPacket := stream.Send(&querypb.ReserveStreamExecuteResponse{
+	err = stream.Send(&querypb.ReserveStreamExecuteResponse{
+		Error:       vterrors.ToVTRPC(err),
 		ReservedId:  state.ReservedID,
 		TabletAlias: state.TabletAlias,
 	})
-	return vterrors.ToGRPC(errInLastPacket)
+	return vterrors.ToGRPC(err)
 }
 
 // ReserveBeginExecute implements the QueryServer interface
@@ -452,17 +455,18 @@ func (q *query) ReserveBeginStreamExecute(request *querypb.ReserveBeginStreamExe
 			Result: sqltypes.ResultToProto3(reply),
 		})
 	})
-	if err != nil {
+	if err != nil && state.ReservedID == 0 && state.TransactionID == 0 {
 		return vterrors.ToGRPC(err)
 	}
 
-	errInLastPacket := stream.Send(&querypb.ReserveBeginStreamExecuteResponse{
+	err = stream.Send(&querypb.ReserveBeginStreamExecuteResponse{
+		Error:               vterrors.ToVTRPC(err),
 		ReservedId:          state.ReservedID,
 		TransactionId:       state.TransactionID,
 		TabletAlias:         state.TabletAlias,
 		SessionStateChanges: state.SessionStateChanges,
 	})
-	return vterrors.ToGRPC(errInLastPacket)
+	return vterrors.ToGRPC(err)
 }
 
 // Release implements the QueryServer interface

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -524,6 +524,10 @@ func (conn *gRPCQueryClient) BeginStreamExecute(ctx context.Context, target *que
 			return state, tabletconn.ErrorFromGRPC(err)
 		}
 
+		if ser.Error != nil {
+			return state, tabletconn.ErrorFromVTRPC(ser.Error)
+		}
+
 		// The last stream receive will not have a result, so callback will not be called for it.
 		if ser.Result == nil {
 			return state, nil
@@ -867,6 +871,10 @@ func (conn *gRPCQueryClient) ReserveBeginStreamExecute(ctx context.Context, targ
 			return state, tabletconn.ErrorFromGRPC(err)
 		}
 
+		if ser.Error != nil {
+			return state, tabletconn.ErrorFromVTRPC(ser.Error)
+		}
+
 		// The last stream receive will not have a result, so callback will not be called for it.
 		if ser.Result == nil {
 			return state, nil
@@ -966,6 +974,10 @@ func (conn *gRPCQueryClient) ReserveStreamExecute(ctx context.Context, target *q
 
 		if err != nil {
 			return state, tabletconn.ErrorFromGRPC(err)
+		}
+
+		if ser.Error != nil {
+			return state, tabletconn.ErrorFromVTRPC(ser.Error)
 		}
 
 		// The last stream receive will not have a result, so callback will not be called for it.

--- a/go/vt/vttablet/tabletconntest/fakequeryservice.go
+++ b/go/vt/vttablet/tabletconntest/fakequeryservice.go
@@ -42,10 +42,11 @@ type FakeQueryService struct {
 	TestingGateway bool
 
 	// these fields are used to simulate and synchronize on errors
-	HasError      bool
-	HasBeginError bool
-	TabletError   error
-	ErrorWait     chan struct{}
+	HasError        bool
+	HasBeginError   bool
+	HasReserveError bool
+	TabletError     error
+	ErrorWait       chan struct{}
 
 	// these fields are used to simulate and synchronize on panics
 	Panics                   bool
@@ -723,7 +724,24 @@ func (f *FakeQueryService) ReserveExecute(ctx context.Context, target *querypb.T
 
 // ReserveStreamExecute satisfies the Gateway interface
 func (f *FakeQueryService) ReserveStreamExecute(ctx context.Context, target *querypb.Target, preQueries []string, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) (queryservice.ReservedState, error) {
-	panic("implement me")
+	state, err := f.reserve(transactionID)
+	if err != nil {
+		return state, err
+	}
+	err = f.StreamExecute(ctx, target, sql, bindVariables, transactionID, state.ReservedID, options, callback)
+	return state, err
+}
+
+func (f *FakeQueryService) reserve(transactionID int64) (queryservice.ReservedState, error) {
+	reserveID := transactionID
+	if reserveID == 0 {
+		reserveID = beginTransactionID
+	}
+	if f.HasReserveError {
+		return queryservice.ReservedState{}, f.TabletError
+	}
+	state := queryservice.ReservedState{ReservedID: reserveID, TabletAlias: TestAlias}
+	return state, nil
 }
 
 // Release implements the QueryService interface

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -761,6 +761,61 @@ func TestTabletServerStreamExecuteComments(t *testing.T) {
 	}
 }
 
+func TestTabletServerBeginStreamExecute(t *testing.T) {
+	db, tsv := setupTabletServerTest(t, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	executeSQL := "select * from test_table limit 1000"
+	executeSQLResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Type: sqltypes.VarBinary},
+		},
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewVarBinary("row01")},
+		},
+	}
+	db.AddQuery(executeSQL, executeSQLResult)
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+	callback := func(*sqltypes.Result) error { return nil }
+	state, err := tsv.BeginStreamExecute(ctx, &target, nil, executeSQL, nil, 0, nil, callback)
+	if err != nil {
+		t.Fatalf("TabletServer.BeginStreamExecute should success: %s, but get error: %v",
+			executeSQL, err)
+	}
+	require.NoError(t, err)
+	_, err = tsv.Commit(ctx, &target, state.TransactionID)
+	require.NoError(t, err)
+}
+
+func TestTabletServerBeginStreamExecuteWithError(t *testing.T) {
+	db, tsv := setupTabletServerTest(t, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	// Enforce an error so we can validate we get one back properly
+	tsv.qe.strictTableACL = true
+
+	executeSQL := "select * from test_table limit 1000"
+	executeSQLResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Type: sqltypes.VarBinary},
+		},
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewVarBinary("row01")},
+		},
+	}
+	db.AddQuery(executeSQL, executeSQLResult)
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+	callback := func(*sqltypes.Result) error { return nil }
+	state, err := tsv.BeginStreamExecute(ctx, &target, nil, executeSQL, nil, 0, nil, callback)
+	require.Error(t, err)
+	err = tsv.Release(ctx, &target, state.TransactionID, 0)
+	require.NoError(t, err)
+}
+
 func TestSerializeTransactionsSameRow(t *testing.T) {
 	// This test runs three transaction in parallel:
 	// tx1 | tx2 | tx3


### PR DESCRIPTION
Backport PR of https://github.com/vitessio/vitess/pull/11592 and https://github.com/vitessio/vitess/pull/11656