### PR TITLE
don't reuse bindvars for LIMIT and OFFSET

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -92,8 +92,11 @@ func (nz *normalizer) WalkSelect(cursor *Cursor) bool {
 		switch parent.(type) {
 		case *Order, GroupBy:
 			return false
+		case *Limit:
+			nz.convertLiteral(node, cursor)
+		default:
+			nz.convertLiteralDedup(node, cursor)
 		}
-		nz.convertLiteralDedup(node, cursor)
 	case *ComparisonExpr:
 		nz.convertComparison(node)
 	case *FramePoint:

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -306,9 +306,10 @@ func TestNormalize(t *testing.T) {
 	}, {
 		// TimestampVal should also be normalized
 		in:      `explain select comms_by_companies.* from comms_by_companies where comms_by_companies.id = 'rjve634shXzaavKHbAH16ql6OrxJ' limit 1,1`,
-		outstmt: `explain select comms_by_companies.* from comms_by_companies where comms_by_companies.id = :comms_by_companies_id limit :bv1, :bv1`,
+		outstmt: `explain select comms_by_companies.* from comms_by_companies where comms_by_companies.id = :comms_by_companies_id limit :bv1, :bv2`,
 		outbv: map[string]*querypb.BindVariable{
 			"bv1":                   sqltypes.Int64BindVariable(1),
+			"bv2":                   sqltypes.Int64BindVariable(1),
 			"comms_by_companies_id": sqltypes.StringBindVariable("rjve634shXzaavKHbAH16ql6OrxJ"),
 		},
 	}, {
@@ -317,6 +318,15 @@ func TestNormalize(t *testing.T) {
 		outstmt: `select * from t where zipcode = :zipcode`,
 		outbv: map[string]*querypb.BindVariable{
 			"zipcode": sqltypes.ValueBindVariable(sqltypes.MakeTrusted(sqltypes.Int64, []byte("01001900"))),
+		},
+	}, {
+		// Int leading with zero should also be normalized
+		in:      `select * from t where id = 10 limit 10 offset 10`,
+		outstmt: `select * from t where id = :id limit :bv1, :bv2`,
+		outbv: map[string]*querypb.BindVariable{
+			"bv1": sqltypes.Int64BindVariable(10),
+			"bv2": sqltypes.Int64BindVariable(10),
+			"id":  sqltypes.Int64BindVariable(10),
 		},
 	}}
 	for _, tc := range testcases {


### PR DESCRIPTION
## Description
When normalizing (automatically parameterising) queries, we try to re-use bindvars for the same literal. So the query:

```sql
select * 
from user, user_extra 
where user.id = 5 and user_extra.id = 5
```

would get normalized to:

```sql
select * 
from user, user_extra 
where user.id = :bv1 and user_extra.id = :bv1
```

This then allows the planner to see that the two literal values are expected to be the same, and it can use this information to make routing decisions.

The rule of re-using literal values doesn't make sense on the `LIMIT` and `OFFSET` clauses. Even if they are using the same literal, we should not expect these two numbers to change hand-in-hand. The best solution is to always use a unique bindvar for these clauses.



## Related Issue(s)

## Checklist
-   [x] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required