### PR TITLE
improve handling of ORDER BY/HAVING rewriting

### DIFF
--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -53,7 +53,7 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 			node.Join = sqlparser.NormalJoinType
 			r.warning = "straight join is converted to normal join"
 		}
-	case *sqlparser.Order:
+	case sqlparser.OrderBy:
 		r.clause = "order clause"
 		rewriteHavingAndOrderBy(cursor, node)
 	case sqlparser.GroupBy:
@@ -127,6 +127,15 @@ func (r *earlyRewriter) expandStar(cursor *sqlparser.Cursor, node sqlparser.Sele
 	return nil
 }
 
+// rewriteHavingAndOrderBy rewrites columns on the ORDER BY/HAVING
+// clauses to use aliases from the SELECT expressions when available.
+// The scoping rules are:
+//  - A column identifier with no table qualifier that matches an alias introduced
+//    in SELECT points to that expression, and not at any table column
+//  - Except when expression aliased is an aggregation, and the column identifier in the
+//    HAVING/ORDER BY clause is inside an aggregation function
+//
+// This is a fucking weird scoping rule, but it's what MySQL seems to do... ¯\_(ツ)_/¯
 func rewriteHavingAndOrderBy(cursor *sqlparser.Cursor, node sqlparser.SQLNode) {
 	sel, isSel := cursor.Parent().(*sqlparser.Select)
 	if !isSel {
@@ -140,12 +149,18 @@ func rewriteHavingAndOrderBy(cursor *sqlparser.Cursor, node sqlparser.SQLNode) {
 			if !col.Qualifier.IsEmpty() {
 				return false
 			}
+			_, parentIsAggr := inner.Parent().(sqlparser.AggrFunc)
 			for _, e := range sel.SelectExprs {
 				ae, ok := e.(*sqlparser.AliasedExpr)
 				if !ok {
 					continue
 				}
 				if ae.As.Equal(col.Name) {
+					_, aliasPointsToAggr := ae.Expr.(sqlparser.AggrFunc)
+					if parentIsAggr && aliasPointsToAggr {
+						return false
+					}
+
 					safeToRewrite := true
 					sqlparser.Rewrite(ae.Expr, func(cursor *sqlparser.Cursor) bool {
 						switch cursor.Node().(type) {

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -130,10 +130,10 @@ func (r *earlyRewriter) expandStar(cursor *sqlparser.Cursor, node sqlparser.Sele
 // rewriteHavingAndOrderBy rewrites columns on the ORDER BY/HAVING
 // clauses to use aliases from the SELECT expressions when available.
 // The scoping rules are:
-//  - A column identifier with no table qualifier that matches an alias introduced
-//    in SELECT points to that expression, and not at any table column
-//  - Except when expression aliased is an aggregation, and the column identifier in the
-//    HAVING/ORDER BY clause is inside an aggregation function
+//   - A column identifier with no table qualifier that matches an alias introduced
+//     in SELECT points to that expression, and not at any table column
+//   - Except when expression aliased is an aggregation, and the column identifier in the
+//     HAVING/ORDER BY clause is inside an aggregation function
 //
 // This is a fucking weird scoping rule, but it's what MySQL seems to do... ¯\_(ツ)_/¯
 func rewriteHavingAndOrderBy(cursor *sqlparser.Cursor, node sqlparser.SQLNode) {

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -341,7 +341,7 @@ func TestOrderByGroupByLiteral(t *testing.T) {
 	}
 }
 
-func TestHavingByColumnName(t *testing.T) {
+func TestHavingAndOrderByColumnName(t *testing.T) {
 	schemaInfo := &FakeSI{
 		Tables: map[string]*vindexes.Table{},
 	}
@@ -353,6 +353,12 @@ func TestHavingByColumnName(t *testing.T) {
 	}{{
 		sql:    "select id, sum(foo) as sumOfFoo from t1 having sumOfFoo > 1",
 		expSQL: "select id, sum(foo) as sumOfFoo from t1 having sum(foo) > 1",
+	}, {
+		sql:    "select id, sum(foo) as sumOfFoo from t1 order by sumOfFoo",
+		expSQL: "select id, sum(foo) as sumOfFoo from t1 order by sum(foo) asc",
+	}, {
+		sql:    "select id, sum(foo) as foo from t1 having sum(foo) > 1",
+		expSQL: "select id, sum(foo) as foo from t1 having sum(foo) > 1",
 	}}
 	for _, tcase := range tcases {
 		t.Run(tcase.sql, func(t *testing.T) {


### PR DESCRIPTION
## Description
MySQLs scoping rules around HAVING and ORDER BY are not easy to mimic.
The issue here was that we rewrite column names used in `ORDER BY`/`HAVING` if they match an alias introduced in `SELECT`.

For the query:

```sql
select min(id) as id from tbl having id > 10
```

the `HAVING` clause is comparing the aggregate value of `min(id)`, not the column id on the table. This can easily be shown by not introducing the alias:

```sql
> select min(id) from apa having id = 10;

Error: (1054, "Unknown column 'id' in 'having clause'")
```

But if you then wrap the `id` column in an aggregation, somehow that changes the scoping, and the following query is valid in MySQL:

```sql
select min(id) as id from tbl having min(id) > 10
```

Why we want to rewrite the use of `id` outside aggregations but not inside them is beyond me, but this is MySQLs behaviours, from my black box testing of it.

## Related Issue(s)
Fixes #11641
