### PR TITLE
[13.0] Send errors in stream instead of a grpc error from streaming rpcs when transaction or reserved connection is acquired

### DIFF
--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -17,11 +17,10 @@ limitations under the License.
 package grpctabletconn
 
 import (
+	"context"
 	"flag"
 	"io"
 	"sync"
-
-	"context"
 
 	"google.golang.org/grpc"
 
@@ -498,6 +497,10 @@ func (conn *gRPCQueryClient) BeginStreamExecute(ctx context.Context, target *que
 			return transactionID, alias, tabletconn.ErrorFromGRPC(err)
 		}
 
+		if ser.Error != nil {
+			return transactionID, alias, tabletconn.ErrorFromVTRPC(ser.Error)
+		}
+
 		// The last stream receive will not have a result, so callback will not be called for it.
 		if ser.Result == nil {
 			return transactionID, alias, nil
@@ -834,6 +837,10 @@ func (conn *gRPCQueryClient) ReserveBeginStreamExecute(ctx context.Context, targ
 			return transactionID, reservedID, alias, tabletconn.ErrorFromGRPC(err)
 		}
 
+		if ser.Error != nil {
+			return transactionID, reservedID, alias, tabletconn.ErrorFromVTRPC(ser.Error)
+		}
+
 		// The last stream receive will not have a result, so callback will not be called for it.
 		if ser.Result == nil {
 			return transactionID, reservedID, alias, nil
@@ -931,6 +938,10 @@ func (conn *gRPCQueryClient) ReserveStreamExecute(ctx context.Context, target *q
 
 		if err != nil {
 			return reservedID, alias, tabletconn.ErrorFromGRPC(err)
+		}
+
+		if ser.Error != nil {
+			return reservedID, alias, tabletconn.ErrorFromVTRPC(ser.Error)
 		}
 
 		// The last stream receive will not have a result, so callback will not be called for it.

--- a/go/vt/vttablet/tabletconntest/tabletconntest.go
+++ b/go/vt/vttablet/tabletconntest/tabletconntest.go
@@ -19,6 +19,7 @@ limitations under the License.
 package tabletconntest
 
 import (
+	"context"
 	"flag"
 	"io"
 	"os"
@@ -26,9 +27,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"context"
-
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -583,6 +582,231 @@ func testStreamExecutePanics(t *testing.T, conn queryservice.QueryService, f *Fa
 	})
 }
 
+func testBeginStreamExecute(t *testing.T, conn queryservice.QueryService, f *FakeQueryService) {
+	t.Log("testBeginStreamExecute")
+	ctx := context.Background()
+	ctx = callerid.NewContext(ctx, TestCallerID, TestVTGateCallerID)
+	i := 0
+	_, _, err := conn.BeginStreamExecute(ctx, TestTarget, nil, StreamExecuteQuery, StreamExecuteBindVars, 0, TestExecuteOptions, func(qr *sqltypes.Result) error {
+		switch i {
+		case 0:
+			if len(qr.Rows) == 0 {
+				qr.Rows = nil
+			}
+			if !qr.Equal(&StreamExecuteQueryResult1) {
+				t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, StreamExecuteQueryResult1)
+			}
+		case 1:
+			if len(qr.Fields) == 0 {
+				qr.Fields = nil
+			}
+			if !qr.Equal(&StreamExecuteQueryResult2) {
+				t.Errorf("Unexpected result2 from StreamExecute: got %v wanted %v", qr, StreamExecuteQueryResult2)
+			}
+		default:
+			t.Fatal("callback should not be called any more")
+		}
+		i++
+		if i >= 2 {
+			return io.EOF
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testReserveStreamExecute(t *testing.T, conn queryservice.QueryService, f *FakeQueryService) {
+	t.Log("testReserveStreamExecute")
+	ctx := context.Background()
+	ctx = callerid.NewContext(ctx, TestCallerID, TestVTGateCallerID)
+	i := 0
+	_, _, err := conn.ReserveStreamExecute(ctx, TestTarget, nil, StreamExecuteQuery, StreamExecuteBindVars, 0, TestExecuteOptions, func(qr *sqltypes.Result) error {
+		switch i {
+		case 0:
+			if len(qr.Rows) == 0 {
+				qr.Rows = nil
+			}
+			if !qr.Equal(&StreamExecuteQueryResult1) {
+				t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, StreamExecuteQueryResult1)
+			}
+		case 1:
+			if len(qr.Fields) == 0 {
+				qr.Fields = nil
+			}
+			if !qr.Equal(&StreamExecuteQueryResult2) {
+				t.Errorf("Unexpected result2 from StreamExecute: got %v wanted %v", qr, StreamExecuteQueryResult2)
+			}
+		default:
+			t.Fatal("callback should not be called any more")
+		}
+		i++
+		if i >= 2 {
+			return io.EOF
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testBeginStreamExecuteErrorInBegin(t *testing.T, conn queryservice.QueryService, f *FakeQueryService) {
+	t.Log("testBeginExecuteErrorInBegin")
+	f.HasBeginError = true
+	testErrorHelper(t, f, "StreamExecute", func(ctx context.Context) error {
+		f.ErrorWait = make(chan struct{})
+		ctx = callerid.NewContext(ctx, TestCallerID, TestVTGateCallerID)
+		transactionID, _, err := conn.BeginStreamExecute(ctx, TestTarget, nil, StreamExecuteQuery, StreamExecuteBindVars, 0, TestExecuteOptions, func(qr *sqltypes.Result) error {
+			// For some errors, the call can be retried.
+			select {
+			case <-f.ErrorWait:
+				return nil
+			default:
+			}
+			if len(qr.Rows) == 0 {
+				qr.Rows = nil
+			}
+			if !qr.Equal(&StreamExecuteQueryResult1) {
+				t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, StreamExecuteQueryResult1)
+			}
+			// signal to the server that the first result has been received
+			close(f.ErrorWait)
+			return nil
+		})
+		require.Zero(t, transactionID)
+		return err
+	})
+	f.HasBeginError = false
+}
+
+func testBeginStreamExecuteErrorInExecute(t *testing.T, conn queryservice.QueryService, f *FakeQueryService) {
+	t.Log("testBeginStreamExecuteErrorInExecute")
+	f.HasError = true
+	testErrorHelper(t, f, "StreamExecute", func(ctx context.Context) error {
+		f.ErrorWait = make(chan struct{})
+		ctx = callerid.NewContext(ctx, TestCallerID, TestVTGateCallerID)
+		transactionID, _, err := conn.BeginStreamExecute(ctx, TestTarget, nil, StreamExecuteQuery, StreamExecuteBindVars, 0, TestExecuteOptions, func(qr *sqltypes.Result) error {
+			// For some errors, the call can be retried.
+			select {
+			case <-f.ErrorWait:
+				return nil
+			default:
+			}
+			if len(qr.Rows) == 0 {
+				qr.Rows = nil
+			}
+			if !qr.Equal(&StreamExecuteQueryResult1) {
+				t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, StreamExecuteQueryResult1)
+			}
+			// signal to the server that the first result has been received
+			close(f.ErrorWait)
+			return nil
+		})
+		require.NotZero(t, transactionID)
+		return err
+	})
+	f.HasError = false
+}
+
+func testReserveStreamExecuteErrorInReserve(t *testing.T, conn queryservice.QueryService, f *FakeQueryService) {
+	t.Log("testReserveExecuteErrorInReserve")
+	f.HasReserveError = true
+	testErrorHelper(t, f, "ReserveStreamExecute", func(ctx context.Context) error {
+		f.ErrorWait = make(chan struct{})
+		ctx = callerid.NewContext(ctx, TestCallerID, TestVTGateCallerID)
+		reservedID, _, err := conn.ReserveStreamExecute(ctx, TestTarget, nil, StreamExecuteQuery, StreamExecuteBindVars, 0, TestExecuteOptions, func(qr *sqltypes.Result) error {
+			// For some errors, the call can be retried.
+			select {
+			case <-f.ErrorWait:
+				return nil
+			default:
+			}
+			if len(qr.Rows) == 0 {
+				qr.Rows = nil
+			}
+			if !qr.Equal(&StreamExecuteQueryResult1) {
+				t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, StreamExecuteQueryResult1)
+			}
+			// signal to the server that the first result has been received
+			close(f.ErrorWait)
+			return nil
+		})
+		require.Zero(t, reservedID)
+		return err
+	})
+	f.HasReserveError = false
+}
+
+func testReserveStreamExecuteErrorInExecute(t *testing.T, conn queryservice.QueryService, f *FakeQueryService) {
+	t.Log("testReserveStreamExecuteErrorInExecute")
+	f.HasError = true
+	testErrorHelper(t, f, "ReserveStreamExecute", func(ctx context.Context) error {
+		f.ErrorWait = make(chan struct{})
+		ctx = callerid.NewContext(ctx, TestCallerID, TestVTGateCallerID)
+		reservedID, _, err := conn.ReserveStreamExecute(ctx, TestTarget, nil, StreamExecuteQuery, StreamExecuteBindVars, 0, TestExecuteOptions, func(qr *sqltypes.Result) error {
+			// For some errors, the call can be retried.
+			select {
+			case <-f.ErrorWait:
+				return nil
+			default:
+			}
+			if len(qr.Rows) == 0 {
+				qr.Rows = nil
+			}
+			if !qr.Equal(&StreamExecuteQueryResult1) {
+				t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, StreamExecuteQueryResult1)
+			}
+			// signal to the server that the first result has been received
+			close(f.ErrorWait)
+			return nil
+		})
+		require.NotZero(t, reservedID)
+		return err
+	})
+	f.HasError = false
+}
+
+func testBeginStreamExecutePanics(t *testing.T, conn queryservice.QueryService, f *FakeQueryService) {
+	t.Log("testStreamExecutePanics")
+	// early panic is before sending the Fields, that is returned
+	// by the StreamExecute call itself, or as the first error
+	// by ErrFunc
+	f.StreamExecutePanicsEarly = true
+	testPanicHelper(t, f, "StreamExecute.Early", func(ctx context.Context) error {
+		ctx = callerid.NewContext(ctx, TestCallerID, TestVTGateCallerID)
+		return conn.StreamExecute(ctx, TestTarget, StreamExecuteQuery, StreamExecuteBindVars, 0, 0, TestExecuteOptions, func(qr *sqltypes.Result) error {
+			return nil
+		})
+	})
+
+	// late panic is after sending Fields
+	f.StreamExecutePanicsEarly = false
+	testPanicHelper(t, f, "StreamExecute.Late", func(ctx context.Context) error {
+		f.PanicWait = make(chan struct{})
+		ctx = callerid.NewContext(ctx, TestCallerID, TestVTGateCallerID)
+		_, _, err := conn.BeginStreamExecute(ctx, TestTarget, nil, StreamExecuteQuery, StreamExecuteBindVars, 0, TestExecuteOptions, func(qr *sqltypes.Result) error {
+			// For some errors, the call can be retried.
+			select {
+			case <-f.PanicWait:
+				return nil
+			default:
+			}
+			if len(qr.Rows) == 0 {
+				qr.Rows = nil
+			}
+			if !qr.Equal(&StreamExecuteQueryResult1) {
+				t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, StreamExecuteQueryResult1)
+			}
+			// signal to the server that the first result has been received
+			close(f.PanicWait)
+			return nil
+		})
+		return err
+	})
+}
+
 func testMessageStream(t *testing.T, conn queryservice.QueryService, f *FakeQueryService) {
 	t.Log("testMessageStream")
 	ctx := context.Background()
@@ -715,8 +939,10 @@ func TestSuite(t *testing.T, protocol string, tablet *topodatapb.Tablet, fake *F
 		testExecute,
 		testBeginExecute,
 		testStreamExecute,
+		testBeginStreamExecute,
 		testMessageStream,
 		testMessageAck,
+		testReserveStreamExecute,
 
 		// error test cases
 		testBeginError,
@@ -734,6 +960,10 @@ func TestSuite(t *testing.T, protocol string, tablet *topodatapb.Tablet, fake *F
 		testBeginExecuteErrorInBegin,
 		testBeginExecuteErrorInExecute,
 		testStreamExecuteError,
+		testBeginStreamExecuteErrorInBegin,
+		testBeginStreamExecuteErrorInExecute,
+		testReserveStreamExecuteErrorInReserve,
+		testReserveStreamExecuteErrorInExecute,
 		testMessageStreamError,
 		testMessageAckError,
 
@@ -752,6 +982,7 @@ func TestSuite(t *testing.T, protocol string, tablet *topodatapb.Tablet, fake *F
 		testExecutePanics,
 		testBeginExecutePanics,
 		testStreamExecutePanics,
+		testBeginStreamExecutePanics,
 		testMessageStreamPanics,
 		testMessageAckPanics,
 	}


### PR DESCRIPTION
Backport PR of https://github.com/vitessio/vitess/pull/11592 and https://github.com/vitessio/vitess/pull/11656