### PR TITLE
endtoend: fix race when closing vtgate

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bndr/gotabulate v1.1.2 h1:yC9izuZEphojb9r+KYL4W9IJKO/ceIO8HDwxMA24U4c=
 github.com/bndr/gotabulate v1.1.2/go.mod h1:0+8yUgaPTtLRTjf49E8oju7ojpU11YmXyvq1LbPAb3U=
-github.com/buger/jsonparser v0.0.0-20200322175846-f7e751efca13 h1:+qUNY4VRkEH46bLUwxCyUU+iOGJMQBVibAaYzWiwWcg=
-github.com/buger/jsonparser v0.0.0-20200322175846-f7e751efca13/go.mod h1:tgcrVJ81GPSF0mz+0nu1Xaz0fazGPrmmJfJtxjbHhUQ=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -103,6 +103,7 @@ func (topo *TopoProcess) SetupEtcd() (err error) {
 	topo.exit = make(chan error)
 	go func() {
 		topo.exit <- topo.proc.Wait()
+		close(topo.exit)
 	}()
 
 	timeout := time.Now().Add(60 * time.Second)
@@ -227,6 +228,7 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 	topo.exit = make(chan error)
 	go func() {
 		topo.exit <- topo.proc.Wait()
+		close(topo.exit)
 	}()
 
 	timeout := time.Now().Add(60 * time.Second)
@@ -289,8 +291,9 @@ func (topo *TopoProcess) TearDown(Cell string, originalVtRoot string, currentRoo
 
 		case <-time.After(10 * time.Second):
 			topo.proc.Process.Kill()
+			err := <-topo.exit
 			topo.proc = nil
-			return <-topo.exit
+			return err
 		}
 	}
 

--- a/go/test/endtoend/cluster/vtctld_process.go
+++ b/go/test/endtoend/cluster/vtctld_process.go
@@ -87,6 +87,7 @@ func (vtctld *VtctldProcess) Setup(cell string, extraArgs ...string) (err error)
 	vtctld.exit = make(chan error)
 	go func() {
 		vtctld.exit <- vtctld.proc.Wait()
+		close(vtctld.exit)
 	}()
 
 	timeout := time.Now().Add(60 * time.Second)
@@ -138,8 +139,9 @@ func (vtctld *VtctldProcess) TearDown() error {
 
 	case <-time.After(10 * time.Second):
 		vtctld.proc.Process.Kill()
+		err := <-vtctld.exit
 		vtctld.proc = nil
-		return <-vtctld.exit
+		return err
 	}
 }
 

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -138,6 +138,7 @@ func (vtgate *VtgateProcess) Setup() (err error) {
 	go func() {
 		if vtgate.proc != nil {
 			vtgate.exit <- vtgate.proc.Wait()
+			close(vtgate.exit)
 		}
 	}()
 
@@ -236,8 +237,9 @@ func (vtgate *VtgateProcess) TearDown() error {
 
 	case <-time.After(30 * time.Second):
 		vtgate.proc.Process.Kill()
+		err := <-vtgate.exit
 		vtgate.proc = nil
-		return <-vtgate.exit
+		return err
 	}
 }
 

--- a/go/test/endtoend/cluster/vtgr_process.go
+++ b/go/test/endtoend/cluster/vtgr_process.go
@@ -77,6 +77,7 @@ func (vtgr *VtgrProcess) Start(alias string) (err error) {
 	go func() {
 		if vtgr.proc != nil {
 			vtgr.exit <- vtgr.proc.Wait()
+			close(vtgr.exit)
 		}
 	}()
 
@@ -97,8 +98,9 @@ func (vtgr *VtgrProcess) TearDown() error {
 		return nil
 
 	case <-time.After(10 * time.Second):
-		_ = vtgr.proc.Process.Kill()
+		vtgr.proc.Process.Kill()
+		err := <-vtgr.exit
 		vtgr.proc = nil
-		return <-vtgr.exit
+		return err
 	}
 }

--- a/go/test/endtoend/cluster/vtorc_process.go
+++ b/go/test/endtoend/cluster/vtorc_process.go
@@ -139,6 +139,7 @@ func (orc *VTOrcProcess) Setup() (err error) {
 	go func() {
 		if orc.proc != nil {
 			orc.exit <- orc.proc.Wait()
+			close(orc.exit)
 		}
 	}()
 
@@ -160,8 +161,9 @@ func (orc *VTOrcProcess) TearDown() error {
 
 	case <-time.After(30 * time.Second):
 		_ = orc.proc.Process.Kill()
+		err := <-orc.exit
 		orc.proc = nil
-		return <-orc.exit
+		return err
 	}
 }
 

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -145,6 +145,7 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 	go func() {
 		if vttablet.proc != nil {
 			vttablet.exit <- vttablet.proc.Wait()
+			close(vttablet.exit)
 		}
 	}()
 
@@ -399,12 +400,10 @@ func (vttablet *VttabletProcess) TearDownWithTimeout(timeout time.Duration) erro
 		return nil
 
 	case <-time.After(timeout):
-		proc := vttablet.proc
-		if proc != nil {
-			vttablet.proc.Process.Kill()
-			vttablet.proc = nil
-		}
-		return <-vttablet.exit
+		vttablet.proc.Process.Kill()
+		err := <-vttablet.exit
+		vttablet.proc = nil
+		return err
 	}
 }
 


### PR DESCRIPTION
## Description

This fixes a race we've found that can sometimes get the endtoend tests stuck permanently during shutdown. cc @dbussink 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
