### PR TITLE
query timeout hints in unsharded cases

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package misc
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,7 +93,7 @@ func TestInvalidDateTimeTimestampVals(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestQueryTimeout(t *testing.T) {
+func TestQueryTimeoutWithDual(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()
 
@@ -111,4 +113,44 @@ func TestQueryTimeout(t *testing.T) {
 	assert.Error(t, err)
 	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ PLANNER=gen4 QUERY_TIMEOUT_MS=10 */ sleep(0.001) from dual")
 	assert.NoError(t, err)
+}
+
+func TestQueryTimeoutWithTables(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	// unsharded
+	utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=1000 */ into uks.unsharded(id1) values (1),(2),(3),(4),(5)")
+	for i := 0; i < 12; i++ {
+		utils.Exec(t, mcmp.VtConn, "insert /*vt+ QUERY_TIMEOUT_MS=1000 */ into uks.unsharded(id1) select id1+5 from uks.unsharded")
+	}
+
+	utils.Exec(t, mcmp.VtConn, "select count(*) from uks.unsharded where id1 > 31")
+	utils.Exec(t, mcmp.VtConn, "select /*vt+ PLANNER=gen4 QUERY_TIMEOUT_MS=100 */ count(*) from uks.unsharded where id1 > 31")
+
+	// the query usually takes more than 5ms to return. So this should fail.
+	_, err := utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ PLANNER=gen4 QUERY_TIMEOUT_MS=1 */ count(*) from uks.unsharded where id1 > 31")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded (errno 1317) (sqlstate 70100)")
+
+	// sharded
+	for i := 0; i < 300000; i += 1000 {
+		var str strings.Builder
+		for j := 1; j <= 1000; j++ {
+			if j == 1 {
+				str.WriteString(fmt.Sprintf("(%d)", i*1000+j))
+				continue
+			}
+			str.WriteString(fmt.Sprintf(",(%d)", i*1000+j))
+		}
+		utils.Exec(t, mcmp.VtConn, fmt.Sprintf("insert /*vt+ QUERY_TIMEOUT_MS=1000 */ into t1(id1) values %s", str.String()))
+	}
+
+	utils.Exec(t, mcmp.VtConn, "select count(*) from t1 where id1 > 31")
+	utils.Exec(t, mcmp.VtConn, "select /*vt+ PLANNER=gen4 QUERY_TIMEOUT_MS=100 */ count(*) from t1 where id1 > 31")
+
+	// the query usually takes more than 5ms to return. So this should fail.
+	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ PLANNER=gen4 QUERY_TIMEOUT_MS=1 */ count(*) from t1 where id1 > 31")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded (errno 1317) (sqlstate 70100)")
 }

--- a/go/test/endtoend/vtgate/queries/misc/uschema.sql
+++ b/go/test/endtoend/vtgate/queries/misc/uschema.sql
@@ -1,0 +1,5 @@
+create table unsharded(
+    id1 bigint,
+    id2 bigint,
+    key(id1)
+) Engine=InnoDB;

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -73,6 +73,8 @@ func buildInsertUnshardedPlan(ins *sqlparser.Insert, table *vindexes.Table, rese
 		table,
 		table.Keyspace,
 	)
+	applyCommentDirectives(ins, eins)
+
 	var rows sqlparser.Values
 	tc := &tableCollector{}
 	tc.addVindexTable(table)

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -254,6 +254,45 @@
     }
   },
   {
+    "comment": "select limit with timeout directive sets QueryTimeout in the route",
+    "query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from main.unsharded limit 10",
+    "v3-plan": {
+      "QueryType": "SELECT",
+      "Original": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from main.unsharded limit 10",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select * from unsharded where 1 != 1",
+        "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from unsharded limit 10",
+        "QueryTimeout": 1000,
+        "Table": "unsharded"
+      }
+    },
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from main.unsharded limit 10",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select * from unsharded where 1 != 1",
+        "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from unsharded limit 10",
+        "QueryTimeout": 1000,
+        "Table": "unsharded"
+      },
+      "TablesUsed": [
+        "main.unsharded"
+      ]
+    }
+  },
+  {
     "comment": "select with partial scatter directive",
     "query": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS */ * from user",
     "v3-plan": {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR is an extension of https://github.com/vitessio/vitess/pull/11429. The unsharded cases in select gen4 planner and insert planner were missing the usage of query_timeout_ms comment directive.
This PR fixes that.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/11710

## Checklist

-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
