### PR TITLE
added code owners for go.mod and go.sum files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 * @deepthi
 bootstrap.sh @ajm188 @deepthi @frouioui @vmg
+go.mod @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay
+go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay
 /.github/ISSUE_TEMPLATE/ @deepthi @frouioui @mattlord
 /.github/workflows/ @deepthi @frouioui @mattlord
 /config/mycnf/ @deepthi @shlomi-noach @mattlord

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @deepthi
 bootstrap.sh @ajm188 @deepthi @frouioui @vmg
-go.mod @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay
-go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay
+go.mod @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui
+go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui
 /.github/ISSUE_TEMPLATE/ @deepthi @frouioui @mattlord
 /.github/workflows/ @deepthi @frouioui @mattlord
 /config/mycnf/ @deepthi @shlomi-noach @mattlord


### PR DESCRIPTION
Signed-off-by: Harshit Gangal <harshit@planetscale.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds multiple maintainers to go.mod and go.sum files to unlock the PR for merge when any library usage is changed.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
