### PR TITLE
Move inactive maintainers to "Past" section, change Areas to include more active maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,56 +4,67 @@ The following is the full list, alphabetically ordered.
 
 * Andres Taylor ([systay](https://github.com/systay)) andres@planetscale.com
 * Andrew Mason ([amason](https://github.com/ajm188)) andrew@planetscale.com
-* Anthony Yeh ([enisoc](https://github.com/enisoc)) enisoc@enisoc.dev
 * Dan Kozlowski ([dkhenry](https://github.com/dkhenry)) dan.kozlowski@gmail.com
-* David Weitzman ([dweitzman](https://github.com/dweitzman)) dweitzman@pinterest.com
 * Deepthi Sigireddi ([deepthi](https://github.com/deepthi)) deepthi@planetscale.com
 * Derek Perkins ([derekperkins](https://github.com/derekperkins)) derek@nozzle.io
 * Florent Poinsard ([frouioui](https://github.com/frouioui)) florent@planetscale.com
 * Harshit Gangal ([harshit-gangal](https://github.com/harshit-gangal)) harshit.gangal@gmail.com
-* Jon Tirsen ([tirsen](https://github.com/tirsen)) jontirsen@squareup.com
-* Mali Akmanalp ([makmanalp](https://github.com/makmanalp) makmanalp@hubspot.com
 * Manan Gupta ([GuptaManan100](https://github.com/GuptaManan100)) manan@planetscale.com
 * Matt Lord ([mattlord](https://github.com/mattlord)) mlord@planetscale.com
-* Michael Demmer ([demmer](https://github.com/demmer)) mdemmer@slack-corp.com
-* Michael Pawliszyn ([mpawliszyn](https://github.com/mpawliszyn)) mikepaw@squareup.com
-* Rafael Chacon ([rafael](https://github.com/rafael)) rchacon@figma.com
 * Rohit Nayak ([rohit-nayak-ps](https://github.com/rohit-nayak-ps)) rohit@planetscale.com
 * Shlomi Noach ([shlomi-noach](https://github.com/shlomi-noach)) shlomi@planetscale.com
-* Sugu Sougoumarane ([sougou](https://github.com/sougou)) sougou@planetscale.com
 * Vicent Marti ([vmg](https://github.com/vmg)) vmg@planetscale.com
 
 ## Areas of expertise
 
 ### General Vitess
-sougou, deepthi, demmer, rafael, dweitzman, tirsen, enisoc
+deepthi, mattlord, derekperkins
 
 ### Builds
 dkhenry, shlomi-noach, ajm188, vmg, GuptaManan100, frouioui
 
 ### Resharding
-sougou, rafael, tirsen, dweitzman, systay, rohit-nayak-ps, deepthi, mattlord
+rohit-nayak-ps, deepthi, mattlord
 
 ### Parser
-sougou, dweitzman, systay, harshit-gangal, vmg, GuptaManan100
+systay, harshit-gangal, vmg, GuptaManan100
 
 ### Planner
-sougou, systay, harshit-gangal, GuptaManan100, frouioui
+systay, harshit-gangal, GuptaManan100, frouioui
 
 ### Performance
 vmg
 
 ### Cluster Management
-deepthi, rafael, enisoc, shlomi-noach, ajm188, GuptaManan100
+deepthi, shlomi-noach, ajm188, GuptaManan100
 
 ### Java
-mpawliszyn, makmanalp, harshit-gangal
+harshit-gangal
 
 ### Kubernetes
-derekperkins, dkhenry, enisoc
+derekperkins, dkhenry, GuptaManan100, frouioui
 
 ### VTAdmin
 ajm188
 
 ### Messaging
-derekperkins
+derekperkins, mattlord
+
+## Past Maintainers
+We thank the following past maintainers for their contributions.
+
+* Alain Jobart ([alainjobart](https://github.com/alainjobart))
+* Alkin Tezuysal ([askdba](https://github.com/askdba))
+* Anthony Yeh ([enisoc](https://github.com/enisoc))
+* David Weitzman ([dweitzman](https://github.com/dweitzman))
+* Jon Tirsen ([tirsen](https://github.com/tirsen))
+* Leo X. Lin ([leoxlin](https://github.com/leoxlin))
+* Mali Akmanalp ([makmanalp](https://github.com/makmanalp)
+* Michael Berlin ([michael-berlin](https://github.com/michael-berlin))
+* Michael Demmer ([demmer](https://github.com/demmer))
+* Michael Pawliszyn ([mpawliszyn](https://github.com/mpawliszyn))
+* Morgan Tocker ([morgo](https://github.com/morgo))
+* Paul Hemberger ([pH14](https://github.com/pH14))
+* Rafael Chacon ([rafael](https://github.com/rafael))
+* Sara Bee ([doeg](https://github.com/doeg))
+* Sugu Sougoumarane ([sougou](https://github.com/sougou))


### PR DESCRIPTION
## Description
A number of maintainers who have not been very active will be stepping down to Contributor.
I've updated the Areas of expertise to ensure that others are added in their places.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
