### PR TITLE
Fix `codeql` workflow timeout issue

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -39,6 +39,10 @@ jobs:
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
 
+      - name: toto
+        run: |
+          toto
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -83,7 +87,7 @@ jobs:
         timeout-minutes: 30
         run: |
           source build.env
-          make buildtoto
+          make build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
@@ -96,3 +100,8 @@ jobs:
           slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
           channel: '#codeql'
           name: 'CodeQL Workflows'
+
+      - name: Fail if needed
+        if: ${{ failure() }}
+        run: |
+          exit 1

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -78,8 +78,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install percona-xtrabackup-24
 
-      - name: Building last release's binaries
-        timeout-minutes: 10
+      - name: Building binaries
+        timeout-minutes: 30
         run: |
           source build.env
           make build

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -87,3 +87,11 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@master
+        with:
+          repo_token: ${{secrets.GITHUB_TOKEN}}
+          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+          channel: '#codeql'
+          name: 'CodeQL Workflows'

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -5,9 +5,8 @@ on:
     branches:
       - main
       - release-**.0
-  pull_request:
-#  schedule:
-#    - cron: '0 0 * * 1'
+  schedule:
+    - cron: '0 0 * * 1'
 
 jobs:
   analyze:
@@ -38,10 +37,6 @@ jobs:
 
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
-
-      - name: toto
-        run: |
-          toto
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - main
       - release-**.0
-  schedule:
-    - cron: '0 0 * * 1'
+  pull_request:
+#  schedule:
+#    - cron: '0 0 * * 1'
 
 jobs:
   analyze:

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -83,12 +83,13 @@ jobs:
         timeout-minutes: 30
         run: |
           source build.env
-          make build
+          make buildtoto
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
 
       - name: Slack Workflow Notification
+        if: ${{ failure() }}
         uses: Gamesight/slack-workflow-status@master
         with:
           repo_token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Description

The CodeQL workflow has been failing due to timeouts. This Pull Request increases the timeout for the `make build`.

There is also a new integration that sends a slack message whenever the workflow fails so we can easily know if the build starts failing. It is usually tough the know if the build fails, we have to manually look at it since the PR is executed in a CRON. The message goes to the `#codeql` channel of our OSS Slack workplace.

## Related Issue(s)
Fixes https://github.com/vitessio/vitess/issues/11761

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
