### PR TITLE
Fix some linter errors

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -421,11 +421,13 @@ func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.R
 }
 
 func (db *DB) comQueryOrdered(query string) (*sqltypes.Result, error) {
-	var afterFn func() = func() {}
-	var entry ExpectedExecuteFetch
-	var err error
-	var expected string
-	var result *sqltypes.Result
+	var (
+		afterFn  func()
+		entry    ExpectedExecuteFetch
+		err      error
+		expected string
+		result   *sqltypes.Result
+	)
 
 	defer func() {
 		if afterFn != nil {

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -36,10 +36,12 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+
+	// Register topo implementations.
 	_ "vitess.io/vitess/go/vt/topo/consultopo"
 	_ "vitess.io/vitess/go/vt/topo/etcd2topo"
 	_ "vitess.io/vitess/go/vt/topo/k8stopo"
-	"vitess.io/vitess/go/vt/topo/topoproto"
 	_ "vitess.io/vitess/go/vt/topo/zk2topo"
 )
 

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1262,11 +1262,6 @@ func TestReplaceSchemaName(t *testing.T) {
 }
 
 func TestQueryExecutorShouldConsolidate(t *testing.T) {
-	type dbResponse struct {
-		query  string
-		result *sqltypes.Result
-	}
-
 	testcases := []struct {
 		consolidates  []bool
 		executorFlags executorFlags


### PR DESCRIPTION
## Description

Noticed these when resolving merge conflicts on a separate PR, so just fixing them quickly:

```
go/mysql/fakesqldb/server.go:424:14: var-declaration: should omit type func() from declaration of var afterFn; it will be inferred from the right-hand side (revive)
        var afterFn func() = func() {}
                    ^
go/test/endtoend/vtorc/utils/utils.go:39:2: blank-imports: a blank import should be only in a main or test package, or have a comment justifying it (revive)
        _ "vitess.io/vitess/go/vt/topo/consultopo"
        ^
go/test/endtoend/vtorc/utils/utils.go:43:2: blank-imports: a blank import should be only in a main or test package, or have a comment justifying it (revive)
        _ "vitess.io/vitess/go/vt/topo/zk2topo"
        ^
go/vt/vttablet/tabletserver/query_executor_test.go:1266:3: `query` is unused (structcheck)
                query  string
                ^
go/vt/vttablet/tabletserver/query_executor_test.go:1267:3: `result` is unused (structcheck)
                result *sqltypes.Result
                ^
```

turns out that after removing the "unused" struct fields in query_executor_test, the entire struct wasn't being used (and the test passes without it)

Signed-off-by: Andrew Mason <andrew@planetscale.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->


## Related Issue(s)

N/A

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
