### PR TITLE
Update test runners to run all tests including outside package

### DIFF
--- a/go/vt/vttablet/tmrpctest/test_tm_rpc.go
+++ b/go/vt/vttablet/tmrpctest/test_tm_rpc.go
@@ -592,7 +592,7 @@ func (fra *fakeRPCTM) ExecuteQuery(ctx context.Context, req *tabletmanagerdatapb
 }
 
 var testExecuteFetchQuery = []byte("fetch this invalid utf8 character \x80")
-var testExecuteFetchMaxRows = 100
+var testExecuteFetchMaxRows = uint64(100)
 var testExecuteFetchResult = &querypb.QueryResult{
 	Fields: []*querypb.Field{
 		{
@@ -1190,9 +1190,9 @@ func tmRPCTestReplicaWasRestartedPanic(ctx context.Context, t *testing.T, client
 
 func tmRPCTestStopReplicationAndGetStatus(ctx context.Context, t *testing.T, client tmclient.TabletManagerClient, tablet *topodatapb.Tablet) {
 	rp, err := client.StopReplicationAndGetStatus(ctx, tablet, replicationdatapb.StopReplicationMode_IOANDSQLTHREAD)
-	compareError(t, "StopReplicationAndGetStatus", err, rp, testReplicationStatus)
+	compareError(t, "StopReplicationAndGetStatus", err, rp, &replicationdatapb.StopReplicationStatus{Before: testReplicationStatus, After: testReplicationStatus})
 	rp, err = client.StopReplicationAndGetStatus(ctx, tablet, replicationdatapb.StopReplicationMode_IOTHREADONLY)
-	compareError(t, "StopReplicationAndGetStatus", err, rp, testReplicationStatus)
+	compareError(t, "StopReplicationAndGetStatus", err, rp, &replicationdatapb.StopReplicationStatus{Before: testReplicationStatus, After: testReplicationStatus})
 }
 
 func tmRPCTestStopReplicationAndGetStatusPanic(ctx context.Context, t *testing.T, client tmclient.TabletManagerClient, tablet *topodatapb.Tablet) {
@@ -1221,7 +1221,7 @@ func tmRPCTestPromoteReplicaPanic(ctx context.Context, t *testing.T, client tmcl
 // Backup / restore related methods
 //
 
-var testBackupConcurrency = 24
+var testBackupConcurrency = int64(24)
 var testBackupAllowPrimary = false
 var testBackupCalled = false
 var testRestoreFromBackupCalled = false

--- a/tools/all_test_for_coverage.sh
+++ b/tools/all_test_for_coverage.sh
@@ -25,7 +25,7 @@ source build.env
 make tools
 make build
 echo "--------- executing unit testcases ---------"
-packages_with_all_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/... | sort)
+packages_with_all_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}{{if len .XTestGoFiles}}{{.ImportPath}} {{join .XTestGoFiles " "}}{{end}}' ./go/... | sort)
 all_except_endtoend_tests=$(echo "$packages_with_all_tests" | grep -v "endtoend" | cut -d" " -f1 )
 
 counter=0

--- a/tools/e2e_test_cluster.sh
+++ b/tools/e2e_test_cluster.sh
@@ -22,7 +22,7 @@
 
 source build.env
 
-packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/.../endtoend/... | sort)
+packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}{{if len .XTestGoFiles}}{{.ImportPath}} {{join .XTestGoFiles " "}}{{end}}' ./go/.../endtoend/... | sort)
 
 cluster_tests=$(echo "$packages_with_tests" | grep -E "go/test/endtoend" | cut -d" " -f1)
 

--- a/tools/e2e_test_race.sh
+++ b/tools/e2e_test_race.sh
@@ -32,7 +32,7 @@ trap '[ -f "$temp_log_file" ] && rm $temp_log_file' EXIT
 
 # All endtoend Go packages with test files.
 # Output per line: <full Go package name> <all _test.go files in the package>*
-packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/.../endtoend/... | sort)
+packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}{{if len .XTestGoFiles}}{{.ImportPath}} {{join .XTestGoFiles " "}}{{end}}' ./go/.../endtoend/... | sort)
 packages_with_tests=$(echo "$packages_with_tests" |  grep -vE "go/test/endtoend" | cut -d" " -f1)
 
 # endtoend tests should be in a directory called endtoend

--- a/tools/e2e_test_runner.sh
+++ b/tools/e2e_test_runner.sh
@@ -38,7 +38,7 @@ fi
 
 # All Go packages with test files.
 # Output per line: <full Go package name> <all _test.go files in the package>*
-packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/.../endtoend/... | sort)
+packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}{{if len .XTestGoFiles}}{{.ImportPath}} {{join .XTestGoFiles " "}}{{end}}' ./go/.../endtoend/... | sort)
 
 # Flaky tests have the suffix "_flaky_test.go".
 all_except_flaky_and_cluster_tests=$(echo "$packages_with_tests" | grep -vE ".+ .+_flaky_test\.go" |  grep -vE "go/test/endtoend" | cut -d" " -f1)

--- a/tools/unit_test_race.sh
+++ b/tools/unit_test_race.sh
@@ -23,7 +23,7 @@ fi
 # All Go packages with test files.
 # Output per line: <full Go package name> <all _test.go files in the package>*
 
-packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/... | sort)
+packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}{{if len .XTestGoFiles}}{{.ImportPath}} {{join .XTestGoFiles " "}}{{end}}' ./go/... | sort)
 
 # exclude end to end tests
 packages_to_test=$(echo "$packages_with_tests" | cut -d" " -f1 | grep -v "endtoend")

--- a/tools/unit_test_runner.sh
+++ b/tools/unit_test_runner.sh
@@ -52,7 +52,7 @@ esac
 
 # All Go packages with test files.
 # Output per line: <full Go package name> <all _test.go files in the package>*
-packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/... | sort)
+packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}{{if len .XTestGoFiles}}{{.ImportPath}} {{join .XTestGoFiles " "}}{{end}}' ./go/... | sort)
 
 # Flaky tests have the suffix "_flaky_test.go".
 # Exclude endtoend tests


### PR DESCRIPTION
Sometimes it's necessary to have a separate _test package inside another package. Our current test runner doesn't run such tests though, leading to tests being broken without us knowing.

Worst case it hides real bugs. So we should always ensure to also run these tests as well.

I think we should back port this to avoid future regressions there as well. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required