### PR TITLE
Switch ApplySchema `--sql` argument to be `StringArray` instead of `StringSlice`

### DIFF
--- a/go/cmd/vtctldclient/command/schema.go
+++ b/go/cmd/vtctldclient/command/schema.go
@@ -293,7 +293,7 @@ func init() {
 	ApplySchema.Flags().DurationVar(&applySchemaOptions.WaitReplicasTimeout, "wait-replicas-timeout", wrangler.DefaultWaitReplicasTimeout, "Amount of time to wait for replicas to receive the schema change via replication.")
 	ApplySchema.Flags().BoolVar(&applySchemaOptions.SkipPreflight, "skip-preflight", false, "Skip pre-apply schema checks, and directly forward schema change query to shards.")
 	ApplySchema.Flags().StringVar(&applySchemaOptions.CallerID, "caller-id", "", "Effective caller ID used for the operation and should map to an ACL name which grants this identity the necessary permissions to perform the operation (this is only necessary when strict table ACLs are used).")
-	ApplySchema.Flags().StringSliceVar(&applySchemaOptions.SQL, "sql", nil, "Semicolon-delimited, repeatable SQL commands to apply. Exactly one of --sql|--sql-file is required.")
+	ApplySchema.Flags().StringArrayVar(&applySchemaOptions.SQL, "sql", nil, "Semicolon-delimited, repeatable SQL commands to apply. Exactly one of --sql|--sql-file is required.")
 	ApplySchema.Flags().StringVar(&applySchemaOptions.SQLFile, "sql-file", "", "Path to a file containing semicolon-delimited SQL commands to apply. Exactly one of --sql|--sql-file is required.")
 
 	Root.AddCommand(ApplySchema)

--- a/go/test/endtoend/vtctldclient/cli_test.go
+++ b/go/test/endtoend/vtctldclient/cli_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtctldclient
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"vitess.io/vitess/go/cmd/vtctldclient/command"
+	"vitess.io/vitess/go/protoutil"
+	"vitess.io/vitess/go/vt/vtctl/localvtctldclient"
+
+	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
+	vtctlservicepb "vitess.io/vitess/go/vt/proto/vtctlservice"
+)
+
+type fakeServer struct {
+	vtctlservicepb.UnimplementedVtctldServer
+	t testing.TB
+
+	applySchemaRequests []*vtctldatapb.ApplySchemaRequest
+}
+
+func (s *fakeServer) ApplySchema(ctx context.Context, req *vtctldatapb.ApplySchemaRequest) (*vtctldatapb.ApplySchemaResponse, error) {
+	s.applySchemaRequests = append(s.applySchemaRequests, req)
+	return &vtctldatapb.ApplySchemaResponse{}, nil
+}
+
+func TestApplySchema(t *testing.T) {
+	server := &fakeServer{t: t}
+
+	command.VtctldClientProtocol = "local"
+	localvtctldclient.SetServer(server)
+
+	defer func(argv []string) {
+		os.Args = argv
+	}(append([]string{}, os.Args...))
+
+	os.Args = []string{
+		"vtctldclient",
+		"--server='doesnotmatter'",
+		"ApplySchema",
+		"--sql",
+		`"CREATE TABLE foo(id int not null primary key, name varchar(255)); CREATE TABLE bar (id int not null primary key, foo_id int not null);`,
+		"test",
+	}
+
+	require.NoError(t, command.Root.Execute())
+	expected := &vtctldatapb.ApplySchemaRequest{
+		Keyspace: "test",
+		Sql: []string{
+			`"CREATE TABLE foo(id int not null primary key, name varchar(255)); CREATE TABLE bar (id int not null primary key, foo_id int not null);`,
+		},
+		DdlStrategy:         "direct",
+		WaitReplicasTimeout: protoutil.DurationToProto(10 * time.Second),
+	}
+	actual := server.applySchemaRequests[0]
+	assert.True(t, proto.Equal(actual, expected), "ApplySchema received unexpected request (got %v want %v)", actual, expected)
+}


### PR DESCRIPTION


## Description

See [this comment](https://github.com/vitessio/vitess/issues/11785#issuecomment-1323641942) for an explanation.


## Related Issue(s)

Fixes #11785.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
