### PR TITLE
Prevent etcd topology locks from silently expiring.

### DIFF
--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -290,4 +290,17 @@ func testKeyspaceLock(t *testing.T, ts *topo.Server) {
 	if err := lockDescriptor.Unlock(ctx); err != nil {
 		t.Fatalf("Unlock failed: %v", err)
 	}
+
+	cancellableCtx, cancel := context.WithCancel(ctx)
+	lockDescriptor, err = conn.Lock(cancellableCtx, keyspacePath, "short ttl with context canceled after lock was acquired")
+	if err != nil {
+		t.Fatalf("Lock failed: %v", err)
+	}
+
+	cancel()
+	time.Sleep(5 * time.Second)
+
+	if err := lockDescriptor.Unlock(ctx); err != nil {
+		t.Fatalf("Unlock failed: %v", err)
+	}
 }


### PR DESCRIPTION
## Description

If the context passed in to the `Lock` function was canceled / timed out / had exceeded its deadline _after_ the lock was acquired, Vitess silently stopped sending keepAlive requests to etcd, and the lock would be lost after reaching the lease ttl.

This change prevents that from happening by using a fresh context struct for the `KeepAlive` call, which is canceled once the lock is released.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/11811

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
