### PR TITLE
Accept no more data in session state change as ok

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1483,12 +1483,9 @@ func (c *Conn) parseOKPacket(in []byte) (*PacketOK, error) {
 		// session tracking
 		if statusFlags&ServerSessionStateChanged == ServerSessionStateChanged {
 			length, ok := data.readLenEncInt()
-			if !ok {
-				return fail("invalid OK packet session state change length: %v", data)
-			}
-			// In case we have a zero length string, there's no additional information so
-			// we can return the packet.
-			if length == 0 {
+			if !ok || length == 0 {
+				// In case we have no more data or a zero length string, there's no additional information so
+				// we can return the packet.
 				return packetOK, nil
 			}
 

--- a/go/mysql/conn_flaky_test.go
+++ b/go/mysql/conn_flaky_test.go
@@ -360,6 +360,11 @@ func TestOkPackets(t *testing.T) {
 		expectedErr: "invalid OK packet warnings: &{[0 0 0 2 0] 0}",
 	}, {
 		dataIn: `
+00000000  FE 00 00 22 40 00 00                              |.....|`,
+		dataOut: `00000000  00 00 00 22 40 00 00 00  04 03 02 00 00           |..."@........|`,
+		cc:      CapabilityClientProtocol41 | CapabilityClientTransactions | CapabilityClientSessionTrack | CapabilityClientDeprecateEOF,
+	}, {
+		dataIn: `
 00000000  00 00 00 02 40 00 00 00  2a 03 28 00 26 66 32 37  |....@...*.(.&f27|
 00000010  66 36 39 37 31 2d 30 33  65 37 2d 31 31 65 62 2d  |f6971-03e7-11eb-|
 00000020  38 35 63 35 2d 39 38 61  66 36 35 61 36 64 63 34  |85c5-98af65a6dc4|


### PR DESCRIPTION
On MariaDB, it's possible that an OK packet has `SERVER_SESSION_STATE_CHANGED` set to true, but it has no additional state change information as the end of the packet is reached.

We should not treat this as an error condition and treat this as a proper OK packet.

Fixes https://github.com/vitessio/vitess/issues/11795

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required