### PR TITLE
Fix: return allowed transaction isolation level value on select query

### DIFF
--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -472,9 +472,7 @@ func (er *astRewriter) sysVarRewrite(cursor *Cursor, node *Variable) {
 		sysvars.Version.Name,
 		sysvars.VersionComment.Name,
 		sysvars.QueryTimeout.Name,
-		sysvars.Workload.Name,
-		sysvars.TransactionIsolation.Name,
-		sysvars.TxIsolation.Name:
+		sysvars.Workload.Name:
 		found = true
 	}
 

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -166,18 +166,6 @@ func TestRewrites(in *testing.T) {
 		expected: "SELECT :__vtworkload as `@@workload`",
 		workload: true,
 	}, {
-		in:          "SELECT @@tx_isolation",
-		expected:    "select :__vttx_isolation as `@@tx_isolation` from dual",
-		txIsolation: true,
-	}, {
-		in:          "SELECT @@transaction_isolation",
-		expected:    "select :__vttransaction_isolation as `@@transaction_isolation` from dual",
-		txIsolation: true,
-	}, {
-		in:          "SELECT @@session.transaction_isolation",
-		expected:    "select :__vttransaction_isolation as `@@session.transaction_isolation` from dual",
-		txIsolation: true,
-	}, {
 		in:       "SELECT @@socket",
 		expected: "SELECT :__vtsocket as `@@socket`",
 		socket:   true,
@@ -317,7 +305,6 @@ func TestRewrites(in *testing.T) {
 		sessTrackGTID:               true,
 		socket:                      true,
 		queryTimeout:                true,
-		txIsolation:                 true,
 	}, {
 		in:                          "SHOW GLOBAL VARIABLES",
 		expected:                    "SHOW GLOBAL VARIABLES",
@@ -337,7 +324,6 @@ func TestRewrites(in *testing.T) {
 		sessTrackGTID:               true,
 		socket:                      true,
 		queryTimeout:                true,
-		txIsolation:                 true,
 	}}
 
 	for _, tc := range tests {
@@ -376,8 +362,6 @@ func TestRewrites(in *testing.T) {
 			assert.Equal(tc.version, result.NeedsSysVar(sysvars.Version.Name), "should need Vitess version")
 			assert.Equal(tc.versionComment, result.NeedsSysVar(sysvars.VersionComment.Name), "should need Vitess version")
 			assert.Equal(tc.socket, result.NeedsSysVar(sysvars.Socket.Name), "should need :__vtsocket")
-			assert.Equal(tc.txIsolation, result.NeedsSysVar(sysvars.TxIsolation.Name) || result.NeedsSysVar(sysvars.TransactionIsolation.Name),
-				"should need :__vttx_isolation or :__vttransaction_isolation")
 		})
 	}
 }
@@ -442,6 +426,27 @@ func TestRewritesSysVar(in *testing.T) {
 		in:       "select @x = @@sql_mode",
 		expected: "select :__vtudvx = :__vtsql_mode as `@x = @@sql_mode` from dual",
 		sysVar:   map[string]string{"sql_mode": "' '"},
+	}, {
+		in:       "SELECT @@tx_isolation",
+		expected: "select @@tx_isolation from dual",
+	}, {
+		in:       "SELECT @@transaction_isolation",
+		expected: "select @@transaction_isolation from dual",
+	}, {
+		in:       "SELECT @@session.transaction_isolation",
+		expected: "select @@session.transaction_isolation from dual",
+	}, {
+		in:       "SELECT @@tx_isolation",
+		expected: "select :__vttx_isolation as `@@tx_isolation` from dual",
+		sysVar:   map[string]string{"tx_isolation": "'READ-COMMITTED'"},
+	}, {
+		in:       "SELECT @@transaction_isolation",
+		expected: "select :__vttransaction_isolation as `@@transaction_isolation` from dual",
+		sysVar:   map[string]string{"transaction_isolation": "'READ-COMMITTED'"},
+	}, {
+		in:       "SELECT @@session.transaction_isolation",
+		expected: "select :__vttransaction_isolation as `@@session.transaction_isolation` from dual",
+		sysVar:   map[string]string{"transaction_isolation": "'READ-COMMITTED'"},
 	}}
 
 	for _, tc := range tests {

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -437,16 +437,16 @@ func TestRewritesSysVar(in *testing.T) {
 		expected: "select @@session.transaction_isolation from dual",
 	}, {
 		in:       "SELECT @@tx_isolation",
-		expected: "select :__vttx_isolation as `@@tx_isolation` from dual",
 		sysVar:   map[string]string{"tx_isolation": "'READ-COMMITTED'"},
+		expected: "select :__vttx_isolation as `@@tx_isolation` from dual",
 	}, {
 		in:       "SELECT @@transaction_isolation",
-		expected: "select :__vttransaction_isolation as `@@transaction_isolation` from dual",
 		sysVar:   map[string]string{"transaction_isolation": "'READ-COMMITTED'"},
+		expected: "select :__vttransaction_isolation as `@@transaction_isolation` from dual",
 	}, {
 		in:       "SELECT @@session.transaction_isolation",
-		expected: "select :__vttransaction_isolation as `@@session.transaction_isolation` from dual",
 		sysVar:   map[string]string{"transaction_isolation": "'READ-COMMITTED'"},
+		expected: "select :__vttransaction_isolation as `@@session.transaction_isolation` from dual",
 	}}
 
 	for _, tc := range tests {

--- a/go/vt/sysvars/sysvars.go
+++ b/go/vt/sysvars/sysvars.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package sysvars
 
+import "sync"
+
 // This information lives here, because it's needed from the vtgate planbuilder, the vtgate engine,
 // and the AST rewriter, that happens to live in sqlparser.
 
@@ -271,4 +273,18 @@ func GetInterestingVariables() []string {
 		}
 	}
 	return res
+}
+
+var vitessAwareVariableNames map[string]struct{}
+var vitessAwareInit sync.Once
+
+func IsVitessAware(sysv string) bool {
+	vitessAwareInit.Do(func() {
+		vitessAwareVariableNames = make(map[string]struct{}, len(VitessAware))
+		for _, v := range VitessAware {
+			vitessAwareVariableNames[v.Name] = struct{}{}
+		}
+	})
+	_, found := vitessAwareVariableNames[sysv]
+	return found
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -444,12 +444,6 @@ func (e *Executor) addNeededBindVars(bindVarNeeds *sqlparser.BindVarNeeds, bindV
 				v = options.GetWorkload().String()
 			})
 			bindVars[key] = sqltypes.StringBindVariable(v)
-		case sysvars.TxIsolation.Name, sysvars.TransactionIsolation.Name:
-			var v string
-			ifOptionsExist(session, func(options *querypb.ExecuteOptions) {
-				v = options.GetTransactionIsolation().String()
-			})
-			bindVars[key] = sqltypes.StringBindVariable(v)
 		case sysvars.DDLStrategy.Name:
 			bindVars[key] = sqltypes.StringBindVariable(session.DDLStrategy)
 		case sysvars.SessionUUID.Name:

--- a/go/vt/vtgate/executor_set_test.go
+++ b/go/vt/vtgate/executor_set_test.go
@@ -156,11 +156,19 @@ func TestExecutorSet(t *testing.T) {
 		in:  "set workload = 1",
 		err: "incorrect argument type to variable 'workload': INT64",
 	}, {
-		in:  "set tx_isolation = 'read-committed'",
-		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_COMMITTED}},
+		in: "set tx_isolation = 'read-committed'",
+		out: &vtgatepb.Session{
+			Autocommit:      true,
+			Options:         &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_COMMITTED},
+			SystemVariables: map[string]string{"transaction_isolation": "'READ-COMMITTED'", "tx_isolation": "'READ-COMMITTED'"},
+		},
 	}, {
-		in:  "set transaction_isolation = 'read-committed'",
-		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_COMMITTED}},
+		in: "set transaction_isolation = 'read-committed'",
+		out: &vtgatepb.Session{
+			Autocommit:      true,
+			Options:         &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_COMMITTED},
+			SystemVariables: map[string]string{"transaction_isolation": "'READ-COMMITTED'", "tx_isolation": "'READ-COMMITTED'"},
+		},
 	}, {
 		in:  "set transaction_isolation = 'read_committed'",
 		err: "Variable 'transaction_isolation' can't be set to the value of 'read_committed'",
@@ -219,20 +227,41 @@ func TestExecutorSet(t *testing.T) {
 		in:  "set transaction_read_only = 2",
 		err: "variable 'transaction_read_only' can't be set to the value: 2 is not a boolean",
 	}, {
-		in:  "set session transaction isolation level repeatable read",
-		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_REPEATABLE_READ}},
+		in: "set session transaction isolation level repeatable read",
+		out: &vtgatepb.Session{
+			Autocommit:      true,
+			Options:         &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_REPEATABLE_READ},
+			SystemVariables: map[string]string{"transaction_isolation": "'REPEATABLE-READ'", "tx_isolation": "'REPEATABLE-READ'"},
+		},
 	}, {
-		in:  "set session transaction isolation level read committed",
-		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_COMMITTED}},
+		in: "set session transaction isolation level read committed",
+		out: &vtgatepb.Session{
+			Autocommit:      true,
+			Options:         &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_COMMITTED},
+			SystemVariables: map[string]string{"transaction_isolation": "'READ-COMMITTED'", "tx_isolation": "'READ-COMMITTED'"},
+		},
 	}, {
-		in:  "set session transaction isolation level read uncommitted",
-		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_UNCOMMITTED}},
+		in: "set session transaction isolation level read uncommitted",
+		out: &vtgatepb.Session{
+			Autocommit:      true,
+			Options:         &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_UNCOMMITTED},
+			SystemVariables: map[string]string{"transaction_isolation": "'READ-UNCOMMITTED'", "tx_isolation": "'READ-UNCOMMITTED'"},
+		},
 	}, {
-		in:  "set session transaction isolation level serializable",
-		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_SERIALIZABLE}},
+		in: "set session transaction isolation level serializable",
+		out: &vtgatepb.Session{
+			Autocommit:      true,
+			Options:         &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_SERIALIZABLE},
+			SystemVariables: map[string]string{"transaction_isolation": "'SERIALIZABLE'", "tx_isolation": "'SERIALIZABLE'"},
+		},
 	}, {
-		in:  "set transaction isolation level serializable",
-		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_SERIALIZABLE}, Warnings: []*querypb.QueryWarning{{Code: mysql.ERNotSupportedYet, Message: "converted 'next transaction' scope to 'session' scope"}}},
+		in: "set transaction isolation level serializable",
+		out: &vtgatepb.Session{
+			Autocommit:      true,
+			Options:         &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_SERIALIZABLE},
+			SystemVariables: map[string]string{"transaction_isolation": "'SERIALIZABLE'", "tx_isolation": "'SERIALIZABLE'"},
+			Warnings:        []*querypb.QueryWarning{{Code: mysql.ERNotSupportedYet, Message: "converted 'next transaction' scope to 'session' scope"}},
+		},
 	}, {
 		in:  "set transaction read only",
 		out: &vtgatepb.Session{Autocommit: true, Warnings: []*querypb.QueryWarning{{Code: mysql.ERNotSupportedYet, Message: "converted 'next transaction' scope to 'session' scope"}}},
@@ -574,4 +603,52 @@ func TestSetVarShowVariables(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, session.InReservedConn(), "reserved connection should not be used")
 	assert.Equal(t, `[[VARCHAR("sql_mode") VARCHAR("only_full_group_by")]]`, fmt.Sprintf("%v", qr.Rows))
+}
+
+func TestExecutorSetAndSelect(t *testing.T) {
+	e, _, _, sbc := createExecutorEnv()
+	e.normalize = true
+
+	testcases := []struct {
+		sysVar        string
+		val           string
+		exp           string
+		expShardCount int
+	}{{
+		sysVar:        "transaction_isolation",
+		exp:           `[[VARCHAR("REPEATABLE-READ")]]`,
+		expShardCount: 1, // query should reach the shard only in case of unset transaction isolation level.
+	}, {
+		sysVar: "transaction_isolation",
+		val:    "READ-COMMITTED",
+		exp:    `[[VARCHAR("READ-COMMITTED")]]`,
+	}, {
+		sysVar: "tx_isolation",
+		val:    "READ-UNCOMMITTED",
+		exp:    `[[VARCHAR("READ-UNCOMMITTED")]]`,
+	}, {
+		sysVar: "tx_isolation",
+		exp:    `[[VARCHAR("READ-UNCOMMITTED")]]`, // this returns the value set in previous query.
+	}}
+	session := NewAutocommitSession(&vtgatepb.Session{TargetString: KsTestUnsharded})
+	for _, tcase := range testcases {
+		t.Run(fmt.Sprintf("%s-%s", tcase.sysVar, tcase.val), func(t *testing.T) {
+			sbc.ExecCount.Set(0) // reset the value
+
+			if tcase.val != "" {
+				setQ := fmt.Sprintf("set %s = '%s'", tcase.sysVar, tcase.val)
+				_, err := e.Execute(context.Background(), "TestExecutorSetAndSelect", session, setQ, nil)
+				require.NoError(t, err)
+			}
+
+			selectQ := fmt.Sprintf("select @@%s", tcase.sysVar)
+			// if the query reaches the shard, it will return REPEATABLE-READ isolation level.
+			sbc.SetResults([]*sqltypes.Result{sqltypes.MakeTestResult(sqltypes.MakeTestFields(tcase.sysVar, "varchar"), "REPEATABLE-READ")})
+
+			qr, err := e.Execute(context.Background(), "TestExecutorSetAndSelect", session, selectQ, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tcase.exp, fmt.Sprintf("%v", qr.Rows))
+			assert.EqualValues(t, tcase.expShardCount, sbc.ExecCount.Get())
+		})
+	}
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the regression caused by https://github.com/vitessio/vitess/pull/11673 where when transaction isolation is not set returns `DEFAULT` which is an unknown value from the transaction isolation system variable.
Now, this PR will return the default value from the connection which will be one of these
`READ-UNCOMMITTED`, `READ-COMMITTED`, `REPEATABLE-READ` and `SERIALIZABLE`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/11793

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
