### PR TITLE
Fix the golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,13 +18,10 @@ linters:
   disable-all: true
   enable:
     # Defaults
-    - deadcode
     - errcheck
     - govet
     - ineffassign
-    - structcheck
     - typecheck
-    - varcheck
     - staticcheck
     - gosimple
 
@@ -43,10 +40,6 @@ issues:
       linters:
       - errcheck
       - goimports
-
-    - path: '^go/vt/vtadmin/cache/'
-      linters:
-      - structcheck
 
     ### BEGIN: errcheck exclusion rules. Each rule should be considered
     #   a TODO for removal after adding error checks to that package/file/etc,


### PR DESCRIPTION
There's a bunch of deprecated linters that don't work anymore, so let's remove them:

```
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [linters context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
```

Closes https://github.com/vitessio/vitess/issues/11825

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required