### PR TITLE
Optimize Mysql56GTIDSet.String(), add benchmark

### DIFF
--- a/go/mysql/mysql56_gtid_set.go
+++ b/go/mysql/mysql56_gtid_set.go
@@ -155,7 +155,7 @@ func (set Mysql56GTIDSet) String() string {
 		if i != 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteString(sid.String())
+		buf.Write(sid[:])
 
 		for _, interval := range set[sid] {
 			buf.WriteByte(':')

--- a/go/mysql/mysql56_gtid_set_test.go
+++ b/go/mysql/mysql56_gtid_set_test.go
@@ -151,6 +151,14 @@ func TestMysql56GTIDSetString(t *testing.T) {
 	}
 }
 
+func BenchmarkMysql56GTIDSetString(b *testing.B) {
+	sid := SID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	set := Mysql56GTIDSet{sid: []interval{{1, 5}}}
+	for n := 0; n < b.N; n++ {
+		set.String()
+	}
+}
+
 func TestMysql56GTIDSetFlavor(t *testing.T) {
 	input := Mysql56GTIDSet{}
 	if got, want := input.Flavor(), "MySQL56"; got != want {

--- a/go/mysql/mysql56_gtid_set_test.go
+++ b/go/mysql/mysql56_gtid_set_test.go
@@ -155,7 +155,7 @@ func BenchmarkMysql56GTIDSetString(b *testing.B) {
 	sid := SID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	set := Mysql56GTIDSet{sid: []interval{{1, 5}}}
 	for n := 0; n < b.N; n++ {
-		set.String()
+		_ = set.String()
 	}
 }
 


### PR DESCRIPTION
## Description

This PR optimizes the `.String()` method of `mysql.Mysql56GTIDSet` by appending the byte-representation of the GTID-SID to the `bytes.Buffer` vs converting and writing it to the buffer as a `string`. Also a benchmark test for the `.String()` method was added

I also attempted to optimize further by writing the `start`/`end` intervals _(`int64`s)_ to the `bytes.Buffer` using `binary.Write()`, but confusingly, this performed worse than this change and I can't explain why 😕

In benchmarks this PR improves the efficiency of `.String()` by about 27%: `200.9 ns/op` vs `275.5 ns/op`

#### Before benchmark
```bash
$ go test -v -run BenchmarkMysql56GTIDSetString -bench=BenchmarkMysql56GTIDSetString ./go/mysql/...
goos: darwin
goarch: amd64
pkg: [vitess.io/vitess/go/mysql](http://vitess.io/vitess/go/mysql)
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkMysql56GTIDSetString
BenchmarkMysql56GTIDSetString-16    	 4378540	       275.5 ns/op
PASS
```

#### After benchmark
```bash
$ go test -v -run BenchmarkMysql56GTIDSetString -bench=BenchmarkMysql56GTIDSetString ./go/mysql/...
goos: darwin
goarch: amd64
pkg: [vitess.io/vitess/go/mysql](http://vitess.io/vitess/go/mysql)
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkMysql56GTIDSetString
BenchmarkMysql56GTIDSetString-16    	 6013492	       200.9 ns/op
PASS
```

If possible, please backport this to v13+ 🙇 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
