### PR TITLE
Fix type errors in api.ts and run lint:prettier:fix

### DIFF
--- a/web/vtadmin/src/components/inputs/Select.tsx
+++ b/web/vtadmin/src/components/inputs/Select.tsx
@@ -74,20 +74,13 @@ export const Select = <T,>({
         [onChange]
     );
 
-    const {
-        getItemProps,
-        getLabelProps,
-        getMenuProps,
-        getToggleButtonProps,
-        highlightedIndex,
-        isOpen,
-        selectItem,
-    } = useSelect({
-        itemToString: _itemToString,
-        items,
-        onSelectedItemChange,
-        selectedItem,
-    });
+    const { getItemProps, getLabelProps, getMenuProps, getToggleButtonProps, highlightedIndex, isOpen, selectItem } =
+        useSelect({
+            itemToString: _itemToString,
+            items,
+            onSelectedItemChange,
+            selectedItem,
+        });
 
     const containerClass = cx(style.container, className, {
         [style.large]: size === 'large',

--- a/web/vtadmin/src/components/routes/shard/Advanced.tsx
+++ b/web/vtadmin/src/components/routes/shard/Advanced.tsx
@@ -191,10 +191,8 @@ const Advanced: React.FC = () => {
         }
     );
 
-    const [
-        validateVersionShardResponse,
-        setValidateVersionShardResponse,
-    ] = useState<vtctldata.ValidateVersionShardResponse | null>(null);
+    const [validateVersionShardResponse, setValidateVersionShardResponse] =
+        useState<vtctldata.ValidateVersionShardResponse | null>(null);
 
     const validateVersionShardMutation = useValidateVersionShard(
         {

--- a/web/vtadmin/src/hooks/api.ts
+++ b/web/vtadmin/src/hooks/api.ts
@@ -85,19 +85,20 @@ import { formatAlias } from '../util/tablets';
 /**
  * useBackups is a query hook that fetches all backups across every cluster.
  */
-export const useBackups = (options?: UseQueryOptions<pb.ClusterBackup[], Error> | undefined) =>
-    useQuery(['backups'], fetchBackups, options);
+export const useBackups = (
+    options?: UseQueryOptions<pb.ClusterBackup[], Error, pb.ClusterBackup[], string[]> | undefined
+) => useQuery(['backups'], fetchBackups, options);
 
 /**
  * useClusters is a query hook that fetches all clusters VTAdmin is configured to discover.
  */
-export const useClusters = (options?: UseQueryOptions<pb.Cluster[], Error> | undefined) =>
+export const useClusters = (options?: UseQueryOptions<pb.Cluster[], Error, pb.Cluster[], string[]> | undefined) =>
     useQuery(['clusters'], fetchClusters, options);
 
 /**
  * useGates is a query hook that fetches all VTGates across every cluster.
  */
-export const useGates = (options?: UseQueryOptions<pb.VTGate[], Error> | undefined) =>
+export const useGates = (options?: UseQueryOptions<pb.VTGate[], Error, pb.VTGate[], string[]> | undefined) =>
     useQuery(['gates'], fetchGates, options);
 
 /**
@@ -105,7 +106,7 @@ export const useGates = (options?: UseQueryOptions<pb.VTGate[], Error> | undefin
  */
 export const useKeyspace = (
     params: Parameters<typeof fetchKeyspace>[0],
-    options?: UseQueryOptions<pb.Keyspace, Error>
+    options?: UseQueryOptions<pb.Keyspace, Error, pb.Keyspace, (string | Parameters<typeof fetchKeyspace>[0])[]>
 ) => {
     const queryClient = useQueryClient();
     return useQuery(['keyspace', params], () => fetchKeyspace(params), {
@@ -134,31 +135,34 @@ export const useCreateKeyspace = (
 /**
  * useKeyspaces is a query hook that fetches all keyspaces across every cluster.
  */
-export const useKeyspaces = (options?: UseQueryOptions<pb.Keyspace[], Error> | undefined) =>
+export const useKeyspaces = (options?: UseQueryOptions<pb.Keyspace[], Error, pb.Keyspace[], string[]> | undefined) =>
     useQuery(['keyspaces'], fetchKeyspaces, options);
 
 /**
  * useSchemas is a query hook that fetches all schemas across every cluster.
  */
-export const useSchemas = (options?: UseQueryOptions<pb.Schema[], Error> | undefined) =>
+export const useSchemas = (options?: UseQueryOptions<pb.Schema[], Error, pb.Schema[], string[]> | undefined) =>
     useQuery(['schemas'], fetchSchemas, options);
 
 /**
  * useTablets is a query hook that fetches all tablets across every cluster.
  */
-export const useTablets = (options?: UseQueryOptions<pb.Tablet[], Error> | undefined) =>
+export const useTablets = (options?: UseQueryOptions<pb.Tablet[], Error, pb.Tablet[], string[]> | undefined) =>
     useQuery(['tablets'], fetchTablets, options);
 
 /**
  * useVtctlds is a query hook that fetches all vtctlds across every cluster.
  */
-export const useVtctlds = (options?: UseQueryOptions<pb.Vtctld[], Error> | undefined) =>
+export const useVtctlds = (options?: UseQueryOptions<pb.Vtctld[], Error, pb.Vtctld[], string[]> | undefined) =>
     useQuery(['vtctlds'], fetchVtctlds, options);
 
 /**
  * useTablet is a query hook that fetches a single tablet by alias.
  */
-export const useTablet = (params: Parameters<typeof fetchTablet>[0], options?: UseQueryOptions<pb.Tablet, Error>) => {
+export const useTablet = (
+    params: Parameters<typeof fetchTablet>[0],
+    options?: UseQueryOptions<pb.Tablet, Error, pb.Tablet, (string | Parameters<typeof fetchTablet>[0])[]>
+) => {
     const queryClient = useQueryClient();
     return useQuery(['tablet', params], () => fetchTablet(params), {
         initialData: () => {
@@ -227,7 +231,14 @@ export const useSetReadWrite = (
  */
 export const useShardReplicationPositions = (
     params: Parameters<typeof fetchShardReplicationPositions>[0],
-    options?: UseQueryOptions<pb.GetShardReplicationPositionsResponse, Error> | undefined
+    options?:
+        | UseQueryOptions<
+              pb.GetShardReplicationPositionsResponse,
+              Error,
+              pb.GetShardReplicationPositionsResponse,
+              (string | Parameters<typeof fetchShardReplicationPositions>[0])[]
+          >
+        | undefined
 ) => useQuery(['shard_replication_positions', params], () => fetchShardReplicationPositions(params), options);
 
 /**
@@ -259,7 +270,12 @@ export const useStopReplication = (
  */
 export const usePingTablet = (
     params: Parameters<typeof pingTablet>[0],
-    options?: UseQueryOptions<pb.PingTabletResponse, Error>
+    options?: UseQueryOptions<
+        pb.PingTabletResponse,
+        Error,
+        pb.PingTabletResponse,
+        (string | Parameters<typeof pingTablet>[0])[]
+    >
 ) => {
     return useQuery(['ping-tablet', params], () => pingTablet(params), options);
 };
@@ -269,7 +285,12 @@ export const usePingTablet = (
  */
 export const useRefreshState = (
     params: Parameters<typeof refreshState>[0],
-    options?: UseQueryOptions<pb.RefreshStateResponse, Error>
+    options?: UseQueryOptions<
+        pb.RefreshStateResponse,
+        Error,
+        pb.RefreshStateResponse,
+        (string | Parameters<typeof refreshState>[0])[]
+    >
 ) => {
     return useQuery(['refresh-state', params], () => refreshState(params), options);
 };
@@ -286,7 +307,7 @@ export const useHealthCheck = (
 
 export const useExperimentalTabletDebugVars = (
     params: FetchTabletParams,
-    options?: UseQueryOptions<TabletDebugVarsResponse, Error>
+    options?: UseQueryOptions<TabletDebugVarsResponse, Error, TabletDebugVarsResponse, (string | FetchTabletParams)[]>
 ) => {
     return useQuery(
         ['experimental/tablet/debug/vars', params],
@@ -314,8 +335,9 @@ export const useManyExperimentalTabletDebugVars = (
 /**
  * useWorkflowsResponse is a query hook that fetches all workflows (by cluster) across every cluster.
  */
-export const useWorkflowsResponse = (options?: UseQueryOptions<pb.GetWorkflowsResponse, Error> | undefined) =>
-    useQuery(['workflows'], fetchWorkflows, options);
+export const useWorkflowsResponse = (
+    options?: UseQueryOptions<pb.GetWorkflowsResponse, Error, pb.GetWorkflowsResponse, string[]> | undefined
+) => useQuery(['workflows'], fetchWorkflows, options);
 
 /**
  * useWorkflows is a helper hook for when a flattened list of workflows
@@ -343,7 +365,10 @@ export const useWorkflows = (...args: Parameters<typeof useWorkflowsResponse>) =
 /**
  * useSchema is a query hook that fetches a single schema for the given parameters.
  */
-export const useSchema = (params: FetchSchemaParams, options?: UseQueryOptions<pb.Schema, Error> | undefined) => {
+export const useSchema = (
+    params: FetchSchemaParams,
+    options?: UseQueryOptions<pb.Schema, Error, pb.Schema, (string | FetchSchemaParams)[]> | undefined
+) => {
     const queryClient = useQueryClient();
     return useQuery(['schema', params], () => fetchSchema(params), {
         initialData: () => {
@@ -404,7 +429,14 @@ export const useVSchema = (params: FetchVSchemaParams, options?: UseQueryOptions
 
 export const useVTExplain = (
     params: Parameters<typeof fetchVTExplain>[0],
-    options?: UseQueryOptions<pb.VTExplainResponse, Error> | undefined
+    options?:
+        | UseQueryOptions<
+              pb.VTExplainResponse,
+              Error,
+              pb.VTExplainResponse,
+              (string | Parameters<typeof fetchVTExplain>[0])[]
+          >
+        | undefined
 ) => {
     return useQuery(['vtexplain', params], () => fetchVTExplain(params), { ...options });
 };
@@ -414,7 +446,9 @@ export const useVTExplain = (
  */
 export const useWorkflow = (
     params: Parameters<typeof fetchWorkflow>[0],
-    options?: UseQueryOptions<pb.Workflow, Error> | undefined
+    options?:
+        | UseQueryOptions<pb.Workflow, Error, pb.Workflow, (string | Parameters<typeof fetchWorkflow>[0])[]>
+        | undefined
 ) => {
     const queryClient = useQueryClient();
     return useQuery(['workflow', params], () => fetchWorkflow(params), {
@@ -605,7 +639,14 @@ export const useValidateShard = (
  */
 export const useGetFullStatus = (
     params: GetFullStatusParams,
-    options?: UseQueryOptions<vtctldata.GetFullStatusResponse, Error> | undefined
+    options?:
+        | UseQueryOptions<
+              vtctldata.GetFullStatusResponse,
+              Error,
+              vtctldata.GetFullStatusResponse,
+              (string | GetFullStatusParams)[]
+          >
+        | undefined
 ) => useQuery(['full-status', params], () => getFullStatus(params), options);
 
 /**


### PR DESCRIPTION
Signed-off-by: notfelineit <notfelineit@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR mostly fixes some type errors in `api.ts` by adding more type definitions to our hooks.

I also ran `lint:prettier:fix` and that seemed to correct some issues in unrelated files.

## Related Issue(s)
N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported **No need to backport**
-   [x] Tests were added or are not required **Not necessary**
-   [x] Documentation was added or is not required **Not necessary**

## Deployment Notes
N/A