### PR TITLE
Add instructions on how to fix a self-hosted runner running out of disk space

### DIFF
--- a/GITHUB_SELF_HOSTED_RUNNERS.md
+++ b/GITHUB_SELF_HOSTED_RUNNERS.md
@@ -71,3 +71,21 @@ The logs will be stored in the `savedRuns` directory and can be copied locally v
 
 A cronjob is already setup to empty the `savedRuns` directory every week so please download the runs
 before they are deleted.
+
+## Running out of disk space in Self-hosted runners
+
+If the loads on the self-hosted runners increases due to multiple tests being moved to them or some other reason, 
+they sometimes end up running out of disk space. This causes the runner to stop working all together.
+
+In order to fix this issue follow the following steps -
+1. `ssh` into the self-hosted runner by finding its address from the equinix dashboard.
+2. Clear out the disk by running `docker system prune -f --volumes --all`. This is the same command that we run on a cron on the server.
+3. Switch to the `github-runner` user
+   1. `su github-runner`
+4. Resume an existing `screen`
+   1. `screen -r`
+5. Start the runner again.
+   1. `./run.sh`
+6. Verify that the runner has started accepting jobs again. Detach the screen and close the `ssh` connection.
+
+


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds the instructions to the self-hosted runner guide on how to fix a self-hosted runner if it runs out of disk space.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/11840

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
