### PR TITLE
Simplify recursive data structure in CFC Vindex

### DIFF
--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -177,7 +177,10 @@ var executorVSchema = `
 			"params": {
 				"region_bytes": "1"
 			}
-    	}
+    	},
+		"cfc": {
+          "type": "cfc"
+		}
 	},
 	"tables": {
 		"user": {
@@ -371,6 +374,20 @@ var executorVSchema = `
 				{
 					"columns": ["cola","colb"],
 					"name": "regional_vdx"
+				}
+			]
+    	},
+		"tbl_cfc": {
+			"column_vindexes": [
+                {
+                    "column": "c1",
+                    "name": "cfc"
+                }
+			],
+			"columns": [
+				{
+					"name": "c2",
+					"type": "VARCHAR"
 				}
 			]
     	}

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -179,7 +179,7 @@ var executorVSchema = `
 			}
     	},
 		"cfc": {
-          "type": "cfc"
+			"type": "cfc"
 		}
 	},
 	"tables": {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -867,6 +867,7 @@ func TestExecutorShow(t *testing.T) {
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Keyspace", "Name", "Type", "Params", "Owner"),
 		Rows: [][]sqltypes.Value{
+			buildVarCharRow("TestExecutor", "cfc", "cfc", "", ""),
 			buildVarCharRow("TestExecutor", "hash_index", "hash", "", ""),
 			buildVarCharRow("TestExecutor", "idx1", "hash", "", ""),
 			buildVarCharRow("TestExecutor", "idx_noauto", "hash", "", "noauto_table"),

--- a/go/vt/vtgate/vindexes/cached_size.go
+++ b/go/vt/vtgate/vindexes/cached_size.go
@@ -73,17 +73,13 @@ func (cached *CFC) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(64)
+		size += int64(48)
 	}
 	// field name string
 	size += hack.RuntimeAllocSize(int64(len(cached.name)))
 	// field offsets []int
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.offsets)) * int64(8))
-	}
-	// field prefixVindex vitess.io/vitess/go/vt/vtgate/vindexes.SingleColumn
-	if cc, ok := cached.prefixVindex.(cachedObject); ok {
-		size += cc.CachedSize(true)
 	}
 	return size
 }

--- a/go/vt/vtgate/vindexes/cached_size.go
+++ b/go/vt/vtgate/vindexes/cached_size.go
@@ -73,14 +73,12 @@ func (cached *CFC) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(48)
+		size += int64(16)
 	}
-	// field name string
-	size += hack.RuntimeAllocSize(int64(len(cached.name)))
-	// field offsets []int
-	{
-		size += hack.RuntimeAllocSize(int64(cap(cached.offsets)) * int64(8))
-	}
+	// field cfcCommon *vitess.io/vitess/go/vt/vtgate/vindexes.cfcCommon
+	size += cached.cfcCommon.CachedSize(true)
+	// field prefixCFC *vitess.io/vitess/go/vt/vtgate/vindexes.prefixCFC
+	size += cached.prefixCFC.CachedSize(true)
 	return size
 }
 func (cached *Column) CachedSize(alloc bool) int64 {
@@ -482,6 +480,22 @@ func (cached *XXHash) CachedSize(alloc bool) int64 {
 	size += hack.RuntimeAllocSize(int64(len(cached.name)))
 	return size
 }
+func (cached *cfcCommon) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field name string
+	size += hack.RuntimeAllocSize(int64(len(cached.name)))
+	// field offsets []int
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.offsets)) * int64(8))
+	}
+	return size
+}
 func (cached *clCommon) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -554,7 +568,7 @@ func (cached *prefixCFC) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(8)
 	}
-	// field CFC *vitess.io/vitess/go/vt/vtgate/vindexes.CFC
-	size += cached.CFC.CachedSize(true)
+	// field cfcCommon *vitess.io/vitess/go/vt/vtgate/vindexes.cfcCommon
+	size += cached.cfcCommon.CachedSize(true)
 	return size
 }

--- a/go/vt/vtgate/vindexes/cfc.go
+++ b/go/vt/vtgate/vindexes/cfc.go
@@ -87,6 +87,13 @@ import (
 // Specifically, offsets[0] is the byte offset of the first component,
 // offsets[1] is the byte offset of the second component, etc.
 type CFC struct {
+	// CFC is used in all compare expressions other than 'LIKE'.
+	*cfcCommon
+	// prefixCFC is only used in 'LIKE' compare expressions.
+	prefixCFC *prefixCFC
+}
+
+type cfcCommon struct {
 	name    string
 	hash    func([]byte) []byte
 	offsets []int
@@ -94,18 +101,21 @@ type CFC struct {
 
 // NewCFC creates a new CFC vindex
 func NewCFC(name string, params map[string]string) (Vindex, error) {
-	// CFC is used in all compare expressions other than 'LIKE'.
-	ss := &CFC{
+	ss := &cfcCommon{
 		name: name,
+	}
+	cfc := &CFC{
+		cfcCommon: ss,
+		prefixCFC: &prefixCFC{cfcCommon: ss},
 	}
 
 	if params == nil {
-		return ss, nil
+		return cfc, nil
 	}
 
 	switch h := params["hash"]; h {
 	case "":
-		return ss, nil
+		return cfc, nil
 	case "md5":
 		ss.hash = md5hash
 	case "xxhash64":
@@ -129,7 +139,7 @@ func NewCFC(name string, params map[string]string) (Vindex, error) {
 		prev = off
 	}
 
-	return ss, nil
+	return cfc, nil
 }
 
 func validOffsets(offsets []int) bool {
@@ -170,7 +180,7 @@ func (vind *CFC) NeedsVCursor() bool {
 }
 
 // computeKsid returns the corresponding keyspace id of a key.
-func (vind *CFC) computeKsid(v []byte, prefix bool) ([]byte, error) {
+func (vind *cfcCommon) computeKsid(v []byte, prefix bool) ([]byte, error) {
 
 	if vind.hash == nil {
 		return v, nil
@@ -205,8 +215,7 @@ func (vind *CFC) computeKsid(v []byte, prefix bool) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Verify returns true if ids maps to ksids.
-func (vind *CFC) Verify(ctx context.Context, vcursor VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
+func (vind *cfcCommon) verify(ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
 	out := make([]bool, len(ids))
 	for i := range ids {
 		idBytes, err := ids[i].ToBytes()
@@ -222,8 +231,13 @@ func (vind *CFC) Verify(ctx context.Context, vcursor VCursor, ids []sqltypes.Val
 	return out, nil
 }
 
+// Verify returns true if ids maps to ksids.
+func (vind *CFC) Verify(_ context.Context, _ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
+	return vind.verify(ids, ksids)
+}
+
 // Map can map ids to key.Destination objects.
-func (vind *CFC) Map(ctx context.Context, vcursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
+func (vind *CFC) Map(_ context.Context, _ VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
 	out := make([]key.Destination, len(ids))
 	for i, id := range ids {
 		idBytes, err := id.ToBytes()
@@ -241,8 +255,7 @@ func (vind *CFC) Map(ctx context.Context, vcursor VCursor, ids []sqltypes.Value)
 
 // PrefixVindex switches the vindex to prefix mode
 func (vind *CFC) PrefixVindex() SingleColumn {
-	// prefixCFC is only used in 'LIKE' compare expressions.
-	return &prefixCFC{CFC: vind}
+	return vind.prefixCFC
 }
 
 // NewKeyRangeFromPrefix creates a keyspace range from a prefix of keyspace id.
@@ -282,7 +295,19 @@ func addOne(value []byte) []byte {
 }
 
 type prefixCFC struct {
-	*CFC
+	*cfcCommon
+}
+
+func (vind *prefixCFC) String() string {
+	return vind.name
+}
+
+func (vind *prefixCFC) NeedsVCursor() bool {
+	return false
+}
+
+func (vind *prefixCFC) Verify(_ context.Context, _ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
+	return vind.verify(ids, ksids)
 }
 
 // In prefix mode, i.e. within a LIKE op, the cost is higher than regular mode.
@@ -300,7 +325,7 @@ func (vind *prefixCFC) IsUnique() bool {
 }
 
 // Map can map ids to key.Destination objects.
-func (vind *prefixCFC) Map(ctx context.Context, vcursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
+func (vind *prefixCFC) Map(_ context.Context, _ VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
 	out := make([]key.Destination, len(ids))
 	for i, id := range ids {
 		value, err := id.ToBytes()

--- a/go/vt/vtgate/vindexes/cfc.go
+++ b/go/vt/vtgate/vindexes/cfc.go
@@ -87,10 +87,9 @@ import (
 // Specifically, offsets[0] is the byte offset of the first component,
 // offsets[1] is the byte offset of the second component, etc.
 type CFC struct {
-	name         string
-	hash         func([]byte) []byte
-	offsets      []int
-	prefixVindex SingleColumn
+	name    string
+	hash    func([]byte) []byte
+	offsets []int
 }
 
 // NewCFC creates a new CFC vindex
@@ -99,8 +98,6 @@ func NewCFC(name string, params map[string]string) (Vindex, error) {
 	ss := &CFC{
 		name: name,
 	}
-	// prefixCFC is only used in 'LIKE' compare expressions.
-	ss.prefixVindex = &prefixCFC{CFC: ss}
 
 	if params == nil {
 		return ss, nil
@@ -244,7 +241,8 @@ func (vind *CFC) Map(ctx context.Context, vcursor VCursor, ids []sqltypes.Value)
 
 // PrefixVindex switches the vindex to prefix mode
 func (vind *CFC) PrefixVindex() SingleColumn {
-	return vind.prefixVindex
+	// prefixCFC is only used in 'LIKE' compare expressions.
+	return &prefixCFC{CFC: vind}
 }
 
 // NewKeyRangeFromPrefix creates a keyspace range from a prefix of keyspace id.

--- a/go/vt/vtgate/vindexes/cfc_test.go
+++ b/go/vt/vtgate/vindexes/cfc_test.go
@@ -623,3 +623,10 @@ func TestCFCHashFunction(t *testing.T) {
 		assert.Equal(t, c.outXXHash, len(xxhash64([]byte(c.src))))
 	}
 }
+
+// TestCFCCache tests for CFC vindex, cache size can be calculated.
+func TestCFCCache(t *testing.T) {
+	cfc := makeCFC(t, map[string]string{"hash": "md5", "offsets": "[3,5]"})
+	// should be able to return.
+	_ = cfc.CachedSize(true)
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR simplifies the self-reference of the CFC struct by prefix Vindex in the CFC Vindex.
Prefix Vindex is created when it is required rather than upfront. This resolved the cyclic dependency which was causing cache_size to crash with stack full error.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes CFCInsert Flakyness reported via launchable
- Fixes https://github.com/vitessio/vitess/issues/11858

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

