### PR TITLE
 Fix closing the body for HTTP requests (#11842)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,19 +18,17 @@ linters:
   disable-all: true
   enable:
     # Defaults
-    - deadcode
     - errcheck
     - govet
     - ineffassign
-    - structcheck
     - typecheck
-    - varcheck
     - staticcheck
     - gosimple
 
     # Extras
     - gofmt
     - goimports
+    - bodyclose
 
     # revive is a replacement for golint, but we do not run it in CI for now.
     # This is only enabled as a post-commit hook

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -299,10 +299,8 @@ func (topo *TopoProcess) IsHealthy() bool {
 	if err != nil {
 		return false
 	}
-	if resp.StatusCode == 200 {
-		return true
-	}
-	return false
+	defer resp.Body.Close()
+	return resp.StatusCode == 200
 }
 
 func (topo *TopoProcess) removeTopoDirectories(Cell string) {
@@ -321,11 +319,17 @@ func (topo *TopoProcess) ManageTopoDir(command string, directory string) (err er
 	if command == "mkdir" {
 		req, _ := http.NewRequest("PUT", url, payload)
 		req.Header.Add("content-type", "application/json")
-		_, err = http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			defer resp.Body.Close()
+		}
 		return err
 	} else if command == "rmdir" {
 		req, _ := http.NewRequest("DELETE", url+"?dir=true", payload)
-		_, err = http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			defer resp.Body.Close()
+		}
 		return err
 	} else {
 		return nil

--- a/go/test/endtoend/cluster/vtctlclient_process.go
+++ b/go/test/endtoend/cluster/vtctlclient_process.go
@@ -258,8 +258,5 @@ func (vtctlclient *VtctlClientProcess) InitTablet(tablet *Vttablet, cell string,
 // shouldRetry tells us if the command should be retried based on the results/output -- meaning that it
 // is likely an ephemeral or recoverable issue that is likely to succeed when retried.
 func shouldRetry(cmdResults string) bool {
-	if strings.Contains(cmdResults, "Deadlock found when trying to get lock; try restarting transaction") {
-		return true
-	}
-	return false
+	return strings.Contains(cmdResults, "Deadlock found when trying to get lock; try restarting transaction")
 }

--- a/go/test/endtoend/cluster/vtctld_process.go
+++ b/go/test/endtoend/cluster/vtctld_process.go
@@ -118,10 +118,8 @@ func (vtctld *VtctldProcess) IsHealthy() bool {
 	if err != nil {
 		return false
 	}
-	if resp.StatusCode == 200 {
-		return true
-	}
-	return false
+	defer resp.Body.Close()
+	return resp.StatusCode == 200
 }
 
 // TearDown shutdowns the running vtctld service

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -172,10 +172,9 @@ func (vtgate *VtgateProcess) WaitForStatus() bool {
 	if err != nil {
 		return false
 	}
-	if resp.StatusCode == 200 {
-		return true
-	}
-	return false
+	defer resp.Body.Close()
+
+	return resp.StatusCode == 200
 }
 
 // GetStatusForTabletOfShard function gets status for a specific tablet of a shard in keyspace
@@ -185,6 +184,8 @@ func (vtgate *VtgateProcess) GetStatusForTabletOfShard(name string, endPointsCou
 	if err != nil {
 		return false
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == 200 {
 		resultMap := make(map[string]any)
 		respByte, _ := io.ReadAll(resp.Body)
@@ -294,6 +295,8 @@ func (vtgate *VtgateProcess) GetVars() (map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting response from %s", vtgate.VerifyURL)
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == 200 {
 		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)
@@ -313,6 +316,7 @@ func (vtgate *VtgateProcess) ReadVSchema() (*interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	res, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -164,9 +164,9 @@ func (vttablet *VttabletProcess) GetStatus() string {
 	if err != nil {
 		return ""
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == 200 {
 		respByte, _ := io.ReadAll(resp.Body)
-		defer resp.Body.Close()
 		return string(respByte)
 	}
 	return ""
@@ -178,6 +178,8 @@ func (vttablet *VttabletProcess) GetVars() map[string]any {
 	if err != nil {
 		return nil
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == 200 {
 		resultMap := make(map[string]any)
 		respByte, _ := io.ReadAll(resp.Body)
@@ -196,6 +198,8 @@ func (vttablet *VttabletProcess) GetStatusDetails() string {
 	if err != nil {
 		return fmt.Sprintf("Status details failed: %v", err.Error())
 	}
+	defer resp.Body.Close()
+
 	respByte, _ := io.ReadAll(resp.Body)
 	return string(respByte)
 }

--- a/go/test/endtoend/cluster/vtworker_process.go
+++ b/go/test/endtoend/cluster/vtworker_process.go
@@ -114,10 +114,8 @@ func (vtworker *VtworkerProcess) IsHealthy() bool {
 	if err != nil {
 		return false
 	}
-	if resp.StatusCode == 200 {
-		return true
-	}
-	return false
+	defer resp.Body.Close()
+	return resp.StatusCode == 200
 }
 
 // TearDown shutdowns the running vtworker process
@@ -221,6 +219,7 @@ func (vtworker *VtworkerProcess) GetVars() (map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting response from %s", vtworker.VerifyURL)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == 200 {
 		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)

--- a/go/test/endtoend/clustertest/main_test.go
+++ b/go/test/endtoend/clustertest/main_test.go
@@ -107,9 +107,10 @@ func testURL(t *testing.T, url string, testCaseName string) {
 
 // getStatusForUrl returns the status code for the URL
 func getStatusForURL(url string) int {
-	resp, _ := http.Get(url)
-	if resp != nil {
-		return resp.StatusCode
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0
 	}
-	return 0
+	defer resp.Body.Close()
+	return resp.StatusCode
 }

--- a/go/test/endtoend/clustertest/vtctld_test.go
+++ b/go/test/endtoend/clustertest/vtctld_test.go
@@ -62,13 +62,15 @@ func TestVtctldProcess(t *testing.T) {
 
 func testTopoDataAPI(t *testing.T, url string) {
 	resp, err := http.Get(url)
-	require.Nil(t, err)
+	require.NoError(t, err)
+	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, 200)
 
 	resultMap := make(map[string]any)
-	respByte, _ := io.ReadAll(resp.Body)
+	respByte, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	err = json.Unmarshal(respByte, &resultMap)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	errorValue := reflect.ValueOf(resultMap["Error"])
 	assert.Empty(t, errorValue.String())
@@ -83,7 +85,7 @@ func testTopoDataAPI(t *testing.T, url string) {
 func testListAllTablets(t *testing.T) {
 	// first w/o any filters, aside from cell
 	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ListAllTablets", clusterInstance.Cell)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	tablets := getAllTablets()
 
@@ -104,7 +106,7 @@ func testListAllTablets(t *testing.T) {
 		"ListAllTablets", "--", "--keyspace", clusterInstance.Keyspaces[0].Name,
 		"--tablet_type", "primary",
 		clusterInstance.Cell)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// We should only return a single primary tablet per shard in the first keyspace
 	tabletsFromCMD = strings.Split(result, "\n")
@@ -115,9 +117,10 @@ func testListAllTablets(t *testing.T) {
 
 func testTabletStatus(t *testing.T) {
 	resp, err := http.Get(fmt.Sprintf("http://%s:%d", clusterInstance.Hostname, clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].HTTPPort))
-	require.Nil(t, err)
+	require.NoError(t, err)
+	defer resp.Body.Close()
 	respByte, err := io.ReadAll(resp.Body)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	result := string(respByte)
 	log.Infof("Tablet status response: %v", result)
 	assert.True(t, strings.Contains(result, `Alias: <a href="http://localhost:`))
@@ -126,13 +129,13 @@ func testTabletStatus(t *testing.T) {
 
 func testExecuteAsDba(t *testing.T) {
 	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDba", clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].Alias, `SELECT 1 AS a`)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, result, oneTableOutput)
 }
 
 func testExecuteAsApp(t *testing.T) {
 	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ExecuteFetchAsApp", clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].Alias, `SELECT 1 AS a`)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, result, oneTableOutput)
 }
 

--- a/go/test/endtoend/messaging/message_test.go
+++ b/go/test/endtoend/messaging/message_test.go
@@ -648,8 +648,13 @@ func parseDebugVars(t *testing.T, output interface{}, vttablet *cluster.Vttablet
 	if err != nil {
 		t.Fatalf("failed to fetch %q: %v", debugVarURL, err)
 	}
+	defer resp.Body.Close()
 
-	respByte, _ := io.ReadAll(resp.Body)
+	respByte, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body %q: %v", debugVarURL, err)
+	}
+
 	if resp.StatusCode != 200 {
 		t.Fatalf("status code %d while fetching %q:\n%s", resp.StatusCode, debugVarURL, respByte)
 	}

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -220,24 +219,25 @@ func TestMain(m *testing.M) {
 }
 
 // direct per-tablet throttler API instruction
-func throttleResponse(tablet *cluster.Vttablet, path string) (resp *http.Response, respBody string, err error) {
+func throttleResponse(tablet *cluster.Vttablet, path string) (respBody string, err error) {
 	apiURL := fmt.Sprintf("http://%s:%d/%s", tablet.VttabletProcess.TabletHostname, tablet.HTTPPort, path)
-	resp, err = httpClient.Get(apiURL)
+	resp, err := httpClient.Get(apiURL)
 	if err != nil {
-		return resp, respBody, err
+		return "", err
 	}
+	defer resp.Body.Close()
 	b, err := io.ReadAll(resp.Body)
 	respBody = string(b)
-	return resp, respBody, err
+	return respBody, err
 }
 
 // direct per-tablet throttler API instruction
-func throttleApp(tablet *cluster.Vttablet, app string) (*http.Response, string, error) {
+func throttleApp(tablet *cluster.Vttablet, app string) (string, error) {
 	return throttleResponse(tablet, fmt.Sprintf("throttler/throttle-app?app=%s&duration=1h", app))
 }
 
 // direct per-tablet throttler API instruction
-func unthrottleApp(tablet *cluster.Vttablet, app string) (*http.Response, string, error) {
+func unthrottleApp(tablet *cluster.Vttablet, app string) (string, error) {
 	return throttleResponse(tablet, fmt.Sprintf("throttler/unthrottle-app?app=%s", app))
 }
 
@@ -395,7 +395,7 @@ func TestSchemaChange(t *testing.T) {
 				// vstreamer source; but it's OK to be on the safe side and throttle on all tablets. Doesn't
 				// change the essence of this test.
 				for _, tablet := range shard.Vttablets {
-					_, body, err := throttleApp(tablet, vstreamerThrottlerAppName)
+					body, err := throttleApp(tablet, vstreamerThrottlerAppName)
 					defer unthrottleApp(tablet, vstreamerThrottlerAppName)
 
 					assert.NoError(t, err)
@@ -494,12 +494,12 @@ func TestSchemaChange(t *testing.T) {
 				case 0:
 					// this is the shard where we run PRS
 					// Use per-tablet throttling API
-					_, body, err = throttleApp(shards[i].Vttablets[currentPrimaryTabletIndex], onlineDDLThrottlerAppName)
+					body, err = throttleApp(shards[i].Vttablets[currentPrimaryTabletIndex], onlineDDLThrottlerAppName)
 					defer unthrottleApp(shards[i].Vttablets[currentPrimaryTabletIndex], onlineDDLThrottlerAppName)
 				case 1:
 					// no PRS on this shard
 					// Use per-tablet throttling API
-					_, body, err = throttleApp(shards[i].Vttablets[0], onlineDDLThrottlerAppName)
+					body, err = throttleApp(shards[i].Vttablets[0], onlineDDLThrottlerAppName)
 					defer unthrottleApp(shards[i].Vttablets[0], onlineDDLThrottlerAppName)
 				}
 				assert.NoError(t, err)
@@ -551,11 +551,11 @@ func TestSchemaChange(t *testing.T) {
 					case 0:
 						// this is the shard where we run PRS
 						// Use per-tablet throttling API
-						_, body, err = unthrottleApp(shards[i].Vttablets[currentPrimaryTabletIndex], onlineDDLThrottlerAppName)
+						body, err = unthrottleApp(shards[i].Vttablets[currentPrimaryTabletIndex], onlineDDLThrottlerAppName)
 					case 1:
 						// no PRS on this shard
 						// Use per-tablet throttling API
-						_, body, err = unthrottleApp(shards[i].Vttablets[0], onlineDDLThrottlerAppName)
+						body, err = unthrottleApp(shards[i].Vttablets[0], onlineDDLThrottlerAppName)
 					}
 					assert.NoError(t, err)
 					assert.Contains(t, body, onlineDDLThrottlerAppName)
@@ -680,7 +680,7 @@ func TestSchemaChange(t *testing.T) {
 		// shard 0 will run normally, shard 1 will be throttled
 		defer unthrottleApp(shards[1].Vttablets[0], onlineDDLThrottlerAppName)
 		t.Run("throttle shard 1", func(t *testing.T) {
-			_, body, err := throttleApp(shards[1].Vttablets[0], onlineDDLThrottlerAppName)
+			body, err := throttleApp(shards[1].Vttablets[0], onlineDDLThrottlerAppName)
 			assert.NoError(t, err)
 			assert.Contains(t, body, onlineDDLThrottlerAppName)
 		})
@@ -704,7 +704,7 @@ func TestSchemaChange(t *testing.T) {
 			onlineddl.CheckCancelAllMigrations(t, &vtParams, 1)
 		})
 		t.Run("unthrottle shard 1", func(t *testing.T) {
-			_, body, err := unthrottleApp(shards[1].Vttablets[0], onlineDDLThrottlerAppName)
+			body, err := unthrottleApp(shards[1].Vttablets[0], onlineDDLThrottlerAppName)
 			assert.NoError(t, err)
 			assert.Contains(t, body, onlineDDLThrottlerAppName)
 		})

--- a/go/test/endtoend/sharding/base_sharding.go
+++ b/go/test/endtoend/sharding/base_sharding.go
@@ -92,7 +92,8 @@ func GetSrvKeyspace(t *testing.T, cell string, ksname string, ci cluster.LocalPr
 func VerifyTabletHealth(t *testing.T, vttablet cluster.Vttablet, hostname string) {
 	tabletURL := fmt.Sprintf("http://%s:%d/healthz", hostname, vttablet.HTTPPort)
 	resp, err := http.Get(tabletURL)
-	require.Nil(t, err)
+	require.NoError(t, err)
+	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, 200)
 }
 

--- a/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
+++ b/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
@@ -287,7 +287,7 @@ func (bt *BufferingTest) Test(t *testing.T) {
 	// Healthcheck interval on tablet is set to 1s, so sleep for 2s
 	time.Sleep(2 * time.Second)
 	conn, err := mysql.Connect(context.Background(), &vtParams)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer conn.Close()
 
 	// Insert two rows for the later threads (critical read, update).
@@ -349,11 +349,14 @@ func (bt *BufferingTest) Test(t *testing.T) {
 	//At least one thread should have been buffered.
 	//This may fail if a failover is too fast. Add retries then.
 	resp, err := http.Get(clusterInstance.VtgateProcess.VerifyURL)
-	require.Nil(t, err)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
 	require.Equal(t, 200, resp.StatusCode)
 
 	var metadata VTGateBufferingStats
-	respByte, _ := io.ReadAll(resp.Body)
+	respByte, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	err = json.Unmarshal(respByte, &metadata)
 	require.NoError(t, err)
 

--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -202,6 +202,7 @@ func checkHealth(t *testing.T, port int, shouldError bool) {
 	url := fmt.Sprintf("http://localhost:%d/healthz", port)
 	resp, err := http.Get(url)
 	require.NoError(t, err)
+	defer resp.Body.Close()
 	if shouldError {
 		assert.True(t, resp.StatusCode > 400)
 	} else {

--- a/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
@@ -160,7 +160,8 @@ func TestThrottlerThresholdOK(t *testing.T) {
 
 	{
 		resp, err := throttleCheck(primaryTablet)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	}
 }
@@ -173,12 +174,14 @@ func TestThrottlerAfterMetricsCollected(t *testing.T) {
 	// {"StatusCode":200,"Value":0.282278,"Threshold":1,"Message":""}
 	{
 		resp, err := throttleCheck(primaryTablet)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	}
 	{
 		resp, err := throttleCheckSelf(primaryTablet)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	}
 }
@@ -196,12 +199,14 @@ func TestThreadsRunning(t *testing.T) {
 		// {"StatusCode":429,"Value":2,"Threshold":2,"Message":"Threshold exceeded"}
 		{
 			resp, err := throttleCheck(primaryTablet)
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			defer resp.Body.Close()
 			assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 		}
 		{
 			resp, err := throttleCheckSelf(primaryTablet)
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			defer resp.Body.Close()
 			assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 		}
 	})
@@ -210,12 +215,14 @@ func TestThreadsRunning(t *testing.T) {
 		// Restore
 		{
 			resp, err := throttleCheck(primaryTablet)
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			defer resp.Body.Close()
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 		}
 		{
 			resp, err := throttleCheckSelf(primaryTablet)
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			defer resp.Body.Close()
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 		}
 	})
@@ -226,7 +233,7 @@ func vtgateExec(t *testing.T, query string, expectError string) *sqltypes.Result
 
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer conn.Close()
 
 	qr, err := conn.ExecuteFetch(query, 1000, true)

--- a/go/test/endtoend/topoconncache/main_test.go
+++ b/go/test/endtoend/topoconncache/main_test.go
@@ -239,9 +239,10 @@ func testURL(t *testing.T, url string, testCaseName string) {
 
 // getStatusForUrl returns the status code for the URL
 func getStatusForURL(url string) int {
-	resp, _ := http.Get(url)
-	if resp != nil {
-		return resp.StatusCode
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0
 	}
-	return 0
+	defer resp.Body.Close()
+	return resp.StatusCode
 }

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -97,10 +97,8 @@ func execVtgateQuery(t *testing.T, conn *mysql.Conn, database string, query stri
 func checkHealth(t *testing.T, url string) bool {
 	resp, err := http.Get(url)
 	require.NoError(t, err)
-	if err != nil || resp.StatusCode != 200 {
-		return false
-	}
-	return true
+	defer resp.Body.Close()
+	return resp.StatusCode == 200
 }
 
 func waitForQueryResult(t *testing.T, conn *mysql.Conn, database string, query string, want string) {
@@ -129,9 +127,9 @@ func waitForTabletThrottlingStatus(t *testing.T, tablet *cluster.VttabletProcess
 	timer := time.NewTimer(defaultTimeout)
 	defer timer.Stop()
 	for {
-		_, output, err := throttlerCheckSelf(tablet, appName)
+		output, err := throttlerCheckSelf(tablet, appName)
 		require.NoError(t, err)
-		require.NotNil(t, output)
+
 		gotCode, err = jsonparser.GetInt([]byte(output), "StatusCode")
 		require.NoError(t, err)
 		if wantCode == gotCode {

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -81,34 +81,36 @@ func init() {
 	defaultReplicas = 1
 }
 
-func throttleResponse(tablet *cluster.VttabletProcess, path string) (resp *http.Response, respBody string, err error) {
+func throttleResponse(tablet *cluster.VttabletProcess, path string) (respBody string, err error) {
 	apiURL := fmt.Sprintf("http://%s:%d/%s", tablet.TabletHostname, tablet.Port, path)
-	resp, err = httpClient.Get(apiURL)
+	resp, err := httpClient.Get(apiURL)
 	if err != nil {
-		return resp, respBody, err
+		return "", err
 	}
+	defer resp.Body.Close()
 	b, err := io.ReadAll(resp.Body)
 	respBody = string(b)
-	return resp, respBody, err
+	return respBody, err
 }
 
-func throttleApp(tablet *cluster.VttabletProcess, app string) (*http.Response, string, error) {
+func throttleApp(tablet *cluster.VttabletProcess, app string) (string, error) {
 	return throttleResponse(tablet, fmt.Sprintf("throttler/throttle-app?app=%s&duration=1h", app))
 }
 
-func unthrottleApp(tablet *cluster.VttabletProcess, app string) (*http.Response, string, error) {
+func unthrottleApp(tablet *cluster.VttabletProcess, app string) (string, error) {
 	return throttleResponse(tablet, fmt.Sprintf("throttler/unthrottle-app?app=%s", app))
 }
 
-func throttlerCheckSelf(tablet *cluster.VttabletProcess, app string) (resp *http.Response, respBody string, err error) {
+func throttlerCheckSelf(tablet *cluster.VttabletProcess, app string) (respBody string, err error) {
 	apiURL := fmt.Sprintf("http://%s:%d/throttler/check-self?app=%s", tablet.TabletHostname, tablet.Port, app)
-	resp, err = httpClient.Get(apiURL)
+	resp, err := httpClient.Get(apiURL)
 	if err != nil {
-		return resp, respBody, err
+		return "", err
 	}
+	defer resp.Body.Close()
 	b, err := io.ReadAll(resp.Body)
 	respBody = string(b)
-	return resp, respBody, err
+	return respBody, err
 }
 
 func TestVreplicationCopyThrottling(t *testing.T) {
@@ -882,7 +884,7 @@ func materializeProduct(t *testing.T) {
 		t.Run("throttle-app-product", func(t *testing.T) {
 			// Now, throttle the streamer on source tablets, insert some rows
 			for _, tab := range productTablets {
-				_, body, err := throttleApp(tab, sourceThrottlerAppName)
+				body, err := throttleApp(tab, sourceThrottlerAppName)
 				assert.NoError(t, err)
 				assert.Contains(t, body, sourceThrottlerAppName)
 
@@ -900,7 +902,7 @@ func materializeProduct(t *testing.T) {
 		t.Run("unthrottle-app-product", func(t *testing.T) {
 			// unthrottle on source tablets, and expect the rows to show up
 			for _, tab := range productTablets {
-				_, body, err := unthrottleApp(tab, sourceThrottlerAppName)
+				body, err := unthrottleApp(tab, sourceThrottlerAppName)
 				assert.NoError(t, err)
 				assert.Contains(t, body, sourceThrottlerAppName)
 				// give time for unthrottling to take effect and for target to fetch data
@@ -915,7 +917,7 @@ func materializeProduct(t *testing.T) {
 			// Now, throttle vreplication (vcopier/vapplier) on target tablets, and
 			// insert some more rows.
 			for _, tab := range customerTablets {
-				_, body, err := throttleApp(tab, targetThrottlerAppName)
+				body, err := throttleApp(tab, targetThrottlerAppName)
 				assert.NoError(t, err)
 				assert.Contains(t, body, targetThrottlerAppName)
 				// Wait for throttling to take effect (caching will expire by this time):
@@ -933,7 +935,7 @@ func materializeProduct(t *testing.T) {
 		t.Run("unthrottle-app-customer", func(t *testing.T) {
 			// unthrottle on target tablets, and expect the rows to show up
 			for _, tab := range customerTablets {
-				_, body, err := unthrottleApp(tab, targetThrottlerAppName)
+				body, err := unthrottleApp(tab, targetThrottlerAppName)
 				assert.NoError(t, err)
 				assert.Contains(t, body, targetThrottlerAppName)
 			}

--- a/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
+++ b/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
@@ -158,7 +158,8 @@ func TestVSchemaTrackerKeyspaceReInit(t *testing.T) {
 func readVSchema(t *testing.T, vtgate *cluster.VtgateProcess, results *any) {
 	httpClient := &http.Client{Timeout: 5 * time.Second}
 	resp, err := httpClient.Get(vtgate.VSchemaURL)
-	require.Nil(t, err)
+	require.NoError(t, err)
+	defer resp.Body.Close()
 	assert.Equal(t, 200, resp.StatusCode)
 	json.NewDecoder(resp.Body).Decode(results)
 }

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -726,6 +726,7 @@ func MakeAPICall(t *testing.T, url string) (status int, response string) {
 	t.Helper()
 	res, err := http.Get(url)
 	require.NoError(t, err)
+	defer res.Body.Close()
 	bodyBytes, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
 	body := string(bodyBytes)
@@ -799,7 +800,7 @@ func SetupNewClusterSemiSync(t *testing.T) *VtOrcClusterInfo {
 
 	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
 
-	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, fmt.Sprintf("--durability-policy=semi_sync"))
+	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
 	require.NoError(t, err, out)
 
 	// create topo server connection
@@ -877,7 +878,7 @@ func AddSemiSyncKeyspace(t *testing.T, clusterInfo *VtOrcClusterInfo) {
 	}
 
 	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInfo.ClusterInstance.VtctldProcess.GrpcPort, clusterInfo.ClusterInstance.TmpDirectory)
-	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceSemiSyncName, fmt.Sprintf("--durability-policy=semi_sync"))
+	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceSemiSyncName, "--durability-policy=semi_sync")
 	require.NoError(t, err, out)
 }
 

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -491,6 +491,7 @@ func (throttler *Throttler) generateTabletHTTPProbeFunction(ctx context.Context,
 			mySQLThrottleMetric.Err = err
 			return mySQLThrottleMetric
 		}
+		defer resp.Body.Close()
 		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			mySQLThrottleMetric.Err = err

--- a/go/vt/workflow/long_polling_test.go
+++ b/go/vt/workflow/long_polling_test.go
@@ -94,9 +94,11 @@ func TestLongPolling(t *testing.T) {
 	u.Path = "/workflow/action/1"
 	message := `{"path":"/uuid1","name":"button1"}`
 	buf := bytes.NewReader([]byte(message))
-	if _, err := http.Post(u.String(), "application/json; charset=utf-8", buf); err != nil {
+	pResp, err := http.Post(u.String(), "application/json; charset=utf-8", buf)
+	if err != nil {
 		t.Fatalf("/action/1 post failed: %v", err)
 	}
+	pResp.Body.Close()
 	for timeout := 0; ; timeout++ {
 		// This is an asynchronous action, need to take the lock.
 		tw.mu.Lock()

--- a/go/vt/workflow/websocket_test.go
+++ b/go/vt/workflow/websocket_test.go
@@ -46,10 +46,11 @@ func TestWebSocket(t *testing.T) {
 
 	// Start a client websocket.
 	u := url.URL{Scheme: "ws", Host: listener.Addr().String(), Path: "/workflow"}
-	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	c, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	if err != nil {
 		t.Fatalf("WebSocket dial failed: %v", err)
 	}
+	defer resp.Body.Close()
 
 	// Read the original full dump.
 	_, tree, err := c.ReadMessage()

--- a/test.go
+++ b/test.go
@@ -619,9 +619,11 @@ type TestStats struct {
 func sendStats(values url.Values) {
 	if *remoteStats != "" {
 		log.Printf("Sending remote stats to %v", *remoteStats)
-		if _, err := http.PostForm(*remoteStats, values); err != nil {
+		resp, err := http.PostForm(*remoteStats, values)
+		if err != nil {
 			log.Printf("Can't send remote stats: %v", err)
 		}
+		defer resp.Body.Close()
 	}
 }
 


### PR DESCRIPTION
One of the easy things to miss that can cause resource leaks is not closing a response body for an HTTP request.

There's a linter available to make it easier to catch this, so this enables that linter and fixes all the cases reported.

This is almost all test cases, except for one production code path case in the throttler.

This is a backport of #11842. Additionally, it also cherry-picks #10835 since that has similar (test only) fixes that the linter now also finds so should be addressed a well. Lastly it fixes a few more cases in code removed in Vitess 15 and later.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
