### PR TITLE
update golangci-lint to 1.50.1

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Install golangci-lint
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
       - name: Clean Env
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -154,4 +154,4 @@ issues:
 
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.49.0 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.50.1 # use the fixed version to not introduce new linters unexpectedly

--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -16,7 +16,7 @@
 GOLANGCI_LINT=$(command -v golangci-lint >/dev/null 2>&1)
 if [ $? -eq 1 ]; then
   echo "Downloading golangci-lint..."
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 fi
 
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')


### PR DESCRIPTION
## Description
I ran into an issue with the output of git diff not being parseable. That has been fixed in this new version.
