### PR TITLE
support show tables for global keyspaces

### DIFF
--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -575,6 +575,14 @@ func (vw *vschemaWrapper) FindKeyspace(keyspace string) (*vindexes.Keyspace, err
 	return nil, nil
 }
 
+func (vw *vschemaWrapper) GetGlobalTables() []*vindexes.Table {
+	return vw.v.GetGlobalTables()
+}
+
+func (vw *vschemaWrapper) HasGlobalKeyspaceName(ks string) bool {
+	return vw.v.HasGlobalKeyspaceName(ks)
+}
+
 func (vw *vschemaWrapper) Planner() plancontext.PlannerVersion {
 	return vw.version
 }

--- a/go/vt/vtgate/planbuilder/plancontext/vschema.go
+++ b/go/vt/vtgate/planbuilder/plancontext/vschema.go
@@ -34,6 +34,8 @@ type VSchema interface {
 	KeyspaceExists(keyspace string) bool
 	AllKeyspace() ([]*vindexes.Keyspace, error)
 	FindKeyspace(keyspace string) (*vindexes.Keyspace, error)
+	GetGlobalTables() []*vindexes.Table
+	HasGlobalKeyspaceName(keyspace string) bool
 	GetSemTable() *semantics.SemTable
 	Planner() PlannerVersion
 	SetPlannerVersion(pv PlannerVersion)

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -370,6 +370,15 @@ func (vc *vcursorImpl) FindKeyspace(keyspace string) (*vindexes.Keyspace, error)
 	return nil, nil
 }
 
+func (vc *vcursorImpl) GetGlobalTables() []*vindexes.Table {
+	return vc.vschema.GetGlobalTables()
+}
+
+// HasGlobalKeyspaceName provides there is a global keyspace with this name.
+func (vc *vcursorImpl) HasGlobalKeyspaceName(ks string) bool {
+	return vc.vschema.HasGlobalKeyspaceName(ks)
+}
+
 // Planner implements the ContextVSchema interface
 func (vc *vcursorImpl) Planner() plancontext.PlannerVersion {
 	if vc.safeSession.Options != nil &&

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -812,6 +812,17 @@ func (vschema *VSchema) GetKeyspace(keyspace string) *Keyspace {
 	return v.Keyspace
 }
 
+func (vschema *VSchema) GetGlobalTables() []*Table {
+	var tables []*Table
+	for _, table := range vschema.global.tables {
+		tables = append(tables, table)
+	}
+	sort.Slice(tables, func(i, j int) bool {
+		return tables[i].Name.String() < tables[j].Name.String()
+	})
+	return tables
+}
+
 func (vschema *VSchema) HasGlobalKeyspaceName(keyspace string) bool {
 	return vschema.global.hasKeyspaceName(keyspace)
 }


### PR DESCRIPTION
# Description

This PR adds support for `SHOW TABLES` for global keyspaces:

 * VTGate `--global-keyspace` (https://github.com/vitessio/vitess/pull/11876) flag lets you define a named global keyspace.
 * When a global keyspace or no keyspace is specified as the connection initial schema, `SHOW TABLES` returns the names of global tables, which include globally unique table names as well as reference tables that specify a `source`.
 * `SHOW TABLES IN [global_ks]` returns the names of global tables.

# Examples

With no default database:

```sql
mysql> SELECT DATABASE();
+------------+
| database() |
+------------+
|            |
+------------+
1 row in set (0.00 sec)

mysql> SHOW TABLES;
+---------------+
| Global_tables |
+---------------+
| dual          |
| instructors   |
| subjects      |
| tutorials     |
+---------------+
4 rows in set (0.00 sec)

```

With a global keyspace as default database:

```sql
mysql> use vt_global;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> SELECT DATABASE();
+------------+
| database() |
+------------+
| vt_global  |
+------------+
1 row in set (0.00 sec)

mysql> SHOW TABLES;
+---------------+
| Global_tables |
+---------------+
| dual          |
| instructors   |
| subjects      |
| tutorials     |
+---------------+
4 rows in set (0.00 sec)
```

Specifying database name in command:

```mysql
mysql> USE src;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> SHOW TABLES IN vt_global;
+---------------------+
| Tables_in_vt_global |
+---------------------+
| dual                |
| instructors         |
| subjects            |
| tutorials           |
+---------------------+
4 rows in set (0.00 sec)
```

# Use cases

Helps work around limitations of some ORM frameworks (such as Spring + Hibernate):

 * Hibernate [`auto-ddl=validate`](https://docs.spring.io/spring-boot/docs/1.1.0.M1/reference/html/howto-database-initialization.html#howto-initialize-a-database-using-jpa) attempts to introspect table schemas with `SHOW TABLES IN [table_schema]`.
 * For reference tables that exist in multiple keyspaces (see https://github.com/vitessio/vitess/pull/11875), it would be ideal for the user to tell the ORM that the table lives in a global keyspace, e.g. `vt_global`.
 * When the ORM issues `SHOW TABLES in [vt_global]`, without this PR it will get an error like `database not found`.