### PR TITLE
Fix MySQL56 GTID parsing when SID/UUID repeats

### DIFF
--- a/go/mysql/mysql56_gtid_set.go
+++ b/go/mysql/mysql56_gtid_set.go
@@ -119,6 +119,12 @@ func ParseMysql56GTIDSet(s string) (Mysql56GTIDSet, error) {
 			continue
 		}
 
+		if sidIntervals, ok := set[sid]; ok {
+			// SID already exists, we append
+			// Example:  "00010203-0405-0607-0809-0a0b0c0d0e0f:1-5,00010203-0405-0607-0809-0a0b0c0d0e0f:10-20"
+			// turns to: "00010203-0405-0607-0809-0a0b0c0d0e0f:1-5:10-20"
+			intervals = append(sidIntervals, intervals...)
+		}
 		// Internally we expect intervals to be stored in order.
 		slices.SortFunc(intervals, func(a, b interval) bool {
 			return a.start < b.start

--- a/go/mysql/mysql56_gtid_set_test.go
+++ b/go/mysql/mysql56_gtid_set_test.go
@@ -79,6 +79,14 @@ func TestParseMysql56GTIDSet(t *testing.T) {
 		"00010203-0405-0607-0809-0a0b0c0d0e0f:1-5:8-7:10-20": {
 			sid1: []interval{{1, 5}, {10, 20}},
 		},
+		// Same repeating SIDs
+		"00010203-0405-0607-0809-0a0b0c0d0e0f:1-5,00010203-0405-0607-0809-0a0b0c0d0e0f:10-20": {
+			sid1: []interval{{1, 5}, {10, 20}},
+		},
+		// Same repeating SIDs, backwards order
+		"00010203-0405-0607-0809-0a0b0c0d0e0f:10-20,00010203-0405-0607-0809-0a0b0c0d0e0f:1-5": {
+			sid1: []interval{{1, 5}, {10, 20}},
+		},
 		// Multiple SIDs
 		"00010203-0405-0607-0809-0a0b0c0d0e0f:1-5:10-20,00010203-0405-0607-0809-0a0b0c0d0eff:1-5:50": {
 			sid1: []interval{{1, 5}, {10, 20}},
@@ -97,7 +105,7 @@ func TestParseMysql56GTIDSet(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 			continue
 		}
-		assert.True(t, got.Equal(want), "parseMysql56GTIDSet(%#v) = %#v, want %#v", input, got, want)
+		assert.Equal(t, want, got, "parseMysql56GTIDSet(%#v) = %#v, want %#v", input, got, want)
 	}
 }
 
@@ -611,6 +619,46 @@ func TestSubtract(t *testing.T) {
 			lhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8,8bc65cca-3fe4-11ed-bbfb-091034d48b3e:1",
 			rhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8,8bc65cca-3fe4-11ed-bbfb-091034d48b3e:1",
 			difference: "",
+		}, {
+			name:       "subtract prefix",
+			lhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8",
+			rhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-3",
+			difference: "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:4-8",
+		}, {
+			name:       "subtract mid",
+			lhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8",
+			rhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:2-3",
+			difference: "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1:4-8",
+		}, {
+			name:       "subtract suffix",
+			lhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8",
+			rhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:7-8",
+			difference: "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-6",
+		}, {
+			name:       "subtract complex range 1",
+			lhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8:12-17",
+			rhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:7-8",
+			difference: "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-6:12-17",
+		}, {
+			name:       "subtract complex range 2",
+			lhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8:12-17",
+			rhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:12-13",
+			difference: "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8:14-17",
+		}, {
+			name:       "subtract complex range 3",
+			lhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8:12-17",
+			rhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:7-13",
+			difference: "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-6:14-17",
+		}, {
+			name:       "subtract repeating uuid",
+			lhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8,8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:12-17",
+			rhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:7-13",
+			difference: "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-6:14-17",
+		}, {
+			name:       "subtract repeating uuid in descending order",
+			lhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:12-17,8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-8",
+			rhs:        "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:7-13",
+			difference: "8bc65c84-3fe4-11ed-a912-257f0fcdd6c9:1-6:14-17",
 		}, {
 			name:    "parsing error in left set",
 			lhs:     "incorrect set",


### PR DESCRIPTION

## Description

Current codebase has a bug parsing MySQL56 GTID values, when the same SID (or UUID) repeats itself. For example, the following GTID set is valid:
```
00021324-1111-1111-1111-111111111111:100-200,00021324-1111-1111-1111-111111111111:300-400
```
canonically, it is equal to:
```
00021324-1111-1111-1111-111111111111:100-200:300-400
```

but the current code erroneously overwrites existing SID entries and so we end up parsing as:
```
00021324-1111-1111-1111-111111111111:300-400
```

This PR fixes the parsing logic and adds a few tests. The new behavior is compatible with MySQL.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
