### PR TITLE
Online DDL: fix 'vtctlclient OnlineDDL' template queries

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -78,9 +78,9 @@ var (
 )
 
 var vexecUpdateTemplates = []string{
-	`update _vt.schema_migrations set migration_status='val' where mysql_schema='val'`,
-	`update _vt.schema_migrations set migration_status='val' where migration_uuid='val' and mysql_schema='val'`,
-	`update _vt.schema_migrations set migration_status='val' where migration_uuid='val' and mysql_schema='val' and shard='val'`,
+	`update _vt.schema_migrations set migration_status='val1' where mysql_schema='val2'`,
+	`update _vt.schema_migrations set migration_status='val1' where migration_uuid='val2' and mysql_schema='val3'`,
+	`update _vt.schema_migrations set migration_status='val1' where migration_uuid='val2' and mysql_schema='val3' and shard='val4'`,
 }
 
 var vexecInsertTemplates = []string{
@@ -98,7 +98,7 @@ var vexecInsertTemplates = []string{
 		migration_context,
 		migration_status
 	) VALUES (
-		'val', 'val', 'val', 'val', 'val', 'val', 'val', 'val', 'val', FROM_UNIXTIME(0), 'val', 'val'
+		'val1', 'val2', 'val3', 'val4', 'val5', 'val6', 'val7', 'val8', 'val9', FROM_UNIXTIME(0), 'vala', 'valb'
 	)`,
 }
 

--- a/go/vt/vttablet/onlineddl/executor_test.go
+++ b/go/vt/vttablet/onlineddl/executor_test.go
@@ -31,6 +31,26 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
+func TestVexecUpdateTemplates(t *testing.T) {
+	{
+		match, err := sqlparser.QueryMatchesTemplates("select 1 from dual", vexecUpdateTemplates)
+		assert.NoError(t, err)
+		assert.False(t, match)
+	}
+	queries := []string{
+		`update _vt.schema_migrations set migration_status='cancel-all' where mysql_schema='vt_commerce'`,
+		`update _vt.schema_migrations set migration_status = 'cancel-all' where migration_uuid='a5a563da_dc1a_11ec_a416_0a43f95f28a3' and mysql_schema = 'vt_commerce'`,
+		`update _vt.schema_migrations set migration_status = 'cancel-all' where migration_uuid='a5a563da_dc1a_11ec_a416_0a43f95f28a3' and mysql_schema = 'vt_commerce' and shard='0'`,
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			match, err := sqlparser.QueryMatchesTemplates(query, vexecUpdateTemplates)
+			assert.NoError(t, err)
+			assert.True(t, match)
+		})
+	}
+}
+
 func TestValidateAndEditCreateTableStatement(t *testing.T) {
 	e := Executor{}
 	tt := []struct {


### PR DESCRIPTION

## Description

At some point the behavior of `sqlparser.QueryMatchesTemplates(...)` changed such that if the template has multiple recurring `'val'` values, the new behavior expects them to be equal.

This breaks the `vtctlclient OnlineDDL` behavior, because OnlineDDL's query templates used recurring `'val'`. The templates are now updated, and a new unit test validates their behavior.

## Related Issue(s)

#6926

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
