### PR TITLE
Online DDL: `ALTER VIEW` to respect `--postpone-completion` strategy flag

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -2174,7 +2174,7 @@ func (e *Executor) scheduleNextMigration(ctx context.Context) error {
 
 		if !(isImmediateDDL && postponeCompletion) {
 			// Any non-postponed migration can be scheduled
-			// postponed ALTER ALTER can be scheduled (because gh-ost or vreplication will postpone the cut-over)
+			// postponed ALTER can be scheduled (because gh-ost or vreplication will postpone the cut-over)
 			// We only schedule a single migration in the execution of this function
 			onlyScheduleOneMigration.Do(func() {
 				err = e.updateMigrationStatus(ctx, uuid, schema.OnlineDDLStatusReady)

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -111,6 +111,7 @@ const (
 	sqlSelectQueuedMigrations = `SELECT
 			migration_uuid,
 			ddl_action,
+			is_view,
 			postpone_launch,
 			postpone_completion,
 			ready_to_complete


### PR DESCRIPTION

## Description

Addresses https://github.com/vitessio/vitess/issues/11898, see bug description there.

This PR makes `ALTER VIEW` respect `--postpone-completion` strategy flag, in a forward migration as well as in a revert migration.

Added `endtoend` tests to validate.


## Related Issue(s)

https://github.com/vitessio/vitess/issues/11898

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
