### PR TITLE
Online DDL: ensure message is valid `utf8` in `updateMigrationMessage()`

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -4004,12 +4004,12 @@ func (e *Executor) updateDDLAction(ctx context.Context, uuid string, actionStr s
 func (e *Executor) updateMigrationMessage(ctx context.Context, uuid string, message string) error {
 	log.Infof("updateMigrationMessage: uuid=%s, message=%s", uuid, message)
 
-	maxlen := 2048
+	maxlen := 16383
 	update := func(message string) error {
-		message = strings.ToValidUTF8(message, "�")
 		if len(message) > maxlen {
 			message = message[0:maxlen]
 		}
+		message = strings.ToValidUTF8(message, "�")
 		query, err := sqlparser.ParseAndBind(sqlUpdateMessage,
 			sqltypes.StringBindVariable(message),
 			sqltypes.StringBindVariable(uuid),

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -4004,8 +4004,12 @@ func (e *Executor) updateDDLAction(ctx context.Context, uuid string, actionStr s
 func (e *Executor) updateMigrationMessage(ctx context.Context, uuid string, message string) error {
 	log.Infof("updateMigrationMessage: uuid=%s, message=%s", uuid, message)
 
+	maxlen := 2048
 	update := func(message string) error {
-		message = strings.ToValidUTF8(message, "")
+		message = strings.ToValidUTF8(message, "�")
+		if len(message) > maxlen {
+			message = message[0:maxlen]
+		}
 		query, err := sqlparser.ParseAndBind(sqlUpdateMessage,
 			sqltypes.StringBindVariable(message),
 			sqltypes.StringBindVariable(uuid),


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/11913

This PR ensures to clean up non-utf8 characters from the error message reported in `_vt.schema_migrations`. If writing the message still fails for whatever reason (the text is too long?), we opt for an alternative, generic error message.

## Related Issue(s)


https://github.com/vitessio/vitess/issues/11913
#6926

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
