### PR TITLE
VDiff2: Migrate VDiff1 Unit Tests

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -97,6 +97,16 @@ func NewVtctldServer(ts *topo.Server) *VtctldServer {
 	}
 }
 
+// NewTestVtctldServer returns a new VtctldServer for the given topo server
+// for use in tests. This should NOT be used in production.
+func NewTestVtctldServer(ts *topo.Server, tmc tmclient.TabletManagerClient) *VtctldServer {
+	return &VtctldServer{
+		ts:  ts,
+		tmc: tmc,
+		ws:  workflow.NewServer(ts, tmc),
+	}
+}
+
 func panicHandler(err *error) {
 	if x := recover(); x != nil {
 		*err = fmt.Errorf("uncaught panic: %v", x)

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -98,7 +98,7 @@ func NewVtctldServer(ts *topo.Server) *VtctldServer {
 }
 
 // NewTestVtctldServer returns a new VtctldServer for the given topo server
-// for use in tests. This should NOT be used in production.
+// AND tmclient for use in tests. This should NOT be used in production.
 func NewTestVtctldServer(ts *topo.Server, tmc tmclient.TabletManagerClient) *VtctldServer {
 	return &VtctldServer{
 		ts:  ts,

--- a/go/vt/vtctl/vdiff2_test.go
+++ b/go/vt/vtctl/vdiff2_test.go
@@ -107,7 +107,6 @@ func TestVDiff2Unsharded(t *testing.T) {
 		id     string
 		result *sqltypes.Result
 		report string
-		dr     string
 	}{{
 		id: "1",
 		result: sqltypes.MakeTestResult(fields,
@@ -346,7 +345,6 @@ func TestVDiff2Sharded(t *testing.T) {
 		shard1Res *sqltypes.Result
 		shard2Res *sqltypes.Result
 		report    string
-		dr        string
 	}{{
 		id: "1",
 		shard1Res: sqltypes.MakeTestResult(fields,

--- a/go/vt/vtctl/vdiff2_test.go
+++ b/go/vt/vtctl/vdiff2_test.go
@@ -204,7 +204,7 @@ func TestVDiff2Unsharded(t *testing.T) {
 					}
 				]`),
 	}, {
-		id: "7", // only_pks
+		id: "7", // --only_pks
 		result: sqltypes.MakeTestResult(fields,
 			"completed||t1|"+UUID+"|completed|3|"+starttime+"|3|"+comptime+"|1|"+
 				`{"TableName": "t1", "MatchingRows": 2, "ProcessedRows": 3, "MismatchedRows": 1, "ExtraRowsSource": 0, `+
@@ -227,7 +227,7 @@ func TestVDiff2Unsharded(t *testing.T) {
 					}
 				]`),
 	}, {
-		id: "8",
+		id: "8", // --debug_query
 		result: sqltypes.MakeTestResult(fields,
 			"completed||t1|"+UUID+"|completed|3|"+starttime+"|3|"+comptime+"|1|"+
 				`{"TableName": "t1", "MatchingRows": 2, "ProcessedRows": 3, "MismatchedRows": 1, "ExtraRowsSource": 0, `+

--- a/go/vt/vtctl/vdiff2_test.go
+++ b/go/vt/vtctl/vdiff2_test.go
@@ -1,14 +1,340 @@
 package vtctl
 
 import (
+	"context"
+	"fmt"
 	"math"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
 
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/logutil"
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
+	"vitess.io/vitess/go/vt/wrangler"
 )
+
+func TestVDiff2Unsharded(t *testing.T) {
+	env := newTestVDiffEnv([]string{"0"}, []string{"0"}, "", nil)
+	defer env.close()
+
+	fields := sqltypes.MakeTestFields(
+		"vdiff_state|last_error|table_name|uuid|table_state|table_rows|started_at|rows_compared|completed_at|has_mismatch|report",
+		"varbinary|varbinary|varbinary|varchar|varbinary|int64|timestamp|int64|timestamp|int64|json",
+	)
+	UUID := uuid.New().String()
+	options := &tabletmanagerdatapb.VDiffOptions{
+		PickerOptions: &tabletmanagerdatapb.VDiffPickerOptions{
+			TabletTypes: "primary",
+		},
+		CoreOptions: &tabletmanagerdatapb.VDiffCoreOptions{
+			Tables: "t1",
+		},
+		ReportOptions: &tabletmanagerdatapb.VDiffReportOptions{
+			Format: "json",
+		},
+	}
+	req := &tabletmanagerdatapb.VDiffRequest{
+		Keyspace:  "target",
+		Workflow:  env.workflow,
+		Action:    string(vdiff.ShowAction),
+		ActionArg: UUID,
+		VdiffUuid: UUID,
+		Options:   options,
+	}
+	starttime := time.Now().UTC().Format(vdiff.TimestampFormat)
+	comptime := time.Now().Add(1 * time.Second).UTC().Format(vdiff.TimestampFormat)
+	reportfmt := `{
+	"Workflow": "vdiffTest",
+	"Keyspace": "target",
+	"State": "completed",
+	"UUID": "%s",
+	"RowsCompared": %d,
+	"HasMismatch": %t,
+	"Shards": "0",
+	"StartedAt": "%s",
+	"CompletedAt": "%s"
+}
+
+`
+
+	testcases := []struct {
+		id      string
+		result  *sqltypes.Result
+		report  string
+		onlyPks bool
+		debug   bool
+	}{{
+		id: "1",
+		result: sqltypes.MakeTestResult(fields,
+			"completed||t1|"+UUID+"|completed|3|"+starttime+"|3|"+comptime+`|0|{"TableName": "t1", "MatchingRows": 3, "ProcessedRows": 3, "MismatchedRows": 0, "ExtraRowsSource": 0, "ExtraRowsTarget": 0}`),
+		report: fmt.Sprintf(reportfmt,
+			UUID, 3, false, starttime, comptime,
+		),
+	},
+	/*
+		{
+			id: "1",
+			source: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"2|4",
+				"---",
+				"3|1",
+			),
+			target: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|4",
+				"3|1",
+			),
+			dr: &DiffReport{
+				ProcessedRows: 3,
+				MatchingRows:  3,
+				TableName:     "t1",
+			},
+		}, {
+			id: "2",
+			source: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+			),
+			target: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|4",
+				"3|1",
+			),
+			dr: &DiffReport{
+				ProcessedRows:   3,
+				MatchingRows:    1,
+				ExtraRowsTarget: 2,
+				TableName:       "t1",
+				ExtraRowsTargetDiffs: []*RowDiff{
+					{
+						Row: map[string]sqltypes.Value{
+							"c1": sqltypes.NewInt64(2),
+							"c2": sqltypes.NewInt64(4),
+						},
+						Query: "",
+					},
+				},
+			},
+		}, {
+			id: "3",
+			source: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|4",
+				"3|1",
+			),
+			target: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+			),
+			dr: &DiffReport{
+				ProcessedRows:   3,
+				MatchingRows:    1,
+				ExtraRowsSource: 2,
+				TableName:       "t1",
+				ExtraRowsSourceDiffs: []*RowDiff{
+					{
+						Row: map[string]sqltypes.Value{
+							"c1": sqltypes.NewInt64(2),
+							"c2": sqltypes.NewInt64(4),
+						},
+						Query: "",
+					},
+				},
+			},
+		}, {
+			id: "4",
+			source: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|4",
+				"3|1",
+			),
+			target: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"3|1",
+			),
+			dr: &DiffReport{
+				ProcessedRows:   3,
+				MatchingRows:    2,
+				ExtraRowsSource: 1,
+				TableName:       "t1",
+				ExtraRowsSourceDiffs: []*RowDiff{
+					{
+						Row: map[string]sqltypes.Value{
+							"c1": sqltypes.NewInt64(2),
+							"c2": sqltypes.NewInt64(4),
+						},
+						Query: "",
+					},
+				},
+			},
+		}, {
+			id: "5",
+			source: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"3|1",
+			),
+			target: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|4",
+				"3|1",
+			),
+			dr: &DiffReport{
+				ProcessedRows:   3,
+				MatchingRows:    2,
+				ExtraRowsTarget: 1,
+				TableName:       "t1",
+				ExtraRowsTargetDiffs: []*RowDiff{
+					{
+						Row: map[string]sqltypes.Value{
+							"c1": sqltypes.NewInt64(2),
+							"c2": sqltypes.NewInt64(4),
+						},
+						Query: "",
+					},
+				},
+			},
+		}, {
+			id: "6",
+			source: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|3",
+				"3|1",
+			),
+			target: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|4",
+				"3|1",
+			),
+			dr: &DiffReport{
+				ProcessedRows:  3,
+				MatchingRows:   2,
+				MismatchedRows: 1,
+				TableName:      "t1",
+				MismatchedRowsSample: []*DiffMismatch{
+					{
+						Source: &RowDiff{Row: map[string]sqltypes.Value{
+							"c1": sqltypes.NewInt64(2),
+							"c2": sqltypes.NewInt64(3),
+						},
+							Query: "",
+						},
+						Target: &RowDiff{Row: map[string]sqltypes.Value{
+							"c1": sqltypes.NewInt64(2),
+							"c2": sqltypes.NewInt64(4),
+						},
+							Query: "",
+						},
+					},
+				},
+			},
+		}, {
+			id:      "7",
+			onlyPks: true,
+			source: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|3",
+				"3|1",
+			),
+			target: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|4",
+				"3|1",
+			),
+			dr: &DiffReport{
+				ProcessedRows:  3,
+				MatchingRows:   2,
+				MismatchedRows: 1,
+				TableName:      "t1",
+				MismatchedRowsSample: []*DiffMismatch{
+					{
+						Source: &RowDiff{Row: map[string]sqltypes.Value{
+							"c1": sqltypes.NewInt64(2),
+						},
+							Query: "",
+						},
+						Target: &RowDiff{Row: map[string]sqltypes.Value{
+							"c1": sqltypes.NewInt64(2),
+						},
+							Query: "",
+						},
+					},
+				},
+			},
+		}, {
+			id:    "8",
+			debug: true,
+			source: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|3",
+				"3|1",
+			),
+			target: sqltypes.MakeTestStreamingResults(fields,
+				"1|3",
+				"---",
+				"2|4",
+				"3|1",
+			),
+			dr: &DiffReport{
+				ProcessedRows:  3,
+				MatchingRows:   2,
+				MismatchedRows: 1,
+				TableName:      "t1",
+				MismatchedRowsSample: []*DiffMismatch{
+					{
+						Source: &RowDiff{Row: map[string]sqltypes.Value{
+							"c1": sqltypes.NewInt64(2),
+							"c2": sqltypes.NewInt64(3),
+						},
+							Query: "select c1, c2 from t1 where c1=2;",
+						},
+						Target: &RowDiff{Row: map[string]sqltypes.Value{
+							"c1": sqltypes.NewInt64(2),
+							"c2": sqltypes.NewInt64(4),
+						},
+							Query: "select c1, c2 from t1 where c1=2;",
+						},
+					},
+				},
+			},
+		}
+	*/
+	}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.id, func(t *testing.T) {
+			res := &tabletmanagerdatapb.VDiffResponse{
+				Id:     1,
+				Output: sqltypes.ResultToProto3(tcase.result),
+			}
+			env.tmc.setVDResults(env.tablets[200].tablet, req, res)
+			ls := logutil.NewMemoryLogger()
+			env.wr = wrangler.NewTestWrangler(ls, env.topoServ, env.tmc)
+			output, err := env.wr.VDiff2(context.Background(), "target", env.workflow, vdiff.ShowAction, UUID, UUID, options)
+			require.NoError(t, err)
+			vds, err := displayVDiff2ShowSingleSummary(env.wr, options.ReportOptions.Format, "target", env.workflow, UUID, output, false)
+			require.NoError(t, err)
+			require.Equal(t, vdiff.CompletedState, vds)
+			logstr := ls.String()
+			assert.Equal(t, tcase.report, logstr)
+		})
+	}
+}
 
 func TestGetStructNames(t *testing.T) {
 	type s struct {

--- a/go/vt/vtctl/vdiff2_test.go
+++ b/go/vt/vtctl/vdiff2_test.go
@@ -12,10 +12,8 @@ import (
 	"gotest.tools/assert"
 
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/logutil"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
-	"vitess.io/vitess/go/vt/wrangler"
 )
 
 var (
@@ -264,15 +262,14 @@ func TestVDiff2Unsharded(t *testing.T) {
 				Output: sqltypes.ResultToProto3(tcase.result),
 			}
 			env.tmc.setVDResults(env.tablets[200].tablet, req, res)
-			ls := logutil.NewMemoryLogger()
-			env.wr = wrangler.NewTestWrangler(ls, env.topoServ, env.tmc)
 			output, err := env.wr.VDiff2(context.Background(), "target", env.workflow, vdiff.ShowAction, UUID, UUID, options)
 			require.NoError(t, err)
 			vds, err := displayVDiff2ShowSingleSummary(env.wr, options.ReportOptions.Format, "target", env.workflow, UUID, output, false)
 			require.NoError(t, err)
 			require.Equal(t, vdiff.CompletedState, vds)
-			logstr := ls.String()
+			logstr := env.cmdlog.String()
 			assert.Equal(t, tcase.report, logstr)
+			env.cmdlog.Clear()
 		})
 	}
 }
@@ -372,15 +369,14 @@ func TestVDiff2Sharded(t *testing.T) {
 			}
 			env.tmc.setVDResults(env.tablets[200].tablet, req, shard1Res)
 			env.tmc.setVDResults(env.tablets[210].tablet, req, shard2Res)
-			ls := logutil.NewMemoryLogger()
-			env.wr = wrangler.NewTestWrangler(ls, env.topoServ, env.tmc)
 			output, err := env.wr.VDiff2(context.Background(), "target", env.workflow, vdiff.ShowAction, UUID, UUID, options)
 			require.NoError(t, err)
 			vds, err := displayVDiff2ShowSingleSummary(env.wr, options.ReportOptions.Format, "target", env.workflow, UUID, output, true /* verbose */)
 			require.NoError(t, err)
 			require.Equal(t, vdiff.CompletedState, vds)
-			logstr := ls.String()
+			logstr := env.cmdlog.String()
 			assert.Equal(t, tcase.report, logstr)
+			env.cmdlog.Clear()
 		})
 	}
 }

--- a/go/vt/vtctl/vdiff_env_test.go
+++ b/go/vt/vtctl/vdiff_env_test.go
@@ -41,13 +41,13 @@ import (
 const (
 	// vdiffStopPosition is the default stop position for the target vreplication.
 	// It can be overridden with the positons argument to newTestVDiffEnv.
-	vdiffStopPosition = "MariaDB/5-456-892"
+	vdiffStopPosition = "MySQL56/d834e6b8-7cbf-11ed-a1eb-0242ac120002:1-892"
 	// vdiffSourceGtid should be the position reported by the source side VStreamResults.
 	// It's expected to be higher the vdiffStopPosition.
-	vdiffSourceGtid = "MariaDB/5-456-893"
+	vdiffSourceGtid = "MySQL56/d834e6b8-7cbf-11ed-a1eb-0242ac120002:1-893"
 	// vdiffTargetPrimaryPosition is the primary position of the target after
 	// vreplication has been synchronized.
-	vdiffTargetPrimaryPosition = "MariaDB/6-456-892"
+	vdiffTargetPrimaryPosition = "MySQL56/e34d6fb6-7cbf-11ed-a1eb-0242ac120002:1-892"
 )
 
 type testVDiffEnv struct {

--- a/go/vt/vtctl/vdiff_env_test.go
+++ b/go/vt/vtctl/vdiff_env_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtctl
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/grpcclient"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/vttablet/queryservice"
+	"vitess.io/vitess/go/vt/vttablet/queryservice/fakes"
+	"vitess.io/vitess/go/vt/vttablet/tabletconn"
+	"vitess.io/vitess/go/vt/vttablet/tabletconntest"
+	"vitess.io/vitess/go/vt/vttablet/tmclient"
+	"vitess.io/vitess/go/vt/wrangler"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+const (
+	// vdiffStopPosition is the default stop position for the target vreplication.
+	// It can be overridden with the positons argument to newTestVDiffEnv.
+	vdiffStopPosition = "MariaDB/5-456-892"
+	// vdiffSourceGtid should be the position reported by the source side VStreamResults.
+	// It's expected to be higher the vdiffStopPosition.
+	vdiffSourceGtid = "MariaDB/5-456-893"
+	// vdiffTargetPrimaryPosition is the primary position of the target after
+	// vreplication has been synchronized.
+	vdiffTargetPrimaryPosition = "MariaDB/6-456-892"
+)
+
+type testVDiffEnv struct {
+	wr         *wrangler.Wrangler
+	workflow   string
+	topoServ   *topo.Server
+	cell       string
+	tabletType topodatapb.TabletType
+	tmc        *testVDiffTMClient
+
+	mu      sync.Mutex
+	tablets map[int]*testVDiffTablet
+}
+
+// vdiffEnv has to be a global for RegisterDialer to work.
+var vdiffEnv *testVDiffEnv
+
+func init() {
+	tabletconn.RegisterDialer("VDiffTest", func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
+		vdiffEnv.mu.Lock()
+		defer vdiffEnv.mu.Unlock()
+		if qs, ok := vdiffEnv.tablets[int(tablet.Alias.Uid)]; ok {
+			return qs, nil
+		}
+		return nil, fmt.Errorf("tablet %d not found", tablet.Alias.Uid)
+	})
+}
+
+//----------------------------------------------
+// testVDiffEnv
+
+func newTestVDiffEnv(sourceShards, targetShards []string, query string, positions map[string]string) *testVDiffEnv {
+	tabletconntest.SetProtocol("go.vt.vtctl.vdiff_env_test", "VDiffTest")
+	env := &testVDiffEnv{
+		workflow:   "vdiffTest",
+		tablets:    make(map[int]*testVDiffTablet),
+		topoServ:   memorytopo.NewServer("cell"),
+		cell:       "cell",
+		tabletType: topodatapb.TabletType_REPLICA,
+		tmc:        newTestVDiffTMClient(),
+	}
+	tabletID := 100
+	for _, shard := range sourceShards {
+		_ = env.addTablet(tabletID, "source", shard, topodatapb.TabletType_PRIMARY)
+		env.tmc.waitpos[tabletID+1] = vdiffStopPosition
+
+		tabletID += 10
+	}
+	tabletID = 200
+	for _, shard := range targetShards {
+		primary := env.addTablet(tabletID, "target", shard, topodatapb.TabletType_PRIMARY)
+
+		var rows []string
+		var posRows []string
+		for j, sourceShard := range sourceShards {
+			bls := &binlogdatapb.BinlogSource{
+				Keyspace: "source",
+				Shard:    sourceShard,
+				Filter: &binlogdatapb.Filter{
+					Rules: []*binlogdatapb.Rule{{
+						Match:  "t1",
+						Filter: query,
+					}},
+				},
+			}
+			rows = append(rows, fmt.Sprintf("%d|%v|||", j+1, bls))
+			position := vdiffStopPosition
+			if pos := positions[sourceShard+shard]; pos != "" {
+				position = pos
+			}
+			posRows = append(posRows, fmt.Sprintf("%v|%s", bls, position))
+
+			// vdiff.syncTargets. This actually happens after stopTargets.
+			// But this is one statement per stream.
+			env.tmc.setVRResults(
+				primary.tablet,
+				fmt.Sprintf("update _vt.vreplication set state='Running', stop_pos='%s', message='synchronizing for vdiff' where id=%d", vdiffSourceGtid, j+1),
+				&sqltypes.Result{},
+			)
+		}
+		// migrater buildMigrationTargets
+		env.tmc.setVRResults(
+			primary.tablet,
+			"select id, source, message, cell, tablet_types, workflow_type, workflow_sub_type from _vt.vreplication where workflow='vdiffTest' and db_name='vt_target'",
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+				"id|source|message|cell|tablet_types|workflow_type|workflow_sub_type",
+				"int64|varchar|varchar|varchar|varchar|int64|int64"),
+				rows...,
+			),
+		)
+
+		// vdiff.stopTargets
+		env.tmc.setVRResults(primary.tablet, "update _vt.vreplication set state='Stopped', message='for vdiff' where db_name='vt_target' and workflow='vdiffTest'", &sqltypes.Result{})
+		env.tmc.setVRResults(
+			primary.tablet,
+			"select source, pos from _vt.vreplication where db_name='vt_target' and workflow='vdiffTest'",
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+				"source|pos",
+				"varchar|varchar"),
+				posRows...,
+			),
+		)
+
+		// vdiff.syncTargets (continued)
+		env.tmc.vrpos[tabletID] = vdiffSourceGtid
+		env.tmc.pos[tabletID] = vdiffTargetPrimaryPosition
+
+		// vdiff.startQueryStreams
+		env.tmc.waitpos[tabletID+1] = vdiffTargetPrimaryPosition
+
+		// vdiff.restartTargets
+		env.tmc.setVRResults(primary.tablet, "update _vt.vreplication set state='Running', message='', stop_pos='' where db_name='vt_target' and workflow='vdiffTest'", &sqltypes.Result{})
+
+		tabletID += 10
+	}
+	vdiffEnv = env
+	return env
+}
+
+func (env *testVDiffEnv) close() {
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	for _, t := range env.tablets {
+		env.topoServ.DeleteTablet(context.Background(), t.tablet.Alias)
+	}
+	env.tablets = nil
+}
+
+func (env *testVDiffEnv) addTablet(id int, keyspace, shard string, tabletType topodatapb.TabletType) *testVDiffTablet {
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	tablet := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: env.cell,
+			Uid:  uint32(id),
+		},
+		Keyspace: keyspace,
+		Shard:    shard,
+		KeyRange: &topodatapb.KeyRange{},
+		Type:     tabletType,
+		PortMap: map[string]int32{
+			"test": int32(id),
+		},
+	}
+	env.tablets[id] = newTestVDiffTablet(tablet)
+	if err := env.topoServ.InitTablet(context.Background(), tablet, false /* allowPrimaryOverride */, true /* createShardAndKeyspace */, false /* allowUpdate */); err != nil {
+		panic(err)
+	}
+	if tabletType == topodatapb.TabletType_PRIMARY {
+		_, err := env.topoServ.UpdateShardFields(context.Background(), keyspace, shard, func(si *topo.ShardInfo) error {
+			si.PrimaryAlias = tablet.Alias
+			return nil
+		})
+		if err != nil {
+			panic(err)
+		}
+	}
+	return env.tablets[id]
+}
+
+//----------------------------------------------
+// testVDiffTablet
+
+type testVDiffTablet struct {
+	queryservice.QueryService
+	tablet *topodatapb.Tablet
+}
+
+func newTestVDiffTablet(tablet *topodatapb.Tablet) *testVDiffTablet {
+	return &testVDiffTablet{
+		QueryService: fakes.ErrorQueryService,
+		tablet:       tablet,
+	}
+}
+
+func (tvt *testVDiffTablet) StreamHealth(ctx context.Context, callback func(*querypb.StreamHealthResponse) error) error {
+	return callback(&querypb.StreamHealthResponse{
+		Serving: true,
+		Target: &querypb.Target{
+			Keyspace:   tvt.tablet.Keyspace,
+			Shard:      tvt.tablet.Shard,
+			TabletType: tvt.tablet.Type,
+		},
+		RealtimeStats: &querypb.RealtimeStats{},
+	})
+}
+
+//----------------------------------------------
+// testVDiffTMCclient
+
+type testVDiffTMClient struct {
+	tmclient.TabletManagerClient
+	vrQueries  map[int]map[string]*querypb.QueryResult
+	vdRequests map[int]map[string]*tabletmanagerdatapb.VDiffResponse
+	waitpos    map[int]string
+	vrpos      map[int]string
+	pos        map[int]string
+}
+
+func newTestVDiffTMClient() *testVDiffTMClient {
+	return &testVDiffTMClient{
+		vrQueries:  make(map[int]map[string]*querypb.QueryResult),
+		vdRequests: make(map[int]map[string]*tabletmanagerdatapb.VDiffResponse),
+		waitpos:    make(map[int]string),
+		vrpos:      make(map[int]string),
+		pos:        make(map[int]string),
+	}
+}
+
+func (tmc *testVDiffTMClient) setVRResults(tablet *topodatapb.Tablet, query string, result *sqltypes.Result) {
+	queries, ok := tmc.vrQueries[int(tablet.Alias.Uid)]
+	if !ok {
+		queries = make(map[string]*querypb.QueryResult)
+		tmc.vrQueries[int(tablet.Alias.Uid)] = queries
+	}
+	queries[query] = sqltypes.ResultToProto3(result)
+}
+
+func (tmc *testVDiffTMClient) VReplicationExec(ctx context.Context, tablet *topodatapb.Tablet, query string) (*querypb.QueryResult, error) {
+	result, ok := tmc.vrQueries[int(tablet.Alias.Uid)][query]
+	if !ok {
+		return nil, fmt.Errorf("query %q not found for tablet %d", query, tablet.Alias.Uid)
+	}
+	return result, nil
+}
+
+func (tmc *testVDiffTMClient) setVDResults(tablet *topodatapb.Tablet, req *tabletmanagerdatapb.VDiffRequest, res *tabletmanagerdatapb.VDiffResponse) {
+	reqs, ok := tmc.vdRequests[int(tablet.Alias.Uid)]
+	if !ok {
+		reqs = make(map[string]*tabletmanagerdatapb.VDiffResponse)
+		tmc.vdRequests[int(tablet.Alias.Uid)] = reqs
+	}
+	reqs[req.VdiffUuid] = res
+}
+
+func (tmc *testVDiffTMClient) VDiff(ctx context.Context, tablet *topodatapb.Tablet, req *tabletmanagerdatapb.VDiffRequest) (*tabletmanagerdatapb.VDiffResponse, error) {
+	resp, ok := tmc.vdRequests[int(tablet.Alias.Uid)][req.VdiffUuid]
+	if !ok {
+		return nil, fmt.Errorf("request %+v not found for tablet %d", req, tablet.Alias.Uid)
+	}
+	return resp, nil
+}

--- a/go/vt/vttablet/tabletmanager/vdiff/controller.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/controller.go
@@ -91,7 +91,7 @@ func newController(ctx context.Context, row sqltypes.RowNamedValues, dbClientFac
 		ts:              ts,
 		vde:             vde,
 		done:            make(chan struct{}),
-		tmc:             tmclient.NewTabletManagerClient(),
+		tmc:             vde.tmClientFactory(),
 		sources:         make(map[string]*migrationSource),
 		options:         options,
 	}

--- a/go/vt/vttablet/tabletmanager/vdiff/engine.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine.go
@@ -28,6 +28,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	"vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
+	"vitess.io/vitess/go/vt/vttablet/tmclient"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"
@@ -50,6 +51,7 @@ type Engine struct {
 	cancelRetry context.CancelFunc
 
 	ts                      *topo.Server
+	tmClientFactory         func() tmclient.TabletManagerClient
 	dbClientFactoryFiltered func() binlogplayer.DBClient
 	dbClientFactoryDba      func() binlogplayer.DBClient
 	dbName                  string
@@ -68,9 +70,10 @@ type Engine struct {
 
 func NewEngine(config *tabletenv.TabletConfig, ts *topo.Server, tablet *topodata.Tablet) *Engine {
 	vde := &Engine{
-		controllers: make(map[int64]*controller),
-		ts:          ts,
-		thisTablet:  tablet,
+		controllers:     make(map[int64]*controller),
+		ts:              ts,
+		thisTablet:      tablet,
+		tmClientFactory: func() tmclient.TabletManagerClient { return tmclient.NewTabletManagerClient() },
 	}
 	return vde
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/engine.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine.go
@@ -66,6 +66,11 @@ type Engine struct {
 	snapshotMu sync.Mutex
 
 	vdiffSchemaCreateOnce sync.Once
+
+	// This should only be set when the engine is being used in tests. It then provides
+	// modified behavior for that env, e.g. not starting the retry goroutine. This should
+	// NOT be set in production.
+	fortests bool
 }
 
 func NewEngine(config *tabletenv.TabletConfig, ts *topo.Server, tablet *topodata.Tablet) *Engine {
@@ -78,9 +83,26 @@ func NewEngine(config *tabletenv.TabletConfig, ts *topo.Server, tablet *topodata
 	return vde
 }
 
+// NewTestEngine creates an Engine for use in tests. It uses the custom db client factory and
+// tablet manager client factory, while setting the fortests field to true to modify any engine
+// behavior when used in tests (e.g. not starting the retry goroutine).
+func NewTestEngine(ts *topo.Server, tablet *topodata.Tablet, dbn string, dbcf func() binlogplayer.DBClient, tmcf func() tmclient.TabletManagerClient) *Engine {
+	vde := &Engine{
+		controllers:             make(map[int64]*controller),
+		ts:                      ts,
+		thisTablet:              tablet,
+		dbName:                  dbn,
+		dbClientFactoryFiltered: dbcf,
+		dbClientFactoryDba:      dbcf,
+		tmClientFactory:         tmcf,
+		fortests:                true,
+	}
+	return vde
+}
+
 func (vde *Engine) InitDBConfig(dbcfgs *dbconfigs.DBConfigs) {
-	// If we're already initilized, it's a test engine. Ignore the call.
-	if vde.dbClientFactoryFiltered != nil && vde.dbClientFactoryDba != nil {
+	// If it's a test engine and we're already initilized then do nothing.
+	if vde.fortests && vde.dbClientFactoryFiltered != nil && vde.dbClientFactoryDba != nil {
 		return
 	}
 	vde.dbClientFactoryFiltered = func() binlogplayer.DBClient {
@@ -135,7 +157,14 @@ func (vde *Engine) openLocked(ctx context.Context) error {
 
 	// At this point we've fully and succesfully opened so begin
 	// retrying error'd VDiffs until the engine is closed.
-	go vde.retryErroredVDiffs()
+	vde.wg.Add(1)
+	go func() {
+		defer vde.wg.Done()
+		if vde.fortests {
+			return
+		}
+		vde.retryErroredVDiffs()
+	}()
 
 	return nil
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
@@ -127,7 +127,7 @@ func TestEngineOpen(t *testing.T) {
 	}
 }
 
-// Test the full set of VDiff queries on a tablet
+// Test the full set of VDiff queries on a tablet.
 func TestVDiff(t *testing.T) {
 	vdenv := newTestVDiffEnv(t)
 	defer vdenv.close()

--- a/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
@@ -56,15 +56,9 @@ func TestEngineOpen(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			vdenv.dbClient = binlogplayer.NewMockDBClient(t)
-			vdenv.vde = &Engine{
-				controllers:             make(map[int64]*controller),
-				ts:                      tstenv.TopoServ,
-				thisTablet:              vdenv.tablets[100].tablet,
-				dbClientFactoryFiltered: vdenv.dbClientFactory,
-				dbClientFactoryDba:      vdenv.dbClientFactory,
-				dbName:                  vdiffDBName,
-				tmClientFactory:         vdenv.vde.tmClientFactory,
-			}
+			vdenv.vde.Close() // ensure we close any open one
+			vdenv.vde = nil
+			vdenv.vde = NewTestEngine(tstenv.TopoServ, vdenv.tablets[100].tablet, vdiffDBName, vdenv.dbClientFactory, vdenv.tmClientFactory)
 			require.False(t, vdenv.vde.IsOpen())
 
 			initialQR := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
@@ -75,14 +69,12 @@ func TestEngineOpen(t *testing.T) {
 			)
 
 			vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", initialQR, nil)
-
 			vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 				vdiffTestCols,
 				vdiffTestColTypes,
 			),
 				fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, tt.state, optionsJS),
 			), nil)
-
 			vdenv.dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vreplication where workflow = '%s' and db_name = '%s'", vdiffenv.workflow, vdiffDBName), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 				"id|workflow|source|pos|stop_pos|max_tps|max_replication_lag|cell|tablet_types|time_updated|transaction_timestamp|state|message|db_name|rows_copied|tags|time_heartbeat|workflow_type|time_throttled|component_throttled|workflow_sub_type",
 				"int64|varbinary|blob|varbinary|varbinary|int64|int64|varbinary|varbinary|int64|int64|varbinary|varbinary|varbinary|int64|varbinary|int64|int64|int64|varchar|int64",
@@ -90,33 +82,8 @@ func TestEngineOpen(t *testing.T) {
 				fmt.Sprintf("1|%s|%s|%s||9223372036854775807|9223372036854775807||PRIMARY,REPLICA|1669511347|0|Running||%s|200||1669511347|1|0||1", vdiffenv.workflow, vreplSource, vdiffSourceGtid, vdiffDBName),
 			), nil)
 
-			vdenv.dbClient.ExpectRequest("update _vt.vdiff set state = 'started', last_error = '' , started_at = utc_timestamp() where id = 1", singleRowAffected, nil)
-			vdenv.dbClient.ExpectRequest("insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: started')", singleRowAffected, nil)
-			vdenv.dbClient.ExpectRequest(`select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
-						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
-						where vdt.vdiff_id = 1 and vdt.table_name = 't1'`, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-				"lastpk|mismatch|report",
-				"varbinary|int64|json",
-			),
-				`fields:{name:"c1" type:INT64 table:"t1" org_table:"t1" database:"vt_customer" org_name:"c1" column_length:20 charset:63 flags:53251} rows:{lengths:1 values:"1"}|0|{}`,
-			), nil)
-			vdenv.dbClient.ExpectRequest(fmt.Sprintf("select table_name as table_name, table_rows as table_rows from INFORMATION_SCHEMA.TABLES where table_schema = '%s' and table_name in ('t1')", vdiffDBName), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-				"table_name|table_rows",
-				"varchar|int64",
-			),
-				"t1|1",
-			), nil)
-			vdenv.dbClient.ExpectRequest(`select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
-						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
-						where vdt.vdiff_id = 1 and vdt.table_name = 't1'`, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-				"lastpk|mismatch|report",
-				"varbinary|int64|json",
-			),
-				`fields:{name:"c1" type:INT64 table:"t1" org_table:"t1" database:"vt_customer" org_name:"c1" column_length:20 charset:63 flags:53251} rows:{lengths:1 values:"1"}|0|{"TableName": "t1", "MatchingRows": 1, "ProcessedRows": 1, "MismatchedRows": 0, "ExtraRowsSource": 0, "ExtraRowsTarget": 0}`,
-			), nil)
-
 			// Now let's short circuit the vdiff as we know that the open has worked as expected.
-			shortCircuitTestAfterQuery("update _vt.vdiff_table set table_rows = 1 where vdiff_id = 1 and table_name = 't1'", vdiffenv.dbClient)
+			shortCircuitTestAfterQuery("update _vt.vdiff set state = 'started', last_error = '' , started_at = utc_timestamp() where id = 1", vdiffenv.dbClient)
 
 			vdenv.vde.Open(context.Background(), vdiffenv.vre)
 			defer vdenv.vde.Close()

--- a/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
@@ -126,14 +126,12 @@ func TestVDiff(t *testing.T) {
 	require.NoError(t, err)
 
 	vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", controllerQR, nil)
-
 	vdenv.dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vreplication where workflow = '%s' and db_name = '%s'", vdiffenv.workflow, vdiffDBName), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"id|workflow|source|pos|stop_pos|max_tps|max_replication_lag|cell|tablet_types|time_updated|transaction_timestamp|state|message|db_name|rows_copied|tags|time_heartbeat|workflow_type|time_throttled|component_throttled|workflow_sub_type",
 		"int64|varbinary|blob|varbinary|varbinary|int64|int64|varbinary|varbinary|int64|int64|varbinary|varbinary|varbinary|int64|varbinary|int64|int64|int64|varchar|int64",
 	),
 		fmt.Sprintf("1|%s|%s|%s||9223372036854775807|9223372036854775807||PRIMARY,REPLICA|1669511347|0|Running||%s|200||1669511347|1|0||1", vdiffenv.workflow, vreplSource, vdiffSourceGtid, vdiffDBName),
 	), nil)
-
 	vdenv.dbClient.ExpectRequest("update _vt.vdiff set state = 'started', last_error = '' , started_at = utc_timestamp() where id = 1", singleRowAffected, nil)
 	vdenv.dbClient.ExpectRequest("insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: started')", singleRowAffected, nil)
 	vdenv.dbClient.ExpectRequest(`select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
@@ -159,7 +157,7 @@ func TestVDiff(t *testing.T) {
 		`fields:{name:"c1" type:INT64 table:"t1" org_table:"t1" database:"vt_customer" org_name:"c1" column_length:20 charset:63 flags:53251} rows:{lengths:1 values:"1"}|0|{"TableName": "t1", "MatchingRows": 1, "ProcessedRows": 1, "MismatchedRows": 0, "ExtraRowsSource": 0, "ExtraRowsTarget": 0}`,
 	), nil)
 
-	vdenv.dbClient.ExpectRequest("update _vt.vdiff_table set table_rows = 1 where vdiff_id = 1 and table_name = 't1'", noResults, nil)
+	vdenv.dbClient.ExpectRequest("update _vt.vdiff_table set table_rows = 1 where vdiff_id = 1 and table_name = 't1'", singleRowAffected, nil)
 	vdenv.dbClient.ExpectRequest(`select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
 						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
 						where vdt.vdiff_id = 1 and vdt.table_name = 't1'`, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
@@ -168,8 +166,8 @@ func TestVDiff(t *testing.T) {
 	),
 		`fields:{name:"c1" type:INT64 table:"t1" org_table:"t1" database:"vt_customer" org_name:"c1" column_length:20 charset:63 flags:53251} rows:{lengths:1 values:"1"}|0|{"TableName": "t1", "MatchingRows": 1, "ProcessedRows": 1, "MismatchedRows": 0, "ExtraRowsSource": 0, "ExtraRowsTarget": 0}`,
 	), nil)
-	vdenv.dbClient.ExpectRequest("update _vt.vdiff_table set state = 'started' where vdiff_id = 1 and table_name = 't1'", noResults, nil)
-	vdenv.dbClient.ExpectRequest(`insert into _vt.vdiff_log(vdiff_id, message) values (1, 'started: table \'t1\'')`, noResults, nil)
+	vdenv.dbClient.ExpectRequest("update _vt.vdiff_table set state = 'started' where vdiff_id = 1 and table_name = 't1'", singleRowAffected, nil)
+	vdenv.dbClient.ExpectRequest(`insert into _vt.vdiff_log(vdiff_id, message) values (1, 'started: table \'t1\'')`, singleRowAffected, nil)
 	vdenv.dbClient.ExpectRequest(fmt.Sprintf("select id, source, pos from _vt.vreplication where workflow = '%s' and db_name = '%s'", vdiffenv.workflow, vdiffDBName), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"id|source|pos",
 		"int64|varbinary|varbinary",
@@ -184,14 +182,14 @@ func TestVDiff(t *testing.T) {
 	),
 		`fields:{name:"c1" type:INT64 table:"t1" org_table:"t1" database:"vt_customer" org_name:"c1" column_length:20 charset:63 flags:53251} rows:{lengths:1 values:"1"}|0|{}`,
 	), nil)
-	vdenv.dbClient.ExpectRequest(`update _vt.vdiff_table set rows_compared = 0, report = '{\"TableName\":\"t1\",\"ProcessedRows\":0,\"MatchingRows\":0,\"MismatchedRows\":0,\"ExtraRowsSource\":0,\"ExtraRowsTarget\":0}' where vdiff_id = 1 and table_name = 't1'`, noResults, nil)
-	vdenv.dbClient.ExpectRequest(`update _vt.vdiff_table set state = 'completed', rows_compared = 0, report = '{\"TableName\":\"t1\",\"ProcessedRows\":0,\"MatchingRows\":0,\"MismatchedRows\":0,\"ExtraRowsSource\":0,\"ExtraRowsTarget\":0}' where vdiff_id = 1 and table_name = 't1'`, noResults, nil)
-	vdenv.dbClient.ExpectRequest(`insert into _vt.vdiff_log(vdiff_id, message) values (1, 'completed: table \'t1\'')`, noResults, nil)
-	vdenv.dbClient.ExpectRequest("update _vt.vdiff_table set state = 'completed' where vdiff_id = 1 and table_name = 't1'", noResults, nil)
-	vdenv.dbClient.ExpectRequest(`insert into _vt.vdiff_log(vdiff_id, message) values (1, 'completed: table \'t1\'')`, noResults, nil)
-	vdenv.dbClient.ExpectRequest("select table_name as table_name from _vt.vdiff_table where vdiff_id = 1 and state != 'completed'", noResults, nil)
-	vdenv.dbClient.ExpectRequest("update _vt.vdiff set state = 'completed', last_error = '' , completed_at = utc_timestamp() where id = 1", noResults, nil)
-	vdenv.dbClient.ExpectRequest("insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: completed')", noResults, nil)
+	vdenv.dbClient.ExpectRequest(`update _vt.vdiff_table set rows_compared = 0, report = '{\"TableName\":\"t1\",\"ProcessedRows\":0,\"MatchingRows\":0,\"MismatchedRows\":0,\"ExtraRowsSource\":0,\"ExtraRowsTarget\":0}' where vdiff_id = 1 and table_name = 't1'`, singleRowAffected, nil)
+	vdenv.dbClient.ExpectRequest(`update _vt.vdiff_table set state = 'completed', rows_compared = 0, report = '{\"TableName\":\"t1\",\"ProcessedRows\":0,\"MatchingRows\":0,\"MismatchedRows\":0,\"ExtraRowsSource\":0,\"ExtraRowsTarget\":0}' where vdiff_id = 1 and table_name = 't1'`, singleRowAffected, nil)
+	vdenv.dbClient.ExpectRequest(`insert into _vt.vdiff_log(vdiff_id, message) values (1, 'completed: table \'t1\'')`, singleRowAffected, nil)
+	vdenv.dbClient.ExpectRequest("update _vt.vdiff_table set state = 'completed' where vdiff_id = 1 and table_name = 't1'", singleRowAffected, nil)
+	vdenv.dbClient.ExpectRequest(`insert into _vt.vdiff_log(vdiff_id, message) values (1, 'completed: table \'t1\'')`, singleRowAffected, nil)
+	vdenv.dbClient.ExpectRequest("select table_name as table_name from _vt.vdiff_table where vdiff_id = 1 and state != 'completed'", singleRowAffected, nil)
+	vdenv.dbClient.ExpectRequest("update _vt.vdiff set state = 'completed', last_error = '' , completed_at = utc_timestamp() where id = 1", singleRowAffected, nil)
+	vdenv.dbClient.ExpectRequest("insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: completed')", singleRowAffected, nil)
 
 	vdenv.dbClient.Wait()
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
@@ -46,8 +46,41 @@ var (
 				Columns:           []string{"c1", "c2"},
 				PrimaryKeyColumns: []string{"c1"},
 				Fields:            sqltypes.MakeTestFields("c1|c2", "int64|int64"),
+			}, {
+				Name:              "nonpktext",
+				Columns:           []string{"c1", "textcol"},
+				PrimaryKeyColumns: []string{"c1"},
+				Fields:            sqltypes.MakeTestFields("c1|textcol", "int64|varchar"),
+			}, {
+				Name:              "pktext",
+				Columns:           []string{"textcol", "c2"},
+				PrimaryKeyColumns: []string{"textcol"},
+				Fields:            sqltypes.MakeTestFields("textcol|c2", "varchar|int64"),
+			}, {
+				Name:              "multipk",
+				Columns:           []string{"c1", "c2"},
+				PrimaryKeyColumns: []string{"c1", "c2"},
+				Fields:            sqltypes.MakeTestFields("c1|c2", "int64|int64"),
+			}, {
+				Name:              "aggr",
+				Columns:           []string{"c1", "c2", "c3", "c4"},
+				PrimaryKeyColumns: []string{"c1"},
+				Fields:            sqltypes.MakeTestFields("c1|c2|c3|c4", "int64|int64|int64|int64"),
+			}, {
+				Name:              "datze",
+				Columns:           []string{"id", "dt"},
+				PrimaryKeyColumns: []string{"id"},
+				Fields:            sqltypes.MakeTestFields("id|dt", "int64|datetime"),
 			},
 		},
+	}
+	tableDefMap = map[string]int{
+		"t1":        0,
+		"nonpktext": 1,
+		"pktext":    2,
+		"multipk":   3,
+		"aggr":      4,
+		"datze":     5,
 	}
 )
 

--- a/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
@@ -29,14 +29,9 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 var (
-	wfName            = "testwf"
-	optionsJS         = `{"core_options": {"auto_retry": true}}`
-	vdiffTestCols     = "id|vdiff_uuid|workflow|keyspace|shard|db_name|state|options|last_error"
-	vdiffTestColTypes = "int64|varchar|varbinary|varbinary|varchar|varbinary|varbinary|json|varbinary"
 	singleRowAffected = &sqltypes.Result{RowsAffected: 1}
 	noResults         = &sqltypes.Result{}
 	testSchema        = &tabletmanagerdatapb.SchemaDefinition{
@@ -85,6 +80,8 @@ var (
 )
 
 func TestEngineOpen(t *testing.T) {
+	vdenv := newSingleTabletTestVDiffEnv(t)
+	defer vdenv.close()
 	UUID := uuid.New().String()
 	source := `keyspace:"testsrc" shard:"0" filter:{rules:{match:"t1" filter:"select * from t1"}}`
 	tests := []struct {
@@ -107,48 +104,43 @@ func TestEngineOpen(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tablet := addTablet(100)
-			tablet.Type = topodatapb.TabletType_PRIMARY
-			defer deleteTablet(tablet)
-			resetBinlogClient()
-			dbClient := binlogplayer.NewMockDBClient(t)
-			dbClientFactory := func() binlogplayer.DBClient { return dbClient }
-			vde := &Engine{
+			vdenv.dbClient = binlogplayer.NewMockDBClient(t)
+			vdenv.vde = &Engine{
 				controllers:             make(map[int64]*controller),
-				ts:                      vdiffEnv.tenv.TopoServ,
-				thisTablet:              tablet,
-				dbClientFactoryFiltered: dbClientFactory,
-				dbClientFactoryDba:      dbClientFactory,
-				dbName:                  vdiffdb,
+				ts:                      vdenv.tenv.TopoServ,
+				thisTablet:              vdenv.tablets[100].tablet,
+				dbClientFactoryFiltered: vdenv.dbClientFactory,
+				dbClientFactoryDba:      vdenv.dbClientFactory,
+				dbName:                  vdenv.dbName,
 			}
-			require.False(t, vde.IsOpen())
+			require.False(t, vdenv.vde.IsOpen())
 
 			initialQR := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 				vdiffTestCols,
 				vdiffTestColTypes,
 			),
-				fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, wfName, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffdb, tt.state, optionsJS),
+				fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdenv.workflow, vdenv.tenv.KeyspaceName, vdenv.tenv.ShardName, vdiffEnv.dbName, tt.state, optionsJS),
 			)
 
-			dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", initialQR, nil)
+			vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", initialQR, nil)
 
-			dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+			vdenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 				vdiffTestCols,
 				vdiffTestColTypes,
 			),
-				fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, wfName, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffdb, tt.state, optionsJS),
+				fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffEnv.workflow, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffEnv.dbName, tt.state, optionsJS),
 			), nil)
 
-			dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vreplication where workflow = '%s' and db_name = '%s'", wfName, vdiffdb), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+			vdenv.dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vreplication where workflow = '%s' and db_name = '%s'", vdiffEnv.workflow, vdiffEnv.dbName), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 				"id|workflow|source|pos|stop_pos|max_tps|max_replication_lag|cell|tablet_types|time_updated|transaction_timestamp|state|message|db_name|rows_copied|tags|time_heartbeat|workflow_type|time_throttled|component_throttled|workflow_sub_type",
 				"int64|varbinary|blob|varbinary|varbinary|int64|int64|varbinary|varbinary|int64|int64|varbinary|varbinary|varbinary|int64|varbinary|int64|int64|int64|varchar|int64",
 			),
-				fmt.Sprintf("1|%s|%s|MySQL56/f69ed286-6909-11ed-8342-0a50724f3211:1-110||9223372036854775807|9223372036854775807||PRIMARY,REPLICA|1669511347|0|Running||%s|200||1669511347|1|0||1", wfName, source, vdiffdb),
+				fmt.Sprintf("1|%s|%s|MySQL56/f69ed286-6909-11ed-8342-0a50724f3211:1-110||9223372036854775807|9223372036854775807||PRIMARY,REPLICA|1669511347|0|Running||%s|200||1669511347|1|0||1", vdiffEnv.workflow, source, vdiffEnv.dbName),
 			), nil)
 
-			dbClient.ExpectRequest("update _vt.vdiff set state = 'started', last_error = '' , started_at = utc_timestamp() where id = 1", singleRowAffected, nil)
-			dbClient.ExpectRequest("insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: started')", singleRowAffected, nil)
-			dbClient.ExpectRequest(`select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
+			vdenv.dbClient.ExpectRequest("update _vt.vdiff set state = 'started', last_error = '' , started_at = utc_timestamp() where id = 1", singleRowAffected, nil)
+			vdenv.dbClient.ExpectRequest("insert into _vt.vdiff_log(vdiff_id, message) values (1, 'State changed to: started')", singleRowAffected, nil)
+			vdenv.dbClient.ExpectRequest(`select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
 						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
 						where vdt.vdiff_id = 1 and vdt.table_name = 't1'`, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 				"lastpk|mismatch|report",
@@ -156,13 +148,13 @@ func TestEngineOpen(t *testing.T) {
 			),
 				`fields:{name:"c1" type:INT64 table:"t1" org_table:"t1" database:"vt_customer" org_name:"c1" column_length:20 charset:63 flags:53251} rows:{lengths:1 values:"1"}|0|{}`,
 			), nil)
-			dbClient.ExpectRequest("select table_name as table_name, table_rows as table_rows from INFORMATION_SCHEMA.TABLES where table_schema = 'vdiff_test' and table_name in ('t1')", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+			vdenv.dbClient.ExpectRequest("select table_name as table_name, table_rows as table_rows from INFORMATION_SCHEMA.TABLES where table_schema = 'vdiff_test' and table_name in ('t1')", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 				"table_name|table_rows",
 				"varchar|int64",
 			),
 				"t1|1",
 			), nil)
-			dbClient.ExpectRequest(`select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
+			vdenv.dbClient.ExpectRequest(`select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
 						from _vt.vdiff as vd inner join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
 						where vdt.vdiff_id = 1 and vdt.table_name = 't1'`, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 				"lastpk|mismatch|report",
@@ -172,18 +164,20 @@ func TestEngineOpen(t *testing.T) {
 			), nil)
 
 			// Now let's short circuit the vdiff as we know that the open has worked as expected.
-			shortCircuitTestAfterQuery("update _vt.vdiff_table set table_rows = 1 where vdiff_id = 1 and table_name = 't1'", dbClient)
+			shortCircuitTestAfterQuery("update _vt.vdiff_table set table_rows = 1 where vdiff_id = 1 and table_name = 't1'", vdiffEnv.dbClient)
 
-			vde.Open(context.Background(), vdiffEnv.vreplEngine)
-			defer vde.Close()
-			assert.True(t, vde.IsOpen())
-			assert.Equal(t, 1, len(vde.controllers))
-			dbClient.Wait()
+			vdenv.vde.Open(context.Background(), vdiffEnv.vre)
+			defer vdenv.vde.Close()
+			assert.True(t, vdenv.vde.IsOpen())
+			assert.Equal(t, 1, len(vdenv.vde.controllers))
+			vdenv.dbClient.Wait()
 		})
 	}
 }
 
 func TestEngineRetryErroredVDiffs(t *testing.T) {
+	vdenv := newSingleTabletTestVDiffEnv(t)
+	defer vdenv.close()
 	UUID := uuid.New().String()
 	source := `keyspace:"testsrc" shard:"0" filter:{rules:{match:"t1" filter:"select * from t1"}}`
 	expectedControllerCnt := 0
@@ -202,7 +196,7 @@ func TestEngineRetryErroredVDiffs(t *testing.T) {
 				vdiffTestCols,
 				vdiffTestColTypes,
 			),
-				fmt.Sprintf("1|%s|%s|%s|%s|%s|error|%s|%v", UUID, wfName, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffdb, optionsJS,
+				fmt.Sprintf("1|%s|%s|%s|%s|%s|error|%s|%v", UUID, vdiffEnv.workflow, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffEnv.dbName, optionsJS,
 					mysql.NewSQLError(mysql.ERNoSuchTable, "42S02", "Table 'foo' doesn't exist")),
 			),
 		},
@@ -212,7 +206,7 @@ func TestEngineRetryErroredVDiffs(t *testing.T) {
 				vdiffTestCols,
 				vdiffTestColTypes,
 			),
-				fmt.Sprintf("1|%s|%s|%s|%s|%s|error|%s|%v", UUID, wfName, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffdb, optionsJS,
+				fmt.Sprintf("1|%s|%s|%s|%s|%s|error|%s|%v", UUID, vdiffEnv.workflow, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffEnv.dbName, optionsJS,
 					mysql.NewSQLError(mysql.ERLockWaitTimeout, "HY000", "Lock wait timeout exceeded; try restarting transaction")),
 			),
 			expectRetry: true,
@@ -221,29 +215,8 @@ func TestEngineRetryErroredVDiffs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tablet := addTablet(100)
-			tablet.Type = topodatapb.TabletType_PRIMARY
-			defer deleteTablet(tablet)
-			resetBinlogClient()
-			dbClient := binlogplayer.NewMockDBClient(t)
-			dbClientFactory := func() binlogplayer.DBClient { return dbClient }
-			vde := &Engine{
-				controllers:             make(map[int64]*controller),
-				ts:                      vdiffEnv.tenv.TopoServ,
-				thisTablet:              tablet,
-				dbClientFactoryFiltered: dbClientFactory,
-				dbClientFactoryDba:      dbClientFactory,
-				dbName:                  vdiffdb,
-			}
-			require.False(t, vde.IsOpen())
+			vdiffEnv.dbClient.ExpectRequest("select * from _vt.vdiff where state = 'error' and options->>'$.core_options.auto_retry' = 'true'", tt.retryQueryResults, nil)
 
-			dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", noResults, nil)
-			vde.Open(context.Background(), vdiffEnv.vreplEngine)
-			defer vde.Close()
-			assert.True(t, vde.IsOpen())
-			assert.Equal(t, 0, len(vde.controllers))
-
-			dbClient.ExpectRequest("select * from _vt.vdiff where state = 'error' and options->>'$.core_options.auto_retry' = 'true'", tt.retryQueryResults, nil)
 			// Right now this only supports a single row as with multiple rows we have
 			// multiple controllers in separate goroutines and the order is not
 			// guaranteed. If we want to support multiple rows here then we'll need to
@@ -254,31 +227,31 @@ func TestEngineRetryErroredVDiffs(t *testing.T) {
 			for _, row := range tt.retryQueryResults.Rows {
 				id := row[0].ToString()
 				if tt.expectRetry {
-					dbClient.ExpectRequestRE("update _vt.vdiff as vd left join _vt.vdiff_table as vdt on \\(vd.id = vdt.vdiff_id\\) set vd.state = 'pending'.*", singleRowAffected, nil)
-					dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vdiff where id = %s", id), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+					vdiffEnv.dbClient.ExpectRequestRE("update _vt.vdiff as vd left join _vt.vdiff_table as vdt on \\(vd.id = vdt.vdiff_id\\) set vd.state = 'pending'.*", singleRowAffected, nil)
+					vdiffEnv.dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vdiff where id = %s", id), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 						vdiffTestCols,
 						vdiffTestColTypes,
 					),
-						fmt.Sprintf("%s|%s|%s|%s|%s|%s|pending|%s|", id, UUID, wfName, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffdb, optionsJS),
+						fmt.Sprintf("%s|%s|%s|%s|%s|%s|pending|%s|", id, UUID, vdiffEnv.workflow, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffEnv.dbName, optionsJS),
 					), nil)
-					dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vreplication where workflow = '%s' and db_name = '%s'", wfName, vdiffdb), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+					vdiffEnv.dbClient.ExpectRequest(fmt.Sprintf("select * from _vt.vreplication where workflow = '%s' and db_name = '%s'", vdiffEnv.workflow, vdiffEnv.dbName), sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 						"id|workflow|source|pos|stop_pos|max_tps|max_replication_lag|cell|tablet_types|time_updated|transaction_timestamp|state|message|db_name|rows_copied|tags|time_heartbeat|workflow_type|time_throttled|component_throttled|workflow_sub_type",
 						"int64|varbinary|blob|varbinary|varbinary|int64|int64|varbinary|varbinary|int64|int64|varbinary|varbinary|varbinary|int64|varbinary|int64|int64|int64|varchar|int64",
 					),
-						fmt.Sprintf("%s|%s|%s|MySQL56/f69ed286-6909-11ed-8342-0a50724f3211:1-110||9223372036854775807|9223372036854775807||PRIMARY,REPLICA|1669511347|0|Running||%s|200||1669511347|1|0||1", id, wfName, source, vdiffdb),
+						fmt.Sprintf("%s|%s|%s|MySQL56/f69ed286-6909-11ed-8342-0a50724f3211:1-110||9223372036854775807|9223372036854775807||PRIMARY,REPLICA|1669511347|0|Running||%s|200||1669511347|1|0||1", id, vdiffEnv.workflow, source, vdiffEnv.dbName),
 					), nil)
 
 					// At this point we know that we kicked off the expected retry so we can short circit the vdiff.
-					shortCircuitTestAfterQuery(fmt.Sprintf("update _vt.vdiff set state = 'started', last_error = '' , started_at = utc_timestamp() where id = %s", id), dbClient)
+					shortCircuitTestAfterQuery(fmt.Sprintf("update _vt.vdiff set state = 'started', last_error = '' , started_at = utc_timestamp() where id = %s", id), vdiffEnv.dbClient)
 
 					expectedControllerCnt++
 				}
 			}
 
-			err := vde.retryVDiffs(vde.ctx)
+			err := vdiffEnv.vde.retryVDiffs(vdiffEnv.vde.ctx)
 			assert.NoError(t, err)
-			assert.Equal(t, expectedControllerCnt, len(vde.controllers))
-			dbClient.Wait()
+			assert.Equal(t, expectedControllerCnt, len(vdiffEnv.vde.controllers))
+			vdiffEnv.dbClient.Wait()
 		})
 	}
 

--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -60,7 +60,6 @@ const (
 	vdiffDBName = "vttest"
 
 	// vdiffSourceGtid should be the position reported by the source side VStreamResults.
-	// It's expected to be higher the vdiffStopPosition.
 	vdiffSourceGtid            = "MySQL56/f69ed286-6909-11ed-8342-0a50724f3211:1-110"
 	vdiffTargetPrimaryPosition = vdiffSourceGtid
 )
@@ -154,7 +153,7 @@ func init() {
 		}
 		return nil, fmt.Errorf("tablet %d not found", tablet.Alias.Uid)
 	})
-	// TableDiffer does a default grpc dial just to be sure it can talk to the tablet
+	// TableDiffer does a default grpc dial just to be sure it can talk to the tablet.
 	tabletconn.RegisterDialer("grpc", func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
 		vdiffenv.mu.Lock()
 		defer vdiffenv.mu.Unlock()
@@ -525,7 +524,7 @@ func newTestVDiffEnv(t *testing.T) *testVDiffEnv {
 
 	vdiffenv.tmc.schema = testSchema
 	// We need to add t1, which we use for a full VDiff in TestVDiff, to
-	// the schema engine with the PK val
+	// the schema engine with the PK val.
 	st := &schema.Table{
 		Name:      sqlparser.NewIdentifierCS(testSchema.TableDefinitions[tableDefMap["t1"]].Name),
 		Fields:    testSchema.TableDefinitions[tableDefMap["t1"]].Fields,
@@ -552,7 +551,7 @@ func newTestVDiffEnv(t *testing.T) *testVDiffEnv {
 	)
 
 	// vdiff.stopTargets
-	vdiffenv.tmc.setVRResults(primary.tablet, fmt.Sprintf("update _vt.vreplication set state='Stopped', message='for vdiff' where workflow = '%s' and db_name = '%s'", vdiffenv.workflow, vdiffDBName), &sqltypes.Result{})
+	vdiffenv.tmc.setVRResults(primary.tablet, fmt.Sprintf("update _vt.vreplication set state='Stopped', message='for vdiff' where workflow = '%s' and db_name = '%s'", vdiffenv.workflow, vdiffDBName), singleRowAffected)
 
 	// vdiff.syncTargets (continued)
 	vdiffenv.tmc.vrpos[tabletID] = vdiffSourceGtid
@@ -562,7 +561,7 @@ func newTestVDiffEnv(t *testing.T) *testVDiffEnv {
 	vdiffenv.tmc.waitpos[tabletID] = vdiffTargetPrimaryPosition
 
 	// vdiff.restartTargets
-	vdiffenv.tmc.setVRResults(primary.tablet, fmt.Sprintf("update _vt.vreplication set state='Running', message='', stop_pos='' where db_name='%s' and workflow='%s'", vdiffDBName, vdiffenv.workflow), noResults)
+	vdiffenv.tmc.setVRResults(primary.tablet, fmt.Sprintf("update _vt.vreplication set state='Running', message='', stop_pos='' where db_name='%s' and workflow='%s'", vdiffDBName, vdiffenv.workflow), singleRowAffected)
 
 	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", noResults, nil)
 	vdiffenv.vde.Open(context.Background(), vdiffenv.vre)

--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -522,7 +522,7 @@ func newTestVDiffEnv(t *testing.T) *testVDiffEnv {
 		}
 	})
 
-	vdiffenv.vre = vreplication.NewTestEngine(tstenv.TopoServ, tstenv.Cells[0], tstenv.Mysqld, realDBClientFactory, realDBClientFactory, vdiffDBName, nil)
+	vdiffenv.vre = vreplication.NewSimpleTestEngine(tstenv.TopoServ, tstenv.Cells[0], tstenv.Mysqld, realDBClientFactory, realDBClientFactory, vdiffDBName, nil)
 	vdiffenv.vre.Open(context.Background())
 
 	vdiffenv.tmc.schema = testSchema

--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -487,14 +487,14 @@ func (tmc *fakeTMClient) PrimaryPosition(ctx context.Context, tablet *topodatapb
 
 func newTestVDiffEnv(t *testing.T) *testVDiffEnv {
 	vdiffenv = &testVDiffEnv{
-		workflow:        "testwf",
-		tablets:         make(map[int]*fakeTabletConn),
-		tmc:             newFakeTMClient(),
-		se:              schema.NewEngineForTests(),
-		dbClient:        binlogplayer.NewMockDBClient(t),
-		dbClientFactory: func() binlogplayer.DBClient { return vdiffenv.dbClient },
-		tmClientFactory: func() tmclient.TabletManagerClient { return vdiffenv.tmc },
+		workflow: "testwf",
+		tablets:  make(map[int]*fakeTabletConn),
+		tmc:      newFakeTMClient(),
+		se:       schema.NewEngineForTests(),
+		dbClient: binlogplayer.NewMockDBClient(t),
 	}
+	vdiffenv.dbClientFactory = func() binlogplayer.DBClient { return vdiffenv.dbClient }
+	vdiffenv.tmClientFactory = func() tmclient.TabletManagerClient { return vdiffenv.tmc }
 
 	tstenv.KeyspaceName = vdiffDBName
 
@@ -585,6 +585,7 @@ func (tvde *testVDiffEnv) close() {
 	vdiffenv.vse.Close()
 	vdiffenv.vre.Close()
 	vdiffenv.vde.Close()
+	vdiffenv.dbClient.Close()
 }
 
 func (tvde *testVDiffEnv) addTablet(id int, keyspace, shard string, tabletType topodatapb.TabletType) *fakeTabletConn {

--- a/go/vt/vttablet/tabletmanager/vdiff/schema.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/schema.go
@@ -97,8 +97,8 @@ const (
 							and vd.vdiff_uuid = %s`
 	sqlVDiffSummary = `select vd.state as vdiff_state, vd.last_error as last_error, vdt.table_name as table_name,
 						vd.vdiff_uuid as 'uuid', vdt.state as table_state, vdt.table_rows as table_rows,
-						vd.started_at as started_at, vdt.table_rows as table_rows, vdt.rows_compared as rows_compared,
-						vd.completed_at as completed_at, IF(vdt.mismatch = 1, 1, 0) as has_mismatch, vdt.report as report
+						vd.started_at as started_at, vdt.rows_compared as rows_compared, vd.completed_at as completed_at,
+						IF(vdt.mismatch = 1, 1, 0) as has_mismatch, vdt.report as report
 						from _vt.vdiff as vd left join _vt.vdiff_table as vdt on (vd.id = vdt.vdiff_id)
 						where vd.id = %d`
 	// sqlUpdateVDiffState has a penultimate placeholder for any additional columns you want to update, e.g. `, foo = 1`

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -1,0 +1,589 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vdiff
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+)
+
+func TestBuildPlanSuccess(t *testing.T) {
+	UUID := uuid.New()
+	tablet := addTablet(100)
+	tablet.Type = topodatapb.TabletType_PRIMARY
+	defer deleteTablet(tablet)
+	resetBinlogClient()
+	dbClient := binlogplayer.NewMockDBClient(t)
+	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	vde := &Engine{
+		controllers:             make(map[int64]*controller),
+		ts:                      env.TopoServ,
+		thisTablet:              tablet,
+		dbClientFactoryFiltered: dbClientFactory,
+		dbClientFactoryDba:      dbClientFactory,
+		dbName:                  vdiffdb,
+	}
+	require.False(t, vde.IsOpen())
+	opts := &tabletmanagerdatapb.VDiffOptions{
+		CoreOptions: &tabletmanagerdatapb.VDiffCoreOptions{},
+	}
+
+	dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", noResults, nil)
+	vde.Open(context.Background(), vreplEngine)
+	defer vde.Close()
+	assert.True(t, vde.IsOpen())
+
+	vde.Open(context.Background(), vreplEngine)
+	defer vde.Close()
+	assert.True(t, vde.IsOpen())
+	assert.Equal(t, 0, len(vde.controllers))
+
+	vde.mu.Lock()
+	defer vde.mu.Unlock()
+
+	controllerQR := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		vdiffTestCols,
+		vdiffTestColTypes,
+	),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, wfName, env.KeyspaceName, env.ShardName, vdiffdb, PendingState, optionsJS),
+	)
+	dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	ct, err := newController(context.Background(), controllerQR.Named().Row(), dbClientFactory, env.TopoServ, vde, opts)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		input          *binlogdatapb.Rule
+		table          string
+		tablePlan      *tablePlan
+		sourceTimeZone string
+	}{{
+		input: &binlogdatapb.Rule{
+			Match: "t1",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c1, c2 from t1 order by c1 asc",
+			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "-80",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c1, c2 from t1 where in_keyrange('-80') order by c1 asc",
+			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select * from t1",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c1, c2 from t1 order by c1 asc",
+			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select c2, c1 from t1",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c2, c1 from t1 order by c1 asc",
+			targetQuery: "select c2, c1 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), false, "c2"}, {1, collations.Collation(nil), true, "c1"}},
+			comparePKs:  []compareColInfo{{1, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{1},
+			selectPks:   []int{1},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select c0 as c1, c2 from t2",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c0 as c1, c2 from t2 order by c1 asc",
+			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// non-pk text column.
+		input: &binlogdatapb.Rule{
+			Match:  "nonpktext",
+			Filter: "select c1, textcol from nonpktext",
+		},
+		table: "nonpktext",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["nonpktext"]],
+			sourceQuery: "select c1, textcol from nonpktext order by c1 asc",
+			targetQuery: "select c1, textcol from nonpktext order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "textcol"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// non-pk text column, different order.
+		input: &binlogdatapb.Rule{
+			Match:  "nonpktext",
+			Filter: "select textcol, c1 from nonpktext",
+		},
+		table: "nonpktext",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["nonpktext"]],
+			sourceQuery: "select textcol, c1 from nonpktext order by c1 asc",
+			targetQuery: "select textcol, c1 from nonpktext order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), false, "textcol"}, {1, collations.Collation(nil), true, "c1"}},
+			comparePKs:  []compareColInfo{{1, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{1},
+			selectPks:   []int{1},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// pk text column.
+		input: &binlogdatapb.Rule{
+			Match:  "pktext",
+			Filter: "select textcol, c2 from pktext",
+		},
+		table: "pktext",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["pktext"]],
+			sourceQuery: "select textcol, c2 from pktext order by textcol asc",
+			targetQuery: "select textcol, c2 from pktext order by textcol asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "textcol"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "textcol"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("textcol")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// pk text column, different order.
+		input: &binlogdatapb.Rule{
+			Match:  "pktext",
+			Filter: "select c2, textcol from pktext",
+		},
+		table: "pktext",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["pktext"]],
+			sourceQuery: "select c2, textcol from pktext order by textcol asc",
+			targetQuery: "select c2, textcol from pktext order by textcol asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), false, "c2"}, {1, collations.Collation(nil), true, "textcol"}},
+			comparePKs:  []compareColInfo{{1, collations.Collation(nil), true, "textcol"}},
+			pkCols:      []int{1},
+			selectPks:   []int{1},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("textcol")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// text column as expression.
+		input: &binlogdatapb.Rule{
+			Match:  "pktext",
+			Filter: "select c2, a+b as textcol from pktext",
+		},
+		table: "pktext",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["pktext"]],
+			sourceQuery: "select c2, a + b as textcol from pktext order by textcol asc",
+			targetQuery: "select c2, textcol from pktext order by textcol asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), false, "c2"}, {1, collations.Collation(nil), true, "textcol"}},
+			comparePKs:  []compareColInfo{{1, collations.Collation(nil), true, "textcol"}},
+			pkCols:      []int{1},
+			selectPks:   []int{1},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("textcol")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		input: &binlogdatapb.Rule{
+			Match: "multipk",
+		},
+		table: "multipk",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["multipk"]],
+			sourceQuery: "select c1, c2 from multipk order by c1 asc, c2 asc",
+			targetQuery: "select c1, c2 from multipk order by c1 asc, c2 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), true, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), true, "c2"}},
+			pkCols:      []int{0, 1},
+			selectPks:   []int{0, 1},
+			orderBy: sqlparser.OrderBy{
+				&sqlparser.Order{
+					Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+					Direction: sqlparser.AscOrder,
+				},
+				&sqlparser.Order{
+					Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c2")},
+					Direction: sqlparser.AscOrder,
+				},
+			},
+		},
+	}, {
+		// in_keyrange
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select * from t1 where in_keyrange('-80')",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c1, c2 from t1 where in_keyrange('-80') order by c1 asc",
+			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// in_keyrange on RHS of AND.
+		// This is currently not a valid construct, but will be supported in the future.
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select * from t1 where c2 = 2 and in_keyrange('-80')",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c1, c2 from t1 where c2 = 2 and in_keyrange('-80') order by c1 asc",
+			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// in_keyrange on LHS of AND.
+		// This is currently not a valid construct, but will be supported in the future.
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select * from t1 where in_keyrange('-80') and c2 = 2",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c1, c2 from t1 where in_keyrange('-80') and c2 = 2 order by c1 asc",
+			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// in_keyrange on cascaded AND expression
+		// This is currently not a valid construct, but will be supported in the future.
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select * from t1 where c2 = 2 and c1 = 1 and in_keyrange('-80')",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c1, c2 from t1 where c2 = 2 and c1 = 1 and in_keyrange('-80') order by c1 asc",
+			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// in_keyrange parenthesized
+		// This is currently not a valid construct, but will be supported in the future.
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select * from t1 where (c2 = 2 and in_keyrange('-80'))",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c1, c2 from t1 where c2 = 2 and in_keyrange('-80') order by c1 asc",
+			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// group by
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select * from t1 group by c1",
+		},
+		table: "t1",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["t1"]],
+			sourceQuery: "select c1, c2 from t1 group by c1 order by c1 asc",
+			targetQuery: "select c1, c2 from t1 order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}, {
+		// aggregations
+		input: &binlogdatapb.Rule{
+			Match:  "aggr",
+			Filter: "select c1, c2, count(*) as c3, sum(c4) as c4 from t1 group by c1",
+		},
+		table: "aggr",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["aggr"]],
+			sourceQuery: "select c1, c2, count(*) as c3, sum(c4) as c4 from t1 group by c1 order by c1 asc",
+			targetQuery: "select c1, c2, c3, c4 from aggr order by c1 asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "c1"}, {1, collations.Collation(nil), false, "c2"}, {2, collations.Collation(nil), false, "c3"}, {3, collations.Collation(nil), false, "c4"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "c1"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("c1")},
+				Direction: sqlparser.AscOrder,
+			}},
+			aggregates: []*engine.AggregateParams{{
+				Opcode: engine.AggregateSum,
+				Col:    2,
+			}, {
+				Opcode: engine.AggregateSum,
+				Col:    3,
+			}},
+		},
+	}, {
+		input: &binlogdatapb.Rule{
+			Match: "datze",
+		},
+		sourceTimeZone: "US/Pacific",
+		table:          "datze",
+		tablePlan: &tablePlan{
+			table:       testSchema.TableDefinitions[tableDefMap["datze"]],
+			sourceQuery: "select id, dt from datze order by id asc",
+			targetQuery: "select id, convert_tz(dt, 'UTC', 'US/Pacific') as dt from datze order by id asc",
+			compareCols: []compareColInfo{{0, collations.Collation(nil), true, "id"}, {1, collations.Collation(nil), false, "dt"}},
+			comparePKs:  []compareColInfo{{0, collations.Collation(nil), true, "id"}},
+			pkCols:      []int{0},
+			selectPks:   []int{0},
+			orderBy: sqlparser.OrderBy{&sqlparser.Order{
+				Expr:      &sqlparser.ColName{Name: sqlparser.NewIdentifierCI("id")},
+				Direction: sqlparser.AscOrder,
+			}},
+		},
+	}}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.input.Filter, func(t *testing.T) {
+			if tcase.sourceTimeZone != "" {
+				ct.targetTimeZone = "UTC"
+				ct.sourceTimeZone = tcase.sourceTimeZone
+				defer func() {
+					ct.targetTimeZone = ""
+					ct.sourceTimeZone = ""
+				}()
+			}
+			dbc := binlogplayer.NewMockDBClient(t)
+			filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{tcase.input}}
+			opts.CoreOptions.Tables = tcase.table
+			wd, err := newWorkflowDiffer(ct, opts)
+			require.NoError(t, err)
+			dbc.ExpectRequestRE("select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report", noResults, nil)
+			err = wd.buildPlan(dbc, filter, testSchema)
+			require.NoError(t, err, tcase.input)
+			require.Equal(t, 1, len(wd.tableDiffers), tcase.input)
+			assert.Equal(t, tcase.tablePlan, wd.tableDiffers[tcase.table].tablePlan, tcase.input)
+		})
+	}
+}
+
+func TestBuildPlanFailure(t *testing.T) {
+	UUID := uuid.New()
+	tablet := addTablet(100)
+	tablet.Type = topodatapb.TabletType_PRIMARY
+	defer deleteTablet(tablet)
+	resetBinlogClient()
+	dbClient := binlogplayer.NewMockDBClient(t)
+	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	vde := &Engine{
+		controllers:             make(map[int64]*controller),
+		ts:                      env.TopoServ,
+		thisTablet:              tablet,
+		dbClientFactoryFiltered: dbClientFactory,
+		dbClientFactoryDba:      dbClientFactory,
+		dbName:                  vdiffdb,
+	}
+	require.False(t, vde.IsOpen())
+	opts := &tabletmanagerdatapb.VDiffOptions{
+		CoreOptions: &tabletmanagerdatapb.VDiffCoreOptions{},
+	}
+
+	dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", noResults, nil)
+	vde.Open(context.Background(), vreplEngine)
+	defer vde.Close()
+	assert.True(t, vde.IsOpen())
+
+	vde.Open(context.Background(), vreplEngine)
+	defer vde.Close()
+	assert.True(t, vde.IsOpen())
+	assert.Equal(t, 0, len(vde.controllers))
+
+	vde.mu.Lock()
+	defer vde.mu.Unlock()
+
+	controllerQR := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		vdiffTestCols,
+		vdiffTestColTypes,
+	),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, wfName, env.KeyspaceName, env.ShardName, vdiffdb, PendingState, optionsJS),
+	)
+	dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	ct, err := newController(context.Background(), controllerQR.Named().Row(), dbClientFactory, env.TopoServ, vde, opts)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		input *binlogdatapb.Rule
+		err   string
+	}{{
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "bad query",
+		},
+		err: "syntax error at position 4 near 'bad'",
+	}, {
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "update t1 set c1=2",
+		},
+		err: "unexpected: update t1 set c1 = 2",
+	}, {
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select c1+1 from t1",
+		},
+		err: "expression needs an alias: c1 + 1",
+	}, {
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select next 2 values from t1",
+		},
+		err: "unexpected: select next 2 values from t1",
+	}, {
+		input: &binlogdatapb.Rule{
+			Match:  "t1",
+			Filter: "select c3 from t1",
+		},
+		err: "column c3 not found in table t1 on tablet cell:\"cell1\" uid:100",
+	}}
+	for _, tcase := range testcases {
+		dbc := binlogplayer.NewMockDBClient(t)
+		filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{tcase.input}}
+		opts.CoreOptions.Tables = tcase.input.Match
+		wd, err := newWorkflowDiffer(ct, opts)
+		require.NoError(t, err)
+		dbc.ExpectRequestRE("select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report", noResults, nil)
+		err = wd.buildPlan(dbc, filter, testSchema)
+		assert.EqualError(t, err, tcase.err, tcase.input)
+	}
+}

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -46,7 +46,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
 	vde := &Engine{
 		controllers:             make(map[int64]*controller),
-		ts:                      env.TopoServ,
+		ts:                      vdiffEnv.tenv.TopoServ,
 		thisTablet:              tablet,
 		dbClientFactoryFiltered: dbClientFactory,
 		dbClientFactoryDba:      dbClientFactory,
@@ -58,11 +58,11 @@ func TestBuildPlanSuccess(t *testing.T) {
 	}
 
 	dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", noResults, nil)
-	vde.Open(context.Background(), vreplEngine)
+	vde.Open(context.Background(), vdiffEnv.vreplEngine)
 	defer vde.Close()
 	assert.True(t, vde.IsOpen())
 
-	vde.Open(context.Background(), vreplEngine)
+	vde.Open(context.Background(), vdiffEnv.vreplEngine)
 	defer vde.Close()
 	assert.True(t, vde.IsOpen())
 	assert.Equal(t, 0, len(vde.controllers))
@@ -74,10 +74,10 @@ func TestBuildPlanSuccess(t *testing.T) {
 		vdiffTestCols,
 		vdiffTestColTypes,
 	),
-		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, wfName, env.KeyspaceName, env.ShardName, vdiffdb, PendingState, optionsJS),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, wfName, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffdb, PendingState, optionsJS),
 	)
 	dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
-	ct, err := newController(context.Background(), controllerQR.Named().Row(), dbClientFactory, env.TopoServ, vde, opts)
+	ct, err := newController(context.Background(), controllerQR.Named().Row(), dbClientFactory, vdiffEnv.tenv.TopoServ, vde, opts)
 	require.NoError(t, err)
 
 	testcases := []struct {
@@ -508,7 +508,7 @@ func TestBuildPlanInclude(t *testing.T) {
 	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
 	vde := &Engine{
 		controllers:             make(map[int64]*controller),
-		ts:                      env.TopoServ,
+		ts:                      vdiffEnv.tenv.TopoServ,
 		thisTablet:              tablet,
 		dbClientFactoryFiltered: dbClientFactory,
 		dbClientFactoryDba:      dbClientFactory,
@@ -520,11 +520,11 @@ func TestBuildPlanInclude(t *testing.T) {
 	}
 
 	dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", noResults, nil)
-	vde.Open(context.Background(), vreplEngine)
+	vde.Open(context.Background(), vdiffEnv.vreplEngine)
 	defer vde.Close()
 	assert.True(t, vde.IsOpen())
 
-	vde.Open(context.Background(), vreplEngine)
+	vde.Open(context.Background(), vdiffEnv.vreplEngine)
 	defer vde.Close()
 	assert.True(t, vde.IsOpen())
 	assert.Equal(t, 0, len(vde.controllers))
@@ -536,10 +536,10 @@ func TestBuildPlanInclude(t *testing.T) {
 		vdiffTestCols,
 		vdiffTestColTypes,
 	),
-		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", uuid.New(), wfName, env.KeyspaceName, env.ShardName, vdiffdb, PendingState, optionsJS),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", uuid.New(), wfName, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffdb, PendingState, optionsJS),
 	)
 	dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
-	ct, err := newController(context.Background(), controllerQR.Named().Row(), dbClientFactory, env.TopoServ, vde, opts)
+	ct, err := newController(context.Background(), controllerQR.Named().Row(), dbClientFactory, vdiffEnv.tenv.TopoServ, vde, opts)
 	require.NoError(t, err)
 
 	schm := &tabletmanagerdatapb.SchemaDefinition{
@@ -565,9 +565,9 @@ func TestBuildPlanInclude(t *testing.T) {
 			Fields:            sqltypes.MakeTestFields("c1|c2", "int64|int64"),
 		}},
 	}
-	tmc.schema = schm
+	vdiffEnv.tmc.schema = schm
 	defer func() {
-		tmc.schema = testSchema
+		vdiffEnv.tmc.schema = testSchema
 	}()
 	rule := &binlogdatapb.Rule{
 		Match: "/.*",
@@ -610,7 +610,7 @@ func TestBuildPlanFailure(t *testing.T) {
 	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
 	vde := &Engine{
 		controllers:             make(map[int64]*controller),
-		ts:                      env.TopoServ,
+		ts:                      vdiffEnv.tenv.TopoServ,
 		thisTablet:              tablet,
 		dbClientFactoryFiltered: dbClientFactory,
 		dbClientFactoryDba:      dbClientFactory,
@@ -622,11 +622,11 @@ func TestBuildPlanFailure(t *testing.T) {
 	}
 
 	dbClient.ExpectRequest("select * from _vt.vdiff where state in ('started','pending')", noResults, nil)
-	vde.Open(context.Background(), vreplEngine)
+	vde.Open(context.Background(), vdiffEnv.vreplEngine)
 	defer vde.Close()
 	assert.True(t, vde.IsOpen())
 
-	vde.Open(context.Background(), vreplEngine)
+	vde.Open(context.Background(), vdiffEnv.vreplEngine)
 	defer vde.Close()
 	assert.True(t, vde.IsOpen())
 	assert.Equal(t, 0, len(vde.controllers))
@@ -638,10 +638,10 @@ func TestBuildPlanFailure(t *testing.T) {
 		vdiffTestCols,
 		vdiffTestColTypes,
 	),
-		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, wfName, env.KeyspaceName, env.ShardName, vdiffdb, PendingState, optionsJS),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, wfName, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffdb, PendingState, optionsJS),
 	)
 	dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
-	ct, err := newController(context.Background(), controllerQR.Named().Row(), dbClientFactory, env.TopoServ, vde, opts)
+	ct, err := newController(context.Background(), controllerQR.Named().Row(), dbClientFactory, vdiffEnv.tenv.TopoServ, vde, opts)
 	require.NoError(t, err)
 
 	testcases := []struct {
@@ -694,6 +694,19 @@ func TestDiffTableAggregates(t *testing.T) {
 }
 
 func TestDiffUnsharded(t *testing.T) {
+	vdiffTestEnv := newTestVDiffEnv([]string{"0"}, []string{"0"}, "", nil)
+	defer vdiffTestEnv.close()
+
+	testcases := []struct {
+		id string
+	}{}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.id, func(t *testing.T) {
+			vdiffTestEnv.tablets[101].setResults("select c1, c2 from t1 order by c1 asc", vdiffSourceGtid, make([]*sqltypes.Result, 0))
+			vdiffTestEnv.tablets[201].setResults("select c1, c2 from t1 order by c1 asc", vdiffTargetPrimaryPosition, make([]*sqltypes.Result, 0))
+		})
+	}
 }
 
 func TestDiffSharded(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -36,14 +36,14 @@ import (
 )
 
 func TestBuildPlanSuccess(t *testing.T) {
-	vdenv := newSingleTabletTestVDiffEnv(t)
+	vdenv := newTestVDiffEnv(t)
 	defer vdenv.close()
 	UUID := uuid.New()
 	controllerQR := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		vdiffTestCols,
 		vdiffTestColTypes,
 	),
-		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffenv.dbName, PendingState, optionsJS),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
 	)
 
 	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
@@ -470,14 +470,14 @@ func TestBuildPlanSuccess(t *testing.T) {
 }
 
 func TestBuildPlanInclude(t *testing.T) {
-	vdenv := newSingleTabletTestVDiffEnv(t)
+	vdenv := newTestVDiffEnv(t)
 	defer vdenv.close()
 
 	controllerQR := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		vdiffTestCols,
 		vdiffTestColTypes,
 	),
-		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", uuid.New(), vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffenv.dbName, PendingState, optionsJS),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", uuid.New(), vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
 	)
 	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
 	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffenv.dbClientFactory, tstenv.TopoServ, vdiffenv.vde, vdiffenv.opts)
@@ -542,7 +542,7 @@ func TestBuildPlanInclude(t *testing.T) {
 }
 
 func TestBuildPlanFailure(t *testing.T) {
-	vdenv := newSingleTabletTestVDiffEnv(t)
+	vdenv := newTestVDiffEnv(t)
 	defer vdenv.close()
 	UUID := uuid.New()
 
@@ -550,7 +550,7 @@ func TestBuildPlanFailure(t *testing.T) {
 		vdiffTestCols,
 		vdiffTestColTypes,
 	),
-		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffenv.dbName, PendingState, optionsJS),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffDBName, PendingState, optionsJS),
 	)
 	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
 	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffenv.dbClientFactory, tstenv.TopoServ, vdiffenv.vde, vdiffenv.opts)

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -43,11 +43,11 @@ func TestBuildPlanSuccess(t *testing.T) {
 		vdiffTestCols,
 		vdiffTestColTypes,
 	),
-		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffEnv.workflow, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffEnv.dbName, PendingState, optionsJS),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffenv.dbName, PendingState, optionsJS),
 	)
 
-	vdiffEnv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
-	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffEnv.dbClientFactory, vdiffEnv.tenv.TopoServ, vdiffEnv.vde, vdiffEnv.opts)
+	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffenv.dbClientFactory, tstenv.TopoServ, vdiffenv.vde, vdiffenv.opts)
 	require.NoError(t, err)
 
 	testcases := []struct {
@@ -457,8 +457,8 @@ func TestBuildPlanSuccess(t *testing.T) {
 			}
 			dbc := binlogplayer.NewMockDBClient(t)
 			filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{tcase.input}}
-			vdiffEnv.opts.CoreOptions.Tables = tcase.table
-			wd, err := newWorkflowDiffer(ct, vdiffEnv.opts)
+			vdiffenv.opts.CoreOptions.Tables = tcase.table
+			wd, err := newWorkflowDiffer(ct, vdiffenv.opts)
 			require.NoError(t, err)
 			dbc.ExpectRequestRE("select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report", noResults, nil)
 			err = wd.buildPlan(dbc, filter, testSchema)
@@ -477,10 +477,10 @@ func TestBuildPlanInclude(t *testing.T) {
 		vdiffTestCols,
 		vdiffTestColTypes,
 	),
-		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", uuid.New(), vdiffEnv.workflow, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffEnv.dbName, PendingState, optionsJS),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", uuid.New(), vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffenv.dbName, PendingState, optionsJS),
 	)
-	vdiffEnv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
-	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffEnv.dbClientFactory, vdiffEnv.tenv.TopoServ, vdiffEnv.vde, vdiffEnv.opts)
+	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffenv.dbClientFactory, tstenv.TopoServ, vdiffenv.vde, vdiffenv.opts)
 	require.NoError(t, err)
 
 	schm := &tabletmanagerdatapb.SchemaDefinition{
@@ -506,9 +506,9 @@ func TestBuildPlanInclude(t *testing.T) {
 			Fields:            sqltypes.MakeTestFields("c1|c2", "int64|int64"),
 		}},
 	}
-	vdiffEnv.tmc.schema = schm
+	vdiffenv.tmc.schema = schm
 	defer func() {
-		vdiffEnv.tmc.schema = testSchema
+		vdiffenv.tmc.schema = testSchema
 	}()
 	rule := &binlogdatapb.Rule{
 		Match: "/.*",
@@ -526,8 +526,8 @@ func TestBuildPlanInclude(t *testing.T) {
 
 	for _, tcase := range testcases {
 		dbc := binlogplayer.NewMockDBClient(t)
-		vdiffEnv.opts.CoreOptions.Tables = strings.Join(tcase.tables, ",")
-		wd, err := newWorkflowDiffer(ct, vdiffEnv.opts)
+		vdiffenv.opts.CoreOptions.Tables = strings.Join(tcase.tables, ",")
+		wd, err := newWorkflowDiffer(ct, vdiffenv.opts)
 		require.NoError(t, err)
 		for _, table := range tcase.tables {
 			query := fmt.Sprintf(`select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report
@@ -550,10 +550,10 @@ func TestBuildPlanFailure(t *testing.T) {
 		vdiffTestCols,
 		vdiffTestColTypes,
 	),
-		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffEnv.workflow, vdiffEnv.tenv.KeyspaceName, vdiffEnv.tenv.ShardName, vdiffEnv.dbName, PendingState, optionsJS),
+		fmt.Sprintf("1|%s|%s|%s|%s|%s|%s|%s|", UUID, vdiffenv.workflow, tstenv.KeyspaceName, tstenv.ShardName, vdiffenv.dbName, PendingState, optionsJS),
 	)
-	vdiffEnv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
-	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffEnv.dbClientFactory, vdiffEnv.tenv.TopoServ, vdiffEnv.vde, vdiffEnv.opts)
+	vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where id = 1", noResults, nil)
+	ct, err := newController(context.Background(), controllerQR.Named().Row(), vdiffenv.dbClientFactory, tstenv.TopoServ, vdiffenv.vde, vdiffenv.opts)
 	require.NoError(t, err)
 
 	testcases := []struct {
@@ -593,8 +593,8 @@ func TestBuildPlanFailure(t *testing.T) {
 	for _, tcase := range testcases {
 		dbc := binlogplayer.NewMockDBClient(t)
 		filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{tcase.input}}
-		vdiffEnv.opts.CoreOptions.Tables = tcase.input.Match
-		wd, err := newWorkflowDiffer(ct, vdiffEnv.opts)
+		vdiffenv.opts.CoreOptions.Tables = tcase.input.Match
+		wd, err := newWorkflowDiffer(ct, vdiffenv.opts)
 		require.NoError(t, err)
 		dbc.ExpectRequestRE("select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report", noResults, nil)
 		err = wd.buildPlan(dbc, filter, testSchema)

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -604,9 +604,3 @@ func TestBuildPlanFailure(t *testing.T) {
 
 func TestDiffTableAggregates(t *testing.T) {
 }
-
-func TestDiffUnsharded(t *testing.T) {
-}
-
-func TestDiffSharded(t *testing.T) {
-}

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -250,6 +250,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 			}},
 		},
 	}, {
+		// multiple pk columns.
 		input: &binlogdatapb.Rule{
 			Match: "multipk",
 		},
@@ -336,7 +337,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 			}},
 		},
 	}, {
-		// in_keyrange on cascaded AND expression
+		// in_keyrange on cascaded AND expression.
 		// This is currently not a valid construct, but will be supported in the future.
 		input: &binlogdatapb.Rule{
 			Match:  "t1",
@@ -357,7 +358,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 			}},
 		},
 	}, {
-		// in_keyrange parenthesized
+		// in_keyrange parenthesized.
 		// This is currently not a valid construct, but will be supported in the future.
 		input: &binlogdatapb.Rule{
 			Match:  "t1",
@@ -425,6 +426,7 @@ func TestBuildPlanSuccess(t *testing.T) {
 			}},
 		},
 	}, {
+		// date conversion on import.
 		input: &binlogdatapb.Rule{
 			Match: "datze",
 		},

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -601,6 +601,3 @@ func TestBuildPlanFailure(t *testing.T) {
 		assert.EqualError(t, err, tcase.err, tcase.input)
 	}
 }
-
-func TestDiffTableAggregates(t *testing.T) {
-}

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -136,7 +136,7 @@ type Engine struct {
 
 	// This should only be set in Test Engines in order to short
 	// curcuit functions as needed in unit tests. It's automatically
-	// enabled in NewSimpleTestEngine. This SHOULD NOT be used in
+	// enabled in NewSimpleTestEngine. This should NOT be used in
 	// production.
 	shortcircuit bool
 }

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -653,8 +653,9 @@ func (se *Engine) handleHTTPSchema(response http.ResponseWriter) {
 // doesn't reload.  Use SetTableForTests to set table schema.
 func NewEngineForTests() *Engine {
 	se := &Engine{
-		isOpen: true,
-		tables: make(map[string]*Table),
+		isOpen:    true,
+		tables:    make(map[string]*Table),
+		historian: newHistorian(false, nil),
 	}
 	return se
 }

--- a/go/vt/wrangler/traffic_switcher_test.go
+++ b/go/vt/wrangler/traffic_switcher_test.go
@@ -76,7 +76,7 @@ const (
 func TestTableMigrateMainflow(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	checkCellRouting(t, tme.wr, "cell1", map[string][]string{
 		"t1":     {"ks1.t1"},
@@ -492,7 +492,7 @@ func TestTableMigrateMainflow(t *testing.T) {
 func TestShardMigrateMainflow(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestShardMigrater(ctx, t, []string{"-40", "40-"}, []string{"-80", "80-"})
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	// Initial check
 	checkServedTypes(t, tme.ts, "ks:-40", 3)
@@ -789,7 +789,7 @@ func TestTableMigrateOneToManyKeepAllArtifacts(t *testing.T) {
 func testTableMigrateOneToMany(t *testing.T, keepData, keepRoutingRules bool) {
 	ctx := context.Background()
 	tme := newTestTableMigraterCustom(ctx, t, []string{"0"}, []string{"-80", "80-"}, "select * %s")
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	tme.expectNoPreviousJournals()
 	_, err := tme.wr.SwitchReads(ctx, tme.targetKeyspace, "test", []topodatapb.TabletType{topodatapb.TabletType_RDONLY}, nil, workflow.DirectionForward, false)
@@ -979,7 +979,7 @@ func TestTableMigrateOneToManyDryRun(t *testing.T) {
 	var err error
 	ctx := context.Background()
 	tme := newTestTableMigraterCustom(ctx, t, []string{"0"}, []string{"-80", "80-"}, "select * %s")
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	wantdryRunReads := []string{
 		"Lock keyspace ks1",
@@ -1094,7 +1094,7 @@ func TestTableMigrateOneToManyDryRun(t *testing.T) {
 func TestMigrateFailJournal(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	tme.expectNoPreviousJournals()
 	_, err := tme.wr.SwitchReads(ctx, tme.targetKeyspace, "test", []topodatapb.TabletType{topodatapb.TabletType_RDONLY}, nil, workflow.DirectionForward, false)
@@ -1191,7 +1191,7 @@ func TestMigrateFailJournal(t *testing.T) {
 func TestTableMigrateJournalExists(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	tme.expectNoPreviousJournals()
 	_, err := tme.wr.SwitchReads(ctx, tme.targetKeyspace, "test", []topodatapb.TabletType{topodatapb.TabletType_RDONLY}, nil, workflow.DirectionForward, false)
@@ -1331,7 +1331,7 @@ func TestShardMigrateJournalExists(t *testing.T) {
 func TestTableMigrateCancel(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	tme.expectNoPreviousJournals()
 	_, err := tme.wr.SwitchReads(ctx, tme.targetKeyspace, "test", []topodatapb.TabletType{topodatapb.TabletType_RDONLY}, nil, workflow.DirectionForward, false)
@@ -1383,7 +1383,7 @@ func TestTableMigrateCancel(t *testing.T) {
 func TestTableMigrateCancelDryRun(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	want := []string{
 		"Lock keyspace ks1",
@@ -1441,7 +1441,7 @@ func TestTableMigrateCancelDryRun(t *testing.T) {
 func TestTableMigrateNoReverse(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	tme.expectNoPreviousJournals()
 	_, err := tme.wr.SwitchReads(ctx, tme.targetKeyspace, "test", []topodatapb.TabletType{topodatapb.TabletType_RDONLY}, nil, workflow.DirectionForward, false)
@@ -1542,7 +1542,7 @@ func TestTableMigrateNoReverse(t *testing.T) {
 func TestMigrateFrozen(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	tme.expectNoPreviousJournals()
 	_, err := tme.wr.SwitchReads(ctx, tme.targetKeyspace, "test", []topodatapb.TabletType{topodatapb.TabletType_RDONLY}, nil, workflow.DirectionForward, false)
@@ -1584,7 +1584,7 @@ func TestMigrateFrozen(t *testing.T) {
 func TestMigrateNoStreamsFound(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	tme.dbTargetClients[0].addQuery(streamInfoKs2, &sqltypes.Result{}, nil)
 	tme.dbTargetClients[1].addQuery(streamInfoKs2, &sqltypes.Result{}, nil)
@@ -1600,7 +1600,7 @@ func TestMigrateNoStreamsFound(t *testing.T) {
 func TestMigrateDistinctSources(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	bls := &binlogdatapb.BinlogSource{
 		Keyspace: "ks2",
@@ -1632,7 +1632,7 @@ func TestMigrateDistinctSources(t *testing.T) {
 func TestMigrateMismatchedTables(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	bls := &binlogdatapb.BinlogSource{
 		Keyspace: "ks1",
@@ -1662,7 +1662,7 @@ func TestMigrateMismatchedTables(t *testing.T) {
 func TestTableMigrateAllShardsNotPresent(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	tme.dbTargetClients[0].addQuery(streamInfoKs2, &sqltypes.Result{}, nil)
 
@@ -1677,7 +1677,7 @@ func TestTableMigrateAllShardsNotPresent(t *testing.T) {
 func TestMigrateNoTableWildcards(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigrater(ctx, t)
-	defer tme.stopTablets(t)
+	defer tme.close(t)
 
 	// validate that no previous journals exist
 	tme.dbSourceClients[0].addQueryRE(tsCheckJournals, &sqltypes.Result{}, nil)

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -165,6 +165,7 @@ func TestVExec(t *testing.T) {
 +----------------------+----+--------------------------------+---------+-----------+------------------------------------------+`,
 	}
 	require.Equal(t, strings.Join(dryRunResults, "\n")+"\n\n\n\n\n", logger.String())
+	logger.Clear()
 }
 
 func TestWorkflowStatusUpdate(t *testing.T) {
@@ -364,6 +365,7 @@ func TestWorkflowListAll(t *testing.T) {
 	workflows, err = wr.ListAllWorkflows(ctx, keyspace, false)
 	require.Nil(t, err)
 	require.Equal(t, []string{workflow, "wrWorkflow2"}, workflows)
+	logger.Clear()
 }
 
 func TestVExecValidations(t *testing.T) {

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -731,8 +731,17 @@ func (wr *Wrangler) deleteWorkflowVDiffData(ctx context.Context, tablet *topodat
 // account to be sure that we don't execute the writes if READ_ONLY is set on
 // the MySQL instance.
 func (wr *Wrangler) optimizeCopyStateTable(tablet *topodatapb.Tablet) {
+	if wr.sem != nil {
+		if !wr.sem.TryAcquire() {
+			log.Warningf("Deferring work to optimize the copy_state table on %q due to hitting the maximum concurrent background job limit.",
+				tablet.Alias.String())
+			return
+		}
+		defer wr.sem.Release()
+	}
 	go func() {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
 		sqlOptimizeTable := "optimize table _vt.copy_state"
 		if _, err := wr.tmc.ExecuteFetchAsAllPrivs(ctx, tablet, &tabletmanagerdatapb.ExecuteFetchAsAllPrivsRequest{
 			Query:   []byte(sqlOptimizeTable),

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -737,9 +737,13 @@ func (wr *Wrangler) optimizeCopyStateTable(tablet *topodatapb.Tablet) {
 				tablet.Alias.String())
 			return
 		}
-		defer wr.sem.Release()
 	}
 	go func() {
+		defer func() {
+			if wr.sem != nil {
+				wr.sem.Release()
+			}
+		}()
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
 		sqlOptimizeTable := "optimize table _vt.copy_state"

--- a/go/vt/wrangler/wrangler.go
+++ b/go/vt/wrangler/wrangler.go
@@ -66,6 +66,18 @@ func New(logger logutil.Logger, ts *topo.Server, tmc tmclient.TabletManagerClien
 	}
 }
 
+// New creates a new Wrangler object for use in tests. This should NOT be used
+// in production.
+func NewTestWrangler(logger logutil.Logger, ts *topo.Server, tmc tmclient.TabletManagerClient) *Wrangler {
+	return &Wrangler{
+		logger:   logger,
+		ts:       ts,
+		tmc:      tmc,
+		vtctld:   grpcvtctldserver.NewTestVtctldServer(ts, tmc),
+		sourceTs: ts,
+	}
+}
+
 // TopoServer returns the topo.Server this wrangler is using.
 func (wr *Wrangler) TopoServer() *topo.Server {
 	return wr.ts

--- a/go/vt/wrangler/wrangler.go
+++ b/go/vt/wrangler/wrangler.go
@@ -66,7 +66,7 @@ func New(logger logutil.Logger, ts *topo.Server, tmc tmclient.TabletManagerClien
 	}
 }
 
-// New creates a new Wrangler object for use in tests. This should NOT be used
+// NewTestWrangler creates a new Wrangler object for use in tests. This should NOT be used
 // in production.
 func NewTestWrangler(logger logutil.Logger, ts *topo.Server, tmc tmclient.TabletManagerClient) *Wrangler {
 	return &Wrangler{

--- a/go/vt/wrangler/wrangler.go
+++ b/go/vt/wrangler/wrangler.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver"
@@ -53,6 +54,8 @@ type Wrangler struct {
 	// VExecFunc is a test-only fixture that allows us to short circuit vexec commands.
 	// DO NOT USE in production code.
 	VExecFunc func(ctx context.Context, workflow, keyspace, query string, dryRun bool) (map[*topo.TabletInfo]*sqltypes.Result, error)
+	// Limt the number of concurrent background goroutines if needed.
+	sem *sync2.Semaphore
 }
 
 // New creates a new Wrangler object.


### PR DESCRIPTION
## Description

This effectively ports over the [VDiff1 vtctld/wrangler unit tests](https://github.com/vitessio/vitess/blob/main/go/vt/wrangler/vdiff_test.go) to VDiff2 tablet/tabletmanager and vtctl unit tests, building on the unit test framework code added in https://github.com/vitessio/vitess/pull/11768.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/11151

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added
-   [x] Documentation is not required