### PR TITLE
Fix sending a ServerLost error when reading a packet fails

### DIFF
--- a/go/mysql/conn_flaky_test.go
+++ b/go/mysql/conn_flaky_test.go
@@ -1172,6 +1172,15 @@ func (t testRun) ComQuery(c *Conn, query string, callback func(*sqltypes.Result)
 	if strings.Contains(query, "panic") {
 		panic("test panic attack!")
 	}
+	if strings.Contains(query, "close before rows read") {
+		c.writeFields(selectRowsResult)
+		// We want to close the connection after the fields are written
+		// and read on the client. So we sleep for 100 milliseconds
+		time.Sleep(100 * time.Millisecond)
+		c.Close()
+		return nil
+	}
+
 	if strings.Contains(query, "twice") {
 		callback(selectRowsResult)
 	}

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -416,7 +416,7 @@ func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (*sqltypes.Result, 
 	for {
 		data, err := c.readEphemeralPacket()
 		if err != nil {
-			return nil, false, 0, err
+			return nil, false, 0, NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
 		}
 
 		if c.isEOFPacket(data) {


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Once a connection has received a connection error from MySQL, we close the connection in `dbconn` and other callers. In order for this close to work properly we should be sending a MySQL.`CRServerLost` error. 
All the callers of `readEphemeralPacket` wrap the error and send this error so that the connection can be closed. However, there is one code-path that doesn't do this.

We believe that is an issue. Not sending a mysql.`CRServerLost` error causes the connection to remain open and be reused for the rollback call, even though the connection isn't usable any more. This causes a panic in the code, since we didn't cleanup the state when we error out the first time.

This PR fixes the issue after adding a failing test which ensures that we receive a `CRServerLost` error on MySQL crashing after only sending a field packet.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #11921

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
