### PR TITLE
[ci issue] Tests are running on older versions that do not support the query

### DIFF
--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -58,9 +58,9 @@ func TestSubqueriesHasValues(t *testing.T) {
 	mcmp.AssertMatches(`SELECT id2 FROM t1 WHERE id1 NOT IN (SELECT id1 FROM t1 WHERE id1 > 10) ORDER BY id2`, `[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)] [INT64(5)] [INT64(6)]]`)
 }
 
-// Test only supported in >= v14.0.0
+// Test only supported in >= v16.0.0
 func TestSubqueriesExists(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 14, "vtgate")
+	utils.SkipIfBinaryIsBelowVersion(t, 16, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 


### PR DESCRIPTION
## Description
In a recent PR, I accidentally did not mark on of the end to end tests to only run on the latest version of Vitess.
This change set fixes that issue.

## Related Issue(s)
The problem was introduced in #11875
