### PR TITLE
Also log error on a failure in DiscoverInstance

### DIFF
--- a/go/vt/vtorc/logic/orchestrator.go
+++ b/go/vt/vtorc/logic/orchestrator.go
@@ -234,6 +234,10 @@ func DiscoverInstance(instanceKey inst.InstanceKey, forceDiscovery bool) {
 	backendLatency := latency.Elapsed("backend")
 	instanceLatency := latency.Elapsed("instance")
 
+	if forceDiscovery {
+		log.Infof("Force discovered - %+v, err - %v", instance, err)
+	}
+
 	if instance == nil {
 		failedDiscoveriesCounter.Inc(1)
 		_ = discoveryMetrics.Append(&discovery.Metric{
@@ -253,10 +257,6 @@ func DiscoverInstance(instanceKey inst.InstanceKey, forceDiscovery bool) {
 				err)
 		}
 		return
-	}
-
-	if forceDiscovery {
-		log.Infof("Force discovered - %+v", instance)
 	}
 
 	_ = discoveryMetrics.Append(&discovery.Metric{


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR just moves a single log line around to also print the error if a force discovery of a tablet fails.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #11935

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
