### PR TITLE
CODEOWNERS: Add vrepl team members for vtgate vstream and tablet picker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@ go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @froui
 /go/tools/ @frouioui @systay
 /go/vt/dbconnpool @harshit-gangal @mattlord
 /go/vt/discovery @deepthi @frouioui
+/go/vt/discovery/*tablet_picker* @rohit-nayak-ps @mattlord
 /go/vt/mysqlctl @deepthi @mattlord @rsajwani
 /go/vt/proto @deepthi @harshit-gangal @mattlord
 /go/vt/proto/vtadmin @ajm188 @notfelineit
@@ -53,6 +54,7 @@ go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @froui
 /go/vt/vtexplain @systay @harshit-gangal
 /go/vt/vtgate @harshit-gangal @systay @frouioui @GuptaManan100
 /go/vt/vtgate/planbuilder @harshit-gangal @systay @frouioui @GuptaManan100 @arthurschreiber
+/go/vt/vtgate/*vstream* @rohit-nayak-ps @mattlord
 /go/vt/vtorc @deepthi @shlomi-noach @GuptaManan100 @rsajwani
 /go/vt/vttablet/*conn* @harshit-gangal @systay
 /go/vt/vttablet/endtoend @harshit-gangal @mattlord @rohit-nayak-ps @systay

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,7 @@ go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @froui
 /go/vt/vterrors @harshit-gangal @systay
 /go/vt/vtexplain @systay @harshit-gangal
 /go/vt/vtgate @harshit-gangal @systay @frouioui @GuptaManan100
+/go/vt/vtgate/endtoend/*vstream* @rohit-nayak-ps @mattlord
 /go/vt/vtgate/planbuilder @harshit-gangal @systay @frouioui @GuptaManan100 @arthurschreiber
 /go/vt/vtgate/*vstream* @rohit-nayak-ps @mattlord
 /go/vt/vtorc @deepthi @shlomi-noach @GuptaManan100 @rsajwani


### PR DESCRIPTION
## Description

Both vtgate components/services are related to VReplication:
  - [Tablet Picker](https://vitess.io/docs/16.0/reference/vreplication/tablet_selection/)
  - VStream
    - https://vitess.io/docs/16.0/concepts/vstream/
    - https://deploy-preview-1216--vitess.netlify.app/docs/16.0/reference/vreplication/vstream/

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests are not required
-   [x] Documentation is not required