### PR TITLE
Skip `TestSubqueriesExists` during upgrade-downgrade tests

### DIFF
--- a/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/subquery_test.go
@@ -58,9 +58,9 @@ func TestSubqueriesHasValues(t *testing.T) {
 	mcmp.AssertMatches(`SELECT id2 FROM t1 WHERE id1 NOT IN (SELECT id1 FROM t1 WHERE id1 > 10) ORDER BY id2`, `[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)] [INT64(5)] [INT64(6)]]`)
 }
 
-// Test only supported in >= v14.0.0
+// Test only supported in >= v15.0.0
 func TestSubqueriesExists(t *testing.T) {
-	utils.SkipIfBinaryIsBelowVersion(t, 14, "vtgate")
+	utils.SkipIfBinaryIsBelowVersion(t, 15, "vtgate")
 	mcmp, closer := start(t)
 	defer closer()
 


### PR DESCRIPTION
## Description

The changes made in https://github.com/vitessio/vitess/pull/11911 affected how we treat subqueries/derived tables, it got backported in https://github.com/vitessio/vitess/pull/11922. We skipped the upgrade/downgrade tests for `TestSubqueriesExists` on `main` but did not skip them on `release-15.0`. This PR skips it.

## Related Issue(s)
- Fixes https://github.com/vitessio/vitess/issues/11952

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
