### PR TITLE
Deprecating VExec part1: removing client-side references

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3021,11 +3021,13 @@ func commandOnlineDDL(ctx context.Context, wr *wrangler.Wrangler, subFlags *pfla
 
 		tabletResults := map[string]*sqltypes.Result{}
 		for _, tablet := range resp.Tablets {
+			tabletAlias := topoproto.TabletAliasString(tablet.Alias)
+
 			qrproto, err := wr.ExecuteFetchAsDba(ctx, tablet.Alias, executeFetchQuery, 10000, false, false)
 			if err != nil {
 				return err
 			}
-			tabletResults[tablet.Alias.String()] = sqltypes.Proto3ToResult(qrproto)
+			tabletResults[tabletAlias] = sqltypes.Proto3ToResult(qrproto)
 		}
 		// combine results. This loses sorting if there's more then 1 tablet
 		combinedResults := queryResultForTabletResults(tabletResults)

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -724,16 +724,6 @@ var commands = []commandGroup{
 	{
 		"Workflow", []command{
 			{
-				name:   "VExec",
-				method: commandVExec,
-				params: "<ks.workflow> <query> --dry-run",
-				help:   "Runs query on all tablets in workflow. Example: VExec merchant.morders \"update _vt.vreplication set Status='Running'\"",
-			},
-		},
-	},
-	{
-		"Workflow", []command{
-			{
 				name:   "Workflow",
 				method: commandWorkflow,
 				params: "<ks.workflow> <action> --dry-run",
@@ -3607,45 +3597,6 @@ func commandHelp(ctx context.Context, wr *wrangler.Wrangler, subFlags *pflag.Fla
 		return fmt.Errorf("when calling the Help command, either specify a single argument that identifies the name of the command to get help with or do not specify any additional arguments")
 	}
 
-	return nil
-}
-
-func commandVExec(ctx context.Context, wr *wrangler.Wrangler, subFlags *pflag.FlagSet, args []string) error {
-	deprecationMessage := `VExec command will be deprecated in version v12. For Online DDL control, use "vtctl OnlineDDL" commands or SQL syntax`
-	log.Warningf(deprecationMessage)
-
-	json := subFlags.Bool("json", false, "Output JSON instead of human-readable table")
-	dryRun := subFlags.Bool("dry_run", false, "Does a dry run of VExec and only reports the final query and list of tablets on which it will be applied")
-	if err := subFlags.Parse(args); err != nil {
-		return err
-	}
-	if subFlags.NArg() != 2 {
-		return fmt.Errorf("usage: VExec --dry-run keyspace.workflow \"<query>\"")
-	}
-	keyspace, workflow, err := splitKeyspaceWorkflow(subFlags.Arg(0))
-	if err != nil {
-		return err
-	}
-	_, err = wr.TopoServer().GetKeyspace(ctx, keyspace)
-	if err != nil {
-		wr.Logger().Errorf("keyspace %s not found", keyspace)
-	}
-	query := subFlags.Arg(1)
-
-	qr, err := wr.VExecResult(ctx, workflow, keyspace, query, *dryRun)
-	if err != nil {
-		return err
-	}
-	if *dryRun {
-		return nil
-	}
-	if qr == nil {
-		wr.Logger().Printf("no result returned\n")
-	}
-	if *json {
-		return printJSON(wr.Logger(), qr)
-	}
-	printQueryResult(loggerWriter{wr.Logger()}, qr)
 	return nil
 }
 


### PR DESCRIPTION
## Description


We intended to deprecate `VExec` in `v12` and didn't. A previous iteration, https://github.com/vitessio/vitess/pull/8414, was incorrect because it broke `vtctl OnlineDDL`.

This PR resumes work to be included in `v16`. Additional and final work will only be included in `v17`. Changes are:

- `vtctl OnlineDDL` does not use `VExec` now. Instead, it uses:
  - `ApplySchema` for `cancel`, `retry`, `complete` commands
    the output is changed: previously the output indicated the number of affected migrations. The output now is empty on success.
  - `ExecuteFetchAsDBA` for `select` commands
    the output remains identical to existing codebase
- `vtctl VExec` command is removed.

For backwards compatibility, the server handling of `VExec` is still untouched. We will remove that code in `v17`.

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/8414
- https://github.com/vitessio/vitess/issues/6926#issuecomment-817619302
- 
## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
