### PR TITLE
moved missed flags to pflags in vtgate

### DIFF
--- a/go/vt/vtgate/evalengine/integration/comparison_test.go
+++ b/go/vt/vtgate/evalengine/integration/comparison_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package integration
 
 import (
-	"flag"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations"
@@ -32,13 +33,30 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
-var collationEnv *collations.Environment
+var (
+	collationEnv *collations.Environment
+
+	debugPrintAll        bool
+	debugNormalize       = true
+	debugSimplify        = time.Now().UnixNano()&1 != 0
+	debugCheckTypes      = true
+	debugCheckCollations = true
+)
+
+func registerFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&debugPrintAll, "print-all", debugPrintAll, "print all matching tests")
+	fs.BoolVar(&debugNormalize, "normalize", debugNormalize, "normalize comparisons against MySQL values")
+	fs.BoolVar(&debugSimplify, "simplify", debugSimplify, "simplify expressions before evaluating them")
+	fs.BoolVar(&debugCheckTypes, "check-types", debugCheckTypes, "check the TypeOf operator for all queries")
+	fs.BoolVar(&debugCheckCollations, "check-collations", debugCheckCollations, "check the returned collations for all queries")
+}
 
 func init() {
 	// We require MySQL 8.0 collations for the comparisons in the tests
 	mySQLVersion := "8.0.0"
 	servenv.SetMySQLServerVersionForTest(mySQLVersion)
 	collationEnv = collations.NewEnvironment(mySQLVersion)
+	servenv.OnParse(registerFlags)
 }
 
 func perm(a []string, f func([]string)) {
@@ -83,18 +101,12 @@ func normalize(v sqltypes.Value, coll collations.ID) string {
 	return fmt.Sprintf("%v(%s)", typ, v.Raw())
 }
 
-var debugPrintAll = flag.Bool("print-all", false, "print all matching tests")
-var debugNormalize = flag.Bool("normalize", true, "normalize comparisons against MySQL values")
-var debugSimplify = flag.Bool("simplify", time.Now().UnixNano()&1 != 0, "simplify expressions before evaluating them")
-var debugCheckTypes = flag.Bool("check-types", true, "check the TypeOf operator for all queries")
-var debugCheckCollations = flag.Bool("check-collations", true, "check the returned collations for all queries")
-
 func compareRemoteExpr(t *testing.T, conn *mysql.Conn, expr string) {
 	t.Helper()
 
 	localQuery := "SELECT " + expr
 	remoteQuery := "SELECT " + expr
-	if *debugCheckCollations {
+	if debugCheckCollations {
 		remoteQuery = fmt.Sprintf("SELECT %s, COLLATION(%s)", expr, expr)
 	}
 
@@ -105,33 +117,33 @@ func compareRemoteExpr(t *testing.T, conn *mysql.Conn, expr string) {
 	var localCollation, remoteCollation collations.ID
 	if localErr == nil {
 		v := local.Value()
-		if *debugCheckCollations {
+		if debugCheckCollations {
 			if v.IsNull() {
 				localCollation = collations.CollationBinaryID
 			} else {
 				localCollation = local.Collation()
 			}
 		}
-		if *debugNormalize {
+		if debugNormalize {
 			localVal = normalize(v, local.Collation())
 		} else {
 			localVal = v.String()
 		}
-		if *debugCheckTypes {
+		if debugCheckTypes {
 			tt := v.Type()
 			if tt != sqltypes.Null && tt != localType {
 				t.Errorf("evaluation type mismatch: eval=%v vs typeof=%v\nlocal: %s\nquery: %s (SIMPLIFY=%v)",
-					tt, localType, localVal, localQuery, *debugSimplify)
+					tt, localType, localVal, localQuery, debugSimplify)
 			}
 		}
 	}
 	if remoteErr == nil {
-		if *debugNormalize {
+		if debugNormalize {
 			remoteVal = normalize(remote.Rows[0][0], collations.ID(remote.Fields[0].Charset))
 		} else {
 			remoteVal = remote.Rows[0][0].String()
 		}
-		if *debugCheckCollations {
+		if debugCheckCollations {
 			if remote.Rows[0][0].IsNull() {
 				// TODO: passthrough proper collations for nullable fields
 				remoteCollation = collations.CollationBinaryID
@@ -141,8 +153,8 @@ func compareRemoteExpr(t *testing.T, conn *mysql.Conn, expr string) {
 		}
 	}
 	if diff := compareResult(localErr, remoteErr, localVal, remoteVal, localCollation, remoteCollation); diff != "" {
-		t.Errorf("%s\nquery: %s (SIMPLIFY=%v)", diff, localQuery, *debugSimplify)
-	} else if *debugPrintAll {
+		t.Errorf("%s\nquery: %s (SIMPLIFY=%v)", diff, localQuery, debugSimplify)
+	} else if debugPrintAll {
 		t.Logf("local=%s mysql=%s\nquery: %s", localVal, remoteVal, localQuery)
 	}
 }

--- a/go/vt/vtgate/evalengine/integration/fuzz_test.go
+++ b/go/vt/vtgate/evalengine/integration/fuzz_test.go
@@ -131,7 +131,7 @@ func safeEvaluate(query string) (evalengine.EvalResult, sqltypes.Type, error) {
 				err = fmt.Errorf("PANIC during translate: %v", r)
 			}
 		}()
-		expr, err = evalengine.TranslateEx(astExpr, evalengine.LookupDefaultCollation(collations.CollationUtf8mb4ID), *debugSimplify)
+		expr, err = evalengine.TranslateEx(astExpr, evalengine.LookupDefaultCollation(collations.CollationUtf8mb4ID), debugSimplify)
 		return
 	}()
 
@@ -146,7 +146,7 @@ func safeEvaluate(query string) (evalengine.EvalResult, sqltypes.Type, error) {
 			}()
 			env := evalengine.EnvWithBindVars(nil, 255)
 			eval, err = env.Evaluate(local)
-			if err == nil && *debugCheckTypes {
+			if err == nil && debugCheckTypes {
 				tt, err = env.TypeOf(local)
 			}
 			return

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -18,7 +18,6 @@ package vtgate
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -29,6 +28,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -50,38 +51,55 @@ import (
 )
 
 var (
-	mysqlServerPort               = flag.Int("mysql_server_port", -1, "If set, also listen for MySQL binary protocol connections on this port.")
-	mysqlServerBindAddress        = flag.String("mysql_server_bind_address", "", "Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.")
-	mysqlServerSocketPath         = flag.String("mysql_server_socket_path", "", "This option specifies the Unix socket file to use when listening for local connections. By default it will be empty and it won't listen to a unix socket")
-	mysqlTCPVersion               = flag.String("mysql_tcp_version", "tcp", "Select tcp, tcp4, or tcp6 to control the socket type.")
-	mysqlAuthServerImpl           = flag.String("mysql_auth_server_impl", "static", "Which auth server implementation to use. Options: none, ldap, clientcert, static, vault.")
-	mysqlAllowClearTextWithoutTLS = flag.Bool("mysql_allow_clear_text_without_tls", false, "If set, the server will allow the use of a clear text password over non-SSL connections.")
-	mysqlProxyProtocol            = flag.Bool("proxy_protocol", false, "Enable HAProxy PROXY protocol on MySQL listener socket")
+	mysqlServerPort                   = -1
+	mysqlServerBindAddress            = ""
+	mysqlServerSocketPath             = ""
+	mysqlTCPVersion                   = "tcp"
+	mysqlAuthServerImpl               = "static"
+	mysqlAllowClearTextWithoutTLS     bool
+	mysqlProxyProtocol                bool
+	mysqlServerRequireSecureTransport bool
+	mysqlSslCert                      string
+	mysqlSslKey                       string
+	mysqlSslCa                        string
+	mysqlSslCrl                       string
+	mysqlSslServerCA                  string
+	mysqlTLSMinVersion                string
 
-	mysqlServerRequireSecureTransport = flag.Bool("mysql_server_require_secure_transport", false, "Reject insecure connections but only if mysql_server_ssl_cert and mysql_server_ssl_key are provided")
+	mysqlConnReadTimeout          time.Duration
+	mysqlConnWriteTimeout         time.Duration
+	mysqlQueryTimeout             time.Duration
+	mysqlSlowConnectWarnThreshold time.Duration
+	mysqlConnBufferPooling        bool
 
-	mysqlSslCert = flag.String("mysql_server_ssl_cert", "", "Path to the ssl cert for mysql server plugin SSL")
-	mysqlSslKey  = flag.String("mysql_server_ssl_key", "", "Path to ssl key for mysql server plugin SSL")
-	mysqlSslCa   = flag.String("mysql_server_ssl_ca", "", "Path to ssl CA for mysql server plugin SSL. If specified, server will require and validate client certs.")
-	mysqlSslCrl  = flag.String("mysql_server_ssl_crl", "", "Path to ssl CRL for mysql server plugin SSL")
-
-	mysqlTLSMinVersion = flag.String("mysql_server_tls_min_version", "", "Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.")
-
-	mysqlSslServerCA = flag.String("mysql_server_ssl_server_ca", "", "path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients")
-
-	mysqlSlowConnectWarnThreshold = flag.Duration("mysql_slow_connect_warn_threshold", 0, "Warn if it takes more than the given threshold for a mysql connection to establish")
-
-	mysqlConnReadTimeout  = flag.Duration("mysql_server_read_timeout", 0, "connection read timeout")
-	mysqlConnWriteTimeout = flag.Duration("mysql_server_write_timeout", 0, "connection write timeout")
-	mysqlQueryTimeout     = flag.Duration("mysql_server_query_timeout", 0, "mysql query timeout")
-
-	mysqlConnBufferPooling = flag.Bool("mysql-server-pool-conn-read-buffers", false, "If set, the server will pool incoming connection read buffers")
-
-	mysqlDefaultWorkloadName = flag.String("mysql_default_workload", "OLTP", "Default session workload (OLTP, OLAP, DBA)")
+	mysqlDefaultWorkloadName = "OLTP"
 	mysqlDefaultWorkload     int32
 
 	busyConnections int32
 )
+
+func registerPluginFlags(fs *pflag.FlagSet) {
+	fs.IntVar(&mysqlServerPort, "mysql_server_port", mysqlServerPort, "If set, also listen for MySQL binary protocol connections on this port.")
+	fs.StringVar(&mysqlServerBindAddress, "mysql_server_bind_address", mysqlServerBindAddress, "Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.")
+	fs.StringVar(&mysqlServerSocketPath, "mysql_server_socket_path", mysqlServerSocketPath, "This option specifies the Unix socket file to use when listening for local connections. By default it will be empty and it won't listen to a unix socket")
+	fs.StringVar(&mysqlTCPVersion, "mysql_tcp_version", mysqlTCPVersion, "Select tcp, tcp4, or tcp6 to control the socket type.")
+	fs.StringVar(&mysqlAuthServerImpl, "mysql_auth_server_impl", mysqlAuthServerImpl, "Which auth server implementation to use. Options: none, ldap, clientcert, static, vault.")
+	fs.BoolVar(&mysqlAllowClearTextWithoutTLS, "mysql_allow_clear_text_without_tls", mysqlAllowClearTextWithoutTLS, "If set, the server will allow the use of a clear text password over non-SSL connections.")
+	fs.BoolVar(&mysqlProxyProtocol, "proxy_protocol", mysqlProxyProtocol, "Enable HAProxy PROXY protocol on MySQL listener socket")
+	fs.BoolVar(&mysqlServerRequireSecureTransport, "mysql_server_require_secure_transport", mysqlServerRequireSecureTransport, "Reject insecure connections but only if mysql_server_ssl_cert and mysql_server_ssl_key are provided")
+	fs.StringVar(&mysqlSslCert, "mysql_server_ssl_cert", mysqlSslCert, "Path to the ssl cert for mysql server plugin SSL")
+	fs.StringVar(&mysqlSslKey, "mysql_server_ssl_key", mysqlSslKey, "Path to ssl key for mysql server plugin SSL")
+	fs.StringVar(&mysqlSslCa, "mysql_server_ssl_ca", mysqlSslCa, "Path to ssl CA for mysql server plugin SSL. If specified, server will require and validate client certs.")
+	fs.StringVar(&mysqlSslCrl, "mysql_server_ssl_crl", mysqlSslCrl, "Path to ssl CRL for mysql server plugin SSL")
+	fs.StringVar(&mysqlTLSMinVersion, "mysql_server_tls_min_version", mysqlTLSMinVersion, "Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.")
+	fs.StringVar(&mysqlSslServerCA, "mysql_server_ssl_server_ca", mysqlSslServerCA, "path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients")
+	fs.DurationVar(&mysqlSlowConnectWarnThreshold, "mysql_slow_connect_warn_threshold", mysqlSlowConnectWarnThreshold, "Warn if it takes more than the given threshold for a mysql connection to establish")
+	fs.DurationVar(&mysqlConnReadTimeout, "mysql_server_read_timeout", mysqlConnReadTimeout, "connection read timeout")
+	fs.DurationVar(&mysqlConnWriteTimeout, "mysql_server_write_timeout", mysqlConnWriteTimeout, "connection write timeout")
+	fs.DurationVar(&mysqlQueryTimeout, "mysql_server_query_timeout", mysqlQueryTimeout, "mysql query timeout")
+	fs.BoolVar(&mysqlConnBufferPooling, "mysql-server-pool-conn-read-buffers", mysqlConnBufferPooling, "If set, the server will pool incoming connection read buffers")
+	fs.StringVar(&mysqlDefaultWorkloadName, "mysql_default_workload", mysqlDefaultWorkloadName, "Default session workload (OLTP, OLAP, DBA)")
+}
 
 // vtgateHandler implements the Listener interface.
 // It stores the Session in the ClientData of a Connection.
@@ -134,8 +152,8 @@ func (vh *vtgateHandler) ConnectionClosed(c *mysql.Conn) {
 
 	var ctx context.Context
 	var cancel context.CancelFunc
-	if *mysqlQueryTimeout != 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+	if mysqlQueryTimeout != 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), mysqlQueryTimeout)
 		defer cancel()
 	} else {
 		ctx = context.Background()
@@ -184,8 +202,8 @@ func startSpan(ctx context.Context, query, label string) (trace.Span, context.Co
 func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	ctx := context.Background()
 	var cancel context.CancelFunc
-	if *mysqlQueryTimeout != 0 {
-		ctx, cancel = context.WithTimeout(ctx, *mysqlQueryTimeout)
+	if mysqlQueryTimeout != 0 {
+		ctx, cancel = context.WithTimeout(ctx, mysqlQueryTimeout)
 		defer cancel()
 	}
 
@@ -249,8 +267,8 @@ func fillInTxStatusFlags(c *mysql.Conn, session *vtgatepb.Session) {
 func (vh *vtgateHandler) ComPrepare(c *mysql.Conn, query string, bindVars map[string]*querypb.BindVariable) ([]*querypb.Field, error) {
 	var ctx context.Context
 	var cancel context.CancelFunc
-	if *mysqlQueryTimeout != 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+	if mysqlQueryTimeout != 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), mysqlQueryTimeout)
 		defer cancel()
 	} else {
 		ctx = context.Background()
@@ -291,8 +309,8 @@ func (vh *vtgateHandler) ComPrepare(c *mysql.Conn, query string, bindVars map[st
 func (vh *vtgateHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, callback func(*sqltypes.Result) error) error {
 	var ctx context.Context
 	var cancel context.CancelFunc
-	if *mysqlQueryTimeout != 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+	if mysqlQueryTimeout != 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), mysqlQueryTimeout)
 		defer cancel()
 	} else {
 		ctx = context.Background()
@@ -403,7 +421,7 @@ func initTLSConfig(mysqlListener *mysql.Listener, mysqlSslCert, mysqlSslKey, mys
 // It should be called only once in a process.
 func initMySQLProtocol() {
 	// Flag is not set, just return.
-	if *mysqlServerPort < 0 && *mysqlServerSocketPath == "" {
+	if mysqlServerPort < 0 && mysqlServerSocketPath == "" {
 		return
 	}
 
@@ -416,15 +434,15 @@ func initMySQLProtocol() {
 	for _, initFn := range pluginInitializers {
 		initFn()
 	}
-	authServer := mysql.GetAuthServer(*mysqlAuthServerImpl)
+	authServer := mysql.GetAuthServer(mysqlAuthServerImpl)
 
 	// Check mysql_default_workload
 	var ok bool
-	if mysqlDefaultWorkload, ok = querypb.ExecuteOptions_Workload_value[strings.ToUpper(*mysqlDefaultWorkloadName)]; !ok {
+	if mysqlDefaultWorkload, ok = querypb.ExecuteOptions_Workload_value[strings.ToUpper(mysqlDefaultWorkloadName)]; !ok {
 		log.Exitf("-mysql_default_workload must be one of [OLTP, OLAP, DBA, UNSPECIFIED]")
 	}
 
-	switch *mysqlTCPVersion {
+	switch mysqlTCPVersion {
 	case "tcp", "tcp4", "tcp6":
 		// Valid flag value.
 	default:
@@ -434,16 +452,16 @@ func initMySQLProtocol() {
 	// Create a Listener.
 	var err error
 	vtgateHandle = newVtgateHandler(rpcVTGate)
-	if *mysqlServerPort >= 0 {
+	if mysqlServerPort >= 0 {
 		mysqlListener, err = mysql.NewListener(
-			*mysqlTCPVersion,
-			net.JoinHostPort(*mysqlServerBindAddress, fmt.Sprintf("%v", *mysqlServerPort)),
+			mysqlTCPVersion,
+			net.JoinHostPort(mysqlServerBindAddress, fmt.Sprintf("%v", mysqlServerPort)),
 			authServer,
 			vtgateHandle,
-			*mysqlConnReadTimeout,
-			*mysqlConnWriteTimeout,
-			*mysqlProxyProtocol,
-			*mysqlConnBufferPooling,
+			mysqlConnReadTimeout,
+			mysqlConnWriteTimeout,
+			mysqlProxyProtocol,
+			mysqlConnBufferPooling,
 		)
 		if err != nil {
 			log.Exitf("mysql.NewListener failed: %v", err)
@@ -451,29 +469,29 @@ func initMySQLProtocol() {
 		if mySQLVersion := servenv.MySQLServerVersion(); mySQLVersion != "" {
 			mysqlListener.ServerVersion = mySQLVersion
 		}
-		if *mysqlSslCert != "" && *mysqlSslKey != "" {
-			tlsVersion, err := vttls.TLSVersionToNumber(*mysqlTLSMinVersion)
+		if mysqlSslCert != "" && mysqlSslKey != "" {
+			tlsVersion, err := vttls.TLSVersionToNumber(mysqlTLSMinVersion)
 			if err != nil {
 				log.Exitf("mysql.NewListener failed: %v", err)
 			}
 
-			_ = initTLSConfig(mysqlListener, *mysqlSslCert, *mysqlSslKey, *mysqlSslCa, *mysqlSslCrl, *mysqlSslServerCA, *mysqlServerRequireSecureTransport, tlsVersion)
+			_ = initTLSConfig(mysqlListener, mysqlSslCert, mysqlSslKey, mysqlSslCa, mysqlSslCrl, mysqlSslServerCA, mysqlServerRequireSecureTransport, tlsVersion)
 		}
-		mysqlListener.AllowClearTextWithoutTLS.Set(*mysqlAllowClearTextWithoutTLS)
+		mysqlListener.AllowClearTextWithoutTLS.Set(mysqlAllowClearTextWithoutTLS)
 		// Check for the connection threshold
-		if *mysqlSlowConnectWarnThreshold != 0 {
+		if mysqlSlowConnectWarnThreshold != 0 {
 			log.Infof("setting mysql slow connection threshold to %v", mysqlSlowConnectWarnThreshold)
-			mysqlListener.SlowConnectWarnThreshold.Set(*mysqlSlowConnectWarnThreshold)
+			mysqlListener.SlowConnectWarnThreshold.Set(mysqlSlowConnectWarnThreshold)
 		}
 		// Start listening for tcp
 		go mysqlListener.Accept()
 	}
 
-	if *mysqlServerSocketPath != "" {
+	if mysqlServerSocketPath != "" {
 		// Let's create this unix socket with permissions to all users. In this way,
 		// clients can connect to vtgate mysql server without being vtgate user
 		oldMask := syscall.Umask(000)
-		mysqlUnixListener, err = newMysqlUnixSocket(*mysqlServerSocketPath, authServer, vtgateHandle)
+		mysqlUnixListener, err = newMysqlUnixSocket(mysqlServerSocketPath, authServer, vtgateHandle)
 		_ = syscall.Umask(oldMask)
 		if err != nil {
 			log.Exitf("mysql.NewListener failed: %v", err)
@@ -492,10 +510,10 @@ func newMysqlUnixSocket(address string, authServer mysql.AuthServer, handler mys
 		address,
 		authServer,
 		handler,
-		*mysqlConnReadTimeout,
-		*mysqlConnWriteTimeout,
+		mysqlConnReadTimeout,
+		mysqlConnWriteTimeout,
 		false,
-		*mysqlConnBufferPooling,
+		mysqlConnBufferPooling,
 	)
 
 	switch err := err.(type) {
@@ -523,10 +541,10 @@ func newMysqlUnixSocket(address string, authServer mysql.AuthServer, handler mys
 			address,
 			authServer,
 			handler,
-			*mysqlConnReadTimeout,
-			*mysqlConnWriteTimeout,
+			mysqlConnReadTimeout,
+			mysqlConnWriteTimeout,
 			false,
-			*mysqlConnBufferPooling,
+			mysqlConnBufferPooling,
 		)
 		return listener, listenerErr
 	default:
@@ -597,13 +615,16 @@ func rollbackAtShutdown() {
 }
 
 func mysqlSocketPath() string {
-	if mysqlServerSocketPath == nil {
+	if mysqlServerSocketPath == "" {
 		return ""
 	}
-	return *mysqlServerSocketPath
+	return mysqlServerSocketPath
 }
 
 func init() {
+	servenv.OnParseFor("vtgate", registerPluginFlags)
+	servenv.OnParseFor("vtcombo", registerPluginFlags)
+
 	servenv.OnRun(initMySQLProtocol)
 	servenv.OnTermSync(shutdownMysqlProtocolAndDrain)
 	servenv.OnClose(rollbackAtShutdown)

--- a/go/vt/vtgate/querylog.go
+++ b/go/vt/vtgate/querylog.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vtgate
 
 import (
-	"flag"
 	"net/http"
 
 	"vitess.io/vitess/go/streamlog"
@@ -35,16 +34,10 @@ var (
 
 	// QueryLogger enables streaming logging of queries
 	QueryLogger *streamlog.StreamLogger
-
-	// queryLogToFile controls whether query logs are sent to a file
-	queryLogToFile = flag.String("log_queries_to_file", "", "Enable query logging to the specified file")
-
-	// queryLogBufferSize controls how many query logs will be buffered before dropping them if logging is not fast enough
-	queryLogBufferSize = flag.Int("querylog-buffer-size", 10, "Maximum number of buffered query logs before throttling log output")
 )
 
 func initQueryLogger(vtg *VTGate) error {
-	QueryLogger = streamlog.New("VTGate", *queryLogBufferSize)
+	QueryLogger = streamlog.New("VTGate", queryLogBufferSize)
 	QueryLogger.ServeLogs(QueryLogHandler, streamlog.GetFormatter(QueryLogger))
 
 	http.HandleFunc(QueryLogzHandler, func(w http.ResponseWriter, r *http.Request) {
@@ -57,8 +50,8 @@ func initQueryLogger(vtg *VTGate) error {
 		queryzHandler(vtg.executor, w, r)
 	})
 
-	if *queryLogToFile != "" {
-		_, err := QueryLogger.LogToFile(*queryLogToFile, streamlog.GetFormatter(QueryLogger))
+	if queryLogToFile != "" {
+		_, err := QueryLogger.LogToFile(queryLogToFile, streamlog.GetFormatter(QueryLogger))
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -18,7 +18,6 @@ package vtgate
 
 import (
 	"context"
-	"flag"
 	"io"
 	"sync"
 	"time"
@@ -43,10 +42,6 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
-)
-
-var (
-	messageStreamGracePeriod = flag.Duration("message_stream_grace_period", 30*time.Second, "the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent.")
 )
 
 // ScatterConn is used for executing queries across
@@ -534,17 +529,17 @@ func (stc *ScatterConn) MessageStream(ctx context.Context, rss []*srvtopo.Resolv
 			default:
 			}
 			firstErrorTimeStamp := lastErrors.Record(rs.Target)
-			if time.Since(firstErrorTimeStamp) >= *messageStreamGracePeriod {
+			if time.Since(firstErrorTimeStamp) >= messageStreamGracePeriod {
 				// Cancel all streams and return an error.
 				cancel()
-				return vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "message stream from %v has repeatedly failed for longer than %v", rs.Target, *messageStreamGracePeriod)
+				return vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "message stream from %v has repeatedly failed for longer than %v", rs.Target, messageStreamGracePeriod)
 			}
 
 			// It's not been too long since our last good send. Wait and retry.
 			select {
 			case <-ctx.Done():
 				return nil
-			case <-time.After(*messageStreamGracePeriod / 5):
+			case <-time.After(messageStreamGracePeriod / 5):
 			}
 		}
 	})

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -102,6 +102,13 @@ var (
 	enableSchemaChangeSignal = true
 	schemaChangeUser         string
 	queryTimeout             int
+
+	// queryLogToFile controls whether query logs are sent to a file
+	queryLogToFile string
+	// queryLogBufferSize controls how many query logs will be buffered before dropping them if logging is not fast enough
+	queryLogBufferSize = 10
+
+	messageStreamGracePeriod = 30 * time.Second
 )
 
 func registerFlags(fs *pflag.FlagSet) {
@@ -132,6 +139,9 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&enableSchemaChangeSignal, "schema_change_signal", enableSchemaChangeSignal, "Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work")
 	fs.StringVar(&schemaChangeUser, "schema_change_signal_user", schemaChangeUser, "User to be used to send down query to vttablet to retrieve schema changes")
 	fs.IntVar(&queryTimeout, "query-timeout", queryTimeout, "Sets the default query timeout (in ms). Can be overridden by session variable (query_timeout) or comment directive (QUERY_TIMEOUT_MS)")
+	fs.StringVar(&queryLogToFile, "log_queries_to_file", queryLogToFile, "Enable query logging to the specified file")
+	fs.IntVar(&queryLogBufferSize, "querylog-buffer-size", queryLogBufferSize, "Maximum number of buffered query logs before throttling log output")
+	fs.DurationVar(&messageStreamGracePeriod, "message_stream_grace_period", messageStreamGracePeriod, "the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent.")
 }
 func init() {
 	servenv.OnParseFor("vtgate", registerFlags)

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -75,8 +75,8 @@ func init() {
 	transactionMode = "MULTI"
 	Init(context.Background(), hcVTGateTest, newSandboxForCells([]string{"aa"}), "aa", nil, querypb.ExecuteOptions_Gen4)
 
-	*mysqlServerPort = 0
-	*mysqlAuthServerImpl = "none"
+	mysqlServerPort = 0
+	mysqlAuthServerImpl = "none"
 	initMySQLProtocol()
 }
 


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR moves some remaining flags to pflags in the VTGate.

This would need to backport to 15.0 to be inline with the work carried out in 15.0 regarding the migration.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/11318
- https://github.com/vitessio/vitess/issues/10931

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported - v15
-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
