### PR TITLE
Migrate missed vtctld flags to pflag and immediately deprecate them

### DIFF
--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -146,8 +146,6 @@ Usage of vtctld:
       --v Level                                                          log level for V logs
   -v, --version                                                          print binary version
       --vmodule moduleSpec                                               comma-separated list of pattern=N settings for file-filtered logging
-      --vtctl_healthcheck_retry_delay duration                           delay before retrying a failed healthcheck (default 5s)
-      --vtctl_healthcheck_timeout duration                               the health check timeout period (default 1m0s)
       --vtctl_healthcheck_topology_refresh duration                      refresh interval for re-reading the topology (default 30s)
       --vtctld_sanitize_log_messages                                     When true, vtctld sanitizes logging.
       --vtctld_show_topology_crud                                        Controls the display of the CRUD topology actions in the vtctld UI. (default true)

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -83,7 +83,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"math"
@@ -104,6 +103,7 @@ import (
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/textutil"
+	"vitess.io/vitess/go/vt/discovery"
 	hk "vitess.io/vitess/go/vt/hook"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
@@ -116,6 +116,7 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/proto/vttime"
 	"vitess.io/vitess/go/vt/schema"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -128,14 +129,35 @@ import (
 var (
 	// ErrUnknownCommand is returned for an unknown command
 	ErrUnknownCommand = errors.New("unknown command")
+
+	// Flag variables.
+	healthCheckRetryDelay = 5 * time.Second
+	healthCheckTimeout    = time.Minute
 )
 
-// Flags are exported for use in go/vt/vtctld.
-var (
-	HealthCheckTopologyRefresh = flag.Duration("vtctl_healthcheck_topology_refresh", 30*time.Second, "refresh interval for re-reading the topology")
-	HealthcheckRetryDelay      = flag.Duration("vtctl_healthcheck_retry_delay", 5*time.Second, "delay before retrying a failed healthcheck")
-	HealthCheckTimeout         = flag.Duration("vtctl_healthcheck_timeout", time.Minute, "the health check timeout period")
-)
+func init() {
+	servenv.OnParseFor("vtctl", registerFlags)
+	servenv.OnParseFor("vtctld", registerFlags)
+}
+
+func registerFlags(fs *pflag.FlagSet) {
+	// TODO: https://github.com/vitessio/vitess/issues/11973
+	// Then remove this function and associated code (NewHealthCheck, servenv
+	// OnParseFor hooks, etc) entirely.
+	fs.Duration("vtctl_healthcheck_topology_refresh", 30*time.Second, "refresh interval for re-reading the topology")
+	fs.MarkDeprecated("vtctl_healthcheck_topology_refresh", "")
+
+	fs.DurationVar(&healthCheckRetryDelay, "vtctl_healthcheck_retry_delay", healthCheckRetryDelay, "delay before retrying a failed healthcheck")
+	fs.MarkDeprecated("vtctl_healthcheck_retry_delay", "This is used only by the legacy vtctld UI that is already deprecated and will be removed in the next release.")
+	fs.DurationVar(&healthCheckTimeout, "vtctl_healthcheck_timeout", healthCheckTimeout, "the health check timeout period")
+	fs.MarkDeprecated("vtctl_healthcheck_timeout", "This is used only by the legacy vtctld UI that is already deprecated and will be removed in the next release.")
+}
+
+// NewHealthCheck returns a healthcheck implementation based on the vtctl flags.
+// It is exported for use in go/vt/vtctld.
+func NewHealthCheck(ctx context.Context, ts *topo.Server, local string, cellsToWatch []string) discovery.HealthCheck {
+	return discovery.NewHealthCheck(ctx, healthCheckRetryDelay, healthCheckTimeout, ts, local, strings.Join(cellsToWatch, ","))
+}
 
 type command struct {
 	name   string

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -21,7 +21,6 @@ package vtctld
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/spf13/pflag"
 
@@ -163,7 +162,7 @@ func InitVtctld(ts *topo.Server) error {
 		if err != nil {
 			log.Errorf("Failed to get the list of known cells, failed to instantiate the healthcheck at startup: %v", err)
 		} else {
-			healthCheck = discovery.NewHealthCheck(ctx, *vtctl.HealthcheckRetryDelay, *vtctl.HealthCheckTimeout, ts, localCell, strings.Join(cells, ","))
+			healthCheck = vtctl.NewHealthCheck(ctx, ts, localCell, cells)
 		}
 	}
 


### PR DESCRIPTION


## Description

What it says in the title. These are only used by the vtctld UI (behind the already-deprecated `enable_realtime_stats` flag.

## Related Issue(s)

- #11326 
- #11973 (for the follow up)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
