### PR TITLE
Add `VStreamerCount` stat to `vttablet`

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -97,6 +97,7 @@ type Engine struct {
 	rowStreamerNumPackets     *stats.Counter
 	rowStreamerWaits          *servenv.TimingsWrapper
 	errorCounts               *stats.CountersWithSingleLabel
+	vstreamersActive          *stats.GaugeFunc
 	vstreamersCreated         *stats.Counter
 	vstreamersEndedWithErrors *stats.Counter
 	vstreamerFlushedBinlogs   *stats.Counter
@@ -138,6 +139,7 @@ func NewEngine(env tabletenv.Env, ts srvtopo.Server, se *schema.Engine, lagThrot
 		errorCounts:               env.Exporter().NewCountersWithSingleLabel("VStreamerErrors", "Tracks errors in vstreamer", "type", "Catchup", "Copy", "Send", "TablePlan"),
 		vstreamerFlushedBinlogs:   env.Exporter().NewCounter("VStreamerFlushedBinlogs", "Number of times we've successfully executed a FLUSH BINARY LOGS statement when starting a vstream"),
 	}
+	vse.vstreamersActive = env.Exporter().NewGaugeFunc("VStreamersActive", "Count of vstreamers active", vse.getStreamersActive)
 	env.Exporter().NewGaugeFunc("RowStreamerMaxInnoDBTrxHistLen", "", func() int64 { return env.Config().RowStreamer.MaxInnoDBTrxHistLen })
 	env.Exporter().NewGaugeFunc("RowStreamerMaxMySQLReplLagSecs", "", func() int64 { return env.Config().RowStreamer.MaxMySQLReplLagSecs })
 	env.Exporter().HandleFunc("/debug/tablet_vschema", vse.ServeHTTP)
@@ -381,6 +383,10 @@ func (vse *Engine) setWatch() {
 		vse.vschemaUpdates.Add(1)
 		return true
 	})
+}
+
+func (vse *Engine) getStreamersActive() int64 {
+	return int64(len(vse.streamers))
 }
 
 func getPacketSize() int64 {

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -88,6 +88,7 @@ type Engine struct {
 
 	// vstreamer metrics
 	vstreamerPhaseTimings     *servenv.TimingsWrapper
+	vstreamerCount            *stats.Gauge
 	vstreamerEventsStreamed   *stats.Counter
 	vstreamerPacketSize       *stats.GaugeFunc
 	vstreamerNumPackets       *stats.Counter
@@ -125,6 +126,7 @@ func NewEngine(env tabletenv.Env, ts srvtopo.Server, se *schema.Engine, lagThrot
 		vschemaUpdates: env.Exporter().NewCounter("VSchemaUpdates", "Count of VSchema updates. Does not include errors"),
 
 		vstreamerPhaseTimings:     env.Exporter().NewTimings("VStreamerPhaseTiming", "Time taken for different phases during vstream copy", "phase-timing"),
+		vstreamerCount:            env.Exporter().NewGauge("VStreamerCount", "Current number of vstreamers"),
 		vstreamerEventsStreamed:   env.Exporter().NewCounter("VStreamerEventsStreamed", "Count of events streamed in VStream API"),
 		vstreamerPacketSize:       env.Exporter().NewGaugeFunc("VStreamPacketSize", "Max packet size for sending vstreamer events", getPacketSize),
 		vstreamerNumPackets:       env.Exporter().NewCounter("VStreamerNumPackets", "Number of packets in vstreamer"),
@@ -138,7 +140,6 @@ func NewEngine(env tabletenv.Env, ts srvtopo.Server, se *schema.Engine, lagThrot
 		errorCounts:               env.Exporter().NewCountersWithSingleLabel("VStreamerErrors", "Tracks errors in vstreamer", "type", "Catchup", "Copy", "Send", "TablePlan"),
 		vstreamerFlushedBinlogs:   env.Exporter().NewCounter("VStreamerFlushedBinlogs", "Number of times we've successfully executed a FLUSH BINARY LOGS statement when starting a vstream"),
 	}
-	env.Exporter().NewGaugeFunc("VStreamerCount", "Current number of vstreamers", vse.getVStreamerCount)
 	env.Exporter().NewGaugeFunc("RowStreamerMaxInnoDBTrxHistLen", "", func() int64 { return env.Config().RowStreamer.MaxInnoDBTrxHistLen })
 	env.Exporter().NewGaugeFunc("RowStreamerMaxMySQLReplLagSecs", "", func() int64 { return env.Config().RowStreamer.MaxMySQLReplLagSecs })
 	env.Exporter().HandleFunc("/debug/tablet_vschema", vse.ServeHTTP)
@@ -382,12 +383,6 @@ func (vse *Engine) setWatch() {
 		vse.vschemaUpdates.Add(1)
 		return true
 	})
-}
-
-func (vse *Engine) getVStreamerCount() int64 {
-	vse.mu.Lock()
-	defer vse.mu.Unlock()
-	return int64(len(vse.streamers))
 }
 
 func getPacketSize() int64 {

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -139,7 +139,7 @@ func NewEngine(env tabletenv.Env, ts srvtopo.Server, se *schema.Engine, lagThrot
 		errorCounts:               env.Exporter().NewCountersWithSingleLabel("VStreamerErrors", "Tracks errors in vstreamer", "type", "Catchup", "Copy", "Send", "TablePlan"),
 		vstreamerFlushedBinlogs:   env.Exporter().NewCounter("VStreamerFlushedBinlogs", "Number of times we've successfully executed a FLUSH BINARY LOGS statement when starting a vstream"),
 	}
-	vse.vstreamersActive = env.Exporter().NewGaugeFunc("VStreamersActive", "Count of vstreamers active", vse.getStreamersActive)
+	vse.vstreamersActive = env.Exporter().NewGaugeFunc("VStreamersActive", "Current number of active vstreamers", vse.getStreamersActive)
 	env.Exporter().NewGaugeFunc("RowStreamerMaxInnoDBTrxHistLen", "", func() int64 { return env.Config().RowStreamer.MaxInnoDBTrxHistLen })
 	env.Exporter().NewGaugeFunc("RowStreamerMaxMySQLReplLagSecs", "", func() int64 { return env.Config().RowStreamer.MaxMySQLReplLagSecs })
 	env.Exporter().HandleFunc("/debug/tablet_vschema", vse.ServeHTTP)

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -163,9 +163,11 @@ func (vs *vstreamer) Cancel() {
 func (vs *vstreamer) Stream() error {
 	//defer vs.cancel()
 	ctx := context.Background()
-	defer ctx.Done()
 	vs.vse.vstreamerCount.Add(1)
-	defer vs.vse.vstreamerCount.Add(-1)
+	defer func() {
+		ctx.Done()
+		vs.vse.vstreamerCount.Add(-1)
+	}()
 	vs.vse.vstreamersCreated.Add(1)
 	log.Infof("Starting Stream() with startPos %s", vs.startPos)
 	pos, err := mysql.DecodePosition(vs.startPos)

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -164,6 +164,8 @@ func (vs *vstreamer) Stream() error {
 	//defer vs.cancel()
 	ctx := context.Background()
 	defer ctx.Done()
+	vs.vse.vstreamerCount.Add(1)
+	defer vs.vse.vstreamerCount.Add(-1)
 	vs.vse.vstreamersCreated.Add(1)
 	log.Infof("Starting Stream() with startPos %s", vs.startPos)
 	pos, err := mysql.DecodePosition(vs.startPos)


### PR DESCRIPTION
## Description

This PR adds the ~~`VStreamersActive`~~ `VStreamerCount` stats metric to `vttablet` to make the # of active streams more observable. There may be a way to infer this using rates from a combination of `VStreamersCreated` and other metrics but I was unable to do so myself (in Prometheus/Grafana) after many attempts so this feels like a rough edge

The length of the VStream engine `streamers` map is used as the number of active streams. This is done without a lock but I'm happy to add one

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests are not required
-   [x] Documentation: https://github.com/vitessio/website/pull/1291
