### PR TITLE
support transaction isolation modification through reserved connection system settings

### DIFF
--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -33,6 +33,14 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 )
 
+// AssertContains ensures the given query result contains the expected results.
+func AssertContains(t testing.TB, conn *mysql.Conn, query, expected string) {
+	t.Helper()
+	qr := Exec(t, conn, query)
+	got := fmt.Sprintf("%v", qr.Rows)
+	assert.Contains(t, got, expected, "Query: %s", query)
+}
+
 // AssertMatches ensures the given query produces the expected results.
 func AssertMatches(t testing.TB, conn *mysql.Conn, query, expected string) {
 	t.Helper()

--- a/go/test/endtoend/vtgate/reservedconn/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/main_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/test/endtoend/utils"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 
 	"github.com/stretchr/testify/assert"
 
@@ -144,6 +145,7 @@ func runAllTests(m *testing.M) int {
 	// This test requires setting the mysql_server_version vtgate flag
 	// to 5.7 regardless of the actual MySQL version used for the tests.
 	clusterInstance.VtGateExtraArgs = []string{"--lock_heartbeat_time", "2s", "--mysql_server_version", "5.7.0"}
+	clusterInstance.VtGatePlannerVersion = querypb.ExecuteOptions_Gen4
 	if err := clusterInstance.StartVtgate(); err != nil {
 		return 1
 	}

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -427,18 +427,36 @@ func TestSysVarTxIsolation(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
+	// will run every check twice to see that the isolation level is set for all the queries in the session and
+
 	// default from mysql
 	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("REPEATABLE-READ")]]`)
+	// ensuring it goes to mysql
+	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `REPEATABLE-READ`)
+	// second run, to ensuring the setting is applied on the session and not just on next query after settings.
+	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `REPEATABLE-READ`)
 
 	// setting to different value.
 	utils.Exec(t, conn, "set @@transaction_isolation = 'read-committed'")
-	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-COMMITTED")]]`)
+	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("read-committed")]]`)
+	// ensuring it goes to mysql
+	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `read-committed`)
+	// second run, to ensuring the setting is applied on the session and not just on next query after settings.
+	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `read-committed`)
 
 	// changing setting to different value.
 	utils.Exec(t, conn, "set session transaction isolation level read uncommitted")
-	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("READ-UNCOMMITTED")]]`)
+	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("read-uncommitted")]]`)
+	// ensuring it goes to mysql
+	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `read-uncommitted`)
+	// second run, to ensuring the setting is applied on the session and not just on next query after settings.
+	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `read-uncommitted`)
 
 	// changing setting to different value.
 	utils.Exec(t, conn, "set transaction isolation level serializable")
-	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("SERIALIZABLE")]]`)
+	utils.AssertMatches(t, conn, "select @@transaction_isolation", `[[VARCHAR("serializable")]]`)
+	// ensuring it goes to mysql
+	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `serializable`)
+	// second run, to ensuring the setting is applied on the session and not just on next query after settings.
+	utils.AssertContains(t, conn, "select @@transaction_isolation, connection_id()", `serializable`)
 }

--- a/go/vt/sysvars/sysvars.go
+++ b/go/vt/sysvars/sysvars.go
@@ -61,8 +61,6 @@ var (
 	TxReadOnly                  = SystemVariable{Name: "tx_read_only", IsBoolean: true, Default: off}
 	Workload                    = SystemVariable{Name: "workload", IdentifierAsString: true}
 	QueryTimeout                = SystemVariable{Name: "query_timeout"}
-	TransactionIsolation        = SystemVariable{Name: "transaction_isolation", Default: off}
-	TxIsolation                 = SystemVariable{Name: "tx_isolation", Default: off}
 
 	// Online DDL
 	DDLStrategy    = SystemVariable{Name: "ddl_strategy", IdentifierAsString: true}
@@ -92,8 +90,6 @@ var (
 		ReadAfterWriteTimeOut,
 		SessionTrackGTIDs,
 		QueryTimeout,
-		TransactionIsolation,
-		TxIsolation,
 	}
 
 	ReadOnly = []SystemVariable{
@@ -211,7 +207,9 @@ var (
 		{Name: "sql_warnings", IsBoolean: true},
 		{Name: "time_zone"},
 		{Name: "tmp_table_size", SupportSetVar: true},
+		{Name: "transaction_isolation"},
 		{Name: "transaction_prealloc_size"},
+		{Name: "tx_isolation"},
 		{Name: "unique_checks", IsBoolean: true, SupportSetVar: true},
 		{Name: "updatable_views_with_limit", IsBoolean: true, SupportSetVar: true},
 	}

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -50,11 +50,6 @@ var _ SessionActions = (*noopVCursor)(nil)
 type noopVCursor struct {
 }
 
-func (t *noopVCursor) SetTransactionIsolation(isolation querypb.ExecuteOptions_TransactionIsolation) {
-	//TODO implement me
-	panic("implement me")
-}
-
 func (t *noopVCursor) InTransaction() bool {
 	return false
 }

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -191,9 +191,6 @@ type (
 		// InTransaction returns true if the session has already opened transaction or
 		// will start a transaction on the query execution.
 		InTransaction() bool
-
-		// SetTransactionIsolation sets the transaction isolation level for any new transaction on the session.
-		SetTransactionIsolation(isolation querypb.ExecuteOptions_TransactionIsolation)
 	}
 
 	// Match is used to check if a Primitive matches

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -2474,7 +2474,7 @@ func TestReservedConnDML(t *testing.T) {
 	require.NoError(t, err)
 
 	wantQueries = append(wantQueries,
-		&querypb.BoundQuery{Sql: "set @@default_week_format = 1", BindVariables: map[string]*querypb.BindVariable{}},
+		&querypb.BoundQuery{Sql: "set default_week_format = 1", BindVariables: map[string]*querypb.BindVariable{}},
 		&querypb.BoundQuery{Sql: "insert into `simple`() values ()", BindVariables: map[string]*querypb.BindVariable{}})
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "insert into `simple`() values ()", nil)
 	require.NoError(t, err)
@@ -2489,7 +2489,7 @@ func TestReservedConnDML(t *testing.T) {
 	sbc.EphemeralShardErr = mysql.NewSQLError(mysql.CRServerGone, mysql.SSNetError, "connection gone")
 	// as the first time the query fails due to connection loss i.e. reserved conn lost. It will be recreated to set statement will be executed again.
 	wantQueries = append(wantQueries,
-		&querypb.BoundQuery{Sql: "set @@default_week_format = 1", BindVariables: map[string]*querypb.BindVariable{}},
+		&querypb.BoundQuery{Sql: "set default_week_format = 1", BindVariables: map[string]*querypb.BindVariable{}},
 		&querypb.BoundQuery{Sql: "insert into `simple`() values ()", BindVariables: map[string]*querypb.BindVariable{}})
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "insert into `simple`() values ()", nil)
 	require.NoError(t, err)

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -186,7 +186,7 @@ func TestSystemVariablesMySQLBelow80(t *testing.T) {
 
 	wantQueries := []*querypb.BoundQuery{
 		{Sql: "select @@sql_mode orig, 'only_full_group_by' new"},
-		{Sql: "set @@sql_mode = 'only_full_group_by'", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
+		{Sql: "set sql_mode = 'only_full_group_by'", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
 		{Sql: "select :vtg1 from information_schema.`table`", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
 	}
 
@@ -224,7 +224,7 @@ func TestSystemVariablesWithSetVarDisabled(t *testing.T) {
 
 	wantQueries := []*querypb.BoundQuery{
 		{Sql: "select @@sql_mode orig, 'only_full_group_by' new"},
-		{Sql: "set @@sql_mode = 'only_full_group_by'", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
+		{Sql: "set sql_mode = 'only_full_group_by'", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
 		{Sql: "select :vtg1 from information_schema.`table`", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
 	}
 
@@ -386,7 +386,7 @@ func TestSetSystemVariables(t *testing.T) {
 
 	wantQueries = []*querypb.BoundQuery{
 		{Sql: "select 1 from dual where @@max_tmp_tables != 1"},
-		{Sql: "set @@max_tmp_tables = '1', @@sql_mode = 'only_full_group_by', @@sql_safe_updates = '0'", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
+		{Sql: "set max_tmp_tables = '1', sql_mode = 'only_full_group_by', sql_safe_updates = '0'", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
 		{Sql: "select :vtg1 from information_schema.`table`", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
 	}
 	utils.MustMatch(t, wantQueries, lookup.Queries)
@@ -416,7 +416,7 @@ func TestSetSystemVariablesWithReservedConnection(t *testing.T) {
 	require.True(t, session.InReservedConn())
 	wantQueries := []*querypb.BoundQuery{
 		{Sql: "select @@sql_mode orig, '' new"},
-		{Sql: "set @@sql_mode = ''"},
+		{Sql: "set sql_mode = ''"},
 		{Sql: "select age, city, weight_string(age) from `user` group by age, weight_string(age) order by age asc"},
 	}
 	utils.MustMatch(t, wantQueries, sbc1.Queries)
@@ -426,7 +426,7 @@ func TestSetSystemVariablesWithReservedConnection(t *testing.T) {
 	require.True(t, session.InReservedConn())
 	wantQueries = []*querypb.BoundQuery{
 		{Sql: "select @@sql_mode orig, '' new"},
-		{Sql: "set @@sql_mode = ''"},
+		{Sql: "set sql_mode = ''"},
 		{Sql: "select age, city, weight_string(age) from `user` group by age, weight_string(age) order by age asc"},
 		{Sql: "select age, city + :vtg1, weight_string(age) from `user` group by age, weight_string(age) order by age asc", BindVariables: map[string]*querypb.BindVariable{"vtg1": {Type: sqltypes.Int64, Value: []byte("1")}}},
 	}
@@ -447,7 +447,7 @@ func TestCreateTableValidTimestamp(t *testing.T) {
 	require.True(t, session.InReservedConn())
 
 	wantQueries := []*querypb.BoundQuery{
-		{Sql: "set @@sql_mode = ALLOW_INVALID_DATES", BindVariables: map[string]*querypb.BindVariable{}},
+		{Sql: "set sql_mode = ALLOW_INVALID_DATES", BindVariables: map[string]*querypb.BindVariable{}},
 		{Sql: "create table aa (\n\tt timestamp default 0\n)", BindVariables: map[string]*querypb.BindVariable{}},
 	}
 
@@ -3882,8 +3882,8 @@ func TestSelectCFC(t *testing.T) {
 		_, err := executor.Execute(context.Background(), "TestSelectCFC", session,
 			"select /*vt+ PLANNER=gen4 */ c2 from tbl_cfc where c1 like 'A%'", nil)
 		require.NoError(t, err)
-		assert.EqualValues(t, 1, executor.plans.Misses())
-		assert.EqualValues(t, i-1, executor.plans.Hits())
+		assert.EqualValues(t, 1, executor.plans.Misses(), "missed count:")
+		assert.EqualValues(t, i-1, executor.plans.Hits(), "hit count:")
 	}
 }
 

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -2317,7 +2317,7 @@ func TestExecutorSavepointInTxWithReservedConn(t *testing.T) {
 	sbc1WantQueries := []*querypb.BoundQuery{{
 		Sql: "select @@sql_mode orig, '' new", BindVariables: emptyBV,
 	}, {
-		Sql: "set @@sql_mode = ''", BindVariables: emptyBV,
+		Sql: "set sql_mode = ''", BindVariables: emptyBV,
 	}, {
 		Sql: "savepoint a", BindVariables: emptyBV,
 	}, {
@@ -2329,7 +2329,7 @@ func TestExecutorSavepointInTxWithReservedConn(t *testing.T) {
 	}}
 
 	sbc2WantQueries := []*querypb.BoundQuery{{
-		Sql: "set @@sql_mode = ''", BindVariables: emptyBV,
+		Sql: "set sql_mode = ''", BindVariables: emptyBV,
 	}, {
 		Sql: "savepoint a", BindVariables: emptyBV,
 	}, {

--- a/go/vt/vtgate/planbuilder/testdata/set_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/set_cases.json
@@ -566,9 +566,14 @@
         "OperatorType": "Set",
         "Ops": [
           {
-            "Type": "SysVarAware",
+            "Type": "SysVarSet",
             "Name": "transaction_isolation",
-            "Expr": "VARCHAR(\"read-committed\")"
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "Expr": "'read-committed'",
+            "SupportSetVar": false
           }
         ],
         "Inputs": [

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -597,10 +597,10 @@ func (session *SafeSession) SetPreQueries() []string {
 	first := true
 	for _, k := range keys {
 		if first {
-			preQuery.WriteString(fmt.Sprintf("set @@%s = %s", k, sysVars[k]))
+			preQuery.WriteString(fmt.Sprintf("set %s = %s", k, sysVars[k]))
 			first = false
 		} else {
-			preQuery.WriteString(fmt.Sprintf(", @@%s = %s", k, sysVars[k]))
+			preQuery.WriteString(fmt.Sprintf(", %s = %s", k, sysVars[k]))
 		}
 	}
 	return []string{preQuery.String()}

--- a/go/vt/vtgate/safe_session_test.go
+++ b/go/vt/vtgate/safe_session_test.go
@@ -57,7 +57,7 @@ func TestPrequeries(t *testing.T) {
 		},
 	})
 
-	want := []string{"set @@s1 = 'apa', @@s2 = 42"}
+	want := []string{"set s1 = 'apa', s2 = 42"}
 	preQueries := session.SetPreQueries()
 
 	if !reflect.DeepEqual(want, preQueries) {

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -800,11 +800,6 @@ func (vc *vcursorImpl) SetWorkload(workload querypb.ExecuteOptions_Workload) {
 	vc.safeSession.GetOrCreateOptions().Workload = workload
 }
 
-// SetTransactionIsolation implements the SessionActions interface
-func (vc *vcursorImpl) SetTransactionIsolation(isolation querypb.ExecuteOptions_TransactionIsolation) {
-	vc.safeSession.GetOrCreateOptions().TransactionIsolation = isolation
-}
-
 // SetPlannerVersion implements the SessionActions interface
 func (vc *vcursorImpl) SetPlannerVersion(v plancontext.PlannerVersion) {
 	vc.safeSession.GetOrCreateOptions().PlannerVersion = v


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR moves the transaction isolation system variables (transaction_isolation or set transaction isolation level) from vitess aware to reserved connection.
Earlier it used to only work with transactions. With this change, support will be added for read queries.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Closes https://github.com/vitessio/vitess/issues/11810
- Related to https://github.com/vitessio/vitess/pull/11673 and https://github.com/vitessio/vitess/pull/11804

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
