### PR TITLE
sqlparser: `QueryMatchesTemplates` uses canonical string

### DIFF
--- a/go/vt/sqlparser/utils.go
+++ b/go/vt/sqlparser/utils.go
@@ -44,7 +44,7 @@ func QueryMatchesTemplates(query string, queryTemplates []string) (match bool, e
 		if err != nil {
 			return "", err
 		}
-		normalized := String(stmt)
+		normalized := CanonicalString(stmt)
 		return normalized, nil
 	}
 

--- a/go/vt/sqlparser/utils_test.go
+++ b/go/vt/sqlparser/utils_test.go
@@ -59,103 +59,119 @@ func TestQueryMatchesTemplates(t *testing.T) {
 		q    string
 		tmpl []string
 		out  bool
-	}{{
-		name: "trivial, identical",
-		q:    "select id from tbl",
-		tmpl: []string{
-			"select id from tbl",
+	}{
+		{
+			name: "trivial, identical",
+			q:    "select id from tbl",
+			tmpl: []string{
+				"select id from tbl",
+			},
+			out: true,
+		}, {
+			name: "trivial, canonical",
+			q:    "select `id` from tbl",
+			tmpl: []string{
+				"select id FROM `tbl`",
+			},
+			out: true,
+		}, {
+			name: "trivial, identical from list",
+			q:    "select id from tbl",
+			tmpl: []string{
+				"select name from tbl",
+				"select id from tbl",
+			},
+			out: true,
+		}, {
+			name: "trivial no match",
+			q:    "select id from tbl where a=3",
+			tmpl: []string{
+				"select id from tbl",
+			},
+			out: false,
+		}, {
+			name: "int value",
+			q:    "select id from tbl where a=3",
+			tmpl: []string{
+				"select name from tbl where a=17",
+				"select id from tbl where a=5",
+			},
+			out: true,
+		}, {
+			name: "string value",
+			q:    "select id from tbl where a='abc'",
+			tmpl: []string{
+				"select name from tbl where a='x'",
+				"select id from tbl where a='y'",
+			},
+			out: true,
+		}, {
+			name: "two params",
+			q:    "select id from tbl where a='abc' and b='def'",
+			tmpl: []string{
+				"select name from tbl where a='x' and b = 'y'",
+				"select id from tbl where a='x' and b = 'y'",
+			},
+			out: true,
+		}, {
+			name: "no match",
+			q:    "select id from tbl where a='abc' and b='def'",
+			tmpl: []string{
+				"select name from tbl where a='x' and b = 'y'",
+				"select id from tbl where a='x' and c = 'y'",
+			},
+			out: false,
+		}, {
+			name: "reorder AND params",
+			q:    "select id from tbl where a='abc' and b='def'",
+			tmpl: []string{
+				"select id from tbl where b='x' and a = 'y'",
+			},
+			out: true,
+		}, {
+			name: "no reorder OR params",
+			q:    "select id from tbl where a='abc' or b='def'",
+			tmpl: []string{
+				"select id from tbl where b='x' or a = 'y'",
+			},
+			out: false,
+		}, {
+			name: "strict reorder OR params",
+			q:    "select id from tbl where a='abc' or b='def'",
+			tmpl: []string{
+				"select id from tbl where a='x' or b = 'y'",
+			},
+			out: true,
+		}, {
+			name: "identical 'x' annotation in template, identical query values",
+			q:    "select id from tbl where a='abc' or b='abc'",
+			tmpl: []string{
+				"select id from tbl where a='x' or b = 'x'",
+			},
+			out: true,
+		}, {
+			name: "identical 'x' annotation in template, different query values",
+			q:    "select id from tbl where a='abc' or b='def'",
+			tmpl: []string{
+				"select id from tbl where a='x' or b = 'x'",
+			},
+			out: false,
+		}, {
+			name: "reorder AND params, range test",
+			q:    "select id from tbl where a >'abc' and b<3",
+			tmpl: []string{
+				"select id from tbl where b<17 and a > 'y'",
+			},
+			out: true,
+		}, {
+			name: "canonical, case",
+			q:    "SHOW BINARY LOGS",
+			tmpl: []string{
+				"show binary logs",
+			},
+			out: true,
 		},
-		out: true,
-	}, {
-		name: "trivial, identical from list",
-		q:    "select id from tbl",
-		tmpl: []string{
-			"select name from tbl",
-			"select id from tbl",
-		},
-		out: true,
-	}, {
-		name: "trivial no match",
-		q:    "select id from tbl where a=3",
-		tmpl: []string{
-			"select id from tbl",
-		},
-		out: false,
-	}, {
-		name: "int value",
-		q:    "select id from tbl where a=3",
-		tmpl: []string{
-			"select name from tbl where a=17",
-			"select id from tbl where a=5",
-		},
-		out: true,
-	}, {
-		name: "string value",
-		q:    "select id from tbl where a='abc'",
-		tmpl: []string{
-			"select name from tbl where a='x'",
-			"select id from tbl where a='y'",
-		},
-		out: true,
-	}, {
-		name: "two params",
-		q:    "select id from tbl where a='abc' and b='def'",
-		tmpl: []string{
-			"select name from tbl where a='x' and b = 'y'",
-			"select id from tbl where a='x' and b = 'y'",
-		},
-		out: true,
-	}, {
-		name: "no match",
-		q:    "select id from tbl where a='abc' and b='def'",
-		tmpl: []string{
-			"select name from tbl where a='x' and b = 'y'",
-			"select id from tbl where a='x' and c = 'y'",
-		},
-		out: false,
-	}, {
-		name: "reorder AND params",
-		q:    "select id from tbl where a='abc' and b='def'",
-		tmpl: []string{
-			"select id from tbl where b='x' and a = 'y'",
-		},
-		out: true,
-	}, {
-		name: "no reorder OR params",
-		q:    "select id from tbl where a='abc' or b='def'",
-		tmpl: []string{
-			"select id from tbl where b='x' or a = 'y'",
-		},
-		out: false,
-	}, {
-		name: "strict reorder OR params",
-		q:    "select id from tbl where a='abc' or b='def'",
-		tmpl: []string{
-			"select id from tbl where a='x' or b = 'y'",
-		},
-		out: true,
-	}, {
-		name: "identical 'x' annotation in template, identical query values",
-		q:    "select id from tbl where a='abc' or b='abc'",
-		tmpl: []string{
-			"select id from tbl where a='x' or b = 'x'",
-		},
-		out: true,
-	}, {
-		name: "identical 'x' annotation in template, different query values",
-		q:    "select id from tbl where a='abc' or b='def'",
-		tmpl: []string{
-			"select id from tbl where a='x' or b = 'x'",
-		},
-		out: false,
-	}, {
-		name: "reorder AND params, range test",
-		q:    "select id from tbl where a >'abc' and b<3",
-		tmpl: []string{
-			"select id from tbl where b<17 and a > 'y'",
-		},
-		out: true,
-	}}
+	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			match, err := QueryMatchesTemplates(tc.q, tc.tmpl)


### PR DESCRIPTION

## Description

Additional followup to https://github.com/vitessio/vitess/issues/11893. When `QueryMatchesTemplates()` was created, we only had `sqlparser.String(stmt)`. But today, we have `sqlparser.CanonicalString(stmt)` which is the better function to use, because it canonically and reliably normalizes a query (e.g. fully qualifies names, upper-lower casing it, etc.).

This PR now uses the latter function. All existing tests must pass. Added a couple more tests that specifically targets canonical statement properties.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/11893
- https://github.com/vitessio/vitess/pull/11894
- 
## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
