### PR TITLE
[release-13] backport query service bugfix v13

### DIFF
--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -87,6 +87,12 @@ func (txc *TxConn) queryService(alias *topodatapb.TabletAlias) (queryservice.Que
 	if qs != nil {
 		return qs, nil
 	}
+
+	// backport to fix https://github.com/vitessio/vitess/issues/11904
+	if alias == nil {
+		return txc.gateway, nil
+	}
+
 	return txc.gateway.QueryServiceByAlias(alias, nil)
 }
 

--- a/go/vt/vtgate/tx_conn_test.go
+++ b/go/vt/vtgate/tx_conn_test.go
@@ -1180,6 +1180,24 @@ func TestTxConnMultiGoTargets(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestTxConnQueryService(t *testing.T) {
+	txc := &TxConn{gateway: &DiscoveryGateway{}}
+
+	qs, err := txc.queryService(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, qs.(*DiscoveryGateway))
+
+	qs, err = txc.queryService(&topodatapb.TabletAlias{Cell: "aa", Uid: 123})
+	require.NoError(t, err)
+	assert.NotNil(t, qs.(*DiscoveryGateway))
+
+	txc.gateway = &TabletGateway{}
+
+	qs, err = txc.queryService(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, qs.(*TabletGateway))
+}
+
 func newLegacyTestTxConnEnv(t *testing.T, name string) (sc *ScatterConn, sbc0, sbc1 *sandboxconn.SandboxConn, rss0, rss1, rss01 []*srvtopo.ResolvedShard) {
 	t.Helper()
 	createSandbox(name)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

v13 users using the `tabletgateway` may run into the following error when running COMMIT type transactions:

```
tablet: <nil> is either down or nonexistent"
```

This is because the `QueryServiceByAlias` implementation in `TabletGateway` does not account for a nil alias. This was fixed when the `discoverygateway` was deprecated so backporting that here.

Also done for v12: https://github.com/vitessio/vitess/pull/11992

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

https://github.com/vitessio/vitess/issues/11904

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
