### PR TITLE
go/vt/mysqlctl: add compression benchmarks

### DIFF
--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -273,29 +273,32 @@ this shouldn't be a concern.
 
 Compression benchmarks have been added to the `mysqlctl` package.
 
-The benchmarks fetch and compress a ~60GB InnoDB file using different built-in and external compressors. Here are sample results from a 2020-era Mac M1 with 16GB of memory:
+The benchmarks fetch and compress a ~6 GiB tar file containing 3 InnoDB files using different built-in and external compressors.
 
-```
-$ go test -bench=BenchmarkCompress ./go/vt/mysqlctl -run=NONE -timeout=12h
+Here are sample results from a 2020-era Mac M1 with 16 GiB of memory:
+
+```sh
+$ go test -bench=BenchmarkCompress ./go/vt/mysqlctl -run=NONE -timeout=12h -benchtime=1x -v
 goos: darwin
 goarch: arm64
 pkg: vitess.io/vitess/go/vt/mysqlctl
 BenchmarkCompressLz4Builtin
-BenchmarkCompressLz4Builtin-8                  1        59562955167 ns/op       1121.27 MB/s             3.101 compression-ratio/op
-BenchmarkCompressPargzipBuiltin
-BenchmarkCompressPargzipBuiltin-8              1        207188453500 ns/op       322.34 MB/s             2.937 compression-ratio/op
-BenchmarkCompressPgzipBuiltin
-BenchmarkCompressPgzipBuiltin-8                1        90866210375 ns/op        734.99 MB/s             2.985 compression-ratio/op
-BenchmarkCompressZstdBuiltin
-BenchmarkCompressZstdBuiltin-8                 1        119344223833 ns/op       559.61 MB/s             3.221 compression-ratio/op
-BenchmarkCompressZstdExternal
-BenchmarkCompressZstdExternal-8                1        69447584292 ns/op        961.67 MB/s             3.251 compression-ratio/op
-BenchmarkCompressZstdExternalFast4
-BenchmarkCompressZstdExternalFast4-8           1        44269130042 ns/op       1508.63 MB/s             3.118 compression-ratio/op
-BenchmarkCompressZstdExternalT0
-BenchmarkCompressZstdExternalT0-8              1        46315237875 ns/op       1441.99 MB/s             3.251 compression-ratio/op
-BenchmarkCompressZstdExternalT4
-BenchmarkCompressZstdExternalT4-8              1        47368026583 ns/op       1409.94 MB/s             3.251 compression-ratio/op
-PASS
-ok      vitess.io/vitess/go/vt/mysqlctl 684.655s
+    compression_benchmark_test.go:310: downloading data from https://www.dropbox.com/s/raw/smmgifsooy5qytd/enwiki-20080103-pages-articles.ibd.tar.zst
+    BenchmarkCompressLz4Builtin-8                  1        11737493087 ns/op        577.98 MB/s             2.554 compression-ratio
+    BenchmarkCompressPargzipBuiltin
+    BenchmarkCompressPargzipBuiltin-8              1        31083784040 ns/op        218.25 MB/s             2.943 compression-ratio
+    BenchmarkCompressPgzipBuiltin
+    BenchmarkCompressPgzipBuiltin-8                1        13325299680 ns/op        509.11 MB/s             2.910 compression-ratio
+    BenchmarkCompressZstdBuiltin
+    BenchmarkCompressZstdBuiltin-8                 1        18683863911 ns/op        363.09 MB/s             3.150 compression-ratio
+    BenchmarkCompressZstdExternal
+    BenchmarkCompressZstdExternal-8                1        10795487675 ns/op        628.41 MB/s             3.093 compression-ratio
+    BenchmarkCompressZstdExternalFast4
+    BenchmarkCompressZstdExternalFast4-8           1        7139319009 ns/op         950.23 MB/s             2.323 compression-ratio
+    BenchmarkCompressZstdExternalT0
+    BenchmarkCompressZstdExternalT0-8              1        4393860434 ns/op        1543.97 MB/s             3.093 compression-ratio
+    BenchmarkCompressZstdExternalT4
+    BenchmarkCompressZstdExternalT4-8              1        4389559744 ns/op        1545.49 MB/s             3.093 compression-ratio
+    PASS
+    cleaning up "/var/folders/96/k7gzd7q10zdb749vr02q7sjh0000gn/T/ee7d47b45ef09786c54fa2d7354d2a68.dat"
 ```

--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -273,23 +273,29 @@ this shouldn't be a concern.
 
 Compression benchmarks have been added to the `mysqlctl` package.
 
-Here are sample results from compressing a 20 GB chunk of Wikipedia articles on a 2020-era Mac M1 with 16 GB of memory:
+The benchmarks fetch and compress a ~60GB InnoDB file using different built-in and external compressors. Here are sample results from a 2020-era Mac M1 with 16GB of memory:
 
 ```
-$ go test -bench=BenchmarkCompress ./go/vt/mysqlctl -run=NONE -timeout=2h -benchtime=300s 
+$ go test -bench=BenchmarkCompress ./go/vt/mysqlctl -run=NONE -timeout=12h
 goos: darwin
 goarch: arm64
 pkg: vitess.io/vitess/go/vt/mysqlctl
-BenchmarkCompressLz4Builtin-8                  7        59521566387 ns/op
-BenchmarkCompressPargzipBuiltin-8              3        131137483444 ns/op
-BenchmarkCompressPgzipBuiltin-8                6        61871191048 ns/op
-BenchmarkCompressZstdBuiltin-8                 4        80345240271 ns/op
-BenchmarkCompressZstdExternal-8                6        50756806348 ns/op
-BenchmarkCompressZstdExternalFast4-8           8        39936071110 ns/op
-BenchmarkCompressZstdExternalT0-8             15        24292118122 ns/op
-BenchmarkCompressZstdExternalT4-8             12        27094172323 ns/op
+BenchmarkCompressLz4Builtin
+BenchmarkCompressLz4Builtin-8                  1        59562955167 ns/op       1121.27 MB/s             3.101 compression-ratio/op
+BenchmarkCompressPargzipBuiltin
+BenchmarkCompressPargzipBuiltin-8              1        207188453500 ns/op       322.34 MB/s             2.937 compression-ratio/op
+BenchmarkCompressPgzipBuiltin
+BenchmarkCompressPgzipBuiltin-8                1        90866210375 ns/op        734.99 MB/s             2.985 compression-ratio/op
+BenchmarkCompressZstdBuiltin
+BenchmarkCompressZstdBuiltin-8                 1        119344223833 ns/op       559.61 MB/s             3.221 compression-ratio/op
+BenchmarkCompressZstdExternal
+BenchmarkCompressZstdExternal-8                1        69447584292 ns/op        961.67 MB/s             3.251 compression-ratio/op
+BenchmarkCompressZstdExternalFast4
+BenchmarkCompressZstdExternalFast4-8           1        44269130042 ns/op       1508.63 MB/s             3.118 compression-ratio/op
+BenchmarkCompressZstdExternalT0
+BenchmarkCompressZstdExternalT0-8              1        46315237875 ns/op       1441.99 MB/s             3.251 compression-ratio/op
+BenchmarkCompressZstdExternalT4
+BenchmarkCompressZstdExternalT4-8              1        47368026583 ns/op       1409.94 MB/s             3.251 compression-ratio/op
 PASS
-ok      vitess.io/vitess/go/vt/mysqlctl 3780.882s
+ok      vitess.io/vitess/go/vt/mysqlctl 684.655s
 ```
-
-See [here](https://github.com/vitessio/vitess/pull/11994) for more details on this sample and how to run the benchmarks yourself.

--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -266,3 +266,30 @@ Creating a database with vttestserver was taking ~45 seconds. This can be proble
 In an effort to minimize the database creation time, we have changed the value of `tablet_refresh_interval` to 10s while instantiating vtcombo during vttestserver initialization. We have also made this configurable so that it can be reduced further if desired.
 For any production cluster the default value of this flag is still [1 minute](https://vitess.io/docs/15.0/reference/programs/vtgate/). Reducing this values might put more stress on Topo Server (since we now read from Topo server more often) but for testing purposes 
 this shouldn't be a concern.
+
+## Minor changes
+
+### Backup compression benchmarks
+
+Compression benchmarks have been added to the `mysqlctl` package.
+
+Here are sample results from compressing a 20 GB chunk of Wikipedia articles on a 2020-era Mac M1 with 16 GB of memory:
+
+```
+$ go test -bench=BenchmarkCompress ./go/vt/mysqlctl -run=NONE -timeout=2h -benchtime=300s 
+goos: darwin
+goarch: arm64
+pkg: vitess.io/vitess/go/vt/mysqlctl
+BenchmarkCompressLz4Builtin-8                  7        59521566387 ns/op
+BenchmarkCompressPargzipBuiltin-8              3        131137483444 ns/op
+BenchmarkCompressPgzipBuiltin-8                6        61871191048 ns/op
+BenchmarkCompressZstdBuiltin-8                 4        80345240271 ns/op
+BenchmarkCompressZstdExternal-8                6        50756806348 ns/op
+BenchmarkCompressZstdExternalFast4-8           8        39936071110 ns/op
+BenchmarkCompressZstdExternalT0-8             15        24292118122 ns/op
+BenchmarkCompressZstdExternalT4-8             12        27094172323 ns/op
+PASS
+ok      vitess.io/vitess/go/vt/mysqlctl 3780.882s
+```
+
+See [here](https://github.com/vitessio/vitess/pull/11994) for more details on this sample and how to run the benchmarks yourself.

--- a/go/vt/mysqlctl/compression_benchmark_test.go
+++ b/go/vt/mysqlctl/compression_benchmark_test.go
@@ -61,7 +61,7 @@ const (
 	// built from this Wikipedia dataset:
 	//
 	//     https://dumps.wikimedia.org/archive/enwiki/20080103/enwiki-20080103-pages-articles.xml.bz2
-	defaultDataURL = "https://www.dropbox.com/s/raw/smmgifsooy5qytd/enwiki-20080103-pages-articles.ibd.tar.zst"
+	defaultDataURL = "https://github.com/vitessio/vitess-resources/releases/download/testdata-v1.0/enwiki-20080103-pages-articles.ibd.tar.zst"
 
 	// By default, don't limit how many bytes we input into compression.
 	defaultMaxBytes int64 = 0

--- a/go/vt/mysqlctl/compression_benchmark_test.go
+++ b/go/vt/mysqlctl/compression_benchmark_test.go
@@ -277,7 +277,7 @@ func BenchmarkCompressThenDiscardZstdBuiltin(b *testing.B) {
 func BenchmarkCompressThenDiscardZstdExternal(b *testing.B) {
 	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
 		b:        b,
-		external: fmt.Sprintf("zstd -%d", compressionLevel),
+		external: fmt.Sprintf("zstd -%d -c", compressionLevel),
 	})
 	env.compress()
 }
@@ -285,7 +285,7 @@ func BenchmarkCompressThenDiscardZstdExternal(b *testing.B) {
 func BenchmarkCompressThenDiscardZstdExternalFast4(b *testing.B) {
 	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
 		b:        b,
-		external: fmt.Sprintf("zstd -%d --fast=4", compressionLevel),
+		external: fmt.Sprintf("zstd -%d --fast=4 -c", compressionLevel),
 	})
 	env.compress()
 }
@@ -293,7 +293,7 @@ func BenchmarkCompressThenDiscardZstdExternalFast4(b *testing.B) {
 func BenchmarkCompressThenDiscardZstdExternalT0(b *testing.B) {
 	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
 		b:        b,
-		external: fmt.Sprintf("zstd -%d -T0", compressionLevel),
+		external: fmt.Sprintf("zstd -%d -T0 -c", compressionLevel),
 	})
 	env.compress()
 }
@@ -301,7 +301,7 @@ func BenchmarkCompressThenDiscardZstdExternalT0(b *testing.B) {
 func BenchmarkCompressThenDiscardZstdExternalT4(b *testing.B) {
 	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
 		b:        b,
-		external: fmt.Sprintf("zstd -%d -T4", compressionLevel),
+		external: fmt.Sprintf("zstd -%d -T4 -c", compressionLevel),
 	})
 	env.compress()
 }
@@ -345,7 +345,7 @@ func BenchmarkCompressToFileZstdBuiltin(b *testing.B) {
 func BenchmarkCompressToFileZstdExternal(b *testing.B) {
 	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
 		b:          b,
-		external:   fmt.Sprintf("zstd -%d", compressionLevel),
+		external:   fmt.Sprintf("zstd -%d -c", compressionLevel),
 		saveToFile: true,
 	})
 	env.compress()
@@ -354,7 +354,7 @@ func BenchmarkCompressToFileZstdExternal(b *testing.B) {
 func BenchmarkCompressToFileZstdExternalFast4(b *testing.B) {
 	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
 		b:          b,
-		external:   fmt.Sprintf("zstd -%d --fast=4", compressionLevel),
+		external:   fmt.Sprintf("zstd -%d --fast=4 -c", compressionLevel),
 		saveToFile: true,
 	})
 	env.compress()
@@ -363,7 +363,7 @@ func BenchmarkCompressToFileZstdExternalFast4(b *testing.B) {
 func BenchmarkCompressToFileZstdExternalT0(b *testing.B) {
 	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
 		b:          b,
-		external:   fmt.Sprintf("zstd -%d -T0", compressionLevel),
+		external:   fmt.Sprintf("zstd -%d -T0 -c", compressionLevel),
 		saveToFile: true,
 	})
 	env.compress()
@@ -372,7 +372,7 @@ func BenchmarkCompressToFileZstdExternalT0(b *testing.B) {
 func BenchmarkCompressToFileZstdExternalT4(b *testing.B) {
 	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
 		b:          b,
-		external:   fmt.Sprintf("zstd -%d -T4", compressionLevel),
+		external:   fmt.Sprintf("zstd -%d -T4 -c", compressionLevel),
 		saveToFile: true,
 	})
 	env.compress()

--- a/go/vt/mysqlctl/compression_benchmark_test.go
+++ b/go/vt/mysqlctl/compression_benchmark_test.go
@@ -1,10 +1,15 @@
 package mysqlctl
 
 import (
+	"compress/gzip"
 	"context"
+	"crypto/md5"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"path"
 	"strings"
 	"testing"
 
@@ -22,32 +27,24 @@ type (
 
 	benchmarkCompressEnv struct {
 		benchmarkCompressArgs
+		dataLocalPath string
+		dataURL       string
 	}
 )
 
 const (
-	usage = `
-This benchmark tests the performance of built-in and external compressors,
-using mysqlctl.newBuiltinDecompressor and mysqlctl.newExternalCompressor
-to obtain compressors.
+	// This is the default file which will be downloaded, gunzipped, and used
+	// by the compression benchmarks in this suite. It's a ~60GB gzipped InnoDB
+	// file, which was built from this Wikipedia dataset:
+	//
+	// https://dumps.wikimedia.org/enwiki/20221220/enwiki-20221220-externallinks.sql.gz
+	defaultDataURL = "https://archive.org/download/enwiki-20221220-externallinks.ibd/enwiki-20221220-externallinks.ibd.gz"
 
-You must supply a file to compress by setting this environment variable:
-
-    export VT_MYSQLCTL_COMPRESSION_BENCHMARK_DATA_PATH=path/to/data.xml
-
-We recommend using a data set that compresses well, such as:
-
- - The enwik9 dataset: http://mattmahoney.net/dc/textdata
- - A larger Wikipedia dataset from: https://en.wikipedia.org/wiki/Wikipedia:Database_download
-
-Once you've set that environment variable, you can run the tests like this:
-
-    go test -bench=BenchmarkCompressZstd ./go/vt/mysqlctl -run=NONE -timeout=2h -benchtime=300s
-
-Set -timeout and -benchtime to taste (or don't set them at all).
-`
-
-	userDefinedDataPathEnvVar = "VT_MYSQLCTL_COMPRESSION_BENCHMARK_DATA_PATH"
+	// Users may specify an alternate gzipped URL. This option is intended
+	// purely for development and debugging purposes. For example:
+	//
+	//     export VT_MYSQLCTL_COMPRESSION_BENCHMARK_DATA_URL=https://wiki.mozilla.org/images/f/ff/Example.json.gz
+	userDefinedDataURLEnvVar = "VT_MYSQLCTL_COMPRESSION_BENCHMARK_DATA_URL"
 )
 
 func setupBenchmarkCompressEnv(args benchmarkCompressArgs) benchmarkCompressEnv {
@@ -64,18 +61,18 @@ func (bce *benchmarkCompressEnv) benchmark() {
 
 	for i := 0; i < bce.b.N; i++ {
 		logger := logutil.NewMemoryLogger()
-
 		compressor := bce.compressor(logger)
-		defer compressor.Close()
-
-		reader := bce.reader()
-		defer reader.Close()
+		reader, err := bce.reader()
+		require.Nil(bce.b, err, "Failed to get data reader.")
 
 		// Only time the part we care about.
 		bce.b.StartTimer()
-		_, err := io.Copy(compressor, reader)
+		_, err = io.Copy(compressor, reader)
 		bce.b.StopTimer()
 
+		// Don't defer closing, otherwise we can exhaust open file limit.
+		reader.Close()
+		compressor.Close()
 		require.Nil(bce.b, err, logger.Events)
 	}
 }
@@ -94,11 +91,55 @@ func (bce *benchmarkCompressEnv) compressor(logger logutil.Logger) io.WriteClose
 	return compressor
 }
 
-func (bce *benchmarkCompressEnv) reader() io.ReadCloser {
-	dataPath := os.Getenv(userDefinedDataPathEnvVar)
-	f, err := os.Open(dataPath)
-	require.Nil(bce.b, err, "Failed to open data path: %s", dataPath)
-	return f
+func (bce *benchmarkCompressEnv) reader() (io.ReadCloser, error) {
+	url := defaultDataURL
+
+	// Use user-defined URL, if specified.
+	if udURL := os.Getenv(userDefinedDataURLEnvVar); udURL != "" {
+		url = udURL
+	}
+
+	// Compute a local path for a file by hashing the URL.
+	localPath := path.Join(os.TempDir(), fmt.Sprintf("%x.dat", md5.Sum([]byte(url))))
+
+	if _, err := os.Stat(localPath); errors.Is(err, os.ErrNotExist) {
+		bce.b.Logf("File not found at local path: %s\n", localPath)
+
+		// If the local path does not exist, download the file from the URL.
+		httpClient := http.Client{
+			CheckRedirect: func(r *http.Request, via []*http.Request) error {
+				r.URL.Opaque = r.URL.Path
+				return nil
+			},
+		}
+
+		resp, err := httpClient.Get(url)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get data at URL %q: %v", url, err)
+		}
+		defer resp.Body.Close()
+
+		// Assume the data we're downloading is gzipped.
+		gzr, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to gunzip data at URL %q: %v", url, err)
+		}
+		defer gzr.Close()
+
+		// Create a local file to write the HTTP response to.
+		file, err := os.OpenFile(localPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+		if err != nil {
+			return nil, err
+		}
+		defer file.Close()
+
+		// Write the gunzipped  HTTP response to local path.
+		if _, err := io.Copy(file, gzr); err != nil {
+			return nil, err
+		}
+	}
+
+	return os.Open(localPath)
 }
 
 func (bce *benchmarkCompressEnv) validate() {
@@ -113,15 +154,6 @@ func (bce *benchmarkCompressEnv) validate() {
 
 	if bce.builtin == "" && bce.external == "" {
 		require.Fail(bce.b, "Either builtin or external compressor must be specified.")
-	}
-
-	dataPath := os.Getenv(userDefinedDataPathEnvVar)
-	if dataPath == "" {
-		require.Fail(bce.b, fmt.Sprintf(
-			"Required environment variable %q is not set.\n\nUSAGE:\n%s",
-			userDefinedDataPathEnvVar,
-			usage,
-		))
 	}
 }
 

--- a/go/vt/mysqlctl/compression_benchmark_test.go
+++ b/go/vt/mysqlctl/compression_benchmark_test.go
@@ -1,0 +1,190 @@
+package mysqlctl
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/logutil"
+)
+
+type (
+	benchmarkCompressArgs struct {
+		b        *testing.B
+		builtin  string
+		external string
+	}
+
+	benchmarkCompressEnv struct {
+		benchmarkCompressArgs
+	}
+)
+
+const (
+	usage = `
+This benchmark tests the performance of built-in and external compressors,
+using mysqlctl.newBuiltinDecompressor and mysqlctl.newExternalCompressor
+to obtain compressors.
+
+You must supply a file to compress by setting this environment variable:
+
+    export VT_MYSQLCTL_COMPRESSION_BENCHMARK_DATA_PATH=path/to/data.xml
+
+We recommend using a data set that compresses well, such as:
+
+ - The enwik9 dataset: http://mattmahoney.net/dc/textdata
+ - A larger Wikipedia dataset from: https://en.wikipedia.org/wiki/Wikipedia:Database_download
+
+Once you've set that environment variable, you can run the tests like this:
+
+    go test -bench=BenchmarkCompressZstd ./go/vt/mysqlctl -run=NONE -timeout=2h -benchtime=300s
+
+Set -timeout and -benchtime to taste (or don't set them at all).
+`
+
+	userDefinedDataPathEnvVar = "VT_MYSQLCTL_COMPRESSION_BENCHMARK_DATA_PATH"
+)
+
+func setupBenchmarkCompressEnv(args benchmarkCompressArgs) benchmarkCompressEnv {
+	bce := benchmarkCompressEnv{
+		benchmarkCompressArgs: args,
+	}
+	bce.validate()
+	return bce
+}
+
+func (bce *benchmarkCompressEnv) benchmark() {
+	bce.b.StopTimer()
+	bce.b.ResetTimer()
+
+	for i := 0; i < bce.b.N; i++ {
+		logger := logutil.NewMemoryLogger()
+
+		compressor := bce.compressor(logger)
+		defer compressor.Close()
+
+		reader := bce.reader()
+		defer reader.Close()
+
+		// Only time the part we care about.
+		bce.b.StartTimer()
+		_, err := io.Copy(compressor, reader)
+		bce.b.StopTimer()
+
+		require.Nil(bce.b, err, logger.Events)
+	}
+}
+
+func (bce *benchmarkCompressEnv) compressor(logger logutil.Logger) io.WriteCloser {
+	var compressor io.WriteCloser
+	var err error
+
+	if bce.builtin != "" {
+		compressor, err = newBuiltinCompressor(bce.builtin, io.Discard, logger)
+	} else if bce.external != "" {
+		compressor, err = newExternalCompressor(context.Background(), bce.external, io.Discard, logger)
+	}
+
+	require.Nil(bce.b, err, "Failed to create compressor.")
+	return compressor
+}
+
+func (bce *benchmarkCompressEnv) reader() io.ReadCloser {
+	dataPath := os.Getenv(userDefinedDataPathEnvVar)
+	f, err := os.Open(dataPath)
+	require.Nil(bce.b, err, "Failed to open data path: %s", dataPath)
+	return f
+}
+
+func (bce *benchmarkCompressEnv) validate() {
+	if bce.external != "" {
+		cmdArgs := strings.Split(bce.external, " ")
+
+		_, err := validateExternalCmd(cmdArgs[0])
+		if err != nil {
+			bce.b.Skipf("Command %q not available in this host: %v; skipping...", cmdArgs[0], err)
+		}
+	}
+
+	if bce.builtin == "" && bce.external == "" {
+		require.Fail(bce.b, "Either builtin or external compressor must be specified.")
+	}
+
+	dataPath := os.Getenv(userDefinedDataPathEnvVar)
+	if dataPath == "" {
+		require.Fail(bce.b, fmt.Sprintf(
+			"Required environment variable %q is not set.\n\nUSAGE:\n%s",
+			userDefinedDataPathEnvVar,
+			usage,
+		))
+	}
+}
+
+func BenchmarkCompressLz4Builtin(b *testing.B) {
+	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
+		b:       b,
+		builtin: Lz4Compressor,
+	})
+	env.benchmark()
+}
+
+func BenchmarkCompressPargzipBuiltin(b *testing.B) {
+	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
+		b:       b,
+		builtin: PargzipCompressor,
+	})
+	env.benchmark()
+}
+
+func BenchmarkCompressPgzipBuiltin(b *testing.B) {
+	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
+		b:       b,
+		builtin: PgzipCompressor,
+	})
+	env.benchmark()
+}
+
+func BenchmarkCompressZstdBuiltin(b *testing.B) {
+	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
+		b:       b,
+		builtin: ZstdCompressor,
+	})
+	env.benchmark()
+}
+
+func BenchmarkCompressZstdExternal(b *testing.B) {
+	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
+		b:        b,
+		external: fmt.Sprintf("zstd -%d", compressionLevel),
+	})
+	env.benchmark()
+}
+
+func BenchmarkCompressZstdExternalFast4(b *testing.B) {
+	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
+		b:        b,
+		external: fmt.Sprintf("zstd -%d --fast=4", compressionLevel),
+	})
+	env.benchmark()
+}
+
+func BenchmarkCompressZstdExternalT0(b *testing.B) {
+	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
+		b:        b,
+		external: fmt.Sprintf("zstd -%d -T0", compressionLevel),
+	})
+	env.benchmark()
+}
+
+func BenchmarkCompressZstdExternalT4(b *testing.B) {
+	env := setupBenchmarkCompressEnv(benchmarkCompressArgs{
+		b:        b,
+		external: fmt.Sprintf("zstd -%d -T4", compressionLevel),
+	})
+	env.benchmark()
+}


### PR DESCRIPTION
Relates to #7802.

These benchmarks are proving useful in internal discussions around improving the performance of backups. Sharing here in case others find them useful. 

This benchmark downloads and compresses [this ~60GB InnoDB file](https://archive.org/details/enwiki-20221220-externallinks.ibd), which was built by loading [this Wikipedia dataset](https://dumps.wikimedia.org/enwiki/20221220/enwiki-20221220-externallinks.sql.gz) into MySQL 8.

```
$ go test -bench=BenchmarkCompress ./go/vt/mysqlctl -run=NONE -timeout=12h -benchtime=1x -v
goos: darwin
goarch: arm64
pkg: vitess.io/vitess/go/vt/mysqlctl
BenchmarkCompressLz4Builtin
    compression_benchmark_test.go:310: downloading data from https://www.dropbox.com/s/raw/smmgifsooy5qytd/enwiki-20080103-pages-articles.ibd.tar.zst
BenchmarkCompressLz4Builtin-8                  1        11737493087 ns/op        577.98 MB/s             2.554 compression-ratio
BenchmarkCompressPargzipBuiltin
BenchmarkCompressPargzipBuiltin-8              1        31083784040 ns/op        218.25 MB/s             2.943 compression-ratio
BenchmarkCompressPgzipBuiltin
BenchmarkCompressPgzipBuiltin-8                1        13325299680 ns/op        509.11 MB/s             2.910 compression-ratio
BenchmarkCompressZstdBuiltin
BenchmarkCompressZstdBuiltin-8                 1        18683863911 ns/op        363.09 MB/s             3.150 compression-ratio
BenchmarkCompressZstdExternal
BenchmarkCompressZstdExternal-8                1        10795487675 ns/op        628.41 MB/s             3.093 compression-ratio
BenchmarkCompressZstdExternalFast4
BenchmarkCompressZstdExternalFast4-8           1        7139319009 ns/op         950.23 MB/s             2.323 compression-ratio
BenchmarkCompressZstdExternalT0
BenchmarkCompressZstdExternalT0-8              1        4393860434 ns/op        1543.97 MB/s             3.093 compression-ratio
BenchmarkCompressZstdExternalT4
BenchmarkCompressZstdExternalT4-8              1        4389559744 ns/op        1545.49 MB/s             3.093 compression-ratio
PASS
cleaning up "/var/folders/96/k7gzd7q10zdb749vr02q7sjh0000gn/T/ee7d47b45ef09786c54fa2d7354d2a68.dat"
```

System info:

 * `Version: 16.0.0-SNAPSHOT (Git revision 90baaedac2ce6aef89977846c44c313a371ef234 branch 'maxeng-zstd-faster') built on Tue Dec 20 00:00:48 EST 2022 by maxenglander@planetscale.local using go1.19.4 darwin/arm64`
 * `Darwin planetscale.local 21.6.0 Darwin Kernel Version 21.6.0: Thu Sep 29 20:13:46 PDT 2022; root:xnu-8020.240.7~1/RELEASE_ARM64_T8101 arm64`
 * <img width="213" alt="image" src="https://user-images.githubusercontent.com/340318/208711689-c7e8ff42-a94d-41fb-a524-c265fafbf3ca.png">
