### PR TITLE
docker/lite: +zstd dep

### DIFF
--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -58,6 +58,7 @@ BASE_PACKAGES=(
     wget
     curl
     percona-toolkit
+    zstd
 )
 
 apt-get update


### PR DESCRIPTION
Related to #7802

# Description

I would like to have zstd CLI available in Docker lite images so that when using VTOP-deployed Vitess I can take advantage of the fact that zstd external is apparently much faster (see https://github.com/vitessio/vitess/pull/11994) than the native Go library.

# Image sizes

`docker inspect <image> | jq -r .[].Size`

| Target | 7fc1b48d9 | This PR | ∆ |
|-------|--------|------|-------|
| lite_mysql57  | 1230530599 | 1231544936 | +1014337 (+0.082%) |
| lite_mysql80  | 1222034851 | 1223049180 | +1014329 (+0.083%) |
| lite_percona57  | 1151917943 | 1152923524 | +1005581 (+0.087%) |
| lite_percona80  | 1818075338 | 1819080907 | +1005569 (+0.0553%) |
| lite_testing  | 797503720 | 798774969 | +1271249 (+0.159%) |
| lite_ubi7.mysql57  | ⚠️ | ⚠️ | ⚠️ |
| lite_ubi7.mysql80  | ⚠️ | ⚠️ | ⚠️ |
| lite_ubi7.percona57  | 1478300308 | 1478790334 | +490026 (+0.033%) |
| lite_ubi7.percona80  | 1671904530 | 1672394556 | +490026 (+0.029%) |
| lite_ubi8.arm64.mysql80  | 1399800336 | 1399454317 | -346019 (-0.024%) |
| lite_ubi8.mysql80  | ⚠️ | ⚠️ | ⚠️ |

Not sure if there is a better way to find out these image sizes, but here's what I did.

Since I'm building these on my Mac I need to use `docker buildx` to build linux/amd64 images. I made a small change to Makefile to make this easier: https://github.com/vitessio/vitess/pull/12081

Then I ran `GOOS=linux GOARCH=amd64 make docker_<target>` on `main` (7fc1b48d9ea8f10afa597a1e3885b4fb55f3b6be) and this branch. Except for `lite_ubi8.arm64.mysql80` which with just plain `make`.

⚠️ I'm not able to build the `ubi7.mysql57`, `ubi7.mysql80` or `ubi8.mysql80` images locally though, I get this error: 

```
#0 11.87 Total download size: 11 k
#0 11.87 Downloading packages:
#0 11.88 Delta RPMs disabled because /usr/bin/applydeltarpm not installed.
#0 13.06 warning: /var/cache/yum/x86_64/7Server/mysql80-community/packages/mysql80-community-release-el7-7.noarch.rpm: Header V4 RSA/SHA256 Signature, key ID 3a79bd29: NOKEY
#0 13.07 Public key for mysql80-community-release-el7-7.noarch.rpm is not installed
#0 13.17 Retrieving key from file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
#0 14.61
#0 14.61
#0 14.61 The GPG keys listed for the "MySQL 8.0 Community Server" repository are already installed but they are not correct for this package.
#0 14.61 Check that the correct key URLs are configured for this repository.
#0 14.61
#0 14.61
#0 14.61  Failing package is: mysql80-community-release-el7-7.noarch
#0 14.61  GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
#0 14.61
------
ERROR: failed to solve: executor failed running [/bin/sh -c yum update -y --setopt=alwaysprompt=no --setopt=tsflags=nodocs  && yum install -y --setopt=alwaysprompt=no --setopt=tsflags=nodocs bzip2 ca-certificates gnupg libaio libcurl     jemalloc gperftools-libs procps-ng rsync wget openssl hostname curl tzdata make  && yum install -y --setopt=tsflags=nodocs --enablerepo mysql80-community --disablerepo mysql57-community     mysql-community-client mysql-community-server  && mkdir -p /tmp/1  && yum install -y --setopt=alwaysprompt=no --downloadonly --downloaddir=/tmp/1 --enablerepo mysql80-community --disablerepo mysql57-community percona-xtrabackup-80 percona-toolkit  && rpm -Uvh --replacefiles /tmp/1/*rpm  && rm -rf /tmp/1  && yum clean all  && yum clean all --enablerepo mysql80-community --disablerepo mysql57-community  && rm -rf /etc/my.cnf /var/lib/mysql /tmp/gpg /sbin/mysqld-debug]: exit code: 1
```