### PR TITLE
only expand when we have full information

### DIFF
--- a/go/vt/vtgate/semantics/derived_table.go
+++ b/go/vt/vtgate/semantics/derived_table.go
@@ -27,17 +27,18 @@ import (
 
 // DerivedTable contains the information about the projection, tables involved in derived table.
 type DerivedTable struct {
-	tableName   string
-	ASTNode     *sqlparser.AliasedTableExpr
-	columnNames []string
-	cols        []sqlparser.Expr
-	tables      TableSet
+	tableName       string
+	ASTNode         *sqlparser.AliasedTableExpr
+	columnNames     []string
+	cols            []sqlparser.Expr
+	tables          TableSet
+	isAuthoritative bool
 }
 
 var _ TableInfo = (*DerivedTable)(nil)
 
 func createDerivedTableForExpressions(expressions sqlparser.SelectExprs, cols sqlparser.Columns, tables []TableInfo, org originable) *DerivedTable {
-	vTbl := &DerivedTable{}
+	vTbl := &DerivedTable{isAuthoritative: true}
 	for i, selectExpr := range expressions {
 		switch expr := selectExpr.(type) {
 		case *sqlparser.AliasedExpr:
@@ -58,6 +59,9 @@ func createDerivedTableForExpressions(expressions sqlparser.SelectExprs, cols sq
 		case *sqlparser.StarExpr:
 			for _, table := range tables {
 				vTbl.tables = vTbl.tables.Merge(table.getTableSet(org))
+				if !table.authoritative() {
+					vTbl.isAuthoritative = false
+				}
 			}
 		}
 	}
@@ -93,7 +97,7 @@ func (dt *DerivedTable) matches(name sqlparser.TableName) bool {
 }
 
 func (dt *DerivedTable) authoritative() bool {
-	return true
+	return dt.isAuthoritative
 }
 
 // Name implements the TableInfo interface

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -164,6 +164,13 @@ func TestExpandStar(t *testing.T) {
 	}, {
 		sql:    "select * from (select 12) as t",
 		expSQL: "select t.`12` from (select 12 from dual) as t",
+	}, {
+		sql:    "SELECT * FROM (SELECT *, 12 AS foo FROM t3) as results",
+		expSQL: "select * from (select *, 12 as foo from t3) as results",
+	}, {
+		// if we are only star-expanding authoritative tables, we don't need to stop the expansion
+		sql:    "SELECT * FROM (SELECT t2.*, 12 AS foo FROM t3, t2) as results",
+		expSQL: "select results.c1, results.c2, results.foo from (select t2.c1 as c1, t2.c2 as c2, 12 as foo from t3, t2) as results",
 	}}
 	for _, tcase := range tcases {
 		t.Run(tcase.sql, func(t *testing.T) {

--- a/go/vt/vtgate/semantics/vtable.go
+++ b/go/vt/vtgate/semantics/vtable.go
@@ -26,10 +26,11 @@ import (
 // vTableInfo is used to represent projected results, not real tables. It is used for
 // ORDER BY, GROUP BY and HAVING that need to access result columns
 type vTableInfo struct {
-	tableName   string
-	columnNames []string
-	cols        []sqlparser.Expr
-	tables      TableSet
+	tableName       string
+	columnNames     []string
+	cols            []sqlparser.Expr
+	tables          TableSet
+	isAuthoritative bool
 }
 
 var _ TableInfo = (*vTableInfo)(nil)
@@ -62,7 +63,7 @@ func (v *vTableInfo) matches(name sqlparser.TableName) bool {
 }
 
 func (v *vTableInfo) authoritative() bool {
-	return true
+	return v.isAuthoritative
 }
 
 func (v *vTableInfo) Name() (sqlparser.TableName, error) {
@@ -108,11 +109,12 @@ func (v *vTableInfo) getExprFor(s string) (sqlparser.Expr, error) {
 }
 
 func createVTableInfoForExpressions(expressions sqlparser.SelectExprs, tables []TableInfo, org originable) *vTableInfo {
-	cols, colNames, ts := selectExprsToInfos(expressions, tables, org)
+	cols, colNames, ts, isAuthoritative := selectExprsToInfos(expressions, tables, org)
 	return &vTableInfo{
-		columnNames: colNames,
-		cols:        cols,
-		tables:      ts,
+		columnNames:     colNames,
+		cols:            cols,
+		tables:          ts,
+		isAuthoritative: isAuthoritative,
 	}
 }
 
@@ -120,7 +122,8 @@ func selectExprsToInfos(
 	expressions sqlparser.SelectExprs,
 	tables []TableInfo,
 	org originable,
-) (cols []sqlparser.Expr, colNames []string, ts TableSet) {
+) (cols []sqlparser.Expr, colNames []string, ts TableSet, isAuthoritative bool) {
+	isAuthoritative = true
 	for _, selectExpr := range expressions {
 		switch expr := selectExpr.(type) {
 		case *sqlparser.AliasedExpr:
@@ -139,6 +142,9 @@ func selectExprsToInfos(
 		case *sqlparser.StarExpr:
 			for _, table := range tables {
 				ts = ts.Merge(table.getTableSet(org))
+				if !table.authoritative() {
+					isAuthoritative = false
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Before planning a query, vtgate will simplify the query. One of the simplifications is to expand `*` outputs in the query.
This is only done if we have enough schema information about the tables in the query.

The issue reported in #11880 is related to a derived table where we don't have enough information to expand the columns. Before this fix, we would just use whatever column information we had, which is not correct.

This PR changes the semantic analysis so it keeps track in more places if we can successfully expand columns or not, and will just not expand when we are missing necessary information.

## Related Issue(s)
Fixes #11880

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
