### PR TITLE
Remove unnecessary logging

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -23,7 +23,6 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
 
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
@@ -74,10 +73,7 @@ func (qb *queryBuilder) addTableExpr(
 		Hints:      hints,
 		Columns:    columnAliases,
 	}
-	err := qb.ctx.SemTable.ReplaceTableSetFor(tableID, elems)
-	if err != nil {
-		log.Warningf("error in replacing table expression in semtable: %v", err)
-	}
+	qb.ctx.SemTable.ReplaceTableSetFor(tableID, elems)
 	sel.From = append(sel.From, elems)
 	qb.sel = sel
 	qb.tableNames = append(qb.tableNames, tableName)

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -151,23 +151,22 @@ func (st *SemTable) TableSetFor(t *sqlparser.AliasedTableExpr) TableSet {
 }
 
 // ReplaceTableSetFor replaces the given single TabletSet with the new *sqlparser.AliasedTableExpr
-func (st *SemTable) ReplaceTableSetFor(id TableSet, t *sqlparser.AliasedTableExpr) error {
+func (st *SemTable) ReplaceTableSetFor(id TableSet, t *sqlparser.AliasedTableExpr) {
 	if id.NumberOfTables() != 1 {
-		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "BUG: tablet identifier should represent single table: %v", id)
+		// This is probably a derived table
+		return
 	}
 	tblOffset := id.TableOffset()
 	if tblOffset > len(st.Tables) {
-		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "BUG: tablet identifier greater than number of tables: %v, %d", id, len(st.Tables))
+		// This should not happen and is probably a bug, but the output query will still work fine
+		return
 	}
 	switch tbl := st.Tables[id.TableOffset()].(type) {
 	case *RealTable:
 		tbl.ASTNode = t
 	case *DerivedTable:
 		tbl.ASTNode = t
-	default:
-		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "BUG: replacement not expected for : %T", tbl)
 	}
-	return nil
 }
 
 // TableInfoFor returns the table info for the table set. It should contains only single table.


### PR DESCRIPTION
## Description
The perfectly valid use case of derived tables that have been pushed under a `Route` lead to a warning from the planner that wasn't really helpful or informative. The solution was to simply remove this logging altogether.

## Related Issue(s)
Fixes #11869

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
