### PR TITLE
Add vtorc port to vitess local docker run

### DIFF
--- a/docker/local/run.sh
+++ b/docker/local/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run -p 15000:15000 -p 15001:15001 -p 15991:15991 -p 15999:15999 --rm -it vitess/local
+docker run -p 15000:15000 -p 15001:15001 -p 15991:15991 -p 15999:15999 -p 16000:16000 --rm -it vitess/local


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds the VTOrc port to be exported from the docker-local example so that VTOrc dashboard can be accessed.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required - https://github.com/vitessio/website/pull/1307

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
