### PR TITLE
Fix vttestserver run script defaults

### DIFF
--- a/docker/vttestserver/run.sh
+++ b/docker/vttestserver/run.sh
@@ -40,8 +40,8 @@ rm -vf "$VTDATAROOT"/"$tablet_dir"/{mysql.sock,mysql.sock.lock}
 	--foreign_key_mode "${FOREIGN_KEY_MODE:-allow}" \
 	--enable_online_ddl="${ENABLE_ONLINE_DDL:-true}" \
 	--enable_direct_ddl="${ENABLE_DIRECT_DDL:-true}" \
-	--planner-version="${PLANNER_VERSION:-v3}" \
+	--planner-version="${PLANNER_VERSION:-gen4}" \
 	--vschema_ddl_authorized_users=% \
-	--tablet_refresh_interval "$TABLET_REFRESH_INTERVAL"
+	--tablet_refresh_interval "${TABLET_REFRESH_INTERVAL:-10s}"
 	--schema_dir="/vt/schema/"
 


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the default values for a couple of parameters in the run script used by the vttestserver docker image.

This fixes the issue described in https://github.com/vitessio/vitess/issues/12003. Running the docker image without specifying the `TABLET_REFRESH_INTERVAL` environment variable works just fine after these changes.

The default planner has also been changed to gen4.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #12003 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
