### PR TITLE
remove e2e test from partial_keyspace config

### DIFF
--- a/test/config_partial_keyspace.json
+++ b/test/config_partial_keyspace.json
@@ -143,15 +143,6 @@
       "Shard": "vtgate_partial_keyspace",
       "RetryMax": 2,
       "Tags": []
-    },
-    "vtgate_queries_vexplain_partial_keyspace": {
-      "File": "unused.go",
-      "Args": ["vitess.io/vitess/go/test/endtoend/vtgate/queries/vexplain"],
-      "Command": [],
-      "Manual": false,
-      "Shard": "vtgate_partial_keyspace",
-      "RetryMax": 2,
-      "Tags": []
     }
   }
 }


### PR DESCRIPTION
## Description
There is no need to run the `vexplain` end-to-end tests on the partial_keyspace test configuration, so this PR removes it.
