### PR TITLE
OnlineDDL: scheduleNextMigration() to only read reviewed migrations

### DIFF
--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -121,6 +121,7 @@ const (
 		FROM _vt.schema_migrations
 		WHERE
 			migration_status='queued'
+			AND reviewed_timestamp IS NOT NULL
 	`
 	sqlUpdateMySQLTable = `UPDATE _vt.schema_migrations
 			SET mysql_table=%a


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/12013 by adding `AND reviewed_timestamp IS NOT NULL` 

## Related Issue(s)

fixes https://github.com/vitessio/vitess/issues/12013

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
