### PR TITLE
Use Gen4 as the default planner version for VTExplain

### DIFF
--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -26,6 +26,7 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtexplain"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 
 	"github.com/spf13/pflag"
@@ -44,7 +45,7 @@ var (
 	ksShardMapFileFlag string
 	normalize          bool
 	dbName             string
-	plannerVersionStr  string
+	plannerVersionStr  = planbuilder.Gen4.String()
 
 	numShards       = 2
 	replicationMode = "ROW"

--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -17,7 +17,7 @@ Usage of vtexplain:
       --mysql_server_version string                 MySQL server version to advertise.
       --normalize                                   Whether to enable vtgate normalization
       --output-mode string                          Output in human-friendly text or json (default "text")
-      --planner-version string                      Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4 (default "Gen4")
+      --planner-version string                      Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4. An empty value will use VTGate's default planner
       --pprof strings                               enable profiling
       --purge_logs_interval duration                how often try to remove old logs (default 1h0m0s)
       --replication-mode string                     The replication mode to simulate -- must be set to either ROW or STATEMENT (default "ROW")

--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -17,7 +17,7 @@ Usage of vtexplain:
       --mysql_server_version string                 MySQL server version to advertise.
       --normalize                                   Whether to enable vtgate normalization
       --output-mode string                          Output in human-friendly text or json (default "text")
-      --planner-version string                      Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4
+      --planner-version string                      Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4 (default "Gen4")
       --pprof strings                               enable profiling
       --purge_logs_interval duration                how often try to remove old logs (default 1h0m0s)
       --replication-mode string                     The replication mode to simulate -- must be set to either ROW or STATEMENT (default "ROW")


### PR DESCRIPTION
## Description

This PR fixes the issue described in #12020. Gen4 is now the default planner version for VTExplain.

## Related Issue(s)

- Fixes #12020.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
