### PR TITLE
BugFix: Errant GTID detection for a single replica

### DIFF
--- a/go/mysql/replication_status.go
+++ b/go/mysql/replication_status.go
@@ -178,6 +178,7 @@ func ProtoToReplicationStatus(s *replicationdatapb.Status) ReplicationStatus {
 // FindErrantGTIDs can be used to find errant GTIDs in the receiver's relay log, by comparing it against all known replicas,
 // provided as a list of ReplicationStatus's. This method only works if the flavor for all retrieved ReplicationStatus's is MySQL.
 // The result is returned as a Mysql56GTIDSet, each of whose elements is a found errant GTID.
+// This function is best effort in nature. If it marks something as errant, then it is for sure errant. But there may be cases of errant GTIDs, which aren't caught by this function.
 func (s *ReplicationStatus) FindErrantGTIDs(otherReplicaStatuses []*ReplicationStatus) (Mysql56GTIDSet, error) {
 	if len(otherReplicaStatuses) == 0 {
 		// If there is nothing to compare this replica against, then we must assume that its GTID set is the correct one.

--- a/go/mysql/replication_status.go
+++ b/go/mysql/replication_status.go
@@ -179,6 +179,11 @@ func ProtoToReplicationStatus(s *replicationdatapb.Status) ReplicationStatus {
 // provided as a list of ReplicationStatus's. This method only works if the flavor for all retrieved ReplicationStatus's is MySQL.
 // The result is returned as a Mysql56GTIDSet, each of whose elements is a found errant GTID.
 func (s *ReplicationStatus) FindErrantGTIDs(otherReplicaStatuses []*ReplicationStatus) (Mysql56GTIDSet, error) {
+	if len(otherReplicaStatuses) == 0 {
+		// If there is nothing to compare this replica against, then we must assume that its GTID set is the correct one.
+		return nil, nil
+	}
+
 	relayLogSet, ok := s.RelayLogPosition.GTIDSet.(Mysql56GTIDSet)
 	if !ok {
 		return nil, fmt.Errorf("errant GTIDs can only be computed on the MySQL flavor")

--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -55,3 +55,43 @@ func TestRecoverWithMultipleVttabletFailures(t *testing.T) {
 	newPrimary := utils.GetNewPrimary(t, clusterInstance)
 	utils.ConfirmReplication(t, newPrimary, []*cluster.Vttablet{tablets[2], tablets[3]})
 }
+
+// TetsSingeReplicaERS tests that ERS works even when there is only 1 tablet left
+// as long the durability policy allows this failure. Moreover, this also tests that the
+// replica is one such that it was a primary itself before. This way its executed gtid set
+// will have atleast 2 tablets in it. We want to make sure this tablet is not marked as errant
+// and ERS succeeds.
+func TestSingleReplicaERS(t *testing.T) {
+	// Set up a cluster with none durability policy
+	defer cluster.PanicHandler(t)
+	clusterInstance := utils.SetupReparentCluster(t, "none")
+	defer utils.TeardownCluster(clusterInstance)
+	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
+	// Confirm that the replication is setup correctly in the beginning
+	utils.ConfirmReplication(t, tablets[0], []*cluster.Vttablet{tablets[1], tablets[2], tablets[3]})
+
+	// Delete and stop two tablets. We only want to have 2 tablets for this test.
+	utils.DeleteTablet(t, clusterInstance, tablets[2])
+	utils.DeleteTablet(t, clusterInstance, tablets[3])
+	utils.StopTablet(t, tablets[2], true)
+	utils.StopTablet(t, tablets[3], true)
+
+	// Reparent to the other replica
+	output, err := utils.Prs(t, clusterInstance, tablets[1])
+	require.NoError(t, err, "error in PlannedReparentShard output - %s", output)
+
+	// Check the replication is set up correctly before we failover
+	utils.ConfirmReplication(t, tablets[1], []*cluster.Vttablet{tablets[0]})
+
+	// Make the current primary vttablet unavailable.
+	utils.StopTablet(t, tablets[1], true)
+
+	// Run an ERS with only one replica reachable. Also, this replica is such that it was a primary before.
+	output, err = utils.Ers(clusterInstance, tablets[0], "", "")
+	require.NoError(t, err, "error in Emergency Reparent Shard output - %s", output)
+
+	// Check the tablet is indeed promoted
+	utils.CheckPrimaryTablet(t, clusterInstance, tablets[0])
+	// Also check the writes succeed after failover
+	utils.ConfirmReplication(t, tablets[0], []*cluster.Vttablet{})
+}

--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -67,7 +67,8 @@ func TestSingleReplicaERS(t *testing.T) {
 	clusterInstance := utils.SetupReparentCluster(t, "none")
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
-	// Confirm that the replication is setup correctly in the beginning
+	// Confirm that the replication is setup correctly in the beginning.
+	// tablets[0] is the primary tablet in the beginning.
 	utils.ConfirmReplication(t, tablets[0], []*cluster.Vttablet{tablets[1], tablets[2], tablets[3]})
 
 	// Delete and stop two tablets. We only want to have 2 tablets for this test.

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -610,9 +610,9 @@ func (erp *EmergencyReparenter) reparentReplicas(
 			return nil, vterrors.Wrapf(rec.Error(), "received more errors (= %d) than replicas (= %d), which should be impossible: %v", errCount, numReplicas, rec.Error())
 		case errCount == numReplicas:
 			if len(tabletMap) <= 2 {
-				// If there are atmost 2 tablets in the tablet map, we shouldn't be failing the promotion if the replica fails to SetReplicationSource.
-				// The failing replica is probably the old primary that is down, so it is okay if if fails. We still log a warning message in the logs.
-				erp.logger.Warningf("The only replica failed to set replication source: %v", rec.Error())
+				// If there are at most 2 tablets in the tablet map, we shouldn't be failing the promotion if the replica fails to SetReplicationSource.
+				// The failing replica is probably the old primary that is down, so it is okay if it fails. We still log a warning message in the logs.
+				erp.logger.Warningf("Failed to set the MySQL replication source during ERS but because there is only one other tablet we assume it is the one that had failed and will progress with the reparent. Error: %v", rec.Error())
 				return nil, nil
 			}
 			return nil, vterrors.Wrapf(rec.Error(), "%d replica(s) failed: %v", numReplicas, rec.Error())

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -609,6 +609,12 @@ func (erp *EmergencyReparenter) reparentReplicas(
 			// we're going to be explicit that this is doubly unexpected.
 			return nil, vterrors.Wrapf(rec.Error(), "received more errors (= %d) than replicas (= %d), which should be impossible: %v", errCount, numReplicas, rec.Error())
 		case errCount == numReplicas:
+			if len(tabletMap) <= 2 {
+				// If there are atmost 2 tablets in the tablet map, we shouldn't be failing the promotion if the replica fails to SetReplicationSource.
+				// The failing replica is probably the old primary that is down, so it is okay if if fails. We still log a warning message in the logs.
+				erp.logger.Warningf("The only replica failed to set replication source: %v", rec.Error())
+				return nil, nil
+			}
 			return nil, vterrors.Wrapf(rec.Error(), "%d replica(s) failed: %v", numReplicas, rec.Error())
 		default:
 			return replicasStartedReplication, nil

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -3489,6 +3489,49 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 			shard:     "-",
 			ts:        memorytopo.NewServer("zone1"),
 			shouldErr: false,
+		}, {
+			name:                 "single replica failing to SetReplicationSource does not fail the promotion",
+			emergencyReparentOps: EmergencyReparentOptions{},
+			tmc: &testutil.TabletManagerClient{
+				PopulateReparentJournalResults: map[string]error{
+					"zone1-0000000100": nil,
+				},
+				PrimaryPositionResults: map[string]struct {
+					Position string
+					Error    error
+				}{
+					"zone1-0000000100": {
+						Error: nil,
+					},
+				},
+				SetReplicationSourceResults: map[string]error{
+					"zone1-0000000101": assert.AnError,
+				},
+			},
+			newPrimaryTabletAlias: "zone1-0000000100",
+			tabletMap: map[string]*topo.TabletInfo{
+				"zone1-0000000100": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
+				},
+				"zone1-0000000101": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  101,
+						},
+					},
+				},
+			},
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{},
+			keyspace:  "testkeyspace",
+			shard:     "-",
+			ts:        memorytopo.NewServer("zone1"),
+			shouldErr: false,
 		},
 	}
 

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -89,6 +89,19 @@ func TestFindValidEmergencyReparentCandidates(t *testing.T) {
 			},
 			expected:  []string{"r1", "r2", "p1"},
 			shouldErr: false,
+		}, {
+			name: "success for single tablet",
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{
+				"r1": {
+					After: &replicationdatapb.Status{
+						SourceUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
+						RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5,AAAAAAAA-71CA-11E1-9E33-C80AA9429562:1",
+					},
+				},
+			},
+			primaryStatusMap: map[string]*replicationdatapb.PrimaryStatus{},
+			expected:         []string{"r1"},
+			shouldErr:        false,
 		},
 		{
 			name: "mixed replication modes",


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the issue raised in #12023. The errant GTID detection code has been fixed to not mark a single replica as errant.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #12023 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
