### PR TITLE
Add missing backslash to run.sh script

### DIFF
--- a/docker/vttestserver/run.sh
+++ b/docker/vttestserver/run.sh
@@ -42,6 +42,6 @@ rm -vf "$VTDATAROOT"/"$tablet_dir"/{mysql.sock,mysql.sock.lock}
 	--enable_direct_ddl="${ENABLE_DIRECT_DDL:-true}" \
 	--planner-version="${PLANNER_VERSION:-gen4}" \
 	--vschema_ddl_authorized_users=% \
-	--tablet_refresh_interval "${TABLET_REFRESH_INTERVAL:-10s}"
+	--tablet_refresh_interval "${TABLET_REFRESH_INTERVAL:-10s}" \
 	--schema_dir="/vt/schema/"
 


### PR DESCRIPTION
Backslash was missing, which was causing, that --schema_dir was not applied and therefore alters were not applied and tables in databases were not created. This will fix it

Signed-off-by: kbslvsk <76602353+kbslvsk@users.noreply.github.com>

## Description

This is a bug fix, that will fix unapplied option --schema_dir, which was causing alters not applying
## Related Issue(s)

https://github.com/vitessio/vitess/issues/12032

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A
