### PR TITLE
BugFix: Fix race in `IsFlagProvided`

### DIFF
--- a/go/internal/flag/flag.go
+++ b/go/internal/flag/flag.go
@@ -72,13 +72,11 @@ func Parse(fs *flag.FlagSet) {
 
 // IsFlagProvided returns if the given flag has been provided by the user explicitly or not
 func IsFlagProvided(name string) bool {
-	found := false
-	flag.Visit(func(f *flag.Flag) {
-		if f.Name == name {
-			found = true
-		}
-	})
-	return found
+	fl := flag.Lookup(name)
+	if fl != nil {
+		return fl.Changed
+	}
+	return false
 }
 
 // TrickGlog tricks glog into understanding that flags have been parsed.

--- a/go/vt/topo/locks_test.go
+++ b/go/vt/topo/locks_test.go
@@ -58,11 +58,27 @@ func TestGetLockTimeout(t *testing.T) {
 			lockTimeoutValue:            "33s",
 			remoteOperationTimeoutValue: "22s",
 			expectedLockTimeout:         33 * time.Second,
+		}, {
+			description:                 "remote operation timeout flag specified to the default",
+			lockTimeoutValue:            "",
+			remoteOperationTimeoutValue: "15s",
+			expectedLockTimeout:         15 * time.Second,
+		}, {
+			description:                 "lock-timeout flag specified to the default",
+			lockTimeoutValue:            "45s",
+			remoteOperationTimeoutValue: "33s",
+			expectedLockTimeout:         45 * time.Second,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
+			oldLockTimeout := LockTimeout
+			oldRemoteOpsTimeout := RemoteOperationTimeout
+			defer func() {
+				LockTimeout = oldLockTimeout
+				RemoteOperationTimeout = oldRemoteOpsTimeout
+			}()
 			var args []string
 			if tt.lockTimeoutValue != "" {
 				args = append(args, "--lock-timeout", tt.lockTimeoutValue)


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the race in `IsFlagProvided` as described in issue #12041. 

The way the fix is accomplished is to replace the usage of `flag.Visit` with `flag.Lookup` which just reads from a single map and doesn't write anything, making it thread-safe.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #12041 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
