### PR TITLE
mysqlctl: flags should be added to vtbackup

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -12,6 +12,8 @@ Usage of vtbackup:
       --backup_storage_implementation string            Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, at once, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
       --ceph_backup_storage_config string               Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
+      --compression-engine-name string                  compressor engine used for compression. (default "pargzip")
+      --compression-level int                           what level to pass to the compressor. (default 1)
       --concurrency int                                 (init restore parameter) how many concurrent files to restore at once (default 4)
       --consul_auth_static_file string                  JSON File to read the topos/tokens from.
       --db-credentials-file string                      db credentials file; send SIGHUP to reload this file
@@ -63,6 +65,9 @@ Usage of vtbackup:
       --db_tls_min_version string                       Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
       --detach                                          detached mode - run backups detached from the terminal
       --emit_stats                                      If set, emit stats to push-based monitoring and stats backends
+      --external-compressor string                      command with arguments to use when compressing a backup.
+      --external-compressor-extension string            extension to use when using an external compressor.
+      --external-decompressor string                    command with arguments to use when decompressing a backup.
       --file_backup_storage_root string                 Root directory for the file backup storage.
       --gcs_backup_storage_bucket string                Google Cloud Storage bucket to use for backups.
       --gcs_backup_storage_root string                  Root prefix for all backup-related object names.

--- a/go/vt/mysqlctl/compression.go
+++ b/go/vt/mysqlctl/compression.go
@@ -65,7 +65,7 @@ var (
 )
 
 func init() {
-	for _, cmd := range []string{"vtcombo", "vttablet", "vttestserver", "vtctld", "vtctldclient"} {
+	for _, cmd := range []string{"vtbackup", "vtcombo", "vttablet", "vttestserver", "vtctld", "vtctldclient"} {
 		servenv.OnParseFor(cmd, registerBackupCompressionFlags)
 	}
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
We missed adding compression related flags to vtbackup during the flags refactor. This PR fixes that.

## Related Issue(s)
Fixes #12047 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
