### PR TITLE
VTGate: Set immediate caller id from gRPC static auth username

### DIFF
--- a/go/test/endtoend/vtgate/grpc_server_auth_static/main_test.go
+++ b/go/test/endtoend/vtgate/grpc_server_auth_static/main_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcserverauthstatic
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/vt/grpcclient"
+	"vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+)
+
+var (
+	clusterInstance   *cluster.LocalProcessCluster
+	vtgateGrpcAddress string
+	hostname          = "localhost"
+	keyspaceName      = "ks"
+	cell              = "zone1"
+	sqlSchema         = `
+		create table test_table (
+			id bigint,
+			val varchar(128),
+			primary key(id)
+		) Engine=InnoDB;
+`
+	grpcServerAuthStaticJSON = `
+		[
+		  {
+			"Username": "user_with_access",
+			"Password": "test_password"
+		  },
+		  {
+			"Username": "user_no_access",
+			"Password": "test_password"
+		  }
+		]
+`
+	tableACLJSON = `
+		{
+		  "table_groups": [
+			{
+			  "name": "default",
+			  "table_names_or_prefixes": ["%"],
+			  "readers": ["user_with_access"],
+			  "writers": ["user_with_access"],
+			  "admins": ["user_with_access"]
+			}
+		  ]
+		}
+`
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitcode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1
+		}
+
+		// Directory for authn / authz config files
+		authDirectory := path.Join(clusterInstance.TmpDirectory, "auth")
+		if err := os.Mkdir(authDirectory, 0700); err != nil {
+			return 1
+		}
+
+		// Create grpc_server_auth_static.json file
+		grpcServerAuthStaticPath := path.Join(authDirectory, "grpc_server_auth_static.json")
+		if err := createFile(grpcServerAuthStaticPath, grpcServerAuthStaticJSON); err != nil {
+			return 1
+		}
+
+		// Create table_acl.json file
+		tableACLPath := path.Join(authDirectory, "table_acl.json")
+		if err := createFile(tableACLPath, tableACLJSON); err != nil {
+			return 1
+		}
+
+		// Configure vtgate to use static auth
+		clusterInstance.VtGateExtraArgs = []string{
+			"--grpc_auth_mode", "static",
+			"--grpc_auth_static_password_file", grpcServerAuthStaticPath,
+		}
+
+		// Configure vttablet to use table ACL
+		clusterInstance.VtTabletExtraArgs = []string{
+			"--enforce-tableacl-config",
+			"--queryserver-config-strict-table-acl",
+			"--table-acl-config", tableACLPath,
+		}
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      keyspaceName,
+			SchemaSQL: sqlSchema,
+		}
+		if err := clusterInstance.StartUnshardedKeyspace(*keyspace, 1, false); err != nil {
+			return 1
+		}
+
+		// Start vtgate
+		if err := clusterInstance.StartVtgate(); err != nil {
+			clusterInstance.VtgateProcess = cluster.VtgateProcess{}
+			return 1
+		}
+		vtgateGrpcAddress = fmt.Sprintf("%s:%d", clusterInstance.Hostname, clusterInstance.VtgateGrpcPort)
+
+		return m.Run()
+	}()
+	os.Exit(exitcode)
+}
+
+func TestAuthenticatedUserWithAccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	vtgateConn, err := dialVTGate(ctx, t, "user_with_access", "test_password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer vtgateConn.Close()
+
+	session := vtgateConn.Session(keyspaceName+"@primary", nil)
+	query := "SELECT id FROM test_table"
+	_, err = session.Execute(ctx, query, nil)
+	assert.NoError(t, err)
+}
+
+func TestAuthenticatedUserNoAccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	vtgateConn, err := dialVTGate(ctx, t, "user_no_access", "test_password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer vtgateConn.Close()
+
+	session := vtgateConn.Session(keyspaceName+"@primary", nil)
+	query := "SELECT id FROM test_table"
+	_, err = session.Execute(ctx, query, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Select command denied to user")
+	assert.Contains(t, err.Error(), "for table 'test_table' (ACL check error)")
+}
+
+func TestUnauthenticatedUser(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	vtgateConn, err := dialVTGate(ctx, t, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer vtgateConn.Close()
+
+	session := vtgateConn.Session(keyspaceName+"@primary", nil)
+	query := "SELECT id FROM test_table"
+	_, err = session.Execute(ctx, query, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid credentials")
+}
+
+func dialVTGate(ctx context.Context, t *testing.T, username string, password string) (*vtgateconn.VTGateConn, error) {
+	clientCreds := &grpcclient.StaticAuthClientCreds{Username: username, Password: password}
+	creds := grpc.WithPerRPCCredentials(clientCreds)
+	dialerFunc := grpcvtgateconn.DialWithOpts(ctx, creds)
+	dialerName := t.Name()
+	vtgateconn.RegisterDialer(dialerName, dialerFunc)
+	return vtgateconn.DialProtocol(ctx, dialerName, vtgateGrpcAddress)
+}
+
+func createFile(path string, contents string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(contents)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/go/test/endtoend/vtgate/grpc_server_auth_static/main_test.go
+++ b/go/test/endtoend/vtgate/grpc_server_auth_static/main_test.go
@@ -139,6 +139,7 @@ func TestMain(m *testing.M) {
 	os.Exit(exitcode)
 }
 
+// TestAuthenticatedUserWithAccess verifies that an authenticated gRPC static user with ACL access can execute queries
 func TestAuthenticatedUserWithAccess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -155,6 +156,7 @@ func TestAuthenticatedUserWithAccess(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestAuthenticatedUserNoAccess verifies that an authenticated gRPC static user with no ACL access cannot execute queries
 func TestAuthenticatedUserNoAccess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -173,6 +175,7 @@ func TestAuthenticatedUserNoAccess(t *testing.T) {
 	assert.Contains(t, err.Error(), "for table 'test_table' (ACL check error)")
 }
 
+// TestUnauthenticatedUser verifies that an unauthenticated gRPC user cannot execute queries
 func TestUnauthenticatedUser(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/config.json
+++ b/test/config.json
@@ -900,6 +900,15 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
+		"vtgate_grpc_server_auth_static": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/grpc_server_auth_static"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_general_heavy",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"topo_zk2": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/topotest/zk2", "--topo-flavor=zk2"],


### PR DESCRIPTION
Signed-off-by: Brendan Dougherty <brendan.dougherty@shopify.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Currently, when using gRPC static auth on VTGate, the immediate caller id is always set to `unsecure_grpc_client`, rather than the username provided by the client. This means that table ACLs on VTTablet will reject the client's queries.

The problem appears to have been discussed when static auth was originally added [here](https://github.com/vitessio/vitess/pull/3418#discussion_r154534073), but was not changed in a followup.

This PR takes a similar approach to what was suggested and sets the authenticated username in the Context. This allows the VTGate server to retrieve the username in a similar manner to how it retrieves the certificate common name as the immediate caller id when using mTLS ([source](https://github.com/vitessio/vitess/blob/371be9e919adc7c3c277834974fb666656775f5d/go/vt/vtgate/grpcvtgateservice/server.go#L69-L95)).

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/12049

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
