### PR TITLE
stats/prometheus: normalize labels for single-label implementations

### DIFF
--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -75,6 +75,10 @@ The default value for `remote_operation_timeout` has also changed from 30 second
 During upgrades, if the users want to preserve the same behaviour as previous releases, then they should provide the `remote_operation_timeout` flag explicitly before upgrading.
 After the upgrade, they should then alter their configuration to also specify `lock-timeout` explicitly.
 
+#### Normalized labels in the Prometheus Exporter
+
+The Prometheus metrics exporter now properly normalizes _all_ label names into their `snake_case` form, as it is idiomatic for Prometheus metrics. Previously, Vitess instances were emitting inconsistent labels for their metrics, with some of them being `CamelCase` and others being `snake_case`.
+
 ### New command line flags and behavior
 
 #### VTGate: Support query timeout --query-timeout

--- a/go/stats/prometheusbackend/collectors.go
+++ b/go/stats/prometheusbackend/collectors.go
@@ -74,7 +74,7 @@ func newCountersWithSingleLabelCollector(c *stats.CountersWithSingleLabel, name 
 		desc: prometheus.NewDesc(
 			name,
 			c.Help(),
-			[]string{labelName},
+			[]string{normalizeMetric(labelName)},
 			nil),
 		vt: vt}
 
@@ -111,7 +111,7 @@ func newGaugesWithSingleLabelCollector(g *stats.GaugesWithSingleLabel, name stri
 		desc: prometheus.NewDesc(
 			name,
 			g.Help(),
-			[]string{labelName},
+			[]string{normalizeMetric(labelName)},
 			nil),
 		vt: vt}
 
@@ -266,7 +266,7 @@ func newTimingsCollector(t *stats.Timings, name string) {
 		desc: prometheus.NewDesc(
 			name,
 			t.Help(),
-			[]string{t.Label()},
+			[]string{normalizeMetric(t.Label())},
 			nil),
 	}
 


### PR DESCRIPTION
## Description

Here's a bug we've found in production: when exporting Prometheus metrics, the name of the labels is not consistent when using Single-Label metrics vs Multi-Label metrics. More precisely, the Single-Label metrics API does not perform label normalization (i.e. from CamelCase to snake_case), while the Multi-Label API does perform this normalization.

The normalization into snake_case *is* sensible, as metric names in Prometheus are idiomatically written in snake case, so the lack of normalization when using single-label metrics feels like an oversight that caused our Prometheus metrics exports to report the wrong metrics.

After this change, the behavior between using a Single-Label metric and a Multi-Label metric with just one label is consistent. This is, however, a breaking change so it should be noted in the release notes.

## Related Issue(s)

Fixes #12058

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
