### PR TITLE
Refactor sqlparser.Rewrite uses

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2145,21 +2145,22 @@ func defaultRequiresParens(ct *ColumnType) bool {
 }
 
 // RemoveKeyspaceFromColName removes the Qualifier.Qualifier on all ColNames in the expression tree
-func RemoveKeyspaceFromColName(expr Expr) Expr {
-	return RemoveKeyspace(expr).(Expr) // This hard cast is safe because we do not change the type the input
+func RemoveKeyspaceFromColName(expr Expr) {
+	RemoveKeyspace(expr)
 }
 
 // RemoveKeyspace removes the Qualifier.Qualifier on all ColNames in the AST
-func RemoveKeyspace(in SQLNode) SQLNode {
-	return Rewrite(in, nil, func(cursor *Cursor) bool {
-		switch col := cursor.Node().(type) {
+func RemoveKeyspace(in SQLNode) {
+	// Walk will only return an error if we return an error from the inner func. safe to ignore here
+	_ = Walk(func(node SQLNode) (kontinue bool, err error) {
+		switch col := node.(type) {
 		case *ColName:
 			if !col.Qualifier.Qualifier.IsEmpty() {
 				col.Qualifier.Qualifier = NewIdentifierCS("")
 			}
 		}
-		return true
-	})
+		return true, nil
+	}, in)
 }
 
 func convertStringToInt(integer string) int {

--- a/go/vt/sqlparser/predicate_rewriting.go
+++ b/go/vt/sqlparser/predicate_rewriting.go
@@ -30,7 +30,7 @@ type RewriteState bool
 func RewritePredicate(ast SQLNode) SQLNode {
 	for {
 		finishedRewrite := true
-		ast = Rewrite(ast, nil, func(cursor *Cursor) bool {
+		ast = SafeRewrite(ast, nil, func(cursor *Cursor) bool {
 			if e, isExpr := cursor.node.(Expr); isExpr {
 				rewritten, state := simplifyExpression(e)
 				if state == Changed {

--- a/go/vt/sqlparser/rewriter_api.go
+++ b/go/vt/sqlparser/rewriter_api.go
@@ -51,6 +51,18 @@ func Rewrite(node SQLNode, pre, post ApplyFunc) (result SQLNode) {
 	return parent.SQLNode
 }
 
+// SafeRewrite does not allow replacing nodes on the down walk of the tree walking
+// Long term this is the only Rewrite functionality we want
+func SafeRewrite(node SQLNode, down func(SQLNode) bool, up ApplyFunc) (result SQLNode) {
+	var pre func(cursor *Cursor) bool
+	if down != nil {
+		pre = func(cursor *Cursor) bool {
+			return down(cursor.Node())
+		}
+	}
+	return Rewrite(node, pre, up)
+}
+
 // RootNode is the root node of the AST when rewriting. It is the first element of the tree.
 type RootNode struct {
 	SQLNode

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -224,7 +224,7 @@ func buildAlterView(vschema plancontext.VSchema, ddl *sqlparser.AlterView, reser
 	if opCode != engine.Unsharded && opCode != engine.EqualUnique && opCode != engine.Scatter {
 		return nil, nil, vterrors.VT12001(ViewComplex)
 	}
-	_ = sqlparser.Rewrite(ddl.Select, nil, func(cursor *sqlparser.Cursor) bool {
+	_ = sqlparser.SafeRewrite(ddl.Select, nil, func(cursor *sqlparser.Cursor) bool {
 		switch tableName := cursor.Node().(type) {
 		case sqlparser.TableName:
 			cursor.Replace(sqlparser.TableName{
@@ -265,7 +265,7 @@ func buildCreateView(vschema plancontext.VSchema, ddl *sqlparser.CreateView, res
 	if opCode != engine.Unsharded && opCode != engine.EqualUnique && opCode != engine.Scatter {
 		return nil, nil, vterrors.VT12001(ViewComplex)
 	}
-	_ = sqlparser.Rewrite(ddl.Select, nil, func(cursor *sqlparser.Cursor) bool {
+	_ = sqlparser.SafeRewrite(ddl.Select, nil, func(cursor *sqlparser.Cursor) bool {
 		switch tableName := cursor.Node().(type) {
 		case sqlparser.TableName:
 			cursor.Replace(sqlparser.TableName{

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -224,7 +224,7 @@ func buildAlterView(vschema plancontext.VSchema, ddl *sqlparser.AlterView, reser
 	if opCode != engine.Unsharded && opCode != engine.EqualUnique && opCode != engine.Scatter {
 		return nil, nil, vterrors.VT12001(ViewComplex)
 	}
-	_ = sqlparser.Rewrite(ddl.Select, func(cursor *sqlparser.Cursor) bool {
+	_ = sqlparser.Rewrite(ddl.Select, nil, func(cursor *sqlparser.Cursor) bool {
 		switch tableName := cursor.Node().(type) {
 		case sqlparser.TableName:
 			cursor.Replace(sqlparser.TableName{
@@ -232,7 +232,7 @@ func buildAlterView(vschema plancontext.VSchema, ddl *sqlparser.AlterView, reser
 			})
 		}
 		return true
-	}, nil)
+	})
 	return destination, keyspace, nil
 }
 
@@ -265,7 +265,7 @@ func buildCreateView(vschema plancontext.VSchema, ddl *sqlparser.CreateView, res
 	if opCode != engine.Unsharded && opCode != engine.EqualUnique && opCode != engine.Scatter {
 		return nil, nil, vterrors.VT12001(ViewComplex)
 	}
-	_ = sqlparser.Rewrite(ddl.Select, func(cursor *sqlparser.Cursor) bool {
+	_ = sqlparser.Rewrite(ddl.Select, nil, func(cursor *sqlparser.Cursor) bool {
 		switch tableName := cursor.Node().(type) {
 		case sqlparser.TableName:
 			cursor.Replace(sqlparser.TableName{
@@ -273,7 +273,7 @@ func buildCreateView(vschema plancontext.VSchema, ddl *sqlparser.CreateView, res
 			})
 		}
 		return true
-	}, nil)
+	})
 	return destination, keyspace, nil
 }
 

--- a/go/vt/vtgate/planbuilder/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/horizon_planning.go
@@ -1096,13 +1096,13 @@ func planSingleShardRoutePlan(sel sqlparser.SelectStatement, rb *routeGen4) erro
 	if err != nil {
 		return err
 	}
-	sqlparser.Rewrite(rb.Select, func(cursor *sqlparser.Cursor) bool {
-		if aliasedExpr, ok := cursor.Node().(sqlparser.SelectExpr); ok {
+	return sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		if aliasedExpr, ok := node.(sqlparser.SelectExpr); ok {
 			removeKeyspaceFromSelectExpr(aliasedExpr)
 		}
-		return true
-	}, nil)
-	return nil
+		return true, nil
+	}, rb.Select)
+
 }
 
 func removeKeyspaceFromSelectExpr(expr sqlparser.SelectExpr) {

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -161,18 +161,19 @@ func (qb *queryBuilder) joinOuterWith(other *queryBuilder, onCondition sqlparser
 }
 
 func (qb *queryBuilder) rewriteExprForDerivedTable(expr sqlparser.Expr, dtName string) {
-	sqlparser.Rewrite(expr, func(cursor *sqlparser.Cursor) bool {
-		switch node := cursor.Node().(type) {
-		case *sqlparser.ColName:
-			hasTable := qb.hasTable(node.Qualifier.Name.String())
-			if hasTable {
-				node.Qualifier = sqlparser.TableName{
-					Name: sqlparser.NewIdentifierCS(dtName),
-				}
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		col, ok := node.(*sqlparser.ColName)
+		if !ok {
+			return true, nil
+		}
+		hasTable := qb.hasTable(col.Qualifier.Name.String())
+		if hasTable {
+			col.Qualifier = sqlparser.TableName{
+				Name: sqlparser.NewIdentifierCS(dtName),
 			}
 		}
-		return true
-	}, nil)
+		return true, nil
+	}, expr)
 }
 
 func (qb *queryBuilder) hasTable(tableName string) bool {
@@ -236,12 +237,12 @@ func (h *Horizon) toSQL(qb *queryBuilder) error {
 	if err != nil {
 		return err
 	}
-	sqlparser.Rewrite(qb.sel, func(cursor *sqlparser.Cursor) bool {
-		if aliasedExpr, ok := cursor.Node().(sqlparser.SelectExpr); ok {
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		if aliasedExpr, ok := node.(sqlparser.SelectExpr); ok {
 			removeKeyspaceFromSelectExpr(aliasedExpr)
 		}
-		return true
-	}, nil)
+		return true, nil
+	}, qb.sel)
 	return nil
 }
 
@@ -343,7 +344,8 @@ func buildQuery(op ops.Operator, qb *queryBuilder) error {
 		}
 		sel := qb.sel.(*sqlparser.Select) // we can only handle SELECT in derived tables at the moment
 		qb.sel = nil
-		opQuery := sqlparser.RemoveKeyspace(op.Query).(*sqlparser.Select)
+		sqlparser.RemoveKeyspace(op.Query)
+		opQuery := op.Query.(*sqlparser.Select)
 		sel.Limit = opQuery.Limit
 		sel.OrderBy = opQuery.OrderBy
 		sel.GroupBy = opQuery.GroupBy
@@ -365,12 +367,12 @@ func buildQuery(op ops.Operator, qb *queryBuilder) error {
 		if err != nil {
 			return err
 		}
-		sqlparser.Rewrite(qb.sel, func(cursor *sqlparser.Cursor) bool {
-			if aliasedExpr, ok := cursor.Node().(sqlparser.SelectExpr); ok {
+		_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+			if aliasedExpr, ok := node.(sqlparser.SelectExpr); ok {
 				removeKeyspaceFromSelectExpr(aliasedExpr)
 			}
-			return true
-		}, nil)
+			return true, nil
+		}, qb.sel)
 		return nil
 
 	default:

--- a/go/vt/vtgate/planbuilder/operators/expressions.go
+++ b/go/vt/vtgate/planbuilder/operators/expressions.go
@@ -32,25 +32,28 @@ func BreakExpressionInLHSandRHS(
 ) (bvNames []string, columns []*sqlparser.ColName, rewrittenExpr sqlparser.Expr, err error) {
 	rewrittenExpr = sqlparser.CloneExpr(expr)
 	_ = sqlparser.Rewrite(rewrittenExpr, nil, func(cursor *sqlparser.Cursor) bool {
-		switch node := cursor.Node().(type) {
-		case *sqlparser.ColName:
-			deps := ctx.SemTable.RecursiveDeps(node)
-			if deps.IsEmpty() {
-				err = vterrors.VT13001("unknown column. has the AST been copied?")
-				return false
-			}
-			if deps.IsSolvedBy(lhs) {
-				node.Qualifier.Qualifier = sqlparser.NewIdentifierCS("")
-				columns = append(columns, node)
-				bvName := node.CompliantName()
-				bvNames = append(bvNames, bvName)
-				arg := sqlparser.NewArgument(bvName)
-				// we are replacing one of the sides of the comparison with an argument,
-				// but we don't want to lose the type information we have, so we copy it over
-				ctx.SemTable.CopyExprInfo(node, arg)
-				cursor.Replace(arg)
-			}
+		node, ok := cursor.Node().(*sqlparser.ColName)
+		if !ok {
+			return true
 		}
+		deps := ctx.SemTable.RecursiveDeps(node)
+		if deps.IsEmpty() {
+			err = vterrors.VT13001("unknown column. has the AST been copied?")
+			return false
+		}
+		if !deps.IsSolvedBy(lhs) {
+			return true
+		}
+
+		node.Qualifier.Qualifier = sqlparser.NewIdentifierCS("")
+		columns = append(columns, node)
+		bvName := node.CompliantName()
+		bvNames = append(bvNames, bvName)
+		arg := sqlparser.NewArgument(bvName)
+		// we are replacing one of the sides of the comparison with an argument,
+		// but we don't want to lose the type information we have, so we copy it over
+		ctx.SemTable.CopyExprInfo(node, arg)
+		cursor.Replace(arg)
 		return true
 	})
 	if err != nil {

--- a/go/vt/vtgate/planbuilder/operators/expressions.go
+++ b/go/vt/vtgate/planbuilder/operators/expressions.go
@@ -31,7 +31,7 @@ func BreakExpressionInLHSandRHS(
 	lhs semantics.TableSet,
 ) (bvNames []string, columns []*sqlparser.ColName, rewrittenExpr sqlparser.Expr, err error) {
 	rewrittenExpr = sqlparser.CloneExpr(expr)
-	_ = sqlparser.Rewrite(rewrittenExpr, nil, func(cursor *sqlparser.Cursor) bool {
+	_ = sqlparser.SafeRewrite(rewrittenExpr, nil, func(cursor *sqlparser.Cursor) bool {
 		node, ok := cursor.Node().(*sqlparser.ColName)
 		if !ok {
 			return true

--- a/go/vt/vtgate/planbuilder/operators/join.go
+++ b/go/vt/vtgate/planbuilder/operators/join.go
@@ -82,7 +82,9 @@ func createOuterJoin(tableExpr *sqlparser.JoinTableExpr, lhs, rhs ops.Operator) 
 	if tableExpr.Join == sqlparser.RightJoinType {
 		lhs, rhs = rhs, lhs
 	}
-	return &Join{LHS: lhs, RHS: rhs, LeftJoin: true, Predicate: sqlparser.RemoveKeyspaceFromColName(tableExpr.Condition.On)}, nil
+	predicate := tableExpr.Condition.On
+	sqlparser.RemoveKeyspaceFromColName(predicate)
+	return &Join{LHS: lhs, RHS: rhs, LeftJoin: true, Predicate: predicate}, nil
 }
 
 func createJoin(ctx *plancontext.PlanningContext, LHS, RHS ops.Operator) ops.Operator {
@@ -101,10 +103,11 @@ func createJoin(ctx *plancontext.PlanningContext, LHS, RHS ops.Operator) ops.Ope
 
 func createInnerJoin(ctx *plancontext.PlanningContext, tableExpr *sqlparser.JoinTableExpr, lhs, rhs ops.Operator) (ops.Operator, error) {
 	op := createJoin(ctx, lhs, rhs)
-	if tableExpr.Condition.On != nil {
+	pred := tableExpr.Condition.On
+	if pred != nil {
 		var err error
-		predicate := sqlparser.RemoveKeyspaceFromColName(tableExpr.Condition.On)
-		op, err = op.AddPredicate(ctx, predicate)
+		sqlparser.RemoveKeyspaceFromColName(pred)
+		op, err = op.AddPredicate(ctx, pred)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/planbuilder/operators/logical.go
+++ b/go/vt/vtgate/planbuilder/operators/logical.go
@@ -61,7 +61,8 @@ func createOperatorFromSelect(ctx *plancontext.PlanningContext, sel *sqlparser.S
 	if sel.Where != nil {
 		exprs := sqlparser.SplitAndExpression(nil, sel.Where.Expr)
 		for _, expr := range exprs {
-			op, err = op.AddPredicate(ctx, sqlparser.RemoveKeyspaceFromColName(expr))
+			sqlparser.RemoveKeyspaceFromColName(expr)
+			op, err = op.AddPredicate(ctx, expr)
 			if err != nil {
 				return nil, err
 			}

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -333,32 +333,34 @@ func rewriteColumnsInSubqueryOpForJoin(
 	resultInnerOp := innerOp
 	var rewriteError error
 	// go over the entire expression in the subquery
-	sqlparser.Rewrite(subQueryInner.ExtractedSubquery.Original, func(cursor *sqlparser.Cursor) bool {
-		sqlNode := cursor.Node()
-		switch node := sqlNode.(type) {
-		case *sqlparser.ColName:
-			// check whether the column name belongs to the other side of the join tree
-			if ctx.SemTable.RecursiveDeps(node).IsSolvedBy(TableID(resultInnerOp)) {
-				// get the bindVariable for that column name and replace it in the subquery
-				bindVar := ctx.ReservedVars.ReserveColName(node)
-				cursor.Replace(sqlparser.NewArgument(bindVar))
-				// check whether the bindVariable already exists in the joinVars of the other tree
-				_, alreadyExists := outerTree.Vars[bindVar]
-				if alreadyExists {
-					return false
-				}
-				// if it does not exist, then push this as an output column there and add it to the joinVars
-				offset, err := resultInnerOp.AddColumn(ctx, node)
-				if err != nil {
-					rewriteError = err
-					return false
-				}
-				outerTree.Vars[bindVar] = offset
-				return false
-			}
+	sqlparser.Rewrite(subQueryInner.ExtractedSubquery.Original, nil, func(cursor *sqlparser.Cursor) bool {
+		node, ok := cursor.Node().(*sqlparser.ColName)
+		if !ok {
+			return true
 		}
+
+		// check whether the column name belongs to the other side of the join tree
+		if !ctx.SemTable.RecursiveDeps(node).IsSolvedBy(TableID(resultInnerOp)) {
+			return true
+		}
+
+		// get the bindVariable for that column name and replace it in the subquery
+		bindVar := ctx.ReservedVars.ReserveColName(node)
+		cursor.Replace(sqlparser.NewArgument(bindVar))
+		// check whether the bindVariable already exists in the joinVars of the other tree
+		_, alreadyExists := outerTree.Vars[bindVar]
+		if alreadyExists {
+			return true
+		}
+		// if it does not exist, then push this as an output column there and add it to the joinVars
+		offset, err := resultInnerOp.AddColumn(ctx, node)
+		if err != nil {
+			rewriteError = err
+			return false
+		}
+		outerTree.Vars[bindVar] = offset
 		return true
-	}, nil)
+	})
 
 	// update the dependencies for the subquery by removing the dependencies from the innerOp
 	tableSet := ctx.SemTable.Direct[subQueryInner.ExtractedSubquery.Subquery]
@@ -387,40 +389,43 @@ func createCorrelatedSubqueryOp(
 	var lhsCols []*sqlparser.ColName
 	for _, pred := range preds {
 		var rewriteError error
-		sqlparser.Rewrite(pred, func(cursor *sqlparser.Cursor) bool {
-			switch node := cursor.Node().(type) {
-			case *sqlparser.ColName:
-				nodeDeps := ctx.SemTable.RecursiveDeps(node)
-				if nodeDeps.IsSolvedBy(TableID(resultOuterOp)) {
-					// check whether the bindVariable already exists in the map
-					// we do so by checking that the column names are the same and their recursive dependencies are the same
-					// so the column names `user.a` and `a` would be considered equal as long as both are bound to the same table
-					for colName, bindVar := range bindVars {
-						if ctx.SemTable.EqualsExpr(node, colName) {
-							cursor.Replace(sqlparser.NewArgument(bindVar))
-							return false
-						}
-					}
+		sqlparser.Rewrite(pred, nil, func(cursor *sqlparser.Cursor) bool {
+			node, ok := cursor.Node().(*sqlparser.ColName)
+			if !ok {
+				return true
+			}
 
-					// get the bindVariable for that column name and replace it in the predicate
-					bindVar := ctx.ReservedVars.ReserveColName(node)
+			nodeDeps := ctx.SemTable.RecursiveDeps(node)
+			if !nodeDeps.IsSolvedBy(TableID(resultOuterOp)) {
+				return true
+			}
+
+			// check whether the bindVariable already exists in the map
+			// we do so by checking that the column names are the same and their recursive dependencies are the same
+			// so the column names `user.a` and `a` would be considered equal as long as both are bound to the same table
+			for colName, bindVar := range bindVars {
+				if ctx.SemTable.EqualsExpr(node, colName) {
 					cursor.Replace(sqlparser.NewArgument(bindVar))
-					// store it in the map for future comparisons
-					bindVars[node] = bindVar
-
-					// if it does not exist, then push this as an output column in the outerOp and add it to the joinVars
-					offset, err := resultOuterOp.AddColumn(ctx, node)
-					if err != nil {
-						rewriteError = err
-						return false
-					}
-					lhsCols = append(lhsCols, node)
-					vars[bindVar] = offset
-					return false
+					return true
 				}
 			}
+
+			// get the bindVariable for that column name and replace it in the predicate
+			bindVar := ctx.ReservedVars.ReserveColName(node)
+			cursor.Replace(sqlparser.NewArgument(bindVar))
+			// store it in the map for future comparisons
+			bindVars[node] = bindVar
+
+			// if it does not exist, then push this as an output column in the outerOp and add it to the joinVars
+			offset, err := resultOuterOp.AddColumn(ctx, node)
+			if err != nil {
+				rewriteError = err
+				return true
+			}
+			lhsCols = append(lhsCols, node)
+			vars[bindVar] = offset
 			return true
-		}, nil)
+		})
 		if rewriteError != nil {
 			return nil, rewriteError
 		}

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -333,7 +333,7 @@ func rewriteColumnsInSubqueryOpForJoin(
 	resultInnerOp := innerOp
 	var rewriteError error
 	// go over the entire expression in the subquery
-	sqlparser.Rewrite(subQueryInner.ExtractedSubquery.Original, nil, func(cursor *sqlparser.Cursor) bool {
+	sqlparser.SafeRewrite(subQueryInner.ExtractedSubquery.Original, nil, func(cursor *sqlparser.Cursor) bool {
 		node, ok := cursor.Node().(*sqlparser.ColName)
 		if !ok {
 			return true
@@ -389,7 +389,7 @@ func createCorrelatedSubqueryOp(
 	var lhsCols []*sqlparser.ColName
 	for _, pred := range preds {
 		var rewriteError error
-		sqlparser.Rewrite(pred, nil, func(cursor *sqlparser.Cursor) bool {
+		sqlparser.SafeRewrite(pred, nil, func(cursor *sqlparser.Cursor) bool {
 			node, ok := cursor.Node().(*sqlparser.ColName)
 			if !ok {
 				return true

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -94,9 +94,10 @@ func (u *Union) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Ex
 	}
 
 	for i := range u.Sources {
+		// TODO copy-on-rewrite should be used here
 		predicate := sqlparser.CloneExpr(expr)
 		var err error
-		predicate = sqlparser.Rewrite(predicate, func(cursor *sqlparser.Cursor) bool {
+		predicate = sqlparser.Rewrite(predicate, nil, func(cursor *sqlparser.Cursor) bool {
 			col, ok := cursor.Node().(*sqlparser.ColName)
 			if !ok {
 				return err == nil
@@ -120,8 +121,8 @@ func (u *Union) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Ex
 				return false
 			}
 			cursor.Replace(ae.Expr)
-			return false
-		}, nil).(sqlparser.Expr)
+			return true
+		}).(sqlparser.Expr)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -97,7 +97,7 @@ func (u *Union) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Ex
 		// TODO copy-on-rewrite should be used here
 		predicate := sqlparser.CloneExpr(expr)
 		var err error
-		predicate = sqlparser.Rewrite(predicate, nil, func(cursor *sqlparser.Cursor) bool {
+		predicate = sqlparser.SafeRewrite(predicate, nil, func(cursor *sqlparser.Cursor) bool {
 			col, ok := cursor.Node().(*sqlparser.ColName)
 			if !ok {
 				return err == nil

--- a/go/vt/vtgate/planbuilder/projection_pushing.go
+++ b/go/vt/vtgate/planbuilder/projection_pushing.go
@@ -300,7 +300,7 @@ func addExpressionToRoute(ctx *plancontext.PlanningContext, rb *routeGen4, expr 
 			return i, false, nil
 		}
 	}
-	expr.Expr = sqlparser.RemoveKeyspaceFromColName(expr.Expr)
+	sqlparser.RemoveKeyspaceFromColName(expr.Expr)
 	sel, isSel := rb.Select.(*sqlparser.Select)
 	if !isSel {
 		return 0, false, vterrors.VT12001(fmt.Sprintf("pushing projection '%s' on %T", sqlparser.String(expr), rb.Select))

--- a/go/vt/vtgate/planbuilder/single_sharded_shortcut.go
+++ b/go/vt/vtgate/planbuilder/single_sharded_shortcut.go
@@ -31,7 +31,7 @@ import (
 
 func unshardedShortcut(ctx *plancontext.PlanningContext, stmt sqlparser.SelectStatement, ks *vindexes.Keyspace) (logicalPlan, []string, error) {
 	// this method is used when the query we are handling has all tables in the same unsharded keyspace
-	sqlparser.Rewrite(stmt, nil, func(cursor *sqlparser.Cursor) bool {
+	sqlparser.SafeRewrite(stmt, nil, func(cursor *sqlparser.Cursor) bool {
 		switch node := cursor.Node().(type) {
 		case sqlparser.SelectExpr:
 			removeKeyspaceFromSelectExpr(node)

--- a/go/vt/vtgate/planbuilder/single_sharded_shortcut.go
+++ b/go/vt/vtgate/planbuilder/single_sharded_shortcut.go
@@ -31,7 +31,7 @@ import (
 
 func unshardedShortcut(ctx *plancontext.PlanningContext, stmt sqlparser.SelectStatement, ks *vindexes.Keyspace) (logicalPlan, []string, error) {
 	// this method is used when the query we are handling has all tables in the same unsharded keyspace
-	sqlparser.Rewrite(stmt, func(cursor *sqlparser.Cursor) bool {
+	sqlparser.Rewrite(stmt, nil, func(cursor *sqlparser.Cursor) bool {
 		switch node := cursor.Node().(type) {
 		case sqlparser.SelectExpr:
 			removeKeyspaceFromSelectExpr(node)
@@ -41,7 +41,7 @@ func unshardedShortcut(ctx *plancontext.PlanningContext, stmt sqlparser.SelectSt
 			})
 		}
 		return true
-	}, nil)
+	})
 
 	tableNames, err := getTableNames(ctx.SemTable)
 	if err != nil {

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -80,7 +80,7 @@ func Analyze(statement sqlparser.Statement, currentDb string, si SchemaInformati
 	return semTable, nil
 }
 
-func (a analyzer) newSemTable(statement sqlparser.Statement, coll collations.ID) *SemTable {
+func (a *analyzer) newSemTable(statement sqlparser.Statement, coll collations.ID) *SemTable {
 	var comments *sqlparser.ParsedComments
 	commentedStmt, isCommented := statement.(sqlparser.Commented)
 	if isCommented {

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -230,7 +230,7 @@ func (r *earlyRewriter) rewriteOrderByExpr(node *sqlparser.Literal) (sqlparser.E
 // Since sqlparser.CloneRefOfColName does not clone col names, this method is needed.
 func realCloneOfColNames(expr sqlparser.Expr, union bool) sqlparser.Expr {
 	// todo copy-on-rewrite!
-	return sqlparser.Rewrite(sqlparser.CloneExpr(expr), nil, func(cursor *sqlparser.Cursor) bool {
+	return sqlparser.SafeRewrite(sqlparser.CloneExpr(expr), nil, func(cursor *sqlparser.Cursor) bool {
 		exp, ok := cursor.Node().(*sqlparser.ColName)
 		if !ok {
 			return true

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -310,22 +310,22 @@ func (d ExprDependencies) dependencies(expr sqlparser.Expr) (deps TableSet) {
 // SELECT foo FROM (SELECT id+42 as foo FROM user) as t
 // We need `foo` to be translated to `id+42` on the inside of the derived table
 func RewriteDerivedTableExpression(expr sqlparser.Expr, vt TableInfo) (sqlparser.Expr, error) {
-	newExpr := sqlparser.Rewrite(sqlparser.CloneExpr(expr), func(cursor *sqlparser.Cursor) bool {
-		switch node := cursor.Node().(type) {
-		case *sqlparser.ColName:
-			exp, err := vt.getExprFor(node.Name.String())
-			if err == nil {
-				cursor.Replace(exp)
-			} else {
-				// cloning the expression and removing the qualifier
-				col := *node
-				col.Qualifier = sqlparser.TableName{}
-				cursor.Replace(&col)
-			}
-			return false
+	newExpr := sqlparser.Rewrite(sqlparser.CloneExpr(expr), nil, func(cursor *sqlparser.Cursor) bool {
+		node, ok := cursor.Node().(*sqlparser.ColName)
+		if !ok {
+			return true
+		}
+		exp, err := vt.getExprFor(node.Name.String())
+		if err == nil {
+			cursor.Replace(exp)
+		} else {
+			// cloning the expression and removing the qualifier
+			col := *node
+			col.Qualifier = sqlparser.TableName{}
+			cursor.Replace(&col)
 		}
 		return true
-	}, nil)
+	})
 
 	return newExpr.(sqlparser.Expr), nil
 }

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -310,7 +310,7 @@ func (d ExprDependencies) dependencies(expr sqlparser.Expr) (deps TableSet) {
 // SELECT foo FROM (SELECT id+42 as foo FROM user) as t
 // We need `foo` to be translated to `id+42` on the inside of the derived table
 func RewriteDerivedTableExpression(expr sqlparser.Expr, vt TableInfo) (sqlparser.Expr, error) {
-	newExpr := sqlparser.Rewrite(sqlparser.CloneExpr(expr), nil, func(cursor *sqlparser.Cursor) bool {
+	newExpr := sqlparser.SafeRewrite(sqlparser.CloneExpr(expr), nil, func(cursor *sqlparser.Cursor) bool {
 		node, ok := cursor.Node().(*sqlparser.ColName)
 		if !ok {
 			return true

--- a/go/vt/vtgate/simplifier/expression_simplifier.go
+++ b/go/vt/vtgate/simplifier/expression_simplifier.go
@@ -81,7 +81,6 @@ func SimplifyExpr(in sqlparser.Expr, test CheckF) (smallestKnown sqlparser.Expr)
 func getNodesAtLevel(e sqlparser.Expr, level int) (result []sqlparser.Expr, replaceF []func(node sqlparser.SQLNode)) {
 	lvl := 0
 	pre := func(cursor *sqlparser.Cursor) bool {
-
 		if expr, isExpr := cursor.Node().(sqlparser.Expr); level == lvl && isExpr {
 			result = append(result, expr)
 			replaceF = append(replaceF, cursor.ReplacerF())

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -957,14 +957,15 @@ func (vschema *VSchema) FindView(keyspace, name string) sqlparser.SelectStatemen
 	}
 
 	// We do this to make sure there is no shared state between uses of this AST
+	// todo copy-on-rewrite!
 	statement = sqlparser.CloneSelectStatement(statement)
-	sqlparser.Rewrite(statement, func(cursor *sqlparser.Cursor) bool {
+	sqlparser.Rewrite(statement, nil, func(cursor *sqlparser.Cursor) bool {
 		col, ok := cursor.Node().(*sqlparser.ColName)
 		if ok {
 			cursor.Replace(sqlparser.NewColNameWithQualifier(col.Name.String(), col.Qualifier))
 		}
 		return true
-	}, nil)
+	})
 	return statement
 }
 

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -959,7 +959,7 @@ func (vschema *VSchema) FindView(keyspace, name string) sqlparser.SelectStatemen
 	// We do this to make sure there is no shared state between uses of this AST
 	// todo copy-on-rewrite!
 	statement = sqlparser.CloneSelectStatement(statement)
-	sqlparser.Rewrite(statement, nil, func(cursor *sqlparser.Cursor) bool {
+	sqlparser.SafeRewrite(statement, nil, func(cursor *sqlparser.Cursor) bool {
 		col, ok := cursor.Node().(*sqlparser.ColName)
 		if ok {
 			cursor.Replace(sqlparser.NewColNameWithQualifier(col.Name.String(), col.Qualifier))

--- a/go/vt/vttablet/tabletserver/planbuilder/builder.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/builder.go
@@ -162,7 +162,7 @@ func showTableRewrite(show *sqlparser.ShowBasic, dbName string) {
 	if filter == nil {
 		return
 	}
-	_ = sqlparser.Rewrite(filter, func(cursor *sqlparser.Cursor) bool {
+	_ = sqlparser.SafeRewrite(filter, nil, func(cursor *sqlparser.Cursor) bool {
 		switch n := cursor.Node().(type) {
 		case *sqlparser.ColName:
 			if n.Qualifier.IsEmpty() && strings.HasPrefix(n.Name.Lowered(), "tables_in_") {
@@ -170,7 +170,7 @@ func showTableRewrite(show *sqlparser.ShowBasic, dbName string) {
 			}
 		}
 		return true
-	}, nil)
+	})
 }
 
 func analyzeSet(set *sqlparser.Set) (plan *Plan) {


### PR DESCRIPTION
## Description
Refactor of sqlparser.Rewrite usages.

Doing cursor.Replace() on the down path is not great.
It makes it difficult to understand what happens after - do we visit the children of the old AST object or the new one?

This change moves most uses of Rewrite so cursor.Replace() happens on the up path.
In a separate PR, I'll change the API so it's not possible to do replace on the down path.

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required