### PR TITLE
Mark VReplicationExec Client Command as Deprecated

### DIFF
--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -213,7 +213,9 @@ is now fixed. The full issue can be found [here](https://github.com/vitessio/vit
 
 - The [VReplication v1 commands](https://vitess.io/docs/15.0/reference/vreplication/v1/) — which were deprecated in Vitess 11.0 — have been removed. You will need to use the [VReplication v2 commands](https://vitess.io/docs/16.0/reference/vreplication/v2/) instead.
 
-- `vtctlclient VExec` command was removed, having been deprecated since v13.
+- The `vtctlclient VExec` command was removed, having been deprecated since v12.
+
+- The `vtctlclient VReplicationExec` command has now been deprecated and will be removed in a future release. Please see [#12070](https://github.com/vitessio/vitess/pull/12070) for additional details.
 
 - `vtctlclient OnlineDDL ... [complete|retry|cancel|cancel-all]` returns empty result on success instead of number of shard affected.
 

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -300,10 +300,12 @@ var commands = []commandGroup{
 				help:   "Runs the given SQL command as a DBA on the remote tablet.",
 			},
 			{
-				name:   "VReplicationExec",
-				method: commandVReplicationExec,
-				params: "[--json] <tablet alias> <sql command>",
-				help:   "Runs the given VReplication command on the remote tablet.",
+				name:         "VReplicationExec",
+				method:       commandVReplicationExec,
+				params:       "[--json] <tablet alias> <sql command>",
+				help:         "Runs the given VReplication command on the remote tablet.",
+				deprecated:   true,
+				deprecatedBy: "Workflow -- <keyspace.workflow> <action>",
 			},
 		},
 	},
@@ -1339,6 +1341,8 @@ func commandExecuteFetchAsDba(ctx context.Context, wr *wrangler.Wrangler, subFla
 }
 
 func commandVReplicationExec(ctx context.Context, wr *wrangler.Wrangler, subFlags *pflag.FlagSet, args []string) error {
+	wr.Logger().Printf("\nWARNING: VReplicationExec is deprecated and will be removed in a future release. Please use 'Workflow -- <keyspace.workflow> <action>' instead.\n\n")
+
 	json := subFlags.Bool("json", false, "Output JSON instead of human-readable table")
 
 	if err := subFlags.Parse(args); err != nil {


### PR DESCRIPTION
## Description

The [`VReplicationExec` client command](https://vitess.io/docs/16.0/reference/vreplication/vreplicationexec/) leverages the `VReplicationExec` tabletmanager RPC: https://github.com/vitessio/vitess/blob/7fc1b48d9ea8f10afa597a1e3885b4fb55f3b6be/go/vt/vttablet/grpctmserver/server.go#L355-L361 ▶️ ▶️ ▶️  https://github.com/vitessio/vitess/blob/7fc1b48d9ea8f10afa597a1e3885b4fb55f3b6be/go/vt/vttablet/tabletmanager/rpc_vreplication.go#L27-L34 

This client-server interface needs to be replaced because it does not do proper encapsulation and instead exposes the raw SQL interface. This causes problems for upgrades/downgrades where the internal schema changes as e.g. shown in https://github.com/vitessio/vitess/issues/11535. As you can see from that bug report this RPC is used internally by, among other things, the implementation of the [`Workflow` client command](https://vitess.io/docs/16.0/reference/vreplication/workflow/).

The [`VExec` client command](https://vitess.io/docs/15.0/reference/vreplication/vreplicationexec/) was already deprecated in v12 and has been removed in v16 via: https://github.com/vitessio/vitess/pull/11955. This PR deprecates the `VReplicationExec` client command with plans to replace any remaining usage in v17. 

As a Vitess user it should no longer be necessary in v16 to use `VExec`/`VReplicationExec` **except** for one rare case, and that is when you want to update the vreplication workflow record to e.g. change some settings. For example, if for any reason you need to update the `cells` or `tablet_types` values for a workflow you could do so this way:
```
## No longer an option in v16 where VExec has been removed
$ vtctlclient VExec -- customer.commerce2customer 'update _vt.vreplication set tablet_types="replica,primary" where workflow="commerce2customer"'

OR 

$ for tablet in $(vtctlclient ListAllTablets -- --keyspace=customer --tablet_type=primary | awk '{print $1}'); do
      vtctlclient VReplicationExec -- ${tablet} 'update _vt.vreplication set tablet_types="replica,primary" where workflow="commerce2customer"'
done
# You could also of course update the mysqld instance directly in a similar manner
```

Neither of these options offered a good user experience and was far too low level, so the current plan is to offer new functionality in v17. For example by adding a new `update` action to the [`Workflow` client command](https://vitess.io/docs/16.0/reference/vreplication/workflow/), for example:
```
$ vtctldclient Workflow -- customer.commerce2customer update --tablet-types "replica,primary"
```

Internally the `Workflow` client command implementation in `vtctldserver` would leverage a new tabletmanager RPC, something like `WorkflowAction` where it passes the `keyspace.workflow` value, the `action`, and optional parameters such as the `tablet-types` or `cells` values for the `update` action (this still needs to be spec'd out). All other internal uses of the `VReplicationExec` RPC (primarily by `vtctldserver` via the `wrangler` component) would also be replaced.

The end result being that the raw SQL client-server interface for executing VReplication commands will be gone and replaced by 1 or more new RPCs with proper encapsulation. 

## Related Issue(s)

  - Related to: https://github.com/vitessio/vitess/issues/11535
  - Related to: https://github.com/vitessio/vitess/pull/11955
  - Related to: https://github.com/vitessio/vitess/issues/12053

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation: https://github.com/vitessio/website/pull/1346