### PR TITLE
Remove Deprecated flags, code and stats.

### DIFF
--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -72,6 +72,11 @@ If your application is searching for specific errors, you might need to update y
 Information about which tables are used is now reported by the field TablesUsed added in V15, that is a string array, listing all tables and which keyspace they are in.
 The Table/Keyspace fields were deprecated in V15 and are now removed in the V16 release of Vitess.
 
+#### Removed flags
+
+The following flags are removed in V16 -
+- `enable_semi_sync`
+
 #### <a id="lock-timeout-introduction"/> `lock-timeout` and `remote_operation_timeout` Changes
 
 Earlier, the shard and keyspace locks used to be capped by the `remote_operation_timeout`. This is no longer the case and instead a new flag called `lock-timeout` is introduced. 

--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -70,19 +70,19 @@ If your application is searching for specific errors, you might need to update y
 #### Logstats Table and Keyspace removed
 
 Information about which tables are used is now reported by the field TablesUsed added in v15, that is a string array, listing all tables and which keyspace they are in.
-The Table/Keyspace fields were deprecated in v15 and are now removed in the v16.0.0 release of Vitess.
+The Table/Keyspace fields were deprecated in v15 and are now removed in the v16 release of Vitess.
 
 #### Removed Stats
 
-The stat `QueryRowCounts` is removed in V16. `QueryRowsAffected` and `QueryRowsReturned` can be used instead to gather the same information.
+The stat `QueryRowCounts` is removed in v16. `QueryRowsAffected` and `QueryRowsReturned` can be used instead to gather the same information.
 
 #### Deprecated Stats
 
-The stats `QueriesProcessed` and `QueriesRouted` are deprecated in V16. The same information can be inferred from the stats `QueriesProcessedByTable` and `QueriesRoutedByTable` respectively. These stats will be removed in the next release.
+The stats `QueriesProcessed` and `QueriesRouted` are deprecated in v16. The same information can be inferred from the stats `QueriesProcessedByTable` and `QueriesRoutedByTable` respectively. These stats will be removed in the next release.
 
 #### Removed flag
 
-The following flag is removed in v16.0.0:
+The following flag is removed in v16:
 - `enable_semi_sync`
 
 #### <a id="lock-timeout-introduction"/> `lock-timeout` and `remote_operation_timeout` Changes
@@ -227,7 +227,7 @@ is now fixed. The full issue can be found [here](https://github.com/vitessio/vit
 
 ### Deprecations and Removals
 
-- The V3 planner is deprecated as of the v16.0.0 release, and will be removed in the V17 release of Vitess.
+- The V3 planner is deprecated as of the v16 release, and will be removed in the v17 release of Vitess.
 
 - The [VReplication v1 commands](https://vitess.io/docs/15.0/reference/vreplication/v1/) — which were deprecated in Vitess 11.0 — have been removed. You will need to use the [VReplication v2 commands](https://vitess.io/docs/16.0/reference/vreplication/v2/) instead.
 

--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -76,6 +76,10 @@ The Table/Keyspace fields were deprecated in v15 and are now removed in the v16.
 
 The stat `QueryRowCounts` is removed in V16. `QueryRowsAffected` and `QueryRowsReturned` can be used instead to gather the same information.
 
+#### Deprecated Stats
+
+The stats `QueriesProcessed` and `QueriesRouted` are deprecated in V16. The same information can be inferred from the stats `QueriesProcessedByTable` and `QueriesRoutedByTable` respectively. These stats will be removed in the next release.
+
 #### Removed flag
 
 The following flag is removed in v16.0.0:

--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -69,16 +69,16 @@ If your application is searching for specific errors, you might need to update y
 
 #### Logstats Table and Keyspace removed
 
-Information about which tables are used is now reported by the field TablesUsed added in V15, that is a string array, listing all tables and which keyspace they are in.
-The Table/Keyspace fields were deprecated in V15 and are now removed in the V16 release of Vitess.
+Information about which tables are used is now reported by the field TablesUsed added in v15, that is a string array, listing all tables and which keyspace they are in.
+The Table/Keyspace fields were deprecated in v15 and are now removed in the v16.0.0 release of Vitess.
 
 #### Removed Stats
 
 The stat `QueryRowCounts` is removed in V16. `QueryRowsAffected` and `QueryRowsReturned` can be used instead to gather the same information.
 
-#### Removed flags
+#### Removed flag
 
-The following flags are removed in V16 -
+The following flag is removed in v16.0.0:
 - `enable_semi_sync`
 
 #### <a id="lock-timeout-introduction"/> `lock-timeout` and `remote_operation_timeout` Changes
@@ -223,7 +223,7 @@ is now fixed. The full issue can be found [here](https://github.com/vitessio/vit
 
 ### Deprecations and Removals
 
-- The V3 planner is deprecated as of the V16 release, and will be removed in the V17 release of Vitess.
+- The V3 planner is deprecated as of the v16.0.0 release, and will be removed in the V17 release of Vitess.
 
 - The [VReplication v1 commands](https://vitess.io/docs/15.0/reference/vreplication/v1/) — which were deprecated in Vitess 11.0 — have been removed. You will need to use the [VReplication v2 commands](https://vitess.io/docs/16.0/reference/vreplication/v2/) instead.
 

--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -72,6 +72,10 @@ If your application is searching for specific errors, you might need to update y
 Information about which tables are used is now reported by the field TablesUsed added in V15, that is a string array, listing all tables and which keyspace they are in.
 The Table/Keyspace fields were deprecated in V15 and are now removed in the V16 release of Vitess.
 
+#### Removed Stats
+
+The stat `QueryRowCounts` is removed in V16. `QueryRowsAffected` and `QueryRowsReturned` can be used instead to gather the same information.
+
 #### Removed flags
 
 The following flags are removed in V16 -

--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -67,6 +67,11 @@ If you have code searching for error strings from Vitess, this is a breaking cha
 Many error strings have been tweaked.
 If your application is searching for specific errors, you might need to update your code.
 
+#### Logstats Table and Keyspace removed
+
+Information about which tables are used is now reported by the field TablesUsed added in V15, that is a string array, listing all tables and which keyspace they are in.
+The Table/Keyspace fields were deprecated in V15 and are now removed in the V16 release of Vitess.
+
 #### <a id="lock-timeout-introduction"/> `lock-timeout` and `remote_operation_timeout` Changes
 
 Earlier, the shard and keyspace locks used to be capped by the `remote_operation_timeout`. This is no longer the case and instead a new flag called `lock-timeout` is introduced. 

--- a/docker/mini/vttablet-mini-up.sh
+++ b/docker/mini/vttablet-mini-up.sh
@@ -50,7 +50,6 @@ vttablet \
  -init_shard $shard \
  -init_tablet_type $tablet_type \
  -health_check_interval 5s \
- -enable_semi_sync \
  -enable_replication_reporter \
  -backup_storage_implementation file \
  -file_backup_storage_root $VTDATAROOT/backups \

--- a/go/internal/flag/flag.go
+++ b/go/internal/flag/flag.go
@@ -31,8 +31,6 @@ import (
 	"strings"
 
 	flag "github.com/spf13/pflag"
-
-	"vitess.io/vitess/go/vt/log"
 )
 
 // Parse wraps the standard library's flag.Parse to perform some sanity checking
@@ -243,46 +241,6 @@ func Arg(i int) string {
 	}
 
 	return ""
-}
-
-const (
-	singleDashLongFlagsWarning  = "Use of single-dash long flags is deprecated and will be removed in the next version of Vitess. Please use --%s instead"
-	mixedFlagsAndPosargsWarning = "Detected a dashed argument after a positional argument. " +
-		"Currently these are treated as posargs that may be parsed by a subcommand, but in the next version of Vitess they will be parsed as top-level flags, which may not be defined, causing errors. " +
-		"To preserve existing behavior, please update your invocation to include a \"--\" after all top-level flags to continue treating %s as a positional argument."
-)
-
-// Check and warn on any single-dash flags.
-// nolint:deadcode
-func warnOnSingleDashLongFlags(fs *goflag.FlagSet, argv []string, warningf func(msg string, args ...any)) {
-	fs.Visit(func(f *goflag.Flag) {
-		// Boolean flags with single-character names are okay to use the
-		// single-dash form. I don't _think_ we have any of these, but I'm being
-		// conservative here.
-		if bf, ok := f.Value.(maybeBoolFlag); ok && bf.IsBoolFlag() && len(f.Name) == 1 {
-			return
-		}
-
-		for _, arg := range argv {
-			if strings.HasPrefix(arg, "-"+f.Name) {
-				warningf(singleDashLongFlagsWarning, f.Name)
-			}
-		}
-	})
-}
-
-// Check and warn for any mixed posarg / dashed-arg on the CLI.
-// nolint:deadcode
-func warnOnMixedPositionalAndFlagArguments(posargs []string, warningf func(msg string, args ...any)) {
-	for _, arg := range posargs {
-		if arg == "--" {
-			break
-		}
-
-		if strings.HasPrefix(arg, "-") {
-			log.Warningf(mixedFlagsAndPosargsWarning, arg)
-		}
-	}
 }
 
 // From the standard library documentation:

--- a/go/mysql/conn_params.go
+++ b/go/mysql/conn_params.go
@@ -47,10 +47,6 @@ type ConnParams struct {
 	ServerName       string        `json:"server_name"`
 	ConnectTimeoutMs uint64        `json:"connect_timeout_ms"`
 
-	// The following is only set when the deprecated "dbname" flags are
-	// supplied and will be removed.
-	DeprecatedDBName string
-
 	// The following is only set to force the client to connect without
 	// using CapabilityClientDeprecateEOF
 	DisableClientDeprecateEOF bool

--- a/go/test/endtoend/backup/vtbackup/main_test.go
+++ b/go/test/endtoend/backup/vtbackup/main_test.go
@@ -111,7 +111,6 @@ func TestMain(m *testing.M) {
 			tablet.VttabletProcess.DbPassword = dbPassword
 			tablet.VttabletProcess.ExtraArgs = commonTabletArg
 			tablet.VttabletProcess.SupportsBackup = true
-			tablet.VttabletProcess.EnableSemiSync = true
 
 			tablet.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, localCluster.TmpDirectory)
 			tablet.MysqlctlProcess.InitDBFile = newInitDBFile

--- a/go/test/endtoend/cellalias/cell_alias_test.go
+++ b/go/test/endtoend/cellalias/cell_alias_test.go
@@ -116,6 +116,12 @@ func TestMain(m *testing.M) {
 			return 1, err
 		}
 
+		vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", localCluster.VtctldProcess.GrpcPort, localCluster.TmpDirectory)
+		_, err = vtctldClientProcess.ExecuteCommandWithOutput("CreateKeyspace", keyspaceName, "--durability-policy=semi_sync")
+		if err != nil {
+			return 1, err
+		}
+
 		shard1Primary = localCluster.NewVttabletInstance("primary", 0, cell1)
 		shard1Replica = localCluster.NewVttabletInstance("replica", 0, cell2)
 		shard1Rdonly = localCluster.NewVttabletInstance("rdonly", 0, cell2)
@@ -139,7 +145,6 @@ func TestMain(m *testing.M) {
 				hostname,
 				localCluster.TmpDirectory,
 				commonTabletArg,
-				true,
 				localCluster.DefaultCharset,
 			)
 			tablet.VttabletProcess.SupportsBackup = true
@@ -153,10 +158,6 @@ func TestMain(m *testing.M) {
 			if err := proc.Wait(); err != nil {
 				return 1, err
 			}
-		}
-
-		if err := localCluster.VtctlProcess.CreateKeyspace(keyspaceName); err != nil {
-			return 1, err
 		}
 
 		shard1 := cluster.Shard{

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -117,8 +117,6 @@ type LocalProcessCluster struct {
 
 	VtctldExtraArgs []string
 
-	EnableSemiSync bool
-
 	// mutex added to handle the parallel teardowns
 	mx                *sync.Mutex
 	teardownCompleted bool
@@ -359,7 +357,6 @@ func (cluster *LocalProcessCluster) startKeyspace(keyspace Keyspace, shardNames 
 				cluster.Hostname,
 				cluster.TmpDirectory,
 				cluster.VtTabletExtraArgs,
-				cluster.EnableSemiSync,
 				cluster.DefaultCharset)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
 			if cluster.ReusingVTDATAROOT {
@@ -500,7 +497,6 @@ func (cluster *LocalProcessCluster) StartKeyspaceLegacy(keyspace Keyspace, shard
 				cluster.Hostname,
 				cluster.TmpDirectory,
 				cluster.VtTabletExtraArgs,
-				cluster.EnableSemiSync,
 				cluster.DefaultCharset)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
 			if cluster.ReusingVTDATAROOT {
@@ -614,7 +610,6 @@ func (cluster *LocalProcessCluster) SetupCluster(keyspace *Keyspace, shards []Sh
 				cluster.Hostname,
 				cluster.TmpDirectory,
 				cluster.VtTabletExtraArgs,
-				cluster.EnableSemiSync,
 				cluster.DefaultCharset)
 		}
 
@@ -1162,7 +1157,6 @@ func (cluster *LocalProcessCluster) VtprocessInstanceFromVttablet(tablet *Vttabl
 		cluster.Hostname,
 		cluster.TmpDirectory,
 		cluster.VtTabletExtraArgs,
-		cluster.EnableSemiSync,
 		cluster.DefaultCharset)
 }
 
@@ -1182,7 +1176,6 @@ func (cluster *LocalProcessCluster) StartVttablet(tablet *Vttablet, servingStatu
 		hostname,
 		cluster.TmpDirectory,
 		cluster.VtTabletExtraArgs,
-		cluster.EnableSemiSync,
 		cluster.DefaultCharset)
 
 	tablet.VttabletProcess.SupportsBackup = supportBackup

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -66,7 +66,6 @@ type VttabletProcess struct {
 	VerifyURL                   string
 	QueryzURL                   string
 	StatusDetailsURL            string
-	EnableSemiSync              bool
 	SupportsBackup              bool
 	ServingStatus               string
 	DbPassword                  string
@@ -119,9 +118,6 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 
 	if vttablet.SupportsBackup {
 		vttablet.proc.Args = append(vttablet.proc.Args, "--restore_from_backup")
-	}
-	if vttablet.EnableSemiSync {
-		vttablet.proc.Args = append(vttablet.proc.Args, "--enable_semi_sync")
 	}
 	if vttablet.DbFlavor != "" {
 		vttablet.proc.Args = append(vttablet.proc.Args, fmt.Sprintf("--db_flavor=%s", vttablet.DbFlavor))
@@ -593,7 +589,7 @@ func (vttablet *VttabletProcess) IsShutdown() bool {
 // VttabletProcessInstance returns a VttabletProcess handle for vttablet process
 // configured with the given Config.
 // The process must be manually started by calling setup()
-func VttabletProcessInstance(port, grpcPort, tabletUID int, cell, shard, keyspace string, vtctldPort int, tabletType string, topoPort int, hostname, tmpDirectory string, extraArgs []string, enableSemiSync bool, charset string) *VttabletProcess {
+func VttabletProcessInstance(port, grpcPort, tabletUID int, cell, shard, keyspace string, vtctldPort int, tabletType string, topoPort int, hostname, tmpDirectory string, extraArgs []string, charset string) *VttabletProcess {
 	vtctl := VtctlProcessInstance(topoPort, hostname)
 	vttablet := &VttabletProcess{
 		Name:                        "vttablet",
@@ -613,7 +609,6 @@ func VttabletProcessInstance(port, grpcPort, tabletUID int, cell, shard, keyspac
 		GrpcPort:                    grpcPort,
 		VtctldAddress:               fmt.Sprintf("http://%s:%d", hostname, vtctldPort),
 		ExtraArgs:                   extraArgs,
-		EnableSemiSync:              enableSemiSync,
 		SupportsBackup:              true,
 		ServingStatus:               "NOT_SERVING",
 		BackupStorageImplementation: "file",

--- a/go/test/endtoend/encryption/encryptedreplication/encrypted_replication_test.go
+++ b/go/test/endtoend/encryption/encryptedreplication/encrypted_replication_test.go
@@ -159,7 +159,6 @@ func initializeCluster(t *testing.T) (int, error) {
 				clusterInstance.Hostname,
 				clusterInstance.TmpDirectory,
 				clusterInstance.VtTabletExtraArgs,
-				clusterInstance.EnableSemiSync,
 				clusterInstance.DefaultCharset)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
 			shard.Vttablets = append(shard.Vttablets, tablet)

--- a/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
+++ b/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
@@ -377,7 +377,6 @@ func clusterSetUp(t *testing.T) (int, error) {
 				clusterInstance.Hostname,
 				clusterInstance.TmpDirectory,
 				clusterInstance.VtTabletExtraArgs,
-				clusterInstance.EnableSemiSync,
 				clusterInstance.DefaultCharset)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
 			shard.Vttablets = append(shard.Vttablets, tablet)

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -117,7 +117,6 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 				clusterInstance.Hostname,
 				clusterInstance.TmpDirectory,
 				clusterInstance.VtTabletExtraArgs,
-				clusterInstance.EnableSemiSync,
 				clusterInstance.DefaultCharset)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
 

--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -116,7 +116,6 @@ func initCluster(shardNames []string, totalTabletsRequired int) error {
 				clusterInstance.Hostname,
 				clusterInstance.TmpDirectory,
 				clusterInstance.VtTabletExtraArgs,
-				clusterInstance.EnableSemiSync,
 				clusterInstance.DefaultCharset)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
 

--- a/go/test/endtoend/recovery/pitr/shardedpitr_test.go
+++ b/go/test/endtoend/recovery/pitr/shardedpitr_test.go
@@ -523,7 +523,6 @@ func launchRecoveryTablet(t *testing.T, tablet *cluster.Vttablet, binlogServer *
 		clusterInstance.Hostname,
 		clusterInstance.TmpDirectory,
 		clusterInstance.VtTabletExtraArgs,
-		clusterInstance.EnableSemiSync,
 		clusterInstance.DefaultCharset)
 	tablet.Alias = tablet.VttabletProcess.TabletPath
 	tablet.VttabletProcess.SupportsBackup = true

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -387,7 +387,6 @@ func TestERSForInitialization(t *testing.T) {
 	shard.Vttablets = tablets
 	clusterInstance.VtTabletExtraArgs = []string{
 		"--lock_tables_timeout", "5s",
-		"--enable_semi_sync",
 		"--init_populate_metadata",
 		"--track_schema_versions=true",
 	}

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -82,10 +82,6 @@ func setupCluster(ctx context.Context, t *testing.T, shardName string, cells []s
 	clusterInstance := cluster.NewCluster(cells[0], Hostname)
 	keyspace := &cluster.Keyspace{Name: KeyspaceName}
 
-	if durability == "semi_sync" {
-		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--enable_semi_sync")
-	}
-
 	// Start topo server
 	err := clusterInstance.StartTopo()
 	require.NoError(t, err, "Error starting topo")
@@ -218,7 +214,6 @@ func StartNewVTTablet(t *testing.T, clusterInstance *cluster.LocalProcessCluster
 			"--track_schema_versions=true",
 			"--queryserver_enable_online_ddl=false",
 		},
-		clusterInstance.EnableSemiSync,
 		clusterInstance.DefaultCharset)
 	tablet.VttabletProcess.SupportsBackup = supportsBackup
 

--- a/go/test/endtoend/sharded/sharded_keyspace_test.go
+++ b/go/test/endtoend/sharded/sharded_keyspace_test.go
@@ -233,7 +233,6 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 				clusterInstance.Hostname,
 				clusterInstance.TmpDirectory,
 				clusterInstance.VtTabletExtraArgs,
-				clusterInstance.EnableSemiSync,
 				clusterInstance.DefaultCharset)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
 

--- a/go/test/endtoend/tabletgateway/buffer/reparent/failover_buffer_test.go
+++ b/go/test/endtoend/tabletgateway/buffer/reparent/failover_buffer_test.go
@@ -30,10 +30,8 @@ import (
 )
 
 const (
-	demoteQuery                = "SET GLOBAL read_only = ON;FLUSH TABLES WITH READ LOCK;UNLOCK TABLES;"
-	disableSemiSyncSourceQuery = "SET GLOBAL rpl_semi_sync_master_enabled = 0"
-	enableSemiSyncSourceQuery  = "SET GLOBAL rpl_semi_sync_master_enabled = 1"
-	promoteQuery               = "STOP SLAVE;RESET SLAVE ALL;SET GLOBAL read_only = OFF;"
+	demoteQuery  = "SET GLOBAL read_only = ON;FLUSH TABLES WITH READ LOCK;UNLOCK TABLES;"
+	promoteQuery = "STOP SLAVE;RESET SLAVE ALL;SET GLOBAL read_only = OFF;"
 
 	hostname = "localhost"
 )
@@ -51,9 +49,6 @@ func failoverExternalReparenting(t *testing.T, clusterInstance *cluster.LocalPro
 	oldPrimary := primary
 	newPrimary := replica
 	primary.VttabletProcess.QueryTablet(demoteQuery, keyspaceUnshardedName, true)
-	if primary.VttabletProcess.EnableSemiSync {
-		primary.VttabletProcess.QueryTablet(disableSemiSyncSourceQuery, keyspaceUnshardedName, true)
-	}
 
 	// Wait for replica to catch up to primary.
 	cluster.WaitForReplicationPos(t, primary, replica, "localhost", 60.0)
@@ -68,10 +63,6 @@ func failoverExternalReparenting(t *testing.T, clusterInstance *cluster.LocalPro
 
 	// Promote replica to new primary.
 	replica.VttabletProcess.QueryTablet(promoteQuery, keyspaceUnshardedName, true)
-
-	if replica.VttabletProcess.EnableSemiSync {
-		replica.VttabletProcess.QueryTablet(enableSemiSyncSourceQuery, keyspaceUnshardedName, true)
-	}
 
 	// Configure old primary to replicate from new primary.
 

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -105,8 +105,6 @@ func TestMain(m *testing.M) {
 			"--health_check_interval", tabletHealthcheckRefreshInterval.String(),
 			"--unhealthy_threshold", tabletUnhealthyThreshold.String(),
 		}
-		// We do not need semiSync for this test case.
-		clusterInstance.EnableSemiSync = false
 
 		// Start keyspace
 		keyspace := &cluster.Keyspace{

--- a/go/test/endtoend/tabletmanager/primary/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/primary/tablet_test.go
@@ -89,8 +89,6 @@ func TestMain(m *testing.M) {
 			"--watch_replication_stream",
 			"--enable_replication_reporter",
 		}
-		// We do not need semiSync for this test case.
-		clusterInstance.EnableSemiSync = false
 
 		// Start keyspace
 		keyspace := &cluster.Keyspace{

--- a/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
@@ -84,9 +84,6 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		// We do not need semiSync for this test case.
-		clusterInstance.EnableSemiSync = false
-
 		// Start keyspace
 		keyspace := &cluster.Keyspace{
 			Name:      keyspaceName,

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -103,8 +103,6 @@ func TestMain(m *testing.M) {
 			"--gc_purge_check_interval", gcPurgeCheckInterval.String(),
 			"--table_gc_lifecycle", "hold,purge,evac,drop",
 		}
-		// We do not need semiSync for this test case.
-		clusterInstance.EnableSemiSync = false
 
 		// Start keyspace
 		keyspace := &cluster.Keyspace{

--- a/go/test/endtoend/tabletmanager/throttler/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler/throttler_test.go
@@ -106,8 +106,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat_on_demand_duration", onDemandHeartbeatDuration.String(),
 			"--disable_active_reparents",
 		}
-		// We do not need semiSync for this test case.
-		clusterInstance.EnableSemiSync = false
 
 		// Start keyspace
 		keyspace := &cluster.Keyspace{

--- a/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
@@ -107,8 +107,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 		}
-		// We do not need semiSync for this test case.
-		clusterInstance.EnableSemiSync = false
 
 		// Start keyspace
 		keyspace := &cluster.Keyspace{

--- a/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
@@ -114,8 +114,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat_on_demand_duration", onDemandHeartbeatDuration.String(),
 			"--disable_active_reparents",
 		}
-		// We do not need semiSync for this test case.
-		clusterInstance.EnableSemiSync = false
 
 		// Start keyspace
 		keyspace := &cluster.Keyspace{

--- a/go/test/endtoend/topoconncache/main_test.go
+++ b/go/test/endtoend/topoconncache/main_test.go
@@ -124,6 +124,12 @@ func TestMain(m *testing.M) {
 			return 1, err
 		}
 
+		vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
+		_, err = vtctldClientProcess.ExecuteCommandWithOutput("CreateKeyspace", keyspaceName, "--durability-policy=semi_sync")
+		if err != nil {
+			return 1, err
+		}
+
 		shard1Primary = clusterInstance.NewVttabletInstance("primary", 0, cell1)
 		shard1Replica = clusterInstance.NewVttabletInstance("replica", 0, cell2)
 		shard1Rdonly = clusterInstance.NewVttabletInstance("rdonly", 0, cell2)
@@ -147,7 +153,6 @@ func TestMain(m *testing.M) {
 				hostname,
 				clusterInstance.TmpDirectory,
 				commonTabletArg,
-				true,
 				clusterInstance.DefaultCharset,
 			)
 			tablet.VttabletProcess.SupportsBackup = true
@@ -161,10 +166,6 @@ func TestMain(m *testing.M) {
 			if err := proc.Wait(); err != nil {
 				return 1, err
 			}
-		}
-
-		if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspaceName); err != nil {
-			return 1, err
 		}
 
 		shard1 = cluster.Shard{

--- a/go/test/endtoend/topoconncache/topo_conn_cache_test.go
+++ b/go/test/endtoend/topoconncache/topo_conn_cache_test.go
@@ -149,7 +149,6 @@ func addCellback(t *testing.T) {
 			hostname,
 			clusterInstance.TmpDirectory,
 			commonTabletArg,
-			true,
 			clusterInstance.DefaultCharset,
 		)
 		tablet.VttabletProcess.SupportsBackup = true

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -417,7 +417,6 @@ func (vc *VitessCluster) AddTablet(t testing.TB, cell *Cell, keyspace *Keyspace,
 		vc.ClusterConfig.hostname,
 		vc.ClusterConfig.tmpDir,
 		options,
-		false,
 		vc.ClusterConfig.charset)
 
 	require.NotNil(t, vttablet)

--- a/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
+++ b/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
@@ -201,7 +201,6 @@ func addTablet(t *testing.T, tabletUID int, tabletType string) *cluster.Vttablet
 		clusterInstance.Hostname,
 		clusterInstance.TmpDirectory,
 		clusterInstance.VtTabletExtraArgs,
-		clusterInstance.EnableSemiSync,
 		clusterInstance.DefaultCharset)
 
 	// wait for mysqld to be ready

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -254,12 +254,6 @@ func (dbcfgs *DBConfigs) ExternalRepl() Connector {
 // ExternalReplWithDB returns connection parameters for repl with dbname set.
 func (dbcfgs *DBConfigs) ExternalReplWithDB() Connector {
 	params := dbcfgs.makeParams(&dbcfgs.externalReplParams, true)
-	// TODO @rafael: This is a hack to allows to configure external databases by providing
-	// db-config-erepl-dbname.
-	if params.connParams.DeprecatedDBName != "" {
-		params.connParams.DbName = params.connParams.DeprecatedDBName
-		return params
-	}
 	return params
 }
 

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -68,7 +68,7 @@ var (
 	errNoKeyspace     = vterrors.VT09005()
 	defaultTabletType = topodatapb.TabletType_PRIMARY
 
-	// TODO: @rafael - These two counters should be deprecated in favor of the ByTable ones. They are kept for now for backwards compatibility.
+	// TODO: @rafael - These two counters should be deprecated in favor of the ByTable ones in v17+. They are kept for now for backwards compatibility.
 	queriesProcessed = stats.NewCountersWithSingleLabel("QueriesProcessed", "Queries processed at vtgate by plan type", "Plan")
 	queriesRouted    = stats.NewCountersWithSingleLabel("QueriesRouted", "Queries routed from vtgate to vttablet by plan type", "Plan")
 

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -320,8 +320,6 @@ func (e *Executor) StreamExecute(
 		}
 
 		// 5: Log and add statistics
-		logStats.Keyspace = plan.Instructions.GetKeyspaceName()
-		logStats.Table = plan.Instructions.GetTableName()
 		logStats.TablesUsed = plan.TablesUsed
 		logStats.TabletType = vc.TabletType().String()
 		logStats.ExecuteTime = time.Since(execStart)

--- a/go/vt/vtgate/logstats/logstats.go
+++ b/go/vt/vtgate/logstats/logstats.go
@@ -17,14 +17,13 @@ limitations under the License.
 package logstats
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
 	"net/url"
 	"time"
-
-	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"
@@ -57,10 +56,6 @@ type LogStats struct {
 	SessionUUID    string
 	CachedPlan     bool
 	ActiveKeyspace string // ActiveKeyspace is the selected keyspace `use ks`
-
-	// These two fields are deprecated and will be removed in the Vitess V16 release
-	Keyspace string
-	Table    string
 }
 
 // NewLogStats constructs a new LogStats with supplied Method and ctx
@@ -156,9 +151,9 @@ func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
 	var fmtString string
 	switch streamlog.GetQueryLogFormat() {
 	case streamlog.QueryLogFormatText:
-		fmtString = "%v\t%v\t%v\t'%v'\t'%v'\t%v\t%v\t%.6f\t%.6f\t%.6f\t%.6f\t%v\t%q\t%v\t%v\t%v\t%q\t%q\t%q\t%q\t%q\t%v\t%v\t%q\n"
+		fmtString = "%v\t%v\t%v\t'%v'\t'%v'\t%v\t%v\t%.6f\t%.6f\t%.6f\t%.6f\t%v\t%q\t%v\t%v\t%v\t%q\t%q\t%q\t%v\t%v\t%q\n"
 	case streamlog.QueryLogFormatJSON:
-		fmtString = "{\"Method\": %q, \"RemoteAddr\": %q, \"Username\": %q, \"ImmediateCaller\": %q, \"Effective Caller\": %q, \"Start\": \"%v\", \"End\": \"%v\", \"TotalTime\": %.6f, \"PlanTime\": %v, \"ExecuteTime\": %v, \"CommitTime\": %v, \"StmtType\": %q, \"SQL\": %q, \"BindVars\": %v, \"ShardQueries\": %v, \"RowsAffected\": %v, \"Error\": %q,  \"Keyspace\": %q, \"Table\": %q, \"TabletType\": %q, \"SessionUUID\": %q, \"Cached Plan\": %v, \"TablesUsed\": %v, \"ActiveKeyspace\": %q}\n"
+		fmtString = "{\"Method\": %q, \"RemoteAddr\": %q, \"Username\": %q, \"ImmediateCaller\": %q, \"Effective Caller\": %q, \"Start\": \"%v\", \"End\": \"%v\", \"TotalTime\": %.6f, \"PlanTime\": %v, \"ExecuteTime\": %v, \"CommitTime\": %v, \"StmtType\": %q, \"SQL\": %q, \"BindVars\": %v, \"ShardQueries\": %v, \"RowsAffected\": %v, \"Error\": %q, \"TabletType\": %q, \"SessionUUID\": %q, \"Cached Plan\": %v, \"TablesUsed\": %v, \"ActiveKeyspace\": %q}\n"
 	}
 
 	tables := stats.TablesUsed
@@ -189,8 +184,6 @@ func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
 		stats.ShardQueries,
 		stats.RowsAffected,
 		stats.ErrorStr(),
-		stats.Keyspace,
-		stats.Table,
 		stats.TabletType,
 		stats.SessionUUID,
 		stats.CachedPlan,

--- a/go/vt/vtgate/logstats/logstats_test.go
+++ b/go/vt/vtgate/logstats/logstats_test.go
@@ -61,8 +61,6 @@ func TestLogStatsFormat(t *testing.T) {
 	logStats := NewLogStats(context.Background(), "test", "sql1", "suuid", nil)
 	logStats.StartTime = time.Date(2017, time.January, 1, 1, 2, 3, 0, time.UTC)
 	logStats.EndTime = time.Date(2017, time.January, 1, 1, 2, 4, 1234, time.UTC)
-	logStats.Keyspace = "ks"
-	logStats.Table = "table"
 	logStats.TablesUsed = []string{"ks1.tbl1", "ks2.tbl2"}
 	logStats.TabletType = "PRIMARY"
 	logStats.ActiveKeyspace = "db"
@@ -80,42 +78,42 @@ func TestLogStatsFormat(t *testing.T) {
 		{ // 0
 			redact:   false,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\tmap[intVal:type:INT64 value:\"1\"]\t0\t0\t\"\"\t\"ks\"\t\"table\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\tmap[intVal:type:INT64 value:\"1\"]\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
 			bindVars: intBindVar,
 		}, { // 1
 			redact:   true,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"ks\"\t\"table\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
 			bindVars: intBindVar,
 		}, { // 2
 			redact:   false,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"intVal\":{\"type\":\"INT64\",\"value\":1}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Keyspace\":\"ks\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"Table\":\"table\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"intVal\":{\"type\":\"INT64\",\"value\":1}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: intBindVar,
 		}, { // 3
 			redact:   true,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Keyspace\":\"ks\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"Table\":\"table\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: intBindVar,
 		}, { // 4
 			redact:   false,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\tmap[strVal:type:VARCHAR value:\"abc\"]\t0\t0\t\"\"\t\"ks\"\t\"table\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\tmap[strVal:type:VARCHAR value:\"abc\"]\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
 			bindVars: stringBindVar,
 		}, { // 5
 			redact:   true,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"ks\"\t\"table\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t\"db\"\n",
 			bindVars: stringBindVar,
 		}, { // 6
 			redact:   false,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"strVal\":{\"type\":\"VARCHAR\",\"value\":\"abc\"}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Keyspace\":\"ks\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"Table\":\"table\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"strVal\":{\"type\":\"VARCHAR\",\"value\":\"abc\"}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: stringBindVar,
 		}, { // 7
 			redact:   true,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Keyspace\":\"ks\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"Table\":\"table\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"PlanTime\":0,\"RemoteAddr\":\"\",\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: stringBindVar,
 		},
 	}
@@ -158,12 +156,12 @@ func TestLogStatsFilter(t *testing.T) {
 	params := map[string][]string{"full": {}}
 
 	got := testFormat(t, logStats, params)
-	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\tmap[intVal:type:INT64 value:\"1\"]\t0\t0\t\"\"\t\"\"\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
+	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\tmap[intVal:type:INT64 value:\"1\"]\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
 	assert.Equal(t, want, got)
 
 	streamlog.SetQueryLogFilterTag("LOG_THIS_QUERY")
 	got = testFormat(t, logStats, params)
-	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\tmap[intVal:type:INT64 value:\"1\"]\t0\t0\t\"\"\t\"\"\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
+	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\tmap[intVal:type:INT64 value:\"1\"]\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
 	assert.Equal(t, want, got)
 
 	streamlog.SetQueryLogFilterTag("NOT_THIS_QUERY")
@@ -181,12 +179,12 @@ func TestLogStatsRowThreshold(t *testing.T) {
 	params := map[string][]string{"full": {}}
 
 	got := testFormat(t, logStats, params)
-	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\tmap[intVal:type:INT64 value:\"1\"]\t0\t0\t\"\"\t\"\"\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
+	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\tmap[intVal:type:INT64 value:\"1\"]\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
 	assert.Equal(t, want, got)
 
 	streamlog.SetQueryLogRowThreshold(0)
 	got = testFormat(t, logStats, params)
-	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\tmap[intVal:type:INT64 value:\"1\"]\t0\t0\t\"\"\t\"\"\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
+	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\tmap[intVal:type:INT64 value:\"1\"]\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\n"
 	assert.Equal(t, want, got)
 	streamlog.SetQueryLogRowThreshold(1)
 	got = testFormat(t, logStats, params)

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -257,9 +257,7 @@ func (e *Executor) rollbackPartialExec(ctx context.Context, safeSession *SafeSes
 
 func (e *Executor) setLogStats(logStats *logstats.LogStats, plan *engine.Plan, vcursor *vcursorImpl, execStart time.Time, err error, qr *sqltypes.Result) {
 	logStats.StmtType = plan.Type.String()
-	logStats.Keyspace = plan.Instructions.GetKeyspaceName()
 	logStats.ActiveKeyspace = vcursor.keyspace
-	logStats.Table = plan.Instructions.GetTableName()
 	logStats.TablesUsed = plan.TablesUsed
 	logStats.TabletType = vcursor.TabletType().String()
 	errCount := e.logExecutionEnd(logStats, execStart, plan, err, qr)

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -469,7 +469,6 @@ func TestQueryStats(t *testing.T) {
 	vend := framework.DebugVars()
 	require.False(t, framework.IsPresent(vend, "QueryRowsAffected/vitess_a.Select"))
 	compareIntDiff(t, vend, "QueryCounts/vitess_a.Select", vstart, 2)
-	compareIntDiff(t, vend, "QueryRowCounts/vitess_a.Select", vstart, 0)
 	compareIntDiff(t, vend, "QueryRowsReturned/vitess_a.Select", vstart, 2)
 	compareIntDiff(t, vend, "QueryErrorCounts/vitess_a.Select", vstart, 1)
 
@@ -498,7 +497,6 @@ func TestQueryStats(t *testing.T) {
 	vend = framework.DebugVars()
 	require.False(t, framework.IsPresent(vend, "QueryRowsReturned/vitess_a.UpdateLimit"))
 	compareIntDiff(t, vend, "QueryCounts/vitess_a.UpdateLimit", vstart, 1)
-	compareIntDiff(t, vend, "QueryRowCounts/vitess_a.UpdateLimit", vstart, 2)
 	compareIntDiff(t, vend, "QueryRowsAffected/vitess_a.UpdateLimit", vstart, 2)
 	compareIntDiff(t, vend, "QueryErrorCounts/vitess_a.UpdateLimit", vstart, 0)
 
@@ -520,7 +518,6 @@ func TestQueryStats(t *testing.T) {
 	vend = framework.DebugVars()
 	require.False(t, framework.IsPresent(vend, "QueryRowsReturned/vitess_a.Insert"))
 	compareIntDiff(t, vend, "QueryCounts/vitess_a.Insert", vstart, 1)
-	compareIntDiff(t, vend, "QueryRowCounts/vitess_a.Insert", vstart, 1)
 	compareIntDiff(t, vend, "QueryRowsAffected/vitess_a.Insert", vstart, 1)
 	compareIntDiff(t, vend, "QueryErrorCounts/vitess_a.Insert", vstart, 0)
 
@@ -542,7 +539,6 @@ func TestQueryStats(t *testing.T) {
 	vend = framework.DebugVars()
 	require.False(t, framework.IsPresent(vend, "QueryRowsReturned/vitess_a.DeleteLimit"))
 	compareIntDiff(t, vend, "QueryCounts/vitess_a.DeleteLimit", vstart, 1)
-	compareIntDiff(t, vend, "QueryRowCounts/vitess_a.DeleteLimit", vstart, 1)
 	compareIntDiff(t, vend, "QueryRowsAffected/vitess_a.DeleteLimit", vstart, 1)
 	compareIntDiff(t, vend, "QueryErrorCounts/vitess_a.DeleteLimit", vstart, 0)
 

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -42,9 +42,6 @@ var setSuperReadOnly bool
 var disableReplicationManager bool
 
 func registerReplicationFlags(fs *pflag.FlagSet) {
-	fs.Bool("enable_semi_sync", false, "")
-	fs.MarkDeprecated("enable_semi_sync", "please set the correct durability policy on the keyspace instead.")
-
 	fs.BoolVar(&setSuperReadOnly, "use_super_read_only", setSuperReadOnly, "Set super_read_only flag when performing planned failover.")
 	fs.BoolVar(&disableReplicationManager, "disable-replication-manager", disableReplicationManager, "Disable replication manager to prevent replication repairs.")
 }

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -171,7 +171,7 @@ type QueryEngine struct {
 	consolidatorMode sync2.AtomicString
 
 	// stats
-	queryCounts, queryTimes, queryRowCounts, queryErrorCounts, queryRowsAffected, queryRowsReturned *stats.CountersWithMultiLabels
+	queryCounts, queryTimes, queryErrorCounts, queryRowsAffected, queryRowsReturned *stats.CountersWithMultiLabels
 
 	// Loggers
 	accessCheckerLogger *logutil.ThrottledLogger
@@ -248,7 +248,6 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 	env.Exporter().NewCounterFunc("QueryCacheEvictions", "Query engine query cache evictions", qe.plans.Evictions)
 	qe.queryCounts = env.Exporter().NewCountersWithMultiLabels("QueryCounts", "query counts", []string{"Table", "Plan"})
 	qe.queryTimes = env.Exporter().NewCountersWithMultiLabels("QueryTimesNs", "query times in ns", []string{"Table", "Plan"})
-	qe.queryRowCounts = env.Exporter().NewCountersWithMultiLabels("QueryRowCounts", "(DEPRECATED - use QueryRowsAffected and QueryRowsReturned instead) query row counts", []string{"Table", "Plan"})
 	qe.queryRowsAffected = env.Exporter().NewCountersWithMultiLabels("QueryRowsAffected", "query rows affected", []string{"Table", "Plan"})
 	qe.queryRowsReturned = env.Exporter().NewCountersWithMultiLabels("QueryRowsReturned", "query rows returned", []string{"Table", "Plan"})
 	qe.queryErrorCounts = env.Exporter().NewCountersWithMultiLabels("QueryErrorCounts", "query error counts", []string{"Table", "Plan"})
@@ -484,7 +483,6 @@ func (qe *QueryEngine) AddStats(planType planbuilder.PlanType, tableName string,
 	keys := []string{tableName, planType.String()}
 	qe.queryCounts.Add(keys, queryCount)
 	qe.queryTimes.Add(keys, int64(duration))
-	qe.queryRowCounts.Add(keys, rowsAffected)
 	qe.queryErrorCounts.Add(keys, errorCount)
 
 	// For certain plan types like select, we only want to add their metrics to rows returned

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -587,7 +587,6 @@ func TestAddQueryStats(t *testing.T) {
 		expectedQueryTimes        string
 		expectedQueryRowsAffected string
 		expectedQueryRowsReturned string
-		expectedQueryRowCounts    string
 		expectedQueryErrorCounts  string
 	}{
 		{
@@ -603,7 +602,6 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:        `{"A.Select": 10}`,
 			expectedQueryRowsAffected: `{}`,
 			expectedQueryRowsReturned: `{"A.Select": 15}`,
-			expectedQueryRowCounts:    `{"A.Select": 0}`,
 			expectedQueryErrorCounts:  `{"A.Select": 0}`,
 		}, {
 			name:                      "select into query",
@@ -618,7 +616,6 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:        `{"A.Select": 10}`,
 			expectedQueryRowsAffected: `{"A.Select": 15}`,
 			expectedQueryRowsReturned: `{"A.Select": 0}`,
-			expectedQueryRowCounts:    `{"A.Select": 15}`,
 			expectedQueryErrorCounts:  `{"A.Select": 0}`,
 		}, {
 			name:                      "error",
@@ -633,7 +630,6 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:        `{"A.Select": 10}`,
 			expectedQueryRowsAffected: `{}`,
 			expectedQueryRowsReturned: `{"A.Select": 0}`,
-			expectedQueryRowCounts:    `{"A.Select": 0}`,
 			expectedQueryErrorCounts:  `{"A.Select": 1}`,
 		}, {
 			name:                      "insert query",
@@ -648,7 +644,6 @@ func TestAddQueryStats(t *testing.T) {
 			expectedQueryTimes:        `{"A.Insert": 10}`,
 			expectedQueryRowsAffected: `{"A.Insert": 15}`,
 			expectedQueryRowsReturned: `{}`,
-			expectedQueryRowCounts:    `{"A.Insert": 15}`,
 			expectedQueryErrorCounts:  `{"A.Insert": 0}`,
 		},
 	}

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -666,7 +666,6 @@ func TestAddQueryStats(t *testing.T) {
 			assert.Equal(t, testcase.expectedQueryTimes, qe.queryTimes.String())
 			assert.Equal(t, testcase.expectedQueryRowsAffected, qe.queryRowsAffected.String())
 			assert.Equal(t, testcase.expectedQueryRowsReturned, qe.queryRowsReturned.String())
-			assert.Equal(t, testcase.expectedQueryRowCounts, qe.queryRowCounts.String())
 			assert.Equal(t, testcase.expectedQueryErrorCounts, qe.queryErrorCounts.String())
 		})
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR removed a lot of deprecated flags, code and stats which were deprecated in previous Vitess releases. The following changes have been made - 

1. `Keyspace` and `TableName` fields have been removed from LogStats.
2. `QueriesProcessed`, `QueriesRoutedStats` and `QueryRowCounts` have been removed.
3. `enable_semi_sync` flag has been removed.
4. DeprecatedDBName field which wasn't been written to is also removed.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #5960 
- #11749 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
