### PR TITLE
Internal: Fix Bad Merge

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -766,7 +766,7 @@ func TestSchemaChange(t *testing.T) {
 	// 'mysql' strategy
 	t.Run("mysql strategy", func(t *testing.T) {
 		t.Run("declarative", func(t *testing.T) {
-			t1uuid = testOnlineDDLStatement(t, createT1Statement, "mysql --declarative", "vtgate", "just-created", "", false)
+			t1uuid = testOnlineDDLStatement(t, createParams(createT1Statement, "mysql --declarative", "vtgate", "just-created", "", false))
 
 			status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, t1uuid, normalWaitTime, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 			fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
@@ -775,7 +775,7 @@ func TestSchemaChange(t *testing.T) {
 		})
 
 		t.Run("fail postpone-completion", func(t *testing.T) {
-			t1uuid := testOnlineDDLStatement(t, trivialAlterT1Statement, "mysql --postpone-completion", "vtgate", "", "", true)
+			t1uuid := testOnlineDDLStatement(t, createParams(trivialAlterT1Statement, "mysql --postpone-completion", "vtgate", "", "", true))
 
 			// --postpone-completion not supported in mysql strategy
 			time.Sleep(ensureStateNotChangedTime)
@@ -783,7 +783,7 @@ func TestSchemaChange(t *testing.T) {
 			onlineddl.CheckMigrationStatus(t, &vtParams, shards, t1uuid, schema.OnlineDDLStatusFailed)
 		})
 		t.Run("trivial", func(t *testing.T) {
-			t1uuid := testOnlineDDLStatement(t, trivialAlterT1Statement, "mysql", "vtgate", "", "", true)
+			t1uuid := testOnlineDDLStatement(t, createParams(trivialAlterT1Statement, "mysql", "vtgate", "", "", true))
 
 			status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, t1uuid, normalWaitTime, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 			fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
@@ -797,7 +797,7 @@ func TestSchemaChange(t *testing.T) {
 			}
 		})
 		t.Run("instant", func(t *testing.T) {
-			t1uuid := testOnlineDDLStatement(t, instantAlterT1Statement, "mysql", "vtgate", "", "", true)
+			t1uuid := testOnlineDDLStatement(t, createParams(instantAlterT1Statement, "mysql", "vtgate", "", "", true))
 
 			status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, t1uuid, normalWaitTime, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 			fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)


### PR DESCRIPTION
## Description

GitHub did not seem to pick up the merge conflict between these two commits (older to newer):
  - https://github.com/vitessio/vitess/commit/673573ab5097eb48289ce32d3093fb3d6d2b027a
  - https://github.com/vitessio/vitess/commit/836b3c1e7df43c1474f0686363a824e7aeefdecc

The first (earlier) commit changed the function signature for `testOnlineDDLStatement()`, while the second (later) commit used the old signature. I noticed that GitHub/Azure was having all sorts of strange issues around the time that https://github.com/vitessio/vitess/pull/12027 was merged so I suspect that's why it did not pick up on the merge conflict.

This was then blocking new PRs as it caused all of these workflows to fail:
  - `onlineddl_declarative`
  - `onlineddl_scheduler`
  - `onlineddl_scheduler/mysql57`
  - `Static Code Checks, Etc.`

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/12027

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests are not required
-   [x] Documentation is not required