### PR TITLE
VReplication: Propagate Binlog Stream Errors

### DIFF
--- a/go/vt/binlog/binlog_connection.go
+++ b/go/vt/binlog/binlog_connection.go
@@ -155,7 +155,6 @@ func (bc *BinlogConnection) streamEvents(ctx context.Context) (chan mysql.Binlog
 				select {
 				case errChan <- err:
 				case <-ctx.Done():
-					return
 				}
 				if sqlErr, ok := err.(*mysql.SQLError); ok && sqlErr.Number() == mysql.CRServerLost {
 					// CRServerLost = Lost connection to MySQL server during query

--- a/go/vt/binlog/binlog_connection.go
+++ b/go/vt/binlog/binlog_connection.go
@@ -136,7 +136,8 @@ func (bc *BinlogConnection) StartBinlogDumpFromPosition(ctx context.Context, bin
 	return c, e, nil
 }
 
-// streamEvents returns a channel on which events are streamed.
+// streamEvents returns a channel on which events are streamed and a channel on
+// which errors are propagated.
 func (bc *BinlogConnection) streamEvents(ctx context.Context) (chan mysql.BinlogEvent, chan error) {
 	// FIXME(alainjobart) I think we can use a buffered channel for better performance.
 	eventChan := make(chan mysql.BinlogEvent)
@@ -147,6 +148,7 @@ func (bc *BinlogConnection) streamEvents(ctx context.Context) (chan mysql.Binlog
 	go func() {
 		defer func() {
 			close(eventChan)
+			close(errChan)
 			bc.wg.Done()
 		}()
 		for {

--- a/go/vt/binlog/binlog_streamer.go
+++ b/go/vt/binlog/binlog_streamer.go
@@ -207,6 +207,7 @@ func (bls *Streamer) Stream(ctx context.Context) (err error) {
 	}
 
 	var events <-chan mysql.BinlogEvent
+	var errs <-chan error
 	if bls.timestamp != 0 {
 		// MySQL 5.6 only: We are going to start reading the
 		// logs from the beginning of a binlog file. That is
@@ -214,7 +215,7 @@ func (bls *Streamer) Stream(ctx context.Context) (err error) {
 		// contains the starting GTIDSet, and we will save
 		// that as the current position.
 		bls.usePreviousGTIDs = true
-		events, err = bls.conn.StartBinlogDumpFromBinlogBeforeTimestamp(ctx, bls.timestamp)
+		events, errs, err = bls.conn.StartBinlogDumpFromBinlogBeforeTimestamp(ctx, bls.timestamp)
 	} else if !bls.startPos.IsZero() {
 		// MySQL 5.6 only: we are starting from a random
 		// binlog position. It turns out we will receive a
@@ -223,16 +224,16 @@ func (bls *Streamer) Stream(ctx context.Context) (err error) {
 		// the starting position we pass in, it seems it is
 		// just the PREVIOUS_GTIDS_EVENT from the file we're reading.
 		// So we have to skip it.
-		events, err = bls.conn.StartBinlogDumpFromPosition(ctx, "", bls.startPos)
+		events, errs, err = bls.conn.StartBinlogDumpFromPosition(ctx, "", bls.startPos)
 	} else {
-		bls.startPos, events, err = bls.conn.StartBinlogDumpFromCurrent(ctx)
+		bls.startPos, events, errs, err = bls.conn.StartBinlogDumpFromCurrent(ctx)
 	}
 	if err != nil {
 		return err
 	}
 	// parseEvents will loop until the events channel is closed, the
 	// service enters the SHUTTING_DOWN state, or an error occurs.
-	stopPos, err = bls.parseEvents(ctx, events)
+	stopPos, err = bls.parseEvents(ctx, events, errs)
 	return err
 }
 
@@ -243,7 +244,7 @@ func (bls *Streamer) Stream(ctx context.Context) (err error) {
 // If the sendTransaction func returns io.EOF, parseEvents returns ErrClientEOF.
 // If the events channel is closed, parseEvents returns ErrServerEOF.
 // If the context is done, returns ctx.Err().
-func (bls *Streamer) parseEvents(ctx context.Context, events <-chan mysql.BinlogEvent) (mysql.Position, error) {
+func (bls *Streamer) parseEvents(ctx context.Context, events <-chan mysql.BinlogEvent, errs <-chan error) (mysql.Position, error) {
 	var statements []FullBinlogStatement
 	var format mysql.BinlogFormat
 	var gtid mysql.GTID
@@ -297,6 +298,8 @@ func (bls *Streamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 				log.Infof("reached end of binlog event stream")
 				return pos, ErrServerEOF
 			}
+		case err = <-errs:
+			return pos, err
 		case <-ctx.Done():
 			log.Infof("stopping early due to binlog Streamer service shutdown or client disconnect")
 			return pos, ctx.Err()

--- a/go/vt/binlog/binlog_streamer.go
+++ b/go/vt/binlog/binlog_streamer.go
@@ -231,6 +231,7 @@ func (bls *Streamer) Stream(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+
 	// parseEvents will loop until the events channel is closed, the
 	// service enters the SHUTTING_DOWN state, or an error occurs.
 	stopPos, err = bls.parseEvents(ctx, events, errs)

--- a/go/vt/binlog/binlog_streamer_rbr_test.go
+++ b/go/vt/binlog/binlog_streamer_rbr_test.go
@@ -175,6 +175,7 @@ func TestStreamerParseRBREvents(t *testing.T) {
 	}
 
 	events := make(chan mysql.BinlogEvent)
+	errs := make(chan error)
 
 	want := []fullBinlogTransaction{
 		{
@@ -263,7 +264,7 @@ func TestStreamerParseRBREvents(t *testing.T) {
 	bls := NewStreamer(dbcfgs, se, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
-	_, err := bls.parseEvents(context.Background(), events)
+	_, err := bls.parseEvents(context.Background(), events, errs)
 	if err != ErrServerEOF {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -420,6 +421,7 @@ func TestStreamerParseRBRNameEscapes(t *testing.T) {
 	}
 
 	events := make(chan mysql.BinlogEvent)
+	errs := make(chan error)
 
 	want := []fullBinlogTransaction{
 		{
@@ -508,7 +510,7 @@ func TestStreamerParseRBRNameEscapes(t *testing.T) {
 	bls := NewStreamer(dbcfgs, se, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
-	_, err := bls.parseEvents(context.Background(), events)
+	_, err := bls.parseEvents(context.Background(), events, errs)
 	if err != ErrServerEOF {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/go/vt/binlog/binlog_streamer_test.go
+++ b/go/vt/binlog/binlog_streamer_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -321,10 +320,7 @@ func TestStreamerParseEventsGTIDPurged(t *testing.T) {
 	}
 	dbcfgs := dbconfigs.New(mcp)
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		tmr := time.NewTimer(10 * time.Second)
 		defer tmr.Stop()
 		select {
@@ -341,8 +337,6 @@ func TestStreamerParseEventsGTIDPurged(t *testing.T) {
 	require.True(t, ok, "expected SQLError, got %T", err)
 	require.True(t, sqlErr.Num == mysql.ERMasterFatalReadingBinlog, "expected ERMasterFatalReadingBinlog (%d), got %d",
 		mysql.ERMasterFatalReadingBinlog, sqlErr.Num)
-
-	wg.Wait()
 }
 
 func TestStreamerParseEventsSendErrorXID(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -194,16 +194,16 @@ func (vs *vstreamer) replicate(ctx context.Context) error {
 	}
 	defer conn.Close()
 
-	events, err := conn.StartBinlogDumpFromPosition(vs.ctx, "", vs.pos)
+	events, errs, err := conn.StartBinlogDumpFromPosition(vs.ctx, "", vs.pos)
 	if err != nil {
 		return wrapError(err, vs.pos, vs.vse)
 	}
-	err = vs.parseEvents(vs.ctx, events)
+	err = vs.parseEvents(vs.ctx, events, errs)
 	return wrapError(err, vs.pos, vs.vse)
 }
 
 // parseEvents parses and sends events.
-func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.BinlogEvent) error {
+func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.BinlogEvent, errs <-chan error) error {
 	// bufferAndTransmit uses bufferedEvents and curSize to buffer events.
 	var (
 		bufferedEvents []*binlogdatapb.VEvent
@@ -388,6 +388,8 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 				// Increment this counter for testing.
 				vschemaUpdateCount.Add(1)
 			}
+		case err := <-errs:
+			return err
 		case <-ctx.Done():
 			return nil
 		case <-hbTimer.C:


### PR DESCRIPTION
## Description

This PR adds an errors channel to the binlog streamer so that we can propagate stream errors back to the caller/client. See [the bug report](https://github.com/vitessio/vitess/issues/12093) for additional details.

The key final snippet of the `show` output from the bug report's test case is now:
```
"State": "Error",
"Message": "vttablet: rpc error: code = Unknown desc = stream (at source tablet) error @ a61630ee-9379-11ed-b080-97c823585086:1-71: Cannot replicate because the master purged required binary logs. Replicate the missing transactions from elsewhere, or provision a new slave from backup. Consider increasing the master's binary log expiration period. The GTID set sent by the slave is 'a61630ee-9379-11ed-b080-97c823585086:1-71', and the missing transactions are 'a61630ee-9379-11ed-b080-97c823585086:72-83' (errno 1236) (sqlstate HY000)",
```

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/12093

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added
-   [x] Documentation is not required