### PR TITLE
schemadiff: find if a schema diff has ordering constraints

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -771,7 +771,7 @@ func TestDiffsHaveDependencies(t *testing.T) {
 			name:            "introduce column with view dependency",
 			from:            "create table t1(id int primary key)",
 			to:              "create table t1(id int primary key, t text default null); create view v1 as select t from t1",
-			dependencyFound: true,
+			dependencyFound: false, // at some point in the future, we will support per-column dependency detection, and this will change to 'true'
 		},
 	}
 	hints := &DiffHints{}

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -617,3 +617,23 @@ func (s *Schema) Apply(diffs []EntityDiff) (*Schema, error) {
 	}
 	return dup, nil
 }
+
+// DiffsHaveDependencies chceks whether there is an ordering importance to the given diffs, if these were to apply on this schema.
+// The function checks whether it is possible to apply any of the given diffs as the first change to this schema. If so, then there
+// is no ordering constraint. It's enough that a single diff cannot be applied, that the function determines there's an ordering constraint.
+// The function does not modify this schema.
+func (s *Schema) DiffsHaveDependencies(diffs []EntityDiff) (bool, error) {
+	for _, diff := range diffs {
+		_, err := s.Apply([]EntityDiff{diff})
+		if err == nil {
+			continue
+		}
+		switch err.(type) {
+		case *ViewDependencyUnresolvedError:
+			return true, nil
+		default:
+			return false, err
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
This checks if the order of diffs is required; a new function `DiffsHaveDependencies()` returns 'true' when there is _some_ ordering conflict between any two diffs

The question is of general interest, when we have a list of diffs of two schemas, and wish to apply them onto the original schema. The ordering constraint tells us whether we can just apply them in any random order, or concurrently, or whether we have to restrict ourselves to some strict order.
