### PR TITLE
Keep the correct case for the charset for canonical string

### DIFF
--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -1773,7 +1773,7 @@ func (node *ConvertExpr) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *ConvertUsingExpr) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "convert(%v using %s)", node.Expr, node.Type)
+	buf.astPrintf(node, "convert(%v using %#s)", node.Expr, node.Type)
 }
 
 // Format formats the node.

--- a/go/vt/sqlparser/tracked_buffer_test.go
+++ b/go/vt/sqlparser/tracked_buffer_test.go
@@ -224,6 +224,10 @@ func TestCanonicalOutput(t *testing.T) {
 			"create table t1 (id int primary key, name tinytext not null, fulltext key name_ft(name) with parser ngram)",
 			"CREATE TABLE `t1` (\n\t`id` int PRIMARY KEY,\n\t`name` tinytext NOT NULL,\n\tFULLTEXT KEY `name_ft` (`name`) WITH PARSER ngram\n)",
 		},
+		{
+			"select convert('abc' using utf8mb4)",
+			"SELECT CONVERT('abc' USING utf8mb4) FROM `dual`",
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
The canonical string representation needs to keep the correct case for the charset. Those are never upcased in MySQL so we should not enforce that here either.

## Related Issue(s)

Fixes #12104

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required