### PR TITLE
CI, tabletmanager throttler topo tests: polling until status received

### DIFF
--- a/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
@@ -271,10 +271,7 @@ func TestInitialThrottler(t *testing.T) {
 	defer cluster.PanicHandler(t)
 
 	t.Run("validating OK response from disabled throttler", func(t *testing.T) {
-		resp, err := throttleCheck(primaryTablet, false)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		waitForThrottleCheckStatus(t, primaryTablet, http.StatusOK)
 	})
 	t.Run("enabling throttler with low threshold", func(t *testing.T) {
 		_, err := updateThrottlerConfig(true, false, unreasonablyLowThreshold.Seconds(), "", false)
@@ -288,10 +285,7 @@ func TestInitialThrottler(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("validating OK response from disabled throttler, again", func(t *testing.T) {
-		resp, err := throttleCheck(primaryTablet, false)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		waitForThrottleCheckStatus(t, primaryTablet, http.StatusOK)
 	})
 	t.Run("enabling throttler, again", func(t *testing.T) {
 		_, err := updateThrottlerConfig(true, false, 0, "", true)
@@ -516,15 +510,8 @@ func TestRestoreDefaultQuery(t *testing.T) {
 		_, err := updateThrottlerConfig(true, false, throttlerThreshold.Seconds(), "", false)
 		assert.NoError(t, err)
 	})
-	t.Run("requesting heartbeats", func(t *testing.T) {
-		_ = warmUpHeartbeat(t)
-	})
 	t.Run("validating OK response from throttler with low threshold, heartbeats running", func(t *testing.T) {
-		time.Sleep(1 * time.Second)
-		resp, err := throttleCheck(primaryTablet, false)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		waitForThrottleCheckStatus(t, primaryTablet, http.StatusOK)
 	})
 	t.Run("validating pushback response from throttler on low threshold once heartbeats go stale", func(t *testing.T) {
 		time.Sleep(2 * onDemandHeartbeatDuration) // just... really wait long enough, make sure on-demand stops


### PR DESCRIPTION

## Description

An attempt to fix `tabletmanager_throttler_topo` flakiness, as seen [here](https://github.com/planetscale/vitess-private/actions/runs/3913922615/jobs/6690389759#logs). In a few places where we expect to find a status "OK", we now poll for the status until "OK" is received, or until some timeout (at which time the test fails).

The flakiness is only found in GitHub CI and never in my local tests, which suggests this is a timing issue. This fix hopefully works around it.


## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
