### PR TITLE
BugFix: Cast expression translation by evaluation engine

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -173,3 +173,15 @@ func TestIntervalWithMathFunctions(t *testing.T) {
 	mcmp.AssertMatches("select '2020-01-01' + interval month(DATE_SUB(FROM_UNIXTIME(1234), interval 1 month))-1 month", `[[CHAR("2020-12-01")]]`)
 	mcmp.AssertMatches("select DATE_ADD(MIN(FROM_UNIXTIME(1673444922)),interval -DAYOFWEEK(MIN(FROM_UNIXTIME(1673444922)))+1 DAY)", `[[DATETIME("2023-01-08 13:48:42")]]`)
 }
+
+// TestCast tests the queries that contain the cast function.
+func TestCast(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.AssertMatches("select cast('2023-01-07 12:34:56' as date) limit 1", `[[DATE("2023-01-07")]]`)
+	mcmp.AssertMatches("select cast('2023-01-07 12:34:56' as date)", `[[DATE("2023-01-07")]]`)
+	mcmp.AssertMatches("select cast('3.2' as float)", `[[FLOAT32(3.2)]]`)
+	mcmp.AssertMatches("select cast('3.2' as double)", `[[FLOAT64(3.2)]]`)
+	mcmp.AssertMatches("select cast('3.2' as unsigned)", `[[UINT64(3)]]`)
+}

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -493,6 +493,11 @@ func translateConvertExpr(expr sqlparser.Expr, convertType *sqlparser.ConvertTyp
 		if err != nil {
 			return nil, err
 		}
+	case "BINARY", "DOUBLE", "REAL", "SIGNED", "SIGNED INTEGER", "UNSIGNED", "UNSIGNED INTEGER":
+		// Supported types for conv expression
+	default:
+		// For unsupported types, we should return an error on translation instead of returning an error on runtime.
+		return nil, convert.returnUnsupportedError()
 	}
 
 	return &convert, nil


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the bug described in #12110. The issue is that the evalengine converts the expression into a eval engine expression whose evaluation isn't supported at runtime. What this means is that planning phase succeeds but the runtime throws an error.
This isn't correct since we have an alternate way of planning of not using the evaluation engine and send the query to a vttablet like we did before evalengine existed. 

This PR fixes this bug by failing the translation itself instead of creating an expression that can't be evaluated.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #12110 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
