### PR TITLE
Remove removed flags from being used for v16+ binaries

### DIFF
--- a/go/test/endtoend/cluster/vtctld_process.go
+++ b/go/test/endtoend/cluster/vtctld_process.go
@@ -58,8 +58,6 @@ func (vtctld *VtctldProcess) Setup(cell string, extraArgs ...string) (err error)
 		"--topo_global_server_address", vtctld.CommonArg.TopoGlobalAddress,
 		"--topo_global_root", vtctld.CommonArg.TopoGlobalRoot,
 		"--cell", cell,
-		"--workflow_manager_init",
-		"--workflow_manager_use_election",
 		"--service_map", vtctld.ServiceMap,
 		"--backup_storage_implementation", vtctld.BackupStorageImplementation,
 		"--file_backup_storage_root", vtctld.FileBackupStorageRoot,
@@ -67,6 +65,18 @@ func (vtctld *VtctldProcess) Setup(cell string, extraArgs ...string) (err error)
 		"--port", fmt.Sprintf("%d", vtctld.Port),
 		"--grpc_port", fmt.Sprintf("%d", vtctld.GrpcPort),
 	)
+	var majorVersion int
+	majorVersion, err = GetMajorVersion("vtctld")
+	if err != nil {
+		return err
+	}
+	// workflow_manager_init and workflow_manager_use_election are removed in v16 and shouldn't be set on any release v16+
+	if majorVersion <= 15 {
+		vtctld.proc.Args = append(vtctld.proc.Args,
+			"--workflow_manager_init",
+			"--workflow_manager_use_election")
+	}
+
 	if *isCoverage {
 		vtctld.proc.Args = append(vtctld.proc.Args, "--test.coverprofile="+getCoveragePath("vtctld.out"))
 	}

--- a/go/test/endtoend/cluster/vtctld_process.go
+++ b/go/test/endtoend/cluster/vtctld_process.go
@@ -65,17 +65,6 @@ func (vtctld *VtctldProcess) Setup(cell string, extraArgs ...string) (err error)
 		"--port", fmt.Sprintf("%d", vtctld.Port),
 		"--grpc_port", fmt.Sprintf("%d", vtctld.GrpcPort),
 	)
-	var majorVersion int
-	majorVersion, err = GetMajorVersion("vtctld")
-	if err != nil {
-		return err
-	}
-	// workflow_manager_init and workflow_manager_use_election are removed in v16 and shouldn't be set on any release v16+
-	if majorVersion <= 15 {
-		vtctld.proc.Args = append(vtctld.proc.Args,
-			"--workflow_manager_init",
-			"--workflow_manager_use_election")
-	}
 
 	if *isCoverage {
 		vtctld.proc.Args = append(vtctld.proc.Args, "--test.coverprofile="+getCoveragePath("vtctld.out"))

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -118,7 +118,15 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		vttablet.proc.Args = append(vttablet.proc.Args, "--restore_from_backup")
 	}
 	if vttablet.EnableSemiSync {
-		vttablet.proc.Args = append(vttablet.proc.Args, "--enable_semi_sync")
+		var majorVersion int
+		majorVersion, err = GetMajorVersion("vttablet")
+		if err != nil {
+			return err
+		}
+		// enable_semi_sync is removed in v16 and shouldn't be set on any release v16+
+		if majorVersion <= 15 {
+			vttablet.proc.Args = append(vttablet.proc.Args, "--enable_semi_sync")
+		}
 	}
 	if vttablet.DbFlavor != "" {
 		vttablet.proc.Args = append(vttablet.proc.Args, fmt.Sprintf("--db_flavor=%s", vttablet.DbFlavor))

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -387,9 +387,11 @@ func TestERSForInitialization(t *testing.T) {
 	shard.Vttablets = tablets
 	clusterInstance.VtTabletExtraArgs = []string{
 		"--lock_tables_timeout", "5s",
-		"--enable_semi_sync",
 		"--init_populate_metadata",
 		"--track_schema_versions=true",
+	}
+	if clusterInstance.VtTabletMajorVersion <= 15 {
+		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--enable_semi_sync")
 	}
 
 	// Initialize Cluster

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -82,7 +82,8 @@ func setupCluster(ctx context.Context, t *testing.T, shardName string, cells []s
 	clusterInstance := cluster.NewCluster(cells[0], Hostname)
 	keyspace := &cluster.Keyspace{Name: KeyspaceName}
 
-	if durability == "semi_sync" {
+	// enable_semi_sync is removed in v16 and shouldn't be set on any release v16+
+	if durability == "semi_sync" && clusterInstance.VtTabletMajorVersion <= 15 {
 		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--enable_semi_sync")
 	}
 


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR removes the flags removed from v16 to be set on binaries from that and later releases. This change is required because we run upgrade-downgrade tests which spawn binaries from the next release too. So the flags removed in #12083 and #12085 have to be put behind a condition check to see if the spawned binary is from a version higher than 15 or not.

This PR makes these changes to fix the upgrade-downgrade tests which are currently broken as seen in https://github.com/vitessio/vitess/actions/runs/3949422838/jobs/6763433594

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
