### PR TITLE
schemadiff: TableCharsetCollateStrategy hint

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -863,6 +863,12 @@ func (c *CreateTableEntity) diffOptions(alterTable *sqlparser.AlterTable,
 				// skip
 			case "AVG_ROW_LENGTH":
 				// skip. MyISAM only, not interesting
+			case "CHARSET":
+				switch hints.TableCharsetCollateStrategy {
+				case TableCharsetCollateStrict:
+					tableOption = &sqlparser.TableOption{String: ""}
+					// in all other strategies we ignore the charset
+				}
 			case "CHECKSUM":
 				tableOption = &sqlparser.TableOption{Value: sqlparser.NewIntLiteral("0")}
 			case "COLLATE":
@@ -930,6 +936,18 @@ func (c *CreateTableEntity) diffOptions(alterTable *sqlparser.AlterTable,
 				// options are different.
 				// However, we don't automatically apply these changes. It depends on the option!
 				switch strings.ToUpper(t1Option.Name) {
+				case "CHARSET", "COLLATE":
+					switch hints.TableCharsetCollateStrategy {
+					case TableCharsetCollateStrict:
+						alterTableOptions = append(alterTableOptions, t2Option)
+					case TableCharsetCollateIgnoreEmpty:
+						if t1Option.String != "" && t2Option.String != "" {
+							alterTableOptions = append(alterTableOptions, t2Option)
+						}
+						// if one is empty, we ignore
+					case TableCharsetCollateIgnoreAlways:
+						// ignore always
+					}
 				case "AUTO_INCREMENT":
 					switch hints.AutoIncrementStrategy {
 					case AutoIncrementApplyAlways:
@@ -961,6 +979,12 @@ func (c *CreateTableEntity) diffOptions(alterTable *sqlparser.AlterTable,
 	for _, t2Option := range t2Options {
 		if _, ok := t1OptionsMap[t2Option.Name]; !ok {
 			switch strings.ToUpper(t2Option.Name) {
+			case "CHARSET", "COLLATE":
+				switch hints.TableCharsetCollateStrategy {
+				case TableCharsetCollateStrict:
+					alterTableOptions = append(alterTableOptions, t2Option)
+					// in all other strategies we ignore the charset
+				}
 			case "AUTO_INCREMENT":
 				switch hints.AutoIncrementStrategy {
 				case AutoIncrementApplyAlways, AutoIncrementApplyHigher:

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -88,13 +88,20 @@ const (
 	FullTextKeyUnifyStatements
 )
 
+const (
+	TableCharsetCollateStrict int = iota
+	TableCharsetCollateIgnoreEmpty
+	TableCharsetCollateIgnoreAlways
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
-	StrictIndexOrdering     bool
-	AutoIncrementStrategy   int
-	RangeRotationStrategy   int
-	ConstraintNamesStrategy int
-	ColumnRenameStrategy    int
-	TableRenameStrategy     int
-	FullTextKeyStrategy     int
+	StrictIndexOrdering         bool
+	AutoIncrementStrategy       int
+	RangeRotationStrategy       int
+	ConstraintNamesStrategy     int
+	ColumnRenameStrategy        int
+	TableRenameStrategy         int
+	FullTextKeyStrategy         int
+	TableCharsetCollateStrategy int
 }


### PR DESCRIPTION

## Description

`schemadiff`: adding a new hint, named `TableCharsetCollateStrategy`, which controls how `schemadiff` treats diffs in a table's `CHARSET` and `COLLATE` option values:

- `TableCharsetCollateStrict` - default, if charsets or collations are different, that's a diff.
- `TableCharsetCollateIgnoreEmpty` - if one of the tables has no value for `CHARSET` or `COLLATE`, ignore the diff (works whether the source table or target table have empty values)
- `TableCharsetCollateIgnoreAlways` - never generate a table charset/collate diff


## Related Issue(s)

- https://github.com/vitessio/vitess/issues/10203

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
