### PR TITLE
DDL: do not Reload() for 'CREATE TEMPORARY' and 'DROP TEMPORARY' statements

### DIFF
--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -66,8 +66,17 @@ func (p *Plan) MarshalJSON() ([]byte, error) {
 }
 
 func TestPlan(t *testing.T) {
+	testPlan(t, "exec_cases.txt")
+}
+
+func TestDDLPlan(t *testing.T) {
+	testPlan(t, "ddl_cases.txt")
+}
+
+func testPlan(t *testing.T, fileName string) {
+	t.Helper()
 	testSchema := loadSchema("schema_test.json")
-	for tcase := range iterateExecFile("exec_cases.txt") {
+	for tcase := range iterateExecFile(fileName) {
 		t.Run(tcase.input, func(t *testing.T) {
 			if strings.Contains(tcase.options, "PassthroughDMLs") {
 				PassthroughDMLs = true

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/ddl_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/ddl_cases.txt
@@ -1,118 +1,302 @@
-"create table a(abcd)"
+"create table a(abcd bigint)"
 {
-  "Action": "create"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "create table a (\n\tabcd bigint\n)"
 }
 
 "drop  table b"
 {
-  "Action": "drop"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "b",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "drop table b"
 }
 
 "drop table b.c"
 {
-  "Action": "drop"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "c",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "drop table b.c"
 }
 
-"alter table c alter foo"
+"alter table c add column foo bigint"
 {
-  "Action": "alter"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "c",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table c add column foo bigint"
 }
 
 "alter table c comment 'aa'"
 {
-  "Action": "alter"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "c",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table c comment 'aa'"
 }
 
 "alter table b.c comment 'aa'"
 {
-  "Action": "alter"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "c",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table b.c comment 'aa'"
 }
 
 "drop index a on b"
 {
-  "Action": "alter"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "b",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table b drop key a"
 }
 
 "drop index a on b.c"
 {
-  "Action": "alter"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "c",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table b.c drop key a"
 }
 
 "drop index a on b lock=none"
 {
-  "Action": "alter"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "b",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table b drop key a, lock none"
 }
 
 "rename table a to b"
 {
-  "Action": "rename"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    },
+    {
+      "TableName": "b",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "rename table a to b"
 }
 
 "rename table c.a to c.b"
 {
-  "Action": "rename"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    },
+    {
+      "TableName": "b",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "rename table c.a to c.b"
 }
+
 
 "alter table a rename b"
 {
-  "Action": "rename"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    },
+    {
+      "TableName": "b",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table a rename b"
 }
 
 "alter table a rename to b"
 {
-  "Action": "rename"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    },
+    {
+      "TableName": "b",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table a rename b"
 }
+
 
 "alter table c.a rename to c.b"
 {
-  "Action": "rename"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    },
+    {
+      "TableName": "b",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table c.a rename c.b"
 }
 
-"create view a asdasd"
+"create view a as select * from asdasd"
 {
-  "Action": "create"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "create view a as select * from asdasd"
 }
 
+# syntax error
 "alter view c as foo"
-{
-  "Action": "alter"
-}
+"syntax error at position 20 near 'foo'"
 
 "drop  view b"
 {
-  "Action": "drop"
-}
-
-"select * from a"
-{
-  "Action": ""
-}
-
-"syntax error"
-{
-  "Action": ""
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "b",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "drop view b"
 }
 
 "alter table a reorganize partition b into (partition c values less than (1000), partition d values less than (maxvalue))"
 {
-  "Action": "alter"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table a reorganize partition b into (partition c values less than (1000), partition d values less than maxvalue)"
 }
 
 "alter table a partition by range (id) (partition p0 values less than (10), partition p1 values less than (maxvalue))"
 {
-  "Action": "alter"
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table a \npartition by range (id)\n(partition p0 values less than (10),\n partition p1 values less than maxvalue)"
 }
 
 # truncate
 "truncate a"
 {
   "PlanID": "DDL",
-  "TableName": "a"
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "truncate table a"
 }
 
 # truncate
 "truncate table a"
 {
   "PlanID": "DDL",
-  "TableName": "a"
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "truncate table a"
+}
+
+# create a temporary table
+"create temporary table a(id bigint primary key)"
+{
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "create temporary table a (\n\tid bigint primary key\n)",
+  "NeedsReservedConn": true
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/ddl_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/ddl_cases.txt
@@ -300,3 +300,17 @@
   "FullQuery": "create temporary table a (\n\tid bigint primary key\n)",
   "NeedsReservedConn": true
 }
+
+# temporary table with ddl statement only partially parsed
+"create temporary table x"
+{
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "x",
+      "Role": 2
+    }
+  ],
+  "NeedsReservedConn": true
+}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -658,9 +658,8 @@ func (qre *QueryExecutor) execDDL(conn *StatefulConnection) (*sqltypes.Result, e
 	}
 
 	isTemporaryTable := false
-	switch stmt := qre.plan.FullStmt.(type) {
-	case sqlparser.DDLStatement:
-		isTemporaryTable = stmt.IsTemporary()
+	if ddlStmt, ok := qre.plan.FullStmt.(sqlparser.DDLStatement); ok {
+		isTemporaryTable = ddlStmt.IsTemporary()
 	}
 	if !isTemporaryTable {
 		// Temporary tables are limited to the session creating them. There is no need to Reload()

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -657,20 +657,31 @@ func (qre *QueryExecutor) execDDL(conn *StatefulConnection) (*sqltypes.Result, e
 		}
 	}
 
-	defer func() {
-		// Call se.Reload() with includeStats=false as obtaining table
-		// size stats involves joining `information_schema.tables`,
-		// which can be very costly on systems with a large number of
-		// tables.
-		//
-		// Instead of synchronously recalculating table size stats
-		// after every DDL, let them be outdated until the periodic
-		// schema reload fixes it.
-		if err := qre.tsv.se.ReloadAtEx(qre.ctx, mysql.Position{}, false); err != nil {
-			log.Errorf("failed to reload schema %v", err)
-		}
-	}()
+	isTemporaryTable := false
+	switch stmt := qre.plan.FullStmt.(type) {
+	case *sqlparser.CreateTable:
+		isTemporaryTable = stmt.IsTemporary()
+	case *sqlparser.DropTable:
+		isTemporaryTable = stmt.IsTemporary()
+	}
 
+	if !isTemporaryTable {
+		// Temporary tables are limited to the session creating them. There is no need to Reload()
+		// the table because other connections will not be able to see the table anyway.
+		defer func() {
+			// Call se.Reload() with includeStats=false as obtaining table
+			// size stats involves joining `information_schema.tables`,
+			// which can be very costly on systems with a large number of
+			// tables.
+			//
+			// Instead of synchronously recalculating table size stats
+			// after every DDL, let them be outdated until the periodic
+			// schema reload fixes it.
+			if err := qre.tsv.se.ReloadAtEx(qre.ctx, mysql.Position{}, false); err != nil {
+				log.Errorf("failed to reload schema %v", err)
+			}
+		}()
+	}
 	sql := qre.query
 	// If FullQuery is not nil, then the DDL query was fully parsed
 	// and we should use the ast to generate the query instead.

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -659,12 +659,9 @@ func (qre *QueryExecutor) execDDL(conn *StatefulConnection) (*sqltypes.Result, e
 
 	isTemporaryTable := false
 	switch stmt := qre.plan.FullStmt.(type) {
-	case *sqlparser.CreateTable:
-		isTemporaryTable = stmt.IsTemporary()
-	case *sqlparser.DropTable:
+	case sqlparser.DDLStatement:
 		isTemporaryTable = stmt.IsTemporary()
 	}
-
 	if !isTemporaryTable {
 		// Temporary tables are limited to the session creating them. There is no need to Reload()
 		// the table because other connections will not be able to see the table anyway.

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1702,3 +1702,85 @@ func addQueryExecutorSupportedQueries(db *fakesqldb.DB) {
 		}},
 	})
 }
+
+func TestQueryExecSchemaReloadCount(t *testing.T) {
+	type dbResponse struct {
+		query  string
+		result *sqltypes.Result
+	}
+
+	dmlResult := &sqltypes.Result{
+		RowsAffected: 1,
+	}
+	fields := sqltypes.MakeTestFields("a|b", "int64|varchar")
+	selectResult := sqltypes.MakeTestResult(fields, "1|aaa")
+	emptyResult := &sqltypes.Result{}
+
+	// The queries are run both in and outside a transaction.
+	testcases := []struct {
+		// input is the input query.
+		input string
+		// dbResponses specifes the list of queries and responses to add to the fake db.
+		dbResponses       []dbResponse
+		schemaReloadCount int
+	}{{
+		input: "select * from t",
+		dbResponses: []dbResponse{{
+			query:  `select \* from t.*`,
+			result: selectResult,
+		}},
+	}, {
+		input: "insert into t values(1, 'aaa')",
+		dbResponses: []dbResponse{{
+			query:  "insert.*",
+			result: dmlResult,
+		}},
+	}, {
+		input: "create table t(a int, b varchar(64))",
+		dbResponses: []dbResponse{{
+			query:  "create.*",
+			result: emptyResult,
+		}},
+		schemaReloadCount: 1,
+	}, {
+		input: "drop table t",
+		dbResponses: []dbResponse{{
+			query:  "drop.*",
+			result: dmlResult,
+		}},
+		schemaReloadCount: 1,
+	}, {
+		input: "create table t(a int, b varchar(64))",
+		dbResponses: []dbResponse{{
+			query:  "create.*",
+			result: emptyResult,
+		}},
+		schemaReloadCount: 1,
+	}, {
+		input: "drop table t",
+		dbResponses: []dbResponse{{
+			query:  "drop.*",
+			result: dmlResult,
+		}},
+		schemaReloadCount: 1,
+	}}
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	tsv := newTestTabletServer(context.Background(), noFlags, db)
+	tsv.config.DB.DBName = "ks"
+	defer tsv.StopService()
+	for _, tcase := range testcases {
+		t.Run(tcase.input, func(t *testing.T) {
+			// reset the schema reload metric before running the test.
+			tsv.se.SchemaReloadTimings.Reset()
+			for _, dbr := range tcase.dbResponses {
+				db.AddQueryPattern(dbr.query, dbr.result)
+			}
+
+			qre := newTestQueryExecutor(context.Background(), tsv, tcase.input, 0)
+			_, err := qre.Execute()
+			require.NoError(t, err)
+			assert.EqualValues(t, tcase.schemaReloadCount, qre.tsv.se.SchemaReloadTimings.Counts()["TabletServerTest.SchemaReload"], "got: %v", qre.tsv.se.SchemaReloadTimings.Counts())
+		})
+	}
+}

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,9 +28,8 @@ import (
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/schema"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
-
-	"context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/mysql"
@@ -82,6 +82,7 @@ type Engine struct {
 	tableFileSizeGauge      *stats.GaugesWithSingleLabel
 	tableAllocatedSizeGauge *stats.GaugesWithSingleLabel
 	innoDbReadRowsCounter   *stats.Counter
+	SchemaReloadTimings     *servenv.TimingsWrapper
 }
 
 // NewEngine creates a new Engine.
@@ -102,6 +103,7 @@ func NewEngine(env tabletenv.Env) *Engine {
 	se.tableFileSizeGauge = env.Exporter().NewGaugesWithSingleLabel("TableFileSize", "tracks table file size", "Table")
 	se.tableAllocatedSizeGauge = env.Exporter().NewGaugesWithSingleLabel("TableAllocatedSize", "tracks table allocated size", "Table")
 	se.innoDbReadRowsCounter = env.Exporter().NewCounter("InnodbRowsRead", "number of rows read by mysql")
+	se.SchemaReloadTimings = env.Exporter().NewTimings("SchemaReload", "time taken to reload the schema", "type")
 
 	env.Exporter().HandleFunc("/debug/schema", se.handleDebugSchema)
 	env.Exporter().HandleFunc("/schemaz", func(w http.ResponseWriter, r *http.Request) {
@@ -325,8 +327,10 @@ func (se *Engine) ReloadAtEx(ctx context.Context, pos mysql.Position, includeSta
 
 // reload reloads the schema. It can also be used to initialize it.
 func (se *Engine) reload(ctx context.Context, includeStats bool) error {
+	start := time.Now()
 	defer func() {
 		se.env.LogError()
+		se.SchemaReloadTimings.Record("SchemaReload", start)
 	}()
 
 	conn, err := se.conns.Get(ctx, nil)


### PR DESCRIPTION
## Description

In `query_executor.go`, in `execDDL()`, we differentiate two cases:

1. The query is an Online DDL
2. The query is not Online DDL

In the latter case, we always invoke `Reload()` (specifically `ReloadAtEx()`) to reload table schema. 
However, for `CREATE TEMPORARY TABLE` and `DROP TEMPORARY TABLE` this is wasteful:

- Only the connections which created or dropped the table is at all aware of the existence of the table
- `Reload()` adds an overhead which becomes significant if temporary tables are created and dropped intensively.

With this PR we skip `Reload()` for temporary tables.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
