### PR TITLE
Support BETWEEN in the evalengine

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -185,3 +185,19 @@ func TestCast(t *testing.T) {
 	mcmp.AssertMatches("select cast('3.2' as double)", `[[FLOAT64(3.2)]]`)
 	mcmp.AssertMatches("select cast('3.2' as unsigned)", `[[UINT64(3)]]`)
 }
+
+// TestCast tests the queries that contain the cast function.
+func TestOuterJoinWithPredicate(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	// This test uses a predicate on the outer side.
+	// These can't be pushed down to MySQL and have
+	// to be evaluated on the vtgate, so we are checking
+	// that evalengine handles the predicate correctly
+
+	mcmp.Exec("insert into t1(id1, id2) values (0,0), (1,10), (2,20), (3,30), (4,40)")
+
+	mcmp.AssertMatches("select A.id1, B.id2 from t1 as A left join t1 as B on A.id1*10 = B.id2 WHERE B.id2 BETWEEN 20 AND 30",
+		`[[INT64(2) INT64(20)] [INT64(3) INT64(30)]]`)
+}

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -186,7 +186,6 @@ func TestCast(t *testing.T) {
 	mcmp.AssertMatches("select cast('3.2' as unsigned)", `[[UINT64(3)]]`)
 }
 
-// TestCast tests the queries that contain the cast function.
 func TestOuterJoinWithPredicate(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()
@@ -198,8 +197,8 @@ func TestOuterJoinWithPredicate(t *testing.T) {
 
 	mcmp.Exec("insert into t1(id1, id2) values (0,0), (1,10), (2,20), (3,30), (4,40)")
 
-	mcmp.AssertMatches("select A.id1, B.id2 from t1 as A left join t1 as B on A.id1*10 = B.id2 WHERE B.id2 BETWEEN 20 AND 30",
+	mcmp.AssertMatchesNoOrder("select A.id1, B.id2 from t1 as A left join t1 as B on A.id1*10 = B.id2 WHERE B.id2 BETWEEN 20 AND 30",
 		`[[INT64(2) INT64(20)] [INT64(3) INT64(30)]]`)
-	mcmp.AssertMatches("select A.id1, B.id2 from t1 as A left join t1 as B on A.id1*10 = B.id2 WHERE B.id2 NOT BETWEEN 20 AND 30",
+	mcmp.AssertMatchesNoOrder("select A.id1, B.id2 from t1 as A left join t1 as B on A.id1*10 = B.id2 WHERE B.id2 NOT BETWEEN 20 AND 30",
 		`[[INT64(0) INT64(0)] [INT64(1) INT64(10)] [INT64(4) INT64(40)]]`)
 }

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -200,4 +200,6 @@ func TestOuterJoinWithPredicate(t *testing.T) {
 
 	mcmp.AssertMatches("select A.id1, B.id2 from t1 as A left join t1 as B on A.id1*10 = B.id2 WHERE B.id2 BETWEEN 20 AND 30",
 		`[[INT64(2) INT64(20)] [INT64(3) INT64(30)]]`)
+	mcmp.AssertMatches("select A.id1, B.id2 from t1 as A left join t1 as B on A.id1*10 = B.id2 WHERE B.id2 NOT BETWEEN 20 AND 30",
+		`[[INT64(0) INT64(0)] [INT64(1) INT64(10)] [INT64(4) INT64(40)]]`)
 }

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -584,9 +584,10 @@ func translateBetweenExpr(node *sqlparser.BetweenExpr, lookup TranslationLookup)
 	}
 
 	if !node.IsBetween {
-		// x NOT BETWEEN a AND b  => x < a AND x > b
+		// x NOT BETWEEN a AND b  => x < a OR x > b
 		from.Operator = sqlparser.LessThanOp
 		to.Operator = sqlparser.GreaterThanOp
+		return translateExpr(&sqlparser.OrExpr{Left: from, Right: to}, lookup)
 	}
 
 	return translateExpr(sqlparser.AndExpressions(from, to), lookup)

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -571,7 +571,7 @@ func translateCaseExpr(node *sqlparser.CaseExpr, lookup TranslationLookup) (Expr
 }
 
 func translateBetweenExpr(node *sqlparser.BetweenExpr, lookup TranslationLookup) (Expr, error) {
-	// x BETWEEN a AND b => x >= a AND c <= b
+	// x BETWEEN a AND b => x >= a AND x <= b
 	from := &sqlparser.ComparisonExpr{
 		Operator: sqlparser.GreaterEqualOp,
 		Left:     node.Left,
@@ -582,6 +582,13 @@ func translateBetweenExpr(node *sqlparser.BetweenExpr, lookup TranslationLookup)
 		Left:     node.Left,
 		Right:    node.To,
 	}
+
+	if !node.IsBetween {
+		// x NOT BETWEEN a AND b  => x < a AND x > b
+		from.Operator = sqlparser.LessThanOp
+		to.Operator = sqlparser.GreaterThanOp
+	}
+
 	return translateExpr(sqlparser.AndExpressions(from, to), lookup)
 }
 

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -104,6 +104,9 @@ func TestTranslateSimplification(t *testing.T) {
 		{"ifnull(null, 23)", ok(`CASE WHEN NULL IS NULL THEN INT64(23) ELSE NULL`), ok(`INT64(23)`)},
 		{"nullif(1, 1)", ok(`CASE WHEN INT64(1) = INT64(1) THEN NULL ELSE INT64(1)`), ok(`NULL`)},
 		{"nullif(1, 2)", ok(`CASE WHEN INT64(1) = INT64(2) THEN NULL ELSE INT64(1)`), ok(`INT64(1)`)},
+		{"12 between 5 and 20", ok("(INT64(12) >= INT64(5)) AND (INT64(12) <= INT64(20))"), ok(`INT64(1)`)},
+		{"12 not between 5 and 20", ok("(INT64(12) < INT64(5)) OR (INT64(12) > INT64(20))"), ok(`INT64(0)`)},
+		{"2 not between 5 and 20", ok("(INT64(2) < INT64(5)) OR (INT64(2) > INT64(20))"), ok(`INT64(1)`)},
 	}
 
 	for _, tc := range testCases {

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -6284,5 +6284,64 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "left join where clauses #3 - assert that we can evaluate BETWEEN with the evalengine",
+    "query": "select user.id from user left join user_extra on user.col = user_extra.col where user_extra.col between 10 and 20",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select user.id from user left join user_extra on user.col = user_extra.col where user_extra.col between 10 and 20",
+      "Instructions": {
+        "OperatorType": "SimpleProjection",
+        "Columns": [
+          1
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Filter",
+            "Predicate": "user_extra.col between 10 and 20",
+            "Inputs": [
+              {
+                "OperatorType": "Join",
+                "Variant": "LeftJoin",
+                "JoinColumnIndexes": "R:0,L:1",
+                "JoinVars": {
+                  "user_col": 0
+                },
+                "TableName": "`user`_user_extra",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select `user`.col, `user`.id from `user` where 1 != 1",
+                    "Query": "select `user`.col, `user`.id from `user`",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
+                    "Query": "select user_extra.col from user_extra where user_extra.col = :user_col",
+                    "Table": "user_extra"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description
Adds support for `BETWEEN` in the eval engine, by translating them to `=>` and `=<` comparisons, or the equivalent for `NOT BETWEEN.

## Related Issue(s)
Solves part of https://github.com/vitessio/vitess/issues/9647

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
