### PR TITLE
[vtadmin] deprecated vtexplain

### DIFF
--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -282,6 +282,8 @@ is now fixed. The full issue can be found [here](https://github.com/vitessio/vit
 
 - The dead legacy Workflow Manager related code was removed in [#12085](https://github.com/vitessio/vitess/pull/12085). This included the following `vtctl` client commands: `WorkflowAction`, `WorkflowCreate`, `WorkflowWait`, `WorkflowStart`, `WorkflowStop`, `WorkflowTree`, `WorkflowDelete`.
 
+- VTAdmin's `VTExplain` endpoint has been deprecated. Users can use the new `vexplain` query format instead. The endpoint will be deleted in a future release.
+
 
 ### MySQL Compatibility
 

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -1913,6 +1913,9 @@ func (api *API) ValidateVersionShard(ctx context.Context, req *vtadminpb.Validat
 
 // VTExplain is part of the vtadminpb.VTAdminServer interface.
 func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) (*vtadminpb.VTExplainResponse, error) {
+	// TODO (andrew): https://github.com/vitessio/vitess/issues/12161.
+	log.Warningf("VTAdminServer.VTExplain is deprecated; please use a vexplain query instead. For more details, see https://vitess.io/docs/user-guides/sql/vexplain/.")
+
 	span, ctx := trace.NewSpan(ctx, "API.VTExplain")
 	defer span.Finish()
 


### PR DESCRIPTION
## Description

Title says it all (mostly). With the introduction of [`vexplain`], we're phasing out use of the simulated vtexplain code, which can sometimes, and I quote, "make stuff up".

[`vexplain`]: https://github.com/vitessio/vitess/pull/11892

Since vtadmin is GA, we're going with the two-step deprecate (this PR) and delete (for which I have filed #12161)

## Related Issue(s)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
