### PR TITLE
OnlineDDL: avoid schema_migrations AUTO_INCREMENT gaps by pre-checking for existing migration

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -237,6 +237,9 @@ func TestSchemaChange(t *testing.T) {
 	t.Run("singleton", testSingleton)
 	t.Run("declarative", testDeclarative)
 	t.Run("foreign-keys", testForeignKeys)
+	t.Run("summary: validate sequential migration IDs", func(t *testing.T) {
+		onlineddl.ValidateSequentialMigrationIDs(t, &vtParams, shards)
+	})
 }
 
 func testScheduler(t *testing.T) {
@@ -1958,10 +1961,6 @@ func testForeignKeys(t *testing.T) {
 			})
 		})
 	}
-}
-
-func TestSequentialMigrationIds(t *testing.T) {
-	onlineddl.ValidateSequentialMigrationIDs(t, &vtParams, shards)
 }
 
 // testOnlineDDLStatement runs an online DDL, ALTER statement

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -1226,6 +1226,10 @@ func TestForeignKeys(t *testing.T) {
 	}
 }
 
+func TestSequentialMigrationIds(t *testing.T) {
+	onlineddl.ValidateSequentialMigrationIDs(t, &vtParams, shards)
+}
+
 // testOnlineDDLStatement runs an online DDL, ALTER statement
 func testOnlineDDLStatement(t *testing.T, params *testOnlineDDLStatementParams) (uuid string) {
 	strategySetting, err := schema.ParseDDLStrategy(params.ddlStrategy)

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -755,6 +755,9 @@ func TestSchemaChange(t *testing.T) {
 			}
 		})
 	})
+	t.Run("summary: validate sequential migration IDs", func(t *testing.T) {
+		onlineddl.ValidateSequentialMigrationIDs(t, &vtParams, shards)
+	})
 }
 
 func insertRow(t *testing.T) {

--- a/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
@@ -310,6 +310,10 @@ func TestSchemaChange(t *testing.T) {
 			})
 		})
 	}
+
+	t.Run("summary: validate sequential migration IDs", func(t *testing.T) {
+		onlineddl.ValidateSequentialMigrationIDs(t, &vtParams, shards)
+	})
 }
 
 func testWithInitialSchema(t *testing.T) {


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/12168
This PR prevents excessive gaps in `_vt.schema_migrations` `id` values with a small refactor:

- Instead of relying on `INSERT IGNORE`, we first `SELECT` for existing migration UUID, and only if it does not exist, we `INSERT`.
- Because this is now a two-step logic, we add a mutex around the function (the mutex is only used by `SubmitMigration` function and does not otherwise conflict with the rest of the scheduler's work)
- The logic that used to _follow_ the `INSERT IGNORE`, which addresses the case where the UUID pre-existed, is now moved to run _before_ `INSERT IGNORE`

Tests are unchanged. We expect no change in behavior.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/12168

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
