### PR TITLE
handle system databases other that information_schema correctly

### DIFF
--- a/go/test/endtoend/vtgate/gen4/system_schema_test.go
+++ b/go/test/endtoend/vtgate/gen4/system_schema_test.go
@@ -214,3 +214,15 @@ func TestMultipleSchemaPredicates(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "specifying two different database in the query is not supported")
 }
+
+func TestQuerySystemTables(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	utils.Exec(t, conn, `select * from sys.sys_config`)
+	utils.Exec(t, conn, "select * from mysql.`db`")
+	utils.Exec(t, conn, "select * from performance_schema.error_log")
+}

--- a/go/vt/vtgate/planbuilder/testdata/systemtables_cases80.json
+++ b/go/vt/vtgate/planbuilder/testdata/systemtables_cases80.json
@@ -1602,5 +1602,62 @@
         "Table": "INFORMATION_SCHEMA.`TABLES`"
       }
     }
+  },
+  {
+    "comment": "select variable, value from sys.sys_config",
+    "query": "select variable, value from sys.sys_config",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select variable, value from sys.sys_config",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select variable, value from sys.sys_config where 1 != 1",
+        "Query": "select variable, value from sys.sys_config",
+        "Table": "sys.sys_config"
+      }
+    }
+  },
+  {
+    "comment": "select host, db from mysql.`db`",
+    "query": "select host, db from mysql.`db`",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select host, db from mysql.`db`",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select host, db from mysql.db where 1 != 1",
+        "Query": "select host, db from mysql.db",
+        "Table": "mysql.db"
+      }
+    }
+  },
+  {
+    "comment": "select logged, prio from performance_schema.error_log",
+    "query": "select logged, prio from performance_schema.error_log",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select logged, prio from performance_schema.error_log",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select logged, prio from performance_schema.error_log where 1 != 1",
+        "Query": "select logged, prio from performance_schema.error_log",
+        "Table": "performance_schema.error_log"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -87,7 +87,8 @@ func (tc *tableCollector) up(cursor *sqlparser.Cursor) error {
 		isInfSchema := sqlparser.SystemSchema(t.Qualifier.String())
 		var err error
 		tbl, vindex, _, _, _, err = tc.si.FindTableOrVindex(t)
-		if err != nil {
+		if err != nil && !isInfSchema {
+			// if we are dealing with a system table, it might not be available in the vschema, but that is OK
 			return err
 		}
 		if tbl == nil && vindex != nil {


### PR DESCRIPTION
## Description
In recent changes, we have added schema information about the `information_schema` database to the vschema. This means that we started asking the vschema about schema information even about system tables.

Since `sys`, `performance_schema` and `mysql` were not added to the vschema, vtgate started to fail planning queries against these databases complaining about the database not existing.

```sql
> SELECT variable, value, set_time, set_by FROM sys.sys_config;

ERROR 1105 (HY000): Unknown database 'sys' in vschema
```

## Related Issue(s)
The bug was introduced in https://github.com/vitessio/vitess/pull/11941
Fixes: https://github.com/vitessio/vitess/issues/12176

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
