### PR TITLE
VTGate: Ensure HealthCheck Cache Secondary Maps Stay in Sync With Authoritative Map on Tablet Delete

### DIFF
--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -684,7 +684,7 @@ func TestRemoveTablet(t *testing.T) {
 	// there will be a first result, get and discard it
 	<-resultChan
 
-	shr := &querypb.StreamHealthResponse{
+	shrReplica := &querypb.StreamHealthResponse{
 		TabletAlias:                         tablet.Alias,
 		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
 		Serving:                             true,
@@ -698,7 +698,7 @@ func TestRemoveTablet(t *testing.T) {
 		Stats:                &querypb.RealtimeStats{ReplicationLagSeconds: 1, CpuUsage: 0.2},
 		PrimaryTermStartTime: 0,
 	}}
-	input <- shr
+	input <- shrReplica
 	<-resultChan
 	// check it's there
 	a := hc.GetHealthyTabletStats(&querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA})
@@ -707,6 +707,59 @@ func TestRemoveTablet(t *testing.T) {
 	// delete the tablet
 	hc.RemoveTablet(tablet)
 	a = hc.GetHealthyTabletStats(&querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA})
+	assert.Empty(t, a, "wrong result, expected empty list")
+
+	// Now confirm that when a tablet's type changes between when it's added to the cache
+	// and when it's removed, that the tablet is entirely removed from the cache since
+	// in the secondary maps it's keyed in part by tablet type.
+	// Note: we are using GetTabletStats here to check the healthData map (rather than
+	// the healthy map that we checked above) because that is the data structure that
+	// is used when printing the contents of the healthcheck cache in the /debug/status
+	// endpoint and in the SHOW VITESS_TABLETS; SQL command output.
+
+	// Add the tablet back.
+	hc.AddTablet(tablet)
+	// Receive and discard the initial result.
+	<-resultChan
+	input <- shrReplica
+	// Confirm it's there in the cache.
+	a = hc.GetTabletStats(&querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA})
+	mustMatch(t, want, a, "unexpected result")
+	// Change the tablet type to RDONLY.
+	tablet.Type = topodatapb.TabletType_RDONLY
+	shrRdonly := &querypb.StreamHealthResponse{
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_RDONLY},
+		Serving:                             true,
+		TabletExternallyReparentedTimestamp: 0,
+		RealtimeStats:                       &querypb.RealtimeStats{ReplicationLagSeconds: 2, CpuUsage: 0.4},
+	}
+	// Now replace it, which does a Remove and Add. The tablet should
+	// be removed from the cache and all its maps even though the
+	// tablet type had changed in-between the initial Add and Remove.
+	hc.ReplaceTablet(tablet, tablet)
+	// Confirm that the old entry is gone.
+	a = hc.GetTabletStats(&querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA})
+	assert.Empty(t, a, "wrong result, expected empty list")
+	// Receive and discard the initial result.
+	<-resultChan
+	input <- shrRdonly
+	// Confirm that the new entry is there in the cache.
+	want = []*TabletHealth{{
+		Tablet:               tablet,
+		Target:               &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_RDONLY},
+		Serving:              true,
+		Stats:                &querypb.RealtimeStats{ReplicationLagSeconds: 2, CpuUsage: 0.4},
+		PrimaryTermStartTime: 0,
+	}}
+	a = hc.GetTabletStats(&querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_RDONLY})
+	mustMatch(t, want, a, "unexpected result")
+	// Delete the tablet, confirm again that it's gone in both
+	// tablet type forms.
+	hc.RemoveTablet(tablet)
+	a = hc.GetTabletStats(&querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA})
+	assert.Empty(t, a, "wrong result, expected empty list")
+	a = hc.GetTabletStats(&querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_RDONLY})
 	assert.Empty(t, a, "wrong result, expected empty list")
 }
 


### PR DESCRIPTION
## Description

The VTGate HealthCheck cache has an [authoritative map of tablets](https://github.com/vitessio/vitess/blob/release-15.0/go/vt/discovery/healthcheck.go#L267-L268) — keyed by tabletAlias — that it uses for query serving. It has a [secondary map](https://github.com/vitessio/vitess/blob/release-15.0/go/vt/discovery/healthcheck.go#L269-L272) — keyed by `<keyspace>.<shard>.<tabletType>` which has a sorted list of tablets that is used when printing the contents of the cache for the vtgate `/debug/status` endpoint and for the `show vitess_tablets` SQL statement without blocking query serving (lock free in the hot path).

The healthcheck cache implementation in the `discovery` package is responsible for keeping those two maps in sync as tablets are added and removed. There was one case, however, where it was failing to do so. That was in deleteTablet: https://github.com/vitessio/vitess/blob/release-15.0/go/vt/discovery/healthcheck.go#L432-L455

1. We incorrectly assumed that if the tablet was NOT in the authoritative map it was not in the secondary maps and did not attempt to delete it from those in order to ensure that they stay in sync.
2. The secondary maps are keyed in part by the tabletType, which can change in-between cache updates, so when deleting a tablet from the cache (by alias) we should be sure that the tablet is deleted from the secondary maps in any form it could take. 

This PR addresses both of these points.

> **Note** [several people have reported this recently, all of which I believe were using k8s](https://vitess.slack.com/archives/C0PQY0PTK/p1671735878009459). So I suspect that part of what triggered it was tablets being restarted/rescheduled and [coming up with a different `host:port` value which triggers a ReplaceTablet codepath](https://github.com/vitessio/vitess/blob/release-15.0/go/vt/discovery/topology_watcher.go#L219-L230) which does a Delete and Add. This would also have to coincide with the tablet type changing concurrently as well — e.g. from `REPLICA` to `PRIMARY` or `DRAINED` to `BACKUP`.

The new unit test case added in `TestRemoveTablet` demonstrates the issue as the test fails currently on `main` here:
```
--- FAIL: TestRemoveTablet (0.00s)
    /Users/matt/git/vitess/go/vt/discovery/healthcheck_test.go:743: 
        	Error Trace:	/Users/matt/git/vitess/go/vt/discovery/healthcheck_test.go:743
        	Error:      	Should be empty, but was [0x140000b07d0]
        	Test:       	TestRemoveTablet
        	Messages:   	wrong result, expected empty list
```

Which is this point in the test:
```
	// Now replace it, which does a Remove and Add. The tablet should
	// be removed from the cache and all its maps even though the
	// tablet type had changed in-between the initial Add and Remove.
	hc.ReplaceTablet(tablet, tablet)
	// Confirm that the old entry is gone.
	a = hc.GetTabletStats(&querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA})
	assert.Empty(t, a, "wrong result, expected empty list")
```

## Related Issue(s)

  - Related to: https://github.com/vitessio/vitess/pull/9237
  - Fixes: https://github.com/vitessio/vitess/issues/12011

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added
-   [x] Documentation was added or is not required