### PR TITLE
*WIP* schemadiff: `Diff()` of schemas ordered by valid dependencies

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -479,21 +479,21 @@ func TestDiffSchemas(t *testing.T) {
 			tableRename: TableRenameHeuristicStatement,
 		},
 		{
-			name: "identical tables: drop and create",
+			name: "drop and create all",
 			from: "create table t1a(id int primary key); create table t2a(id int unsigned primary key); create table t3a(id smallint primary key); ",
 			to:   "create table t1b(id bigint primary key); create table t2b(id int unsigned primary key); create table t3b(id int primary key); ",
 			diffs: []string{
-				"drop table t1a",
-				"drop table t2a",
 				"drop table t3a",
+				"drop table t2a",
+				"drop table t1a",
 				"create table t1b (\n\tid bigint,\n\tprimary key (id)\n)",
 				"create table t2b (\n\tid int unsigned,\n\tprimary key (id)\n)",
 				"create table t3b (\n\tid int,\n\tprimary key (id)\n)",
 			},
 			cdiffs: []string{
-				"DROP TABLE `t1a`",
-				"DROP TABLE `t2a`",
 				"DROP TABLE `t3a`",
+				"DROP TABLE `t2a`",
+				"DROP TABLE `t1a`",
 				"CREATE TABLE `t1b` (\n\t`id` bigint,\n\tPRIMARY KEY (`id`)\n)",
 				"CREATE TABLE `t2b` (\n\t`id` int unsigned,\n\tPRIMARY KEY (`id`)\n)",
 				"CREATE TABLE `t3b` (\n\t`id` int,\n\tPRIMARY KEY (`id`)\n)",
@@ -506,16 +506,45 @@ func TestDiffSchemas(t *testing.T) {
 			diffs: []string{
 				"drop table t3a",
 				"create table t1b (\n\tid bigint,\n\tprimary key (id)\n)",
-				"rename table t1a to t3b",
 				"rename table t2a to t2b",
+				"rename table t1a to t3b",
 			},
 			cdiffs: []string{
 				"DROP TABLE `t3a`",
 				"CREATE TABLE `t1b` (\n\t`id` bigint,\n\tPRIMARY KEY (`id`)\n)",
-				"RENAME TABLE `t1a` TO `t3b`",
 				"RENAME TABLE `t2a` TO `t2b`",
+				"RENAME TABLE `t1a` TO `t3b`",
 			},
 			tableRename: TableRenameHeuristicStatement,
+		},
+		// Foreign keys
+		{
+			name: "create tables with foreign keys, expect specific order",
+			to:   "create table t7(id int primary key); create table t5 (id int primary key, i int, constraint f5 foreign key (i) references t7(id)); create table t4 (id int primary key, i int, constraint f4 foreign key (i) references t7(id));",
+			diffs: []string{
+				"create table t7 (\n\tid int,\n\tprimary key (id)\n)",
+				"create table t4 (\n\tid int,\n\ti int,\n\tprimary key (id),\n\tkey f4 (i),\n\tconstraint f4 foreign key (i) references t7 (id)\n)",
+				"create table t5 (\n\tid int,\n\ti int,\n\tprimary key (id),\n\tkey f5 (i),\n\tconstraint f5 foreign key (i) references t7 (id)\n)",
+			},
+			cdiffs: []string{
+				"CREATE TABLE `t7` (\n\t`id` int,\n\tPRIMARY KEY (`id`)\n)",
+				"CREATE TABLE `t4` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f4` (`i`),\n\tCONSTRAINT `f4` FOREIGN KEY (`i`) REFERENCES `t7` (`id`)\n)",
+				"CREATE TABLE `t5` (\n\t`id` int,\n\t`i` int,\n\tPRIMARY KEY (`id`),\n\tKEY `f5` (`i`),\n\tCONSTRAINT `f5` FOREIGN KEY (`i`) REFERENCES `t7` (`id`)\n)",
+			},
+		},
+		{
+			name: "drop tables with foreign keys, expect specific order",
+			from: "create table t7(id int primary key); create table t5 (id int primary key, i int, constraint f5 foreign key (i) references t7(id)); create table t4 (id int primary key, i int, constraint f4 foreign key (i) references t7(id));",
+			diffs: []string{
+				"drop table t5",
+				"drop table t4",
+				"drop table t7",
+			},
+			cdiffs: []string{
+				"DROP TABLE `t5`",
+				"DROP TABLE `t4`",
+				"DROP TABLE `t7`",
+			},
 		},
 		// Views
 		{
@@ -599,16 +628,16 @@ func TestDiffSchemas(t *testing.T) {
 			from: "create view v1 as select * from t1; create table t1(id int primary key); create table t2(id int primary key); create view v2 as select * from t2; create table t3(id int primary key);",
 			to:   "create view v0 as select * from v2, t2; create table t4(id int primary key); create view v2 as select id from t2; create table t2(id bigint primary key); create table t3(id int primary key)",
 			diffs: []string{
-				"drop table t1",
 				"drop view v1",
+				"drop table t1",
 				"alter table t2 modify column id bigint",
 				"alter view v2 as select id from t2",
 				"create table t4 (\n\tid int,\n\tprimary key (id)\n)",
 				"create view v0 as select * from v2, t2",
 			},
 			cdiffs: []string{
-				"DROP TABLE `t1`",
 				"DROP VIEW `v1`",
+				"DROP TABLE `t1`",
 				"ALTER TABLE `t2` MODIFY COLUMN `id` bigint",
 				"ALTER VIEW `v2` AS SELECT `id` FROM `t2`",
 				"CREATE TABLE `t4` (\n\t`id` int,\n\tPRIMARY KEY (`id`)\n)",
@@ -656,11 +685,11 @@ func TestDiffSchemas(t *testing.T) {
 				{
 					// Validate "apply()" on "from" converges with "to"
 					schema1, err := NewSchemaFromSQL(ts.from)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					schema1SQL := schema1.ToSQL()
 
 					schema2, err := NewSchemaFromSQL(ts.to)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					applied, err := schema1.Apply(diffs)
 					require.NoError(t, err)
 

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -438,7 +438,11 @@ func (s *Schema) Diff(other *Schema, hints *DiffHints) (diffs []EntityDiff, err 
 	for _, e := range s.Entities() {
 		if _, ok := other.named[e.Name()]; !ok {
 			// other schema does not have the entity
-			dropDiffs = append(dropDiffs, e.Drop())
+			// Entities are sorted in foreign key CREATE TABLE valid order (create parents first ,then children).
+			// When issuing DROPs, we want to reverse that order. We want to first frop children, then parents.
+			// Instead of analyzing all relationships again, we just reverse the entire order of DROPs, foreign key
+			// related or not.
+			dropDiffs = append([]EntityDiff{e.Drop()}, dropDiffs...)
 		}
 	}
 	// We iterate by order of "other" schema because we need to construct queries that will be valid


### PR DESCRIPTION
## Description

A `schemadiff`'s `Schema` is normalized to have tables in foreign key dependency order (parents come first, children later), as well as in view dependency order (tables first, then views that only rely on tables, then 2nd level views etc.). This makes it possible to create, or apply, the schema by iterating its entities in order.

With this PR, we also sort the `Diff()` of two schemas, such that the diff can be applied in-order to a schema and without error. At this time, the diff is sorted like so:

- `CREATE TABLE` follow the same ordering for schema creation, ie. foreign key parents come first, then their children, and recursively onwards.
- `CREATE TABLE` comes before `CREATE VIEW`, again following same logic as illustrated above.
- `DROP VIEW` uses reverse order of creation, such that we first drop the views with most dependencies, then those with fewest dependencies
- `DROP TABLE` uses reverse order of creation, such that we first `DROP` a foreign key relationship's child before `DROP`ping its parent.

There is still work to be done where it comes to modifying foreign key constraints in existing tables.

## Related Issue(s)

- Foreign keys tracking issue: https://github.com/vitessio/vitess/issues/11975
- schemadiff tracking issue: https://github.com/vitessio/vitess/issues/10203
- https://github.com/vitessio/vitess/pull/12026
- 
## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
