### PR TITLE
schemadiff: fix scenario where no tables exist in schema and with just views reading from DUAL

### DIFF
--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -263,6 +263,12 @@ func (s *Schema) normalize() error {
 	// - then we only want views that depend on 1st level views or on tables. These are 2nd level views.
 	// - etc.
 	// we stop when we have been unable to find a view in an iteration.
+
+	// it's possible that the hasn't been any table in this schema.
+	// for purposes of the algorithm, the iterationLevel must be at least 1
+	if iterationLevel < 1 {
+		iterationLevel = 1
+	}
 	for {
 		handledAnyViewsInIteration := false
 		for _, v := range s.views {

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -264,8 +264,11 @@ func (s *Schema) normalize() error {
 	// - etc.
 	// we stop when we have been unable to find a view in an iteration.
 
-	// it's possible that the hasn't been any table in this schema.
-	// for purposes of the algorithm, the iterationLevel must be at least 1
+	// It's possible that there's never been any tables in this schema. Which means
+	// iterationLevel remains zero.
+	// To deal with views, we must have iterationLevel at least 1. This is because any view reads
+	// from _something_: at the very least it reads from DUAL (inplicitly or explicitly). Which
+	// puts the view at a higher level.
 	if iterationLevel < 1 {
 		iterationLevel = 1
 	}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -127,6 +127,7 @@ func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {
 }
 
 func TestNewSchemaFromQueriesViewFromDual(t *testing.T) {
+	// Schema will not contain any tables, just a view selecting from DUAL
 	queries := []string{
 		"create view v20 as select 1 from dual",
 	}
@@ -135,6 +136,7 @@ func TestNewSchemaFromQueriesViewFromDual(t *testing.T) {
 }
 
 func TestNewSchemaFromQueriesViewFromDualImplicit(t *testing.T) {
+	// Schema will not contain any tables, just a view implicitly selecting from DUAL
 	queries := []string{
 		"create view v20 as select 1",
 	}

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -129,7 +129,7 @@ func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {
 func TestNewSchemaFromQueriesViewFromDual(t *testing.T) {
 	// v8 does not exist
 	queries := []string{
-		"create view v20 as select 1 from dual2",
+		"create view v20 as select 1 from dual",
 	}
 	_, err := NewSchemaFromQueries(queries)
 	assert.NoError(t, err)

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -126,6 +126,24 @@ func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {
 	assert.EqualError(t, err, (&ViewDependencyUnresolvedError{View: "v7"}).Error())
 }
 
+func TestNewSchemaFromQueriesViewFromDual(t *testing.T) {
+	// v8 does not exist
+	queries := []string{
+		"create view v20 as select 1 from dual2",
+	}
+	_, err := NewSchemaFromQueries(queries)
+	assert.NoError(t, err)
+}
+
+func TestNewSchemaFromQueriesViewFromDualImplicit(t *testing.T) {
+	// v8 does not exist
+	queries := []string{
+		"create view v20 as select 1",
+	}
+	_, err := NewSchemaFromQueries(queries)
+	assert.NoError(t, err)
+}
+
 func TestNewSchemaFromQueriesLoop(t *testing.T) {
 	// v7 and v8 depend on each other
 	queries := append(createQueries,

--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -127,7 +127,6 @@ func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {
 }
 
 func TestNewSchemaFromQueriesViewFromDual(t *testing.T) {
-	// v8 does not exist
 	queries := []string{
 		"create view v20 as select 1 from dual",
 	}
@@ -136,7 +135,6 @@ func TestNewSchemaFromQueriesViewFromDual(t *testing.T) {
 }
 
 func TestNewSchemaFromQueriesViewFromDualImplicit(t *testing.T) {
-	// v8 does not exist
 	queries := []string{
 		"create view v20 as select 1",
 	}


### PR DESCRIPTION
## Description

fixes https://github.com/vitessio/vitess/issues/12188

Ensures an internal counter is at least `1` after iterating list of tables; if the list of tables is empty, the counter was never incremented.

Added tests that fail before the fix and of course pass with the fix. 

## Related Issue(s)

https://github.com/vitessio/vitess/issues/12188

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
