### PR TITLE
Fix parsing of bitnum values larger than 64 bit

### DIFF
--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -527,17 +528,12 @@ func (v *Value) decodeBitNum() ([]byte, error) {
 	if len(v.val) < 3 || v.val[0] != '0' || v.val[1] != 'b' {
 		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid bit number: %v", v.val)
 	}
-	bitBytes := v.val[2:]
-	ui, err := strconv.ParseUint(string(bitBytes), 2, 64)
-	if err != nil {
-		return nil, err
+	var i big.Int
+	_, ok := i.SetString(string(v.val), 0)
+	if !ok {
+		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid bit number: %v", v.val)
 	}
-	hexVal := fmt.Sprintf("%x", ui)
-	decodedHexBytes, err := hex.DecodeString(hexVal)
-	if err != nil {
-		return nil, err
-	}
-	return decodedHexBytes, nil
+	return i.Bytes(), nil
 }
 
 func encodeBytesSQL(val []byte, b BinWriter) {

--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -499,6 +499,9 @@ func TestHexAndBitToBytes(t *testing.T) {
 	}, {
 		in:  MakeTrusted(BitNum, []byte("0b1001000110100")),
 		out: []byte{0x12, 0x34},
+	}, {
+		in:  MakeTrusted(BitNum, []byte("0b11101010100101010010101010101010101010101000100100100100100101001101010101010101000001")),
+		out: []byte{0x3a, 0xa5, 0x4a, 0xaa, 0xaa, 0xa2, 0x49, 0x25, 0x35, 0x55, 0x41},
 	}}
 
 	for _, tcase := range tcases {


### PR DESCRIPTION
We can use big.Int directly to parse this and convert it to bytes. We don't need to parse it into an integer, nor use an intermediate hex encoding either.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/12190

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required