### PR TITLE
Bug fix: Cache filtered out tablets in toplogogy watcher to avoid unnecessary GetTablet calls to topo

### DIFF
--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -199,9 +199,6 @@ func (tw *TopologyWatcher) loadTablets() {
 				log.Errorf("cannot get tablet for alias %v: %v", alias, err)
 				return
 			}
-			if !(tw.tabletFilter == nil || tw.tabletFilter.IsIncluded(tablet.Tablet)) {
-				return
-			}
 			tw.mu.Lock()
 			aliasStr := topoproto.TabletAliasString(alias)
 			newTablets[aliasStr] = &tabletInfo{
@@ -217,6 +214,10 @@ func (tw *TopologyWatcher) loadTablets() {
 	tw.mu.Lock()
 
 	for alias, newVal := range newTablets {
+		if !(tw.tabletFilter == nil || tw.tabletFilter.IsIncluded(newVal.tablet)) {
+			continue
+		}
+
 		// trust the alias from topo and add it if it doesn't exist
 		if val, ok := tw.tablets[alias]; ok {
 			// check if the host and port have changed. If yes, replace tablet.
@@ -236,6 +237,10 @@ func (tw *TopologyWatcher) loadTablets() {
 	}
 
 	for _, val := range tw.tablets {
+		if !(tw.tabletFilter == nil || tw.tabletFilter.IsIncluded(val.tablet)) {
+			continue
+		}
+
 		if _, ok := newTablets[val.alias]; !ok {
 			tw.healthcheck.RemoveTablet(val.tablet)
 			topologyWatcherOperations.Add(topologyWatcherOpRemoveTablet, 1)


### PR DESCRIPTION
## Description

This addresses https://github.com/vitessio/vitess/issues/12179 by moving the point at which the topology watcher applies the provided `TabletFilter` in order to avoid too many `GetTablet` calls to the topology server. A failing test was added to confirm that this PR fixes the referenced issue

## Related Issue(s)

https://github.com/vitessio/vitess/issues/12179

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
