### PR TITLE
Fix CodeQL identified issues

### DIFF
--- a/go/vt/throttler/throttlerlogz.go
+++ b/go/vt/throttler/throttlerlogz.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"vitess.io/vitess/go/vt/logz"
 )
 
@@ -109,8 +111,7 @@ func throttlerlogzHandler(w http.ResponseWriter, r *http.Request, m *managerImpl
 	parts := strings.SplitN(r.URL.Path, "/", 3)
 
 	if len(parts) != 3 {
-		errMsg := fmt.Sprintf("invalid /throttlerlogz path: %q expected paths: /throttlerlogz/ or /throttlerlogz/<throttler name>", r.URL.Path)
-		http.Error(w, errMsg, http.StatusInternalServerError)
+		http.Error(w, "invalid /throttlerlogz path", http.StatusNotFound)
 		return
 	}
 
@@ -118,6 +119,11 @@ func throttlerlogzHandler(w http.ResponseWriter, r *http.Request, m *managerImpl
 	if name == "" {
 		// If no name is given, redirect to the list of throttlers at /throttlerz.
 		http.Redirect(w, r, "/throttlerz", http.StatusTemporaryRedirect)
+		return
+	}
+
+	if !slices.Contains(m.Throttlers(), name) {
+		http.Error(w, "throttler not found", http.StatusNotFound)
 		return
 	}
 

--- a/go/vt/throttler/throttlerlogz_test.go
+++ b/go/vt/throttler/throttlerlogz_test.go
@@ -41,7 +41,7 @@ func TestThrottlerlogzHandler_NonExistantThrottler(t *testing.T) {
 
 	throttlerlogzHandler(response, request, newManager())
 
-	if got, want := response.Body.String(), `throttler: t1 does not exist`; !strings.Contains(got, want) {
+	if got, want := response.Body.String(), `throttler not found`; !strings.Contains(got, want) {
 		t.Fatalf("/throttlerlogz page for non-existent t1 should not succeed. got = %v, want = %v", got, want)
 	}
 }

--- a/go/vt/vtctl/vtctldclient/codegen/main.go
+++ b/go/vt/vtctl/vtctldclient/codegen/main.go
@@ -332,7 +332,7 @@ func extractSourceInterface(pkg *packages.Package, name string) (*types.Interfac
 	return nil, fmt.Errorf("symbol %s was not an interface but %T", name, obj.Type())
 }
 
-var vitessProtoRegexp = regexp.MustCompile(`^vitess.io.*/proto/.*`)
+var vitessProtoRegexp = regexp.MustCompile(`^vitess\.io.*/proto/.*`)
 
 func rewriteProtoImports(pkg *types.Package) string {
 	if vitessProtoRegexp.MatchString(pkg.Path()) {


### PR DESCRIPTION
This addresses two classes of issues that CodeQL found. One is a not as strict as needed regexp for a domain match, where there's no literal `.` being matched.

The other is a user controlled XSS since we run the template with arbitrary user input. Instead we validate if the throttler with that name actually exists before trying to execute the template.

On error we also don't reflect the input to avoid the same XSS.

## Related Issue(s)

Part of #12216

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
