### PR TITLE
Allow manually kicking off CodeQL

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -7,6 +7,7 @@ on:
       - release-**.0
   schedule:
     - cron: '0 0 * * 1'
+  workflow_dispatch:
 
 jobs:
   analyze:
@@ -39,7 +40,7 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19.4
 


### PR DESCRIPTION
This allows for running it on other branches manually to test to see if it helps address issues that it reports.

## Related Issue(s)

Wanted to see what it reports for #12199 but we can't run it today without merging things. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required