### PR TITLE
Use Ubuntu 20.04 for Release Builds

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -10,7 +10,12 @@ on:
 jobs:
   build:
     name: Create Release
-    runs-on: ubuntu-22.04
+    # Use the oldest supported Ubuntu release for vtorc as that uses
+    # sqlite and the library dynamically links in glibc with versioned
+    # symbols. Older libc symbols will allow the vtorc binary we build
+    # to be usable on a wider array of Linux distros. For more
+    # details see: https://github.com/vitessio/vitess/issues/12185
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Set up Go


### PR DESCRIPTION
## Description

This moves the release package build CI workflow to Ubuntu 20.04, which is the [oldest supported Linux distro available on GitHub hosted runners](https://github.com/actions/runner-images/blob/main/README.md) today.

This will get us back to what we were using with v14 and the `vtorc` binary — which links in the native `sqlite` `C` library via `cgo` — will be usable on a larger set of Linux distros. For additional details see: https://github.com/vitessio/vitess/issues/12185

We may want to investigate additional options at some point, even going so far as attempting to statically link `glibc` in `sqlite` and using that resulting archive rather than shared object, but this PR gets us back to where we were and improves the situation significantly.

## Related Issue(s)

  - Helps with: https://github.com/vitessio/vitess/issues/12185

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests are not required
-   [x] Documentation is not required