### PR TITLE
fix dual table handling

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/helpers.go
+++ b/go/vt/vtgate/planbuilder/operators/helpers.go
@@ -35,7 +35,7 @@ func Compact(ctx *plancontext.PlanningContext, op ops.Operator) (ops.Operator, e
 		Compact(ctx *plancontext.PlanningContext) (ops.Operator, rewrite.TreeIdentity, error)
 	}
 
-	newOp, err := rewrite.BottomUp(op, func(op ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
+	newOp, err := rewrite.BottomUp(op, semantics.EmptyTableSet(), TableID, func(_ semantics.TableSet, op ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
 		newOp, ok := op.(compactable)
 		if !ok {
 			return op, rewrite.SameTree, nil

--- a/go/vt/vtgate/planbuilder/operators/rewrite/rewriters.go
+++ b/go/vt/vtgate/planbuilder/operators/rewrite/rewriters.go
@@ -18,10 +18,11 @@ package rewrite
 
 import (
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
+	"vitess.io/vitess/go/vt/vtgate/semantics"
 )
 
 type (
-	Func          func(ops.Operator) (ops.Operator, TreeIdentity, error)
+	Func          func(semantics.TableSet, ops.Operator) (ops.Operator, TreeIdentity, error)
 	BreakableFunc func(ops.Operator) (ops.Operator, TreeIdentity, VisitRule, error)
 
 	// TreeIdentity tracks modifications to node and expression trees.
@@ -56,8 +57,8 @@ func Visit(root ops.Operator, visitor func(ops.Operator) error) error {
 // BottomUp rewrites an operator tree from the bottom up. BottomUp applies a transformation function to
 // the given operator tree from the bottom up. Each callback [f] returns a TreeIdentity that is aggregated
 // into a final output indicating whether the operator tree was changed.
-func BottomUp(root ops.Operator, f Func) (ops.Operator, error) {
-	op, _, err := bottomUp(root, f)
+func BottomUp(root ops.Operator, rootID semantics.TableSet, resolveID func(ops.Operator) semantics.TableSet, f Func) (ops.Operator, error) {
+	op, _, err := bottomUp(root, rootID, resolveID, f)
 	if err != nil {
 		return nil, err
 	}
@@ -73,12 +74,22 @@ func TopDown(in ops.Operator, rewriter BreakableFunc) (ops.Operator, error) {
 	return op, err
 }
 
-func bottomUp(root ops.Operator, rewriter Func) (ops.Operator, TreeIdentity, error) {
+func bottomUp(root ops.Operator, rootID semantics.TableSet, resolveID func(ops.Operator) semantics.TableSet, rewriter Func) (ops.Operator, TreeIdentity, error) {
 	oldInputs := root.Inputs()
 	anythingChanged := false
 	newInputs := make([]ops.Operator, len(oldInputs))
+	childID := rootID
+
+	type noLHSTableSet interface{ NoLHSTableSet() }
+
 	for i, operator := range oldInputs {
-		in, changed, err := bottomUp(operator, rewriter)
+		// We merge the table set of all the LHS above the current root so that we can
+		// send it down to the current RHS.
+		// We don't want to send the LHS table set to the RHS if the root is an UNION.
+		if _, isUnion := root.(noLHSTableSet); !isUnion && i == 1 {
+			childID = childID.Merge(resolveID(oldInputs[0]))
+		}
+		in, changed, err := bottomUp(operator, childID, resolveID, rewriter)
 		if err != nil {
 			return nil, SameTree, err
 		}
@@ -92,7 +103,7 @@ func bottomUp(root ops.Operator, rewriter Func) (ops.Operator, TreeIdentity, err
 		root = root.Clone(newInputs)
 	}
 
-	newOp, treeIdentity, err := rewriter(root)
+	newOp, treeIdentity, err := rewriter(rootID, root)
 	if err != nil {
 		return nil, SameTree, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -553,7 +553,7 @@ func tryMerge(
 		}
 
 		if !sameKeyspace {
-			return nil, vterrors.VT12001("cross-shard correlated subquery")
+			return nil, nil
 		}
 
 		canMerge := canMergeOnFilters(ctx, aRoute, bRoute, joinPredicates)

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -51,7 +51,7 @@ type (
 // Here we try to merge query parts into the same route primitives. At the end of this process,
 // all the operators in the tree are guaranteed to be PhysicalOperators
 func transformToPhysical(ctx *plancontext.PlanningContext, in ops.Operator) (ops.Operator, error) {
-	op, err := rewrite.BottomUp(in, func(operator ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
+	op, err := rewrite.BottomUp(in, semantics.EmptyTableSet(), TableID, func(ts semantics.TableSet, operator ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
 		switch op := operator.(type) {
 		case *QueryGraph:
 			return optimizeQueryGraph(ctx, op)
@@ -60,7 +60,7 @@ func transformToPhysical(ctx *plancontext.PlanningContext, in ops.Operator) (ops
 		case *Derived:
 			return optimizeDerived(ctx, op)
 		case *SubQuery:
-			return optimizeSubQuery(ctx, op)
+			return optimizeSubQuery(ctx, op, ts)
 		case *Filter:
 			return optimizeFilter(op)
 		default:

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -226,6 +226,11 @@ func tryMergeSubqueryWithRoute(
 		return nil, nil
 	}
 
+	deps := ctx.SemTable.DirectDeps(subQueryInner.ExtractedSubquery.Subquery)
+	if !deps.IsSolvedBy(TableID(outerOp)) {
+		return nil, nil
+	}
+
 	merged, err := tryMerge(ctx, outerOp, subq, joinPredicates, merger)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -27,7 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 )
 
-func optimizeSubQuery(ctx *plancontext.PlanningContext, op *SubQuery) (ops.Operator, rewrite.TreeIdentity, error) {
+func optimizeSubQuery(ctx *plancontext.PlanningContext, op *SubQuery, ts semantics.TableSet) (ops.Operator, rewrite.TreeIdentity, error) {
 	var unmerged []*SubQueryOp
 
 	// first loop over the subqueries and try to merge them into the outer plan
@@ -45,7 +45,7 @@ func optimizeSubQuery(ctx *plancontext.PlanningContext, op *SubQuery) (ops.Opera
 			Inner:             inner.Inner,
 			ExtractedSubquery: inner.ExtractedSubquery,
 		}
-		merged, err := tryMergeSubQueryOp(ctx, outer, innerOp, newInner, preds, merger, semantics.EmptyTableSet())
+		merged, err := tryMergeSubQueryOp(ctx, outer, innerOp, newInner, preds, merger, ts)
 		if err != nil {
 			return nil, rewrite.SameTree, err
 		}

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -187,3 +187,5 @@ func (u *Union) Compact(*plancontext.PlanningContext) (ops.Operator, rewrite.Tre
 
 	return u, identity, nil
 }
+
+func (u *Union) NoLHSTableSet() {}

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -2427,51 +2427,7 @@
         ]
       }
     },
-    "gen4-plan": {
-      "QueryType": "SELECT",
-      "Original": "select u.m from user_extra join user u where u.id in (select m2 from user where user.id = u.id and user_extra.col = user.col) and u.id in (user_extra.col, 1)",
-      "Instructions": {
-        "OperatorType": "Join",
-        "Variant": "Join",
-        "JoinColumnIndexes": "R:0",
-        "JoinVars": {
-          "user_extra_col": 0
-        },
-        "TableName": "user_extra_`user`",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-            "Query": "select user_extra.col from user_extra",
-            "Table": "user_extra"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "IN",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select u.m from `user` as u where 1 != 1",
-            "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col) and u.id in ::__vals",
-            "Table": "`user`",
-            "Values": [
-              "(:user_extra_col, INT64(1))"
-            ],
-            "Vindex": "user_index"
-          }
-        ]
-      },
-      "TablesUsed": [
-        "user.user",
-        "user.user_extra"
-      ]
-    }
+    "gen4-plan": "VT12001: unsupported: cross-shard correlated subquery"
   },
   {
     "comment": "correlated subquery merge-able into a route of a join tree",
@@ -2691,51 +2647,7 @@
         ]
       }
     },
-    "gen4-plan": {
-      "QueryType": "SELECT",
-      "Original": "select u.m from user_extra join user u where u.id in (select m2 from user where user.id = u.id and user_extra.col = user.col and user.id in (select m3 from user_extra where user_extra.user_id = user.id)) and u.id in (user_extra.col, 1)",
-      "Instructions": {
-        "OperatorType": "Join",
-        "Variant": "Join",
-        "JoinColumnIndexes": "R:0",
-        "JoinVars": {
-          "user_extra_col": 0
-        },
-        "TableName": "user_extra_`user`",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
-            "Query": "select user_extra.col from user_extra",
-            "Table": "user_extra"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "IN",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select u.m from `user` as u where 1 != 1",
-            "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col and `user`.id in (select m3 from user_extra where user_extra.user_id = `user`.id)) and u.id in ::__vals",
-            "Table": "`user`",
-            "Values": [
-              "(:user_extra_col, INT64(1))"
-            ],
-            "Vindex": "user_index"
-          }
-        ]
-      },
-      "TablesUsed": [
-        "user.user",
-        "user.user_extra"
-      ]
-    }
+    "gen4-plan": "VT12001: unsupported: cross-shard correlated subquery"
   },
   {
     "comment": "Correlated subquery in where clause",
@@ -2937,25 +2849,7 @@
         "Table": "`user`"
       }
     },
-    "gen4-plan": {
-      "QueryType": "SELECT",
-      "Original": "select id2 from user uu where id in (select id from user where id = uu.id and user.col in (select user_extra.col from user_extra where user_extra.user_id = uu.id))",
-      "Instructions": {
-        "OperatorType": "Route",
-        "Variant": "Scatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select id2 from `user` as uu where 1 != 1",
-        "Query": "select id2 from `user` as uu where id in (select id from `user` where id = uu.id and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = uu.id))",
-        "Table": "`user`"
-      },
-      "TablesUsed": [
-        "user.user",
-        "user.user_extra"
-      ]
-    }
+    "gen4-plan": "VT12001: unsupported: cross-shard correlated subquery"
   },
   {
     "comment": "cross-shard subquery in IN clause.\n# Note the improved Underlying plan as SelectIN.",

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -6678,5 +6678,69 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "must merge subquery with the right side of the join",
+    "query": "select 1 from unsharded join user u1 where exists (select 1 from unsharded u2 where u1.bar = u2.baz)",
+    "v3-plan": "VT12001: unsupported: cross-shard correlated subquery",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select 1 from unsharded join user u1 where exists (select 1 from unsharded u2 where u1.bar = u2.baz)",
+      "Instructions": {
+        "OperatorType": "SemiJoin",
+        "JoinVars": {
+          "u1_bar": 0
+        },
+        "ProjectedIndexes": "-2",
+        "TableName": "unsharded_`user`_unsharded",
+        "Inputs": [
+          {
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "R:0,L:0",
+            "TableName": "unsharded_`user`",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1 from unsharded where 1 != 1",
+                "Query": "select 1 from unsharded",
+                "Table": "unsharded"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select u1.bar from `user` as u1 where 1 != 1",
+                "Query": "select u1.bar from `user` as u1",
+                "Table": "`user`"
+              }
+            ]
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select 1 from unsharded as u2 where 1 != 1",
+            "Query": "select 1 from unsharded as u2 where u2.baz = :u1_bar",
+            "Table": "unsharded"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -2937,7 +2937,25 @@
         "Table": "`user`"
       }
     },
-    "gen4-plan": "VT12001: unsupported: cross-shard correlated subquery"
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select id2 from user uu where id in (select id from user where id = uu.id and user.col in (select user_extra.col from user_extra where user_extra.user_id = uu.id))",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id2 from `user` as uu where 1 != 1",
+        "Query": "select id2 from `user` as uu where id in (select id from `user` where id = uu.id and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = uu.id))",
+        "Table": "`user`"
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   },
   {
     "comment": "cross-shard subquery in IN clause.\n# Note the improved Underlying plan as SelectIN.",

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -2427,7 +2427,51 @@
         ]
       }
     },
-    "gen4-plan": "VT12001: unsupported: cross-shard correlated subquery"
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select u.m from user_extra join user u where u.id in (select m2 from user where user.id = u.id and user_extra.col = user.col) and u.id in (user_extra.col, 1)",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "user_extra_col": 0
+        },
+        "TableName": "user_extra_`user`",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
+            "Query": "select user_extra.col from user_extra",
+            "Table": "user_extra"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "IN",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select u.m from `user` as u where 1 != 1",
+            "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col) and u.id in ::__vals",
+            "Table": "`user`",
+            "Values": [
+              "(:user_extra_col, INT64(1))"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   },
   {
     "comment": "correlated subquery merge-able into a route of a join tree",
@@ -2647,7 +2691,51 @@
         ]
       }
     },
-    "gen4-plan": "VT12001: unsupported: cross-shard correlated subquery"
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select u.m from user_extra join user u where u.id in (select m2 from user where user.id = u.id and user_extra.col = user.col and user.id in (select m3 from user_extra where user_extra.user_id = user.id)) and u.id in (user_extra.col, 1)",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "user_extra_col": 0
+        },
+        "TableName": "user_extra_`user`",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
+            "Query": "select user_extra.col from user_extra",
+            "Table": "user_extra"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "IN",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select u.m from `user` as u where 1 != 1",
+            "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col and `user`.id in (select m3 from user_extra where user_extra.user_id = `user`.id)) and u.id in ::__vals",
+            "Table": "`user`",
+            "Values": [
+              "(:user_extra_col, INT64(1))"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   },
   {
     "comment": "Correlated subquery in where clause",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1568,12 +1568,25 @@
       "QueryType": "SELECT",
       "Original": "select user.id, (select user.id+outm.m+unsharded.m from unsharded) from user join unsharded outm",
       "Instructions": {
-        "OperatorType": "Subquery",
-        "Variant": "PulloutValue",
-        "PulloutVars": [
-          "__sq1"
-        ],
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0,R:0",
+        "JoinVars": {
+          "user_id": 0
+        },
+        "TableName": "`user`_unsharded",
         "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select `user`.id from `user` where 1 != 1",
+            "Query": "select `user`.id from `user`",
+            "Table": "`user`"
+          },
           {
             "OperatorType": "Route",
             "Variant": "Unsharded",
@@ -1581,39 +1594,9 @@
               "Name": "main",
               "Sharded": false
             },
-            "FieldQuery": "select `user`.id + outm.m + unsharded.m from unsharded where 1 != 1",
-            "Query": "select `user`.id + outm.m + unsharded.m from unsharded",
+            "FieldQuery": "select (select :user_id + outm.m + unsharded.m from unsharded where 1 != 1) from unsharded as outm where 1 != 1",
+            "Query": "select (select :user_id + outm.m + unsharded.m from unsharded) from unsharded as outm",
             "Table": "unsharded"
-          },
-          {
-            "OperatorType": "Join",
-            "Variant": "Join",
-            "JoinColumnIndexes": "L:0,L:1",
-            "TableName": "`user`_unsharded",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `user`.id, :__sq1 from `user` where 1 != 1",
-                "Query": "select `user`.id, :__sq1 from `user`",
-                "Table": "`user`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Unsharded",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select 1 from unsharded as outm where 1 != 1",
-                "Query": "select 1 from unsharded as outm",
-                "Table": "unsharded"
-              }
-            ]
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1568,25 +1568,12 @@
       "QueryType": "SELECT",
       "Original": "select user.id, (select user.id+outm.m+unsharded.m from unsharded) from user join unsharded outm",
       "Instructions": {
-        "OperatorType": "Join",
-        "Variant": "Join",
-        "JoinColumnIndexes": "L:0,R:0",
-        "JoinVars": {
-          "user_id": 0
-        },
-        "TableName": "`user`_unsharded",
+        "OperatorType": "Subquery",
+        "Variant": "PulloutValue",
+        "PulloutVars": [
+          "__sq1"
+        ],
         "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select `user`.id from `user` where 1 != 1",
-            "Query": "select `user`.id from `user`",
-            "Table": "`user`"
-          },
           {
             "OperatorType": "Route",
             "Variant": "Unsharded",
@@ -1594,9 +1581,39 @@
               "Name": "main",
               "Sharded": false
             },
-            "FieldQuery": "select (select :user_id + outm.m + unsharded.m from unsharded where 1 != 1) from unsharded as outm where 1 != 1",
-            "Query": "select (select :user_id + outm.m + unsharded.m from unsharded) from unsharded as outm",
+            "FieldQuery": "select `user`.id + outm.m + unsharded.m from unsharded where 1 != 1",
+            "Query": "select `user`.id + outm.m + unsharded.m from unsharded",
             "Table": "unsharded"
+          },
+          {
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "L:0,L:1",
+            "TableName": "`user`_unsharded",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select `user`.id, :__sq1 from `user` where 1 != 1",
+                "Query": "select `user`.id, :__sq1 from `user`",
+                "Table": "`user`"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1 from unsharded as outm where 1 != 1",
+                "Query": "select 1 from unsharded as outm",
+                "Table": "unsharded"
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
## Description
Fixes how we route dual tables. MySQL has a little weird way of routing the `dual` table.

```sql
mysql> select 1 from dual;
+---+
| 1 |
+---+
| 1 |
+---+
1 row in set (0.00 sec)

mysql> select 1 from `dual`;
ERROR 1046 (3D000): No database selected
mysql> use test;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> create table `dual`(id bigint not null);
Query OK, 0 rows affected (0.01 sec)

mysql> select 1 from `dual`;
Empty set (0.00 sec)

mysql> select 1 from dual;
+---+
| 1 |
+---+
| 1 |
+---+
1 row in set (0.00 sec)

mysql> select 1 from test.dual;
Empty set (0.00 sec)
```

As can be seen in the little session above, ``` `dual` ``` and ```dual``` are handled differently. When qualified by the db name, you can select from the user table. But even when standing on the correct database, doing a `select 1 from dual` will still always use the magic dual and not the user table with the same name.

Additionally, if you prefix the table with a database name, it will never resolve to the magic dual, only complain that dual does not exist.

```sql
mysql> drop table test.dual;
Query OK, 0 rows affected (0.01 sec)

mysql> select 1 from test.dual;
ERROR 1146 (42S02): Table 'test.dual' doesn't exist
```

This PR fixes so that magic `dual` is only routed to if the table is not prefixed with any db name.
That means that the `dual` table is no longer in every keyspace, and will not show up when doing `SHOW VSCHEMA TABLES`.

It's now possible to use a real user table named `dual` (why anyone would want that is a separate question).

The fact that MySQL differentiates between ``` `dual` ``` and ```dual``` needs parser and AST support that we are currently lacking.

## Related Issue(s)
Fixes #6429

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
