### PR TITLE
Backport 15.0: Use Ubuntu 20.04 for Release Builds

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -10,7 +10,12 @@ on:
 jobs:
   build:
     name: Create Release
-    runs-on: ubuntu-latest
+    # Use the oldest supported Ubuntu release for vtorc as that uses
+    # sqlite and the library dynamically links in glibc with versioned
+    # symbols. Older libc symbols will allow the vtorc binary we build
+    # to be usable on a wider array of Linux distros. For more
+    # details see: https://github.com/vitessio/vitess/issues/12185
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Set up Go


### PR DESCRIPTION
## Description

This is a backport / cherry-pick of https://github.com/vitessio/vitess/pull/12202 to v15 (where `vtorc` was marked as Generally Available).

## Related Issue(s)

  - Cherry-picks: https://github.com/vitessio/vitess/pull/12202

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests are not required
-   [x] Documentation is not required