### PR TITLE
grpcvtgateconn: add Dial and deprecate DialWithOpts

### DIFF
--- a/go/test/endtoend/vtgate/grpc_server_auth_static/main_test.go
+++ b/go/test/endtoend/vtgate/grpc_server_auth_static/main_test.go
@@ -196,7 +196,7 @@ func TestUnauthenticatedUser(t *testing.T) {
 func dialVTGate(ctx context.Context, t *testing.T, username string, password string) (*vtgateconn.VTGateConn, error) {
 	clientCreds := &grpcclient.StaticAuthClientCreds{Username: username, Password: password}
 	creds := grpc.WithPerRPCCredentials(clientCreds)
-	dialerFunc := grpcvtgateconn.DialWithOpts(ctx, creds)
+	dialerFunc := grpcvtgateconn.Dial(creds)
 	dialerName := t.Name()
 	vtgateconn.RegisterDialer(dialerName, dialerFunc)
 	return vtgateconn.DialProtocol(ctx, dialerName, vtgateGrpcAddress)

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -89,7 +89,7 @@ func OpenWithConfiguration(c Configuration) (*sql.DB, error) {
 	}
 
 	if len(c.GRPCDialOptions) != 0 {
-		vtgateconn.RegisterDialer(c.Protocol, grpcvtgateconn.DialWithOpts(context.TODO(), c.GRPCDialOptions...))
+		vtgateconn.RegisterDialer(c.Protocol, grpcvtgateconn.Dial(c.GRPCDialOptions...))
 	}
 
 	return sql.Open(c.DriverName, json)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Resolves a linked issue relating to Go variable scopes.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Fixes #12209.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
