### PR TITLE
Fix typecasting issue for workflow types

### DIFF
--- a/go/sqltypes/named_result.go
+++ b/go/sqltypes/named_result.go
@@ -54,6 +54,13 @@ func (r RowNamedValues) ToInt64(fieldName string) (int64, error) {
 	return 0, ErrNoSuchField
 }
 
+func (r RowNamedValues) ToInt32(fieldName string) (int32, error) {
+	if v, ok := r[fieldName]; ok {
+		return v.ToInt32()
+	}
+	return 0, ErrNoSuchField
+}
+
 // AsInt64 returns the named field as int64, or default value if nonexistent/error
 func (r RowNamedValues) AsInt64(fieldName string, def int64) int64 {
 	if v, err := r.ToInt64(fieldName); err == nil {

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -281,6 +281,15 @@ func (v Value) ToInt64() (int64, error) {
 	return strconv.ParseInt(v.RawStr(), 10, 64)
 }
 
+func (v Value) ToInt32() (int32, error) {
+	if !v.IsIntegral() {
+		return 0, ErrIncompatibleTypeCast
+	}
+
+	i, err := strconv.ParseInt(v.RawStr(), 10, 32)
+	return int32(i), err
+}
+
 // ToFloat64 returns the value as MySQL would return it as a float64.
 func (v Value) ToFloat64() (float64, error) {
 	if !IsNumber(v.typ) {

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -597,7 +597,7 @@ func CreateVReplication(workflow string, source *binlogdatapb.BinlogSource, posi
 	workflowType binlogdatapb.VReplicationWorkflowType, workflowSubType binlogdatapb.VReplicationWorkflowSubType, deferSecondaryKeys bool) string {
 	return fmt.Sprintf("insert into _vt.vreplication "+
 		"(workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state, db_name, workflow_type, workflow_sub_type, defer_secondary_keys) "+
-		"values (%v, %v, %v, %v, %v, %v, 0, '%v', %v, %v, %v, %v)",
+		"values (%v, %v, %v, %v, %v, %v, 0, '%v', %v, %d, %d, %v)",
 		encodeString(workflow), encodeString(source.String()), encodeString(position), maxTPS, maxReplicationLag,
 		timeUpdated, BlpRunning, encodeString(dbName), workflowType, workflowSubType, deferSecondaryKeys)
 }
@@ -607,7 +607,7 @@ func CreateVReplicationState(workflow string, source *binlogdatapb.BinlogSource,
 	workflowType binlogdatapb.VReplicationWorkflowType, workflowSubType binlogdatapb.VReplicationWorkflowSubType) string {
 	return fmt.Sprintf("insert into _vt.vreplication "+
 		"(workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state, db_name, workflow_type, workflow_sub_type) "+
-		"values (%v, %v, %v, %v, %v, %v, 0, '%v', %v, %v, %v)",
+		"values (%v, %v, %v, %v, %v, %v, 0, '%v', %v, %d, %d)",
 		encodeString(workflow), encodeString(source.String()), encodeString(position), throttler.MaxRateModuleDisabled,
 		throttler.ReplicationLagModuleDisabled, time.Now().Unix(), state, encodeString(dbName),
 		workflowType, workflowSubType)

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -530,8 +530,8 @@ type VRSettings struct {
 	MaxTPS             int64
 	MaxReplicationLag  int64
 	State              string
-	WorkflowType       int32
-	WorkflowSubType    int32
+	WorkflowType       binlogdatapb.VReplicationWorkflowType
+	WorkflowSubType    binlogdatapb.VReplicationWorkflowSubType
 	WorkflowName       string
 	DeferSecondaryKeys bool
 }
@@ -566,13 +566,11 @@ func ReadVRSettings(dbClient DBClient, uid uint32) (VRSettings, error) {
 	if err != nil {
 		return VRSettings{}, fmt.Errorf("failed to parse stop_pos column: %v", err)
 	}
-	workflowTypeTmp, err := vrRow.ToInt64("workflow_type")
-	workflowType := int32(workflowTypeTmp)
+	workflowType, err := vrRow.ToInt32("workflow_type")
 	if err != nil {
 		return VRSettings{}, fmt.Errorf("failed to parse workflow_type column: %v", err)
 	}
-	workflowSubTypeTmp, err := vrRow.ToInt64("workflow_sub_type")
-	workflowSubType := int32(workflowSubTypeTmp)
+	workflowSubType, err := vrRow.ToInt32("workflow_sub_type")
 	if err != nil {
 		return VRSettings{}, fmt.Errorf("failed to parse workflow_sub_type column: %v", err)
 	}
@@ -586,9 +584,9 @@ func ReadVRSettings(dbClient DBClient, uid uint32) (VRSettings, error) {
 		MaxTPS:             maxTPS,
 		MaxReplicationLag:  maxReplicationLag,
 		State:              vrRow.AsString("state", ""),
-		WorkflowType:       workflowType,
+		WorkflowType:       binlogdatapb.VReplicationWorkflowType(workflowType),
 		WorkflowName:       vrRow.AsString("workflow", ""),
-		WorkflowSubType:    workflowSubType,
+		WorkflowSubType:    binlogdatapb.VReplicationWorkflowSubType(workflowSubType),
 		DeferSecondaryKeys: deferSecondaryKeys,
 	}, nil
 }
@@ -601,7 +599,7 @@ func CreateVReplication(workflow string, source *binlogdatapb.BinlogSource, posi
 		"(workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state, db_name, workflow_type, workflow_sub_type, defer_secondary_keys) "+
 		"values (%v, %v, %v, %v, %v, %v, 0, '%v', %v, %v, %v, %v)",
 		encodeString(workflow), encodeString(source.String()), encodeString(position), maxTPS, maxReplicationLag,
-		timeUpdated, BlpRunning, encodeString(dbName), int64(workflowType), int64(workflowSubType), deferSecondaryKeys)
+		timeUpdated, BlpRunning, encodeString(dbName), workflowType, workflowSubType, deferSecondaryKeys)
 }
 
 // CreateVReplicationState returns a statement to create a stopped vreplication.
@@ -612,7 +610,7 @@ func CreateVReplicationState(workflow string, source *binlogdatapb.BinlogSource,
 		"values (%v, %v, %v, %v, %v, %v, 0, '%v', %v, %v, %v)",
 		encodeString(workflow), encodeString(source.String()), encodeString(position), throttler.MaxRateModuleDisabled,
 		throttler.ReplicationLagModuleDisabled, time.Now().Unix(), state, encodeString(dbName),
-		int64(workflowType), int64(workflowSubType))
+		workflowType, workflowSubType)
 }
 
 // GenerateUpdatePos returns a statement to record the latest processed gtid in the _vt.vreplication table.

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -370,8 +370,8 @@ func (s *Server) GetWorkflows(ctx context.Context, req *vtctldatapb.GetWorkflows
 		if tags != "" {
 			tagArray = strings.Split(tags, ",")
 		}
-		workflowType, _ := row["workflow_type"].ToInt64()
-		workflowSubType, _ := row["workflow_sub_type"].ToInt64()
+		workflowType, _ := row["workflow_type"].ToInt32()
+		workflowSubType, _ := row["workflow_sub_type"].ToInt32()
 		stream := &vtctldatapb.Workflow_Stream{
 			Id:           id,
 			Shard:        tablet.Shard,
@@ -390,8 +390,8 @@ func (s *Server) GetWorkflows(ctx context.Context, req *vtctldatapb.GetWorkflows
 			Message: message,
 			Tags:    tagArray,
 		}
-		workflow.WorkflowType = binlogdatapb.VReplicationWorkflowType_name[int32(workflowType)]
-		workflow.WorkflowSubType = binlogdatapb.VReplicationWorkflowSubType_name[int32(workflowSubType)]
+		workflow.WorkflowType = binlogdatapb.VReplicationWorkflowType_name[workflowType]
+		workflow.WorkflowSubType = binlogdatapb.VReplicationWorkflowSubType_name[workflowSubType]
 		stream.CopyStates, err = s.getWorkflowCopyStates(ctx, tablet, id)
 		if err != nil {
 			return err

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -229,11 +229,11 @@ func (sm *StreamMigrator) readTabletStreams(ctx context.Context, ti *topo.Tablet
 				ti.Keyspace, ti.Shard, id)
 		}
 
-		workflowType, err := row["workflow_type"].ToInt64()
+		workflowType, err := row["workflow_type"].ToInt32()
 		if err != nil {
 			return nil, err
 		}
-		workflowSubType, err := row["workflow_sub_type"].ToInt64()
+		workflowSubType, err := row["workflow_sub_type"].ToInt32()
 		if err != nil {
 			return nil, err
 		}
@@ -580,7 +580,7 @@ func (sm *StreamMigrator) createTargetStreams(ctx context.Context, tmpl []*VRepl
 			}
 
 			ig.AddRow(vrs.Workflow, vrs.BinlogSource, mysql.EncodePosition(vrs.Position), "", "",
-				int64(vrs.WorkflowType), int64(vrs.WorkflowSubType), vrs.DeferSecondaryKeys)
+				vrs.WorkflowType, vrs.WorkflowSubType, vrs.DeferSecondaryKeys)
 		}
 
 		_, err := sm.ts.VReplicationExec(ctx, target.GetPrimary().GetAlias(), ig.String())

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -289,12 +289,12 @@ func BuildTargets(ctx context.Context, ts *topo.Server, tmc tmclient.TabletManag
 }
 
 func getVReplicationWorkflowType(row sqltypes.RowNamedValues) binlogdatapb.VReplicationWorkflowType {
-	i, _ := row["workflow_type"].ToInt64()
+	i, _ := row["workflow_type"].ToInt32()
 	return binlogdatapb.VReplicationWorkflowType(i)
 }
 
 func getVReplicationWorkflowSubType(row sqltypes.RowNamedValues) binlogdatapb.VReplicationWorkflowSubType {
-	i, _ := row["workflow_sub_type"].ToInt64()
+	i, _ := row["workflow_sub_type"].ToInt32()
 	return binlogdatapb.VReplicationWorkflowSubType(i)
 }
 

--- a/go/vt/vttablet/onlineddl/vrepl.go
+++ b/go/vt/vttablet/onlineddl/vrepl.go
@@ -566,7 +566,7 @@ func (v *VRepl) analyze(ctx context.Context, conn *dbconnpool.DBConnection) erro
 func (v *VRepl) generateInsertStatement(ctx context.Context) (string, error) {
 	ig := vreplication.NewInsertGenerator(binlogplayer.BlpStopped, v.dbName)
 	ig.AddRow(v.workflow, v.bls, v.pos, "", "in_order:REPLICA,PRIMARY",
-		int64(binlogdatapb.VReplicationWorkflowType_OnlineDDL), int64(binlogdatapb.VReplicationWorkflowSubType_None), false)
+		binlogdatapb.VReplicationWorkflowType_OnlineDDL, binlogdatapb.VReplicationWorkflowSubType_None, false)
 
 	return ig.String(), nil
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -660,11 +660,12 @@ func (vre *Engine) transitionJournal(je *journalEvent) {
 		bls := proto.Clone(vre.controllers[refid].source).(*binlogdatapb.BinlogSource)
 		bls.Keyspace, bls.Shard = sgtid.Keyspace, sgtid.Shard
 
-		workflowType, _ := strconv.ParseInt(params["workflow_type"], 10, 64)
-		workflowSubType, _ := strconv.ParseInt(params["workflow_sub_type"], 10, 64)
+		workflowType, _ := strconv.ParseInt(params["workflow_type"], 10, 32)
+		workflowSubType, _ := strconv.ParseInt(params["workflow_sub_type"], 10, 32)
 		deferSecondaryKeys, _ := strconv.ParseBool(params["defer_secondary_keys"])
 		ig := NewInsertGenerator(binlogplayer.BlpRunning, vre.dbName)
-		ig.AddRow(params["workflow"], bls, sgtid.Gtid, params["cell"], params["tablet_types"], workflowType, workflowSubType, deferSecondaryKeys)
+		ig.AddRow(params["workflow"], bls, sgtid.Gtid, params["cell"], params["tablet_types"],
+			binlogdatapb.VReplicationWorkflowType(workflowType), binlogdatapb.VReplicationWorkflowSubType(workflowSubType), deferSecondaryKeys)
 		qr, err := dbClient.ExecuteFetch(ig.String(), maxRows)
 		if err != nil {
 			log.Errorf("transitionJournal: %v", err)

--- a/go/vt/vttablet/tabletmanager/vreplication/insert_generator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/insert_generator.go
@@ -50,7 +50,7 @@ func NewInsertGenerator(state, dbname string) *InsertGenerator {
 // AddRow adds a row to the insert statement.
 func (ig *InsertGenerator) AddRow(workflow string, bls *binlogdatapb.BinlogSource, pos, cell, tabletTypes string,
 	workflowType binlogdatapb.VReplicationWorkflowType, workflowSubType binlogdatapb.VReplicationWorkflowSubType, deferSecondaryKeys bool) {
-	fmt.Fprintf(ig.buf, "%s(%v, %v, %v, %v, %v, %v, %v, %v, 0, '%v', %v, %v, %v, %v)",
+	fmt.Fprintf(ig.buf, "%s(%v, %v, %v, %v, %v, %v, %v, %v, 0, '%v', %v, %d, %d, %v)",
 		ig.prefix,
 		encodeString(workflow),
 		encodeString(bls.String()),

--- a/go/vt/vttablet/tabletmanager/vreplication/insert_generator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/insert_generator.go
@@ -49,7 +49,7 @@ func NewInsertGenerator(state, dbname string) *InsertGenerator {
 
 // AddRow adds a row to the insert statement.
 func (ig *InsertGenerator) AddRow(workflow string, bls *binlogdatapb.BinlogSource, pos, cell, tabletTypes string,
-	workflowType int64, workflowSubType int64, deferSecondaryKeys bool) {
+	workflowType binlogdatapb.VReplicationWorkflowType, workflowSubType binlogdatapb.VReplicationWorkflowSubType, deferSecondaryKeys bool) {
 	fmt.Fprintf(ig.buf, "%s(%v, %v, %v, %v, %v, %v, %v, %v, 0, '%v', %v, %v, %v, %v)",
 		ig.prefix,
 		encodeString(workflow),

--- a/go/vt/vttablet/tabletmanager/vreplication/insert_generator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/insert_generator_test.go
@@ -28,12 +28,12 @@ import (
 func TestInsertGenerator(t *testing.T) {
 	ig := NewInsertGenerator(binlogplayer.BlpStopped, "a")
 	ig.now = 111
-	ig.AddRow("b", &binlogdatapb.BinlogSource{Keyspace: "c"}, "d", "e", "f", int64(binlogdatapb.VReplicationWorkflowType_Materialize), int64(binlogdatapb.VReplicationWorkflowSubType_None), false)
+	ig.AddRow("b", &binlogdatapb.BinlogSource{Keyspace: "c"}, "d", "e", "f", binlogdatapb.VReplicationWorkflowType_Materialize, binlogdatapb.VReplicationWorkflowSubType_None, false)
 	want := `insert into _vt.vreplication(workflow, source, pos, max_tps, max_replication_lag, cell, tablet_types, time_updated, transaction_timestamp, state, db_name, workflow_type, workflow_sub_type, defer_secondary_keys) values ` +
 		`('b', 'keyspace:\"c\"', 'd', 9223372036854775807, 9223372036854775807, 'e', 'f', 111, 0, 'Stopped', 'a', 0, 0, false)`
 	assert.Equal(t, ig.String(), want)
 
-	ig.AddRow("g", &binlogdatapb.BinlogSource{Keyspace: "h"}, "i", "j", "k", int64(binlogdatapb.VReplicationWorkflowType_Reshard), int64(binlogdatapb.VReplicationWorkflowSubType_Partial), true)
+	ig.AddRow("g", &binlogdatapb.BinlogSource{Keyspace: "h"}, "i", "j", "k", binlogdatapb.VReplicationWorkflowType_Reshard, binlogdatapb.VReplicationWorkflowSubType_Partial, true)
 	want += `, ('g', 'keyspace:\"h\"', 'i', 9223372036854775807, 9223372036854775807, 'j', 'k', 111, 0, 'Stopped', 'a', 4, 1, true)`
 	assert.Equal(t, ig.String(), want)
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vreplication
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -33,8 +34,6 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
-
-	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
@@ -499,7 +498,7 @@ func (vr *vreplicator) setSQLMode(ctx context.Context, dbClient *vdbClient) (fun
 	if err != nil {
 		return resetFunc, err
 	}
-	if settings.WorkflowType == int32(binlogdatapb.VReplicationWorkflowType_OnlineDDL) {
+	if settings.WorkflowType == binlogdatapb.VReplicationWorkflowType_OnlineDDL {
 		vreplicationSQLMode = StrictSQLMode
 	}
 

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -1309,9 +1309,19 @@ func (mz *materializer) generateInserts(ctx context.Context, targetShard *topo.S
 		if mz.isPartial {
 			workflowSubType = binlogdatapb.VReplicationWorkflowSubType_Partial
 		}
+		var workflowType binlogdatapb.VReplicationWorkflowType
+		switch mz.ms.MaterializationIntent {
+		case vtctldatapb.MaterializationIntent_CUSTOM:
+			workflowType = binlogdatapb.VReplicationWorkflowType_Materialize
+		case vtctldatapb.MaterializationIntent_MOVETABLES:
+			workflowType = binlogdatapb.VReplicationWorkflowType_MoveTables
+		case vtctldatapb.MaterializationIntent_CREATELOOKUPINDEX:
+			workflowType = binlogdatapb.VReplicationWorkflowType_CreateLookupIndex
+		}
+
 		ig.AddRow(mz.ms.Workflow, bls, "", mz.ms.Cell, mz.ms.TabletTypes,
-			int64(mz.ms.MaterializationIntent),
-			int64(workflowSubType),
+			workflowType,
+			workflowSubType,
 			mz.ms.DeferSecondaryKeys,
 		)
 	}

--- a/go/vt/wrangler/resharder.go
+++ b/go/vt/wrangler/resharder.go
@@ -334,16 +334,16 @@ func (rs *resharder) createStreams(ctx context.Context) error {
 				OnDdl:         binlogdatapb.OnDDLAction(binlogdatapb.OnDDLAction_value[rs.onDDL]),
 			}
 			ig.AddRow(rs.workflow, bls, "", rs.cell, rs.tabletTypes,
-				int64(binlogdatapb.VReplicationWorkflowType_Reshard),
-				int64(binlogdatapb.VReplicationWorkflowSubType_None),
+				binlogdatapb.VReplicationWorkflowType_Reshard,
+				binlogdatapb.VReplicationWorkflowSubType_None,
 				rs.deferSecondaryKeys)
 		}
 
 		for _, rstream := range rs.refStreams {
 			ig.AddRow(rstream.workflow, rstream.bls, "", rstream.cell, rstream.tabletTypes,
 				//todo: fix based on original stream
-				int64(binlogdatapb.VReplicationWorkflowType_Reshard),
-				int64(binlogdatapb.VReplicationWorkflowSubType_None),
+				binlogdatapb.VReplicationWorkflowType_Reshard,
+				binlogdatapb.VReplicationWorkflowSubType_None,
 				rs.deferSecondaryKeys)
 		}
 		query := ig.String()

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -446,7 +446,7 @@ func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row sqltype
 	var err error
 	var id, timeUpdated, transactionTimestamp, timeHeartbeat, timeThrottled int64
 	var state, dbName, pos, stopPos, message, tags, componentThrottled string
-	var workflowType, workflowSubType int64
+	var workflowType, workflowSubType int32
 	var deferSecondaryKeys bool
 	var bls binlogdatapb.BinlogSource
 	var mpos mysql.Position
@@ -515,8 +515,8 @@ func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row sqltype
 	if err != nil {
 		return nil, "", err
 	}
-	workflowType, _ = row.ToInt64("workflow_type")
-	workflowSubType, _ = row.ToInt64("workflow_sub_type")
+	workflowType, _ = row.ToInt32("workflow_type")
+	workflowSubType, _ = row.ToInt32("workflow_sub_type")
 	deferSecondaryKeys, _ = row.ToBool("defer_secondary_keys")
 
 	status := &ReplicationStatus{
@@ -537,8 +537,8 @@ func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row sqltype
 		Tags:                 tags,
 		sourceTimeZone:       bls.SourceTimeZone,
 		targetTimeZone:       bls.TargetTimeZone,
-		WorkflowType:         binlogdatapb.VReplicationWorkflowType_name[int32(workflowType)],
-		WorkflowSubType:      binlogdatapb.VReplicationWorkflowSubType_name[int32(workflowSubType)],
+		WorkflowType:         binlogdatapb.VReplicationWorkflowType_name[workflowType],
+		WorkflowSubType:      binlogdatapb.VReplicationWorkflowSubType_name[workflowSubType],
 		deferSecondaryKeys:   deferSecondaryKeys,
 	}
 	status.CopyState, err = wr.getCopyState(ctx, primary, id)


### PR DESCRIPTION
This addresses a number of the issues identified by CodeQL around typecasting. We use 32 bit integers for these, so let's make sure we parse and cast then as those everywhere it matters.

## Related Issue(s)

Part of https://github.com/vitessio/vitess/issues/12216

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required