### PR TITLE
Revert "Use ubuntu 20.04 for release builds (#12202)"

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -10,12 +10,7 @@ on:
 jobs:
   build:
     name: Create Release
-    # Use the oldest supported Ubuntu release for vtorc as that uses
-    # sqlite and the library dynamically links in glibc with versioned
-    # symbols. Older libc symbols will allow the vtorc binary we build
-    # to be usable on a wider array of Linux distros. For more
-    # details see: https://github.com/vitessio/vitess/issues/12185
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Set up Go


### PR DESCRIPTION
## Description

The underlying issue has now been addressed in: https://github.com/vitessio/vitess/pull/12214

## Related Issue(s)

  - Related to: https://github.com/vitessio/vitess/issues/12185
  - Follow-up to: https://github.com/vitessio/vitess/pull/12214

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests re not required
-   [x] Documentation is not required