### PR TITLE
Use the correct uint32 type for the GTID file position

### DIFF
--- a/go/mysql/binlog_event_filepos.go
+++ b/go/mysql/binlog_event_filepos.go
@@ -73,12 +73,12 @@ func (ev *filePosBinlogEvent) StripChecksum(f BinlogFormat) (BinlogEvent, []byte
 
 // nextPosition returns the next file position of the binlog.
 // If no information is available, it returns 0.
-func (ev *filePosBinlogEvent) nextPosition(f BinlogFormat) int {
+func (ev *filePosBinlogEvent) nextPosition(f BinlogFormat) uint32 {
 	if f.HeaderLength <= 13 {
 		// Dead code. This is just a failsafe.
 		return 0
 	}
-	return int(binary.LittleEndian.Uint32(ev.Bytes()[13:17]))
+	return binary.LittleEndian.Uint32(ev.Bytes()[13:17])
 }
 
 // rotate implements BinlogEvent.Rotate().
@@ -269,7 +269,7 @@ type filePosGTIDEvent struct {
 	gtid filePosGTID
 }
 
-func newFilePosGTIDEvent(file string, pos int, timestamp uint32) filePosGTIDEvent {
+func newFilePosGTIDEvent(file string, pos uint32, timestamp uint32) filePosGTIDEvent {
 	return filePosGTIDEvent{
 		filePosFakeEvent: filePosFakeEvent{
 			timestamp: timestamp,

--- a/go/mysql/filepos_gtid.go
+++ b/go/mysql/filepos_gtid.go
@@ -33,14 +33,14 @@ func parseFilePosGTID(s string) (GTID, error) {
 		return nil, fmt.Errorf("invalid FilePos GTID (%v): expecting file:pos", s)
 	}
 
-	pos, err := strconv.Atoi(parts[1])
+	pos, err := strconv.ParseUint(parts[1], 0, 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid FilePos GTID (%v): expecting pos to be an integer", s)
 	}
 
 	return filePosGTID{
 		file: parts[0],
-		pos:  pos,
+		pos:  uint32(pos),
 	}, nil
 }
 
@@ -56,7 +56,7 @@ func ParseFilePosGTIDSet(s string) (GTIDSet, error) {
 // filePosGTID implements GTID.
 type filePosGTID struct {
 	file string
-	pos  int
+	pos  uint32
 }
 
 // String implements GTID.String().

--- a/go/mysql/filepos_gtid_test.go
+++ b/go/mysql/filepos_gtid_test.go
@@ -23,7 +23,7 @@ import (
 func Test_filePosGTID_String(t *testing.T) {
 	type fields struct {
 		file string
-		pos  int
+		pos  uint32
 	}
 	tests := []struct {
 		name   string
@@ -52,7 +52,7 @@ func Test_filePosGTID_String(t *testing.T) {
 func Test_filePosGTID_ContainsGTID(t *testing.T) {
 	type fields struct {
 		file string
-		pos  int
+		pos  uint32
 	}
 	type args struct {
 		other GTID

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -17,12 +17,11 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
@@ -479,11 +478,11 @@ func parseReplicationStatus(fields map[string]string) ReplicationStatus {
 	executedPosStr := fields["Exec_Master_Log_Pos"]
 	file := fields["Relay_Master_Log_File"]
 	if file != "" && executedPosStr != "" {
-		filePos, err := strconv.Atoi(executedPosStr)
+		filePos, err := strconv.ParseUint(executedPosStr, 10, 32)
 		if err == nil {
 			status.FilePosition.GTIDSet = filePosGTID{
 				file: file,
-				pos:  filePos,
+				pos:  uint32(filePos),
 			}
 		}
 	}
@@ -491,11 +490,11 @@ func parseReplicationStatus(fields map[string]string) ReplicationStatus {
 	readPosStr := fields["Read_Master_Log_Pos"]
 	file = fields["Master_Log_File"]
 	if file != "" && readPosStr != "" {
-		fileRelayPos, err := strconv.Atoi(readPosStr)
+		fileRelayPos, err := strconv.ParseUint(readPosStr, 10, 32)
 		if err == nil {
 			status.RelayLogSourceBinlogEquivalentPosition.GTIDSet = filePosGTID{
 				file: file,
-				pos:  fileRelayPos,
+				pos:  uint32(fileRelayPos),
 			}
 		}
 	}
@@ -503,11 +502,11 @@ func parseReplicationStatus(fields map[string]string) ReplicationStatus {
 	relayPosStr := fields["Relay_Log_Pos"]
 	file = fields["Relay_Log_File"]
 	if file != "" && relayPosStr != "" {
-		relayFilePos, err := strconv.Atoi(relayPosStr)
+		relayFilePos, err := strconv.ParseUint(relayPosStr, 10, 32)
 		if err == nil {
 			status.RelayLogFilePosition.GTIDSet = filePosGTID{
 				file: file,
-				pos:  relayFilePos,
+				pos:  uint32(relayFilePos),
 			}
 		}
 	}
@@ -527,11 +526,11 @@ func parsePrimaryStatus(fields map[string]string) PrimaryStatus {
 	fileExecPosStr := fields["Position"]
 	file := fields["File"]
 	if file != "" && fileExecPosStr != "" {
-		filePos, err := strconv.Atoi(fileExecPosStr)
+		filePos, err := strconv.ParseUint(fileExecPosStr, 10, 32)
 		if err == nil {
 			status.FilePosition.GTIDSet = filePosGTID{
 				file: file,
-				pos:  filePos,
+				pos:  uint32(filePos),
 			}
 		}
 	}

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -53,14 +53,14 @@ func (flv *filePosFlavor) primaryGTIDSet(c *Conn) (GTIDSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	pos, err := strconv.Atoi(resultMap["Position"])
+	pos, err := strconv.ParseUint(resultMap["Position"], 0, 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid FilePos GTID (%v): expecting pos to be an integer", resultMap["Position"])
 	}
 
 	return filePosGTID{
 		file: resultMap["File"],
-		pos:  pos,
+		pos:  uint32(pos),
 	}, nil
 }
 
@@ -126,7 +126,7 @@ func (flv *filePosFlavor) sendBinlogDumpCommand(c *Conn, serverID uint32, binlog
 	}
 
 	flv.file = rpos.file
-	return c.WriteComBinlogDump(serverID, rpos.file, uint32(rpos.pos), 0)
+	return c.WriteComBinlogDump(serverID, rpos.file, rpos.pos, 0)
 }
 
 // readBinlogEvent is part of the Flavor interface.


### PR DESCRIPTION
This is defined as uint32 at the protocol level, so better to use that type consistently and also parse it accordingly with `ParseUint` with the right size.

## Related Issue(s)

Part of #12216 as this was flagged there.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required