### PR TITLE
Prevent bootstrap of ZK from clearing previous dist binaries

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -127,16 +127,14 @@ install_zookeeper() {
   local version="$1"
   local dist="$2"
   zk="zookeeper-$version"
-  vtzk="vt-zookeeper-$version"
   # This is how we'd download directly from source:
   # wget "https://dlcdn.apache.org/zookeeper/$zk/apache-$zk.tar.gz"
   $VTROOT/tools/wget-retry "${VITESS_RESOURCES_DOWNLOAD_URL}/apache-${zk}.tar.gz"
   tar -xzf "$dist/apache-$zk.tar.gz"
-  mv $dist/apache-$zk $dist/$vtzk
-  mvn -f $dist/$vtzk/zookeeper-contrib/zookeeper-contrib-fatjar/pom.xml clean install -P fatjar -DskipTests
-  mkdir -p $dist/$vtzk/lib
-  cp "$dist/$vtzk/zookeeper-contrib/zookeeper-contrib-fatjar/target/$zk-fatjar.jar" "$dist/$vtzk/lib/$zk-fatjar.jar"
-  rm -rf "$zk.tar.gz"
+  mvn -f $dist/apache-$zk/zookeeper-contrib/zookeeper-contrib-fatjar/pom.xml clean install -P fatjar -DskipTests
+  mkdir -p $dist/lib
+  cp "$dist/apache-$zk/zookeeper-contrib/zookeeper-contrib-fatjar/target/$zk-fatjar.jar" "$dist/lib/$zk-fatjar.jar"
+  rm -rf "$dist/apache-$zk"
 }
 
 
@@ -270,7 +268,7 @@ install_all() {
   # zk
   zk_ver=${ZK_VERSION:-3.8.0}
   if [ "$BUILD_JAVA" == 1 ] ; then
-    install_dep "Zookeeper" "$zk_ver" "$VTROOT/dist" install_zookeeper
+    install_dep "Zookeeper" "$zk_ver" "$VTROOT/dist/vt-zookeeper-$zk_ver" install_zookeeper
   fi
 
   # etcd


### PR DESCRIPTION
## Description

Presently [protoc bootstrap](https://github.com/vitessio/vitess/blob/b09ce8baee19144ec28e6753714a6dae74907d1d/bootstrap.sh#L268) gets wiped out by [ZK bootstrap](https://github.com/vitessio/vitess/blob/b09ce8baee19144ec28e6753714a6dae74907d1d/bootstrap.sh#L273) via [this rm](https://github.com/vitessio/vitess/blob/b09ce8baee19144ec28e6753714a6dae74907d1d/bootstrap.sh#L65) in `install_dep`. The fix in this patch is to invoke `install_dep` for ZK with subdir of `dist/` instead of the top-level `dist/`, similar to the other deps.

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

N/A