### PR TITLE
Fix typecasting alerts inside vtgate engine

### DIFF
--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -466,11 +466,11 @@ func (ins *Insert) getInsertSelectQueries(
 		bvs := sqltypes.CopyBindVariables(bindVars) // we don't want to create one huge bindvars for all values
 		var mids sqlparser.Values
 		for _, indexValue := range indexesPerRss[i] {
-			index, _ := strconv.ParseInt(string(indexValue.Value), 0, 64)
+			index, _ := strconv.Atoi(string(indexValue.Value))
 			if keyspaceIDs[index] != nil {
 				row := sqlparser.ValTuple{}
 				for colOffset, value := range rows[index] {
-					bvName := insertVarOffset(int(index), colOffset)
+					bvName := insertVarOffset(index, colOffset)
 					bvs[bvName] = sqltypes.ValueBindVariable(value)
 					row = append(row, sqlparser.NewArgument(bvName))
 				}

--- a/go/vt/vtgate/engine/limit.go
+++ b/go/vt/vtgate/engine/limit.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
@@ -188,13 +189,13 @@ func getIntFrom(env *evalengine.ExpressionEnv, expr evalengine.Expr) (int, error
 		return 0, nil
 	}
 
-	num, err := value.ToUint64()
-	if err != nil {
-		return 0, err
+	if !value.IsIntegral() {
+		return 0, sqltypes.ErrIncompatibleTypeCast
 	}
-	count := int(num)
-	if count < 0 {
-		return 0, fmt.Errorf("requested limit is out of range: %v", num)
+
+	count, err := strconv.Atoi(value.RawStr())
+	if err != nil || count < 0 {
+		return 0, fmt.Errorf("requested limit is out of range: %v", value.RawStr())
 	}
 	return count, nil
 }


### PR DESCRIPTION
CodeQL reported a few cases in the vtgate engine where we can simplify and make the typecasting more correct.

We were double casting for the eval as well which isn't useful, so reduce this to it doing one for the hash code.

## Related Issue(s)

Part of #12216 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required