### PR TITLE
Change SQL error codes to use explicit type

### DIFF
--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 // assertSQLError makes sure we get the right error.
-func assertSQLError(t *testing.T, err error, code int, sqlState, subtext, query, pattern string) {
+func assertSQLError(t *testing.T, err error, code ErrorCode, sqlState, subtext, query, pattern string) {
 	t.Helper()
 
 	require.Error(t, err, "was expecting SQLError %v / %v / %v but got no error.", code, sqlState, subtext)

--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"strconv"
 	"strings"
 
 	"golang.org/x/text/encoding"
@@ -280,30 +281,30 @@ const (
 // https://dev.mysql.com/doc/mysql-errors/en/client-error-reference.html
 const (
 	// CRUnknownError is CR_UNKNOWN_ERROR
-	CRUnknownError = 2000
+	CRUnknownError = ErrorCode(2000)
 
 	// CRConnectionError is CR_CONNECTION_ERROR
 	// This is returned if a connection via a Unix socket fails.
-	CRConnectionError = 2002
+	CRConnectionError = ErrorCode(2002)
 
 	// CRConnHostError is CR_CONN_HOST_ERROR
 	// This is returned if a connection via a TCP socket fails.
-	CRConnHostError = 2003
+	CRConnHostError = ErrorCode(2003)
 
 	// CRUnknownHost is CR_UNKNOWN_HOST
 	// This is returned if the host name cannot be resolved.
-	CRUnknownHost = 2005
+	CRUnknownHost = ErrorCode(2005)
 
 	// CRServerGone is CR_SERVER_GONE_ERROR.
 	// This is returned if the client tries to send a command but it fails.
-	CRServerGone = 2006
+	CRServerGone = ErrorCode(2006)
 
 	// CRVersionError is CR_VERSION_ERROR
 	// This is returned if the server versions don't match what we support.
-	CRVersionError = 2007
+	CRVersionError = ErrorCode(2007)
 
 	// CRServerHandshakeErr is CR_SERVER_HANDSHAKE_ERR
-	CRServerHandshakeErr = 2012
+	CRServerHandshakeErr = ErrorCode(2012)
 
 	// CRServerLost is CR_SERVER_LOST.
 	// Used when:
@@ -311,25 +312,31 @@ const (
 	// - the client cannot read an initial auth packet.
 	// - the client cannot read a response from the server.
 	//     This happens when a running query is killed.
-	CRServerLost = 2013
+	CRServerLost = ErrorCode(2013)
 
 	// CRCommandsOutOfSync is CR_COMMANDS_OUT_OF_SYNC
 	// Sent when the streaming calls are not done in the right order.
-	CRCommandsOutOfSync = 2014
+	CRCommandsOutOfSync = ErrorCode(2014)
 
 	// CRNamedPipeStateError is CR_NAMEDPIPESETSTATE_ERROR.
 	// This is the highest possible number for a connection error.
-	CRNamedPipeStateError = 2018
+	CRNamedPipeStateError = ErrorCode(2018)
 
 	// CRCantReadCharset is CR_CANT_READ_CHARSET
-	CRCantReadCharset = 2019
+	CRCantReadCharset = ErrorCode(2019)
 
 	// CRSSLConnectionError is CR_SSL_CONNECTION_ERROR
-	CRSSLConnectionError = 2026
+	CRSSLConnectionError = ErrorCode(2026)
 
 	// CRMalformedPacket is CR_MALFORMED_PACKET
-	CRMalformedPacket = 2027
+	CRMalformedPacket = ErrorCode(2027)
 )
+
+type ErrorCode uint16
+
+func (e ErrorCode) ToString() string {
+	return strconv.FormatUint(uint64(e), 10)
+}
 
 // Error codes for server-side errors.
 // Originally found in include/mysql/mysqld_error.h and
@@ -338,231 +345,231 @@ const (
 // See above reference for more information on each code.
 const (
 	// Vitess specific errors, (100-999)
-	ERNotReplica = 100
+	ERNotReplica = ErrorCode(100)
 
 	// unknown
-	ERUnknownError = 1105
+	ERUnknownError = ErrorCode(1105)
 
 	// internal
-	ERInternalError = 1815
+	ERInternalError = ErrorCode(1815)
 
 	// unimplemented
-	ERNotSupportedYet = 1235
-	ERUnsupportedPS   = 1295
+	ERNotSupportedYet = ErrorCode(1235)
+	ERUnsupportedPS   = ErrorCode(1295)
 
 	// resource exhausted
-	ERDiskFull               = 1021
-	EROutOfMemory            = 1037
-	EROutOfSortMemory        = 1038
-	ERConCount               = 1040
-	EROutOfResources         = 1041
-	ERRecordFileFull         = 1114
-	ERHostIsBlocked          = 1129
-	ERCantCreateThread       = 1135
-	ERTooManyDelayedThreads  = 1151
-	ERNetPacketTooLarge      = 1153
-	ERTooManyUserConnections = 1203
-	ERLockTableFull          = 1206
-	ERUserLimitReached       = 1226
+	ERDiskFull               = ErrorCode(1021)
+	EROutOfMemory            = ErrorCode(1037)
+	EROutOfSortMemory        = ErrorCode(1038)
+	ERConCount               = ErrorCode(1040)
+	EROutOfResources         = ErrorCode(1041)
+	ERRecordFileFull         = ErrorCode(1114)
+	ERHostIsBlocked          = ErrorCode(1129)
+	ERCantCreateThread       = ErrorCode(1135)
+	ERTooManyDelayedThreads  = ErrorCode(1151)
+	ERNetPacketTooLarge      = ErrorCode(1153)
+	ERTooManyUserConnections = ErrorCode(1203)
+	ERLockTableFull          = ErrorCode(1206)
+	ERUserLimitReached       = ErrorCode(1226)
 
 	// deadline exceeded
-	ERLockWaitTimeout = 1205
+	ERLockWaitTimeout = ErrorCode(1205)
 
 	// unavailable
-	ERServerShutdown = 1053
+	ERServerShutdown = ErrorCode(1053)
 
 	// not found
-	ERDbDropExists          = 1008
-	ERCantFindFile          = 1017
-	ERFormNotFound          = 1029
-	ERKeyNotFound           = 1032
-	ERBadFieldError         = 1054
-	ERNoSuchThread          = 1094
-	ERUnknownTable          = 1109
-	ERCantFindUDF           = 1122
-	ERNonExistingGrant      = 1141
-	ERNoSuchTable           = 1146
-	ERNonExistingTableGrant = 1147
-	ERKeyDoesNotExist       = 1176
+	ERDbDropExists          = ErrorCode(1008)
+	ERCantFindFile          = ErrorCode(1017)
+	ERFormNotFound          = ErrorCode(1029)
+	ERKeyNotFound           = ErrorCode(1032)
+	ERBadFieldError         = ErrorCode(1054)
+	ERNoSuchThread          = ErrorCode(1094)
+	ERUnknownTable          = ErrorCode(1109)
+	ERCantFindUDF           = ErrorCode(1122)
+	ERNonExistingGrant      = ErrorCode(1141)
+	ERNoSuchTable           = ErrorCode(1146)
+	ERNonExistingTableGrant = ErrorCode(1147)
+	ERKeyDoesNotExist       = ErrorCode(1176)
 
 	// permissions
-	ERDBAccessDenied            = 1044
-	ERAccessDeniedError         = 1045
-	ERKillDenied                = 1095
-	ERNoPermissionToCreateUsers = 1211
-	ERSpecifiedAccessDenied     = 1227
+	ERDBAccessDenied            = ErrorCode(1044)
+	ERAccessDeniedError         = ErrorCode(1045)
+	ERKillDenied                = ErrorCode(1095)
+	ERNoPermissionToCreateUsers = ErrorCode(1211)
+	ERSpecifiedAccessDenied     = ErrorCode(1227)
 
 	// failed precondition
-	ERNoDb                          = 1046
-	ERNoSuchIndex                   = 1082
-	ERCantDropFieldOrKey            = 1091
-	ERTableNotLockedForWrite        = 1099
-	ERTableNotLocked                = 1100
-	ERTooBigSelect                  = 1104
-	ERNotAllowedCommand             = 1148
-	ERTooLongString                 = 1162
-	ERDelayedInsertTableLocked      = 1165
-	ERDupUnique                     = 1169
-	ERRequiresPrimaryKey            = 1173
-	ERCantDoThisDuringAnTransaction = 1179
-	ERReadOnlyTransaction           = 1207
-	ERCannotAddForeign              = 1215
-	ERNoReferencedRow               = 1216
-	ERRowIsReferenced               = 1217
-	ERCantUpdateWithReadLock        = 1223
-	ERNoDefault                     = 1230
-	ERMasterFatalReadingBinlog      = 1236
-	EROperandColumns                = 1241
-	ERSubqueryNo1Row                = 1242
-	ERWarnDataOutOfRange            = 1264
-	ERNonUpdateableTable            = 1288
-	ERFeatureDisabled               = 1289
-	EROptionPreventsStatement       = 1290
-	ERDuplicatedValueInType         = 1291
-	ERSPDoesNotExist                = 1305
-	ERNoDefaultForField             = 1364
-	ErSPNotVarArg                   = 1414
-	ERRowIsReferenced2              = 1451
-	ErNoReferencedRow2              = 1452
-	ERDupIndex                      = 1831
-	ERInnodbReadOnly                = 1874
+	ERNoDb                          = ErrorCode(1046)
+	ERNoSuchIndex                   = ErrorCode(1082)
+	ERCantDropFieldOrKey            = ErrorCode(1091)
+	ERTableNotLockedForWrite        = ErrorCode(1099)
+	ERTableNotLocked                = ErrorCode(1100)
+	ERTooBigSelect                  = ErrorCode(1104)
+	ERNotAllowedCommand             = ErrorCode(1148)
+	ERTooLongString                 = ErrorCode(1162)
+	ERDelayedInsertTableLocked      = ErrorCode(1165)
+	ERDupUnique                     = ErrorCode(1169)
+	ERRequiresPrimaryKey            = ErrorCode(1173)
+	ERCantDoThisDuringAnTransaction = ErrorCode(1179)
+	ERReadOnlyTransaction           = ErrorCode(1207)
+	ERCannotAddForeign              = ErrorCode(1215)
+	ERNoReferencedRow               = ErrorCode(1216)
+	ERRowIsReferenced               = ErrorCode(1217)
+	ERCantUpdateWithReadLock        = ErrorCode(1223)
+	ERNoDefault                     = ErrorCode(1230)
+	ERMasterFatalReadingBinlog      = ErrorCode(1236)
+	EROperandColumns                = ErrorCode(1241)
+	ERSubqueryNo1Row                = ErrorCode(1242)
+	ERWarnDataOutOfRange            = ErrorCode(1264)
+	ERNonUpdateableTable            = ErrorCode(1288)
+	ERFeatureDisabled               = ErrorCode(1289)
+	EROptionPreventsStatement       = ErrorCode(1290)
+	ERDuplicatedValueInType         = ErrorCode(1291)
+	ERSPDoesNotExist                = ErrorCode(1305)
+	ERNoDefaultForField             = ErrorCode(1364)
+	ErSPNotVarArg                   = ErrorCode(1414)
+	ERRowIsReferenced2              = ErrorCode(1451)
+	ErNoReferencedRow2              = ErrorCode(1452)
+	ERDupIndex                      = ErrorCode(1831)
+	ERInnodbReadOnly                = ErrorCode(1874)
 
 	// already exists
-	ERDbCreateExists = 1007
-	ERTableExists    = 1050
-	ERDupEntry       = 1062
-	ERFileExists     = 1086
-	ERUDFExists      = 1125
+	ERDbCreateExists = ErrorCode(1007)
+	ERTableExists    = ErrorCode(1050)
+	ERDupEntry       = ErrorCode(1062)
+	ERFileExists     = ErrorCode(1086)
+	ERUDFExists      = ErrorCode(1125)
 
 	// aborted
-	ERGotSignal          = 1078
-	ERForcingClose       = 1080
-	ERAbortingConnection = 1152
-	ERLockDeadlock       = 1213
+	ERGotSignal          = ErrorCode(1078)
+	ERForcingClose       = ErrorCode(1080)
+	ERAbortingConnection = ErrorCode(1152)
+	ERLockDeadlock       = ErrorCode(1213)
 
 	// invalid arg
-	ERUnknownComError              = 1047
-	ERBadNullError                 = 1048
-	ERBadDb                        = 1049
-	ERBadTable                     = 1051
-	ERNonUniq                      = 1052
-	ERWrongFieldWithGroup          = 1055
-	ERWrongGroupField              = 1056
-	ERWrongSumSelect               = 1057
-	ERWrongValueCount              = 1058
-	ERTooLongIdent                 = 1059
-	ERDupFieldName                 = 1060
-	ERDupKeyName                   = 1061
-	ERWrongFieldSpec               = 1063
-	ERParseError                   = 1064
-	EREmptyQuery                   = 1065
-	ERNonUniqTable                 = 1066
-	ERInvalidDefault               = 1067
-	ERMultiplePriKey               = 1068
-	ERTooManyKeys                  = 1069
-	ERTooManyKeyParts              = 1070
-	ERTooLongKey                   = 1071
-	ERKeyColumnDoesNotExist        = 1072
-	ERBlobUsedAsKey                = 1073
-	ERTooBigFieldLength            = 1074
-	ERWrongAutoKey                 = 1075
-	ERWrongFieldTerminators        = 1083
-	ERBlobsAndNoTerminated         = 1084
-	ERTextFileNotReadable          = 1085
-	ERWrongSubKey                  = 1089
-	ERCantRemoveAllFields          = 1090
-	ERUpdateTableUsed              = 1093
-	ERNoTablesUsed                 = 1096
-	ERTooBigSet                    = 1097
-	ERBlobCantHaveDefault          = 1101
-	ERWrongDbName                  = 1102
-	ERWrongTableName               = 1103
-	ERUnknownProcedure             = 1106
-	ERWrongParamCountToProcedure   = 1107
-	ERWrongParametersToProcedure   = 1108
-	ERFieldSpecifiedTwice          = 1110
-	ERInvalidGroupFuncUse          = 1111
-	ERTableMustHaveColumns         = 1113
-	ERUnknownCharacterSet          = 1115
-	ERTooManyTables                = 1116
-	ERTooManyFields                = 1117
-	ERTooBigRowSize                = 1118
-	ERWrongOuterJoin               = 1120
-	ERNullColumnInIndex            = 1121
-	ERFunctionNotDefined           = 1128
-	ERWrongValueCountOnRow         = 1136
-	ERInvalidUseOfNull             = 1138
-	ERRegexpError                  = 1139
-	ERMixOfGroupFuncAndFields      = 1140
-	ERIllegalGrantForTable         = 1144
-	ERSyntaxError                  = 1149
-	ERWrongColumnName              = 1166
-	ERWrongKeyColumn               = 1167
-	ERBlobKeyWithoutLength         = 1170
-	ERPrimaryCantHaveNull          = 1171
-	ERTooManyRows                  = 1172
-	ERLockOrActiveTransaction      = 1192
-	ERUnknownSystemVariable        = 1193
-	ERSetConstantsOnly             = 1204
-	ERWrongArguments               = 1210
-	ERWrongUsage                   = 1221
-	ERWrongNumberOfColumnsInSelect = 1222
-	ERDupArgument                  = 1225
-	ERLocalVariable                = 1228
-	ERGlobalVariable               = 1229
-	ERWrongValueForVar             = 1231
-	ERWrongTypeForVar              = 1232
-	ERVarCantBeRead                = 1233
-	ERCantUseOptionHere            = 1234
-	ERIncorrectGlobalLocalVar      = 1238
-	ERWrongFKDef                   = 1239
-	ERKeyRefDoNotMatchTableRef     = 1240
-	ERCyclicReference              = 1245
-	ERIllegalReference             = 1247
-	ERDerivedMustHaveAlias         = 1248
-	ERTableNameNotAllowedHere      = 1250
-	ERCollationCharsetMismatch     = 1253
-	ERWarnDataTruncated            = 1265
-	ERCantAggregate2Collations     = 1267
-	ERCantAggregate3Collations     = 1270
-	ERCantAggregateNCollations     = 1271
-	ERVariableIsNotStruct          = 1272
-	ERUnknownCollation             = 1273
-	ERWrongNameForIndex            = 1280
-	ERWrongNameForCatalog          = 1281
-	ERBadFTColumn                  = 1283
-	ERTruncatedWrongValue          = 1292
-	ERTooMuchAutoTimestampCols     = 1293
-	ERInvalidOnUpdate              = 1294
-	ERUnknownTimeZone              = 1298
-	ERInvalidCharacterString       = 1300
-	ERQueryInterrupted             = 1317
-	ERTruncatedWrongValueForField  = 1366
-	ERIllegalValueForType          = 1367
-	ERDataTooLong                  = 1406
-	ErrWrongValueForType           = 1411
-	ERForbidSchemaChange           = 1450
-	ERWrongValue                   = 1525
-	ERDataOutOfRange               = 1690
-	ERInvalidJSONText              = 3140
-	ERInvalidJSONTextInParams      = 3141
-	ERInvalidJSONBinaryData        = 3142
-	ERInvalidJSONCharset           = 3144
-	ERInvalidCastToJSON            = 3147
-	ERJSONValueTooBig              = 3150
-	ERJSONDocumentTooDeep          = 3157
+	ERUnknownComError              = ErrorCode(1047)
+	ERBadNullError                 = ErrorCode(1048)
+	ERBadDb                        = ErrorCode(1049)
+	ERBadTable                     = ErrorCode(1051)
+	ERNonUniq                      = ErrorCode(1052)
+	ERWrongFieldWithGroup          = ErrorCode(1055)
+	ERWrongGroupField              = ErrorCode(1056)
+	ERWrongSumSelect               = ErrorCode(1057)
+	ERWrongValueCount              = ErrorCode(1058)
+	ERTooLongIdent                 = ErrorCode(1059)
+	ERDupFieldName                 = ErrorCode(1060)
+	ERDupKeyName                   = ErrorCode(1061)
+	ERWrongFieldSpec               = ErrorCode(1063)
+	ERParseError                   = ErrorCode(1064)
+	EREmptyQuery                   = ErrorCode(1065)
+	ERNonUniqTable                 = ErrorCode(1066)
+	ERInvalidDefault               = ErrorCode(1067)
+	ERMultiplePriKey               = ErrorCode(1068)
+	ERTooManyKeys                  = ErrorCode(1069)
+	ERTooManyKeyParts              = ErrorCode(1070)
+	ERTooLongKey                   = ErrorCode(1071)
+	ERKeyColumnDoesNotExist        = ErrorCode(1072)
+	ERBlobUsedAsKey                = ErrorCode(1073)
+	ERTooBigFieldLength            = ErrorCode(1074)
+	ERWrongAutoKey                 = ErrorCode(1075)
+	ERWrongFieldTerminators        = ErrorCode(1083)
+	ERBlobsAndNoTerminated         = ErrorCode(1084)
+	ERTextFileNotReadable          = ErrorCode(1085)
+	ERWrongSubKey                  = ErrorCode(1089)
+	ERCantRemoveAllFields          = ErrorCode(1090)
+	ERUpdateTableUsed              = ErrorCode(1093)
+	ERNoTablesUsed                 = ErrorCode(1096)
+	ERTooBigSet                    = ErrorCode(1097)
+	ERBlobCantHaveDefault          = ErrorCode(1101)
+	ERWrongDbName                  = ErrorCode(1102)
+	ERWrongTableName               = ErrorCode(1103)
+	ERUnknownProcedure             = ErrorCode(1106)
+	ERWrongParamCountToProcedure   = ErrorCode(1107)
+	ERWrongParametersToProcedure   = ErrorCode(1108)
+	ERFieldSpecifiedTwice          = ErrorCode(1110)
+	ERInvalidGroupFuncUse          = ErrorCode(1111)
+	ERTableMustHaveColumns         = ErrorCode(1113)
+	ERUnknownCharacterSet          = ErrorCode(1115)
+	ERTooManyTables                = ErrorCode(1116)
+	ERTooManyFields                = ErrorCode(1117)
+	ERTooBigRowSize                = ErrorCode(1118)
+	ERWrongOuterJoin               = ErrorCode(1120)
+	ERNullColumnInIndex            = ErrorCode(1121)
+	ERFunctionNotDefined           = ErrorCode(1128)
+	ERWrongValueCountOnRow         = ErrorCode(1136)
+	ERInvalidUseOfNull             = ErrorCode(1138)
+	ERRegexpError                  = ErrorCode(1139)
+	ERMixOfGroupFuncAndFields      = ErrorCode(1140)
+	ERIllegalGrantForTable         = ErrorCode(1144)
+	ERSyntaxError                  = ErrorCode(1149)
+	ERWrongColumnName              = ErrorCode(1166)
+	ERWrongKeyColumn               = ErrorCode(1167)
+	ERBlobKeyWithoutLength         = ErrorCode(1170)
+	ERPrimaryCantHaveNull          = ErrorCode(1171)
+	ERTooManyRows                  = ErrorCode(1172)
+	ERLockOrActiveTransaction      = ErrorCode(1192)
+	ERUnknownSystemVariable        = ErrorCode(1193)
+	ERSetConstantsOnly             = ErrorCode(1204)
+	ERWrongArguments               = ErrorCode(1210)
+	ERWrongUsage                   = ErrorCode(1221)
+	ERWrongNumberOfColumnsInSelect = ErrorCode(1222)
+	ERDupArgument                  = ErrorCode(1225)
+	ERLocalVariable                = ErrorCode(1228)
+	ERGlobalVariable               = ErrorCode(1229)
+	ERWrongValueForVar             = ErrorCode(1231)
+	ERWrongTypeForVar              = ErrorCode(1232)
+	ERVarCantBeRead                = ErrorCode(1233)
+	ERCantUseOptionHere            = ErrorCode(1234)
+	ERIncorrectGlobalLocalVar      = ErrorCode(1238)
+	ERWrongFKDef                   = ErrorCode(1239)
+	ERKeyRefDoNotMatchTableRef     = ErrorCode(1240)
+	ERCyclicReference              = ErrorCode(1245)
+	ERIllegalReference             = ErrorCode(1247)
+	ERDerivedMustHaveAlias         = ErrorCode(1248)
+	ERTableNameNotAllowedHere      = ErrorCode(1250)
+	ERCollationCharsetMismatch     = ErrorCode(1253)
+	ERWarnDataTruncated            = ErrorCode(1265)
+	ERCantAggregate2Collations     = ErrorCode(1267)
+	ERCantAggregate3Collations     = ErrorCode(1270)
+	ERCantAggregateNCollations     = ErrorCode(1271)
+	ERVariableIsNotStruct          = ErrorCode(1272)
+	ERUnknownCollation             = ErrorCode(1273)
+	ERWrongNameForIndex            = ErrorCode(1280)
+	ERWrongNameForCatalog          = ErrorCode(1281)
+	ERBadFTColumn                  = ErrorCode(1283)
+	ERTruncatedWrongValue          = ErrorCode(1292)
+	ERTooMuchAutoTimestampCols     = ErrorCode(1293)
+	ERInvalidOnUpdate              = ErrorCode(1294)
+	ERUnknownTimeZone              = ErrorCode(1298)
+	ERInvalidCharacterString       = ErrorCode(1300)
+	ERQueryInterrupted             = ErrorCode(1317)
+	ERTruncatedWrongValueForField  = ErrorCode(1366)
+	ERIllegalValueForType          = ErrorCode(1367)
+	ERDataTooLong                  = ErrorCode(1406)
+	ErrWrongValueForType           = ErrorCode(1411)
+	ERForbidSchemaChange           = ErrorCode(1450)
+	ERWrongValue                   = ErrorCode(1525)
+	ERDataOutOfRange               = ErrorCode(1690)
+	ERInvalidJSONText              = ErrorCode(3140)
+	ERInvalidJSONTextInParams      = ErrorCode(3141)
+	ERInvalidJSONBinaryData        = ErrorCode(3142)
+	ERInvalidJSONCharset           = ErrorCode(3144)
+	ERInvalidCastToJSON            = ErrorCode(3147)
+	ERJSONValueTooBig              = ErrorCode(3150)
+	ERJSONDocumentTooDeep          = ErrorCode(3157)
 
 	// max execution time exceeded
-	ERQueryTimeout = 3024
+	ERQueryTimeout = ErrorCode(3024)
 
-	ErrCantCreateGeometryObject      = 1416
-	ErrGISDataWrongEndianess         = 3055
-	ErrNotImplementedForCartesianSRS = 3704
-	ErrNotImplementedForProjectedSRS = 3705
-	ErrNonPositiveRadius             = 3706
+	ErrCantCreateGeometryObject      = ErrorCode(1416)
+	ErrGISDataWrongEndianess         = ErrorCode(3055)
+	ErrNotImplementedForCartesianSRS = ErrorCode(3704)
+	ErrNotImplementedForProjectedSRS = ErrorCode(3705)
+	ErrNonPositiveRadius             = ErrorCode(3706)
 
 	// server not available
-	ERServerIsntAvailable = 3168
+	ERServerIsntAvailable = ErrorCode(3168)
 )
 
 // Sql states for errors.

--- a/go/mysql/endtoend/main_test.go
+++ b/go/mysql/endtoend/main_test.go
@@ -41,7 +41,7 @@ var (
 )
 
 // assertSQLError makes sure we get the right error.
-func assertSQLError(t *testing.T, err error, code int, sqlState string, subtext string, query string) {
+func assertSQLError(t *testing.T, err error, code mysql.ErrorCode, sqlState string, subtext string, query string) {
 	t.Helper()
 	require.Error(t, err, "was expecting SQLError %v / %v / %v but got no error.", code, sqlState, subtext)
 

--- a/go/mysql/server_flaky_test.go
+++ b/go/mysql/server_flaky_test.go
@@ -1233,7 +1233,7 @@ func TestErrorCodes(t *testing.T) {
 	// internal vitess errors
 	tests := []struct {
 		err      error
-		code     int
+		code     ErrorCode
 		sqlState string
 		text     string
 	}{

--- a/go/mysql/sql_error_test.go
+++ b/go/mysql/sql_error_test.go
@@ -28,7 +28,7 @@ import (
 func TestDumuxResourceExhaustedErrors(t *testing.T) {
 	type testCase struct {
 		msg  string
-		want int
+		want ErrorCode
 	}
 
 	cases := []testCase{
@@ -53,7 +53,7 @@ func TestDumuxResourceExhaustedErrors(t *testing.T) {
 func TestNewSQLErrorFromError(t *testing.T) {
 	var tCases = []struct {
 		err error
-		num int
+		num ErrorCode
 		ss  string
 	}{
 		{

--- a/go/test/endtoend/mysqlserver/mysql_server_test.go
+++ b/go/test/endtoend/mysqlserver/mysql_server_test.go
@@ -19,6 +19,7 @@ package mysqlserver
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"net/http"
@@ -33,8 +34,6 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
-
-	"database/sql"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -119,7 +118,7 @@ func TestTimeout(t *testing.T) {
 	require.NotNilf(t, err, "quiry timeout error expected")
 	mysqlErr, ok := err.(*mysql.SQLError)
 	require.Truef(t, ok, "invalid error type")
-	assert.Equal(t, 1317, mysqlErr.Number(), err)
+	assert.Equal(t, mysql.ERQueryInterrupted, mysqlErr.Number(), err)
 }
 
 // TestInvalidField tries to fetch invalid column and verifies the error.
@@ -135,7 +134,7 @@ func TestInvalidField(t *testing.T) {
 	require.NotNil(t, err, "invalid field error expected")
 	mysqlErr, ok := err.(*mysql.SQLError)
 	require.Truef(t, ok, "invalid error type")
-	assert.Equal(t, 1054, mysqlErr.Number(), err)
+	assert.Equal(t, mysql.ERBadFieldError, mysqlErr.Number(), err)
 }
 
 // TestWarnings validates the behaviour of SHOW WARNINGS.

--- a/go/test/endtoend/vtgate/errors_as_warnings/main_test.go
+++ b/go/test/endtoend/vtgate/errors_as_warnings/main_test.go
@@ -148,7 +148,7 @@ func TestScatterErrsAsWarns(t *testing.T) {
 			_, err = mode.conn.ExecuteFetch("SELECT /*vt+ PLANNER=Gen4 SCATTER_ERRORS_AS_WARNINGS */ invalid_field from t1;", 1, false)
 			require.Error(t, err)
 			serr := mysql.NewSQLErrorFromError(err).(*mysql.SQLError)
-			require.Equal(t, 1054, serr.Number(), serr.Error())
+			require.Equal(t, mysql.ERBadFieldError, serr.Number(), serr.Error())
 		})
 	}
 }

--- a/go/test/endtoend/vtgate/lookup_test.go
+++ b/go/test/endtoend/vtgate/lookup_test.go
@@ -129,7 +129,7 @@ func TestConsistentLookup(t *testing.T) {
 	utils.Exec(t, conn, "rollback")
 	require.Error(t, err)
 	mysqlErr := err.(*mysql.SQLError)
-	assert.Equal(t, 1062, mysqlErr.Num)
+	assert.Equal(t, mysql.ERDupEntry, mysqlErr.Num)
 	assert.Equal(t, "23000", mysqlErr.State)
 	assert.Contains(t, mysqlErr.Message, "reverted partial DML execution")
 

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -695,7 +695,7 @@ func TestDescribeVindex(t *testing.T) {
 	_, err := conn.ExecuteFetch("describe hash", 1000, false)
 	require.Error(t, err)
 	mysqlErr := err.(*mysql.SQLError)
-	assert.Equal(t, 1146, mysqlErr.Num)
+	assert.Equal(t, mysql.ERNoSuchTable, mysqlErr.Num)
 	assert.Equal(t, "42S02", mysqlErr.State)
 	assert.Contains(t, mysqlErr.Message, "NotFound desc")
 }

--- a/go/test/endtoend/vtgate/sequence/seq_test.go
+++ b/go/test/endtoend/vtgate/sequence/seq_test.go
@@ -290,7 +290,7 @@ func TestDotTableSeq(t *testing.T) {
 	_, err = conn.ExecuteFetch("insert into `dotted.tablename` (c1,c2) values (10,10)", 1000, true)
 	require.Error(t, err)
 	mysqlErr := err.(*mysql.SQLError)
-	assert.Equal(t, 1062, mysqlErr.Num)
+	assert.Equal(t, mysql.ERDupEntry, mysqlErr.Num)
 	assert.Equal(t, "23000", mysqlErr.State)
 	assert.Contains(t, mysqlErr.Message, "Duplicate entry")
 }

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -17,19 +17,17 @@ limitations under the License.
 package mysqlctl
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/servenv"
-
-	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/stats"
@@ -351,7 +349,7 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 	// This is safe, since we're restarting MySQL after the restore anyway
 	params.Logger.Infof("Restore: disabling super_read_only")
 	if err := params.Mysqld.SetSuperReadOnly(false); err != nil {
-		if strings.Contains(err.Error(), strconv.Itoa(mysql.ERUnknownSystemVariable)) {
+		if strings.Contains(err.Error(), mysql.ERUnknownSystemVariable.ToString()) {
 			params.Logger.Warningf("Restore: server does not know about super_read_only, continuing anyway...")
 		} else {
 			params.Logger.Errorf("Restore: unexpected error while trying to set super_read_only: %v", err)

--- a/go/vt/vtgate/endtoend/lookup_test.go
+++ b/go/vt/vtgate/endtoend/lookup_test.go
@@ -62,7 +62,7 @@ func TestConsistentLookup(t *testing.T) {
 	exec(t, conn, "rollback")
 	require.Error(t, err)
 	mysqlErr := err.(*mysql.SQLError)
-	assert.Equal(t, 1062, mysqlErr.Num)
+	assert.Equal(t, mysql.ERDupEntry, mysqlErr.Num)
 	assert.Equal(t, "23000", mysqlErr.State)
 
 	// Simple delete.

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -1447,7 +1447,7 @@ func TestExecFail(t *testing.T) {
 		}}
 		_, err = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
 		require.NoError(t, err, "unexpected ScatterErrorsAsWarnings error %v", err)
-		vc.ExpectWarnings(t, []*querypb.QueryWarning{{Code: mysql.ERQueryInterrupted, Message: "query timeout -20 (errno 1317) (sqlstate HY000)"}})
+		vc.ExpectWarnings(t, []*querypb.QueryWarning{{Code: uint32(mysql.ERQueryInterrupted), Message: "query timeout -20 (errno 1317) (sqlstate HY000)"}})
 	})
 }
 

--- a/go/vt/vtgate/executor_set_test.go
+++ b/go/vt/vtgate/executor_set_test.go
@@ -228,14 +228,14 @@ func TestExecutorSet(t *testing.T) {
 		in: "set transaction isolation level serializable",
 		out: &vtgatepb.Session{
 			Autocommit: true,
-			Warnings:   []*querypb.QueryWarning{{Code: mysql.ERNotSupportedYet, Message: "converted 'next transaction' scope to 'session' scope"}},
+			Warnings:   []*querypb.QueryWarning{{Code: uint32(mysql.ERNotSupportedYet), Message: "converted 'next transaction' scope to 'session' scope"}},
 		},
 	}, {
 		in:  "set transaction read only",
-		out: &vtgatepb.Session{Autocommit: true, Warnings: []*querypb.QueryWarning{{Code: mysql.ERNotSupportedYet, Message: "converted 'next transaction' scope to 'session' scope"}}},
+		out: &vtgatepb.Session{Autocommit: true, Warnings: []*querypb.QueryWarning{{Code: uint32(mysql.ERNotSupportedYet), Message: "converted 'next transaction' scope to 'session' scope"}}},
 	}, {
 		in:  "set transaction read write",
-		out: &vtgatepb.Session{Autocommit: true, Warnings: []*querypb.QueryWarning{{Code: mysql.ERNotSupportedYet, Message: "converted 'next transaction' scope to 'session' scope"}}},
+		out: &vtgatepb.Session{Autocommit: true, Warnings: []*querypb.QueryWarning{{Code: uint32(mysql.ERNotSupportedYet), Message: "converted 'next transaction' scope to 'session' scope"}}},
 	}, {
 		in:  "set session transaction read write",
 		out: &vtgatepb.Session{Autocommit: true},

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -973,8 +973,8 @@ func TestExecutorShow(t *testing.T) {
 
 	query = "show warnings"
 	session.Warnings = []*querypb.QueryWarning{
-		{Code: mysql.ERBadTable, Message: "bad table"},
-		{Code: mysql.EROutOfResources, Message: "ks/-40: query timed out"},
+		{Code: uint32(mysql.ERBadTable), Message: "bad table"},
+		{Code: uint32(mysql.EROutOfResources), Message: "ks/-40: query timed out"},
 	}
 	qr, err = executor.Execute(ctx, "TestExecute", session, query, nil)
 	require.NoError(t, err)
@@ -986,8 +986,8 @@ func TestExecutorShow(t *testing.T) {
 		},
 
 		Rows: [][]sqltypes.Value{
-			{sqltypes.NewVarChar("Warning"), sqltypes.NewUint32(mysql.ERBadTable), sqltypes.NewVarChar("bad table")},
-			{sqltypes.NewVarChar("Warning"), sqltypes.NewUint32(mysql.EROutOfResources), sqltypes.NewVarChar("ks/-40: query timed out")},
+			{sqltypes.NewVarChar("Warning"), sqltypes.NewUint32(uint32(mysql.ERBadTable)), sqltypes.NewVarChar("bad table")},
+			{sqltypes.NewVarChar("Warning"), sqltypes.NewUint32(uint32(mysql.EROutOfResources)), sqltypes.NewVarChar("ks/-40: query timed out")},
 		},
 	}
 	utils.MustMatch(t, wantqr, qr, query)

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -933,7 +933,7 @@ func (vc *vcursorImpl) ErrorIfShardedF(ks *vindexes.Keyspace, warn, errFormat st
 func (vc *vcursorImpl) WarnUnshardedOnly(format string, params ...any) {
 	if vc.warnShardedOnly {
 		vc.warnings = append(vc.warnings, &querypb.QueryWarning{
-			Code:    mysql.ERNotSupportedYet,
+			Code:    uint32(mysql.ERNotSupportedYet),
 			Message: fmt.Sprintf(format, params...),
 		})
 	}
@@ -945,7 +945,7 @@ func (vc *vcursorImpl) PlannerWarning(message string) {
 		return
 	}
 	vc.warnings = append(vc.warnings, &querypb.QueryWarning{
-		Code:    mysql.ERNotSupportedYet,
+		Code:    uint32(mysql.ERNotSupportedYet),
 		Message: message,
 	})
 }

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -101,7 +101,7 @@ var vexecInsertTemplates = []string{
 }
 
 var emptyResult = &sqltypes.Result{}
-var acceptableDropTableIfExistsErrorCodes = []int{mysql.ERCantFindFile, mysql.ERNoSuchTable}
+var acceptableDropTableIfExistsErrorCodes = []mysql.ErrorCode{mysql.ERCantFindFile, mysql.ERNoSuchTable}
 
 var (
 	ghostOverridePath       string
@@ -600,7 +600,7 @@ func (e *Executor) parseAlterOptions(ctx context.Context, onlineDDL *schema.Onli
 }
 
 // executeDirectly runs a DDL query directly on the backend MySQL server
-func (e *Executor) executeDirectly(ctx context.Context, onlineDDL *schema.OnlineDDL, acceptableMySQLErrorCodes ...int) (acceptableErrorCodeFound bool, err error) {
+func (e *Executor) executeDirectly(ctx context.Context, onlineDDL *schema.OnlineDDL, acceptableMySQLErrorCodes ...mysql.ErrorCode) (acceptableErrorCodeFound bool, err error) {
 	conn, err := dbconnpool.NewDBConnection(ctx, e.env.Config().DB.DbaWithDB())
 	if err != nil {
 		return false, err
@@ -2689,7 +2689,7 @@ func (e *Executor) executeDropDDLActionMigration(ctx context.Context, onlineDDL 
 		return err
 	}
 
-	acceptableErrorCodes := []int{}
+	acceptableErrorCodes := []mysql.ErrorCode{}
 	if ddlStmt.GetIfExists() {
 		acceptableErrorCodes = acceptableDropTableIfExistsErrorCodes
 	}

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -19,7 +19,6 @@ package tabletmanager
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -301,7 +300,7 @@ func (tm *TabletManager) InitPrimary(ctx context.Context, semiSync bool) (string
 	if setSuperReadOnly {
 		// Setting super_read_only off so that we can run the DDL commands
 		if err := tm.MysqlDaemon.SetSuperReadOnly(false); err != nil {
-			if strings.Contains(err.Error(), strconv.Itoa(mysql.ERUnknownSystemVariable)) {
+			if strings.Contains(err.Error(), mysql.ERUnknownSystemVariable.ToString()) {
 				log.Warningf("server does not know about super_read_only, continuing anyway...")
 			} else {
 				return "", err
@@ -470,7 +469,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	if setSuperReadOnly {
 		// Setting super_read_only also sets read_only
 		if err := tm.MysqlDaemon.SetSuperReadOnly(true); err != nil {
-			if strings.Contains(err.Error(), strconv.Itoa(mysql.ERUnknownSystemVariable)) {
+			if strings.Contains(err.Error(), mysql.ERUnknownSystemVariable.ToString()) {
 				log.Warningf("server does not know about super_read_only, continuing anyway...")
 			} else {
 				return nil, err


### PR DESCRIPTION
This ErrorCode type maps to a uint16 to match what MySQL has as the range and parses things accordingly as well. With the explicit type we know better when we use the specific error code.

## Related Issue(s)

Fixes some of the issues from #12216 which were identified here because of the pretty loose typing.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required