### PR TITLE
backport partial fix from 11786

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -3915,29 +3915,15 @@ Gen4 plan same as above
   "QueryType": "SELECT",
   "Original": "select user.col from user_extra left outer join user on user_extra.user_id = user.id WHERE user.id IS NULL",
   "Instructions": {
-    "OperatorType": "SimpleProjection",
-    "Columns": [
-      1
-    ],
-    "Inputs": [
-      {
-        "OperatorType": "Filter",
-        "Predicate": "`user`.id is null",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select `user`.id, `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where 1 != 1",
-            "Query": "select `user`.id, `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id",
-            "Table": "`user`, user_extra"
-          }
-        ]
-      }
-    ]
+    "OperatorType": "Route",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where 1 != 1",
+    "Query": "select `user`.col from user_extra left join `user` on user_extra.user_id = `user`.id where `user`.id is null",
+    "Table": "`user`, user_extra"
   }
 }
 Gen4 plan same as above


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

An outer join query used to work in v12 but got a planner error: `unknown plan type for DISTINCT *planbuilder.filter`
a sample query:
```
 SELECT DISTINCT
       wie.id,
       wie.c2,
       wie.c3,
       wie.status,
       wie.data,
       wie.error,
       wie.created
     FROM wb_tbl wie
     INNER JOIN
       wb_tbl wie_f
       ON (
         wie.c2 = wie_f.c2
         AND wie.c3 = wie_f.c3
          AND wie_f.created >= "2023-01-24 00:00:00.000"
       )
     LEFT JOIN
       wb_tbl wie_g
       ON (
         wie.c2 = wie_g.c2
         AND wie.c3= wie_g.c3
         AND wie.created < "2023-01-24 00:00:00.000"
         AND wie.id < wie_g.id
       )
     WHERE
       wie_g.id IS NULL
       AND wie.c2 =10000
      AND wie.status = "completed"
      ORDER BY wie.created DESC, wie.id DESC LIMIT 10;
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
https://github.com/vitessio/vitess/issues/12259

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
