### PR TITLE
[vtctldserver] Remove parallelization from tests that mutate shared state

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -11365,8 +11365,6 @@ func TestValidateVersionShard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			tt.setup()
 			resp, err := vtctld.ValidateVersionShard(ctx, tt.req)
 			if tt.shouldErr {


### PR DESCRIPTION
## Description

This removes `t.Parallel` from the test cases that mutate the stubbed out "get version" function, which trips the race detector.

VTAdmin integration tests _also_ indirectly hit this, because `testutil.BuildIntegrationTestCluster` instantiates a `grpcvtctldserver.Server`, which can race. This is why I believe we've been seeing vtadmin tests showing up as flaky in launchable.

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
