### PR TITLE
Bugfix/Backport to v15: Fix schema migrations requested_timestamp zero values

### DIFF
--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -393,6 +393,12 @@ const (
 			AND cleanup_timestamp IS NULL
 			AND completed_timestamp IS NULL
 	`
+	sqlFixRequestedTimestamp = `UPDATE _vt.schema_migrations
+		SET
+			requested_timestamp = added_timestamp
+		WHERE
+			requested_timestamp < added_timestamp;
+	`
 	sqlSelectMigration = `SELECT
 			id,
 			migration_uuid,
@@ -612,6 +618,13 @@ var (
 var ApplyDDL = []string{
 	sqlCreateSidecarDB,
 	sqlCreateSchemaMigrationsTable,
+	// Fixing a historical issue: past values of requested_timestamp could be '0000-00-00 00:00:00'.
+	// In turn, those cause `ERROR 1292 (22007): Incorrect datetime value` when attempting to
+	// make any DDL on the table.
+	// We trust added_timestamp to be non-zero (it defaults CURRENT_TIMESTAMP and never modified),
+	// and so we set requested_timestamp to that value.
+	// The query makes a full table scan, because neither column is indexed.
+	sqlFixRequestedTimestamp, // end  of fix
 	alterSchemaMigrationsTableRetries,
 	alterSchemaMigrationsTableTablet,
 	alterSchemaMigrationsTableArtifacts,


### PR DESCRIPTION
Fixes https://github.com/vitessio/vitess/issues/12261

The fix  in https://github.com/vitessio/vitess/pull/12262 cannot be backported because of how internal schema management was redesigned in https://github.com/vitessio/vitess/pull/11520


The solution in this PR is to fix the actual values. They should not be zero. They should have some timestamp value, which we borrow from `added_timestamp` column.

An `UPDATE` query runs on PRIMARY tablet initialization, just after table is created and before the rest of DDLs kick. So it runs once in the lifetime of the tablet. It's a full table scan query, but `_vt.schema_migrations` is never too large.


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
