### PR TITLE
[release-16.0] Revert default MySQL 80 version to `8.0.30` (#12252)

### DIFF
--- a/doc/releasenotes/16_0_0_summary.md
+++ b/doc/releasenotes/16_0_0_summary.md
@@ -12,6 +12,7 @@
   - **[Breaking Changes](#breaking-changes)**
     - [VTGate Advertised MySQL Version](#advertised-mysql-version)
     - [Default MySQL version on Docker](#default-mysql-version)
+    - [Running Vitess on the Operator](#running-vitess-on-the-operator)
     - [vtctld UI Removal](#vtcltd-ui-removal)
     - [vtctld Flag Deprecation & Deletions](#vtctld-flag-deprecations)
     - [Orchestrator Integration Deletion](#orc-integration-removal)
@@ -88,12 +89,25 @@ The flag `disable-replication-manager` is deprecated and will be removed in a la
 
 #### <a id="advertised-mysql-version"/> VTGate Advertised MySQL Version
 
-VTGate now advertises MySQL version 8.0.31. This is a breaking change for clients that rely on the VTGate advertised MySQL version and still use MySQL 5.7.
+VTGate now advertises MySQL version 8.0.30. This is a breaking change for clients that rely on the VTGate advertised MySQL version and still use MySQL 5.7.
 The users can set the `mysql_server_version` flag to advertise the correct version.
 
 #### <a id="default-mysql-version"/> Default MySQL version on Docker
 
-The default major MySQL version used by our `vitess/lite:latest` image is going from `5.7` to `8.0`. Additionally, the default patch version of the `vitess/lite:mysql80` image goes from `8.0.23` to `8.0.31`.
+The default major MySQL version used by our `vitess/lite:latest` image is going from `5.7` to `8.0`. Additionally, the patch version of MySQL80 has been upgraded from `8.0.23` to `8.0.30`.
+
+#### <a id="running-vitess-on-the-operator"/> Running Vitess on the Operator
+
+If you are using the vitess-operator and want to remain on MySQL 5.7, we invite you to use the `vitess/lite:v16.0.0-mysql57` Docker Image.
+
+However, if you are running MySQL 8.0 on the vitess-operator, with for instance `vitess/lite:v15.0.2-mysql80`, considering that we are bumping the patch version of MySQL 80 from `8.0.23` to `8.0.30`, you will have to manually upgrade:
+
+1. Add `innodb_fast_shutdown=0` to your extra cnf in your YAML file.
+2. Apply this file.
+3. Wait for all the pods to be healthy.
+4. Then change your YAML file to use the new Docker Images (`vitess/lite:v16.0.0`, defaults to mysql80).
+5. Remove `innodb_fast_shutdown=0` from your extra cnf in your YAML file.
+6. Apply this file.
 
 #### <a id="vtcltd-ui-removal"/> vtctld UI Removal
 In v13, the vtctld UI was deprecated. As of this release, the `web/vtctld2` directory is deleted and the UI will no longer be included in any Vitess images going forward. All build scripts and the Makefile have been updated to reflect this change.

--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -83,7 +83,7 @@ mysql57)
     )
     ;;
 mysql80)
-    mysql8_version=8.0.31
+    mysql8_version=8.0.30
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb /tmp/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-client-plugins_${mysql8_version}-1debian10_amd64.deb

--- a/go/flags/endtoend/mysqlctl.txt
+++ b/go/flags/endtoend/mysqlctl.txt
@@ -57,7 +57,7 @@ Global flags:
       --logtostderr                                     log to standard error instead of files
       --max-stack-size int                              configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                  MySQL port (default 3306)
-      --mysql_server_version string                     MySQL server version to advertise. (default "8.0.31-Vitess")
+      --mysql_server_version string                     MySQL server version to advertise. (default "8.0.30-Vitess")
       --mysql_socket string                             Path to the mysqld socket file
       --mysqlctl_client_protocol string                 the protocol to use to talk to the mysqlctl server (default "grpc")
       --mysqlctl_mycnf_template string                  template file to use for generating the my.cnf file during server init

--- a/go/flags/endtoend/mysqlctld.txt
+++ b/go/flags/endtoend/mysqlctld.txt
@@ -68,7 +68,7 @@ Usage of mysqlctld:
       --logtostderr                                                      log to standard error instead of files
       --max-stack-size int                                               configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                                   MySQL port (default 3306)
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.31-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
       --mysql_socket string                                              Path to the mysqld socket file
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -119,7 +119,7 @@ Usage of vtbackup:
       --mycnf_socket_file string                        mysql socket file
       --mycnf_tmp_dir string                            mysql tmp directory
       --mysql_port int                                  mysql port (default 3306)
-      --mysql_server_version string                     MySQL server version to advertise. (default "8.0.31-Vitess")
+      --mysql_server_version string                     MySQL server version to advertise. (default "8.0.30-Vitess")
       --mysql_socket string                             path to the mysql socket
       --mysql_timeout duration                          how long to wait for mysqld startup (default 5m0s)
       --port int                                        port for the server

--- a/go/flags/endtoend/vtctldclient.txt
+++ b/go/flags/endtoend/vtctldclient.txt
@@ -108,7 +108,7 @@ Flags:
       --log_dir string                         If non-empty, write log files in this directory
       --log_rotate_max_size uint               size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                            log to standard error instead of files
-      --mysql_server_version string            MySQL server version to advertise. (default "8.0.31-Vitess")
+      --mysql_server_version string            MySQL server version to advertise. (default "8.0.30-Vitess")
       --purge_logs_interval duration           how often try to remove old logs (default 1h0m0s)
       --security_policy string                 the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --server string                          server to use for connection (required)

--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -14,7 +14,7 @@ Usage of vtexplain:
       --log_err_stacks                              log stack traces for errors
       --log_rotate_max_size uint                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                 log to standard error instead of files
-      --mysql_server_version string                 MySQL server version to advertise. (default "8.0.31-Vitess")
+      --mysql_server_version string                 MySQL server version to advertise. (default "8.0.30-Vitess")
       --normalize                                   Whether to enable vtgate normalization
       --output-mode string                          Output in human-friendly text or json (default "text")
       --planner-version string                      Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4. An empty value will use VTGate's default planner

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -115,7 +115,7 @@ Usage of vtgate:
       --mysql_server_ssl_key string                                      Path to ssl key for mysql server plugin SSL
       --mysql_server_ssl_server_ca string                                path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
       --mysql_server_tls_min_version string                              Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.31-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
       --mysql_server_write_timeout duration                              connection write timeout
       --mysql_slow_connect_warn_threshold duration                       Warn if it takes more than the given threshold for a mysql connection to establish
       --mysql_tcp_version string                                         Select tcp, tcp4, or tcp6 to control the socket type. (default "tcp")

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -188,7 +188,7 @@ Usage of vttablet:
       --mycnf_slow_log_path string                                       mysql slow query log path
       --mycnf_socket_file string                                         mysql socket file
       --mycnf_tmp_dir string                                             mysql tmp directory
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.31-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 10s)

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -71,7 +71,7 @@ Usage of vttestserver:
       --min_table_shard_size int                                         The minimum number of initial rows in a table shard. Ignored if--initialize_with_random_data is false. The actual number is chosen randomly. (default 1000)
       --mysql_bind_host string                                           which host to bind vtgate mysql listener to (default "localhost")
       --mysql_only                                                       If this flag is set only mysql is initialized. The rest of the vitess components are not started. Also, the output specifies the mysql unix socket instead of the vtgate port.
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.31-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
       --null_probability float                                           The probability to initialize a field with 'NULL'  if --initialize_with_random_data is true. Only applies to fields that can contain NULL values. (default 0.1)

--- a/go/vt/servenv/buildinfo_test.go
+++ b/go/vt/servenv/buildinfo_test.go
@@ -45,5 +45,5 @@ func TestVersionString(t *testing.T) {
 
 	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Jenkins build 422) (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.19.3 amiga/amd64", v.String())
 
-	assert.Equal(t, "8.0.31-Vitess", v.MySQLVersion())
+	assert.Equal(t, "8.0.30-Vitess", v.MySQLVersion())
 }

--- a/go/vt/servenv/mysql.go
+++ b/go/vt/servenv/mysql.go
@@ -23,7 +23,7 @@ import (
 // mySQLServerVersion is what Vitess will present as it's version during the connection handshake,
 // and as the value to the @@version system variable. If nothing is provided, Vitess will report itself as
 // a specific MySQL version with the vitess version appended to it
-var mySQLServerVersion = "8.0.31-Vitess"
+var mySQLServerVersion = "8.0.30-Vitess"
 
 // RegisterMySQLServerFlags installs the flags needed to specify or expose a
 // particular MySQL server version from Vitess.


### PR DESCRIPTION
## Description

This is a backport of #12252.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
