### PR TITLE
Online DDL: remove legacy "stowaway table" logic

### DIFF
--- a/go/vt/sidecardb/schema/onlineddl/schema_migrations.sql
+++ b/go/vt/sidecardb/schema/onlineddl/schema_migrations.sql
@@ -58,7 +58,6 @@ CREATE TABLE IF NOT EXISTS _vt.schema_migrations
     `reverted_uuid`                   varchar(64)      NOT NULL DEFAULT '',
     `is_view`                         tinyint unsigned NOT NULL DEFAULT '0',
     `ready_to_complete`               tinyint unsigned NOT NULL DEFAULT '0',
-    `stowaway_table`                  tinytext         NOT NULL,
     `vitess_liveness_indicator`       bigint           NOT NULL DEFAULT '0',
     `user_throttle_ratio`             float            NOT NULL DEFAULT '0',
     `special_plan`                    text             NOT NULL,

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -777,7 +777,7 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream) er
 	}
 
 	if !isVreplicationTestSuite {
-		// A bit early on, we generate names for stowaway and temporary tables
+		// A bit early on, we generate a name for the sentry table
 		// We do this here because right now we're in a safe place where nothing happened yet. If there's an error now, bail out
 		// and no harm done.
 		// Later on, when traffic is blocked and tables renamed, that's a more dangerous place to be in; we want as little logic
@@ -3509,30 +3509,6 @@ func (e *Executor) reviewRunningMigrations(ctx context.Context) (countRunnning i
 		postponeCompletion := row.AsBool("postpone_completion", false)
 		elapsedSeconds := row.AsInt64("elapsed_seconds", 0)
 
-		if stowawayTable := row.AsString("stowaway_table", ""); stowawayTable != "" {
-			// whoa
-			// stowawayTable is an original table stowed away while cutting over a vrepl migration, see call to cutOverVReplMigration() down below in this function.
-			// In a normal operation, the table should not exist outside the scope of cutOverVReplMigration
-			// If it exists, that means a tablet crashed while running a cut-over, and left the database in a bad state, where the migrated table does not exist.
-			// thankfully, we have tracked this situation and just realized what happened. Now, first thing to do is to restore the original table.
-			log.Infof("found stowaway table %s journal in migration %s for table %s", stowawayTable, uuid, onlineDDL.Table)
-			attemptMade, err := e.renameTableIfApplicable(ctx, stowawayTable, onlineDDL.Table)
-			if err != nil {
-				// unable to restore table; we bail out, and we will try again next round.
-				return countRunnning, cancellable, err
-			}
-			// success
-			if attemptMade {
-				log.Infof("stowaway table %s restored back into %s", stowawayTable, onlineDDL.Table)
-			} else {
-				log.Infof("stowaway table %s did not exist and there was no need to restore it", stowawayTable)
-			}
-			// OK good, table restored. We can remove the record.
-			if err := e.updateMigrationStowawayTable(ctx, uuid, ""); err != nil {
-				return countRunnning, cancellable, err
-			}
-		}
-
 		uuidsFoundRunning[uuid] = true
 
 		_ = e.updateMigrationUserThrottleRatio(ctx, uuid, currentUserThrottleRatio)
@@ -4325,18 +4301,6 @@ func (e *Executor) updateMigrationReadyToComplete(ctx context.Context, uuid stri
 		}
 	}
 	return nil
-}
-
-func (e *Executor) updateMigrationStowawayTable(ctx context.Context, uuid string, tableName string) error {
-	query, err := sqlparser.ParseAndBind(sqlUpdateMigrationStowawayTable,
-		sqltypes.StringBindVariable(tableName),
-		sqltypes.StringBindVariable(uuid),
-	)
-	if err != nil {
-		return err
-	}
-	_, err = e.execQuery(ctx, query)
-	return err
 }
 
 func (e *Executor) updateMigrationUserThrottleRatio(ctx context.Context, uuid string, ratio float64) error {

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -100,11 +100,6 @@ const (
 		WHERE
 			migration_uuid=%a
 	`
-	sqlUpdateMigrationStowawayTable = `UPDATE _vt.schema_migrations
-			SET stowaway_table=%a
-		WHERE
-			migration_uuid=%a
-	`
 	sqlUpdateMigrationUserThrottleRatio = `UPDATE _vt.schema_migrations
 			SET user_throttle_ratio=%a
 		WHERE
@@ -278,7 +273,6 @@ const (
 	sqlSelectRunningMigrations = `SELECT
 			migration_uuid,
 			postpone_completion,
-			stowaway_table,
 			timestampdiff(second, started_timestamp, now()) as elapsed_seconds
 		FROM _vt.schema_migrations
 		WHERE
@@ -382,7 +376,6 @@ const (
 			is_view,
 			ready_to_complete,
 			reverted_uuid,
-			stowaway_table,
 			rows_copied,
 			vitess_liveness_indicator,
 			user_throttle_ratio,


### PR DESCRIPTION


## Description

The "stowaway table" was part of the previous `vitess` cut-over mechanism, described in https://vitess.io/blog/2022-04-06-online-ddl-vitess-cut-over/

However, the logic has changed in https://github.com/vitessio/vitess/pull/11460. We no longer use a stowaway table in the cut-over mechanism. The stowaway table was the place where we would store our original table at cut-over phase. But because the cut-over was not atomic, we had to journal that changed. That was done with the `stowaway_table` column in `_vt.schema_migrations`. We would check this value to be able to rollback a halfway executed migration.

Anyway, now we use atomic cutover. We have a "sentry table" now. But this isn't merely a change of name. The sentry table is ephemeral. That is, it's a real table, but we don't care what happens to it. It's temporary in use. There's no situation where we have to resurrect it.

This PR cleans up all the stowaway table logic, which is unused now. To clarify how unused it is, the only scenario where anyone would still need this logic is if they had a failover during a cut-over phase, and at the same time chose to upgrade their vitess cluster. Which is unreasonable.

## Related Issue(s)

- #6926
- #11460 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
