### PR TITLE
fix dual table handling

### DIFF
--- a/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
+++ b/go/test/endtoend/vtgate/schematracker/restarttablet/schema_restart_test.go
@@ -122,7 +122,7 @@ func TestVSchemaTrackerInit(t *testing.T) {
 
 	qr := utils.Exec(t, conn, "SHOW VSCHEMA TABLES")
 	got := fmt.Sprintf("%v", qr.Rows)
-	want := `[[VARCHAR("dual")] [VARCHAR("main")] [VARCHAR("test_table")] [VARCHAR("vt_user")]]`
+	want := `[[VARCHAR("main")] [VARCHAR("test_table")] [VARCHAR("vt_user")]]`
 	assert.Equal(t, want, got)
 }
 

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -162,7 +162,7 @@ func TestInitAndUpdate(t *testing.T) {
 
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
-		`[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`,
+		`[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`,
 		100*time.Millisecond,
 		3*time.Second,
 		"initial table list not complete")
@@ -171,7 +171,7 @@ func TestInitAndUpdate(t *testing.T) {
 	_ = utils.Exec(t, conn, "create table test_sc (id bigint primary key)")
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
-		`[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")]]`,
+		`[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")]]`,
 		100*time.Millisecond,
 		3*time.Second,
 		"test_sc not in vschema tables")
@@ -180,7 +180,7 @@ func TestInitAndUpdate(t *testing.T) {
 	_ = utils.Exec(t, conn, "create table test_sc1 (id bigint primary key)")
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
-		`[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")] [VARCHAR("test_sc1")]]`,
+		`[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")] [VARCHAR("test_sc")] [VARCHAR("test_sc1")]]`,
 		100*time.Millisecond,
 		3*time.Second,
 		"test_sc1 not in vschema tables")
@@ -188,7 +188,7 @@ func TestInitAndUpdate(t *testing.T) {
 	_ = utils.Exec(t, conn, "drop table test_sc, test_sc1")
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
-		`[[VARCHAR("dual")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`,
+		`[[VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`,
 		100*time.Millisecond,
 		3*time.Second,
 		"test_sc and test_sc_1 should not be in vschema tables")
@@ -207,7 +207,7 @@ func TestDMLOnNewTable(t *testing.T) {
 	// wait for vttablet's schema reload interval to pass
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
-		`[[VARCHAR("dual")] [VARCHAR("new_table_tracked")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`,
+		`[[VARCHAR("new_table_tracked")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t8")]]`,
 		100*time.Millisecond,
 		3*time.Second,
 		"test_sc not in vschema tables")

--- a/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
@@ -98,7 +98,7 @@ func TestNewUnshardedTable(t *testing.T) {
 	// ensuring our initial table "main" is in the schema
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
-		`[[VARCHAR("dual")] [VARCHAR("main")]]`,
+		`[[VARCHAR("main")]]`,
 		100*time.Millisecond,
 		3*time.Second,
 		"initial table list not complete")
@@ -109,7 +109,7 @@ func TestNewUnshardedTable(t *testing.T) {
 	// waiting for the vttablet's schema_reload interval to kick in
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
-		`[[VARCHAR("dual")] [VARCHAR("main")] [VARCHAR("new_table_tracked")]]`,
+		`[[VARCHAR("main")] [VARCHAR("new_table_tracked")]]`,
 		100*time.Millisecond,
 		3*time.Second,
 		"new_table_tracked not in vschema tables")
@@ -128,7 +128,7 @@ func TestNewUnshardedTable(t *testing.T) {
 	// waiting for the vttablet's schema_reload interval to kick in
 	utils.AssertMatchesWithTimeout(t, conn,
 		"SHOW VSCHEMA TABLES",
-		`[[VARCHAR("dual")] [VARCHAR("main")]]`,
+		`[[VARCHAR("main")]]`,
 		100*time.Millisecond,
 		3*time.Second,
 		"new_table_tracked not in vschema tables")

--- a/go/test/endtoend/vtgate/vschema/vschema_test.go
+++ b/go/test/endtoend/vtgate/vschema/vschema_test.go
@@ -112,7 +112,7 @@ func TestVSchema(t *testing.T) {
 	utils.AssertMatches(t, conn, "delete from vt_user", `[]`)
 
 	// Test empty vschema
-	utils.AssertMatches(t, conn, "SHOW VSCHEMA TABLES", `[[VARCHAR("dual")]]`)
+	utils.AssertMatches(t, conn, "SHOW VSCHEMA TABLES", `[]`)
 
 	// Use the DDL to create an unsharded vschema and test again
 
@@ -130,7 +130,7 @@ func TestVSchema(t *testing.T) {
 	// Test Showing Tables
 	utils.AssertMatches(t, conn,
 		"SHOW VSCHEMA TABLES",
-		`[[VARCHAR("dual")] [VARCHAR("main")] [VARCHAR("vt_user")]]`)
+		`[[VARCHAR("main")] [VARCHAR("vt_user")]]`)
 
 	// Test Showing Vindexes
 	utils.AssertMatches(t, conn, "SHOW VSCHEMA VINDEXES", `[]`)

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1015,7 +1015,6 @@ func TestExecutorShow(t *testing.T) {
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Tables"),
 		Rows: [][]sqltypes.Value{
-			buildVarCharRow("dual"),
 			buildVarCharRow("erl_lu_idx"),
 			buildVarCharRow("ins_lookup"),
 			buildVarCharRow("lu_idx"),

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -678,6 +678,22 @@ func (vw *vschemaWrapper) FindView(tab sqlparser.TableName) sqlparser.SelectStat
 }
 
 func (vw *vschemaWrapper) FindTableOrVindex(tab sqlparser.TableName) (*vindexes.Table, vindexes.Vindex, string, topodatapb.TabletType, key.Destination, error) {
+	if tab.Qualifier.IsEmpty() && tab.Name.String() == "dual" {
+		ksName := vw.getActualKeyspace()
+		var ks *vindexes.Keyspace
+		if ksName == "" {
+			ks = vw.getfirstKeyspace()
+			ksName = ks.Name
+		} else {
+			ks = vw.v.Keyspaces[ksName].Keyspace
+		}
+		tbl := &vindexes.Table{
+			Name:     sqlparser.NewIdentifierCS("dual"),
+			Keyspace: ks,
+			Type:     vindexes.TypeReference,
+		}
+		return tbl, nil, ksName, topodatapb.TabletType_PRIMARY, nil, nil
+	}
 	destKeyspace, destTabletType, destTarget, err := topoproto.ParseDestination(tab.Qualifier.String(), topodatapb.TabletType_PRIMARY)
 	if err != nil {
 		return nil, nil, destKeyspace, destTabletType, destTarget, err
@@ -692,6 +708,16 @@ func (vw *vschemaWrapper) FindTableOrVindex(tab sqlparser.TableName) (*vindexes.
 	return table, vindex, destKeyspace, destTabletType, destTarget, nil
 }
 
+func (vw *vschemaWrapper) getfirstKeyspace() (ks *vindexes.Keyspace) {
+	var f string
+	for name, schema := range vw.v.Keyspaces {
+		if f == "" || f > name {
+			f = name
+			ks = schema.Keyspace
+		}
+	}
+	return
+}
 func (vw *vschemaWrapper) getActualKeyspace() string {
 	if vw.keyspace == nil {
 		return ""

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1032,41 +1032,9 @@
     }
   },
   {
-    "comment": "select from dual on sharded keyspace",
-    "query": "select @@session.auto_increment_increment from user.dual",
-    "v3-plan": {
-      "QueryType": "SELECT",
-      "Original": "select @@session.auto_increment_increment from user.dual",
-      "Instructions": {
-        "OperatorType": "Route",
-        "Variant": "Reference",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select @@auto_increment_increment from dual where 1 != 1",
-        "Query": "select @@auto_increment_increment from dual",
-        "Table": "dual"
-      }
-    },
-    "gen4-plan": {
-      "QueryType": "SELECT",
-      "Original": "select @@session.auto_increment_increment from user.dual",
-      "Instructions": {
-        "OperatorType": "Route",
-        "Variant": "Reference",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select @@auto_increment_increment from dual where 1 != 1",
-        "Query": "select @@auto_increment_increment from dual",
-        "Table": "dual"
-      },
-      "TablesUsed": [
-        "user.dual"
-      ]
-    }
+    "comment": "prefixing dual with a keyspace should not work",
+    "query": "select 1 from user.dual",
+    "plan": "table dual not found"
   },
   {
     "comment": "RHS route referenced",
@@ -3545,82 +3513,6 @@
         "FieldQuery": "select 42, id from dual, `user` where 1 != 1",
         "Query": "select 42, id from dual, `user`",
         "Table": "`user`, dual"
-      },
-      "TablesUsed": [
-        "main.dual",
-        "user.user"
-      ]
-    }
-  },
-  {
-    "comment": "Table named \"dual\" with a qualifier joined on user should not be merged",
-    "query": "select 42, user.id from main.dual, user",
-    "v3-plan": {
-      "QueryType": "SELECT",
-      "Original": "select 42, user.id from main.dual, user",
-      "Instructions": {
-        "OperatorType": "Join",
-        "Variant": "Join",
-        "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "dual_`user`",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Reference",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 42 from dual where 1 != 1",
-            "Query": "select 42 from dual",
-            "Table": "dual"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select `user`.id from `user` where 1 != 1",
-            "Query": "select `user`.id from `user`",
-            "Table": "`user`"
-          }
-        ]
-      }
-    },
-    "gen4-plan": {
-      "QueryType": "SELECT",
-      "Original": "select 42, user.id from main.dual, user",
-      "Instructions": {
-        "OperatorType": "Join",
-        "Variant": "Join",
-        "JoinColumnIndexes": "L:0,R:0",
-        "TableName": "dual_`user`",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "Reference",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 42 from dual where 1 != 1",
-            "Query": "select 42 from dual",
-            "Table": "dual"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select `user`.id from `user` where 1 != 1",
-            "Query": "select `user`.id from `user`",
-            "Table": "`user`"
-          }
-        ]
       },
       "TablesUsed": [
         "main.dual",

--- a/go/vt/vtgate/planbuilder/testdata/show_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/show_cases.json
@@ -716,7 +716,7 @@
         "Fields": {
           "Tables": "VARCHAR"
         },
-        "RowCount": 11
+        "RowCount": 10
       }
     }
   },

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -231,7 +231,6 @@ func BuildVSchema(source *vschemapb.SrvVSchema) (vschema *VSchema) {
 	buildReferences(source, vschema)
 	buildGlobalTables(source, vschema)
 	resolveAutoIncrement(source, vschema)
-	addDual(vschema)
 	buildRoutingRule(source, vschema)
 	buildShardRoutingRule(source, vschema)
 	return vschema
@@ -681,28 +680,6 @@ func resolveAutoIncrement(source *vschemapb.SrvVSchema, vschema *VSchema) {
 	}
 }
 
-// addDual adds dual as a valid table to all keyspaces.
-// For sharded keyspaces, it gets pinned against keyspace id '0x00'.
-func addDual(vschema *VSchema) {
-	first := ""
-	for ksname, ks := range vschema.Keyspaces {
-		t := &Table{
-			Name:     sqlparser.NewIdentifierCS("dual"),
-			Keyspace: ks.Keyspace,
-			Type:     TypeReference,
-		}
-		ks.Tables["dual"] = t
-		if first == "" || first > ksname {
-			// In case of a reference to dual that's not qualified
-			// by keyspace, we still want to resolve it to one of
-			// the keyspaces. For consistency, we'll always use the
-			// first keyspace by lexical ordering.
-			first = ksname
-			vschema.globalTables["dual"] = t
-		}
-	}
-}
-
 // expects table name of the form <keyspace>.<tablename>
 func escapeQualifiedTable(qualifiedTableName string) (string, error) {
 	keyspace, tableName, err := extractQualifiedTableParts(qualifiedTableName)
@@ -885,6 +862,18 @@ func (vschema *VSchema) findTable(keyspace, tablename string) (*Table, error) {
 		return &Table{Name: sqlparser.NewIdentifierCS(tablename), Keyspace: ks.Keyspace}, nil
 	}
 	return table, nil
+}
+
+func (vschema *VSchema) FirstKeyspace() *Keyspace {
+	var first string
+	for ksname := range vschema.Keyspaces {
+		if first == "" || first > ksname {
+			first = ksname
+		}
+	}
+	ks := vschema.Keyspaces[first]
+
+	return ks.Keyspace
 }
 
 // FindRoutedTable finds a table checking the routing rules.

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -265,10 +265,6 @@ func TestUnshardedVSchema(t *testing.T) {
 	table, err = got.FindTable("", "t1")
 	require.NoError(t, err)
 	assert.NotNil(t, table)
-
-	table, err = got.FindTable("", "dual")
-	require.NoError(t, err)
-	assert.Equal(t, TypeReference, table.Type)
 }
 
 func TestVSchemaColumns(t *testing.T) {
@@ -328,10 +324,6 @@ func TestVSchemaViews(t *testing.T) {
 	want := `
 {
   "tables": {
-    "dual": {
-      "type": "reference",
-      "name": "dual"
-    },
     "t1": {
       "name": "t1",
       "columns": [
@@ -633,16 +625,6 @@ func TestVSchemaRoutingRules(t *testing.T) {
 		Name:     sqlparser.NewIdentifierCS("t2"),
 		Keyspace: ks2,
 	}
-	dual1 := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ks1,
-		Type:     TypeReference,
-	}
-	dual2 := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ks2,
-		Type:     TypeReference,
-	}
 	want := &VSchema{
 		RoutingRules: map[string]*RoutingRule{
 			"rt1": {
@@ -671,9 +653,8 @@ func TestVSchemaRoutingRules(t *testing.T) {
 			},
 		},
 		globalTables: map[string]*Table{
-			"t1":   t1,
-			"t2":   t2,
-			"dual": dual1,
+			"t1": t1,
+			"t2": t2,
 		},
 		uniqueVindexes: map[string]Vindex{
 			"stfu1": vindex1,
@@ -682,8 +663,7 @@ func TestVSchemaRoutingRules(t *testing.T) {
 			"ks1": {
 				Keyspace: ks1,
 				Tables: map[string]*Table{
-					"t1":   t1,
-					"dual": dual1,
+					"t1": t1,
 				},
 				Vindexes: map[string]Vindex{
 					"stfu1": vindex1,
@@ -692,8 +672,7 @@ func TestVSchemaRoutingRules(t *testing.T) {
 			"ks2": {
 				Keyspace: ks2,
 				Tables: map[string]*Table{
-					"t2":   t2,
-					"dual": dual2,
+					"t2": t2,
 				},
 				Vindexes: map[string]Vindex{},
 			},
@@ -1063,16 +1042,10 @@ func TestShardedVSchemaMultiColumnVindex(t *testing.T) {
 	t1.Ordered = []*ColumnVindex{
 		t1.ColumnVindexes[0],
 	}
-	dual := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ks,
-		Type:     TypeReference,
-	}
 	want := &VSchema{
 		RoutingRules: map[string]*RoutingRule{},
 		globalTables: map[string]*Table{
-			"t1":   t1,
-			"dual": dual,
+			"t1": t1,
 		},
 		uniqueVindexes: map[string]Vindex{
 			"stfu1": vindex1,
@@ -1081,8 +1054,7 @@ func TestShardedVSchemaMultiColumnVindex(t *testing.T) {
 			"sharded": {
 				Keyspace: ks,
 				Tables: map[string]*Table{
-					"t1":   t1,
-					"dual": dual},
+					"t1": t1},
 				Vindexes: map[string]Vindex{
 					"stfu1": vindex1},
 			}}}
@@ -1144,15 +1116,11 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 	t1.Ordered = []*ColumnVindex{
 		t1.ColumnVindexes[1],
 		t1.ColumnVindexes[0]}
-	dual := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ks,
-		Type:     TypeReference}
 	want := &VSchema{
 		RoutingRules: map[string]*RoutingRule{},
 		globalTables: map[string]*Table{
-			"t1":   t1,
-			"dual": dual},
+			"t1": t1,
+		},
 		uniqueVindexes: map[string]Vindex{
 			"stlu1": vindex1,
 			"stfu1": vindex2},
@@ -1160,8 +1128,8 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 			"sharded": {
 				Keyspace: ks,
 				Tables: map[string]*Table{
-					"t1":   t1,
-					"dual": dual},
+					"t1": t1,
+				},
 				Vindexes: map[string]Vindex{
 					"stlu1": vindex1,
 					"stfu1": vindex2},
@@ -1252,33 +1220,25 @@ func TestBuildVSchemaDupSeq(t *testing.T) {
 		Name:     sqlparser.NewIdentifierCS("t1"),
 		Keyspace: ksb,
 		Type:     "sequence"}
-	duala := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ksa,
-		Type:     TypeReference}
-	dualb := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ksb,
-		Type:     TypeReference}
 	want := &VSchema{
 		RoutingRules: map[string]*RoutingRule{},
 		globalTables: map[string]*Table{
-			"t1":   nil,
-			"dual": duala},
+			"t1": nil,
+		},
 		uniqueVindexes: map[string]Vindex{},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"ksa": {
 				Keyspace: ksa,
 				Tables: map[string]*Table{
-					"t1":   t1a,
-					"dual": duala},
+					"t1": t1a,
+				},
 				Vindexes: map[string]Vindex{},
 			},
 			"ksb": {
 				Keyspace: ksb,
 				Tables: map[string]*Table{
-					"t1":   t1b,
-					"dual": dualb},
+					"t1": t1b,
+				},
 				Vindexes: map[string]Vindex{}}}}
 	if !reflect.DeepEqual(got, want) {
 		gotjson, _ := json.Marshal(got)
@@ -1317,37 +1277,24 @@ func TestBuildVSchemaDupTable(t *testing.T) {
 		Name:     sqlparser.NewIdentifierCS("t1"),
 		Keyspace: ksb,
 	}
-	duala := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ksa,
-		Type:     TypeReference,
-	}
-	dualb := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ksb,
-		Type:     TypeReference,
-	}
 	want := &VSchema{
 		RoutingRules: map[string]*RoutingRule{},
 		globalTables: map[string]*Table{
-			"t1":   nil,
-			"dual": duala,
+			"t1": nil,
 		},
 		uniqueVindexes: map[string]Vindex{},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"ksa": {
 				Keyspace: ksa,
 				Tables: map[string]*Table{
-					"t1":   t1a,
-					"dual": duala,
+					"t1": t1a,
 				},
 				Vindexes: map[string]Vindex{},
 			},
 			"ksb": {
 				Keyspace: ksb,
 				Tables: map[string]*Table{
-					"t1":   t1b,
-					"dual": dualb,
+					"t1": t1b,
 				},
 				Vindexes: map[string]Vindex{},
 			},
@@ -1455,21 +1402,10 @@ func TestBuildVSchemaDupVindex(t *testing.T) {
 	t2.Ordered = []*ColumnVindex{
 		t2.ColumnVindexes[0],
 	}
-	duala := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ksa,
-		Type:     TypeReference,
-	}
-	dualb := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ksb,
-		Type:     TypeReference,
-	}
 	want := &VSchema{
 		RoutingRules: map[string]*RoutingRule{},
 		globalTables: map[string]*Table{
-			"t1":   nil,
-			"dual": duala,
+			"t1": nil,
 		},
 		uniqueVindexes: map[string]Vindex{
 			"stlu1": nil,
@@ -1478,8 +1414,7 @@ func TestBuildVSchemaDupVindex(t *testing.T) {
 			"ksa": {
 				Keyspace: ksa,
 				Tables: map[string]*Table{
-					"t1":   t1,
-					"dual": duala,
+					"t1": t1,
 				},
 				Vindexes: map[string]Vindex{
 					"stlu1": vindex1,
@@ -1488,8 +1423,7 @@ func TestBuildVSchemaDupVindex(t *testing.T) {
 			"ksb": {
 				Keyspace: ksb,
 				Tables: map[string]*Table{
-					"t1":   t2,
-					"dual": dualb,
+					"t1": t2,
 				},
 				Vindexes: map[string]Vindex{
 					"stlu1": vindex1,
@@ -2041,23 +1975,12 @@ func TestSequence(t *testing.T) {
 	t2.Ordered = []*ColumnVindex{
 		t2.ColumnVindexes[0],
 	}
-	duala := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: ksu,
-		Type:     TypeReference,
-	}
-	dualb := &Table{
-		Name:     sqlparser.NewIdentifierCS("dual"),
-		Keyspace: kss,
-		Type:     TypeReference,
-	}
 	want := &VSchema{
 		RoutingRules: map[string]*RoutingRule{},
 		globalTables: map[string]*Table{
-			"seq":  seq,
-			"t1":   t1,
-			"t2":   t2,
-			"dual": dualb,
+			"seq": seq,
+			"t1":  t1,
+			"t2":  t2,
 		},
 		uniqueVindexes: map[string]Vindex{
 			"stfu1": vindex1,
@@ -2066,17 +1989,15 @@ func TestSequence(t *testing.T) {
 			"unsharded": {
 				Keyspace: ksu,
 				Tables: map[string]*Table{
-					"seq":  seq,
-					"dual": duala,
+					"seq": seq,
 				},
 				Vindexes: map[string]Vindex{},
 			},
 			"sharded": {
 				Keyspace: kss,
 				Tables: map[string]*Table{
-					"t1":   t1,
-					"t2":   t2,
-					"dual": dualb,
+					"t1": t1,
+					"t2": t2,
 				},
 				Vindexes: map[string]Vindex{
 					"stfu1": vindex1,

--- a/go/vt/vtgate/vschema_manager_test.go
+++ b/go/vt/vtgate/vschema_manager_test.go
@@ -24,7 +24,6 @@ func TestVSchemaUpdate(t *testing.T) {
 		Type: querypb.Type_VARCHAR,
 	}}
 	ks := &vindexes.Keyspace{Name: "ks"}
-	dual := &vindexes.Table{Type: vindexes.TypeReference, Name: sqlparser.NewIdentifierCS("dual"), Keyspace: ks}
 	tblNoCol := &vindexes.Table{Name: sqlparser.NewIdentifierCS("tbl"), Keyspace: ks, ColumnListAuthoritative: true}
 	tblCol1 := &vindexes.Table{Name: sqlparser.NewIdentifierCS("tbl"), Keyspace: ks, Columns: cols1, ColumnListAuthoritative: true}
 	tblCol2 := &vindexes.Table{Name: sqlparser.NewIdentifierCS("tbl"), Keyspace: ks, Columns: cols2, ColumnListAuthoritative: true}
@@ -44,18 +43,18 @@ func TestVSchemaUpdate(t *testing.T) {
 				ColumnListAuthoritative: false,
 			},
 		}),
-		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblCol2NA}),
+		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblCol2NA}),
 	}, {
 		name:       "1 Schematracking- 0 srvVSchema",
 		srvVschema: makeTestSrvVSchema("ks", false, nil),
 		schema:     map[string][]vindexes.Column{"tbl": cols1},
-		expected:   makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblCol1}),
+		expected:   makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblCol1}),
 	}, {
 		name:       "1 Schematracking - 1 srvVSchema (no columns) not authoritative",
 		srvVschema: makeTestSrvVSchema("ks", false, map[string]*vschemapb.Table{"tbl": {}}),
 		schema:     map[string][]vindexes.Column{"tbl": cols1},
 		// schema will override what srvSchema has.
-		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblCol1}),
+		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblCol1}),
 	}, {
 		name: "1 Schematracking - 1 srvVSchema (have columns) not authoritative",
 		srvVschema: makeTestSrvVSchema("ks", false, map[string]*vschemapb.Table{
@@ -66,7 +65,7 @@ func TestVSchemaUpdate(t *testing.T) {
 		}),
 		schema: map[string][]vindexes.Column{"tbl": cols1},
 		// schema will override what srvSchema has.
-		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblCol1}),
+		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblCol1}),
 	}, {
 		name: "1 Schematracking - 1 srvVSchema (no columns) authoritative",
 		srvVschema: makeTestSrvVSchema("ks", false, map[string]*vschemapb.Table{"tbl": {
@@ -74,7 +73,7 @@ func TestVSchemaUpdate(t *testing.T) {
 		}}),
 		schema: map[string][]vindexes.Column{"tbl": cols1},
 		// schema will override what srvSchema has.
-		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblNoCol}),
+		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblNoCol}),
 	}, {
 		name: "1 Schematracking - 1 srvVSchema (have columns) authoritative",
 		srvVschema: makeTestSrvVSchema("ks", false, map[string]*vschemapb.Table{
@@ -85,7 +84,7 @@ func TestVSchemaUpdate(t *testing.T) {
 		}),
 		schema: map[string][]vindexes.Column{"tbl": cols1},
 		// schema tracker will be ignored for authoritative tables.
-		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblCol2}),
+		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblCol2}),
 	}, {
 		name:     "srvVschema received as nil",
 		schema:   map[string][]vindexes.Column{"tbl": cols1},
@@ -131,7 +130,6 @@ func TestRebuildVSchema(t *testing.T) {
 		Type: querypb.Type_VARCHAR,
 	}}
 	ks := &vindexes.Keyspace{Name: "ks"}
-	dual := &vindexes.Table{Type: vindexes.TypeReference, Name: sqlparser.NewIdentifierCS("dual"), Keyspace: ks}
 	tblNoCol := &vindexes.Table{Name: sqlparser.NewIdentifierCS("tbl"), Keyspace: ks, ColumnListAuthoritative: true}
 	tblCol1 := &vindexes.Table{Name: sqlparser.NewIdentifierCS("tbl"), Keyspace: ks, Columns: cols1, ColumnListAuthoritative: true}
 	tblCol2 := &vindexes.Table{Name: sqlparser.NewIdentifierCS("tbl"), Keyspace: ks, Columns: cols2, ColumnListAuthoritative: true}
@@ -150,18 +148,18 @@ func TestRebuildVSchema(t *testing.T) {
 				ColumnListAuthoritative: false,
 			},
 		}),
-		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblCol2NA}),
+		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblCol2NA}),
 	}, {
 		name:       "1 Schematracking- 0 srvVSchema",
 		srvVschema: makeTestSrvVSchema("ks", false, nil),
 		schema:     map[string][]vindexes.Column{"tbl": cols1},
-		expected:   makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblCol1}),
+		expected:   makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblCol1}),
 	}, {
 		name:       "1 Schematracking - 1 srvVSchema (no columns) not authoritative",
 		srvVschema: makeTestSrvVSchema("ks", false, map[string]*vschemapb.Table{"tbl": {}}),
 		schema:     map[string][]vindexes.Column{"tbl": cols1},
 		// schema will override what srvSchema has.
-		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblCol1}),
+		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblCol1}),
 	}, {
 		name: "1 Schematracking - 1 srvVSchema (have columns) not authoritative",
 		srvVschema: makeTestSrvVSchema("ks", false, map[string]*vschemapb.Table{
@@ -172,7 +170,7 @@ func TestRebuildVSchema(t *testing.T) {
 		}),
 		schema: map[string][]vindexes.Column{"tbl": cols1},
 		// schema will override what srvSchema has.
-		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblCol1}),
+		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblCol1}),
 	}, {
 		name: "1 Schematracking - 1 srvVSchema (no columns) authoritative",
 		srvVschema: makeTestSrvVSchema("ks", false, map[string]*vschemapb.Table{"tbl": {
@@ -180,7 +178,7 @@ func TestRebuildVSchema(t *testing.T) {
 		}}),
 		schema: map[string][]vindexes.Column{"tbl": cols1},
 		// schema will override what srvSchema has.
-		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblNoCol}),
+		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblNoCol}),
 	}, {
 		name: "1 Schematracking - 1 srvVSchema (have columns) authoritative",
 		srvVschema: makeTestSrvVSchema("ks", false, map[string]*vschemapb.Table{
@@ -191,7 +189,7 @@ func TestRebuildVSchema(t *testing.T) {
 		}),
 		schema: map[string][]vindexes.Column{"tbl": cols1},
 		// schema tracker will be ignored for authoritative tables.
-		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"dual": dual, "tbl": tblCol2}),
+		expected: makeTestVSchema("ks", false, map[string]*vindexes.Table{"tbl": tblCol2}),
 	}, {
 		name:   "srvVschema received as nil",
 		schema: map[string][]vindexes.Column{"tbl": cols1},

--- a/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
@@ -110,10 +110,6 @@ func TestUpdateVSchema(t *testing.T) {
     "vttest": {
       "sharded": true,
       "tables": {
-        "dual": {
-          "type": "reference",
-          "name": "dual"
-        },
         "t1": {
           "name": "t1",
           "column_vindexes": [


### PR DESCRIPTION
## Description
Fixes how we route dual tables. MySQL has a little weird way of routing the `dual` table.

```sql
mysql> select 1 from dual;
+---+
| 1 |
+---+
| 1 |
+---+
1 row in set (0.00 sec)

mysql> select 1 from `dual`;
ERROR 1046 (3D000): No database selected
mysql> use test;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> create table `dual`(id bigint not null);
Query OK, 0 rows affected (0.01 sec)

mysql> select 1 from `dual`;
Empty set (0.00 sec)

mysql> select 1 from dual;
+---+
| 1 |
+---+
| 1 |
+---+
1 row in set (0.00 sec)

mysql> select 1 from test.dual;
Empty set (0.00 sec)
```

As can be seen in the little session above, ``` `dual` ``` and ```dual``` are handled differently. When qualified by the db name, you can select from the user table. But even when standing on the correct database, doing a `select 1 from dual` will still always use the magic dual and not the user table with the same name.

Additionally, if you prefix the table with a database name, it will never resolve to the magic dual, only complain that dual does not exist.

```sql
mysql> drop table test.dual;
Query OK, 0 rows affected (0.01 sec)

mysql> select 1 from test.dual;
ERROR 1146 (42S02): Table 'test.dual' doesn't exist
```

This PR fixes so that magic `dual` is only routed to if the table is not prefixed with any db name.
That means that the `dual` table is no longer in every keyspace, and will not show up when doing `SHOW VSCHEMA TABLES`.

It's now possible to use a real user table named `dual` (why anyone would want that is a separate question).

The fact that MySQL differentiates between ``` `dual` ``` and ```dual``` needs parser and AST support that we are currently lacking.

## Related Issue(s)
Fixes #6429

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

(if this feels similar to a recent [PR](https://github.com/vitessio/vitess/pull/12204), it's because it is. I accidentally pushed the wrong branch to the 12204 PR, and it got merged with the wrong content. 🤦 )