### PR TITLE
adding flag to disable automated recovery in vtorc

### DIFF
--- a/go/vt/vtorc/inst/cluster.go
+++ b/go/vt/vtorc/inst/cluster.go
@@ -16,6 +16,8 @@
 
 package inst
 
+import "vitess.io/vitess/go/vt/vtorc/config"
+
 // ClusterInfo makes for a cluster status/info summary
 type ClusterInfo struct {
 	Keyspace                                string
@@ -28,6 +30,6 @@ type ClusterInfo struct {
 
 // ReadRecoveryInfo
 func (clusterInfo *ClusterInfo) ReadRecoveryInfo() {
-	clusterInfo.HasAutomatedPrimaryRecovery = true
-	clusterInfo.HasAutomatedIntermediatePrimaryRecovery = true
+	clusterInfo.HasAutomatedPrimaryRecovery = !config.Config.DisableAutomatedMasterRecovery
+	clusterInfo.HasAutomatedIntermediatePrimaryRecovery = !config.Config.DisableAutomatedIntermediateMasterRecovery
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Adding a flag to disable automated recovery in vtorc

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fix for #11958 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
