### PR TITLE
Addition of flag to disable automated recovery in VTOrc at startup

### DIFF
--- a/doc/releasenotes/17_0_0_summary.md
+++ b/doc/releasenotes/17_0_0_summary.md
@@ -1,0 +1,18 @@
+## Summary
+
+### Table of Contents
+
+- **[Major Changes](#major-changes)**
+  - **[New Command Line Flags and Behavior](#new-flag)**
+    - [VTOrc Flag to Disable Global Recoveries](vtorc-disable-recovery-flag)
+
+
+## <a id="major-changes"/>Major Changes
+
+### <a id="new-flag"/>New Command Line Flags and Behavior
+
+#### <a id="vtorc-disable-recovery-flag"/>VTOrc Flag to Disable Global Recoveries
+
+A new flag `--disable-global-recoveries` has been added to VTOrc. Specifying this flag disables the global recoveries from VTOrc on start-up. 
+VTOrc will only monitor the tablets and won't fix anything. The problems can be seen at the api endpoints `/api/replication-analysis` and `/api/problems`.
+To make VTOrc start running recoveries, the users will have to enable the global recoveries using the api endpoint `/api/enable-global-recoveries`.

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -8,6 +8,7 @@ Usage of vtorc:
       --clusters_to_watch strings                    Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"
       --config string                                config file name
       --consul_auth_static_file string               JSON File to read the topos/tokens from.
+      --disable-global-recoveries                    Disable global recoveries when VTOrc starts up
       --emit_stats                                   If set, emit stats to push-based monitoring and stats backends
       --grpc_auth_static_client_creds string         When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_compression string                      Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -67,6 +67,7 @@ var (
 	waitReplicasTimeout            = 30 * time.Second
 	topoInformationRefreshDuration = 15 * time.Second
 	recoveryPollDuration           = 1 * time.Second
+	DisableGlobalRecoveries        = false
 )
 
 // RegisterFlags registers the flags required by VTOrc
@@ -86,6 +87,7 @@ func RegisterFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&waitReplicasTimeout, "wait-replicas-timeout", waitReplicasTimeout, "Duration for which to wait for replica's to respond when issuing RPCs")
 	fs.DurationVar(&topoInformationRefreshDuration, "topo-information-refresh-duration", topoInformationRefreshDuration, "Timer duration on which VTOrc refreshes the keyspace and vttablet records from the topology server")
 	fs.DurationVar(&recoveryPollDuration, "recovery-poll-duration", recoveryPollDuration, "Timer duration on which VTOrc polls its database to run a recovery")
+	fs.BoolVar(&DisableGlobalRecoveries, "disable-global-recoveries", DisableGlobalRecoveries, "Disable global recoveries when VTOrc starts up")
 }
 
 // Configuration makes for vtorc configuration input, which can be provided by user via JSON formatted file.

--- a/go/vt/vtorc/logic/orchestrator.go
+++ b/go/vt/vtorc/logic/orchestrator.go
@@ -17,6 +17,7 @@
 package logic
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"sync"
@@ -373,7 +374,7 @@ func ContinuousDiscovery() {
 		log.Infof("Disabling global recoveries. VTOrc won't run any fixes until global recoveries are enabled")
 		err := DisableRecovery()
 		if err != nil {
-			log.Errorf("Unable to disable recoveries - %v", err)
+			panic(fmt.Sprintf("Unable to disable recoveries - %v", err))
 		}
 	}
 	for {

--- a/go/vt/vtorc/logic/orchestrator.go
+++ b/go/vt/vtorc/logic/orchestrator.go
@@ -366,6 +366,16 @@ func ContinuousDiscovery() {
 	servenv.OnTermSync(closeVTOrc)
 
 	log.Infof("continuous discovery: starting")
+	// Disable global recoveries according to the flags
+	// We are guaranteed that the VTOrc database has already been initialized,
+	// so this is the correct place to disable recoveries.
+	if config.DisableGlobalRecoveries {
+		log.Infof("Disabling global recoveries. VTOrc won't run any fixes until global recoveries are enabled")
+		err := DisableRecovery()
+		if err != nil {
+			log.Errorf("Unable to disable recoveries - %v", err)
+		}
+	}
 	for {
 		select {
 		case <-healthTick:


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds a flag to VTOrc which allows the users to disable the global recoveries from VTOrc on start-up. VTOrc will only monitor the tablets and won't fix anything. The problems can be seen at the api endpoints `/api/replication-analysis` and `/api/problems`. 

To make VTOrc start running recoveries, the users will have to enable the global recoveries using the api endpoint `/api/enable-global-recoveries`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #11958 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
