### PR TITLE
Switch to using new Go 1.19 CRL parser

### DIFF
--- a/go/vt/tlstest/tlstest.go
+++ b/go/vt/tlstest/tlstest.go
@@ -337,12 +337,18 @@ func RevokeCertAndRegenerateCRL(root, parent, name string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	crlList, err := x509.ParseCRL(data)
+
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "X509 CRL" {
+		log.Fatal("failed to parse CRL PEM")
+	}
+
+	crlList, err := x509.ParseRevocationList(block.Bytes)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	revoked := crlList.TBSCertList.RevokedCertificates
+	revoked := crlList.RevokedCertificates
 	revoked = append(revoked, pkix.RevokedCertificate{
 		SerialNumber:   certificate.SerialNumber,
 		RevocationTime: time.Now(),
@@ -357,9 +363,10 @@ func RevokeCertAndRegenerateCRL(root, parent, name string) {
 		log.Fatal(err)
 	}
 
+	var crlNumber big.Int
 	newCrl, err := x509.CreateRevocationList(rand.Reader, &x509.RevocationList{
 		RevokedCertificates: revoked,
-		Number:              big.NewInt(int64(crlList.TBSCertList.Version) + 1),
+		Number:              crlNumber.Add(crlList.Number, big.NewInt(1)),
 	}, caCert, caKey.(crypto.Signer))
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
`x509.ParseCRL` is deprecated, we should use `x509.ParseRevocationList` instead which is new in Go 1.19.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/12314

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required