### PR TITLE
Component: vtgate Auto Update tables in "Status For Vtgate" page

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,7 @@ The following is the full list, alphabetically ordered.
 * Dan Kozlowski ([dkhenry](https://github.com/dkhenry)) dan.kozlowski@gmail.com
 * Deepthi Sigireddi ([deepthi](https://github.com/deepthi)) deepthi@planetscale.com
 * Derek Perkins ([derekperkins](https://github.com/derekperkins)) derek@nozzle.io
+* Dirkjan Bussink ([dbussink](https://github.com/dbussink)) dbussink@planetscale.com
 * Florent Poinsard ([frouioui](https://github.com/frouioui)) florent@planetscale.com
 * Frances Thai ([notfelineit](https://github.com/notfelineit)) frances@planetscale.com
 * Harshit Gangal ([harshit-gangal](https://github.com/harshit-gangal)) harshit.gangal@gmail.com
@@ -29,16 +30,25 @@ dkhenry, shlomi-noach, ajm188, vmg, GuptaManan100, frouioui
 rohit-nayak-ps, deepthi, mattlord
 
 ### Parser
-systay, harshit-gangal, vmg, GuptaManan100
+systay, harshit-gangal, vmg, GuptaManan100, dbussink
+
+### Evaluation Engine
+vmg
 
 ### Planner
-systay, harshit-gangal, GuptaManan100, frouioui
+systay, harshit-gangal, GuptaManan100, frouioui 
+
+### Query Serving
+systay, harshit-gangal, GuptaManan100, frouioui, vmg, dbussink
+
+### Online DDL
+shlomi-noach, dbussink
 
 ### Performance
 vmg
 
 ### Cluster Management
-deepthi, shlomi-noach, ajm188, GuptaManan100
+deepthi, ajm188, GuptaManan100, dbussink
 
 ### Java
 harshit-gangal

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -113,7 +113,7 @@ const (
     padding: 0.2rem;
   }
 </style>
-<table>
+<table id="HealthCheckCache">
   <tr>
     <th colspan="5">HealthCheck Tablet Cache</th>
   </tr>

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -113,7 +113,7 @@ const (
     padding: 0.2rem;
   }
 </style>
-<table id="HealthCheckTabletCache">
+<table class="refreshRequired">
   <tr>
     <th colspan="5">HealthCheck Tablet Cache</th>
   </tr>

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -113,7 +113,7 @@ const (
     padding: 0.2rem;
   }
 </style>
-<table id="HealthCheckCache">
+<table id="HealthCheckTabletCache">
   <tr>
     <th colspan="5">HealthCheck Tablet Cache</th>
   </tr>

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -2003,6 +2003,21 @@ func TestNormalize(t *testing.T) {
 			from: "create table t (id int primary key, i1 int invisible)",
 			to:   "CREATE TABLE `t` (\n\t`id` int,\n\t`i1` int INVISIBLE,\n\tPRIMARY KEY (`id`)\n)",
 		},
+		{
+			name: "normalize boolean, default true",
+			from: "create table t (id int primary key, b boolean default true)",
+			to:   "CREATE TABLE `t` (\n\t`id` int,\n\t`b` tinyint(1) DEFAULT '1',\n\tPRIMARY KEY (`id`)\n)",
+		},
+		{
+			name: "normalize boolean, default false",
+			from: "create table t (id int primary key, b boolean default false)",
+			to:   "CREATE TABLE `t` (\n\t`id` int,\n\t`b` tinyint(1) DEFAULT '0',\n\tPRIMARY KEY (`id`)\n)",
+		},
+		{
+			name: "normalize primary key and column with no default, with type boolean",
+			from: "create table t (id boolean primary key, b boolean)",
+			to:   "CREATE TABLE `t` (\n\t`id` tinyint(1),\n\t`b` tinyint(1),\n\tPRIMARY KEY (`id`)\n)",
+		},
 	}
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -94,6 +94,11 @@ const (
 	TableCharsetCollateIgnoreAlways
 )
 
+const (
+	TableQualifierDefault int = iota
+	TableQualifierDeclared
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
 	StrictIndexOrdering         bool
@@ -104,4 +109,5 @@ type DiffHints struct {
 	TableRenameStrategy         int
 	FullTextKeyStrategy         int
 	TableCharsetCollateStrategy int
+	TableQualifierHint          int
 }

--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -81,6 +81,26 @@ var statusHTML = `<!DOCTYPE html>
 <html>
 <head>
 <title>Status for {{.BinaryName}}</title>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js"></script>
+<script>
+function refreshTableContentIfTableHasID() {
+  $.get("/debug/status", function(data) {
+    var data = $.parseHTML(data);
+    $("table").each(function() {
+  	  var findTableID = $(this).attr("id");
+  	  if (typeof findTableID !== "undefined") {
+  	    var newTable = $(data).filter("#" + findTableID);
+  	    if (newTable.length > 0) {
+  	  	  $(this).empty().append(newTable.html());
+  	    }
+  	  }
+    });
+  });
+}
+$(document).ready(function() {
+	setInterval(refreshTableContentIfTableHasID, 5000);
+});
+</script>
 <style>
 body {
 font-family: sans-serif;

--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -75,6 +75,9 @@ var (
 	blockProfileRate = 0
 
 	globalStatus = newStatusPage("")
+	// tableRefreshRate defines the time interval in milliseconds of tables get updated,
+	// and only update tables those have "refreshRequired" class
+	tableRefreshRate = 10000
 )
 
 var statusHTML = `<!DOCTYPE html>
@@ -84,21 +87,21 @@ var statusHTML = `<!DOCTYPE html>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js"></script>
 <script>
 function refreshTableContentIfTableHasID() {
-  $.get("/debug/status", function(data) {
-    var data = $.parseHTML(data);
-    $("table").each(function() {
-  	  var findTableID = $(this).attr("id");
-  	  if (typeof findTableID !== "undefined") {
-  	    var newTable = $(data).filter("#" + findTableID);
-  	    if (newTable.length > 0) {
-  	  	  $(this).empty().append(newTable.html());
-  	    }
-  	  }
-    });
-  });
-}
+	$.get("/debug/status", function(data) {
+	  var data = $.parseHTML(data);
+	  var counter = 0;
+	  $("table.refreshRequired").each(function() {
+		var currentTable = $(this);
+		var newTable = $(data).filter("table.refreshRequired").eq(counter);
+		if (newTable.length > 0) {
+		  currentTable.empty().append(newTable.html());
+		}
+		counter++;
+	  });
+	});
+}  
 $(document).ready(function() {
-	setInterval(refreshTableContentIfTableHasID, 5000);
+	setInterval(refreshTableContentIfTableHasID, ` + strconv.Itoa(tableRefreshRate) + `);
 });
 </script>
 <style>

--- a/go/vt/sidecardb/sidecardb_test.go
+++ b/go/vt/sidecardb/sidecardb_test.go
@@ -27,11 +27,18 @@ import (
 )
 
 // Tests all non-error code paths in sidecardb
-func TestAll(t *testing.T) {
+func TestAllSidecarDB(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	AddSchemaInitQueries(db, false)
 	db.AddQuery("use dbname", &sqltypes.Result{})
+	sqlMode := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"sql_mode",
+		"varchar"),
+		"ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION",
+	)
+	db.AddQuery("select @@session.sql_mode as sql_mode", sqlMode)
+	db.AddQueryPattern("set @@session.sql_mode=.*", &sqltypes.Result{})
 
 	ctx := context.Background()
 	cp := db.ConnParams()

--- a/go/vt/srvtopo/status.go
+++ b/go/vt/srvtopo/status.go
@@ -37,7 +37,7 @@ const TopoTemplate = `
     padding: 0.2rem;
   }
 </style>
-<table>
+<table id="TopologyCache">
   <tr>
     <th colspan="4">SrvKeyspace Names Cache</th>
   </tr>

--- a/go/vt/srvtopo/status.go
+++ b/go/vt/srvtopo/status.go
@@ -37,7 +37,7 @@ const TopoTemplate = `
     padding: 0.2rem;
   }
 </style>
-<table id="SrvKeyspaceNamesCache">
+<table class="refreshRequired">
   <tr>
     <th colspan="4">SrvKeyspace Names Cache</th>
   </tr>
@@ -57,7 +57,7 @@ const TopoTemplate = `
   {{end}}
 </table>
 <br>
-<table id="SrvKeyspaceCache">
+<table class="refreshRequired">
   <tr>
     <th colspan="5">SrvKeyspace Cache</th>
   </tr>

--- a/go/vt/srvtopo/status.go
+++ b/go/vt/srvtopo/status.go
@@ -37,7 +37,7 @@ const TopoTemplate = `
     padding: 0.2rem;
   }
 </style>
-<table id="TopologyCache">
+<table id="SrvKeyspaceNamesCache">
   <tr>
     <th colspan="4">SrvKeyspace Names Cache</th>
   </tr>
@@ -57,7 +57,7 @@ const TopoTemplate = `
   {{end}}
 </table>
 <br>
-<table>
+<table id="SrvKeyspaceCache">
   <tr>
     <th colspan="5">SrvKeyspace Cache</th>
   </tr>

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -144,7 +144,7 @@ func (vte *VTExplain) newTablet(opts *Options, t *topodatapb.Tablet) *explainTab
 	tsv.StartService(&target, dbcfgs, nil /* mysqld */)
 
 	// clear all the schema initialization queries out of the tablet
-	// to avoid clutttering the output
+	// to avoid cluttering the output
 	tablet.mysqlQueries = nil
 
 	return &tablet
@@ -294,6 +294,15 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options) (*tablet
 		},
 		"select @@global.sql_mode": {
 			Fields: []*querypb.Field{{
+				Type: sqltypes.VarChar,
+			}},
+			Rows: [][]sqltypes.Value{
+				{sqltypes.NewVarBinary("STRICT_TRANS_TABLES")},
+			},
+		},
+		"select @@session.sql_mode as sql_mode": {
+			Fields: []*querypb.Field{{
+				Name: "sql_mode",
 				Type: sqltypes.VarChar,
 			}},
 			Rows: [][]sqltypes.Value{

--- a/go/vt/vtgate/status.go
+++ b/go/vt/vtgate/status.go
@@ -48,7 +48,7 @@ const (
     background-color: #fff;
   }
 </style>
-<table id="GatewayStatus">
+<table class="refreshRequired">
   <tr>
     <th>Keyspace</th>
     <th>Shard</th>

--- a/go/vt/vtgate/status.go
+++ b/go/vt/vtgate/status.go
@@ -48,7 +48,7 @@ const (
     background-color: #fff;
   }
 </style>
-<table>
+<table id="GatewayStatus">
   <tr>
     <th>Keyspace</th>
     <th>Shard</th>

--- a/go/vt/vtgate/vschema_stats.go
+++ b/go/vt/vtgate/vschema_stats.go
@@ -77,7 +77,7 @@ const (
     padding: 0.2rem;
   }
 </style>
-<table id="VSchemaCache">
+<table class="refreshRequired">
   <tr>
     <th colspan="5">VSchema Cache <i><a href="/debug/vschema">in JSON</a></i></th>
   </tr>

--- a/go/vt/vtgate/vschema_stats.go
+++ b/go/vt/vtgate/vschema_stats.go
@@ -77,7 +77,7 @@ const (
     padding: 0.2rem;
   }
 </style>
-<table>
+<table id="VSchema">
   <tr>
     <th colspan="5">VSchema Cache <i><a href="/debug/vschema">in JSON</a></i></th>
   </tr>

--- a/go/vt/vtgate/vschema_stats.go
+++ b/go/vt/vtgate/vschema_stats.go
@@ -77,7 +77,7 @@ const (
     padding: 0.2rem;
   }
 </style>
-<table id="VSchema">
+<table id="VSchemaCache">
   <tr>
     <th colspan="5">VSchema Cache <i><a href="/debug/vschema">in JSON</a></i></th>
   </tr>

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -147,7 +147,7 @@ func (se *Engine) syncSidecarDB(ctx context.Context, conn *dbconnpool.DBConnecti
 				return nil, err
 			}
 		}
-		return conn.ExecuteFetch(query, maxRows, false)
+		return conn.ExecuteFetch(query, maxRows, true)
 	}
 	if err := sidecardb.Init(ctx, exec); err != nil {
 		log.Errorf("Error in sidecardb.Init: %+v", err)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Currently, for each component that has **/debug/status** page, the page is static and does not refresh containing tables. Vtgate page is particularly useful, as a daily user, I'd like to see those tables to be refreshed, this is quite useful when doing deployments && updates.

This PR, added **refreshTableContentIfTableHasID()** javascript function, it access "/debug/status" in the background(every 5 seconds) and looks for those tables ONLY if they have **id** html attribute defined, and only updates those tables.

Because I only care about the status page of Vtgate, I only added the id html attribute on those relevant tables, but it can be applied to any component which has a static page.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
There is None, this is rather a new feature.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
