### PR TITLE
TableFilter: fix excluded RE listing

### DIFF
--- a/go/vt/mysqlctl/tmutils/schema.go
+++ b/go/vt/mysqlctl/tmutils/schema.go
@@ -119,7 +119,7 @@ func NewTableFilter(tables, excludeTables []string, includeViews bool) (*TableFi
 					return nil, fmt.Errorf("cannot compile regexp %v for excludeTable: %v", table, err)
 				}
 
-				f.excludeTableREs = append(f.tableREs, re)
+				f.excludeTableREs = append(f.excludeTableREs, re)
 			} else {
 				f.excludeTableNames = append(f.excludeTableNames, table)
 			}


### PR DESCRIPTION

## Description

Per https://github.com/vitessio/vitess/issues/12317, this PR fixes the slice concatenation for `excludeTableREs`. While at it, adding more unit tests to validate expected behavior, and while at it, modernize the unit test file to use `testify` rather than "bare meta" golang tests.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/12317

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
