### PR TITLE
Internal refactor: LastError as a public struct

### DIFF
--- a/go/vt/vterrors/last_error.go
+++ b/go/vt/vterrors/last_error.go
@@ -86,7 +86,7 @@ func (le *LastError) ShouldRetry() bool {
 		// within the max time range
 		return true
 	}
-	log.Errorf("%s: the same error was encountered continuously since %s, it is now assumed to be unrecoverable; any affected workflows will need to be manually restarted once error '%s' has been addressed",
+	log.Errorf("%s: the same error was encountered continuously since %s, it is now assumed to be unrecoverable; any affected operations will need to be manually restarted once error '%s' has been addressed",
 		le.name, le.firstSeen.UTC(), le.err)
 	return false
 }

--- a/go/vt/vterrors/last_error_test.go
+++ b/go/vt/vterrors/last_error_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vreplication
+package vterrors
 
 import (
 	"fmt"
@@ -30,57 +30,57 @@ const maxTimeInError = 100 * time.Millisecond
 
 // TestLastErrorZeroMaxTime tests maxTimeInError = 0, should always retry
 func TestLastErrorZeroMaxTime(t *testing.T) {
-	le := newLastError("test", 0)
+	le := NewLastError("test", 0)
 	err1 := fmt.Errorf("error1")
-	le.record(err1)
-	require.True(t, le.shouldRetry())
+	le.Record(err1)
+	require.True(t, le.ShouldRetry())
 	time.Sleep(shortWait)
-	require.True(t, le.shouldRetry())
+	require.True(t, le.ShouldRetry())
 	time.Sleep(longWait)
-	require.True(t, le.shouldRetry())
+	require.True(t, le.ShouldRetry())
 }
 
 // TestLastErrorNoError ensures that an uninitialized lastError always retries
 func TestLastErrorNoError(t *testing.T) {
-	le := newLastError("test", maxTimeInError)
-	require.True(t, le.shouldRetry())
+	le := NewLastError("test", maxTimeInError)
+	require.True(t, le.ShouldRetry())
 	err1 := fmt.Errorf("error1")
-	le.record(err1)
-	require.True(t, le.shouldRetry())
-	le.record(nil)
-	require.True(t, le.shouldRetry())
+	le.Record(err1)
+	require.True(t, le.ShouldRetry())
+	le.Record(nil)
+	require.True(t, le.ShouldRetry())
 }
 
 // TestLastErrorOneError validates that we retry an error if happening within the maxTimeInError, but not after
 func TestLastErrorOneError(t *testing.T) {
-	le := newLastError("test", maxTimeInError)
+	le := NewLastError("test", maxTimeInError)
 	err1 := fmt.Errorf("error1")
-	le.record(err1)
-	require.True(t, le.shouldRetry())
+	le.Record(err1)
+	require.True(t, le.ShouldRetry())
 	time.Sleep(shortWait)
-	require.True(t, le.shouldRetry())
+	require.True(t, le.ShouldRetry())
 	time.Sleep(shortWait)
-	require.True(t, le.shouldRetry())
+	require.True(t, le.ShouldRetry())
 	time.Sleep(longWait)
-	require.False(t, le.shouldRetry())
+	require.False(t, le.ShouldRetry())
 }
 
 // TestLastErrorRepeatedError confirms that if same error is repeated we don't retry
 // unless it happens after maxTimeInError
 func TestLastErrorRepeatedError(t *testing.T) {
-	le := newLastError("test", maxTimeInError)
+	le := NewLastError("test", maxTimeInError)
 	err1 := fmt.Errorf("error1")
-	le.record(err1)
-	require.True(t, le.shouldRetry())
+	le.Record(err1)
+	require.True(t, le.ShouldRetry())
 	for i := 1; i < 10; i++ {
-		le.record(err1)
+		le.Record(err1)
 		time.Sleep(shortWait)
 	}
-	require.True(t, le.shouldRetry())
+	require.True(t, le.ShouldRetry())
 
 	// same error happens after maxTimeInError, so it should retry
 	time.Sleep(longWait)
-	require.False(t, le.shouldRetry())
-	le.record(err1)
-	require.True(t, le.shouldRetry())
+	require.False(t, le.ShouldRetry())
+	le.Record(err1)
+	require.True(t, le.ShouldRetry())
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -67,7 +67,7 @@ type controller struct {
 	// The following fields are updated after start. So, they need synchronization.
 	sourceTablet sync2.AtomicString
 
-	lastWorkflowError *lastError
+	lastWorkflowError *vterrors.LastError
 }
 
 // newController creates a new controller. Unless a stream is explicitly 'Stopped',
@@ -94,7 +94,7 @@ func newController(ctx context.Context, params map[string]string, dbClientFactor
 	}
 	ct.id = int32(id)
 	ct.workflow = params["workflow"]
-	ct.lastWorkflowError = newLastError(fmt.Sprintf("VReplication controller %d for workflow %q", ct.id, ct.workflow), maxTimeToRetryError)
+	ct.lastWorkflowError = vterrors.NewLastError(fmt.Sprintf("VReplication controller %d for workflow %q", ct.id, ct.workflow), maxTimeToRetryError)
 
 	state := params["state"]
 	blpStats.State.Set(state)
@@ -270,10 +270,10 @@ func (ct *controller) runBlp(ctx context.Context) (err error) {
 
 		vr := newVReplicator(ct.id, ct.source, vsClient, ct.blpStats, dbClient, ct.mysqld, ct.vre)
 		err = vr.Replicate(ctx)
-		ct.lastWorkflowError.record(err)
+		ct.lastWorkflowError.Record(err)
 		// If this is a mysql error that we know needs manual intervention OR
 		// we cannot identify this as non-recoverable, but it has persisted beyond the retry limit (maxTimeToRetryError)
-		if isUnrecoverableError(err) || !ct.lastWorkflowError.shouldRetry() {
+		if isUnrecoverableError(err) || !ct.lastWorkflowError.ShouldRetry() {
 			log.Errorf("vreplication stream %d going into error state due to %+v", ct.id, err)
 			if errSetState := vr.setState(binlogplayer.BlpError, err.Error()); errSetState != nil {
 				return err // yes, err and not errSetState.


### PR DESCRIPTION

## Description

`lastError` is a mechanism introduced into `VReplication` in https://github.com/vitessio/vitess/pull/10429 ; the idea is that we can have a retry-able operation that waits for some error to clean up, or times out if the error persists.

Up till now this was a local class in `vreplication` package. I have a use case outside VReplication (well, related, it's Online DDL). Anyway, the mechanism is really quite generic and useful, and so I'm externalizing the structure and moving it to `go/vt/vterrors`.

There's no real code changes here other than using the `name` field of `LastError` in place of hard coded `"Vreplication"` text.

This refactor includes the recent changes made in https://github.com/vitessio/vitess/pull/12114


## Related Issue(s)

- #10429
- #12114

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
