### PR TITLE
SidecarDB Init: don't fail on schema init errors

### DIFF
--- a/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
@@ -164,11 +164,12 @@ func waitForSourcePort(ctx context.Context, t *testing.T, tablet cluster.Vttable
 	return fmt.Errorf("time out before source port became %v for %v", expectedPort, tablet.Alias)
 }
 
-func getSidecarDbDDLQueryCount(tablet *cluster.VttabletProcess) (int64, error) {
+func getSidecarDBDDLQueryCount(tablet *cluster.VttabletProcess) (int64, error) {
 	vars := tablet.GetVars()
-	val, ok := vars["SidecarDbDDLQueryCount"]
+	key := "SidecarDBDDLQueryCount"
+	val, ok := vars[key]
 	if !ok {
-		return 0, fmt.Errorf("SidecarDbDDLQueryCount not found in debug/vars")
+		return 0, fmt.Errorf("%s not found in debug/vars", key)
 	}
 	return int64(val.(float64)), nil
 }
@@ -178,7 +179,7 @@ func TestReplicationRepairAfterPrimaryTabletChange(t *testing.T) {
 	err := waitForSourcePort(ctx, t, replicaTablet, int32(primaryTablet.MySQLPort))
 	require.NoError(t, err)
 
-	sidecarDDLCount, err := getSidecarDbDDLQueryCount(primaryTablet.VttabletProcess)
+	sidecarDDLCount, err := getSidecarDBDDLQueryCount(primaryTablet.VttabletProcess)
 	require.NoError(t, err)
 	// sidecar db should create all _vt tables when vttablet started
 	require.Greater(t, sidecarDDLCount, int64(0))
@@ -197,7 +198,7 @@ func TestReplicationRepairAfterPrimaryTabletChange(t *testing.T) {
 	err = waitForSourcePort(ctx, t, replicaTablet, int32(newMysqlPort))
 	require.NoError(t, err)
 
-	sidecarDDLCount, err = getSidecarDbDDLQueryCount(primaryTablet.VttabletProcess)
+	sidecarDDLCount, err = getSidecarDBDDLQueryCount(primaryTablet.VttabletProcess)
 	require.NoError(t, err)
 	// sidecardb should find the desired _vt schema and not apply any new creates or upgrades when the tablet comes up again
 	require.Equal(t, sidecarDDLCount, int64(0))

--- a/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/sidecardb"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
@@ -166,7 +168,7 @@ func waitForSourcePort(ctx context.Context, t *testing.T, tablet cluster.Vttable
 
 func getSidecarDBDDLQueryCount(tablet *cluster.VttabletProcess) (int64, error) {
 	vars := tablet.GetVars()
-	key := "SidecarDBDDLQueryCount"
+	key := sidecardb.StatsKeyQueryCount
 	val, ok := vars[key]
 	if !ok {
 		return 0, fmt.Errorf("%s not found in debug/vars", key)

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -526,6 +526,7 @@ func getDebugVar(t *testing.T, port int, varPath []string) (string, error) {
 	var val []byte
 	var err error
 	url := fmt.Sprintf("http://localhost:%d/debug/vars", port)
+	log.Infof("url: %s, varPath: %s", url, strings.Join(varPath, ":"))
 	body := getHTTPBody(url)
 	val, _, _, err = jsonparser.Get([]byte(body), varPath...)
 	require.NoError(t, err)

--- a/go/test/endtoend/vreplication/sidecardb_test.go
+++ b/go/test/endtoend/vreplication/sidecardb_test.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"testing"
 
+	"vitess.io/vitess/go/vt/sidecardb"
+
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -130,7 +132,7 @@ func modifySidecarDBSchema(t *testing.T, vc *VitessCluster, tabletID string, ddl
 }
 
 func getNumExecutedDDLQueries(t *testing.T, port int) int {
-	val, err := getDebugVar(t, port, []string{"SidecarDBDDLQueryCount"})
+	val, err := getDebugVar(t, port, []string{sidecardb.StatsKeyQueryCount})
 	require.NoError(t, err)
 	i, err := strconv.Atoi(val)
 	require.NoError(t, err)

--- a/go/test/endtoend/vreplication/sidecardb_test.go
+++ b/go/test/endtoend/vreplication/sidecardb_test.go
@@ -130,7 +130,7 @@ func modifySidecarDBSchema(t *testing.T, vc *VitessCluster, tabletID string, ddl
 }
 
 func getNumExecutedDDLQueries(t *testing.T, port int) int {
-	val, err := getDebugVar(t, port, []string{"SidecarDbDDLQueryCount"})
+	val, err := getDebugVar(t, port, []string{"SidecarDBDDLQueryCount"})
 	require.NoError(t, err)
 	i, err := strconv.Atoi(val)
 	require.NoError(t, err)

--- a/go/vt/sidecardb/sidecardb.go
+++ b/go/vt/sidecardb/sidecardb.go
@@ -97,7 +97,7 @@ const failOnSchemaInitError = false
 
 func init() {
 	initSchemaFiles()
-	ddlCount = stats.NewCounter("SidecarDBDDLQueryCount", "Number of create/upgrade queries executed")
+	ddlCount = stats.NewCounter("SidecarDBDDLQueryCount", "Number of queries executed")
 	ddlErrorCount = stats.NewCounter("SidecarDBDDLErrorCount", "Number of errors during sidecar schema upgrade")
 	ddlErrorHistory = history.New(maxDDLErrorHistoryLength)
 	stats.Publish("SidecarDBDDLErrors", stats.StringMapFunc(func() map[string]string {

--- a/go/vt/sidecardb/sidecardb.go
+++ b/go/vt/sidecardb/sidecardb.go
@@ -25,7 +25,9 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 
+	"vitess.io/vitess/go/history"
 	"vitess.io/vitess/go/mysql"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
@@ -71,10 +73,43 @@ func (t *sidecarTable) String() string {
 
 var sidecarTables []*sidecarTable
 var ddlCount *stats.Counter
+var ddlErrorCount *stats.Counter
+var ddlErrorHistory *history.History
+var mu sync.Mutex
+
+type ddlError struct {
+	tableName string
+	err       error
+}
+
+const maxDDLErrorHistoryLength = 100
+
+// failOnSchemaInitError decides whether we fail the schema init process when we encounter an error while
+// applying a table schema upgrade ddl or continue with the next table.
+// If true, tablets will not launch. The cluster will not come up until the issue is resolved.
+// If false, the init process will continue trying to upgrade other tables. So some functionality might be broken
+// due to an incorrect schema, but the cluster should come up and serve queries.
+// This is an operational trade-off: if we always fail it could cause a major incident since the entire cluster will be down.
+// If we are more permissive, it could cause hard-to-detect errors, because a module
+// doesn't load or behaves incorrectly due to an incomplete upgrade. Errors however will be reported and if the
+// related stats endpoints are monitored we should be able to diagnose/get alerted in a timely fashion.
+const failOnSchemaInitError = false
 
 func init() {
 	initSchemaFiles()
-	ddlCount = stats.NewCounter("SidecarDbDDLQueryCount", "Number of create/upgrade queries executed")
+	ddlCount = stats.NewCounter("SidecarDBDDLQueryCount", "Number of create/upgrade queries executed")
+	ddlErrorCount = stats.NewCounter("SidecarDBDDLErrorCount", "Number of errors during sidecar schema upgrade")
+	ddlErrorHistory = history.New(maxDDLErrorHistoryLength)
+	stats.Publish("SidecarDBDDLErrors", stats.StringMapFunc(func() map[string]string {
+		mu.Lock()
+		defer mu.Unlock()
+		result := make(map[string]string, len(ddlErrorHistory.Records()))
+		for _, e := range ddlErrorHistory.Records() {
+			d := e.(*ddlError)
+			result[d.tableName] = d.err.Error()
+		}
+		return result
+	}))
 }
 
 func validateSchemaDefinition(name, schema string) (string, error) {
@@ -90,14 +125,14 @@ func validateSchemaDefinition(name, schema string) (string, error) {
 	tableName := createTable.Table.Name.String()
 	qualifier := createTable.Table.Qualifier.String()
 	if qualifier != SidecarDBName {
-		return "", fmt.Errorf("database qualifier specified for the %s table is %s rather than the expected value of %s",
+		return "", vterrors.Errorf(vtrpcpb.Code_INTERNAL, "database qualifier specified for the %s table is %s rather than the expected value of %s",
 			name, qualifier, SidecarDBName)
 	}
 	if !strings.EqualFold(tableName, name) {
-		return "", fmt.Errorf("table name of %s does not match the table name specified within the file: %s", name, tableName)
+		return "", vterrors.Errorf(vtrpcpb.Code_INTERNAL, "table name of %s does not match the table name specified within the file: %s", name, tableName)
 	}
 	if !createTable.IfNotExists {
-		return "", fmt.Errorf("%s file did not include the required IF NOT EXISTS clause in the CREATE TABLE statement for the %s table", name, tableName)
+		return "", vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "%s file did not include the required IF NOT EXISTS clause in the CREATE TABLE statement for the %s table", name, tableName)
 	}
 	normalizedSchema := sqlparser.CanonicalString(createTable)
 	return normalizedSchema, nil
@@ -123,7 +158,7 @@ func initSchemaFiles() {
 			case 2:
 				module = fmt.Sprintf("%s/%s", dirparts[0], dirparts[1])
 			default:
-				return fmt.Errorf("unexpected path value of %s specified for sidecar schema table; expected structure is <module>[/<submodule>]/<tablename>.sql", dir)
+				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unexpected path value of %s specified for sidecar schema table; expected structure is <module>[/<submodule>]/<tablename>.sql", dir)
 			}
 
 			name := strings.Split(fname, ".")[0]
@@ -163,9 +198,23 @@ type schemaInit struct {
 // Exec is a callback that has to be passed to Init() to execute the specified query in the database.
 type Exec func(ctx context.Context, query string, maxRows int, useDB bool) (*sqltypes.Result, error)
 
-// GetDDLCount metric returns the count of sidecardb ddls that have been run as part of this vttablet's init process.
+// GetDDLCount returns the count of sidecardb ddls that have been run as part of this vttablet's init process.
 func GetDDLCount() int64 {
 	return ddlCount.Get()
+}
+
+// GetDDLErrorCount returns the count of sidecardb ddls that have been errored out as part of this vttablet's init process.
+func GetDDLErrorCount() int64 {
+	return ddlErrorCount.Get()
+}
+
+// GetDDLErrorHistory returns the errors encountered as part of this vttablet's init process..
+func GetDDLErrorHistory() []*ddlError {
+	var errors []*ddlError
+	for _, e := range ddlErrorHistory.Records() {
+		errors = append(errors, e.(*ddlError))
+	}
+	return errors
 }
 
 // Init creates or upgrades the sidecar database based on declarative schema for all tables in the schema.
@@ -249,7 +298,7 @@ func (si *schemaInit) doesSidecarDBExist() (bool, error) {
 		return true, nil
 	default:
 		log.Errorf("found too many rows for sidecarDB %s: %d", SidecarDBName, len(rs.Rows))
-		return false, fmt.Errorf("found too many rows for sidecarDB %s: %d", SidecarDBName, len(rs.Rows))
+		return false, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "found too many rows for sidecarDB %s: %d", SidecarDBName, len(rs.Rows))
 	}
 }
 
@@ -357,15 +406,29 @@ func (si *schemaInit) ensureSchema(table *sidecarTable) error {
 		}
 		_, err := si.exec(ctx, ddl, 1, true)
 		if err != nil {
-			log.Errorf("Error running ddl %s for table %s during sidecar database initialization %s: %+v", ddl, table, err)
-			return err
+			ddlErr := vterrors.Wrapf(err,
+				"Error running ddl %s for table %s during sidecar database initialization", ddl, table)
+			recordDDLError(table.name, ddlErr)
+			if failOnSchemaInitError {
+				return ddlErr
+			}
+			return nil
 		}
-		log.Infof("Applied ddl %s for table %s during sidecar database initialization %s", ddl, table)
+		log.Infof("Applied ddl %s for table %s during sidecar database initialization", ddl, table)
 		ddlCount.Add(1)
 		return nil
 	}
 	log.Infof("Table schema was already up to date for the %s table in the %s sidecar database", table.name, SidecarDBName)
 	return nil
+}
+
+func recordDDLError(tableName string, err error) {
+	log.Error(err)
+	ddlErrorCount.Add(1)
+	ddlErrorHistory.Add(&ddlError{
+		tableName: tableName,
+		err:       err,
+	})
 }
 
 // region unit-test-only

--- a/go/vt/sidecardb/sidecardb_test.go
+++ b/go/vt/sidecardb/sidecardb_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"testing"
 
+	"vitess.io/vitess/go/vt/sqlparser"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/stats"
@@ -60,28 +62,35 @@ func TestInitErrors(t *testing.T) {
 		errorValue string
 	}
 
-	// simulate two errors
+	// simulate two errors during table creation to validate error stats
 	schemaErrors := []schemaError{
 		{"vreplication_log", "vreplication_log error"},
 		{"copy_state", "copy_state error"},
 	}
+
 	exec := func(ctx context.Context, query string, maxRows int, useDB bool) (*sqltypes.Result, error) {
 		if useDB {
 			if _, err := conn.ExecuteFetch(UseSidecarDatabaseQuery, maxRows, true); err != nil {
 				return nil, err
 			}
 		}
-		// return errors for the table creation ddls applied for tables specified in schemaError
-		showCreateTableQueryPrefix := "show create table"
-		if !strings.Contains(strings.ToLower(query), showCreateTableQueryPrefix) {
+
+		// simulate errors for the table creation DDLs applied for tables specified in schemaErrors
+		stmt, err := sqlparser.Parse(query)
+		if err != nil {
+			return nil, err
+		}
+		createTable, ok := stmt.(*sqlparser.CreateTable)
+		if ok {
 			for _, e := range schemaErrors {
-				if strings.Contains(query, e.tableName) {
+				if strings.EqualFold(e.tableName, createTable.Table.Name.String()) {
 					return nil, fmt.Errorf(e.errorValue)
 				}
 			}
 		}
 		return conn.ExecuteFetch(query, maxRows, true)
 	}
+
 	require.Equal(t, int64(0), GetDDLCount())
 	err = Init(ctx, exec)
 	require.NoError(t, err)
@@ -100,12 +109,12 @@ func TestInitErrors(t *testing.T) {
 	})
 	var gotErrors string
 	stats.Register(func(name string, v expvar.Var) {
-		if name == "SidecarDBDDLErrors" {
+		if name == StatsKeyErrors {
 			gotErrors = v.String()
 		}
 	})
 
-	// for ddl errors, validate both the internal data structure and the stats endpoint
+	// for DDL errors, validate both the internal data structure and the stats endpoint
 	for i := range want {
 		if !strings.Contains(got[i].err.Error(), want[i]) {
 			require.FailNowf(t, "incorrect schema error", "got %s, want %s", got[i], want[i])
@@ -152,6 +161,7 @@ func TestMiscSidecarDB(t *testing.T) {
 	defer db.Close()
 	AddSchemaInitQueries(db, false)
 	db.AddQuery("use dbname", &sqltypes.Result{})
+	db.AddQueryPattern("set @@session.sql_mode=.*", &sqltypes.Result{})
 
 	cp := db.ConnParams()
 	conn, err := cp.Connect(ctx)

--- a/go/vt/sidecardb/sidecardb_test.go
+++ b/go/vt/sidecardb/sidecardb_test.go
@@ -18,16 +18,24 @@ package sidecardb
 
 import (
 	"context"
+	"expvar"
+	"fmt"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/stats"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 )
 
-// Tests all non-error code paths in sidecardb
-func TestAllSidecarDB(t *testing.T) {
+// TestInitErrors validates that the schema init error stats are being correctly set
+func TestInitErrors(t *testing.T) {
+	ctx := context.Background()
+
 	db := fakesqldb.New(t)
 	defer db.Close()
 	AddSchemaInitQueries(db, false)
@@ -40,7 +48,111 @@ func TestAllSidecarDB(t *testing.T) {
 	db.AddQuery("select @@session.sql_mode as sql_mode", sqlMode)
 	db.AddQueryPattern("set @@session.sql_mode=.*", &sqltypes.Result{})
 
+	ddlErrorCount.Set(0)
+	ddlCount.Set(0)
+
+	cp := db.ConnParams()
+	conn, err := cp.Connect(ctx)
+	require.NoError(t, err)
+
+	type schemaError struct {
+		tableName  string
+		errorValue string
+	}
+
+	// simulate two errors
+	schemaErrors := []schemaError{
+		{"vreplication_log", "vreplication_log error"},
+		{"copy_state", "copy_state error"},
+	}
+	exec := func(ctx context.Context, query string, maxRows int, useDB bool) (*sqltypes.Result, error) {
+		if useDB {
+			if _, err := conn.ExecuteFetch(UseSidecarDatabaseQuery, maxRows, true); err != nil {
+				return nil, err
+			}
+		}
+		// return errors for the table creation ddls applied for tables specified in schemaError
+		showCreateTableQueryPrefix := "show create table"
+		if !strings.Contains(strings.ToLower(query), showCreateTableQueryPrefix) {
+			for _, e := range schemaErrors {
+				if strings.Contains(query, e.tableName) {
+					return nil, fmt.Errorf(e.errorValue)
+				}
+			}
+		}
+		return conn.ExecuteFetch(query, maxRows, true)
+	}
+	require.Equal(t, int64(0), GetDDLCount())
+	err = Init(ctx, exec)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(sidecarTables)-len(schemaErrors)), GetDDLCount())
+	require.Equal(t, int64(len(schemaErrors)), GetDDLErrorCount())
+
+	var want []string
+	for _, e := range schemaErrors {
+		want = append(want, e.errorValue)
+	}
+	// sort expected and reported errors for easy comparison
+	sort.Strings(want)
+	got := GetDDLErrorHistory()
+	sort.Slice(got, func(i, j int) bool {
+		return got[i].tableName < got[j].tableName
+	})
+	var gotErrors string
+	stats.Register(func(name string, v expvar.Var) {
+		if name == "SidecarDBDDLErrors" {
+			gotErrors = v.String()
+		}
+	})
+
+	// for ddl errors, validate both the internal data structure and the stats endpoint
+	for i := range want {
+		if !strings.Contains(got[i].err.Error(), want[i]) {
+			require.FailNowf(t, "incorrect schema error", "got %s, want %s", got[i], want[i])
+		}
+		if !strings.Contains(gotErrors, want[i]) {
+			require.FailNowf(t, "schema error not published", "got %s, want %s", gotErrors, want[i])
+		}
+	}
+}
+
+// test the logic that confirms that the user defined schema's table name and qualifier are valid
+func TestValidateSchema(t *testing.T) {
+	type testCase struct {
+		testName  string
+		name      string
+		schema    string
+		mustError bool
+	}
+	testCases := []testCase{
+		{"valid", "t1", "create table if not exists _vt.t1(i int)", false},
+		{"no if not exists", "t1", "create table _vt.t1(i int)", true},
+		{"invalid table name", "t2", "create table if not exists _vt.t1(i int)", true},
+		{"invalid table name", "t1", "create table if not exists _vt.t2(i int)", true},
+		{"invalid qualifier", "t1", "create table if not exists vt_product.t1(i int)", true},
+		{"invalid qualifier", "t1", "create table if not exists t1(i int)", true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			_, err := validateSchemaDefinition(tc.name, tc.schema)
+			if tc.mustError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Tests various non-error code paths in sidecardb
+func TestMiscSidecarDB(t *testing.T) {
 	ctx := context.Background()
+
+	db := fakesqldb.New(t)
+	defer db.Close()
+	AddSchemaInitQueries(db, false)
+	db.AddQuery("use dbname", &sqltypes.Result{})
+
 	cp := db.ConnParams()
 	conn, err := cp.Connect(ctx)
 	require.NoError(t, err)
@@ -54,6 +166,8 @@ func TestAllSidecarDB(t *testing.T) {
 	}
 
 	// tests init on empty db
+	ddlErrorCount.Set(0)
+	ddlCount.Set(0)
 	require.Equal(t, int64(0), GetDDLCount())
 	err = Init(ctx, exec)
 	require.NoError(t, err)
@@ -84,32 +198,4 @@ func TestAllSidecarDB(t *testing.T) {
 	require.False(t, MatchesInitQuery("abc"))
 	require.True(t, MatchesInitQuery(SelectCurrentDatabaseQuery))
 	require.True(t, MatchesInitQuery("CREATE TABLE IF NOT EXISTS `_vt`.vreplication"))
-}
-
-// test the logic that confirms that the user defined schema's table name and qualifier are valid
-func TestValidateSchema(t *testing.T) {
-	type testCase struct {
-		testName  string
-		name      string
-		schema    string
-		mustError bool
-	}
-	testCases := []testCase{
-		{"valid", "t1", "create table if not exists _vt.t1(i int)", false},
-		{"no if not exists", "t1", "create table _vt.t1(i int)", true},
-		{"invalid table name", "t2", "create table if not exists _vt.t1(i int)", true},
-		{"invalid table name", "t1", "create table if not exists _vt.t2(i int)", true},
-		{"invalid qualifier", "t1", "create table if not exists vt_product.t1(i int)", true},
-		{"invalid qualifier", "t1", "create table if not exists t1(i int)", true},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.testName, func(t *testing.T) {
-			_, err := validateSchemaDefinition(tc.name, tc.schema)
-			if tc.mustError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
 }


### PR DESCRIPTION

## Description

The initial implementation of the new mechanism for initializing the sidecar database in https://github.com/vitessio/vitess/pull/11520 causes a failure if there is an error while applying a DDL to create or alter even a single sidecardb table.  Such a failure causes the tablet initialization to fail. Hence if there is an issue with one of the queries to create or upgrade a table, say due to an incompatible MySQL version we would end up with tablets not reaching the serving state. 

Now, if this happens during a Vitess version upgrade, it would not be catastrophic because the upgrade process would be stopped when the first replica being upgraded fails to launch.

However if, for any reason, the entire cluster rolls over to a new Vitess version in the presence of these failures, we would have a catastrophic incident where we could not serve queries.  This can also happen if we upgrade the MySQL version on all tablets for the same Vitess version.

For example, we recently encountered a user cluster where a schema upgrade (using `withddl`) had caused a cluster to fail when the underlying MySQL was upgraded. This was due to a data inconsistency: one of the sidecar tables had zero dates and a table alter which added an unrelated column failed on newer versions of MySQL.  

While such issues might happen very rarely, the possible existence of such critical issues is a strong reason not to fail tablet launches if we encounter errors during the sidecar init process.

This PR ignores errors in the `sidecardb` module when we execute `create` or `alter` queries on sidecardb tables.  Quietly failing errors or just logging is also not ideal since it means some modules or some functionality of modules can fail due to an incorrect schema of a table used by that module and debugging them can be time consuming (Note that we had the same issue the `withDDL` approach). 

To surface these issues we have added two stats which are available via the `debug/vars` endpoint: 
  * `SidecarDBDDLErrorCount` which is the number of errors encountered
  * `SidecarDBDDLErrors` which is a list of the corresponding golang errors 
 
A future PR will add functionality to VTAdmin to create visual alerts based on these stats.

## Related Issue(s)
https://github.com/vitessio/vitess/issues/10133

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [ ] Documentation was added or is not required
