### PR TITLE
maintainers: add dbussink and rework some sections

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,7 @@ The following is the full list, alphabetically ordered.
 * Dan Kozlowski ([dkhenry](https://github.com/dkhenry)) dan.kozlowski@gmail.com
 * Deepthi Sigireddi ([deepthi](https://github.com/deepthi)) deepthi@planetscale.com
 * Derek Perkins ([derekperkins](https://github.com/derekperkins)) derek@nozzle.io
+* Dirkjan Bussink ([dbussink](https://github.com/dbussink)) dbussink@planetscale.com
 * Florent Poinsard ([frouioui](https://github.com/frouioui)) florent@planetscale.com
 * Frances Thai ([notfelineit](https://github.com/notfelineit)) frances@planetscale.com
 * Harshit Gangal ([harshit-gangal](https://github.com/harshit-gangal)) harshit.gangal@gmail.com
@@ -29,16 +30,25 @@ dkhenry, shlomi-noach, ajm188, vmg, GuptaManan100, frouioui
 rohit-nayak-ps, deepthi, mattlord
 
 ### Parser
-systay, harshit-gangal, vmg, GuptaManan100
+systay, harshit-gangal, vmg, GuptaManan100, dbussink
+
+### Evaluation Engine
+vmg
 
 ### Planner
-systay, harshit-gangal, GuptaManan100, frouioui
+systay, harshit-gangal, GuptaManan100, frouioui 
+
+### Query Serving
+systay, harshit-gangal, GuptaManan100, frouioui, vmg, dbussink
+
+### Online DDL
+shlomi-noach, dbussink
 
 ### Performance
 vmg
 
 ### Cluster Management
-deepthi, shlomi-noach, ajm188, GuptaManan100
+deepthi, ajm188, GuptaManan100, dbussink
 
 ### Java
 harshit-gangal


### PR DESCRIPTION
## Description

Congratulations to @dbussink on joining the Vitess maintainers team!

I signed him up for some shit on `maintaners.md` and reworked some of the sections.

cc @deepthi 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
