### PR TITLE
evalengine: fix bugs with decimal rounding

### DIFF
--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -309,7 +309,7 @@ func decimalTimesAny(v1 *evalDecimal, v2 evalNumeric) (eval, error) {
 	v2d := v2.toDecimal(0, 0)
 	return &evalDecimal{
 		dec:    v1.dec.Mul(v2d.dec),
-		length: maxprec(v1.length, v2d.length),
+		length: v1.length + v2d.length,
 	}, nil
 }
 

--- a/go/vt/vtgate/evalengine/integration/testdata/mysql_golden_1676045458.json
+++ b/go/vt/vtgate/evalengine/integration/testdata/mysql_golden_1676045458.json
@@ -1,0 +1,14 @@
+[
+    {
+        "Query": "SELECT 12.0 * (1 / 12)",
+        "Value": "DECIMAL(1.00000)"
+    },
+    {
+        "Query": "SELECT 12.0 * 0",
+        "Value": "DECIMAL(0.0)"
+    },
+    {
+        "Query": "SELECT 12.0 * 12.0",
+        "Value": "DECIMAL(144.00)"
+    }
+]

--- a/go/vt/vtgate/evalengine/internal/decimal/decimal.go
+++ b/go/vt/vtgate/evalengine/internal/decimal/decimal.go
@@ -66,7 +66,7 @@ var divisionPrecision = 16
 
 // Zero constant, to make computations faster.
 // Zero should never be compared with == or != directly, please use decimal.Equal or decimal.Cmp instead.
-var Zero = New(0, 1)
+var Zero = New(0, 0)
 
 var zeroInt = big.NewInt(0)
 var oneInt = big.NewInt(1)


### PR DESCRIPTION
## Description

These bugs have been in the evalengine for a while, but we were not running the fuzzer properly, so they went undetected!

They are as follows:

- The precision after multiplying two decimals is the sum of their two precisions, not their max. This is required by standard SQL and clearly listed in the MySQL docs, so I don't know what I was thinking. Maybe it was a copy-paste mistake.
- The constant for Decimal zero should be `(0, 0)`, not `(0, 1)`. This is not specified in the SQL standard but it appears to be empirically wrong: it results in the wrong number of decimal points after multiplying any number by zero. Note that the parameters to a Decimal `(X, Y)` result in the decimal value `X * 10^Y`, so having `Y` have a 0 exponent is equivalent to having it be 0, as long as the `X` remains 0.
- The string rounding code could overflow! For those following at home, when printing a decimal number as text with its given precision, we perform the rounding on the decimal string itself because it's both cheaper and easier to program than actually rounding the binary values for the decimal. When rounding the string, we adjust the ASCII characters from `0` to `9`, but our current rounding code has an issue when the rounding overflows. E.g.: when rounding up `9999996`, all the `9`s overflow upwards to `0`, until we reach the very start of the string. Our current code handles this overflow properly by prepending an `1` at the start of the string (`10000000`), but the resulting string now has one extra digit of precision, because all the zeroes have shifted forward in the string. When this happens, the calling code needs to adjust _up_ the exponent of the original decimal. Otherwise the resulted string will be 10 times smaller than what we were expecting (i.e. we need to shift up the exponent so the final result is not divided by 10).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
