### PR TITLE
fix(vitessdriver): correctly handle nil bytes

### DIFF
--- a/go/sqltypes/bind_variables.go
+++ b/go/sqltypes/bind_variables.go
@@ -132,6 +132,9 @@ func StringBindVariable(v string) *querypb.BindVariable {
 
 // BytesBindVariable converts a []byte to a bind var.
 func BytesBindVariable(v []byte) *querypb.BindVariable {
+	if v == nil {
+		return NullBindVariable
+	}
 	return &querypb.BindVariable{Type: VarBinary, Value: v}
 }
 

--- a/go/vt/vitessdriver/driver_test.go
+++ b/go/vt/vitessdriver/driver_test.go
@@ -559,7 +559,7 @@ func TestEmptyValues(t *testing.T) {
 		desc: "empty bytes",
 		in: []driver.NamedValue{{
 			Name:  "n1",
-			Value: []byte(nil),
+			Value: nil,
 		}, {
 			Name:  "n2",
 			Value: []byte(""),


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This fixes an issue with the vitess driver where it incorrectly deserializes NULL as []bytes{}.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

https://github.com/vitessio/vitess/issues/12121

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
