### PR TITLE
sqlparser/schemadiff: normalize CAST type case

### DIFF
--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -1114,6 +1114,24 @@ func TestCreateTableDiff(t *testing.T) {
 			diff:  "alter table t1 comment ''",
 			cdiff: "ALTER TABLE `t1` COMMENT ''",
 		},
+		// expressions
+		{
+			// validates that CannonicalString prints 'signed' and not 'SIGNED', as MySQL's `SHOW CREATE TABLE` outputs lower case 'signed'
+			name: "cast as",
+			from: `
+				CREATE TABLE t4 (
+					id int NOT NULL PRIMARY KEY,
+					properties json NOT NULL
+				)`,
+			to: `
+				CREATE TABLE t4 (
+					id int NOT NULL PRIMARY KEY,
+					properties json NOT NULL,
+					KEY index_on_company_id ((cast(json_unquote(json_extract(properties,_utf8mb4'$.company_id')) as signed)))
+				)`,
+			diff:  "alter table t4 add key index_on_company_id ((cast(json_unquote(json_extract(properties, _utf8mb4 '$.company_id')) as signed)))",
+			cdiff: "ALTER TABLE `t4` ADD KEY `index_on_company_id` ((CAST(JSON_UNQUOTE(JSON_EXTRACT(`properties`, _utf8mb4 '$.company_id')) AS signed)))",
+		},
 	}
 	standardHints := DiffHints{}
 	for _, ts := range tt {
@@ -1157,7 +1175,8 @@ func TestCreateTableDiff(t *testing.T) {
 				assert.NoError(t, err)
 				assert.True(t, alter.IsEmpty(), "expected empty diff, found changes")
 				if !alter.IsEmpty() {
-					t.Logf("statements[0]: %v", alter.StatementString())
+					t.Logf(" statements[0]: %v", alter.StatementString())
+					t.Logf("cstatements[0]: %v", alter.CanonicalStatementString())
 					t.Logf("c: %v", sqlparser.CanonicalString(c.CreateTable))
 					t.Logf("other: %v", sqlparser.CanonicalString(other.CreateTable))
 				}

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -1778,7 +1778,7 @@ func (node *ConvertUsingExpr) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *ConvertType) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "%s", node.Type)
+	buf.astPrintf(node, "%#s", node.Type)
 	if node.Length != nil {
 		buf.astPrintf(node, "(%v", node.Length)
 		if node.Scale != nil {


### PR DESCRIPTION
## Description

Fixes https://github.com/vitessio/vitess/issues/12371

Normalizing the `CAST(...AS <type>)` in `CannonicalString()` ; previously uppercased, but that's incompatible with MySQL's behavior. Now keeping the original case.

## Related Issue(s)

- fixes https://github.com/vitessio/vitess/issues/12371
- https://github.com/vitessio/vitess/issues/10203
- similar to https://github.com/vitessio/vitess/pull/12105

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
