### PR TITLE
Fix for USING when column names not lower cased

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -475,7 +475,7 @@
           "Sharded": false
         },
         "FieldQuery": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where 1 != 1",
-        "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = database() and rc.table_name = :rc_table_name and fk.referenced_column_name is not null and fk.table_schema = database() and fk.table_name = :fk_table_name",
+        "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = database() and rc.table_name = :rc_table_name and fk.referenced_column_name is not null and fk.table_schema = database() and fk.table_name = :fk_table_name and rc.constraint_schema = fk.constraint_schema and rc.constraint_name = fk.constraint_name",
         "SysTableTableName": "[fk_table_name:VARCHAR(\":vtg1\"), rc_table_name:VARCHAR(\":vtg1\")]",
         "Table": "information_schema.key_column_usage, information_schema.referential_constraints"
       }
@@ -569,7 +569,7 @@
           "Sharded": false
         },
         "FieldQuery": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where 1 != 1",
-        "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = :__vtschemaname and rc.table_name = :rc_table_name and fk.referenced_column_name is not null and fk.table_schema = :__vtschemaname and fk.table_name = :fk_table_name",
+        "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = :__vtschemaname and rc.table_name = :rc_table_name and fk.referenced_column_name is not null and fk.table_schema = :__vtschemaname and fk.table_name = :fk_table_name and rc.constraint_schema = fk.constraint_schema and rc.constraint_name = fk.constraint_name",
         "SysTableTableName": "[fk_table_name:VARCHAR(\"table_name\"), rc_table_name:VARCHAR(\"table_name\")]",
         "SysTableTableSchema": "[VARCHAR(\"table_schema\")]",
         "Table": "information_schema.key_column_usage, information_schema.referential_constraints"

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -475,7 +475,7 @@
           "Sharded": false
         },
         "FieldQuery": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where 1 != 1",
-        "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = database() and rc.table_name = :rc_table_name and fk.referenced_column_name is not null and fk.table_schema = database() and fk.table_name = :fk_table_name",
+        "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = database() and rc.table_name = :rc_table_name and fk.referenced_column_name is not null and fk.table_schema = database() and fk.table_name = :fk_table_name and rc.constraint_schema = fk.constraint_schema and rc.constraint_name = fk.constraint_name",
         "SysTableTableName": "[fk_table_name:VARCHAR(\":vtg1\"), rc_table_name:VARCHAR(\":vtg1\")]",
         "Table": "information_schema.key_column_usage, information_schema.referential_constraints"
       }
@@ -569,7 +569,7 @@
           "Sharded": false
         },
         "FieldQuery": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where 1 != 1",
-        "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = :__vtschemaname and rc.table_name = :rc_table_name and fk.referenced_column_name is not null and fk.table_schema = :__vtschemaname and fk.table_name = :fk_table_name",
+        "Query": "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as `name`, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc, information_schema.key_column_usage as fk where rc.constraint_schema = :__vtschemaname and rc.table_name = :rc_table_name and fk.referenced_column_name is not null and fk.table_schema = :__vtschemaname and fk.table_name = :fk_table_name and rc.constraint_schema = fk.constraint_schema and rc.constraint_name = fk.constraint_name",
         "SysTableTableName": "[fk_table_name:VARCHAR(\"table_name\"), rc_table_name:VARCHAR(\"table_name\")]",
         "SysTableTableSchema": "[VARCHAR(\"table_schema\")]",
         "Table": "information_schema.key_column_usage, information_schema.referential_constraints"
@@ -602,7 +602,11 @@
       "Instructions": {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "L:0,L:1",
+        "JoinColumnIndexes": "L:2,L:3",
+        "JoinVars": {
+          "cc_constraint_name": 1,
+          "cc_constraint_schema": 0
+        },
         "TableName": "information_schema.check_constraints_information_schema.table_constraints",
         "Inputs": [
           {
@@ -612,8 +616,8 @@
               "Name": "main",
               "Sharded": false
             },
-            "FieldQuery": "select cc.constraint_name as `name`, cc.check_clause as expression from information_schema.check_constraints as cc where 1 != 1",
-            "Query": "select cc.constraint_name as `name`, cc.check_clause as expression from information_schema.check_constraints as cc where cc.constraint_schema = :__vtschemaname",
+            "FieldQuery": "select cc.constraint_schema, cc.constraint_name, cc.constraint_name as `name`, cc.check_clause as expression from information_schema.check_constraints as cc where 1 != 1",
+            "Query": "select cc.constraint_schema, cc.constraint_name, cc.constraint_name as `name`, cc.check_clause as expression from information_schema.check_constraints as cc where cc.constraint_schema = :__vtschemaname",
             "SysTableTableSchema": "[VARCHAR(\"constraint_schema\")]",
             "Table": "information_schema.check_constraints"
           },
@@ -625,9 +629,9 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 from information_schema.table_constraints as tc where 1 != 1",
-            "Query": "select 1 from information_schema.table_constraints as tc where tc.table_schema = :__vtschemaname and tc.table_name = :tc_table_name",
+            "Query": "select 1 from information_schema.table_constraints as tc where tc.table_schema = :__vtschemaname and tc.table_name = :tc_table_name and tc.constraint_schema = :__vtschemaname and tc.constraint_name = :cc_constraint_name",
             "SysTableTableName": "[tc_table_name:VARCHAR(\"table_name\")]",
-            "SysTableTableSchema": "[VARCHAR(\"table_schema\")]",
+            "SysTableTableSchema": "[VARCHAR(\"table_schema\"), :cc_constraint_schema]",
             "Table": "information_schema.table_constraints"
           }
         ]

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -18,6 +18,7 @@ package semantics
 
 import (
 	"strconv"
+	"strings"
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
@@ -298,7 +299,7 @@ func rewriteJoinUsing(
 				usingCols = map[string]TableSet{}
 			}
 			for _, col := range tbl.getColumns() {
-				_, found := usingCols[col.Name]
+				_, found := usingCols[strings.ToLower(col.Name)]
 				if found {
 					tblName, err := tbl.Name()
 					if err != nil {


### PR DESCRIPTION
## Description
When rewriting `JOIN ... USING` syntax into a `JOIN ... WHERE` form, we missed columns that in the query were not lower cased 🤦 

I'll manually create the backport to 15 and then let the bot do the backport of that to 14.

## Related Issue(s)
Fixes #12332
