### PR TITLE
go/vt/mysqlctl{/backupstats}: throttle backupstats for perf

### DIFF
--- a/go/vt/mysqlctl/backupstats/memory_stats.go
+++ b/go/vt/mysqlctl/backupstats/memory_stats.go
@@ -1,0 +1,44 @@
+package backupstats
+
+import "time"
+
+type memoryStats struct {
+	// bytes stores the sum of bytes passed to TimedIncrementBytes since the last
+	// call to Reset.
+	bytes int
+	// calls stores the number of calls to TimedIncrement or
+	// TimedIncrementBytesCalls since the last call to Reset.
+	calls int
+	// count stores the number of times TimedIncrement was called since the
+	// last call to Reset.
+	count int64
+	// duration stores the sum of durations passed to TimedIncrement and
+	// TimedIncrementBytes since the the last call to Reset.
+	duration time.Duration
+}
+
+func newMemoryStats() *memoryStats {
+	return &memoryStats{}
+}
+
+// TimedIncrement increments Count by 1 and Duration by d.
+func (ms *memoryStats) TimedIncrement(d time.Duration) {
+	ms.calls++
+	ms.count++
+	ms.duration += d
+}
+
+// TimedIncrementBytes increments Bytes by b and Duration by d.
+func (ms *memoryStats) TimedIncrementBytes(b int, d time.Duration) {
+	ms.bytes += b
+	ms.calls++
+	ms.duration += d
+}
+
+// Reset sets Bytes, Count, and Duration to zero.
+func (ms *memoryStats) Reset() {
+	ms.bytes = 0
+	ms.count = 0
+	ms.duration = 0
+	ms.calls = 0
+}

--- a/go/vt/mysqlctl/backupstats/memory_stats_test.go
+++ b/go/vt/mysqlctl/backupstats/memory_stats_test.go
@@ -1,0 +1,57 @@
+package backupstats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMemoryStats(t *testing.T) {
+	ms := newMemoryStats()
+
+	require.Equal(t, 0, ms.bytes)
+	require.Equal(t, int64(0), ms.count)
+	require.Equal(t, time.Duration(0), ms.duration)
+}
+
+func TestIncrement(t *testing.T) {
+	ms := newMemoryStats()
+
+	ms.TimedIncrement(5 * time.Minute)
+	require.Equal(t, 0, ms.bytes)
+	require.Equal(t, int64(1), ms.count)
+	require.Equal(t, 5*time.Minute, ms.duration)
+
+	ms.TimedIncrement(10 * time.Minute)
+	require.Equal(t, 0, ms.bytes)
+	require.Equal(t, int64(2), ms.count)
+	require.Equal(t, 15*time.Minute, ms.duration)
+}
+
+func TestIncrementBytes(t *testing.T) {
+	ms := newMemoryStats()
+
+	ms.TimedIncrementBytes(5, 5*time.Minute)
+	require.Equal(t, 5, ms.bytes)
+	require.Equal(t, int64(0), ms.count)
+	require.Equal(t, 5*time.Minute, ms.duration)
+
+	ms.TimedIncrementBytes(10, 10*time.Minute)
+	require.Equal(t, 15, ms.bytes)
+	require.Equal(t, int64(0), ms.count)
+	require.Equal(t, 15*time.Minute, ms.duration)
+}
+
+func TestReset(t *testing.T) {
+	ms := newMemoryStats()
+
+	ms.TimedIncrement(5 * time.Minute)
+	ms.TimedIncrementBytes(5, 5*time.Minute)
+
+	ms.Reset()
+
+	require.Equal(t, 0, ms.bytes)
+	require.Equal(t, int64(0), ms.count)
+	require.Equal(t, time.Duration(0), ms.duration)
+}

--- a/go/vt/mysqlctl/backupstats/throttled_stats.go
+++ b/go/vt/mysqlctl/backupstats/throttled_stats.go
@@ -1,0 +1,101 @@
+package backupstats
+
+import (
+	"sync"
+	"time"
+)
+
+// ThrottledStats is a Stats object that throttles and batches calls to
+// TimedIncrement and TimedIncrementBytes when they occur more than once within
+// a specified time interval. Unflushed calls are flushed when a subsequent call
+// is made that is at least the specified time interval after the last flush
+// time.
+type ThrottledStats struct {
+	timedCount *memoryStats
+	timedBytes *memoryStats
+
+	children      []*ThrottledStats
+	lastFlushTime time.Time
+	maxInterval   time.Duration
+	mu            *sync.Mutex
+	stats         Stats
+}
+
+// Throttle wraps the provided stats object so that calls to TimedIncrement and
+// TimedIncrementBytes are passed to the provided stats object no more than
+// once per the specified maxInterval.
+func Throttle(stats Stats, maxInterval time.Duration) *ThrottledStats {
+	return &ThrottledStats{
+		timedCount: newMemoryStats(),
+		timedBytes: newMemoryStats(),
+
+		children:    make([]*ThrottledStats, 0),
+		maxInterval: maxInterval,
+		mu:          &sync.Mutex{},
+		stats:       stats,
+	}
+}
+
+// Flush flushes any unflushed TimedIncrement or TimedIncrementBytes calls to
+// the wrapped Stats object. It also flushes any children created with Scope.
+func (ts *ThrottledStats) Flush() {
+	ts.flush()
+	for _, c := range ts.children {
+		c.Flush()
+	}
+}
+
+// Scope scopes the wrapped Stats object with the provided scopes, and returns
+// a new ThrottledStats object wrapping that new Stats object.
+//
+// Scope is safe for use across goroutines.
+func (ts *ThrottledStats) Scope(scopes ...Scope) Stats {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	stats := ts.stats.Scope(scopes...)
+	newTs := Throttle(stats, ts.maxInterval)
+	ts.children = append(ts.children, newTs)
+	return newTs
+}
+
+// Stats returns the wrapped Stats object.
+func (ts *ThrottledStats) Stats() Stats {
+	return ts.stats
+}
+
+// TimedIncrement batches the provided duration d with any previous, unflushed
+// calls to TimedIncrement, and flushes all unflushed calls if enough time has
+// elapsed since the last flush.
+func (ts *ThrottledStats) TimedIncrement(d time.Duration) {
+	ts.timedCount.TimedIncrement(d)
+	ts.maybeFlush()
+}
+
+// TimedIncrementBytes batches the provided bytes b and duration d with any
+// previous, unflushed calls to TimedIncrementBytes, and flushes all unflushed
+// calls if enough time has elapsed since the last flush.
+func (ts *ThrottledStats) TimedIncrementBytes(b int, d time.Duration) {
+	ts.timedBytes.TimedIncrementBytes(b, d)
+	ts.maybeFlush()
+}
+
+func (ts *ThrottledStats) flush() {
+	if ts.timedCount.calls > 0 {
+		ts.stats.TimedIncrement(ts.timedCount.duration)
+		ts.timedCount.Reset()
+	}
+	if ts.timedBytes.calls > 0 {
+		ts.stats.TimedIncrementBytes(ts.timedBytes.bytes, ts.timedBytes.duration)
+		ts.timedBytes.Reset()
+	}
+}
+
+func (ts *ThrottledStats) maybeFlush() {
+	now := time.Now()
+	emitWaitTime := ts.maxInterval - now.Sub(ts.lastFlushTime)
+	if emitWaitTime < 0 {
+		ts.flush()
+		ts.lastFlushTime = now
+	}
+}

--- a/go/vt/mysqlctl/backupstats/throttled_stats_test.go
+++ b/go/vt/mysqlctl/backupstats/throttled_stats_test.go
@@ -1,0 +1,138 @@
+package backupstats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestThrottledStatsFlush(t *testing.T) {
+	fakeStats := NewFakeStats()
+	throttled := Throttle(fakeStats, 5*time.Second)
+
+	// First call to TimedIncrement is not throttled.
+	throttled.TimedIncrement(5 * time.Minute)
+
+	require.Len(t, fakeStats.TimedIncrementCalls, 1)
+	require.Equal(t, 5*time.Minute, fakeStats.TimedIncrementCalls[0])
+
+	// Subsequent calls are throttled, batched and combined...
+	throttled.TimedIncrement(5 * time.Minute)
+	throttled.TimedIncrement(5 * time.Minute)
+
+	require.Len(t, fakeStats.TimedIncrementCalls, 1)
+
+	// ...and are emitted when Flush() is called.
+	throttled.Flush()
+
+	require.Len(t, fakeStats.TimedIncrementCalls, 2)
+	require.Equal(t, 10*time.Minute, fakeStats.TimedIncrementCalls[1])
+
+	// The next call to Flush() is a no-op because there is nothing to flush.
+	throttled.Flush()
+
+	require.Len(t, fakeStats.TimedIncrementCalls, 2)
+	require.Equal(t, 10*time.Minute, fakeStats.TimedIncrementCalls[1])
+
+	// Children are also flushed.
+	childThrottled1 := throttled.Scope(Component(BackupEngine)).(*ThrottledStats)
+	childStats1 := childThrottled1.Stats().(*FakeStats)
+	childThrottled2 := throttled.Scope(Component(BackupEngine)).(*ThrottledStats)
+	childStats2 := childThrottled2.Stats().(*FakeStats)
+
+	require.Len(t, childStats1.TimedIncrementCalls, 0)
+	require.Len(t, childStats2.TimedIncrementCalls, 0)
+
+	childThrottled1.TimedIncrement(5 * time.Minute)
+	childThrottled2.TimedIncrement(5 * time.Minute)
+
+	require.Len(t, childStats1.TimedIncrementCalls, 1)
+	require.Len(t, childStats2.TimedIncrementCalls, 1)
+
+	childThrottled1.TimedIncrement(5 * time.Minute)
+	childThrottled2.TimedIncrement(5 * time.Minute)
+
+	require.Len(t, childStats1.TimedIncrementCalls, 1)
+	require.Len(t, childStats2.TimedIncrementCalls, 1)
+
+	throttled.Flush()
+
+	require.Len(t, childStats1.TimedIncrementCalls, 2)
+	require.Len(t, childStats2.TimedIncrementCalls, 2)
+}
+
+func TestThrottledStatsScope(t *testing.T) {
+	fakeStats := NewFakeStats()
+	throttled := Throttle(fakeStats, 5*time.Second)
+
+	// Get a scoped throttled stats, and the underlying scoped fake stats.
+	scopedThrottled := throttled.Scope(Component(BackupEngine))
+	require.Len(t, fakeStats.ScopeCalls, 1)
+	require.Len(t, fakeStats.ScopeReturns, 1)
+
+	scopedFakeStats := fakeStats.ScopeReturns[0].(*FakeStats)
+	require.Equal(t, BackupEngine.String(), scopedFakeStats.ScopeV[ScopeComponent])
+
+	// Validate that changes to the parent stats don't change the child, and
+	// vice versa.
+	throttled.TimedIncrement(5 * time.Second)
+	require.Len(t, fakeStats.TimedIncrementCalls, 1)
+	require.Len(t, scopedFakeStats.TimedIncrementCalls, 0)
+
+	scopedThrottled.TimedIncrement(5 * time.Second)
+	require.Len(t, fakeStats.TimedIncrementCalls, 1)
+	require.Len(t, scopedFakeStats.TimedIncrementCalls, 1)
+}
+
+func TestThrottledStatsTimedIncrement(t *testing.T) {
+	fakeStats := NewFakeStats()
+	throttled := Throttle(fakeStats, 1*time.Second)
+
+	throttled.TimedIncrement(5 * time.Minute)
+
+	require.Len(t, fakeStats.TimedIncrementCalls, 1)
+	require.Equal(t, 5*time.Minute, fakeStats.TimedIncrementCalls[0])
+
+	throttled.TimedIncrement(5 * time.Minute)
+
+	require.Len(t, fakeStats.TimedIncrementCalls, 1)
+
+	time.Sleep(500 * time.Millisecond)
+
+	require.Len(t, fakeStats.TimedIncrementCalls, 1)
+
+	time.Sleep(501 * time.Millisecond)
+
+	throttled.TimedIncrement(5 * time.Minute)
+
+	require.Len(t, fakeStats.TimedIncrementCalls, 2)
+	require.Equal(t, 10*time.Minute, fakeStats.TimedIncrementCalls[1])
+}
+
+func TestThrottledStatsTimedIncrementBytes(t *testing.T) {
+	fakeStats := NewFakeStats()
+	throttled := Throttle(fakeStats, 1*time.Second)
+
+	throttled.TimedIncrementBytes(5, 5*time.Minute)
+
+	require.Len(t, fakeStats.TimedIncrementBytesCalls, 1)
+	require.Equal(t, 5, fakeStats.TimedIncrementBytesCalls[0].Bytes)
+	require.Equal(t, 5*time.Minute, fakeStats.TimedIncrementBytesCalls[0].Duration)
+
+	throttled.TimedIncrementBytes(5, 5*time.Minute)
+
+	require.Len(t, fakeStats.TimedIncrementBytesCalls, 1)
+
+	time.Sleep(500 * time.Millisecond)
+
+	require.Len(t, fakeStats.TimedIncrementBytesCalls, 1)
+
+	time.Sleep(501 * time.Millisecond)
+
+	throttled.TimedIncrementBytes(5, 5*time.Minute)
+
+	require.Len(t, fakeStats.TimedIncrementBytesCalls, 2)
+	require.Equal(t, 10, fakeStats.TimedIncrementBytesCalls[1].Bytes)
+	require.Equal(t, 10*time.Minute, fakeStats.TimedIncrementBytesCalls[1].Duration)
+}


### PR DESCRIPTION
## Description

https://github.com/vitessio/vitess/pull/11979 added detailed backup/restore metrics, but appeared to add ~4% overhead in a local test. I'm no longer able to reproduce the findings of that test.

In spite of that, this PR attempts to reduce any overhead by throttling stats calls. 

Takes inspiration from [logutil.ThrottledLogger](https://github.com/vitessio/vitess/blob/d90c6f54b7c4349bc78302bc2f49202e547e2491/go/vt/logutil/throttled.go#L29), but does not drop any stats. Instead batches and and combines unflushed stats and then flushes them either when `Flush()` is called by the user, or a subsequent stats call occurs after a user-specified time interval.

## Performance

A repeat of the performance test in https://github.com/vitessio/vitess/pull/11979.

I set up the commerce example cluster, and created a table with ~30 GiB of data  by repeatedly inserting `REPEAT(UUID(),10)`, and then ran...

```
$ vtctlclient Backup -- --allow_primary <tablet>
```

...multiple times, collecting the value of `vttablet_backup_duration_seconds`. 

Did this with the `main` commit before backupstats was introduced, the `main` commit when backupstats  was introduced, and the `HEAD` of this PR.

| # | `main` (7fc1b48d) | `main` (d5364e61) | this PR (65ac8fe2) |
|-|-|-|-|
| 1 | 89 | 90 | 89 |
| 2 | 89 | 90 | 89 |
| 3 | 90 | 89 | 88 | 
| 4 | 91 | 89 | 90 |
| 5 | 89 | 89 | 91 | 
| Δ | N/A | -0.22% | -0.22% |

In the last PR I found that d5364e61 added a bit of overhead 7fc1b48d.

> adds a roughly 3.8% performance overhead.

In this PR, it's not evident that d5364e61 adds any overhead. It's also not evident that 65ac8fe2 is any improvement to d5364e61.

I'm not sure it makes sense to merge this code, since it's not clear that there's anything to fix.

One possible explanation for getting misleading results in the last PR. I used `BackupShard` in the last PR whereas I'm using `Backup` against a specific tablet in this PR. Correct me if I'm wrong but I think that `BackupShard` picks a random replica tablet. Maybe small differences between replicas could result in different performance results from runs against randomly selected replicas.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/11977
https://github.com/vitessio/vitess/pull/11979

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation ~was added or~ is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
