### PR TITLE
Skip `TestReparentDoesntHangIfPrimaryFails` in vttablet v16 and above

### DIFF
--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	utilstest "vitess.io/vitess/go/test/endtoend/utils"
+
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/reparent/utils"
 	"vitess.io/vitess/go/vt/log"
@@ -183,13 +185,13 @@ func TestReparentFromOutsideWithNoPrimary(t *testing.T) {
 }
 
 func reparentFromOutside(t *testing.T, clusterInstance *cluster.LocalProcessCluster, downPrimary bool) {
-	//This test will start a primary and 3 replicas.
-	//Then:
-	//- one replica will be the new primary
-	//- one replica will be reparented to that new primary
-	//- one replica will be busted and dead in the water and we'll call TabletExternallyReparented.
-	//Args:
-	//downPrimary: kills the old primary first
+	// This test will start a primary and 3 replicas.
+	// Then:
+	// - one replica will be the new primary
+	// - one replica will be reparented to that new primary
+	// - one replica will be busted and dead in the water and we'll call TabletExternallyReparented.
+	// Args:
+	// downPrimary: kills the old primary first
 	ctx := context.Background()
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 
@@ -202,7 +204,7 @@ func reparentFromOutside(t *testing.T, clusterInstance *cluster.LocalProcessClus
 		demoteCommands := "SET GLOBAL read_only = ON; FLUSH TABLES WITH READ LOCK; UNLOCK TABLES"
 		utils.RunSQL(ctx, t, demoteCommands, tablets[0])
 
-		//Get the position of the old primary and wait for the new one to catch up.
+		// Get the position of the old primary and wait for the new one to catch up.
 		err := utils.WaitForReplicationPosition(t, tablets[0], tablets[1])
 		require.NoError(t, err)
 	}
@@ -359,6 +361,8 @@ func TestChangeTypeSemiSync(t *testing.T) {
 }
 
 func TestReparentDoesntHangIfPrimaryFails(t *testing.T) {
+	utilstest.SkipIfBinaryIsAboveVersion(t, 15, "vttablet")
+
 	defer cluster.PanicHandler(t)
 	clusterInstance := utils.SetupReparentCluster(t, "semi_sync")
 	defer utils.TeardownCluster(clusterInstance)

--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -154,6 +154,17 @@ func SkipIfBinaryIsBelowVersion(t *testing.T, majorVersion int, binary string) {
 	}
 }
 
+// SkipIfBinaryIsAboveVersion skips the given test if the binary's major version is above majorVersion.
+func SkipIfBinaryIsAboveVersion(t *testing.T, majorVersion int, binary string) {
+	version, err := cluster.GetMajorVersion(binary)
+	if err != nil {
+		return
+	}
+	if version > majorVersion {
+		t.Skip("Current version of ", binary, ": v", version, ", expected version >= v", majorVersion)
+	}
+}
+
 // AssertMatchesWithTimeout asserts that the given query produces the expected result.
 // The query will be executed every 'r' duration until it matches the expected result.
 // If after 'd' duration we still did not find the expected result, the test will be marked as failed.


### PR DESCRIPTION
## Description
This PR is a follow up of the recent work done by @rohit-nayak-ps around vttablet sidecar (https://github.com/vitessio/vitess/pull/11520). In the latter work, we removed `Create`/`Alter` `ReparentJournal`, this PR fixes a test that uses this SQL query. The test will not be ran during upgrade tests when vttablet is on version 16.

## Related Issue(s)

- Follow up of #11520

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
