### PR TITLE
Clean up deprecated flag from test setup

### DIFF
--- a/go/test/endtoend/cluster/vtorc_process.go
+++ b/go/test/endtoend/cluster/vtorc_process.go
@@ -115,7 +115,6 @@ func (orc *VTOrcProcess) Setup() (err error) {
 		"--instance-poll-time", "1s",
 		// Faster topo information refresh speeds up the tests. This doesn't add any significant load either
 		"--topo-information-refresh-duration", "3s",
-		"--orc_web_dir", path.Join(os.Getenv("VTROOT"), "web", "vtorc"),
 	)
 	if *isCoverage {
 		orc.proc.Args = append(orc.proc.Args, "--test.coverprofile="+getCoveragePath("orc.out"))


### PR DESCRIPTION
This was missed in https://github.com/vitessio/vitess/pull/11356 where this flag was deprecated and removed from most other places.

## Related Issue(s)

Missed in https://github.com/vitessio/vitess/pull/11356

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required