### PR TITLE
Remove a bunch of debug logging

### DIFF
--- a/go/cmd/vtaclcheck/vtaclcheck.go
+++ b/go/cmd/vtaclcheck/vtaclcheck.go
@@ -23,7 +23,6 @@ import (
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/exit"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtaclcheck"
@@ -61,8 +60,6 @@ func run() error {
 		ACLFile:        aclFile,
 		StaticAuthFile: staticAuthFile,
 	}
-
-	log.V(100).Infof("acl_file %s\nstatic_auth_file %s\n", aclFile, staticAuthFile)
 
 	if err := vtaclcheck.Init(opts); err != nil {
 		return err

--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -22,7 +22,6 @@ import (
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/exit"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtexplain"
@@ -146,10 +145,6 @@ func parseAndRun() error {
 		Normalize:       normalize,
 		Target:          dbName,
 	}
-
-	log.V(100).Infof("sql %s\n", sql)
-	log.V(100).Infof("schema %s\n", schema)
-	log.V(100).Infof("vschema %s\n", vschema)
 
 	vte, err := vtexplain.Init(vschema, schema, ksShardMap, opts)
 	if err != nil {

--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -17,11 +17,10 @@ limitations under the License.
 package mysqlctl
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
-
-	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
@@ -94,7 +93,6 @@ func (mysqld *Mysqld) FetchSuperQuery(ctx context.Context, query string) (*sqlty
 		return nil, connErr
 	}
 	defer conn.Recycle()
-	log.V(6).Infof("fetch %v", query)
 	qr, err := mysqld.executeFetchContext(ctx, conn, query, 10000, true)
 	if err != nil {
 		return nil, err

--- a/go/vt/topo/k8stopo/directory.go
+++ b/go/vt/topo/k8stopo/directory.go
@@ -17,13 +17,11 @@ limitations under the License.
 package k8stopo
 
 import (
+	"context"
 	"path/filepath"
 	"sort"
 	"strings"
 
-	"context"
-
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
 	vtv1beta1 "vitess.io/vitess/go/vt/topo/k8stopo/apis/topo/v1beta1"
 )
@@ -33,9 +31,6 @@ import (
 // a slice of results sorted alphabetically to emulate the behavior of etcd, zk, consul, etc
 func (s *Server) ListDir(ctx context.Context, dirPath string, full bool) ([]topo.DirEntry, error) {
 	dirPath = filepath.Join(s.root, dirPath)
-
-	log.V(7).Infof("Listing dir at: '%s', full: %v", dirPath, full)
-
 	dirMap := map[string]topo.DirEntry{}
 
 	if children, err := s.memberIndexer.ByIndex("by_parent", dirPath); err == nil {

--- a/go/vt/topo/k8stopo/file.go
+++ b/go/vt/topo/k8stopo/file.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
 	vtv1beta1 "vitess.io/vitess/go/vt/topo/k8stopo/apis/topo/v1beta1"
 )
@@ -136,8 +135,6 @@ func (s *Server) buildFileResource(filePath string, contents []byte) (*vtv1beta1
 
 // Create is part of the topo.Conn interface.
 func (s *Server) Create(ctx context.Context, filePath string, contents []byte) (topo.Version, error) {
-	log.V(7).Infof("Create at '%s' Contents: '%s'", filePath, string(contents))
-
 	resource, err := s.buildFileResource(filePath, contents)
 	if err != nil {
 		return nil, convertError(err, filePath)
@@ -159,8 +156,6 @@ func (s *Server) Create(ctx context.Context, filePath string, contents []byte) (
 
 // Update is part of the topo.Conn interface.
 func (s *Server) Update(ctx context.Context, filePath string, contents []byte, version topo.Version) (topo.Version, error) {
-	log.V(7).Infof("Update at '%s' Contents: '%s'", filePath, string(contents))
-
 	resource, err := s.buildFileResource(filePath, contents)
 	if err != nil {
 		return nil, convertError(err, filePath)
@@ -213,8 +208,6 @@ func (s *Server) Update(ctx context.Context, filePath string, contents []byte, v
 
 // Get is part of the topo.Conn interface.
 func (s *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Version, error) {
-	log.V(7).Infof("Get at '%s'", filePath)
-
 	node := s.newNodeReference(filePath)
 
 	result, err := s.resourceClient.Get(ctx, node.id, metav1.GetOptions{})
@@ -262,8 +255,6 @@ func (s *Server) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo
 
 // Delete is part of the topo.Conn interface.
 func (s *Server) Delete(ctx context.Context, filePath string, version topo.Version) error {
-	log.V(7).Infof("Delete at '%s'", filePath)
-
 	node := s.newNodeReference(filePath)
 
 	// Check version before delete

--- a/go/vt/topo/k8stopo/server.go
+++ b/go/vt/topo/k8stopo/server.go
@@ -183,7 +183,6 @@ func NewServer(_, root string) (*Server, error) {
 		// respect the context flag
 		if configContext != "" {
 			configOverrides.CurrentContext = configContext
-			log.V(7).Info("Overriding Kubernetes config context with: ", configOverrides.CurrentContext)
 		}
 
 		configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
@@ -206,7 +205,6 @@ func NewServer(_, root string) (*Server, error) {
 	// respect the namespace flag
 	if configNamespace != "" {
 		namespace = configNamespace
-		log.V(7).Info("Overriding Kubernetes config namespace with: ", namespace)
 	}
 
 	// create the kubernetes client

--- a/go/vt/topotools/tablet.go
+++ b/go/vt/topotools/tablet.go
@@ -218,7 +218,6 @@ func DeleteTablet(ctx context.Context, ts *topo.Server, tablet *topodatapb.Table
 	// try to remove replication data, no fatal if we fail
 	if err := topo.DeleteTabletReplicationData(ctx, ts, tablet); err != nil {
 		if topo.IsErrType(err, topo.NoNode) {
-			log.V(6).Infof("no ShardReplication object for cell %v", tablet.Alias.Cell)
 			err = nil
 		}
 		if err != nil {

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3903,7 +3903,6 @@ func RunCommand(ctx context.Context, wr *wrangler.Wrangler, args []string) error
 		}
 	}
 
-	wr.Logger().Printf("Unknown command: %v\n", action)
 	return ErrUnknownCommand
 }
 

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -299,7 +299,6 @@ func (vte *VTExplain) Run(sql string) ([]*Explain, error) {
 			if vte.vtgateSession == nil || !vte.vtgateSession.GetInTransaction() {
 				vte.batchTime = sync2.NewBatcher(batchInterval)
 			}
-			log.V(100).Infof("explain %s", sql)
 			e, err := vte.explain(sql)
 			if err != nil {
 				return nil, err

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -18,7 +18,6 @@ package vtexplain
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -637,9 +636,6 @@ func (t *explainTablet) handleSelect(query string) (*sqltypes.Result, error) {
 		InsertID: 0,
 		Rows:     rows,
 	}
-
-	resultJSON, _ := json.MarshalIndent(result, "", "    ")
-	log.V(100).Infof("query %s result %s\n", query, string(resultJSON))
 	return result, nil
 }
 

--- a/go/vt/zkctl/zkctl.go
+++ b/go/vt/zkctl/zkctl.go
@@ -234,7 +234,6 @@ func (zkd *Zkd) Teardown() error {
 	}
 	var removalErr error
 	for _, dir := range zkd.config.DirectoryList() {
-		log.V(6).Infof("remove data dir %v", dir)
 		if err := os.RemoveAll(dir); err != nil {
 			log.Errorf("failed removing %v: %v", dir, err.Error())
 			removalErr = err


### PR DESCRIPTION
This removes a bunch of debug logging that is set for higher log levels. The problem is that many of these are logging user provided values directly which is something CodeQL also alerts on.

If someone needs this kind of additional logging level, I think it suffices to modify the code locally to test something rather than always carrying these high log level entries.

## Related Issue(s)

Part of #12216 where CodeQL identified a bunch of user provided log input issues. 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required