### PR TITLE
Allow zero (in) date when setting up internal _vt schema (#12262)

### DIFF
--- a/go/vt/sidecardb/sidecardb_test.go
+++ b/go/vt/sidecardb/sidecardb_test.go
@@ -27,11 +27,18 @@ import (
 )
 
 // Tests all non-error code paths in sidecardb
-func TestAll(t *testing.T) {
+func TestAllSidecarDB(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	AddSchemaInitQueries(db, false)
 	db.AddQuery("use dbname", &sqltypes.Result{})
+	sqlMode := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"sql_mode",
+		"varchar"),
+		"ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION",
+	)
+	db.AddQuery("select @@session.sql_mode as sql_mode", sqlMode)
+	db.AddQueryPattern("set @@session.sql_mode=.*", &sqltypes.Result{})
 
 	ctx := context.Background()
 	cp := db.ConnParams()

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -144,7 +144,7 @@ func (vte *VTExplain) newTablet(opts *Options, t *topodatapb.Tablet) *explainTab
 	tsv.StartService(&target, dbcfgs, nil /* mysqld */)
 
 	// clear all the schema initialization queries out of the tablet
-	// to avoid clutttering the output
+	// to avoid cluttering the output
 	tablet.mysqlQueries = nil
 
 	return &tablet
@@ -294,6 +294,15 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options) (*tablet
 		},
 		"select @@global.sql_mode": {
 			Fields: []*querypb.Field{{
+				Type: sqltypes.VarChar,
+			}},
+			Rows: [][]sqltypes.Value{
+				{sqltypes.NewVarBinary("STRICT_TRANS_TABLES")},
+			},
+		},
+		"select @@session.sql_mode as sql_mode": {
+			Fields: []*querypb.Field{{
+				Name: "sql_mode",
 				Type: sqltypes.VarChar,
 			}},
 			Rows: [][]sqltypes.Value{

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -147,7 +147,7 @@ func (se *Engine) syncSidecarDB(ctx context.Context, conn *dbconnpool.DBConnecti
 				return nil, err
 			}
 		}
-		return conn.ExecuteFetch(query, maxRows, false)
+		return conn.ExecuteFetch(query, maxRows, true)
 	}
 	if err := sidecardb.Init(ctx, exec); err != nil {
 		log.Errorf("Error in sidecardb.Init: %+v", err)


### PR DESCRIPTION
## Description

This is a backport of #12262 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
