### PR TITLE
Create Views allowed for same keyspace

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -388,7 +388,7 @@
   {
     "comment": "create view with top level subquery in select",
     "query": "create view user.view_a as select a, (select col from user) from unsharded",
-    "plan": "VT12001: unsupported: Complex select queries are not supported in create or alter view statements"
+    "plan": "VT12001: unsupported: Select query does not belong to the same keyspace as the view statement"
   },
   {
     "comment": "create view with sql_calc_found_rows with limit",

--- a/go/vt/vtgate/planbuilder/testdata/view_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/view_cases.json
@@ -19,23 +19,9 @@
     }
   },
   {
-    "comment": "create view",
+    "comment": "create view with different keyspaces",
     "query": "create view user.view_a as (select id from unsharded union select id from unsharded_auto) union (select id from unsharded_auto union select name from unsharded)",
-    "plan": {
-      "QueryType": "DDL",
-      "Original": "create view user.view_a as (select id from unsharded union select id from unsharded_auto) union (select id from unsharded_auto union select name from unsharded)",
-      "Instructions": {
-        "OperatorType": "DDL",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "Query": "create view view_a as select id from unsharded union select id from unsharded_auto union select id from unsharded_auto union select `name` from unsharded"
-      },
-      "TablesUsed": [
-        "user.view_a"
-      ]
-    }
+    "plan": "VT12001: unsupported: Select query does not belong to the same keyspace as the view statement"
   },
   {
     "comment": "create view with authoritative columns",

--- a/go/vt/vttablet/endtoend/views_test.go
+++ b/go/vt/vttablet/endtoend/views_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 var qSelAllRows = "select table_schema, table_name, create_statement from _vt.views"
-var qDelAllRows = "delete from _vt.views"
 
 // Test will validate create view ddls.
 func TestCreateViewDDL(t *testing.T) {
@@ -42,7 +41,7 @@ func TestCreateViewDDL(t *testing.T) {
 		&vtrpcpb.CallerID{},
 		&querypb.VTGateCallerID{Username: "dev"}))
 
-	defer client.Execute(qDelAllRows, nil)
+	defer client.Execute("drop view vitess_view", nil)
 
 	_, err := client.Execute("create view vitess_view as select * from vitess_a", nil)
 	require.NoError(t, err)
@@ -56,7 +55,7 @@ func TestCreateViewDDL(t *testing.T) {
 
 	// view already exists. This should fail.
 	_, err = client.Execute("create view vitess_view as select * from vitess_a", nil)
-	require.ErrorContains(t, err, "View 'vitess_view' already exists")
+	require.ErrorContains(t, err, "'vitess_view' already exists")
 
 	// view already exists, but create or replace syntax should allow it to replace the view.
 	_, err = client.Execute("create or replace view vitess_view as select id, foo from vitess_a", nil)
@@ -79,11 +78,11 @@ func TestAlterViewDDL(t *testing.T) {
 		&vtrpcpb.CallerID{},
 		&querypb.VTGateCallerID{Username: "dev"}))
 
-	defer client.Execute(qDelAllRows, nil)
+	defer client.Execute("drop view vitess_view", nil)
 
 	// view does not exist, should FAIL
 	_, err := client.Execute("alter view vitess_view as select * from vitess_a", nil)
-	require.ErrorContains(t, err, "View 'vitess_view' does not exist")
+	require.ErrorContains(t, err, "'vttest.vitess_view' doesn't exist")
 
 	// create a view.
 	_, err = client.Execute("create view vitess_view as select * from vitess_a", nil)
@@ -110,7 +109,7 @@ func TestDropViewDDL(t *testing.T) {
 		&vtrpcpb.CallerID{},
 		&querypb.VTGateCallerID{Username: "dev"}))
 
-	defer client.Execute(qDelAllRows, nil)
+	defer client.Execute("drop view vitess_view", nil)
 
 	// view does not exist, should FAIL
 	_, err := client.Execute("drop view vitess_view", nil)
@@ -166,7 +165,7 @@ func TestGetSchemaRPC(t *testing.T) {
 		&vtrpcpb.CallerID{},
 		&querypb.VTGateCallerID{Username: "dev"}))
 
-	defer client.Execute(qDelAllRows, nil)
+	defer client.Execute("drop view vitess_view", nil)
 
 	_, err = client.Execute("create view vitess_view as select 1 from vitess_a", nil)
 	require.NoError(t, err)

--- a/go/vt/vttablet/endtoend/views_test.go
+++ b/go/vt/vttablet/endtoend/views_test.go
@@ -82,7 +82,7 @@ func TestAlterViewDDL(t *testing.T) {
 
 	// view does not exist, should FAIL
 	_, err := client.Execute("alter view vitess_view as select * from vitess_a", nil)
-	require.ErrorContains(t, err, "'vttest.vitess_view' doesn't exist")
+	require.ErrorContains(t, err, "Table 'vitess_view' does not exist")
 
 	// create a view.
 	_, err = client.Execute("create view vitess_view as select * from vitess_a", nil)
@@ -113,7 +113,7 @@ func TestDropViewDDL(t *testing.T) {
 
 	// view does not exist, should FAIL
 	_, err := client.Execute("drop view vitess_view", nil)
-	require.ErrorContains(t, err, "Unknown view 'vitess_view'")
+	require.ErrorContains(t, err, "Unknown table 'vttest.vitess_view'")
 
 	// view does not exist, using if exists clause, should PASS
 	_, err = client.Execute("drop view if exists vitess_view", nil)
@@ -131,7 +131,7 @@ func TestDropViewDDL(t *testing.T) {
 
 	// drop three views, only vitess_view2 exists. This should FAIL but drops the existing view.
 	_, err = client.Execute("drop view vitess_view1, vitess_view2, vitess_view3", nil)
-	require.ErrorContains(t, err, "Unknown view 'vitess_view1,vitess_view3'")
+	require.ErrorContains(t, err, "Unknown table 'vttest.vitess_view1,vttest.vitess_view3'")
 
 	// validate ZERO rows in _vt.views.
 	qr, err := client.Execute(qSelAllRows, nil)

--- a/go/vt/vttablet/endtoend/views_test.go
+++ b/go/vt/vttablet/endtoend/views_test.go
@@ -198,8 +198,8 @@ func TestViewAndTableUnique(t *testing.T) {
 		&querypb.VTGateCallerID{Username: "dev"}))
 
 	defer func() {
-		_, _ = client.Execute("drop if exists view vitess_view", nil)
-		_, _ = client.Execute("drop if exists table vitess_view", nil)
+		_, _ = client.Execute("drop view if exists vitess_view", nil)
+		_, _ = client.Execute("drop table if exists vitess_view", nil)
 	}()
 
 	// create a view.

--- a/go/vt/vttablet/tabletserver/health_streamer.go
+++ b/go/vt/vttablet/tabletserver/health_streamer.go
@@ -89,7 +89,8 @@ type healthStreamer struct {
 	conns                  *connpool.Pool
 	signalWhenSchemaChange bool
 
-	views map[string]string
+	viewsEnabled bool
+	views        map[string]string
 }
 
 func newHealthStreamer(env tabletenv.Env, alias *topodatapb.TabletAlias) *healthStreamer {
@@ -122,6 +123,7 @@ func newHealthStreamer(env tabletenv.Env, alias *topodatapb.TabletAlias) *health
 		ticks:                  newTimer,
 		conns:                  pool,
 		signalWhenSchemaChange: env.Config().SignalWhenSchemaChange,
+		viewsEnabled:           env.Config().EnableViews,
 		views:                  map[string]string{},
 	}
 }
@@ -338,7 +340,7 @@ func (hs *healthStreamer) reload() error {
 	}
 	defer conn.Recycle()
 
-	tables, err := getChangedTableNames(ctx, conn)
+	tables, err := hs.getChangedTableNames(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -363,7 +365,7 @@ func (hs *healthStreamer) reload() error {
 	return nil
 }
 
-func getChangedTableNames(ctx context.Context, conn *connpool.DBConn) ([]string, error) {
+func (hs *healthStreamer) getChangedTableNames(ctx context.Context, conn *connpool.DBConn) ([]string, error) {
 	var tables []string
 	var tableNames []string
 
@@ -380,7 +382,13 @@ func getChangedTableNames(ctx context.Context, conn *connpool.DBConn) ([]string,
 	}
 	alloc := func() *sqltypes.Result { return &sqltypes.Result{} }
 	bufferSize := 1000
-	err := conn.Stream(ctx, mysql.DetectSchemaChange, callback, alloc, bufferSize, 0)
+
+	schemaChangeQuery := mysql.DetectSchemaChange
+	// If views are enabled, then views are tracked/handled separately and schema change does not need to track them.
+	if hs.viewsEnabled {
+		schemaChangeQuery = mysql.DetectSchemaChangeOnlyBaseTable
+	}
+	err := conn.Stream(ctx, schemaChangeQuery, callback, alloc, bufferSize, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -419,6 +427,9 @@ func getChangedTableNames(ctx context.Context, conn *connpool.DBConn) ([]string,
 }
 
 func (hs *healthStreamer) getChangedViewNames(ctx context.Context, conn *connpool.DBConn) ([]string, error) {
+	if !hs.viewsEnabled {
+		return nil, nil
+	}
 	var changedViews []string
 	views := map[string]string{}
 

--- a/go/vt/vttablet/tabletserver/health_streamer_test.go
+++ b/go/vt/vttablet/tabletserver/health_streamer_test.go
@@ -336,6 +336,7 @@ func TestReloadView(t *testing.T) {
 	defer db.Close()
 	config := newConfig(db)
 	config.SignalSchemaChangeReloadIntervalSeconds.Set(100 * time.Millisecond)
+	config.EnableViews = true
 
 	env := tabletenv.NewEnv(config, "TestReloadView")
 	alias := &topodatapb.TabletAlias{Cell: "cell", Uid: 1}
@@ -344,7 +345,7 @@ func TestReloadView(t *testing.T) {
 	target := &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
 	configs := config.DB
 
-	db.AddQuery(mysql.DetectSchemaChange, &sqltypes.Result{})
+	db.AddQuery(mysql.DetectSchemaChangeOnlyBaseTable, &sqltypes.Result{})
 	db.AddQuery(mysql.SelectAllViews, &sqltypes.Result{})
 
 	hs.InitDBConfig(target, configs.DbaWithDB())

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -184,7 +184,12 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 	case p.PlanInsert, p.PlanUpdate, p.PlanDelete, p.PlanInsertMessage, p.PlanDDL, p.PlanLoad:
 		return qre.execAutocommit(qre.txConnExec)
 	case p.PlanViewDDL:
-		return qre.execAutocommit(qre.execViewDDL)
+		switch qre.plan.FullStmt.(type) {
+		case *sqlparser.DropView:
+			return qre.execAutocommit(qre.execDropViewDDL)
+		default:
+			return qre.execAsTransaction(qre.execViewDDL)
+		}
 	case p.PlanUpdateLimit, p.PlanDeleteLimit:
 		return qre.execAsTransaction(qre.txConnExec)
 	case p.PlanCallProc:
@@ -293,23 +298,28 @@ func (qre *QueryExecutor) txConnExec(conn *StatefulConnection) (*sqltypes.Result
 }
 
 func (qre *QueryExecutor) execViewDDL(conn *StatefulConnection) (*sqltypes.Result, error) {
-	_, isDropView := qre.plan.FullStmt.(*sqlparser.DropView)
-	_, err := execWithDDLView(qre.ctx, conn, sqlparser.String(qre.plan.FullStmt))
-	if err != nil && !isDropView {
-		// We ignore the error from MySQL in case of drop view statements,
-		// because we need to go on and delete the views listed in the _vt database.
-		// For Alter and Create statements, if MySQL fails, we don't need to do anything.
-		return nil, err
-	}
+	var err error
 	switch stmt := qre.plan.FullStmt.(type) {
 	case *sqlparser.CreateView:
-		return qre.execCreateViewDDL(conn, stmt)
+		_, err = qre.execCreateViewDDL(conn, stmt)
 	case *sqlparser.AlterView:
-		return qre.execAlterViewDDL(conn, stmt)
-	case *sqlparser.DropView:
-		return qre.execDropViewDDL(conn, stmt)
+		_, err = qre.execAlterViewDDL(conn, stmt)
+	default:
+		err = vterrors.Errorf(vtrpcpb.Code_INTERNAL, "BUG: unexpected view DDL type: %T", qre.plan.FullStmt)
 	}
-	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "BUG: unexpected view DDL type: %T", qre.plan.FullStmt)
+	if err != nil {
+		return nil, err
+	}
+	// We need to use a different connection for executing the DDL on MySQL
+	// because the previous DMLs are running in a transaction and we don't want to autocommit
+	// those changes.
+	ddlConn, err := qre.getConn()
+	if err != nil {
+		return nil, err
+	}
+	defer ddlConn.Recycle()
+	// If MySQL fails, then we will Rollback the changes.
+	return ddlConn.Exec(qre.ctx, sqlparser.String(qre.plan.FullStmt), 1000, true)
 }
 
 func (qre *QueryExecutor) execCreateViewDDL(conn *StatefulConnection, stmt *sqlparser.CreateView) (*sqltypes.Result, error) {
@@ -324,7 +334,7 @@ func (qre *QueryExecutor) execCreateViewDDL(conn *StatefulConnection, stmt *sqlp
 		// If it is a MySQL error and its code is of duplicate entry,
 		// then we would return duplicate create view error.
 		if isSQLErr && sqlErr.Number() == mysql.ERDupEntry {
-			return nil, vterrors.Errorf(vtrpcpb.Code_ALREADY_EXISTS, "View '%s' already exists", stmt.ViewName.Name.String())
+			return nil, vterrors.Errorf(vtrpcpb.Code_ALREADY_EXISTS, "Table '%s' already exists", stmt.ViewName.Name.String())
 		}
 		return nil, err
 	}
@@ -352,13 +362,14 @@ func (qre *QueryExecutor) execAlterViewDDL(conn *StatefulConnection, stmt *sqlpa
 		return nil, err
 	}
 	if qr.RowsAffected == 0 {
-		return nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "View '%s' does not exist", stmt.ViewName.Name.String())
+		return nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "Table '%s' does not exist", stmt.ViewName.Name.String())
 	}
 	return qr, nil
 }
 
-func (qre *QueryExecutor) execDropViewDDL(conn *StatefulConnection, stmt *sqlparser.DropView) (*sqltypes.Result, error) {
+func (qre *QueryExecutor) execDropViewDDL(conn *StatefulConnection) (*sqltypes.Result, error) {
 	viewsMap := make(map[string]int)
+	stmt := qre.plan.FullStmt.(*sqlparser.DropView)
 	var viewNames []string
 	for pos, view := range stmt.FromTables {
 		viewName := view.Name.String()
@@ -376,56 +387,21 @@ func (qre *QueryExecutor) execDropViewDDL(conn *StatefulConnection, stmt *sqlpar
 		"table_name": viewNamesBV,
 	}
 
-	existErr := qre.checkViewExists(conn, stmt, bindVars, viewsMap, viewNames)
-
 	sql, _, err := qre.generateFinalSQL(qre.plan.FullQuery, bindVars)
 	if err != nil {
 		return nil, err
 	}
-	qr, err := execWithDDLView(qre.ctx, conn, sql)
+	_, err = execWithDDLView(qre.ctx, conn, sql)
 	if err != nil {
 		return nil, err
 	}
-	if existErr != nil {
-		return nil, existErr
-	}
-	return qr, nil
+
+	// Drop the view on MySQL too.
+	return conn.Exec(qre.ctx, sqlparser.String(qre.plan.FullStmt), 1000, true)
 }
 
 func execWithDDLView(ctx context.Context, conn *StatefulConnection, sql string) (*sqltypes.Result, error) {
 	return conn.Exec(ctx, sql, 10000, true)
-}
-
-func (qre *QueryExecutor) checkViewExists(conn *StatefulConnection, stmt *sqlparser.DropView, bindVars map[string]*querypb.BindVariable, viewsMap map[string]int, viewNames []string) error {
-	if stmt.IfExists {
-		return nil
-	}
-	// run the select to know which views exist.
-	sel, err := sqlparser.Parse(mysql.SelectFromViewsTable)
-	if err != nil {
-		return err
-	}
-	sql, _, err := qre.generateFinalSQL(p.GenerateFullQuery(sel), bindVars)
-	if err != nil {
-		return err
-	}
-
-	qr, err := execWithDDLView(qre.ctx, conn, sql)
-	if err != nil {
-		return err
-	}
-	if len(qr.Rows) != len(viewNames) {
-		// If the number of rows returned by the select is not equal to the number of views
-		// that we are trying to drop, then we would return the error.
-		for _, row := range qr.Rows {
-			viewName := row[0].ToString()
-			if pos, exists := viewsMap[viewName]; exists {
-				viewNames = append(viewNames[:pos], viewNames[pos+1:]...)
-			}
-		}
-		return vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "Unknown view '%s'", strings.Join(viewNames, ","))
-	}
-	return nil
 }
 
 // Stream performs a streaming query execution.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR enables view support on information schema queries by restricting the create views to refer only single keyspace.
The views are now created at the MySQL level so all information schema, show query, describe, and explain query can work.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- https://github.com/vitessio/vitess/issues/11559

## Checklist

-   [X] Tests were added or are not required
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
