### PR TITLE
go/vt/vtgate: add json and use_fallback opts to numeric_static_map vdx

### DIFF
--- a/go/vt/vtgate/vindexes/cached_size.go
+++ b/go/vt/vtgate/vindexes/cached_size.go
@@ -325,10 +325,14 @@ func (cached *NumericStaticMap) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(24)
+		size += int64(48)
 	}
 	// field name string
 	size += hack.RuntimeAllocSize(int64(len(cached.name)))
+	// field hashVdx vitess.io/vitess/go/vt/vtgate/vindexes.Hashing
+	if cc, ok := cached.hashVdx.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
 	// field lookup vitess.io/vitess/go/vt/vtgate/vindexes.NumericLookupTable
 	if cached.lookup != nil {
 		size += int64(48)

--- a/go/vt/vtgate/vindexes/numeric_static_map.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map.go
@@ -42,8 +42,9 @@ type NumericLookupTable map[uint64]uint64
 // NumericStaticMap is similar to vindex Numeric but first attempts a lookup via
 // a JSON file.
 type NumericStaticMap struct {
-	name   string
-	lookup NumericLookupTable
+	name    string
+	hashVdx Hashing
+	lookup  NumericLookupTable
 }
 
 func init() {
@@ -52,19 +53,58 @@ func init() {
 
 // NewNumericStaticMap creates a NumericStaticMap vindex.
 func NewNumericStaticMap(name string, params map[string]string) (Vindex, error) {
-	jsonPath, ok := params["json_path"]
-	if !ok {
-		return nil, errors.New("NumericStaticMap: Could not find `json_path` param in vschema")
+	jsonStr, jsok := params["json"]
+	jsonPath, jpok := params["json_path"]
+
+	if !jsok && !jpok {
+		return nil, errors.New("NumericStaticMap: Could not find either `json_path` params in vschema")
 	}
 
-	lt, err := loadNumericLookupTable(jsonPath)
-	if err != nil {
-		return nil, err
+	if jsok && jpok {
+		return nil, errors.New("NumericStaticMap: Found both `json` and `json_path` params in vschema")
+	}
+
+	var err error
+	var lt NumericLookupTable
+
+	if jpok {
+		lt, err = loadNumericLookupTable(jsonPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if jsok {
+		lt, err = parseNumericLookupTable([]byte(jsonStr))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var hashVdx Hashing
+	var useFallback bool
+
+	if s, ok := params["use_fallback"]; ok {
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return nil, err
+		}
+		useFallback = b
+	}
+
+	if useFallback {
+		// We just use xxhash blindly;  we could make this configurable.
+		vindex, err := CreateVindex("xxhash", name+"_hash", map[string]string{})
+		if err != nil {
+			return nil, err
+		}
+		hashVdx, _ = vindex.(Hashing) // We know this will not fail
 	}
 
 	return &NumericStaticMap{
-		name:   name,
-		lookup: lt,
+		hashVdx: hashVdx,
+		lookup:  lt,
+		name:    name,
 	}, nil
 }
 
@@ -121,22 +161,32 @@ func (vind *NumericStaticMap) Hash(id sqltypes.Value) ([]byte, error) {
 		return nil, err
 	}
 	lookupNum, ok := vind.lookup[num]
-	if ok {
+	if !ok {
+		// Not in lookup, us fallback hash
+		if vind.hashVdx != nil {
+			return vind.hashVdx.Hash(id)
+		}
+	} else {
 		num = lookupNum
 	}
+
 	var keybytes [8]byte
 	binary.BigEndian.PutUint64(keybytes[:], num)
 	return keybytes[:], nil
 }
 
 func loadNumericLookupTable(path string) (NumericLookupTable, error) {
-	var m map[string]uint64
-	lt := make(map[uint64]uint64)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return lt, err
+		return nil, err
 	}
-	err = json.Unmarshal(data, &m)
+	return parseNumericLookupTable(data)
+}
+
+func parseNumericLookupTable(data []byte) (NumericLookupTable, error) {
+	var m map[string]uint64
+	lt := make(map[uint64]uint64)
+	err := json.Unmarshal(data, &m)
 	if err != nil {
 		return lt, err
 	}

--- a/go/vt/vtgate/vindexes/numeric_static_map.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map.go
@@ -51,10 +51,6 @@ func init() {
 	Register("numeric_static_map", NewNumericStaticMap)
 }
 
-const (
-	defaultFallbackType = "xxhash"
-)
-
 // NewNumericStaticMap creates a NumericStaticMap vindex.
 func NewNumericStaticMap(name string, params map[string]string) (Vindex, error) {
 	jsonStr, jsok := params["json"]

--- a/go/vt/vtgate/vindexes/numeric_static_map.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map.go
@@ -87,7 +87,6 @@ func NewNumericStaticMap(name string, params map[string]string) (Vindex, error) 
 		if err != nil {
 			return nil, err
 		}
-		// We just use xxhash blindly;  we could make this configurable.
 		vindex, err := CreateVindex(s, name+"_hash", map[string]string{})
 		if err != nil {
 			return nil, err

--- a/go/vt/vtgate/vindexes/numeric_static_map.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map.go
@@ -51,6 +51,10 @@ func init() {
 	Register("numeric_static_map", NewNumericStaticMap)
 }
 
+const (
+	defaultFallbackType = "xxhash"
+)
+
 // NewNumericStaticMap creates a NumericStaticMap vindex.
 func NewNumericStaticMap(name string, params map[string]string) (Vindex, error) {
 	jsonStr, jsok := params["json"]
@@ -82,23 +86,18 @@ func NewNumericStaticMap(name string, params map[string]string) (Vindex, error) 
 	}
 
 	var hashVdx Hashing
-	var useFallback bool
 
-	if s, ok := params["use_fallback"]; ok {
-		b, err := strconv.ParseBool(s)
+	if s, ok := params["fallback_type"]; ok {
 		if err != nil {
 			return nil, err
 		}
-		useFallback = b
-	}
-
-	if useFallback {
 		// We just use xxhash blindly;  we could make this configurable.
-		vindex, err := CreateVindex("xxhash", name+"_hash", map[string]string{})
+		vindex, err := CreateVindex(s, name+"_hash", map[string]string{})
 		if err != nil {
 			return nil, err
 		}
 		hashVdx, _ = vindex.(Hashing) // We know this will not fail
+
 	}
 
 	return &NumericStaticMap{

--- a/go/vt/vtgate/vindexes/numeric_static_map.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map.go
@@ -84,9 +84,6 @@ func NewNumericStaticMap(name string, params map[string]string) (Vindex, error) 
 	var hashVdx Hashing
 
 	if s, ok := params["fallback_type"]; ok {
-		if err != nil {
-			return nil, err
-		}
 		vindex, err := CreateVindex(s, name+"_hash", map[string]string{})
 		if err != nil {
 			return nil, err
@@ -156,7 +153,7 @@ func (vind *NumericStaticMap) Hash(id sqltypes.Value) ([]byte, error) {
 	}
 	lookupNum, ok := vind.lookup[num]
 	if !ok {
-		// Not in lookup, us fallback hash
+		// Not in lookup, use fallback hash
 		if vind.hashVdx != nil {
 			return vind.hashVdx.Hash(id)
 		}

--- a/go/vt/vtgate/vindexes/numeric_static_map_test.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map_test.go
@@ -141,8 +141,8 @@ func TestNumericStaticMapWithJsonVdx(t *testing.T) {
 // Test mapping of vindex, both for specified map keys and underlying xxhash
 func TestNumericStaticMapWithFallback(t *testing.T) {
 	mapWithFallbackVdx, err := createVindexWithParams(map[string]string{
-		"json":         "{\"1\":2,\"3\":4,\"4\":5,\"5\":6,\"6\":7,\"7\":8,\"8\":9,\"10\":18446744073709551615}",
-		"use_fallback": "true",
+		"json":          "{\"1\":2,\"3\":4,\"4\":5,\"5\":6,\"6\":7,\"7\":8,\"8\":9,\"10\":18446744073709551615}",
+		"fallback_type": "xxhash",
 	})
 	if err != nil {
 		t.Fatalf("failed to create vindex: %v", err)
@@ -184,8 +184,8 @@ func TestNumericStaticMapWithFallback(t *testing.T) {
 
 func TestNumericStaticMapWithFallbackVerify(t *testing.T) {
 	mapWithFallbackVdx, err := createVindexWithParams(map[string]string{
-		"json":         "{\"1\":2,\"3\":4,\"4\":5,\"5\":6,\"6\":7,\"7\":8,\"8\":9,\"10\":18446744073709551615}",
-		"use_fallback": "true",
+		"json":          "{\"1\":2,\"3\":4,\"4\":5,\"5\":6,\"6\":7,\"7\":8,\"8\":9,\"10\":18446744073709551615}",
+		"fallback_type": "xxhash",
 	})
 	if err != nil {
 		t.Fatalf("failed to create vindex: %v", err)

--- a/go/vt/vtgate/vindexes/numeric_static_map_test.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map_test.go
@@ -40,6 +40,16 @@ func createVindex() (SingleColumn, error) {
 	return vindex.(SingleColumn), nil
 }
 
+// createVindexWithParams creates the "numeric_static_map" vindex object with the
+// provided params.
+func createVindexWithParams(params map[string]string) (SingleColumn, error) {
+	vindex, err := CreateVindex("numeric_static_map", "numericStaticMapWithParams", params)
+	if err != nil {
+		return nil, err
+	}
+	return vindex.(SingleColumn), nil
+}
+
 func TestNumericStaticMapInfo(t *testing.T) {
 	numericStaticMap, err := createVindex()
 	require.NoError(t, err)
@@ -101,5 +111,93 @@ func TestNumericStaticMapVerify(t *testing.T) {
 
 	// Failure test
 	_, err = numericStaticMap.Verify(context.Background(), nil, []sqltypes.Value{sqltypes.NewVarBinary("aa")}, [][]byte{nil})
+	require.EqualError(t, err, "could not parse value: 'aa'")
+}
+
+func TestNumericStaticMapWithJsonVdx(t *testing.T) {
+	withFallbackVdx, err := createVindexWithParams(map[string]string{
+		"json": "{\"1\":2,\"3\":4,\"5\":6}",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, withFallbackVdx.Cost())
+	assert.Equal(t, "numericStaticMapWithParams", withFallbackVdx.String())
+	assert.True(t, withFallbackVdx.IsUnique())
+	assert.False(t, withFallbackVdx.NeedsVCursor())
+
+	// Bad format tests
+	_, err = createVindexWithParams(map[string]string{
+		"json": "{\"1\":2,\"3\":4,\"5\":6:8,\"10\":11}",
+	})
+	require.EqualError(t, err, "invalid character ':' after object key:value pair")
+
+	// Letters in key or value not allowed
+	_, err = createVindexWithParams(map[string]string{"json": "{\"1\":a}"})
+	require.EqualError(t, err, "invalid character 'a' looking for beginning of value")
+	_, err = createVindexWithParams(map[string]string{"json": "{\"a\":1}"})
+	require.EqualError(t, err, "strconv.ParseUint: parsing \"a\": invalid syntax")
+}
+
+// Test mapping of vindex, both for specified map keys and underlying xxhash
+func TestNumericStaticMapWithFallback(t *testing.T) {
+	mapWithFallbackVdx, err := createVindexWithParams(map[string]string{
+		"json":         "{\"1\":2,\"3\":4,\"4\":5,\"5\":6,\"6\":7,\"7\":8,\"8\":9,\"10\":18446744073709551615}",
+		"use_fallback": "true",
+	})
+	if err != nil {
+		t.Fatalf("failed to create vindex: %v", err)
+	}
+	got, err := mapWithFallbackVdx.Map(context.Background(), nil, []sqltypes.Value{
+		sqltypes.NewInt64(1),
+		sqltypes.NewInt64(2),
+		sqltypes.NewInt64(3),
+		sqltypes.NewFloat64(1.1),
+		sqltypes.NewVarChar("test1"),
+		sqltypes.NewInt64(4),
+		sqltypes.NewInt64(5),
+		sqltypes.NewInt64(6),
+		sqltypes.NewInt64(7),
+		sqltypes.NewInt64(8),
+		sqltypes.NewInt64(10),
+		sqltypes.NULL,
+	})
+	require.NoError(t, err)
+
+	want := []key.Destination{
+		key.DestinationKeyspaceID([]byte("\x00\x00\x00\x00\x00\x00\x00\x02")),
+		key.DestinationKeyspaceID([]byte("\x8b\x59\x80\x16\x62\xb5\x21\x60")),
+		key.DestinationKeyspaceID([]byte("\x00\x00\x00\x00\x00\x00\x00\x04")),
+		key.DestinationNone{},
+		key.DestinationNone{}, // strings do not map
+		key.DestinationKeyspaceID([]byte("\x00\x00\x00\x00\x00\x00\x00\x05")),
+		key.DestinationKeyspaceID([]byte("\x00\x00\x00\x00\x00\x00\x00\x06")),
+		key.DestinationKeyspaceID([]byte("\x00\x00\x00\x00\x00\x00\x00\x07")),
+		key.DestinationKeyspaceID([]byte("\x00\x00\x00\x00\x00\x00\x00\x08")),
+		key.DestinationKeyspaceID([]byte("\x00\x00\x00\x00\x00\x00\x00\x09")),
+		key.DestinationKeyspaceID([]byte("\xff\xff\xff\xff\xff\xff\xff\xff")),
+		key.DestinationNone{},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Map()\ngot: %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestNumericStaticMapWithFallbackVerify(t *testing.T) {
+	mapWithFallbackVdx, err := createVindexWithParams(map[string]string{
+		"json":         "{\"1\":2,\"3\":4,\"4\":5,\"5\":6,\"6\":7,\"7\":8,\"8\":9,\"10\":18446744073709551615}",
+		"use_fallback": "true",
+	})
+	if err != nil {
+		t.Fatalf("failed to create vindex: %v", err)
+	}
+	got, err := mapWithFallbackVdx.Verify(context.Background(), nil, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2), sqltypes.NewInt64(11), sqltypes.NewInt64(10)}, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x02"), []byte("\x8b\x59\x80\x16\x62\xb5\x21\x60"), []byte("\xff\xff\xff\xff\xff\xff\xff\xff"), []byte("\xff\xff\xff\xff\xff\xff\xff\xff")})
+	require.NoError(t, err)
+	want := []bool{true, true, false, true}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Verify(match): %v, want %v", got, want)
+	}
+
+	// Failure test
+	_, err = mapWithFallbackVdx.Verify(context.Background(), nil, []sqltypes.Value{sqltypes.NewVarBinary("aa")}, [][]byte{nil})
 	require.EqualError(t, err, "could not parse value: 'aa'")
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

`numeric_static_map` supports a JSON file. In some environments it may be more convenient to set this in the VSchema directly, rather than make the JSON file available everywhere it needs to be loaded.

In addition, it would be useful to have the ability to fallback to a hash lookup when there are keys missing from the json mapping.

## Related Issue(s)

 * Fixes https://github.com/vitessio/vitess/issues/12411
 * Addresses https://github.com/vitessio/vitess/issues/12412

One thing @aquarapid and I are not happy about is having to embed a JSON document inside a proto string type. If possible, we would like to amend the proto definition for vindexes to support nested, typed options. Have created https://github.com/vitessio/vitess/issues/12413 to have that discussion, and can amend this PR depending on the outcome of that.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation: https://github.com/vitessio/website/pull/1415
