### PR TITLE
Examples: Correct VTAdmin Discovery File Path And Add Check

### DIFF
--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -37,7 +37,7 @@ vtadmin-api is running!
 # Wait for vtadmin to successfully discover the cluster
 expected_cluster_result="{result\":{\"clusters\":[{\"id\":\"${cluster_name}\",\"name\":\"${cluster_name}\"}]},\"ok\":true}"
 for _ in {0..300}; do
-  result=$(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters")
+  result=$(curl -s "http://localhost:${vtadmin_api_port}/api/clusters")
   if [[ ${result} == "${expected_cluster_result}" ]]; then
     break
   fi
@@ -45,7 +45,7 @@ for _ in {0..300}; do
 done
 
 # Check one last time
-[[ $(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters") == "${expected_cluster_result}" ]] || fail "vtadmin failed to discover the running example Vitess cluster."
+[[ $(curl -s "http://localhost:${vtadmin_api_port}/api/clusters") == "${expected_cluster_result}" ]] || fail "vtadmin failed to discover the running example Vitess cluster."
 
 # As a TODO, it'd be nice to make the assumption that vtadmin-web is already
 # installed and built (since we assume that `make` has already been run for

--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -35,7 +35,7 @@ vtadmin-api is running!
 "
 
 # Wait for vtadmin to successfully discover the cluster
-expected_cluster_result="{result\":{\"clusters\":[{\"id\":\"${cluster_name}\",\"name\":\"${cluster_name}\"}]},\"ok\":true}"
+expected_cluster_result="{\"result\":{\"clusters\":[{\"id\":\"${cluster_name}\",\"name\":\"${cluster_name}\"}]},\"ok\":true}"
 for _ in {0..300}; do
   result=$(curl -s "http://localhost:${vtadmin_api_port}/api/clusters")
   if [[ ${result} == "${expected_cluster_result}" ]]; then

--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -3,6 +3,7 @@
 script_dir="$(dirname "${BASH_SOURCE[0]:-$0}")"
 source "${script_dir}/../env.sh"
 
+cluster_name="local"
 log_dir="${VTDATAROOT}/tmp"
 web_dir="${script_dir}/../../../web/vtadmin"
 
@@ -20,7 +21,7 @@ vtadmin \
   --alsologtostderr \
   --rbac \
   --rbac-config="${script_dir}/../vtadmin/rbac.yaml" \
-  --cluster "id=local,name=local,discovery=staticfile,discovery-staticfile-path=./vtadmin/discovery.json,tablet-fqdn-tmpl={{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
+  --cluster "id=${cluster_name},name=${cluster_name},discovery=staticfile,discovery-staticfile-path=${script_dir}/../vtadmin/discovery.json,tablet-fqdn-tmpl={{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
   > "${log_dir}/vtadmin-api.out" 2>&1 &
 
 vtadmin_api_pid=$!
@@ -33,14 +34,26 @@ vtadmin-api is running!
   - PID: ${vtadmin_api_pid}
 "
 
+# Wait for vtadmin to successfully discover the cluster
+for _ in {0..300}; do
+  id=$(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters" | jq -r '.result.clusters[0].name')
+  if [[ ${id} == "${cluster_name}" ]]; then
+    break
+  fi
+  sleep 0.1
+done
+
+# Check one last time
+[[ $(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters" | jq -r '.result.clusters[0].name') == "${cluster_name}" ]] || fail "vtadmin failed to discover the running example Vitess cluster."
+
 # As a TODO, it'd be nice to make the assumption that vtadmin-web is already
 # installed and built (since we assume that `make` has already been run for
 # other Vitess components.)
-npm --prefix $web_dir --silent install
+npm --prefix "$web_dir" --silent install
 
 REACT_APP_VTADMIN_API_ADDRESS="http://localhost:${vtadmin_api_port}" \
   REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS="true" \
-  npm run --prefix $web_dir build
+  npm run --prefix "$web_dir" build
 
 "${web_dir}/node_modules/.bin/serve" --no-clipboard -l $vtadmin_web_port -s "${web_dir}/build" \
   > "${log_dir}/vtadmin-web.out" 2>&1 &

--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -35,16 +35,17 @@ vtadmin-api is running!
 "
 
 # Wait for vtadmin to successfully discover the cluster
+expected_cluster_result="{result\":{\"clusters\":[{\"id\":\"${cluster_name}\",\"name\":\"${cluster_name}\"}]},\"ok\":true}"
 for _ in {0..300}; do
-  id=$(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters" | jq -r '.result.clusters[0].name')
-  if [[ ${id} == "${cluster_name}" ]]; then
+  result=$(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters")
+  if [[ ${result} == "${expected_cluster_result}" ]]; then
     break
   fi
   sleep 0.1
 done
 
 # Check one last time
-[[ $(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters" | jq -r '.result.clusters[0].name') == "${cluster_name}" ]] || fail "vtadmin failed to discover the running example Vitess cluster."
+[[ $(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters") == "${expected_cluster_result}" ]] || fail "vtadmin failed to discover the running example Vitess cluster."
 
 # As a TODO, it'd be nice to make the assumption that vtadmin-web is already
 # installed and built (since we assume that `make` has already been run for


### PR DESCRIPTION
## Description

VTAdmin failing to discover the Vitess cluster in the local examples was [reported in the Vitess Slack](https://vitess.slack.com/archives/C02JQQ88Z1C/p1676993782703629).

This was caused by the relative path usage missed as part of the refactoring done in: https://github.com/vitessio/vitess/pull/12239

And this was easily missed because there was no check done to confirm proper discovery and thus the local examples CI tests did not fail.

In this PR we correct the static discovery file path AND add a check to ensure that the discovery was successful and if not, we exit with an error (which would cause the tests to fail).

>**Note** While testing/confirming this fix in the CI with manual test re-runs, I saw [another timing issue](https://github.com/vitessio/vitess/actions/runs/4237884075/jobs/7364570381) related to the specific healthy shard indicator that the scripts were using vs. what `vtctld` used in checking that a shard has a healthy serving primary tablet when e.g. executing `ApplySchema` (this was also reported [in the Vitess Slack here](https://vitess.slack.com/archives/C0PQY0PTK/p1676977726069479)). I [changed the example scripts' healthy shard check](https://github.com/vitessio/vitess/pull/12415/commits/48ef9ca9cfb61c989e772a3aae914d22822b3a48) to match [with what vtctld uses](https://github.com/vitessio/vitess/blob/d473a7b0c209790be5ed26a2cc1449db094d2986/go/vt/topo/shard.go#L181-L183). After that commit, [the tests never failed](https://github.com/vitessio/vitess/actions/runs/4238921222).

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/12416
  - Follow-up to: https://github.com/vitessio/vitess/pull/12239

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required