### PR TITLE
Add basic metrics to `vttablet` transaction throttler

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -181,7 +181,7 @@ func NewTabletServer(name string, config *tabletenv.TabletConfig, topoServer *to
 	tsv.tracker = schema.NewTracker(tsv, tsv.vstreamer, tsv.se)
 	tsv.watcher = NewBinlogWatcher(tsv, tsv.vstreamer, tsv.config)
 	tsv.qe = NewQueryEngine(tsv, tsv.se)
-	tsv.txThrottler = txthrottler.NewTxThrottler(tsv.config, topoServer)
+	tsv.txThrottler = txthrottler.NewTxThrottler(tsv, topoServer)
 	tsv.te = NewTxEngine(tsv)
 	tsv.messager = messager.NewEngine(tsv, tsv.se, tsv.vstreamer)
 

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -274,8 +274,8 @@ func (t *TxThrottler) Throttle() (result bool) {
 	if t.state == nil {
 		panic("BUG: Throttle() called on a closed TxThrottler")
 	}
-	requestsTotal.Add(1)
 	result = t.state.throttle()
+	requestsTotal.Add(1)
 	if result {
 		requestsThrottled.Add(1)
 	}

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -79,17 +79,23 @@ type TxThrottler struct {
 
 	target *querypb.Target
 
+	// stats
 	throttlerRunning  *stats.Gauge
 	requestsTotal     *stats.Counter
 	requestsThrottled *stats.Counter
 }
+
+// TxThrottlerName is the name the wrapped go/vt/throttler object will be registered with
+// go/vt/throttler.GlobalManager.
+const TxThrottlerName = "TransactionThrottler"
 
 // NewTxThrottler tries to construct a TxThrottler from the
 // relevant fields in the tabletenv.Config object. It returns a disabled TxThrottler if
 // any error occurs.
 // This function calls tryCreateTxThrottler that does the actual creation work
 // and returns an error if one occurred.
-func NewTxThrottler(env tabletenv.Env, topoServer *topo.Server) *TxThrottler {
+func NewTxThrottler(config *tabletenv.TabletConfig, topoServer *topo.Server) *TxThrottler {
+	env := tabletenv.NewEnv(config, TxThrottlerName)
 	txThrottler, err := tryCreateTxThrottler(env, topoServer)
 	if err != nil {
 		log.Errorf("Error creating transaction throttler. Transaction throttling will"+
@@ -210,10 +216,6 @@ func resetTxThrottlerFactories() {
 	}
 }
 
-// TxThrottlerName is the name the wrapped go/vt/throttler object will be registered with
-// go/vt/throttler.GlobalManager.
-const TxThrottlerName = "TransactionThrottler"
-
 func newTxThrottler(env tabletenv.Env, config *txThrottlerConfig) (*TxThrottler, error) {
 	if config.enabled {
 		// Verify config.
@@ -227,9 +229,9 @@ func newTxThrottler(env tabletenv.Env, config *txThrottlerConfig) (*TxThrottler,
 	}
 	return &TxThrottler{
 		config:            config,
-		throttlerRunning:  env.Exporter().NewGauge("TxThrottlerRunning", "transaction throttler running state"),
-		requestsTotal:     env.Exporter().NewCounter("TxThrottlerRequests", "transaction throttler requests"),
-		requestsThrottled: env.Exporter().NewCounter("TxThrottlerThrottled", "transaction throttler requests throttled"),
+		throttlerRunning:  env.Exporter().NewGauge("TransactionThrottlerRunning", "transaction throttler running state"),
+		requestsTotal:     env.Exporter().NewCounter("TransactionThrottlerRequests", "transaction throttler requests"),
+		requestsThrottled: env.Exporter().NewCounter("TransactionThrottlerThrottled", "transaction throttler requests throttled"),
 	}, nil
 }
 

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -41,9 +41,9 @@ import (
 )
 
 var (
-	throttlerRunning  = stats.NewGauge("TransactionThrottlerRunning", "transaction throttler running")
-	requestsTotal     = stats.NewCounter("TransactionThrottlerRequests", "transaction throttler requests")
-	requestsThrottled = stats.NewCounter("TransactionThrottlerThrottled", "transaction throttler requests throttled")
+	throttlerRunning  = stats.NewGauge("TxThrottlerRunning", "transaction throttler running state")
+	requestsTotal     = stats.NewCounter("TxThrottlerRequests", "transaction throttler requests")
+	requestsThrottled = stats.NewCounter("TxThrottlerThrottled", "transaction throttler requests throttled")
 )
 
 // TxThrottler throttles transactions based on replication lag.

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -94,8 +94,7 @@ const TxThrottlerName = "TransactionThrottler"
 // any error occurs.
 // This function calls tryCreateTxThrottler that does the actual creation work
 // and returns an error if one occurred.
-func NewTxThrottler(config *tabletenv.TabletConfig, topoServer *topo.Server) *TxThrottler {
-	env := tabletenv.NewEnv(config, TxThrottlerName)
+func NewTxThrottler(env tabletenv.Env, topoServer *topo.Server) *TxThrottler {
 	txThrottler, err := tryCreateTxThrottler(env, topoServer)
 	if err != nil {
 		log.Errorf("Error creating transaction throttler. Transaction throttling will"+

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -68,8 +68,6 @@ import (
 // be executing a method. The only exception is the 'Throttle' method where multiple goroutines are
 // allowed to execute it concurrently.
 type TxThrottler struct {
-	env tabletenv.Env
-
 	// config stores the transaction throttler's configuration.
 	// It is populated in NewTxThrottler and is not modified
 	// since.

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -102,8 +102,8 @@ func NewTxThrottler(config *tabletenv.TabletConfig, topoServer *topo.Server) *Tx
 		}
 	} else {
 		log.Infof("Initialized transaction throttler with config: %+v", txThrottler.config)
+		stats.NewGaugeFunc("TxThrottlerMaxRate", "transaction throttler max rate", txThrottler.maxRate)
 	}
-	stats.NewGaugeFunc("TxThrottlerMaxRate", "transaction throttler max rate", txThrottler.maxRate)
 	return txThrottler
 }
 

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -112,7 +112,11 @@ func TestEnabledThrottler(t *testing.T) {
 	})
 	assert.Nil(t, throttler.Open())
 	assert.Equal(t, int64(1), throttlerRunning.Get())
+
 	assert.False(t, throttler.Throttle())
+	assert.Equal(t, int64(1), requestsTotal.Get())
+	assert.Zero(t, requestsThrottled.Get())
+
 	throttler.state.StatsUpdate(tabletStats)
 	rdonlyTabletStats := &discovery.TabletHealth{
 		Target: &querypb.Target{
@@ -123,6 +127,7 @@ func TestEnabledThrottler(t *testing.T) {
 	throttler.state.StatsUpdate(rdonlyTabletStats)
 	// The second throttle call should reject.
 	assert.True(t, throttler.Throttle())
+	assert.Equal(t, int64(1), requestsThrottled.Get())
 	throttler.Close()
 	assert.Zero(t, throttlerRunning.Get())
 }

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -39,8 +39,9 @@ import (
 
 func TestDisabledThrottler(t *testing.T) {
 	config := tabletenv.NewDefaultConfig()
+	env := tabletenv.NewEnv(config, t.Name())
 	config.EnableTxThrottler = false
-	throttler := NewTxThrottler(config, nil)
+	throttler := NewTxThrottler(env, nil)
 	throttler.InitDBConfig(&querypb.Target{
 		Keyspace: "keyspace",
 		Shard:    "shard",

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -39,8 +39,8 @@ import (
 
 func TestDisabledThrottler(t *testing.T) {
 	config := tabletenv.NewDefaultConfig()
-	env := tabletenv.NewEnv(config, t.Name())
 	config.EnableTxThrottler = false
+	env := tabletenv.NewEnv(config, t.Name())
 	throttler := NewTxThrottler(env, nil)
 	throttler.InitDBConfig(&querypb.Target{
 		Keyspace: "keyspace",

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -40,8 +40,7 @@ import (
 func TestDisabledThrottler(t *testing.T) {
 	config := tabletenv.NewDefaultConfig()
 	config.EnableTxThrottler = false
-	env := tabletenv.NewEnv(config, t.Name())
-	throttler := NewTxThrottler(env, nil)
+	throttler := NewTxThrottler(config, nil)
 	throttler.InitDBConfig(&querypb.Target{
 		Keyspace: "keyspace",
 		Shard:    "shard",
@@ -113,7 +112,7 @@ func TestEnabledThrottler(t *testing.T) {
 		Shard:    "shard",
 	})
 	assert.Nil(t, throttler.Open())
-	assert.NotZero(t, throttler.throttlerRunning.Get())
+	assert.Equal(t, int64(1), throttler.throttlerRunning.Get())
 
 	assert.False(t, throttler.Throttle())
 	assert.Equal(t, int64(1), throttler.requestsTotal.Get())


### PR DESCRIPTION
## Description

This PR adds the metrics below to `vttablet` to make it easier to observe the transaction throttler

1. Gauge: `TxThrottlerRunning`
    - `0` (disabled)
    - `1` (enabled)
2. Counter: `TxThrottlerRequests` - total # of calls to `.Throttle()`
3. Counter: `TxThrottlerThrottled` - total # of throttled calls to `.Throttle()`
4. ~~Gauge: `TxThrottlerMaxRate` - the max rate reported from the underlying throttler `.MaxRate()`~~

While updating unit tests for the transaction throttler, I moved the testing to use `github.com/stretchr/testify/assert`

## Related Issue(s)

Resolves: https://github.com/vitessio/vitess/issues/12417

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
