### PR TITLE
VReplication: Use MariaDB Compat JSON Functions

### DIFF
--- a/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine_test.go
@@ -236,7 +236,7 @@ func TestEngineRetryErroredVDiffs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where state = 'error' and options->>'$.core_options.auto_retry' = 'true'", tt.retryQueryResults, nil)
+			vdiffenv.dbClient.ExpectRequest("select * from _vt.vdiff where state = 'error' and json_unquote(json_extract(options, '$.core_options.auto_retry')) = 'true'", tt.retryQueryResults, nil)
 
 			// Right now this only supports a single row as with multiple rows we have
 			// multiple controllers in separate goroutines and the order is not

--- a/go/vt/vttablet/tabletmanager/vdiff/schema.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/schema.go
@@ -43,7 +43,7 @@ const (
 							where vd.id = vdt.vdiff_id and vd.id = %d and vd.state != 'completed'`
 	sqlGetVReplicationEntry = "select * from _vt.vreplication %s"
 	sqlGetVDiffsToRun       = "select * from _vt.vdiff where state in ('started','pending')" // what VDiffs have not been stopped or completed
-	sqlGetVDiffsToRetry     = "select * from _vt.vdiff where state = 'error' and options->>'$.core_options.auto_retry' = 'true'"
+	sqlGetVDiffsToRetry     = "select * from _vt.vdiff where state = 'error' and json_unquote(json_extract(options, '$.core_options.auto_retry')) = 'true'"
 	sqlGetVDiffID           = "select id as id from _vt.vdiff where vdiff_uuid = %s"
 	sqlGetAllVDiffs         = "select * from _vt.vdiff order by id desc"
 	sqlGetAllTableRows      = "select table_name as table_name, table_rows as table_rows from INFORMATION_SCHEMA.TABLES where table_schema = %s and table_name in (%s)"

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -88,8 +88,8 @@ const (
 		select pca.id from _vt.post_copy_action as pca inner join _vt.vreplication as vr on (pca.vrepl_id = vr.id)
 		where pca.table_name=%a
 	) for update`
-	sqlGetPostCopyActionTaskByType = `select action->>'$.task' from _vt.post_copy_action where
-	action->>'$.type'=%a and vrepl_id=%a and table_name=%a`
+	sqlGetPostCopyActionTaskByType = `select json_unquote(json_extract(action, '$.task')) as task from _vt.post_copy_action where
+	json_unquote(json_extract(action, '$.type'))=%a and vrepl_id=%a and table_name=%a`
 	sqlDeletePostCopyAction = `delete from _vt.post_copy_action where vrepl_id=%a and
 	table_name=%a and id=%a`
 )


### PR DESCRIPTION
## Description

This is needed to better support importing from MariaDB to Vitess/MySQL as we leverage MySQL's JSON support more and more in VReplication.

While [we do not fully support MariaDB in Vitess v16](https://github.com/vitessio/vitess/issues/9518) and later (where [VDiff2 is GA and the default](https://github.com/vitessio/vitess/pull/12084)), we DO want to support easy and reliable imports from MariaDB to Vitess and MySQL. This is also a pretty easy and straightforward fix — as `col1->>'$.field1'` is equivalent to `JSON_UNQUOTE(JSON_EXTRACT(col1, '$.field1'))` — and doing so allows us to fully support VDiff2 with MariaDB imports, even when running the diffs are run against the reverse workflows (after `SwitchTraffic` is done).

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/12419

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required