### PR TITLE
Add configuration option for minimum TLS version

### DIFF
--- a/doc/releasenotes/17_0_0_summary.md
+++ b/doc/releasenotes/17_0_0_summary.md
@@ -14,6 +14,10 @@
 
 ### <a id="breaking-changes"/>Breaking Changes
 
+#### <a id="vtgr-default-tls-version"/>Default TLS version changed for `vtgr`
+
+When using TLS with `vtgr`, we now default to TLS 1.2 if no other explicit version is configured. Configuration flags are provided to explicitly configure the minimum TLS version to be used. 
+
 #### <a id="deprecated-stats"/>Deprecated Stats
 
 These stats are deprecated in v17.

--- a/go/vt/vtgr/db/tls.go
+++ b/go/vt/vtgr/db/tls.go
@@ -21,7 +21,6 @@
 package db
 
 import (
-	"crypto/tls"
 	"fmt"
 	"strings"
 	"time"
@@ -95,14 +94,12 @@ func requiresTLS(host string, port int, uri string) bool {
 	return required
 }
 
-// Create a TLS configuration from the config supplied CA, Certificate, and Private key.
+// SetupMySQLTopologyTLS creates a TLS configuration from the config supplied CA, Certificate, and Private key.
 // Register the TLS config with the mysql drivers as the "topology" config
 // Modify the supplied URI to call the TLS config
 func SetupMySQLTopologyTLS(uri string) (string, error) {
 	if !topologyTLSConfigured {
-		tlsConfig, err := ssl.NewTLSConfig(config.Config.MySQLTopologySSLCAFile, !config.Config.MySQLTopologySSLSkipVerify)
-		// Drop to TLS 1.0 for talking to MySQL
-		tlsConfig.MinVersion = tls.VersionTLS10
+		tlsConfig, err := ssl.NewTLSConfig(config.Config.MySQLTopologySSLCAFile, !config.Config.MySQLTopologySSLSkipVerify, config.Config.MySQLTopologyTLSMinVersionNumber())
 		if err != nil {
 			log.Errorf("Can't create TLS configuration for Topology connection %s: %s", uri, err)
 			return "", err
@@ -126,14 +123,12 @@ func SetupMySQLTopologyTLS(uri string) (string, error) {
 	return fmt.Sprintf("%s&tls=topology", uri), nil
 }
 
-// Create a TLS configuration from the config supplied CA, Certificate, and Private key.
+// SetupMySQLOrchestratorTLS creates a TLS configuration from the config supplied CA, Certificate, and Private key.
 // Register the TLS config with the mysql drivers as the "orchestrator" config
 // Modify the supplied URI to call the TLS config
 func SetupMySQLOrchestratorTLS(uri string) (string, error) {
 	if !orchestratorTLSConfigured {
-		tlsConfig, err := ssl.NewTLSConfig(config.Config.MySQLOrchestratorSSLCAFile, !config.Config.MySQLOrchestratorSSLSkipVerify)
-		// Drop to TLS 1.0 for talking to MySQL
-		tlsConfig.MinVersion = tls.VersionTLS10
+		tlsConfig, err := ssl.NewTLSConfig(config.Config.MySQLOrchestratorSSLCAFile, !config.Config.MySQLOrchestratorSSLSkipVerify, config.Config.MySQLOrchestratorTLSMinVersionNumber())
 		if err != nil {
 			log.Fatalf("Can't create TLS configuration for Orchestrator connection %s: %s", uri, err)
 			return "", err

--- a/go/vt/vtgr/ssl/ssl.go
+++ b/go/vt/vtgr/ssl/ssl.go
@@ -34,11 +34,11 @@ func HasString(elem string, arr []string) bool {
 
 // NewTLSConfig returns an initialized TLS configuration suitable for client
 // authentication. If caFile is non-empty, it will be loaded.
-func NewTLSConfig(caFile string, verifyCert bool) (*tls.Config, error) {
+func NewTLSConfig(caFile string, verifyCert bool, minVersion uint16) (*tls.Config, error) {
 	var c tls.Config
 
 	// Set to TLS 1.2 as a minimum.  This is overridden for mysql communication
-	c.MinVersion = tls.VersionTLS12
+	c.MinVersion = minVersion
 
 	if verifyCert {
 		log.Info("verifyCert requested, client certificates will be verified")

--- a/go/vt/vtgr/ssl/ssl_test.go
+++ b/go/vt/vtgr/ssl/ssl_test.go
@@ -39,7 +39,7 @@ func TestNewTLSConfig(t *testing.T) {
 	fakeCA := writeFakeFile(pemCertificate)
 	defer syscall.Unlink(fakeCA)
 
-	conf, err := ssl.NewTLSConfig(fakeCA, true)
+	conf, err := ssl.NewTLSConfig(fakeCA, true, tls.VersionTLS13)
 	if err != nil {
 		t.Errorf("Could not create new TLS config: %s", err)
 	}
@@ -49,8 +49,11 @@ func TestNewTLSConfig(t *testing.T) {
 	if conf.ClientCAs == nil {
 		t.Errorf("ClientCA empty even though cert provided")
 	}
+	if conf.MinVersion != tls.VersionTLS13 {
+		t.Errorf("incorrect tls min version set")
+	}
 
-	conf, err = ssl.NewTLSConfig("", false)
+	conf, err = ssl.NewTLSConfig("", false, tls.VersionTLS12)
 	if err != nil {
 		t.Errorf("Could not create new TLS config: %s", err)
 	}
@@ -59,6 +62,9 @@ func TestNewTLSConfig(t *testing.T) {
 	}
 	if conf.ClientCAs != nil {
 		t.Errorf("Filling in ClientCA somehow without a cert")
+	}
+	if conf.MinVersion != tls.VersionTLS12 {
+		t.Errorf("incorrect tls min version set")
 	}
 }
 
@@ -145,7 +151,7 @@ func TestReadPEMData(t *testing.T) {
 }
 
 func TestAppendKeyPair(t *testing.T) {
-	c, err := ssl.NewTLSConfig("", false)
+	c, err := ssl.NewTLSConfig("", false, tls.VersionTLS12)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +166,7 @@ func TestAppendKeyPair(t *testing.T) {
 }
 
 func TestAppendKeyPairWithPassword(t *testing.T) {
-	c, err := ssl.NewTLSConfig("", false)
+	c, err := ssl.NewTLSConfig("", false, tls.VersionTLS12)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We were hardcoding this to TLS 1.0 which is not considered safe anymore these days and was called out by CodeQL as a security issue.

Instead we should default to TLS 1.2 which we do everywhere else, and allow for an option to change it if needed so that we're safe by default here.

I've also reviewed the documentation about `vtgr`, but we don't make any mention there for any of the SSL/TLS related configuration options, so I don't think there's a good place to add that yet? It's also marked still as experimental. 

I did add a release notes entry with the change that the default is now TLS 1.2. 

## Related Issue(s)

This is the last remaining issue identified in #12216 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
