### PR TITLE
Sidecar schema init: use COPY algorithm while altering sidecardb tables

### DIFF
--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -95,7 +95,7 @@ const (
 )
 
 const (
-	AlterTableAlgorithmStrategyEmpty int = iota
+	AlterTableAlgorithmStrategyNone int = iota
 	AlterTableAlgorithmStrategyInstant
 	AlterTableAlgorithmStrategyInplace
 	AlterTableAlgorithmStrategyCopy

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -94,6 +94,13 @@ const (
 	TableCharsetCollateIgnoreAlways
 )
 
+const (
+	AlterTableAlgorithmStrategyEmpty int = iota
+	AlterTableAlgorithmStrategyInstant
+	AlterTableAlgorithmStrategyInplace
+	AlterTableAlgorithmStrategyCopy
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
 	StrictIndexOrdering         bool
@@ -104,4 +111,5 @@ type DiffHints struct {
 	TableRenameStrategy         int
 	FullTextKeyStrategy         int
 	TableCharsetCollateStrategy int
+	AlterTableAlgorithmStrategy int
 }

--- a/go/vt/sidecardb/sidecardb.go
+++ b/go/vt/sidecardb/sidecardb.go
@@ -306,6 +306,7 @@ func (si *schemaInit) getCurrentSchema(tableName string) (string, error) {
 func (si *schemaInit) findTableSchemaDiff(tableName, current, desired string) (string, error) {
 	hints := &schemadiff.DiffHints{
 		TableCharsetCollateStrategy: schemadiff.TableCharsetCollateIgnoreAlways,
+		AlterTableAlgorithmStrategy: schemadiff.AlterTableAlgorithmStrategyCopy,
 	}
 	diff, err := schemadiff.DiffCreateTablesQueries(current, desired, hints)
 	if err != nil {


### PR DESCRIPTION
## Description

Enforce use of `ALGORITHM=COPY` for all `ALTER TABLE`s used during the sidecar schema init process. By default, MYSQL8.0 uses `INSTANT` which causes `Percona XtraBackup` to fail  with the following error message, at least for `8.0.29` (which was deemed unstable and withdrawn):

```
Percona XtraBackup Error Message
If Percona XtraBackup detects that MySQL 8.0.29 server has tables with instant add/drop columns, it aborts with the following error message

2022-07-01T15:18:35.127689+05:30 0 [ERROR] [MY-011825] [Xtrabackup] Found tables with row versions due to INSTANT ADD/DROP columns
2022-07-01T15:18:35.127714+05:30 0 [ERROR] [MY-011825] [Xtrabackup] This feature is not stable and will cause backup corruption.
2022-07-01T15:18:35.127723+05:30 0 [ERROR] [MY-011825] [Xtrabackup] Tables found:
2022-07-01T15:18:35.127730+05:30 0 [ERROR] [MY-011825] [Xtrabackup] test/t1
2022-07-01T15:18:35.127737+05:30 0 [ERROR] [MY-011825] [Xtrabackup] test/t2
2022-07-01T15:18:35.127744+05:30 0 [ERROR] [MY-011825] [Xtrabackup] test/t3
2022-07-01T15:18:35.127752+05:30 0 [ERROR] [MY-011825] [Xtrabackup] Please run OPTIMIZE TABLE or ALTER TABLE ALGORITHM=COPY on all listed tables to fix this issue.
Summary
The option, ALGORITHM=INSTANT is the default value in MySQL 8.0.29. If you do not specify an algorithm, all ALTER TABLE ADD/DROP COLUMN statements use this algorithm.

The INSTANT algorithm is unstable at this point.

Percona XtraBackup refuses to take backups from MySQL 8.0.29 tables that have used this algorithm. Percona Server users do not suffer the same limitations as the corruption issues are fixed in the upcoming release of Percona Server for MySQL 8.0.29
```

To achieve this the PR adds a hint to `schemadiff` to optionally provide the `ALGORITHM` while generating the `ALTER`s

### Todos

- [ ] Add unit tests in schemadiff
- [ ] Check if we can test the functionality from the bug report in an XtraBackup test

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/12300

Original issue: #11520

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [ ] Documentation was added or is not required
