### PR TITLE
schemadiff: AlterTableAlgorithmStrategy

### DIFF
--- a/go/vt/schemadiff/table.go
+++ b/go/vt/schemadiff/table.go
@@ -805,8 +805,27 @@ func (c *CreateTableEntity) TableDiff(other *CreateTableEntity, hints *DiffHints
 		}
 	}
 	tableSpecHasChanged := len(alterTable.AlterOptions) > 0 || alterTable.PartitionOption != nil || alterTable.PartitionSpec != nil
+
+	newAlterTableEntityDiff := func(alterTable *sqlparser.AlterTable) *AlterTableEntityDiff {
+		d := &AlterTableEntityDiff{alterTable: alterTable, from: c, to: other}
+
+		var algorithmValue sqlparser.AlgorithmValue
+
+		switch hints.AlterTableAlgorithmStrategy {
+		case AlterTableAlgorithmStrategyCopy:
+			algorithmValue = sqlparser.AlgorithmValue("COPY")
+		case AlterTableAlgorithmStrategyInplace:
+			algorithmValue = sqlparser.AlgorithmValue("INPLACE")
+		case AlterTableAlgorithmStrategyInstant:
+			algorithmValue = sqlparser.AlgorithmValue("INSTANT")
+		}
+		if algorithmValue != "" {
+			alterTable.AlterOptions = append(alterTable.AlterOptions, algorithmValue)
+		}
+		return d
+	}
 	if tableSpecHasChanged {
-		parentAlterTableEntityDiff = &AlterTableEntityDiff{alterTable: alterTable, from: c, to: other}
+		parentAlterTableEntityDiff = newAlterTableEntityDiff(alterTable)
 
 	}
 	for _, superfluousFulltextKey := range superfluousFulltextKeys {
@@ -814,7 +833,7 @@ func (c *CreateTableEntity) TableDiff(other *CreateTableEntity, hints *DiffHints
 			Table:        c.CreateTable.Table,
 			AlterOptions: []sqlparser.AlterOption{superfluousFulltextKey},
 		}
-		diff := &AlterTableEntityDiff{alterTable: alterTable, from: c, to: other}
+		diff := newAlterTableEntityDiff(alterTable)
 		// if we got superfluous fulltext keys, that means the table spec has changed, ie
 		// parentAlterTableEntityDiff is not nil
 		parentAlterTableEntityDiff.addSubsequentDiff(diff)
@@ -824,7 +843,7 @@ func (c *CreateTableEntity) TableDiff(other *CreateTableEntity, hints *DiffHints
 			Table:         c.CreateTable.Table,
 			PartitionSpec: partitionSpec,
 		}
-		diff := &AlterTableEntityDiff{alterTable: alterTable, from: c, to: other}
+		diff := newAlterTableEntityDiff(alterTable)
 		if parentAlterTableEntityDiff == nil {
 			parentAlterTableEntityDiff = diff
 		} else {
@@ -2021,6 +2040,8 @@ func (c *CreateTableEntity) apply(diff *AlterTableEntityDiff) error {
 					c.TableSpec.Options = append(c.TableSpec.Options, option)
 				}()
 			}
+		case sqlparser.AlgorithmValue:
+			// silently ignore. This has an operational effect on the MySQL engine, but has no semantical effect.
 		default:
 			return &UnsupportedApplyOperationError{Statement: sqlparser.CanonicalString(opt)}
 		}

--- a/go/vt/schemadiff/table_test.go
+++ b/go/vt/schemadiff/table_test.go
@@ -45,6 +45,7 @@ func TestCreateTableDiff(t *testing.T) {
 		colrename  int
 		constraint int
 		charset    int
+		algorithm  int
 	}{
 		{
 			name: "identical",
@@ -1147,6 +1148,31 @@ func TestCreateTableDiff(t *testing.T) {
 			diff:  "alter table t4 add column created_at datetime(6) not null default (now() + interval 30 minute)",
 			cdiff: "ALTER TABLE `t4` ADD COLUMN `created_at` datetime(6) NOT NULL DEFAULT (now() + INTERVAL 30 minute)",
 		},
+		// algorithm
+		{
+			name:      "algorithm: COPY",
+			from:      "create table t1 (`id` int primary key)",
+			to:        "create table t2 (id int primary key, `i` int not null default 0)",
+			diff:      "alter table t1 add column i int not null default 0, algorithm = COPY",
+			cdiff:     "ALTER TABLE `t1` ADD COLUMN `i` int NOT NULL DEFAULT 0, ALGORITHM = COPY",
+			algorithm: AlterTableAlgorithmStrategyCopy,
+		},
+		{
+			name:      "algorithm: INPLACE",
+			from:      "create table t1 (`id` int primary key)",
+			to:        "create table t2 (id int primary key, `i` int not null default 0)",
+			diff:      "alter table t1 add column i int not null default 0, algorithm = INPLACE",
+			cdiff:     "ALTER TABLE `t1` ADD COLUMN `i` int NOT NULL DEFAULT 0, ALGORITHM = INPLACE",
+			algorithm: AlterTableAlgorithmStrategyInplace,
+		},
+		{
+			name:      "algorithm: INSTANT",
+			from:      "create table t1 (`id` int primary key)",
+			to:        "create table t2 (id int primary key, `i` int not null default 0)",
+			diff:      "alter table t1 add column i int not null default 0, algorithm = INSTANT",
+			cdiff:     "ALTER TABLE `t1` ADD COLUMN `i` int NOT NULL DEFAULT 0, ALGORITHM = INSTANT",
+			algorithm: AlterTableAlgorithmStrategyInstant,
+		},
 	}
 	standardHints := DiffHints{}
 	for _, ts := range tt {
@@ -1173,6 +1199,7 @@ func TestCreateTableDiff(t *testing.T) {
 			hints.ColumnRenameStrategy = ts.colrename
 			hints.FullTextKeyStrategy = ts.fulltext
 			hints.TableCharsetCollateStrategy = ts.charset
+			hints.AlterTableAlgorithmStrategy = ts.algorithm
 			alter, err := c.Diff(other, &hints)
 
 			require.Equal(t, len(ts.diffs), len(ts.cdiffs))

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -99,6 +99,13 @@ const (
 	TableQualifierDeclared
 )
 
+const (
+	AlterTableAlgorithmStrategyEmpty int = iota
+	AlterTableAlgorithmStrategyInstant
+	AlterTableAlgorithmStrategyInplace
+	AlterTableAlgorithmStrategyCopy
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
 	StrictIndexOrdering         bool
@@ -110,4 +117,5 @@ type DiffHints struct {
 	FullTextKeyStrategy         int
 	TableCharsetCollateStrategy int
 	TableQualifierHint          int
+	AlterTableAlgorithmStrategy int
 }

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -100,7 +100,7 @@ const (
 )
 
 const (
-	AlterTableAlgorithmStrategyEmpty int = iota
+	AlterTableAlgorithmStrategyNone int = iota
 	AlterTableAlgorithmStrategyInstant
 	AlterTableAlgorithmStrategyInplace
 	AlterTableAlgorithmStrategyCopy


### PR DESCRIPTION

## Description

`schemadiff` now adds an `ALGORITHM` hint. The algorithm has an operational effect on the MySQL engine, but no semantic effect on the table. It only applies for `AlterTable` diffs.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/10203

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
