### PR TITLE
evalengine: use 128 bit hashing internally

### DIFF
--- a/go/vt/vtgate/evalengine/api_arithmetic_test.go
+++ b/go/vt/vtgate/evalengine/api_arithmetic_test.go
@@ -26,6 +26,7 @@ import (
 
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/test/utils"
+	"vitess.io/vitess/go/vt/vthash"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1097,10 +1098,13 @@ func TestCompareNumeric(t *testing.T) {
 				// if two values are considered equal, they must also produce the same hashcode
 				if result == 0 {
 					if aVal.SQLType() == bVal.SQLType() {
+						hash1 := vthash.New()
+						hash2 := vthash.New()
+
 						// hash codes can only be compared if they are coerced to the same type first
-						aHash, _ := aVal.Hash()
-						bHash, _ := bVal.Hash()
-						assert.Equal(t, aHash, bHash, "hash code does not match")
+						aVal.Hash(&hash1)
+						bVal.Hash(&hash2)
+						assert.Equal(t, hash1.Sum128(), hash2.Sum128(), "hash code does not match")
 					}
 				}
 			})

--- a/go/vt/vtgate/evalengine/api_arithmetic_test.go
+++ b/go/vt/vtgate/evalengine/api_arithmetic_test.go
@@ -1102,8 +1102,8 @@ func TestCompareNumeric(t *testing.T) {
 						hash2 := vthash.New()
 
 						// hash codes can only be compared if they are coerced to the same type first
-						aVal.Hash(&hash1)
-						bVal.Hash(&hash2)
+						aVal.(hashable).Hash(&hash1)
+						bVal.(hashable).Hash(&hash2)
 						assert.Equal(t, hash1.Sum128(), hash2.Sum128(), "hash code does not match")
 					}
 				}

--- a/go/vt/vtgate/evalengine/api_hash.go
+++ b/go/vt/vtgate/evalengine/api_hash.go
@@ -44,6 +44,9 @@ func NullsafeHashcode(v sqltypes.Value, collation collations.ID, coerceType sqlt
 	h := vthash.New()
 	switch e := e.(type) {
 	case *evalBytes:
+		if collations.Local().LookupByID(collation) == nil {
+			return 0, UnsupportedCollationHashError
+		}
 		e.col.Collation = collation
 		e.Hash(&h)
 	case hashable:

--- a/go/vt/vtgate/evalengine/api_hash.go
+++ b/go/vt/vtgate/evalengine/api_hash.go
@@ -43,8 +43,20 @@ func NullsafeHashcode(v sqltypes.Value, collation collations.ID, coerceType sqlt
 	if e, ok := e.(*evalBytes); ok {
 		e.col.Collation = collation
 	}
-	return e.Hash()
+	h := vthash.New()
+	e.Hash(&h)
+	return h.Sum64(), nil
 }
+
+const (
+	hashPrefixNil              = 0x0000
+	hashPrefixFloat            = 0xAAAA
+	hashPrefixIntegralNegative = 0xBBB1
+	hashPrefixIntegralPositive = 0xBBB0
+	hashPrefixBytes            = 0xCCCC
+	hashPrefixDate             = 0xCCC0
+	hashPrefixDecimal          = 0xDDDD
+)
 
 // NullsafeHashcode128 returns a 128-bit hashcode that is guaranteed to be the same
 // for two values that are considered equal by `NullsafeCompare`.
@@ -53,7 +65,7 @@ func NullsafeHashcode(v sqltypes.Value, collation collations.ID, coerceType sqlt
 func NullsafeHashcode128(hash *vthash.Hasher, v sqltypes.Value, collation collations.ID, coerceTo sqltypes.Type) error {
 	switch {
 	case v.IsNull(), sqltypes.IsNull(coerceTo):
-		hash.Write16(0)
+		hash.Write16(hashPrefixNil)
 	case sqltypes.IsFloat(coerceTo):
 		var f float64
 		var err error
@@ -77,7 +89,7 @@ func NullsafeHashcode128(hash *vthash.Hasher, v sqltypes.Value, collation collat
 		if err != nil {
 			return err
 		}
-		hash.Write16(0xAAAA)
+		hash.Write16(hashPrefixFloat)
 		hash.Write64(math.Float64bits(f))
 
 	case sqltypes.IsSigned(coerceTo):
@@ -98,9 +110,9 @@ func NullsafeHashcode128(hash *vthash.Hasher, v sqltypes.Value, collation collat
 			return err
 		}
 		if i < 0 {
-			hash.Write16(0xBBB1)
+			hash.Write16(hashPrefixIntegralNegative)
 		} else {
-			hash.Write16(0xBBB0)
+			hash.Write16(hashPrefixIntegralPositive)
 		}
 		hash.Write64(uint64(i))
 
@@ -121,12 +133,12 @@ func NullsafeHashcode128(hash *vthash.Hasher, v sqltypes.Value, collation collat
 		if err != nil {
 			return err
 		}
-		hash.Write16(0xBBB0)
+		hash.Write16(hashPrefixIntegralPositive)
 		hash.Write64(u)
 
 	case sqltypes.IsBinary(coerceTo):
 		coll := collations.Local().LookupByID(collations.CollationBinaryID)
-		hash.Write16(0xCCCC)
+		hash.Write16(hashPrefixBytes)
 		coll.Hash(hash, v.Raw(), 0)
 
 	case sqltypes.IsText(coerceTo):
@@ -134,7 +146,7 @@ func NullsafeHashcode128(hash *vthash.Hasher, v sqltypes.Value, collation collat
 		if coll == nil {
 			panic("cannot hash unsupported collation")
 		}
-		hash.Write16(0xCCCC)
+		hash.Write16(hashPrefixBytes)
 		coll.Hash(hash, v.Raw(), 0)
 
 	case sqltypes.IsDecimal(coerceTo):
@@ -158,7 +170,7 @@ func NullsafeHashcode128(hash *vthash.Hasher, v sqltypes.Value, collation collat
 		default:
 			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "coercion should not try to coerce this value to a decimal: %v", v)
 		}
-		hash.Write16(0xDDDD)
+		hash.Write16(hashPrefixDecimal)
 		dec.Hash(hash)
 
 	default:

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -221,15 +221,15 @@ func (cached *InExpr) CachedSize(alloc bool) int64 {
 	}
 	// field BinaryExpr vitess.io/vitess/go/vt/vtgate/evalengine.BinaryExpr
 	size += cached.BinaryExpr.CachedSize(false)
-	// field Hashed map[uint64]int
+	// field Hashed map[[16]byte]int
 	if cached.Hashed != nil {
 		size += int64(48)
 		hmap := reflect.ValueOf(cached.Hashed)
 		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
 		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 144))
+		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
 		if len(cached.Hashed) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 144))
+			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
 		}
 	}
 	return size

--- a/go/vt/vtgate/evalengine/eval.go
+++ b/go/vt/vtgate/evalengine/eval.go
@@ -59,6 +59,10 @@ const (
 type eval interface {
 	ToRawBytes() []byte
 	SQLType() sqltypes.Type
+}
+
+type hashable interface {
+	eval
 	Hash(h *vthash.Hasher)
 }
 

--- a/go/vt/vtgate/evalengine/eval.go
+++ b/go/vt/vtgate/evalengine/eval.go
@@ -26,6 +26,7 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/evalengine/internal/decimal"
 	"vitess.io/vitess/go/vt/vtgate/evalengine/internal/json"
+	"vitess.io/vitess/go/vt/vthash"
 )
 
 type typeFlag uint32
@@ -58,7 +59,7 @@ const (
 type eval interface {
 	ToRawBytes() []byte
 	SQLType() sqltypes.Type
-	Hash() (HashCode, error)
+	Hash(h *vthash.Hasher)
 }
 
 func evalToSQLValue(e eval) sqltypes.Value {

--- a/go/vt/vtgate/evalengine/eval_bytes.go
+++ b/go/vt/vtgate/evalengine/eval_bytes.go
@@ -37,6 +37,7 @@ type evalBytes struct {
 }
 
 var _ eval = (*evalBytes)(nil)
+var _ hashable = (*evalBytes)(nil)
 
 func newEvalRaw(typ sqltypes.Type, raw []byte, col collations.TypedCollation) *evalBytes {
 	return &evalBytes{tt: int16(typ), col: col, bytes: raw}

--- a/go/vt/vtgate/evalengine/eval_bytes.go
+++ b/go/vt/vtgate/evalengine/eval_bytes.go
@@ -110,11 +110,8 @@ func (e *evalBytes) Hash(h *vthash.Hasher) {
 		h.Write16(hashPrefixBytes)
 		_, _ = h.Write(e.bytes)
 	default:
-		col := collations.Local().LookupByID(e.col.Collation)
-		if col == nil {
-			panic("unsupported collation in evalBytes")
-		}
 		h.Write16(hashPrefixBytes)
+		col := collations.Local().LookupByID(e.col.Collation)
 		col.Hash(h, e.bytes, 0)
 	}
 }

--- a/go/vt/vtgate/evalengine/eval_bytes.go
+++ b/go/vt/vtgate/evalengine/eval_bytes.go
@@ -96,21 +96,26 @@ func evalToVarchar(e eval, col collations.ID, convert bool) (*evalBytes, error) 
 	return newEvalText(bytes, typedcol), nil
 }
 
-func (e *evalBytes) Hash() (HashCode, error) {
-	if sqltypes.IsDate(e.SQLType()) {
+func (e *evalBytes) Hash(h *vthash.Hasher) {
+	switch tt := e.SQLType(); {
+	case sqltypes.IsDate(tt):
 		t, err := e.parseDate()
 		if err != nil {
-			return 0, err
+			panic("parseDate() in evalBytes should never fail")
 		}
-		return HashCode(t.UnixNano()), nil
+		h.Write16(hashPrefixDate)
+		h.Write64(uint64(t.UnixNano()))
+	case tt == sqltypes.VarBinary:
+		h.Write16(hashPrefixBytes)
+		_, _ = h.Write(e.bytes)
+	default:
+		col := collations.Local().LookupByID(e.col.Collation)
+		if col == nil {
+			panic("unsupported collation in evalBytes")
+		}
+		h.Write16(hashPrefixBytes)
+		col.Hash(h, e.bytes, 0)
 	}
-	col := collations.Local().LookupByID(e.col.Collation)
-	if col == nil {
-		return 0, UnsupportedCollationHashError
-	}
-	hasher := vthash.New()
-	col.Hash(&hasher, e.bytes, 0)
-	return hasher.Sum64(), nil
 }
 
 func (e *evalBytes) isBinary() bool {

--- a/go/vt/vtgate/evalengine/eval_json.go
+++ b/go/vt/vtgate/evalengine/eval_json.go
@@ -40,6 +40,7 @@ var errJSONPath = errors.New("Invalid JSON path expression.")
 type evalJSON = json.Value
 
 var _ eval = (*evalJSON)(nil)
+var _ hashable = (*evalJSON)(nil)
 
 func intoJSON(fn string, e eval) (*evalJSON, error) {
 	switch e := e.(type) {

--- a/go/vt/vtgate/evalengine/eval_numeric.go
+++ b/go/vt/vtgate/evalengine/eval_numeric.go
@@ -30,6 +30,7 @@ import (
 type (
 	evalNumeric interface {
 		eval
+		hashable
 		toFloat() (*evalFloat, bool)
 		toDecimal(m, d int32) *evalDecimal
 		toInt64() *evalInt64

--- a/go/vt/vtgate/evalengine/eval_numeric.go
+++ b/go/vt/vtgate/evalengine/eval_numeric.go
@@ -128,8 +128,13 @@ func evalToNumeric(e eval) evalNumeric {
 	}
 }
 
-func (e *evalInt64) Hash() (HashCode, error) {
-	return HashCode(e.i), nil
+func (e *evalInt64) Hash(h *vthash.Hasher) {
+	if e.i < 0 {
+		h.Write16(hashPrefixIntegralNegative)
+	} else {
+		h.Write16(hashPrefixIntegralPositive)
+	}
+	h.Write64(uint64(e.i))
 }
 
 func (e *evalInt64) SQLType() sqltypes.Type {
@@ -163,8 +168,9 @@ func (e *evalInt64) toUint64() *evalUint64 {
 	return newEvalUint64(uint64(e.i))
 }
 
-func (e *evalUint64) Hash() (HashCode, error) {
-	return HashCode(e.u), nil
+func (e *evalUint64) Hash(h *vthash.Hasher) {
+	h.Write16(hashPrefixIntegralPositive)
+	h.Write64(e.u)
 }
 
 func (e *evalUint64) SQLType() sqltypes.Type {
@@ -201,8 +207,9 @@ func (e *evalUint64) toUint64() *evalUint64 {
 	return e
 }
 
-func (e *evalFloat) Hash() (HashCode, error) {
-	return HashCode(math.Float64bits(e.f)), nil
+func (e *evalFloat) Hash(h *vthash.Hasher) {
+	h.Write16(hashPrefixFloat)
+	h.Write64(math.Float64bits(e.f))
 }
 
 func (e *evalFloat) SQLType() sqltypes.Type {
@@ -273,10 +280,9 @@ func (e *evalFloat) toUint64() *evalUint64 {
 	return newEvalUint64(i)
 }
 
-func (e *evalDecimal) Hash() (HashCode, error) {
-	hasher := vthash.New()
-	e.dec.Hash(&hasher)
-	return hasher.Sum64(), nil
+func (e *evalDecimal) Hash(h *vthash.Hasher) {
+	h.Write16(hashPrefixDecimal)
+	e.dec.Hash(h)
 }
 
 func (e *evalDecimal) SQLType() sqltypes.Type {

--- a/go/vt/vtgate/evalengine/eval_tuple.go
+++ b/go/vt/vtgate/evalengine/eval_tuple.go
@@ -18,15 +18,10 @@ package evalengine
 
 import (
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/vthash"
 )
 
 type evalTuple struct {
 	t []eval
-}
-
-func (e *evalTuple) Hash(h *vthash.Hasher) {
-	panic("should never attempt to hash a TUPLE")
 }
 
 var _ eval = (*evalTuple)(nil)

--- a/go/vt/vtgate/evalengine/eval_tuple.go
+++ b/go/vt/vtgate/evalengine/eval_tuple.go
@@ -18,16 +18,15 @@ package evalengine
 
 import (
 	"vitess.io/vitess/go/sqltypes"
-	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vthash"
 )
 
 type evalTuple struct {
 	t []eval
 }
 
-func (e *evalTuple) Hash() (HashCode, error) {
-	return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "should never attempt to hash a TUPLE")
+func (e *evalTuple) Hash(h *vthash.Hasher) {
+	panic("should never attempt to hash a TUPLE")
 }
 
 var _ eval = (*evalTuple)(nil)

--- a/go/vt/vtgate/evalengine/expr_compare.go
+++ b/go/vt/vtgate/evalengine/expr_compare.go
@@ -21,6 +21,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vthash"
 )
 
 type (
@@ -296,12 +297,11 @@ func (i *InExpr) eval(env *ExpressionEnv) (eval, error) {
 	}
 
 	var foundNull, found bool
+	var hasher = vthash.New()
 	if i.Hashed != nil {
-		hash, err := left.Hash()
-		if err != nil {
-			return nil, err
-		}
-		if idx, ok := i.Hashed[hash]; ok {
+		hasher.Reset()
+		left.Hash(&hasher)
+		if idx, ok := i.Hashed[hasher.Sum64()]; ok {
 			var numeric int
 			numeric, foundNull, err = evalCompareAll(left, rtuple.t[idx], true)
 			if err != nil {

--- a/go/vt/vtgate/evalengine/internal/json/helpers.go
+++ b/go/vt/vtgate/evalengine/internal/json/helpers.go
@@ -17,12 +17,15 @@ limitations under the License.
 package json
 
 import (
-	"vitess.io/vitess/go/hack"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/vthash"
 )
 
-func (v *Value) Hash() (uint64, error) {
-	return hack.RuntimeMemhash(v.ToRawBytes(), 0x3333), nil
+const hashPrefixJSON = 0xCCBB
+
+func (v *Value) Hash(h *vthash.Hasher) {
+	h.Write16(hashPrefixJSON)
+	_, _ = h.Write(v.ToRawBytes())
 }
 
 func (v *Value) ToRawBytes() []byte {


### PR DESCRIPTION
## Description

Follow up on https://github.com/vitessio/vitess/pull/12428. Now that we have support for 128-bit hashing, we should also use it internally for all hashing operations.

cc @dbussink 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
