### PR TITLE
examples schema: demi-idempotency via CREATE TABLE IF NOT EXISTS

### DIFF
--- a/examples/backups/create_commerce_schema.sql
+++ b/examples/backups/create_commerce_schema.sql
@@ -1,11 +1,11 @@
-create table product(
+create table if not exists product(
     sku varbinary(128),
     description varbinary(128),
     price bigint,
     primary key(sku)
 ) ENGINE=InnoDB;
 
-create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
+create table if not exists customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into customer_seq(id, next_id, cache) values(0, 1000, 100);
-create table order_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
+create table if not exists order_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into order_seq(id, next_id, cache) values(0, 1000, 100);

--- a/examples/backups/create_customer_schema.sql
+++ b/examples/backups/create_customer_schema.sql
@@ -1,10 +1,10 @@
-create table customer(
+create table if not exists customer(
     customer_id bigint not null,
     email varbinary(128),
     primary key(customer_id)
 ) ENGINE=InnoDB;
 
-create table corder(
+create table if not exists corder(
     order_id bigint not null,
     customer_id bigint,
     sku varbinary(128),

--- a/examples/compose/external_db/mysql/commerce.sql
+++ b/examples/compose/external_db/mysql/commerce.sql
@@ -1,7 +1,7 @@
 CREATE DATABASE IF NOT EXISTS commerce;
 USE commerce;
 DROP TABLE IF EXISTS users;
-CREATE TABLE users (
+CREATE TABLE IF NOT EXISTS users (
    device_id BIGINT,
    first_name VARCHAR(50),
    last_name VARCHAR(50),

--- a/examples/compose/tables/create_dinosaurs.sql
+++ b/examples/compose/tables/create_dinosaurs.sql
@@ -1,4 +1,4 @@
-CREATE TABLE dinosaurs (
+CREATE TABLE IF NOT EXISTS dinosaurs (
   id BIGINT UNSIGNED,
   time_created_ns BIGINT UNSIGNED,
   name VARCHAR(255),

--- a/examples/compose/tables/create_eggs.sql
+++ b/examples/compose/tables/create_eggs.sql
@@ -1,4 +1,4 @@
-CREATE TABLE eggs (
+CREATE TABLE IF NOT EXISTS eggs (
   id BIGINT UNSIGNED,
   time_created_ns BIGINT UNSIGNED,
   species VARCHAR(255),

--- a/examples/compose/tables/create_messages.sql
+++ b/examples/compose/tables/create_messages.sql
@@ -1,4 +1,4 @@
-CREATE TABLE messages (
+CREATE TABLE IF NOT EXISTS messages (
   page BIGINT(20) UNSIGNED,
   time_created_ns BIGINT(20) UNSIGNED,
   message VARCHAR(10000),

--- a/examples/compose/tables/create_messages_message_lookup.sql
+++ b/examples/compose/tables/create_messages_message_lookup.sql
@@ -1,4 +1,4 @@
-CREATE TABLE messages_message_lookup (
+CREATE TABLE IF NOT EXISTS messages_message_lookup (
   id BIGINT NOT NULL AUTO_INCREMENT,
   page BIGINT UNSIGNED,
   message VARCHAR(1000),

--- a/examples/compose/tables/create_tokens.sql
+++ b/examples/compose/tables/create_tokens.sql
@@ -1,4 +1,4 @@
-CREATE TABLE tokens (
+CREATE TABLE IF NOT EXISTS tokens (
   page BIGINT(20) UNSIGNED,
   time_created_ns BIGINT(20) UNSIGNED,
   token VARCHAR(255) DEFAULT NULL,

--- a/examples/compose/tables/create_tokens_token_lookup.sql
+++ b/examples/compose/tables/create_tokens_token_lookup.sql
@@ -1,4 +1,4 @@
-CREATE TABLE tokens_token_lookup (
+CREATE TABLE IF NOT EXISTS tokens_token_lookup (
   id BIGINT NOT NULL AUTO_INCREMENT,
   page BIGINT UNSIGNED,
   token VARCHAR(255) DEFAULT NULL,

--- a/examples/compose/tables/lookup_keyspace_schema_file.sql
+++ b/examples/compose/tables/lookup_keyspace_schema_file.sql
@@ -1,4 +1,4 @@
-CREATE TABLE tokens_token_lookup (
+CREATE TABLE IF NOT EXISTS tokens_token_lookup (
   id BIGINT NOT NULL AUTO_INCREMENT,
   page BIGINT UNSIGNED,
   token VARCHAR(255) DEFAULT NULL,
@@ -6,7 +6,7 @@ CREATE TABLE tokens_token_lookup (
   UNIQUE KEY idx_token_page (`token`, `page`)
 ) ENGINE=InnoDB;
 
-CREATE TABLE messages_message_lookup (
+CREATE TABLE IF NOT EXISTS messages_message_lookup (
   id BIGINT NOT NULL AUTO_INCREMENT,
   page BIGINT UNSIGNED,
   message VARCHAR(1000),

--- a/examples/compose/tables/test_keyspace_schema_file.sql
+++ b/examples/compose/tables/test_keyspace_schema_file.sql
@@ -1,11 +1,11 @@
-CREATE TABLE messages (
+CREATE TABLE IF NOT EXISTS messages (
   page BIGINT(20) UNSIGNED,
   time_created_ns BIGINT(20) UNSIGNED,
   message VARCHAR(10000),
   PRIMARY KEY (page, time_created_ns)
 ) ENGINE=InnoDB;
 
-CREATE TABLE tokens (
+CREATE TABLE IF NOT EXISTS tokens (
   page BIGINT(20) UNSIGNED,
   time_created_ns BIGINT(20) UNSIGNED,
   token VARCHAR(255) DEFAULT NULL,

--- a/examples/demo/schema/customer/customer_schema.sql
+++ b/examples/demo/schema/customer/customer_schema.sql
@@ -1,4 +1,4 @@
-create table customer(customer_id bigint, uname varchar(128), primary key(customer_id));
-create table corder(corder_id bigint, customer_id bigint, product_id bigint, oname varchar(128), primary key(corder_id));
-create table corder_event(corder_event_id bigint, corder_id bigint, ename varchar(128), keyspace_id varbinary(10), primary key(corder_id, corder_event_id));
-create table oname_keyspace_idx(oname varchar(128), corder_id bigint, keyspace_id varbinary(10), primary key(oname, corder_id));
+create table if not exists customer(customer_id bigint, uname varchar(128), primary key(customer_id));
+create table if not exists corder(corder_id bigint, customer_id bigint, product_id bigint, oname varchar(128), primary key(corder_id));
+create table if not exists corder_event(corder_event_id bigint, corder_id bigint, ename varchar(128), keyspace_id varbinary(10), primary key(corder_id, corder_event_id));
+create table if not exists oname_keyspace_idx(oname varchar(128), corder_id bigint, keyspace_id varbinary(10), primary key(oname, corder_id));

--- a/examples/demo/schema/product/product_schema.sql
+++ b/examples/demo/schema/product/product_schema.sql
@@ -1,8 +1,8 @@
-create table product(product_id bigint auto_increment, pname varchar(128), primary key(product_id));
-create table customer_seq(id bigint, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
+create table if not exists product(product_id bigint auto_increment, pname varchar(128), primary key(product_id));
+create table if not exists customer_seq(id bigint, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into customer_seq(id, next_id, cache) values(0, 1, 3);
-create table corder_seq(id bigint, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
+create table if not exists corder_seq(id bigint, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into corder_seq(id, next_id, cache) values(0, 1, 3);
-create table corder_event_seq(id bigint, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
+create table if not exists corder_event_seq(id bigint, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into corder_event_seq(id, next_id, cache) values(0, 1, 3);
-create table corder_keyspace_idx(corder_id bigint not null auto_increment, keyspace_id varbinary(10), primary key(corder_id));
+create table if not exists corder_keyspace_idx(corder_id bigint not null auto_increment, keyspace_id varbinary(10), primary key(corder_id));

--- a/examples/local/create_commerce_schema.sql
+++ b/examples/local/create_commerce_schema.sql
@@ -1,15 +1,15 @@
-create table product(
+create table if not exists product(
   sku varbinary(128),
   description varbinary(128),
   price bigint,
   primary key(sku)
 ) ENGINE=InnoDB;
-create table customer(
+create table if not exists customer(
   customer_id bigint not null auto_increment,
   email varbinary(128),
   primary key(customer_id)
 ) ENGINE=InnoDB;
-create table corder(
+create table if not exists corder(
   order_id bigint not null auto_increment,
   customer_id bigint,
   sku varbinary(128),

--- a/examples/local/create_commerce_seq.sql
+++ b/examples/local/create_commerce_seq.sql
@@ -1,4 +1,4 @@
-create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
+create table if not exists customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into customer_seq(id, next_id, cache) values(0, 1000, 100);
-create table order_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
+create table if not exists order_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into order_seq(id, next_id, cache) values(0, 1000, 100);

--- a/examples/local/create_test_table.sql
+++ b/examples/local/create_test_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE messages (
+CREATE TABLE IF NOT EXISTS messages (
   page BIGINT(20) UNSIGNED,
   time_created_ns BIGINT(20) UNSIGNED,
   message VARCHAR(10000),

--- a/examples/operator/create_commerce_schema.sql
+++ b/examples/operator/create_commerce_schema.sql
@@ -1,15 +1,15 @@
-create table product(
+create table if not exists product(
   sku varbinary(128),
   description varbinary(128),
   price bigint,
   primary key(sku)
 ) ENGINE=InnoDB;
-create table customer(
+create table if not exists customer(
   customer_id bigint not null auto_increment,
   email varbinary(128),
   primary key(customer_id)
 ) ENGINE=InnoDB;
-create table corder(
+create table if not exists corder(
   order_id bigint not null auto_increment,
   customer_id bigint,
   sku varbinary(128),

--- a/examples/operator/create_commerce_seq.sql
+++ b/examples/operator/create_commerce_seq.sql
@@ -1,4 +1,4 @@
-create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
+create table if not exists customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into customer_seq(id, next_id, cache) values(0, 1000, 100);
-create table order_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
+create table if not exists order_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into order_seq(id, next_id, cache) values(0, 1000, 100);

--- a/examples/region_sharding/create_lookup_schema.sql
+++ b/examples/region_sharding/create_lookup_schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE customer_lookup (
+CREATE TABLE IF NOT EXISTS customer_lookup (
   id int NOT NULL,
   keyspace_id varbinary(128),
   primary key(id)

--- a/examples/region_sharding/create_main_schema.sql
+++ b/examples/region_sharding/create_main_schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE customer (
+CREATE TABLE IF NOT EXISTS customer (
   id int NOT NULL,
   fullname varbinary(256),
   nationalid varbinary(256),

--- a/examples/vtexplain/atomicity_schema.sql
+++ b/examples/vtexplain/atomicity_schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `t1` (
+CREATE TABLE IF NOT EXISTS `t1` (
   `c1` bigint unsigned NOT NULL,
   PRIMARY KEY (`c1`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION

## Description

This PR changes all `CREATE TABLE` into `CREATE TABLE IF NOT EXISTS` in the various `examples` schemas.
This allows the user to take down a cluster and bring it up again with no error (currently the `create table` statements fail the bootstrap script).

## Related Issue(s)


## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
