### PR TITLE
WIP: sqlparser: ParseAndBindWithQualifier() convenience function

### DIFF
--- a/go/vt/sqlparser/parsed_query.go
+++ b/go/vt/sqlparser/parsed_query.go
@@ -218,3 +218,23 @@ func ParseAndBind(in string, binds ...*querypb.BindVariable) (query string, err 
 	}
 	return parsed.GenerateQuery(bindVars, nil)
 }
+
+// ParseAndBind is a one step sweep that binds variables to an input query, in order of placeholders.
+// It is useful when one doesn't have any parser-variables, just bind variables.
+// Example:
+//
+//	query, err := ParseAndBind("select * from tbl where name=%a", sqltypes.StringBindVariable("it's me"))
+func ParseAndBindWithQualifier(in string, qualifier string, binds ...*querypb.BindVariable) (query string, err error) {
+	vars := make([]any, len(binds))
+	for i := range binds {
+		vars[i] = fmt.Sprintf(":var%d", i)
+	}
+	allVars := append([]any{qualifier}, vars...)
+	parsed := BuildParsedQuery(in, allVars...)
+
+	bindVars := map[string]*querypb.BindVariable{}
+	for i := range binds {
+		bindVars[fmt.Sprintf("var%d", i)] = binds[i]
+	}
+	return parsed.GenerateQuery(bindVars, nil)
+}


### PR DESCRIPTION

## Description

There is a use case where it's common to parse a query where we both want to specify a qualifier (schema name or table name) as well as bind variables. It's a bit complicated to mix both types when parsing&binding queries.

This PR offers a new, dedicated function called `ParseAndBindWithQualifier()`. See unit test addition for usage samples. cc @mattlord 

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
