### PR TITLE
Fix shorthand flag for recursive delete in zk tool

### DIFF
--- a/go/cmd/zk/zkcmd.go
+++ b/go/cmd/zk/zkcmd.go
@@ -477,19 +477,15 @@ func cmdTouch(ctx context.Context, subFlags *pflag.FlagSet, args []string) error
 
 func cmdRm(ctx context.Context, subFlags *pflag.FlagSet, args []string) error {
 	var (
-		force             bool
-		recursiveDelete   bool
-		forceAndRecursive bool
+		force           bool
+		recursiveDelete bool
 	)
 	subFlags.BoolVarP(&force, "force", "f", false, "no warning on nonexistent node")
 	subFlags.BoolVarP(&recursiveDelete, "recursivedelete", "r", false, "recursive delete")
-	subFlags.BoolVarP(&forceAndRecursive, "forceandrecursive", "rf", false, "shorthand for -r -f")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
-	force = force || forceAndRecursive
-	recursiveDelete = recursiveDelete || forceAndRecursive
 
 	if subFlags.NArg() == 0 {
 		return fmt.Errorf("rm: no path specified")


### PR DESCRIPTION
## Description

`zk rm` appears to be broken due to a mistake in pflag setup.

The pflag library which we recently migrated to prohibits shorthand flags greater than a single character[1]. As currently written, the `zk` tool panics in `cmdRm` due to the shorthand `rf`. ~The patch fixes by changing this shorthand from `rf` to `F`.~ Fortunately pflag supports combined flags. Since we already have `r` and `f` defined, we don't need a separate `rf` flag, so we can simply remove this line.

[1] https://github.com/spf13/pflag/blob/85dd5c8bc61cfa382fecd072378089d4e856579d/flag.go#L868-L872

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes
