### PR TITLE
Forward port of #12436: Sidecar schema init: use COPY algorithm while altering sidecardb tables

### DIFF
--- a/go/vt/sidecardb/sidecardb.go
+++ b/go/vt/sidecardb/sidecardb.go
@@ -365,6 +365,7 @@ func (si *schemaInit) getCurrentSchema(tableName string) (string, error) {
 func (si *schemaInit) findTableSchemaDiff(tableName, current, desired string) (string, error) {
 	hints := &schemadiff.DiffHints{
 		TableCharsetCollateStrategy: schemadiff.TableCharsetCollateIgnoreAlways,
+		AlterTableAlgorithmStrategy: schemadiff.AlterTableAlgorithmStrategyCopy,
 	}
 	diff, err := schemadiff.DiffCreateTablesQueries(current, desired, hints)
 	if err != nil {

--- a/go/vt/sidecardb/sidecardb_test.go
+++ b/go/vt/sidecardb/sidecardb_test.go
@@ -209,3 +209,37 @@ func TestMiscSidecarDB(t *testing.T) {
 	require.True(t, MatchesInitQuery(SelectCurrentDatabaseQuery))
 	require.True(t, MatchesInitQuery("CREATE TABLE IF NOT EXISTS `_vt`.vreplication"))
 }
+
+// TestAlterTableAlgorithm confirms that we use ALGORITHM=COPY during alter tables
+func TestAlterTableAlgorithm(t *testing.T) {
+	type testCase struct {
+		testName      string
+		tableName     string
+		currentSchema string
+		desiredSchema string
+	}
+	testCases := []testCase{
+		{"add column", "t1", "create table if not exists _vt.t1(i int)", "create table if not exists _vt.t1(i int, i1 int)"},
+		{"modify column", "t1", "create table if not exists _vt.t1(i int)", "create table if not exists _vt.t(i float)"},
+	}
+	si := &schemaInit{}
+	copyAlgo := sqlparser.AlgorithmValue("COPY")
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			diff, err := si.findTableSchemaDiff(tc.tableName, tc.currentSchema, tc.desiredSchema)
+			require.NoError(t, err)
+			stmt, err := sqlparser.Parse(diff)
+			require.NoError(t, err)
+			alterTable, ok := stmt.(*sqlparser.AlterTable)
+			require.True(t, ok)
+			require.NotNil(t, alterTable)
+			var alterAlgo sqlparser.AlterOption
+			for i, opt := range alterTable.AlterOptions {
+				if _, ok := opt.(sqlparser.AlgorithmValue); ok {
+					alterAlgo = alterTable.AlterOptions[i]
+				}
+			}
+			require.Equal(t, copyAlgo, alterAlgo)
+		})
+	}
+}


### PR DESCRIPTION
#### Forward port of #12436

## Description
Enforce use of `ALGORITHM=COPY` for all `ALTER TABLE`s used during the sidecar schema init process. By default, MYSQL8.0 uses `INSTANT` which causes `Percona XtraBackup` to fail  with the following error message, at least for `8.0.29` (which was deemed unstable and withdrawn):

```
Percona XtraBackup Error Message
If Percona XtraBackup detects that MySQL 8.0.29 server has tables with instant add/drop columns, it aborts with the following error message

2022-07-01T15:18:35.127689+05:30 0 [ERROR] [MY-011825] [Xtrabackup] Found tables with row versions due to INSTANT ADD/DROP columns
2022-07-01T15:18:35.127714+05:30 0 [ERROR] [MY-011825] [Xtrabackup] This feature is not stable and will cause backup corruption.
2022-07-01T15:18:35.127723+05:30 0 [ERROR] [MY-011825] [Xtrabackup] Tables found:
2022-07-01T15:18:35.127730+05:30 0 [ERROR] [MY-011825] [Xtrabackup] test/t1
2022-07-01T15:18:35.127737+05:30 0 [ERROR] [MY-011825] [Xtrabackup] test/t2
2022-07-01T15:18:35.127744+05:30 0 [ERROR] [MY-011825] [Xtrabackup] test/t3
2022-07-01T15:18:35.127752+05:30 0 [ERROR] [MY-011825] [Xtrabackup] Please run OPTIMIZE TABLE or ALTER TABLE ALGORITHM=COPY on all listed tables to fix this issue.
Summary
The option, ALGORITHM=INSTANT is the default value in MySQL 8.0.29. If you do not specify an algorithm, all ALTER TABLE ADD/DROP COLUMN statements use this algorithm.

The INSTANT algorithm is unstable at this point.

Percona XtraBackup refuses to take backups from MySQL 8.0.29 tables that have used this algorithm. Percona Server users do not suffer the same limitations as the corruption issues are fixed in the upcoming release of Percona Server for MySQL 8.0.29
```

To achieve this the PR adds a hint to `schemadiff` to optionally provide the `ALGORITHM` while generating the `ALTER`s

### Todos

- [ ] Add unit tests in schemadiff
- [ ] Check if we can test the functionality from the bug report in an XtraBackup test

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/12300

Original issue: #11520

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [ ] Documentation was added or is not required
