### PR TITLE
Fix `vtctldclient`'s Root command to return an error on unknown command

### DIFF
--- a/go/cmd/vtctldclient/command/root.go
+++ b/go/cmd/vtctldclient/command/root.go
@@ -19,6 +19,7 @@ package command
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"time"
@@ -78,6 +79,26 @@ var (
 		// propagated).
 		SilenceErrors: true,
 		Version:       servenv.AppVersion.String(),
+		// If we've reached this function, it means that:
+		//
+		// (1) The user specified some positional arguments, which, for the way
+		// we've structured things can only be a subcommand name, **and**
+		//
+		// (2) Cobra was unable to find a subcommand with that name for which to
+		// call a Run or RunE function.
+		//
+		// From this we conclude that the user was trying to either run a
+		// command that doesn't exist (e.g. "vtctldclient delete-my-data") or
+		// has misspelled a legitimate command (e.g. "vtctldclient StapReplication").
+		// If we think this has happened, return an error, which will get
+		// displayed to the user in main.go along with the usage.
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().NArg() > 0 {
+				return fmt.Errorf("unknown command: %s", cmd.Flags().Arg(0))
+			}
+
+			return nil
+		},
 	}
 )
 

--- a/go/cmd/vtctldclient/command/root_test.go
+++ b/go/cmd/vtctldclient/command/root_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/cmd/vtctldclient/command"
+	"vitess.io/vitess/go/vt/vtctl/localvtctldclient"
+
+	vtctlservicepb "vitess.io/vitess/go/vt/proto/vtctlservice"
+)
+
+type emptyLocalServer struct {
+	vtctlservicepb.UnimplementedVtctldServer
+}
+
+func TestRoot(t *testing.T) {
+	t.Run("error on unknown subcommand", func(t *testing.T) {
+		args := append([]string{}, os.Args...)
+		protocol := command.VtctldClientProtocol
+		localvtctldclient.SetServer(&emptyLocalServer{})
+
+		t.Cleanup(func() {
+			os.Args = append([]string{}, args...)
+			command.VtctldClientProtocol = protocol
+		})
+
+		os.Args = []string{"vtctldclient", "this-is-bunk"}
+		command.VtctldClientProtocol = "local"
+
+		err := command.Root.Execute()
+		require.Error(t, err, "root command should error on unknown command")
+		assert.Contains(t, err.Error(), "unknown command")
+	})
+}

--- a/go/flags/endtoend/vtctldclient.txt
+++ b/go/flags/endtoend/vtctldclient.txt
@@ -1,6 +1,7 @@
 Executes a cluster management command on the remote vtctld server.
 
 Usage:
+  vtctldclient [flags]
   vtctldclient [command]
 
 Available Commands:


### PR DESCRIPTION


## Description

Add a Run func to `vtctldclient`'s Root command to return an error on unknown command.

Cobra can't (and shouldn't!) be distinguish between "we didn't find a subcommand because the user made an error" and "we didn't find a subcommand because the user is trying to invoke a parent command with positional arguments", so we specify a run function (what cobra invokes when executing the command) on the root (top-level parent) and check if there are any positional arguments, which in our case we assume means the user was trying to run a subcommand that doesn't exist.

## Related Issue(s)

Closes #12480.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
