### PR TITLE
streamlog: make generic

### DIFF
--- a/go/streamlog/streamlog_flaky_test.go
+++ b/go/streamlog/streamlog_flaky_test.go
@@ -53,7 +53,7 @@ func TestHTTP(t *testing.T) {
 
 	go http.Serve(l, nil)
 
-	logger := New("logger", 1)
+	logger := New[*logMessage]("logger", 1)
 	logger.ServeLogs("/log", testLogf)
 
 	// This should not block - there are no subscribers yet.
@@ -122,7 +122,7 @@ func TestHTTP(t *testing.T) {
 }
 
 func TestChannel(t *testing.T) {
-	logger := New("logger", 1)
+	logger := New[*logMessage]("logger", 1)
 
 	// Subscribe.
 	ch := logger.Subscribe("test")
@@ -140,7 +140,7 @@ func TestChannel(t *testing.T) {
 		msg := fmt.Sprint("msg", i)
 		done := make(chan struct{})
 		go func() {
-			if want, got := msg+"\n", (<-ch).(*logMessage).Format(nil); got != want {
+			if want, got := msg+"\n", (<-ch).Format(nil); got != want {
 				t.Errorf("Unexpected message in log. got: %q, want: %q", got, want)
 			}
 			close(done)
@@ -158,7 +158,7 @@ func TestChannel(t *testing.T) {
 		for {
 			select {
 			case msg := <-ch:
-				got = append(got, msg.(*logMessage).Format(nil))
+				got = append(got, msg.Format(nil))
 			case <-writeDone:
 				close(readDone)
 				return
@@ -191,7 +191,7 @@ func TestChannel(t *testing.T) {
 }
 
 func TestFile(t *testing.T) {
-	logger := New("logger", 10)
+	logger := New[*logMessage]("logger", 10)
 
 	dir := t.TempDir()
 

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 
+	"vitess.io/vitess/go/vt/vtgate/logstats"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 
 	"vitess.io/vitess/go/cache"
@@ -75,7 +76,7 @@ func (vte *VTExplain) initVtgateExecutor(vSchemaStr, ksShardMapStr string, opts 
 	vte.vtgateExecutor = vtgate.NewExecutor(context.Background(), vte.explainTopo, vtexplainCell, resolver, opts.Normalize, false, streamSize, cache.DefaultConfig, schemaTracker, false, opts.PlannerVersion)
 
 	queryLogBufferSize := 10
-	vtgate.SetQueryLogger(streamlog.New("VTGate", queryLogBufferSize))
+	vtgate.SetQueryLogger(streamlog.New[*logstats.LogStats]("VTGate", queryLogBufferSize))
 
 	return nil
 }

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -328,12 +328,10 @@ func testNonZeroDuration(t *testing.T, what, d string) {
 	}
 }
 
-func getQueryLog(logChan chan any) *logstats.LogStats {
-	var log any
-
+func getQueryLog(logChan chan *logstats.LogStats) *logstats.LogStats {
 	select {
-	case log = <-logChan:
-		return log.(*logstats.LogStats)
+	case log := <-logChan:
+		return log
 	default:
 		return nil
 	}
@@ -346,7 +344,7 @@ func getQueryLog(logChan chan any) *logstats.LogStats {
 // is a repeat query.
 var testPlannedQueries = map[string]bool{}
 
-func testQueryLog(t *testing.T, logChan chan any, method, stmtType, sql string, shardQueries int) *logstats.LogStats {
+func testQueryLog(t *testing.T, logChan chan *logstats.LogStats, method, stmtType, sql string, shardQueries int) *logstats.LogStats {
 	t.Helper()
 
 	logStats := getQueryLog(logChan)

--- a/go/vt/vtgate/querylog.go
+++ b/go/vt/vtgate/querylog.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"vitess.io/vitess/go/streamlog"
+	"vitess.io/vitess/go/vt/vtgate/logstats"
 )
 
 var (
@@ -34,18 +35,18 @@ var (
 	QueryzHandler = "/debug/queryz"
 
 	// QueryLogger enables streaming logging of queries
-	QueryLogger   *streamlog.StreamLogger
+	QueryLogger   *streamlog.StreamLogger[*logstats.LogStats]
 	queryLoggerMu sync.Mutex
 )
 
-func SetQueryLogger(logger *streamlog.StreamLogger) {
+func SetQueryLogger(logger *streamlog.StreamLogger[*logstats.LogStats]) {
 	queryLoggerMu.Lock()
 	defer queryLoggerMu.Unlock()
 	QueryLogger = logger
 }
 
 func initQueryLogger(vtg *VTGate) error {
-	SetQueryLogger(streamlog.New("VTGate", queryLogBufferSize))
+	SetQueryLogger(streamlog.New[*logstats.LogStats]("VTGate", queryLogBufferSize))
 	QueryLogger.ServeLogs(QueryLogHandler, streamlog.GetFormatter(QueryLogger))
 
 	http.HandleFunc(QueryLogzHandler, func(w http.ResponseWriter, r *http.Request) {

--- a/go/vt/vttablet/filelogger/filelogger.go
+++ b/go/vt/vttablet/filelogger/filelogger.go
@@ -51,7 +51,7 @@ type FileLogger interface {
 }
 
 type fileLogger struct {
-	logChan chan any
+	logChan chan *tabletenv.LogStats
 }
 
 func (l *fileLogger) Stop() {

--- a/go/vt/vttablet/sysloglogger/sysloglogger.go
+++ b/go/vt/vttablet/sysloglogger/sysloglogger.go
@@ -38,7 +38,7 @@ type syslogWriter interface {
 var writer syslogWriter
 
 // ch holds the tabletserver.StatsLogger channel to which this plugin subscribes (or a mock when under test).
-var ch chan any
+var ch chan *tabletenv.LogStats
 
 var logQueries bool
 
@@ -76,12 +76,7 @@ func run() {
 	}
 
 	formatParams := map[string][]string{"full": {}}
-	for out := range ch {
-		stats, ok := out.(*tabletenv.LogStats)
-		if !ok {
-			log.Errorf("Unexpected value in query logs: %#v (expecting value of type %T)", out, &tabletenv.LogStats{})
-			continue
-		}
+	for stats := range ch {
 		var b bytes.Buffer
 		if err := stats.Logf(&b, formatParams); err != nil {
 			log.Errorf("Error formatting logStats: %v", err)

--- a/go/vt/vttablet/sysloglogger/sysloglogger_test.go
+++ b/go/vt/vttablet/sysloglogger/sysloglogger_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sysloglogger
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/syslog"
@@ -24,8 +25,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"context"
 
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -101,7 +100,7 @@ func TestSyslog(t *testing.T) {
 	// Overwrite the usual syslog writer and StatsLogger subscription channel with mocks
 	mock := newFakeWriter()
 	writer = mock
-	ch = make(chan any, 10)
+	ch = make(chan *tabletenv.LogStats, 10)
 
 	// Start running the plugin loop
 	syncChannel := make(chan bool)
@@ -147,7 +146,7 @@ func TestSyslogRedacted(t *testing.T) {
 	}()
 	mock := newFakeWriter()
 	writer = mock
-	ch = make(chan any, 10)
+	ch = make(chan *tabletenv.LogStats, 10)
 
 	// Start running the plugin loop
 	syncChannel := make(chan bool)
@@ -188,7 +187,7 @@ func TestSyslogRedacted(t *testing.T) {
 func TestSyslogWithBadData(t *testing.T) {
 	mock := newFakeWriter()
 	writer = mock
-	ch = make(chan any, 10)
+	ch = make(chan *tabletenv.LogStats, 10)
 
 	syncChannel := make(chan bool)
 	go func() {
@@ -200,7 +199,6 @@ func TestSyslogWithBadData(t *testing.T) {
 	ch <- mockLogStats("select 1")
 	ch <- mockLogStats("select 2")
 	ch <- mockLogStats("select 3")
-	ch <- "Wait... this is just a garbage 'string', not of type '*tabletserver.LogStats'!"
 	ch <- mockLogStats("select 5")
 	close(ch)
 	<-syncChannel
@@ -231,7 +229,7 @@ func TestSyslogWithInterruptedConnection(t *testing.T) {
 	// This mock will simulate a broken syslog connection when processing every 4th record
 	mock := newFailingFakeWriter()
 	writer = mock
-	ch = make(chan any, 10)
+	ch = make(chan *tabletenv.LogStats, 10)
 
 	syncChannel := make(chan bool)
 	go func() {

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -441,7 +441,7 @@ func expectDeleteQueries(t *testing.T) {
 	))
 }
 
-func expectLogsAndUnsubscribe(t *testing.T, logs []LogExpectation, logCh chan any) {
+func expectLogsAndUnsubscribe(t *testing.T, logs []LogExpectation, logCh chan *VrLogStats) {
 	t.Helper()
 	defer vrLogStatsLogger.Unsubscribe(logCh)
 	failed := false
@@ -451,11 +451,7 @@ func expectLogsAndUnsubscribe(t *testing.T, logs []LogExpectation, logCh chan an
 			continue
 		}
 		select {
-		case data := <-logCh:
-			got, ok := data.(*VrLogStats)
-			if !ok {
-				t.Errorf("got not ok casting to VrLogStats: %v", data)
-			}
+		case got := <-logCh:
 			var match bool
 			match = (log.Type == got.Type)
 			if match {

--- a/go/vt/vttablet/tabletmanager/vreplication/vrlog.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vrlog.go
@@ -33,7 +33,7 @@ import (
 var (
 	vrLogStatsLogger   = streamlog.New[*VrLogStats]("VReplication", 50)
 	vrLogStatsTemplate = template.Must(template.New("vrlog").
-		Parse("{{.Type}} Event	{{.Detail}}	{{.LogTime}}	{{.DurationNs}}\n"))
+				Parse("{{.Type}} Event	{{.Detail}}	{{.LogTime}}	{{.DurationNs}}\n"))
 )
 
 // VrLogStats collects attributes of a vreplication event for logging

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -51,10 +51,10 @@ var (
 	// TxLogger can be used to enable logging of transactions.
 	// Call TxLogger.ServeLogs in your main program to enable logging.
 	// The log format can be inferred by looking at TxConnection.Format.
-	TxLogger = streamlog.New("TxLog", 10)
+	TxLogger = streamlog.New[any]("TxLog", 10)
 
 	// StatsLogger is the main stream logger object
-	StatsLogger = streamlog.New("TabletServer", 50)
+	StatsLogger = streamlog.New[*LogStats]("TabletServer", 50)
 
 	// The following vars are used for custom initialization of Tabletconfig.
 	enableHotRowProtection       bool

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -749,12 +749,7 @@ func TestTabletServerStreamExecuteComments(t *testing.T) {
 
 	wantSQL := executeSQL
 	select {
-	case out := <-ch:
-		stats, ok := out.(*tabletenv.LogStats)
-		if !ok {
-			t.Errorf("Unexpected value in query logs: %#v (expecting value of type %T)", out, &tabletenv.LogStats{})
-		}
-
+	case stats := <-ch:
 		if wantSQL != stats.OriginalSQL {
 			t.Errorf("logstats: SQL want %s got %s", wantSQL, stats.OriginalSQL)
 		}

--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -28,10 +28,9 @@ import (
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logz"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
-
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
 var (

--- a/go/vt/vttablet/tabletserver/txlogz_test.go
+++ b/go/vt/vttablet/tabletserver/txlogz_test.go
@@ -23,12 +23,12 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
 	"vitess.io/vitess/go/vt/callerid"
 
 	"vitess.io/vitess/go/streamlog"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
 func testNotRedacted(t *testing.T, r *httptest.ResponseRecorder) {


### PR DESCRIPTION
## Description

The `logstats` package is a good example of a primitive that is used throughout the Vitess codebase and that still uses `any` for polymorphism. It's un-ergonomic and it has a lot of type checks that won't be needed if we switch to use Generics.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
