### PR TITLE
vtctldclient: Format GetKeyspace output using cli.MarshalJSON

### DIFF
--- a/go/cmd/vtctldclient/command/keyspaces.go
+++ b/go/cmd/vtctldclient/command/keyspaces.go
@@ -266,12 +266,16 @@ func commandGetKeyspace(cmd *cobra.Command, args []string) error {
 	resp, err := client.GetKeyspace(commandCtx, &vtctldatapb.GetKeyspaceRequest{
 		Keyspace: ks,
 	})
-
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("%+v\n", resp.Keyspace)
+	data, err := cli.MarshalJSON(resp.Keyspace)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s\n", data)
 
 	return nil
 }


### PR DESCRIPTION
## Description

The [`GetKeyspace` vtctldclient command](https://vitess.io/docs/17.0/reference/programs/vtctldclient/vtctldclient_getkeyspace/) returned invalid JSON (using the [vitess local example](https://vitess.io/docs/17.0/get-started/local/)):
```
$ vtctlclient GetKeyspace commerce
{
  "served_froms": [],
  "keyspace_type": 0,
  "base_keyspace": "",
  "snapshot_time": null,
  "durability_policy": "semi_sync"
}

$ vtctldclient GetKeyspace commerce
name:"commerce" keyspace:{durability_policy:"semi_sync"}
```


With this PR:
```
$ vtctlclient GetKeyspace commerce
{
  "served_froms": [],
  "keyspace_type": 0,
  "base_keyspace": "",
  "snapshot_time": null,
  "durability_policy": "semi_sync"
}

$ vtctldclient GetKeyspace commerce
{
  "name": "commerce",
  "keyspace": {
    "served_froms": [],
    "keyspace_type": 0,
    "base_keyspace": "",
    "snapshot_time": null,
    "durability_policy": "semi_sync"
  }
}
```

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/12496

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation is not required (I don't see any example output)