### PR TITLE
go/vt/mysqlctl/backupstats: increment *_bytes metric by actual number of bytes

### DIFF
--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -651,10 +651,10 @@ func testRestoreOldPrimary(t *testing.T, method restoreMethod) {
 	// force the old primary to restore at the latest backup.
 	method(t, primary)
 
-	verifyTabletRestoreStats(t, primary.VttabletProcess.GetVars())
-
 	// wait for it to catch up.
 	cluster.VerifyRowsInTablet(t, primary, keyspaceName, 3)
+
+	verifyTabletRestoreStats(t, primary.VttabletProcess.GetVars())
 
 	// teardown
 	restartPrimaryAndReplica(t)
@@ -926,6 +926,9 @@ func terminateRestore(t *testing.T) {
 	if useXtrabackup {
 		stopRestoreMsg = "Restore: Preparing"
 		useXtrabackup = false
+		defer func() {
+			useXtrabackup = true
+		}()
 	}
 
 	args := append([]string{"--server", localCluster.VtctlclientProcess.Server, "--alsologtostderr"}, "RestoreFromBackup", "--", primary.Alias)

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -75,6 +75,10 @@ type BackupParams struct {
 	Stats backupstats.Stats
 }
 
+func BackupEngineImplementation() string {
+	return backupEngineImplementation
+}
+
 func (b BackupParams) Copy() BackupParams {
 	return BackupParams{
 		b.Cnf,

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -75,10 +75,6 @@ type BackupParams struct {
 	Stats backupstats.Stats
 }
 
-func BackupEngineImplementation() string {
-	return backupEngineImplementation
-}
-
 func (b BackupParams) Copy() BackupParams {
 	return BackupParams{
 		b.Cnf,

--- a/go/vt/mysqlctl/backupstats/stats.go
+++ b/go/vt/mysqlctl/backupstats/stats.go
@@ -194,6 +194,6 @@ func (s *scopedStats) TimedIncrement(d time.Duration) {
 
 // TimedIncrementBytes increments the byte-count and duration of the current scope.
 func (s *scopedStats) TimedIncrementBytes(b int, d time.Duration) {
-	s.bytes.Add(s.labelValues, 1)
+	s.bytes.Add(s.labelValues, int64(b))
 	s.durationNs.Add(s.labelValues, int64(d.Nanoseconds()))
 }


### PR DESCRIPTION
## Description

Recently merged detailed backup stats has a minor bug in that it is not actually counting # of bytes. I know I had this correct at least locally at some point, but looking through commits in #11979 it seems like it was always wrong 😵‍💫 

## Related Issue(s)

#11979 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
