### PR TITLE
Added [Twitter] & [Etsy] to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -3,6 +3,7 @@ This is an alphabetical list of known adopters of Vitess. Some have already gone
 * [Axon](https://axon.com)
 * [BetterCloud](https://bettercloud.com)
 * [CloudSigma](https://www.cloudsigma.com/)
+* [Etsy](https://www.etsy.com)
 * [FlipKart](https://flipkart.com)
 * [GitHub](https://github.com/)
 * [HubSpot](https://product.hubspot.com/)

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -17,5 +17,6 @@ This is an alphabetical list of known adopters of Vitess. Some have already gone
 * [Slack](https://slack.com)
 * [Square](https://square.com)
 * [Stitch Labs](https://stitchlabs.com)
+* [Twitter](https://twitter.com)
 * [Weave](https://www.getweave.com)
 * [YouTube](https://youtube.com)


### PR DESCRIPTION
- Added [Twitter] to ADOPTERS. see: https://blog.twitter.com/engineering/en_us/topics/infrastructure/2023/how-we-scaled-reads-on-the-twitter-users-database
- Added [Etsy] to ADOPTERS. see: https://www.etsy.com/codeascraft/scaling-etsy-payments-with-vitess-part-1--the-data-model

## Description

Hi, I saw today from the article that Twitter uses vitess, this is a simple PR that add Twitter to the ADOPTERS list.

Cheers!