### PR TITLE
Fix `TestFuzz` that hangs on `go1.20.1`

### DIFF
--- a/go/bucketpool/bucketpool_test.go
+++ b/go/bucketpool/bucketpool_test.go
@@ -167,10 +167,12 @@ func TestPoolWeirdMaxSize(t *testing.T) {
 }
 
 func TestFuzz(t *testing.T) {
-	t.Skip()
 	maxTestSize := 16384
 	for i := 0; i < 20000; i++ {
 		minSize := rand.Intn(maxTestSize)
+		if minSize == 0 {
+			minSize = 1
+		}
 		maxSize := rand.Intn(maxTestSize-minSize) + minSize
 		p := New(minSize, maxSize)
 		bufSize := rand.Intn(maxTestSize)


### PR DESCRIPTION
## Description

Fixes https://github.com/vitessio/vitess/issues/12513 on `release-16.0`.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
