### PR TITLE
`ApplyVSchemaDDL`: escape Sequence names when writing the VSchema

### DIFF
--- a/go/vt/topotools/vschema_ddl.go
+++ b/go/vt/topotools/vschema_ddl.go
@@ -17,7 +17,6 @@ limitations under the License.
 package topotools
 
 import (
-	"fmt"
 	"reflect"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -226,15 +225,9 @@ func ApplyVSchemaDDL(ksName string, ks *vschemapb.Keyspace, alterVschema *sqlpar
 			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vschema already contains auto inc %v on table %s in keyspace %s", table.AutoIncrement, name, ksName)
 		}
 
-		sequence := alterVschema.AutoIncSpec.Sequence
-		sequenceFqn := sequence.Name.String()
-		if sequence.Qualifier.String() != "" {
-			sequenceFqn = fmt.Sprintf("%s.%s", sequence.Qualifier.String(), sequenceFqn)
-		}
-
 		table.AutoIncrement = &vschemapb.AutoIncrement{
 			Column:   alterVschema.AutoIncSpec.Column.String(),
-			Sequence: sequenceFqn,
+			Sequence: sqlparser.String(alterVschema.AutoIncSpec.Sequence),
 		}
 
 		return ks, nil

--- a/go/vt/vtgate/executor_vschema_ddl_test.go
+++ b/go/vt/vtgate/executor_vschema_ddl_test.go
@@ -373,13 +373,13 @@ func TestExecutorAddSequenceDDL(t *testing.T) {
 	}
 	time.Sleep(10 * time.Millisecond)
 
-	stmt = "alter vschema on test_table add auto_increment id using test_seq"
+	stmt = "alter vschema on test_table add auto_increment id using `db-name`.`test_seq`"
 	if _, err = executor.Execute(context.Background(), "TestExecute", session, stmt, nil); err != nil {
 		t.Error(err)
 	}
 	time.Sleep(10 * time.Millisecond)
 
-	wantAutoInc := &vschemapb.AutoIncrement{Column: "id", Sequence: "test_seq"}
+	wantAutoInc := &vschemapb.AutoIncrement{Column: "id", Sequence: "`db-name`.test_seq"}
 	gotAutoInc := executor.vm.GetCurrentSrvVschema().Keyspaces[ksSharded].Tables["test_table"].AutoIncrement
 
 	if !reflect.DeepEqual(wantAutoInc, gotAutoInc) {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

We use `ALTER VSCHEMA ... ADD AUTO_INCREMENT ...` statements to provision new sharded tables with their Sequence table references, however we ran into a bug because our sequence tables are stored in keyspaces that contain dashes (e.g. <code>\`app-name-global\`.sequence_table</code>).

The issue is that the `ApplyVSchemaDDL` function does not escape the value of the  `Sequence` field below even though it's capable of parsing user input correctly:

```go
		table.AutoIncrement = &vschemapb.AutoIncrement{
			Column:   alterVschema.AutoIncSpec.Column.String(),
			Sequence: sequenceFqn,
		}
```

Not surprising, since we're going through a cycle of parsing user input (from a SQL statment) and then trying to write something out to the VSchema's `Table.AutoIncrement.Sequence` field with the (new-ish?) understanding that it will be parsed using `sqlparser` again. As [the VSchema docs mention](https://vitess.io/docs/15.0/reference/features/vschema/), "If necessary, the reference to the sequence table lookup.user_seq can be escaped using backticks."

We would _really_ love to have this be backported and have a `v14.0.5` minor version be released with this fix.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

There should be no functional change in correct existing behaviour. The failing case will be fixed by the changes.