### PR TITLE
Use `MarshalVT`/`UnmarshalVT` instead of `proto.Marshal`/`proto.Unmarshal`.

### DIFF
--- a/go/vt/tableacl/tableacl.go
+++ b/go/vt/tableacl/tableacl.go
@@ -113,7 +113,7 @@ func (tacl *tableACL) init(configFile string, aclCB func()) error {
 		return err
 	}
 	config := &tableaclpb.Config{}
-	if err := proto.Unmarshal(data, config); err != nil {
+	if err := config.UnmarshalVT(data); err != nil {
 		// try to parse tableacl as json file
 		if jsonErr := json2.Unmarshal(data, config); jsonErr != nil {
 			log.Infof("unable to parse tableACL config file as a protobuf or json file.  protobuf err: %v  json err: %v", err, jsonErr)

--- a/go/vt/topo/cell_info.go
+++ b/go/vt/topo/cell_info.go
@@ -83,7 +83,7 @@ func (ts *Server) GetCellInfo(ctx context.Context, cell string, strongRead bool)
 // CreateCellInfo creates a new CellInfo with the provided content.
 func (ts *Server) CreateCellInfo(ctx context.Context, cell string, ci *topodatapb.CellInfo) error {
 	// Pack the content.
-	contents, err := proto.Marshal(ci)
+	contents, err := ci.MarshalVT()
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (ts *Server) UpdateCellInfoFields(ctx context.Context, cell string, update 
 		}
 
 		// Pack and save.
-		contents, err = proto.Marshal(ci)
+		contents, err = ci.MarshalVT()
 		if err != nil {
 			return err
 		}

--- a/go/vt/topo/cell_info.go
+++ b/go/vt/topo/cell_info.go
@@ -21,8 +21,6 @@ import (
 	"path"
 	"strings"
 
-	"google.golang.org/protobuf/proto"
-
 	"vitess.io/vitess/go/sets"
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -74,7 +72,7 @@ func (ts *Server) GetCellInfo(ctx context.Context, cell string, strongRead bool)
 
 	// Unpack the contents.
 	ci := &topodatapb.CellInfo{}
-	if err := proto.Unmarshal(contents, ci); err != nil {
+	if err := ci.UnmarshalVT(contents); err != nil {
 		return nil, err
 	}
 	return ci, nil
@@ -108,7 +106,7 @@ func (ts *Server) UpdateCellInfoFields(ctx context.Context, cell string, update 
 		contents, version, err := ts.globalCell.Get(ctx, filePath)
 		switch {
 		case err == nil:
-			if err := proto.Unmarshal(contents, ci); err != nil {
+			if err := ci.UnmarshalVT(contents); err != nil {
 				return err
 			}
 		case IsErrType(err, NoNode):

--- a/go/vt/topo/cells_aliases.go
+++ b/go/vt/topo/cells_aliases.go
@@ -119,7 +119,7 @@ func (ts *Server) CreateCellsAlias(ctx context.Context, alias string, cellsAlias
 	ts.clearCellAliasesCache()
 
 	// Pack the content.
-	contents, err := proto.Marshal(cellsAlias)
+	contents, err := cellsAlias.MarshalVT()
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func (ts *Server) UpdateCellsAlias(ctx context.Context, alias string, update fun
 		}
 
 		// Pack and save.
-		contents, err = proto.Marshal(cellsAlias)
+		contents, err = cellsAlias.MarshalVT()
 		if err != nil {
 			return err
 		}

--- a/go/vt/topo/cells_aliases.go
+++ b/go/vt/topo/cells_aliases.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"path"
 
-	"google.golang.org/protobuf/proto"
-
 	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -63,7 +61,7 @@ func (ts *Server) GetCellsAliases(ctx context.Context, strongRead bool) (ret map
 
 			// Unpack the contents.
 			cellsAlias := &topodatapb.CellsAlias{}
-			if err := proto.Unmarshal(contents, cellsAlias); err != nil {
+			if err := cellsAlias.UnmarshalVT(contents); err != nil {
 				return nil, err
 			}
 
@@ -90,7 +88,7 @@ func (ts *Server) GetCellsAlias(ctx context.Context, name string, strongRead boo
 
 	// Unpack the contents.
 	cellsAlias := &topodatapb.CellsAlias{}
-	if err := proto.Unmarshal(contents, cellsAlias); err != nil {
+	if err := cellsAlias.UnmarshalVT(contents); err != nil {
 		return nil, err
 	}
 
@@ -142,7 +140,7 @@ func (ts *Server) UpdateCellsAlias(ctx context.Context, alias string, update fun
 		contents, version, err := ts.globalCell.Get(ctx, filePath)
 		switch {
 		case err == nil:
-			if err := proto.Unmarshal(contents, cellsAlias); err != nil {
+			if err := cellsAlias.UnmarshalVT(contents); err != nil {
 				return err
 			}
 		case IsErrType(err, NoNode):

--- a/go/vt/topo/external_vitess_cluster.go
+++ b/go/vt/topo/external_vitess_cluster.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"path"
 
-	"google.golang.org/protobuf/proto"
-
 	"vitess.io/vitess/go/event"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo/events"
@@ -77,7 +75,7 @@ func (ts *Server) GetExternalVitessCluster(ctx context.Context, clusterName stri
 		return nil, err
 	}
 	vc := &topodatapb.ExternalVitessCluster{}
-	if err = proto.Unmarshal(data, vc); err != nil {
+	if err = vc.UnmarshalVT(data); err != nil {
 		return nil, vterrors.Wrap(err, "bad vitess cluster data")
 	}
 

--- a/go/vt/topo/external_vitess_cluster.go
+++ b/go/vt/topo/external_vitess_cluster.go
@@ -49,7 +49,7 @@ func GetExternalVitessClusterPath(clusterName string) string {
 
 // CreateExternalVitessCluster creates a topo record for the passed vitess cluster
 func (ts *Server) CreateExternalVitessCluster(ctx context.Context, clusterName string, value *topodatapb.ExternalVitessCluster) error {
-	data, err := proto.Marshal(value)
+	data, err := value.MarshalVT()
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func (ts *Server) GetExternalVitessCluster(ctx context.Context, clusterName stri
 // UpdateExternalVitessCluster updates the topo record for the named vitess cluster
 func (ts *Server) UpdateExternalVitessCluster(ctx context.Context, vc *ExternalVitessClusterInfo) error {
 	//FIXME: check for cluster lock
-	data, err := proto.Marshal(vc.ExternalVitessCluster)
+	data, err := vc.ExternalVitessCluster.MarshalVT()
 	if err != nil {
 		return err
 	}

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -161,7 +161,7 @@ func (ki *KeyspaceInfo) ComputeCellServedFrom(cell string) []*topodatapb.SrvKeys
 // CreateKeyspace wraps the underlying Conn.Create
 // and dispatches the event.
 func (ts *Server) CreateKeyspace(ctx context.Context, keyspace string, value *topodatapb.Keyspace) error {
-	data, err := proto.Marshal(value)
+	data, err := value.MarshalVT()
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (ts *Server) UpdateKeyspace(ctx context.Context, ki *KeyspaceInfo) error {
 		return err
 	}
 
-	data, err := proto.Marshal(ki.Keyspace)
+	data, err := ki.Keyspace.MarshalVT()
 	if err != nil {
 		return err
 	}

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -19,8 +19,6 @@ package topo
 import (
 	"path"
 
-	"google.golang.org/protobuf/proto"
-
 	"context"
 
 	"vitess.io/vitess/go/vt/vterrors"
@@ -188,7 +186,7 @@ func (ts *Server) GetKeyspace(ctx context.Context, keyspace string) (*KeyspaceIn
 	}
 
 	k := &topodatapb.Keyspace{}
-	if err = proto.Unmarshal(data, k); err != nil {
+	if err = k.UnmarshalVT(data); err != nil {
 		return nil, vterrors.Wrap(err, "bad keyspace data")
 	}
 

--- a/go/vt/topo/replication.go
+++ b/go/vt/topo/replication.go
@@ -204,7 +204,7 @@ func (ts *Server) UpdateShardReplicationFields(ctx context.Context, cell, keyspa
 		}
 
 		// marshall and save
-		data, err = proto.Marshal(sr)
+		data, err = sr.MarshalVT()
 		if err != nil {
 			return err
 		}

--- a/go/vt/topo/replication.go
+++ b/go/vt/topo/replication.go
@@ -186,7 +186,7 @@ func (ts *Server) UpdateShardReplicationFields(ctx context.Context, cell, keyspa
 			// Empty node, version is nil
 		case err == nil:
 			// Use any data we got.
-			if err = proto.Unmarshal(data, sr); err != nil {
+			if err = sr.UnmarshalVT(data); err != nil {
 				return vterrors.Wrap(err, "bad ShardReplication data")
 			}
 		default:
@@ -243,7 +243,7 @@ func (ts *Server) GetShardReplication(ctx context.Context, cell, keyspace, shard
 	}
 
 	sr := &topodatapb.ShardReplication{}
-	if err = proto.Unmarshal(data, sr); err != nil {
+	if err = sr.UnmarshalVT(data); err != nil {
 		return nil, vterrors.Wrap(err, "bad ShardReplication data")
 	}
 

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -209,7 +209,7 @@ func (ts *Server) GetShard(ctx context.Context, keyspace, shard string) (*ShardI
 	}
 
 	value := &topodatapb.Shard{}
-	if err = proto.Unmarshal(data, value); err != nil {
+	if err = value.UnmarshalVT(data); err != nil {
 		return nil, vterrors.Wrapf(err, "GetShard(%v,%v): bad shard data", keyspace, shard)
 	}
 	return &ShardInfo{
@@ -666,7 +666,7 @@ func (ts *Server) WatchShard(ctx context.Context, keyspace, shard string) (*Watc
 		return nil, nil, err
 	}
 	value := &topodatapb.Shard{}
-	if err := proto.Unmarshal(current.Contents, value); err != nil {
+	if err := value.UnmarshalVT(current.Contents); err != nil {
 		// Cancel the watch, drain channel.
 		cancel()
 		for range wdChannel {
@@ -694,7 +694,7 @@ func (ts *Server) WatchShard(ctx context.Context, keyspace, shard string) (*Watc
 			}
 
 			value := &topodatapb.Shard{}
-			if err := proto.Unmarshal(wd.Contents, value); err != nil {
+			if err := value.UnmarshalVT(wd.Contents); err != nil {
 				cancel()
 				for range wdChannel {
 				}

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -228,7 +228,7 @@ func (ts *Server) updateShard(ctx context.Context, si *ShardInfo) error {
 	span.Annotate("shard", si.shardName)
 	defer span.Finish()
 
-	data, err := proto.Marshal(si.Shard)
+	data, err := si.Shard.MarshalVT()
 	if err != nil {
 		return err
 	}
@@ -311,7 +311,7 @@ func (ts *Server) CreateShard(ctx context.Context, keyspace, shard string) (err 
 	}
 
 	// Marshal and save.
-	data, err := proto.Marshal(value)
+	data, err := value.MarshalVT()
 	if err != nil {
 		return err
 	}

--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -635,7 +635,7 @@ func (ts *Server) UpdateSrvKeyspace(ctx context.Context, cell, keyspace string, 
 	}
 
 	nodePath := srvKeyspaceFileName(keyspace)
-	data, err := proto.Marshal(srvKeyspace)
+	data, err := srvKeyspace.MarshalVT()
 	if err != nil {
 		return err
 	}

--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -23,8 +23,6 @@ import (
 	"path"
 	"sync"
 
-	"google.golang.org/protobuf/proto"
-
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/vt/concurrency"
@@ -64,7 +62,7 @@ func (ts *Server) WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (
 		return nil, nil, err
 	}
 	value := &topodatapb.SrvKeyspace{}
-	if err := proto.Unmarshal(current.Contents, value); err != nil {
+	if err := value.UnmarshalVT(current.Contents); err != nil {
 		// Cancel the watch, drain channel.
 		cancel()
 		for range wdChannel {
@@ -93,7 +91,7 @@ func (ts *Server) WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (
 			}
 
 			value := &topodatapb.SrvKeyspace{}
-			if err := proto.Unmarshal(wd.Contents, value); err != nil {
+			if err := value.UnmarshalVT(wd.Contents); err != nil {
 				cancel()
 				for range wdChannel {
 				}
@@ -689,7 +687,7 @@ func (ts *Server) GetSrvKeyspace(ctx context.Context, cell, keyspace string) (*t
 		return nil, err
 	}
 	srvKeyspace := &topodatapb.SrvKeyspace{}
-	if err := proto.Unmarshal(data, srvKeyspace); err != nil {
+	if err := srvKeyspace.UnmarshalVT(data); err != nil {
 		return nil, vterrors.Wrapf(err, "SrvKeyspace unmarshal failed: %v", data)
 	}
 	return srvKeyspace, nil

--- a/go/vt/topo/srv_vschema.go
+++ b/go/vt/topo/srv_vschema.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"sync"
 
-	"google.golang.org/protobuf/proto"
-
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -54,7 +52,7 @@ func (ts *Server) WatchSrvVSchema(ctx context.Context, cell string) (*WatchSrvVS
 		return nil, nil, err
 	}
 	value := &vschemapb.SrvVSchema{}
-	if err := proto.Unmarshal(current.Contents, value); err != nil {
+	if err := value.UnmarshalVT(current.Contents); err != nil {
 		// Cancel the watch, drain channel.
 		cancel()
 		for range wdChannel {
@@ -83,7 +81,7 @@ func (ts *Server) WatchSrvVSchema(ctx context.Context, cell string) (*WatchSrvVS
 			}
 
 			value := &vschemapb.SrvVSchema{}
-			if err := proto.Unmarshal(wd.Contents, value); err != nil {
+			if err := value.UnmarshalVT(wd.Contents); err != nil {
 				cancel()
 				for range wdChannel {
 				}
@@ -126,7 +124,7 @@ func (ts *Server) GetSrvVSchema(ctx context.Context, cell string) (*vschemapb.Sr
 		return nil, err
 	}
 	srvVSchema := &vschemapb.SrvVSchema{}
-	if err := proto.Unmarshal(data, srvVSchema); err != nil {
+	if err := srvVSchema.UnmarshalVT(data); err != nil {
 		return nil, vterrors.Wrapf(err, "SrvVSchema unmarshal failed: %v", data)
 	}
 	return srvVSchema, nil

--- a/go/vt/topo/srv_vschema.go
+++ b/go/vt/topo/srv_vschema.go
@@ -105,7 +105,7 @@ func (ts *Server) UpdateSrvVSchema(ctx context.Context, cell string, srvVSchema 
 	}
 
 	nodePath := SrvVSchemaFile
-	data, err := proto.Marshal(srvVSchema)
+	data, err := srvVSchema.MarshalVT()
 	if err != nil {
 		return err
 	}

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -245,7 +245,7 @@ func (ts *Server) GetTablet(ctx context.Context, alias *topodatapb.TabletAlias) 
 		return nil, err
 	}
 	tablet := &topodatapb.Tablet{}
-	if err := proto.Unmarshal(data, tablet); err != nil {
+	if err := tablet.UnmarshalVT(data); err != nil {
 		return nil, err
 	}
 
@@ -310,7 +310,7 @@ func (ts *Server) GetTabletsByCell(ctx context.Context, cellAlias string) ([]*Ta
 	tablets := make([]*TabletInfo, len(listResults))
 	for n := range listResults {
 		tablet := &topodatapb.Tablet{}
-		if err := proto.Unmarshal(listResults[n].Value, tablet); err != nil {
+		if err := tablet.UnmarshalVT(listResults[n].Value); err != nil {
 			return nil, err
 		}
 		tablets[n] = &TabletInfo{Tablet: tablet, version: listResults[n].Version}

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -363,7 +363,7 @@ func (ts *Server) UpdateTablet(ctx context.Context, ti *TabletInfo) error {
 	span.Annotate("tablet", topoproto.TabletAliasString(ti.Alias))
 	defer span.Finish()
 
-	data, err := proto.Marshal(ti.Tablet)
+	data, err := ti.Tablet.MarshalVT()
 	if err != nil {
 		return err
 	}
@@ -441,7 +441,7 @@ func (ts *Server) CreateTablet(ctx context.Context, tablet *topodatapb.Tablet) e
 		return err
 	}
 
-	data, err := proto.Marshal(tablet)
+	data, err := tablet.MarshalVT()
 	if err != nil {
 		return err
 	}

--- a/go/vt/topo/test/watch.go
+++ b/go/vt/topo/test/watch.go
@@ -57,7 +57,7 @@ func waitForInitialValue(t *testing.T, conn topo.Conn, srvKeyspace *topodatapb.S
 		break
 	}
 	got := &topodatapb.SrvKeyspace{}
-	if err := proto.Unmarshal(current.Contents, got); err != nil {
+	if err := got.UnmarshalVT(current.Contents); err != nil {
 		cancel()
 		t.Fatalf("cannot proto-unmarshal data: %v", err)
 	}
@@ -100,7 +100,7 @@ func waitForInitialValueRecursive(t *testing.T, conn topo.Conn, srvKeyspace *top
 		break
 	}
 	got := &topodatapb.SrvKeyspace{}
-	if err := proto.Unmarshal(current[0].Contents, got); err != nil {
+	if err := got.UnmarshalVT(current[0].Contents); err != nil {
 		cancel()
 		t.Fatalf("cannot proto-unmarshal data: %v", err)
 	}
@@ -173,7 +173,7 @@ func checkWatch(t *testing.T, ts *topo.Server) {
 			t.Fatalf("watch interrupted: %v", wd.Err)
 		}
 		got := &topodatapb.SrvKeyspace{}
-		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+		if err := got.UnmarshalVT(wd.Contents); err != nil {
 			t.Fatalf("cannot proto-unmarshal data: %v", err)
 		}
 
@@ -210,7 +210,7 @@ func checkWatch(t *testing.T, ts *topo.Server) {
 		}
 		// we got something, better be the right value
 		got := &topodatapb.SrvKeyspace{}
-		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+		if err := got.UnmarshalVT(wd.Contents); err != nil {
 			t.Fatalf("cannot proto-unmarshal data: %v", err)
 		}
 		if got.Partitions[0].ShardReferences[0].Name == "new_name" {
@@ -278,7 +278,7 @@ func checkWatchInterrupt(t *testing.T, ts *topo.Server) {
 		}
 		// we got something, better be the right value
 		got := &topodatapb.SrvKeyspace{}
-		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+		if err := got.UnmarshalVT(wd.Contents); err != nil {
 			t.Fatalf("cannot proto-unmarshal data: %v", err)
 		}
 		if got.Partitions[0].ShardReferences[0].Name == "name" {
@@ -356,7 +356,7 @@ func checkWatchRecursive(t *testing.T, ts *topo.Server) {
 			t.Fatalf("watch interrupted: %v", wd.Err)
 		}
 		got := &topodatapb.SrvKeyspace{}
-		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+		if err := got.UnmarshalVT(wd.Contents); err != nil {
 			t.Fatalf("cannot proto-unmarshal data: %v", err)
 		}
 
@@ -394,7 +394,7 @@ func checkWatchRecursive(t *testing.T, ts *topo.Server) {
 		}
 		// we got something, better be the right value
 		got := &topodatapb.SrvKeyspace{}
-		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+		if err := got.UnmarshalVT(wd.Contents); err != nil {
 			t.Fatalf("cannot proto-unmarshal data: %v", err)
 		}
 		if got.Partitions[0].ShardReferences[0].Name == "new_name" {
@@ -424,7 +424,7 @@ func checkWatchRecursive(t *testing.T, ts *topo.Server) {
 		}
 		// we got something, better be the right value
 		got := &topodatapb.SrvKeyspace{}
-		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+		if err := got.UnmarshalVT(wd.Contents); err != nil {
 			t.Fatalf("cannot proto-unmarshal data: %v", err)
 		}
 		if got.Partitions[0].ShardReferences[0].Name == "name" {

--- a/go/vt/topo/topotests/shard_watch_test.go
+++ b/go/vt/topo/topotests/shard_watch_test.go
@@ -151,7 +151,7 @@ func TestWatchShard(t *testing.T) {
 		t.Fatalf("expected an initial error setting watch on bad content, but got: %v", err)
 	}
 
-	data, err := proto.Marshal(wanted)
+	data, err := wanted.MarshalVT()
 	if err != nil {
 		t.Fatalf("error marshalling proto data: %v", err)
 	}

--- a/go/vt/topo/vschema.go
+++ b/go/vt/topo/vschema.go
@@ -39,7 +39,7 @@ func (ts *Server) SaveVSchema(ctx context.Context, keyspace string, vschema *vsc
 	}
 
 	nodePath := path.Join(KeyspacesPath, keyspace, VSchemaFile)
-	data, err := proto.Marshal(vschema)
+	data, err := vschema.MarshalVT()
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func (ts *Server) EnsureVSchema(ctx context.Context, keyspace string) error {
 
 // SaveRoutingRules saves the routing rules into the topo.
 func (ts *Server) SaveRoutingRules(ctx context.Context, routingRules *vschemapb.RoutingRules) error {
-	data, err := proto.Marshal(routingRules)
+	data, err := routingRules.MarshalVT()
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (ts *Server) GetRoutingRules(ctx context.Context) (*vschemapb.RoutingRules,
 
 // SaveShardRoutingRules saves the shard routing rules into the topo.
 func (ts *Server) SaveShardRoutingRules(ctx context.Context, shardRoutingRules *vschemapb.ShardRoutingRules) error {
-	data, err := proto.Marshal(shardRoutingRules)
+	data, err := shardRoutingRules.MarshalVT()
 	if err != nil {
 		return err
 	}

--- a/go/vt/topo/vschema.go
+++ b/go/vt/topo/vschema.go
@@ -124,7 +124,7 @@ func (ts *Server) GetRoutingRules(ctx context.Context) (*vschemapb.RoutingRules,
 		}
 		return nil, err
 	}
-	err = proto.Unmarshal(data, rr)
+	err = rr.UnmarshalVT(data)
 	if err != nil {
 		return nil, vterrors.Wrapf(err, "bad routing rules data: %q", data)
 	}
@@ -159,7 +159,7 @@ func (ts *Server) GetShardRoutingRules(ctx context.Context) (*vschemapb.ShardRou
 		}
 		return nil, err
 	}
-	err = proto.Unmarshal(data, srr)
+	err = srr.UnmarshalVT(data)
 	if err != nil {
 		return nil, vterrors.Wrapf(err, "invalid shard routing rules: %q", data)
 	}

--- a/go/vt/topo/workflow.go
+++ b/go/vt/topo/workflow.go
@@ -62,7 +62,7 @@ func (ts *Server) GetWorkflowNames(ctx context.Context) ([]string, error) {
 // WorkflowInfo.
 func (ts *Server) CreateWorkflow(ctx context.Context, w *workflowpb.Workflow) (*WorkflowInfo, error) {
 	// Pack the content.
-	contents, err := proto.Marshal(w)
+	contents, err := w.MarshalVT()
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (ts *Server) GetWorkflow(ctx context.Context, uuid string) (*WorkflowInfo, 
 // good any more, ErrBadVersion is returned.
 func (ts *Server) SaveWorkflow(ctx context.Context, wi *WorkflowInfo) error {
 	// Pack the content.
-	contents, err := proto.Marshal(wi.Workflow)
+	contents, err := wi.Workflow.MarshalVT()
 	if err != nil {
 		return err
 	}

--- a/go/vt/topo/workflow.go
+++ b/go/vt/topo/workflow.go
@@ -21,8 +21,6 @@ import (
 
 	"context"
 
-	"google.golang.org/protobuf/proto"
-
 	workflowpb "vitess.io/vitess/go/vt/proto/workflow"
 )
 
@@ -90,7 +88,7 @@ func (ts *Server) GetWorkflow(ctx context.Context, uuid string) (*WorkflowInfo, 
 
 	// Unpack the contents.
 	w := &workflowpb.Workflow{}
-	if err := proto.Unmarshal(contents, w); err != nil {
+	if err := w.UnmarshalVT(contents); err != nil {
 		return nil, err
 	}
 

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -369,7 +368,7 @@ func sessionTokenToSession(sessionToken string) (*vtgatepb.Session, error) {
 	}
 
 	session := &vtgatepb.Session{}
-	err = proto.Unmarshal(b, session)
+	err = session.UnmarshalVT(b)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -354,7 +354,7 @@ func newSessionTokenRow(session *vtgatepb.Session, c *converter) (driver.Rows, e
 }
 
 func sessionToSessionToken(session *vtgatepb.Session) (string, error) {
-	b, err := proto.Marshal(session)
+	b, err := session.MarshalVT()
 	if err != nil {
 		return "", err
 	}

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -25,8 +25,6 @@ import (
 
 	"vitess.io/vitess/go/vt/sqlparser"
 
-	"google.golang.org/protobuf/proto"
-
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
@@ -516,7 +514,7 @@ func merge(
 			if err != nil {
 				return nil, nil, err
 			}
-			err = proto.Unmarshal(rowBytes, vgtid)
+			err = vgtid.UnmarshalVT(rowBytes)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -575,7 +573,7 @@ func convertFinal(current []sqltypes.Value, aggregates []*AggregateParams) ([]sq
 			if err != nil {
 				return nil, err
 			}
-			err = proto.Unmarshal(currentBytes, vgtid)
+			err = vgtid.UnmarshalVT(currentBytes)
 			if err != nil {
 				return nil, err
 			}

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -402,7 +402,7 @@ func convertRow(row []sqltypes.Value, preProcess bool, aggregates []*AggregatePa
 				Shard:    row[aggr.Col+1].ToString(),
 				Gtid:     row[aggr.Col].ToString(),
 			})
-			data, _ := proto.Marshal(vgtid)
+			data, _ := vgtid.MarshalVT()
 			val, _ := sqltypes.NewValue(sqltypes.VarBinary, data)
 			newRow[aggr.Col] = val
 		}
@@ -525,7 +525,7 @@ func merge(
 				Shard:    row2[aggr.Col+1].ToString(),
 				Gtid:     row2[aggr.Col].ToString(),
 			})
-			data, _ := proto.Marshal(vgtid)
+			data, _ := vgtid.MarshalVT()
 			val, _ := sqltypes.NewValue(sqltypes.VarBinary, data)
 			result[aggr.Col] = val
 		case AggregateRandom:

--- a/go/vt/vttablet/tabletserver/schema/historian.go
+++ b/go/vt/vttablet/tabletserver/schema/historian.go
@@ -22,8 +22,6 @@ import (
 	"sort"
 	"sync"
 
-	"google.golang.org/protobuf/proto"
-
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
@@ -206,7 +204,7 @@ func (h *historian) readRow(row []sqltypes.Value) (*trackedSchema, int64, error)
 	if err != nil {
 		return nil, 0, err
 	}
-	if err := proto.Unmarshal(rowBytes, sch); err != nil {
+	if err := sch.UnmarshalVT(rowBytes); err != nil {
 		return nil, 0, err
 	}
 	log.V(vl).Infof("Read tracked schema from db: id %d, pos %v, ddl %s, schema len %d, time_updated %d \n",

--- a/go/vt/vttablet/tabletserver/schema/historian_test.go
+++ b/go/vt/vttablet/tabletserver/schema/historian_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -65,7 +64,7 @@ func getDbSchemaBlob(t *testing.T, tables map[string]*binlogdatapb.MinimalTable)
 		t.PKColumns = pks
 		dbSchema.Tables = append(dbSchema.Tables, t)
 	}
-	blob, err := proto.Marshal(dbSchema)
+	blob, err := dbSchema.MarshalVT()
 	require.NoError(t, err)
 	return string(blob)
 }

--- a/go/vt/vttablet/tabletserver/schema/tracker.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker.go
@@ -23,8 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/protobuf/proto"
-
 	"vitess.io/vitess/go/vt/schema"
 
 	"vitess.io/vitess/go/mysql"
@@ -227,7 +225,7 @@ func (tr *Tracker) saveCurrentSchemaToDb(ctx context.Context, gtid, ddl string, 
 	for _, table := range tables {
 		dbSchema.Tables = append(dbSchema.Tables, newMinimalTable(table))
 	}
-	blob, _ := proto.Marshal(dbSchema)
+	blob, _ := dbSchema.MarshalVT()
 
 	conn, err := tr.engine.GetConnection(ctx)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
@@ -279,7 +279,7 @@ func TestVersion(t *testing.T) {
 			Name: "t1",
 		}},
 	}
-	blob, _ := proto.Marshal(dbSchema)
+	blob, _ := dbSchema.MarshalVT()
 	engine.se.Reload(context.Background())
 	gtid := "MariaDB/0-41983-20"
 	testcases := []testcase{{

--- a/go/vt/wrangler/testlib/vtctl_topo_test.go
+++ b/go/vt/wrangler/testlib/vtctl_topo_test.go
@@ -82,7 +82,7 @@ keyspace_type:SNAPSHOT
 	}
 	expected := &topodatapb.Keyspace{KeyspaceType: topodatapb.KeyspaceType_NORMAL}
 	got := &topodatapb.Keyspace{}
-	if err = proto.Unmarshal(contents, got); err != nil {
+	if err = got.UnmarshalVT(contents); err != nil {
 		t.Fatalf("bad keyspace data %v", err)
 	}
 	if !proto.Equal(got, expected) {


### PR DESCRIPTION
## Description

Use the more efficient `MarshalVT`/`UnmarshalVT` functions instead of `proto.Marshal`/`proto.Unmarshal`.

The only places I didn't switch over are `go/vt/servenv/grpc_codec.go` (because that is used by the grpc communication for `etcd-client`) and `go/vt/topo/decode.go` (which I can switch over if anyone cares about that).

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
