### PR TITLE
Fix dubious ownership of git directory in `vitess/base` Docker build

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -33,6 +33,9 @@ ARG BUILD_GIT_REV
 USER root
 COPY . /vt/src/vitess.io/vitess
 
+# Trust dubious ownership of git directory
+RUN git config --global --add safe.directory /vt/src/vitess.io/vitess
+
 # Build Vitess
 RUN make build
 


### PR DESCRIPTION
## Description

This Pull Request adds the `git config --global --add safe.directory /vt/src/vitess.io/vitess` to our `vitess/base` Dockerfile in order to trust the `git` directory.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/12529

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
