### PR TITLE
OnlineDDL: optimizing --singleton-context conflict check

### DIFF
--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -310,6 +310,7 @@ const (
 	`
 	sqlSelectPendingMigrations = `SELECT
 			migration_uuid,
+			migration_context,
 			keyspace,
 			mysql_table,
 			migration_status


### PR DESCRIPTION

## Description

An optimization PR.

Intro: When we submit an Online DDL migration, and with `--singleton-context`, the submission is only accepted if there's no pending migration with a different migration context than the submitted migration. i.e., the migration is only ever accepted if all other pending migrations (queued, ready, running) have the exact same migration-context as the submitted migration.

Sometimes we will submit a large number of migrations, e.g. when importing a schema. Say we have `200` `CREATE TABLE` statements. Whether one by one, or whether by `ApplySchema --sql="many; migrations; here;"`, the Online DDL executor is asked to `SubmitMigration()` for each and every DDL,, one at a time.

For each such migration, the executor scans the existing list of pending migrations to see if there's a conflicting migration.

Problem: for the first migration it scans and finds `0` pending migration. For the 2nd migration is scans and find `1` pending migration, ... for the 200th migration it scans and finds `199` pending migrations. And for each found pending migration, it reads that migration to check for conflict. This has `O(n^2)` complexity and more importantly `O(n^2)` database reads.

This PR offers a simple optimization. We're still at `O(n^2)` complexity, the algorithm isn't changed that much. It's just that were able to determine that a pending migration does not, in fact, conflict with the submitted migration, sonner than before, and without having to actually read the migration.

This is done by pre-fetching `migration_context` column; if the value is the same as our migration's, then by definition there's no conflict and no need to read each and every pending migration.

In the "happy path", this does reduce database access to `O(n)`, ie we only need to scan the pending migrations `n` times (although, we still traverse `O(n^2)` elements in-memory). The happy path is actually common, and so this is a win.

On a local dev env, which is otherwise quiet and idle, this reduces overall submission time as follows:

- Without the optimization, submitting `100` migrations takes `4.5` seconds, submitting another `100` migrations (still in same migration context) takes `8sec`) totaling some `12.5` sec. Notice the 2nd batch is significantly slower than first batch.
- With the optimization,  submitting `100` migrations takes about `2.1 - 2.4` seconds, submitting another `100` migrations (still in same migration context) takes similarly `2.1 - 2.4` seconds, totaling about `5sec`. Notice the 2nd batch has same runtime as first batch.

As the number of DDLs per migration-context increases, so does the gain of the optimization.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
