### PR TITLE
handle filter on top of UNION

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/systemtables_cases80.json
+++ b/go/vt/vtgate/planbuilder/testdata/systemtables_cases80.json
@@ -1742,12 +1742,6 @@
     "gen4-plan": "symbol id not found"
   },
   {
-    "comment": "systable union query in derived table with constraint on outside (star projection)",
-    "query": "select * from (select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `constraint_name` = 'primary'",
-    "v3-plan": "symbol constraint_name not found in table or subquery",
-    "gen4-plan": "can't push predicates on concatenate"
-  },
-  {
     "comment": "table_schema OR predicate\n# It is unsupported because we do not route queries to multiple keyspaces right now",
     "query": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'ks' OR TABLE_SCHEMA = 'main'",
     "v3-plan": {
@@ -1792,36 +1786,25 @@
       "QueryType": "SELECT",
       "Original": "SELECT * FROM ( SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'fuelings' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'order_payments' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'pools' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'orders' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'order_hops' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'markets' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'market_outlets' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'prefuel' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'billing_statements' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'perp_markets' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'perp_market_outlets' ) `kcu` WHERE `CONSTRAINT_NAME` = 'PRIMARY'",
       "Instructions": {
-        "OperatorType": "Route",
-        "Variant": "DBA",
-        "Keyspace": {
-          "Name": "main",
-          "Sharded": false
-        },
-        "FieldQuery": "select * from (select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1) as kcu where 1 != 1",
-        "Query": "select * from (select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME1 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME2 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME3 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME4 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME5 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME6 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME7 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME8 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME9 and CONSTRAINT_NAME = 'PRIMARY' union select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME10 and CONSTRAINT_NAME = 'PRIMARY') as kcu",
-        "SysTableTableName": "[kcu_TABLE_NAME10:VARCHAR(\"perp_market_outlets\"), kcu_TABLE_NAME1:VARCHAR(\"order_payments\"), kcu_TABLE_NAME2:VARCHAR(\"pools\"), kcu_TABLE_NAME3:VARCHAR(\"orders\"), kcu_TABLE_NAME4:VARCHAR(\"order_hops\"), kcu_TABLE_NAME5:VARCHAR(\"markets\"), kcu_TABLE_NAME6:VARCHAR(\"market_outlets\"), kcu_TABLE_NAME7:VARCHAR(\"prefuel\"), kcu_TABLE_NAME8:VARCHAR(\"billing_statements\"), kcu_TABLE_NAME9:VARCHAR(\"perp_markets\"), kcu_TABLE_NAME:VARCHAR(\"fuelings\")]",
-        "SysTableTableSchema": "[VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\")]",
-        "Table": "INFORMATION_SCHEMA.KEY_COLUMN_USAGE"
-      }
-    }
-  },
-  {
-    "comment": "systable union query in derived table with constraint on outside (without star projection)",
-    "query": "select id from (select id from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select id from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `id` = 'primary'",
-    "v3-plan": "unsupported: filtering on results of cross-shard subquery",
-    "gen4-plan": {
-      "QueryType": "SELECT",
-      "Original": "select id from (select id from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select id from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `id` = 'primary'",
-      "Instructions": {
         "OperatorType": "SimpleProjection",
         "Columns": [
-          0
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11
         ],
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": "id = 'primary'",
+            "Predicate": "kcu.CONSTRAINT_NAME = 'PRIMARY'",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -1830,8 +1813,47 @@
                   "Name": "main",
                   "Sharded": false
                 },
-                "FieldQuery": "select id from information_schema.key_column_usage as kcu where 1 != 1 union select id from information_schema.key_column_usage as kcu where 1 != 1",
-                "Query": "select id from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname and kcu.table_name = :kcu_table_name union select id from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname and kcu.table_name = :kcu_table_name1",
+                "FieldQuery": "select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1",
+                "Query": "select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME1 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME2 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME3 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME4 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME5 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME6 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME7 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME8 union all select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME9 union select kcu.CONSTRAINT_CATALOG, kcu.CONSTRAINT_SCHEMA, kcu.CONSTRAINT_NAME, kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.ORDINAL_POSITION, kcu.POSITION_IN_UNIQUE_CONSTRAINT, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME10",
+                "SysTableTableName": "[kcu_TABLE_NAME10:VARCHAR(\"perp_market_outlets\"), kcu_TABLE_NAME1:VARCHAR(\"order_payments\"), kcu_TABLE_NAME2:VARCHAR(\"pools\"), kcu_TABLE_NAME3:VARCHAR(\"orders\"), kcu_TABLE_NAME4:VARCHAR(\"order_hops\"), kcu_TABLE_NAME5:VARCHAR(\"markets\"), kcu_TABLE_NAME6:VARCHAR(\"market_outlets\"), kcu_TABLE_NAME7:VARCHAR(\"prefuel\"), kcu_TABLE_NAME8:VARCHAR(\"billing_statements\"), kcu_TABLE_NAME9:VARCHAR(\"perp_markets\"), kcu_TABLE_NAME:VARCHAR(\"fuelings\")]",
+                "SysTableTableSchema": "[VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\")]",
+                "Table": "INFORMATION_SCHEMA.KEY_COLUMN_USAGE"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "information_schema.KEY_COLUMN_USAGE"
+      ]
+    }
+  },
+  {
+    "comment": "systable union query in derived table with constraint on outside (without star projection)",
+    "query": "select CONSTRAINT_NAME from (select CONSTRAINT_NAME from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select CONSTRAINT_NAME from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `CONSTRAINT_NAME` = 'primary'",
+    "v3-plan": "unsupported: filtering on results of cross-shard subquery",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select CONSTRAINT_NAME from (select CONSTRAINT_NAME from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select CONSTRAINT_NAME from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `CONSTRAINT_NAME` = 'primary'",
+      "Instructions": {
+        "OperatorType": "SimpleProjection",
+        "Columns": [
+          0
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Filter",
+            "Predicate": "CONSTRAINT_NAME = 'primary'",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select CONSTRAINT_NAME from information_schema.key_column_usage as kcu where 1 != 1 union select CONSTRAINT_NAME from information_schema.key_column_usage as kcu where 1 != 1",
+                "Query": "select CONSTRAINT_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname and kcu.table_name = :kcu_table_name union select CONSTRAINT_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname and kcu.table_name = :kcu_table_name1",
                 "SysTableTableName": "[kcu_table_name1:VARCHAR(\"music\"), kcu_table_name:VARCHAR(\"user_extra\")]",
                 "SysTableTableSchema": "[VARCHAR(\"user\"), VARCHAR(\"user\")]",
                 "Table": "information_schema.key_column_usage"
@@ -1839,7 +1861,10 @@
             ]
           }
         ]
-      }
+      },
+      "TablesUsed": [
+        "information_schema.key_column_usage"
+      ]
     }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/systemtables_cases80.json
+++ b/go/vt/vtgate/planbuilder/testdata/systemtables_cases80.json
@@ -1783,5 +1783,63 @@
         "information_schema.TABLES"
       ]
     }
+  },
+  {
+    "comment": "Query from TypeORM",
+    "query": "SELECT * FROM ( SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'fuelings' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'order_payments' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'pools' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'orders' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'order_hops' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'markets' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'market_outlets' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'prefuel' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'billing_statements' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'perp_markets' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'perp_market_outlets' ) `kcu` WHERE `CONSTRAINT_NAME` = 'PRIMARY'",
+    "v3-plan": "symbol CONSTRAINT_NAME not found in table or subquery",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "SELECT * FROM ( SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'fuelings' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'order_payments' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'pools' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'orders' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'order_hops' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'markets' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'market_outlets' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'prefuel' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'billing_statements' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'perp_markets' UNION SELECT * FROM `INFORMATION_SCHEMA`.`KEY_COLUMN_USAGE` `kcu` WHERE `kcu`.`TABLE_SCHEMA` = 'rio' AND `kcu`.`TABLE_NAME` = 'perp_market_outlets' ) `kcu` WHERE `CONSTRAINT_NAME` = 'PRIMARY'",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select * from (select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1 union select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where 1 != 1) as kcu where 1 != 1",
+        "Query": "select * from (select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME1 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME2 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME3 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME4 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME5 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME6 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME7 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME8 and CONSTRAINT_NAME = 'PRIMARY' union all select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME9 and CONSTRAINT_NAME = 'PRIMARY' union select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE as kcu where kcu.TABLE_SCHEMA = :__vtschemaname and kcu.TABLE_NAME = :kcu_TABLE_NAME10 and CONSTRAINT_NAME = 'PRIMARY') as kcu",
+        "SysTableTableName": "[kcu_TABLE_NAME10:VARCHAR(\"perp_market_outlets\"), kcu_TABLE_NAME1:VARCHAR(\"order_payments\"), kcu_TABLE_NAME2:VARCHAR(\"pools\"), kcu_TABLE_NAME3:VARCHAR(\"orders\"), kcu_TABLE_NAME4:VARCHAR(\"order_hops\"), kcu_TABLE_NAME5:VARCHAR(\"markets\"), kcu_TABLE_NAME6:VARCHAR(\"market_outlets\"), kcu_TABLE_NAME7:VARCHAR(\"prefuel\"), kcu_TABLE_NAME8:VARCHAR(\"billing_statements\"), kcu_TABLE_NAME9:VARCHAR(\"perp_markets\"), kcu_TABLE_NAME:VARCHAR(\"fuelings\")]",
+        "SysTableTableSchema": "[VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\"), VARCHAR(\"rio\")]",
+        "Table": "INFORMATION_SCHEMA.KEY_COLUMN_USAGE"
+      }
+    }
+  },
+  {
+    "comment": "systable union query in derived table with constraint on outside (without star projection)",
+    "query": "select id from (select id from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select id from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `id` = 'primary'",
+    "v3-plan": "unsupported: filtering on results of cross-shard subquery",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select id from (select id from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select id from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `id` = 'primary'",
+      "Instructions": {
+        "OperatorType": "SimpleProjection",
+        "Columns": [
+          0
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Filter",
+            "Predicate": "id = 'primary'",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select id from information_schema.key_column_usage as kcu where 1 != 1 union select id from information_schema.key_column_usage as kcu where 1 != 1",
+                "Query": "select id from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname and kcu.table_name = :kcu_table_name union select id from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname and kcu.table_name = :kcu_table_name1",
+                "SysTableTableName": "[kcu_table_name1:VARCHAR(\"music\"), kcu_table_name:VARCHAR(\"user_extra\")]",
+                "SysTableTableSchema": "[VARCHAR(\"user\"), VARCHAR(\"user\")]",
+                "Table": "information_schema.key_column_usage"
+              }
+            ]
+          }
+        ]
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -466,5 +466,11 @@
     "comment": "mix lock with other expr",
     "query": "select get_lock('xyz', 10), 1 from dual",
     "plan": "unsupported: lock function and other expression in same select query"
+  },
+  {
+    "comment": "systable union query in derived table with constraint on outside (star projection)",
+    "query": "select * from (select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `constraint_name` = 'primary'",
+    "v3-plan": "symbol constraint_name not found in table or subquery",
+    "gen4-plan": "unsupported: pushing projection 'constraint_name' on *sqlparser.Union"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -448,12 +448,6 @@
     "gen4-plan": "using aggregation on top of a *planbuilder.concatenateGen4 plan is not yet supported"
   },
   {
-    "comment": "systable union query in derived table with constraint on outside (without star projection)",
-    "query": "select id from (select id from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select id from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `id` = 'primary'",
-    "v3-plan": "unsupported: filtering on results of cross-shard subquery",
-    "gen4-plan": "symbol id not found"
-  },
-  {
     "comment": "insert having subquery in row values",
     "query": "insert into user(id, name) values ((select 1 from user where id = 1), 'A')",
     "plan": "expr cannot be translated, not supported: (select 1 from `user` where id = 1)"


### PR DESCRIPTION
## Description
When planning for filtering on top of a derived table that contains an UNION, the planner was just giving up. This change is not the most optimal fix, since we should be able to push the filtering into the route, but at least this plan works.

We need to forward port this fix to `release-16.0` and `main`.

## Related Issue(s)
-  https://github.com/vitessio/vitess/issues/9214

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
