### PR TITLE
Flakes: Address Common Unit Test Races

### DIFF
--- a/go/vt/log/log.go
+++ b/go/vt/log/log.go
@@ -22,6 +22,7 @@ limitations under the License.
 package log
 
 import (
+	"fmt"
 	"strconv"
 	"sync/atomic"
 
@@ -82,7 +83,7 @@ var (
 // command-line arguments.
 func RegisterFlags(fs *pflag.FlagSet) {
 	flagVal := logRotateMaxSize{
-		val: "1887436800", // glog.MaxSize value (which is not concurrency safe)
+		val: fmt.Sprintf("%d", atomic.LoadUint64(&glog.MaxSize)),
 	}
 	fs.Var(&flagVal, "log_rotate_max_size", "size in bytes at which logs are rotated (glog.MaxSize)")
 }

--- a/go/vt/vtctl/vdiff2_test.go
+++ b/go/vt/vtctl/vdiff2_test.go
@@ -35,7 +35,7 @@ var (
 )
 
 func TestVDiff2Unsharded(t *testing.T) {
-	env := newTestVDiffEnv([]string{"0"}, []string{"0"}, "", nil)
+	env := newTestVDiffEnv(t, []string{"0"}, []string{"0"}, "", nil)
 	defer env.close()
 
 	UUID := uuid.New().String()
@@ -275,7 +275,7 @@ func TestVDiff2Unsharded(t *testing.T) {
 }
 
 func TestVDiff2Sharded(t *testing.T) {
-	env := newTestVDiffEnv([]string{"-40", "40-"}, []string{"-80", "80-"}, "", map[string]string{
+	env := newTestVDiffEnv(t, []string{"-40", "40-"}, []string{"-80", "80-"}, "", map[string]string{
 		"-80": "MySQL56/0e45e704-7cb9-11ed-a1eb-0242ac120002:1-890",
 		"80-": "MySQL56/1497ddb0-7cb9-11ed-a1eb-0242ac120002:1-891",
 	})

--- a/go/vt/vtctl/vdiff_env_test.go
+++ b/go/vt/vtctl/vdiff_env_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"testing"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -68,7 +69,7 @@ type testVDiffEnv struct {
 //----------------------------------------------
 // testVDiffEnv
 
-func newTestVDiffEnv(sourceShards, targetShards []string, query string, positions map[string]string) *testVDiffEnv {
+func newTestVDiffEnv(t testing.TB, sourceShards, targetShards []string, query string, positions map[string]string) *testVDiffEnv {
 	env := &testVDiffEnv{
 		workflow:   "vdiffTest",
 		tablets:    make(map[int]*testVDiffTablet),
@@ -80,7 +81,8 @@ func newTestVDiffEnv(sourceShards, targetShards []string, query string, position
 	}
 	env.wr = wrangler.NewTestWrangler(env.cmdlog, env.topoServ, env.tmc)
 
-	dialerName := fmt.Sprintf("VDiffTest-%d", rand.Intn(1000000000))
+	// Generate a unique dialer name.
+	dialerName := fmt.Sprintf("VDiffTest-%s-%d", t.Name(), rand.Intn(1000000000))
 	tabletconn.RegisterDialer(dialerName, func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
 		env.mu.Lock()
 		defer env.mu.Unlock()

--- a/go/vt/vtctl/vdiff_env_test.go
+++ b/go/vt/vtctl/vdiff_env_test.go
@@ -19,6 +19,7 @@ package vtctl
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -64,25 +65,10 @@ type testVDiffEnv struct {
 	tablets map[int]*testVDiffTablet
 }
 
-// vdiffEnv has to be a global for RegisterDialer to work.
-var vdiffEnv *testVDiffEnv
-
-func init() {
-	tabletconn.RegisterDialer("VDiffTest", func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
-		vdiffEnv.mu.Lock()
-		defer vdiffEnv.mu.Unlock()
-		if qs, ok := vdiffEnv.tablets[int(tablet.Alias.Uid)]; ok {
-			return qs, nil
-		}
-		return nil, fmt.Errorf("tablet %d not found", tablet.Alias.Uid)
-	})
-}
-
 //----------------------------------------------
 // testVDiffEnv
 
 func newTestVDiffEnv(sourceShards, targetShards []string, query string, positions map[string]string) *testVDiffEnv {
-	tabletconntest.SetProtocol("go.vt.vtctl.vdiff_env_test", "VDiffTest")
 	env := &testVDiffEnv{
 		workflow:   "vdiffTest",
 		tablets:    make(map[int]*testVDiffTablet),
@@ -93,6 +79,17 @@ func newTestVDiffEnv(sourceShards, targetShards []string, query string, position
 		cmdlog:     logutil.NewMemoryLogger(),
 	}
 	env.wr = wrangler.NewTestWrangler(env.cmdlog, env.topoServ, env.tmc)
+
+	dialerName := fmt.Sprintf("VDiffTest-%d", rand.Intn(1000000000))
+	tabletconn.RegisterDialer(dialerName, func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
+		env.mu.Lock()
+		defer env.mu.Unlock()
+		if qs, ok := env.tablets[int(tablet.Alias.Uid)]; ok {
+			return qs, nil
+		}
+		return nil, fmt.Errorf("tablet %d not found", tablet.Alias.Uid)
+	})
+	tabletconntest.SetProtocol("go.vt.vtctl.vdiff_env_test", dialerName)
 
 	tabletID := 100
 	for _, shard := range sourceShards {

--- a/go/vt/wrangler/vdiff_env_test.go
+++ b/go/vt/wrangler/vdiff_env_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"testing"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -66,7 +67,7 @@ type testVDiffEnv struct {
 //----------------------------------------------
 // testVDiffEnv
 
-func newTestVDiffEnv(sourceShards, targetShards []string, query string, positions map[string]string) *testVDiffEnv {
+func newTestVDiffEnv(t testing.TB, sourceShards, targetShards []string, query string, positions map[string]string) *testVDiffEnv {
 	env := &testVDiffEnv{
 		workflow:   "vdiffTest",
 		tablets:    make(map[int]*testVDiffTablet),
@@ -77,7 +78,8 @@ func newTestVDiffEnv(sourceShards, targetShards []string, query string, position
 	}
 	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc)
 
-	dialerName := fmt.Sprintf("VDiffTest-%d", rand.Intn(1000000000))
+	// Generate a unique dialer name.
+	dialerName := fmt.Sprintf("VDiffTest-%s-%d", t.Name(), rand.Intn(1000000000))
 	tabletconn.RegisterDialer(dialerName, func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
 		env.mu.Lock()
 		defer env.mu.Unlock()

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -490,7 +490,7 @@ func TestVDiffPlanFailure(t *testing.T) {
 }
 
 func TestVDiffUnsharded(t *testing.T) {
-	env := newTestVDiffEnv([]string{"0"}, []string{"0"}, "", nil)
+	env := newTestVDiffEnv(t, []string{"0"}, []string{"0"}, "", nil)
 	defer env.close()
 
 	schm := &tabletmanagerdatapb.SchemaDefinition{
@@ -767,7 +767,7 @@ func TestVDiffUnsharded(t *testing.T) {
 func TestVDiffSharded(t *testing.T) {
 	// Also test that highest position ""MariaDB/5-456-892" will be used
 	// if lower positions are found.
-	env := newTestVDiffEnv([]string{"-40", "40-"}, []string{"-80", "80-"}, "", map[string]string{
+	env := newTestVDiffEnv(t, []string{"-40", "40-"}, []string{"-80", "80-"}, "", map[string]string{
 		"-40-80": "MariaDB/5-456-890",
 		"40-80-": "MariaDB/5-456-891",
 	})
@@ -838,7 +838,7 @@ func TestVDiffSharded(t *testing.T) {
 }
 
 func TestVDiffAggregates(t *testing.T) {
-	env := newTestVDiffEnv([]string{"-40", "40-"}, []string{"-80", "80-"}, "select c1, count(*) c2, sum(c3) c3 from t group by c1", nil)
+	env := newTestVDiffEnv(t, []string{"-40", "40-"}, []string{"-80", "80-"}, "select c1, count(*) c2, sum(c3) c3 from t group by c1", nil)
 	defer env.close()
 
 	schm := &tabletmanagerdatapb.SchemaDefinition{
@@ -905,7 +905,7 @@ func TestVDiffAggregates(t *testing.T) {
 }
 
 func TestVDiffDefaults(t *testing.T) {
-	env := newTestVDiffEnv([]string{"0"}, []string{"0"}, "", nil)
+	env := newTestVDiffEnv(t, []string{"0"}, []string{"0"}, "", nil)
 	defer env.close()
 
 	schm := &tabletmanagerdatapb.SchemaDefinition{
@@ -958,7 +958,7 @@ func TestVDiffDefaults(t *testing.T) {
 }
 
 func TestVDiffReplicationWait(t *testing.T) {
-	env := newTestVDiffEnv([]string{"0"}, []string{"0"}, "", nil)
+	env := newTestVDiffEnv(t, []string{"0"}, []string{"0"}, "", nil)
 	defer env.close()
 
 	schm := &tabletmanagerdatapb.SchemaDefinition{

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -36,7 +36,7 @@ func TestVExec(t *testing.T) {
 	workflow := "wrWorkflow"
 	keyspace := "target"
 	query := "update _vt.vreplication set state = 'Running'"
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, time.Now().Unix())
+	env := newWranglerTestEnv(t, []string{"0"}, []string{"-80", "80-"}, "", nil, time.Now().Unix())
 	defer env.close()
 	var logger = logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc)
@@ -180,7 +180,7 @@ func TestWorkflowListStreams(t *testing.T) {
 	ctx := context.Background()
 	workflow := "wrWorkflow"
 	keyspace := "target"
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, 1234)
+	env := newWranglerTestEnv(t, []string{"0"}, []string{"-80", "80-"}, "", nil, 1234)
 	defer env.close()
 	logger := logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc)
@@ -355,7 +355,7 @@ func TestWorkflowListAll(t *testing.T) {
 	ctx := context.Background()
 	keyspace := "target"
 	workflow := "wrWorkflow"
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, 0)
+	env := newWranglerTestEnv(t, []string{"0"}, []string{"-80", "80-"}, "", nil, 0)
 	defer env.close()
 	logger := logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc)
@@ -375,7 +375,7 @@ func TestVExecValidations(t *testing.T) {
 	workflow := "wf"
 	keyspace := "ks"
 	query := ""
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, 0)
+	env := newWranglerTestEnv(t, []string{"0"}, []string{"-80", "80-"}, "", nil, 0)
 	defer env.close()
 
 	wr := New(logutil.NewConsoleLogger(), env.topoServ, env.tmc)

--- a/go/vt/wrangler/wrangler_env_test.go
+++ b/go/vt/wrangler/wrangler_env_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"testing"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -59,7 +60,7 @@ type testWranglerEnv struct {
 //----------------------------------------------
 // testWranglerEnv
 
-func newWranglerTestEnv(sourceShards, targetShards []string, query string, positions map[string]string, timeUpdated int64) *testWranglerEnv {
+func newWranglerTestEnv(t testing.TB, sourceShards, targetShards []string, query string, positions map[string]string, timeUpdated int64) *testWranglerEnv {
 	env := &testWranglerEnv{
 		workflow:   "wrWorkflow",
 		topoServ:   memorytopo.NewServer("zone1"),
@@ -70,7 +71,8 @@ func newWranglerTestEnv(sourceShards, targetShards []string, query string, posit
 	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc)
 	env.tmc.tablets = make(map[int]*testWranglerTablet)
 
-	dialerName := fmt.Sprintf("WranglerTest-%d", rand.Intn(1000000000))
+	// Generate a unique dialer name.
+	dialerName := fmt.Sprintf("WranglerTest-%s-%d", t.Name(), rand.Intn(1000000000))
 	tabletconn.RegisterDialer(dialerName, func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
 		env.mu.Lock()
 		defer env.mu.Unlock()


### PR DESCRIPTION
## Description

The [unit race workflow](https://github.com/vitessio/vitess/blob/main/.github/workflows/unit_race.yml) was [failing pretty regularly in the CI](https://github.com/vitessio/vitess/actions/workflows/unit_race.yml) (~20% of the time), and the two failures that I would regularly see were:
  1. `testVDiffEnv` related races — most often in the wrangler unit tests, as they  have the widest use
      - These were simply NOT concurrency-safe
  2. `glog.MaxSize` related races — most often in the wrangler unit tests as they create a LOT of loggers, primarily ConsoleLoggers and MemoryLoggers
      - The way we modified the `glog.MaxSize` global exported variable in our `--log_rotate_max_size` flag handling was not concurrency-safe

I was able to quickly repeat these failures locally as well using the method below. After the changes in this PR, I was able to run it successfully 100 times in a row:
```
cnt=1
while true; do
    echo -n "Attempt# ${cnt} :: "
    go test -timeout 30s -parallel 6 -count 1 -race vitess.io/vitess/go/vt/wrangler 2>>/tmp/results
    if [[ $? -ne 0 ]]; then
         echo "Failed on attempt ${cnt}"
         break
    fi
    let cnt+=1
    sleep 1
done
```
```
Attempt# 1 :: ok  	vitess.io/vitess/go/vt/wrangler	9.320s
...
Attempt# 100 :: ok  	vitess.io/vitess/go/vt/wrangler	9.503s
```

It was failing in the CI about 1 in 4-5 attempts. In this PR it [passed 19 out of 20 times, 18 times in a row](https://github.com/vitessio/vitess/actions/runs/4324961110/jobs/7566860171) — which is at least a big improvement.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required