### PR TITLE
Examples: Add ENV Var to Local Examples to Skip VTAdmin

### DIFF
--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -59,5 +59,9 @@ vtctldclient ApplyVSchema --vschema-file vschema_commerce_initial.json commerce 
 CELL=zone1 ../common/scripts/vtgate-up.sh
 
 # start vtadmin
-../common/scripts/vtadmin-up.sh
+if [[ -n ${SKIP_VTADMIN} ]]; then
+	echo -e "\nSkipping VTAdmin! If this is not what you want then please unset the SKIP_VTADMIN env variable in your shell."
+else
+	../common/scripts/vtadmin-up.sh
+fi
 


### PR DESCRIPTION
## Description

This is particularly useful when using the local examples for testing and debugging (as I do on a daily basis) — where you are continually creating and destroying clusters — because building and installing VTAdmin takes a significant amount of time and in these scenarios is unused.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required