### PR TITLE
go/{vt,flags}: register builtin backup flags with vtbackup

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -11,6 +11,10 @@ Usage of vtbackup:
       --backup_storage_compress                         if set, the backup files will be compressed. (default true)
       --backup_storage_implementation string            Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --builtinbackup-file-read-buffer-size uint        read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
+      --builtinbackup-file-write-buffer-size uint       write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
+      --builtinbackup_mysqld_timeout duration           how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
+      --builtinbackup_progress duration                 how often to send progress updates when backing up large files. (default 5s)
       --ceph_backup_storage_config string               Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
       --compression-engine-name string                  compressor engine used for compression. (default "pargzip")
       --compression-level int                           what level to pass to the compressor. (default 1)

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -127,7 +127,7 @@ type FileEntry struct {
 }
 
 func init() {
-	for _, cmd := range []string{"vtcombo", "vttablet", "vttestserver", "vtctld", "vtctldclient"} {
+	for _, cmd := range []string{"vtbackup", "vtcombo", "vttablet", "vttestserver", "vtctld", "vtctldclient"} {
 		servenv.OnParseFor(cmd, registerBuiltinBackupEngineFlags)
 	}
 }


### PR DESCRIPTION
## Description

https://github.com/vitessio/vitess/pull/12073 added support for backup read IO buffering but did not make the new flags available to the `vtbackup` binary. This PR enables that part.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/12069

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation: https://github.com/vitessio/website/pull/1403

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
