### PR TITLE
Examples, Flakes: Wait for Shard's VReplication Engine to Open

### DIFF
--- a/examples/common/lib/utils.sh
+++ b/examples/common/lib/utils.sh
@@ -24,10 +24,10 @@ function wait_for_shard_tablets() {
 	if [[ -z ${1} || -z ${2} || -z ${3} ]]; then
 		fail "A keyspace, shard, and number of tablets must be specified when waiting for tablets to come up"
 	fi
-	keyspace=${1}
-	shard=${2}
-	num_tablets=${3}
-	wait_secs=180
+	local keyspace=${1}
+	local shard=${2}
+	local num_tablets=${3}
+	local wait_secs=180
 
 	for _ in $(seq 1 ${wait_secs}); do
 		cur_tablets=$(vtctldclient GetTablets --keyspace "${keyspace}" --shard "${shard}" | wc -l)
@@ -50,10 +50,10 @@ function wait_for_healthy_shard_primary() {
 	if [[ -z ${1} || -z ${2} ]]; then
 		fail "A keyspace and shard must be specified when waiting for the shard's primary to be healthy"
 	fi
-	keyspace=${1}
-	shard=${2}
-	unhealthy_indicator='"primary_alias": null'
-	wait_secs=180
+	local keyspace=${1}
+	local shard=${2}
+	local unhealthy_indicator='"primary_alias": null'
+	local wait_secs=180
 
 	for _ in $(seq 1 ${wait_secs}); do
                 if ! vtctldclient --server=localhost:15999 GetShard "${keyspace}/${shard}" | grep -qi "${unhealthy_indicator}"; then
@@ -67,21 +67,50 @@ function wait_for_healthy_shard_primary() {
 	fi
 }
 
+# Wait for the shard primary tablet's VReplication engine to open.
+# There is currently no API call or client command that can be specifically used
+# to check the VReplication engine's status (no vars in /debug/vars etc. either).
+# So we use the Workflow listall client command as the method to check for that
+# as it will return an error when the engine is closed -- even when there are
+# no workflows).
+function wait_for_shard_vreplication_engine() {
+        if [[ -z ${1} || -z ${2} ]]; then
+                fail "A keyspace and shard must be specified when waiting for the shard primary tablet's VReplication engine to open"
+        fi
+        local keyspace=${1}
+        local shard=${2}
+        local wait_secs=90
+
+        for _ in $(seq 1 ${wait_secs}); do
+                if vtctlclient --server=localhost:15999 Workflow -- "${keyspace}" listall &>/dev/null; then
+                        break
+                fi
+                sleep 1
+        done;
+
+        if ! vtctlclient --server=localhost:15999 Workflow -- "${keyspace}" listall &>/dev/null; then
+                fail "Timed out after ${wait_secs} seconds waiting for the primary tablet's VReplication engine to open in ${keyspace}/${shard}"
+        fi
+}
+
 # Wait for a specified number of the keyspace/shard's tablets to show up
 # in the topology server (3 is the default if no value is specified) and
 # then wait for one of the tablets to be promoted to primary and become
-# healthy and serving. Example:
+# healthy and serving.
+# Lastly, wait for the new primary tablet's VReplication engine to fully
+# open. Example:
 #  wait_for_healthy_shard commerce 0
 function wait_for_healthy_shard() {
 	if [[ -z ${1} || -z ${2} ]]; then
 		fail "A keyspace and shard must be specified when waiting for tablets to come up"
 	fi
-	keyspace=${1}
-	shard=${2}
-	num_tablets=${3:-3}
+	local keyspace=${1}
+	local shard=${2}
+	local num_tablets=${3:-3}
 
 	wait_for_shard_tablets "${keyspace}" "${shard}" "${num_tablets}"
 	wait_for_healthy_shard_primary "${keyspace}" "${shard}"
+	wait_for_shard_vreplication_engine "${keyspace}" "${shard}"
 }
 
 # Print error message and exit with error code.

--- a/examples/common/lib/utils.sh
+++ b/examples/common/lib/utils.sh
@@ -72,7 +72,7 @@ function wait_for_healthy_shard_primary() {
 # to check the VReplication engine's status (no vars in /debug/vars etc. either).
 # So we use the Workflow listall client command as the method to check for that
 # as it will return an error when the engine is closed -- even when there are
-# no workflows).
+# no workflows.
 function wait_for_shard_vreplication_engine() {
         if [[ -z ${1} || -z ${2} ]]; then
                 fail "A keyspace and shard must be specified when waiting for the shard primary tablet's VReplication engine to open"
@@ -96,9 +96,8 @@ function wait_for_shard_vreplication_engine() {
 # Wait for a specified number of the keyspace/shard's tablets to show up
 # in the topology server (3 is the default if no value is specified) and
 # then wait for one of the tablets to be promoted to primary and become
-# healthy and serving.
-# Lastly, wait for the new primary tablet's VReplication engine to fully
-# open. Example:
+# healthy and serving. Lastly, wait for the new primary tablet's
+# VReplication engine to fully open. Example:
 #  wait_for_healthy_shard commerce 0
 function wait_for_healthy_shard() {
 	if [[ -z ${1} || -z ${2} ]]; then


### PR DESCRIPTION
## Description

The [local examples CI workflow](https://github.com/vitessio/vitess/blob/main/.github/workflows/local_example.yml) is still flaky — [failing ~ 35% of the time](https://github.com/vitessio/vitess/actions/workflows/local_example.yml) — and it always fails here (or in the same way in later VReplication steps):
```
+ for shard in "customer/0"
+ true
+ command mysql --no-defaults -h 127.0.0.1 -P 15306 customer/0 -e 'show tables'
+ break
+ ./202_move_tables.sh
E0306 18:54:21.968491   13432 main.go:96] E0306 18:54:21.967743 traffic_switcher.go:208] buildTrafficSwitcher failed: rpc error: code = Unknown desc = TabletManager.VReplicationExec on zone1-0000000200 error: vreplication engine is closed: vreplication engine is closed
E0306 18:54:21.969504   13432 main.go:105] remote error: rpc error: code = Unknown desc = TabletManager.VReplicationExec on zone1-0000000200 error: vreplication engine is closed: vreplication engine is closed
MoveTables Error: rpc error: code = Unknown desc = TabletManager.VReplicationExec on zone1-0000000200 error: vreplication engine is closed: vreplication engine is closed
```
You can see an example here (see any of the previous 4 failed runs): https://github.com/vitessio/vitess/actions/runs/4346133011

The CI test [specifically waits for the shard to be able to successfully serve a query through the vtgate](https://github.com/vitessio/vitess/blob/main/test/local_example.sh#L37-L49), but for some reason that doesn't always work as expected in the CI; I have not been able to repeat it locally — so perhaps a bash version difference or some other missing context variable OR perhaps the vtgate _is_ able to serve queries but the VReplication engine takes much longer to open (GitHub runners being very slow at times is a common factor in our tests). Given that users can also run into this when running the steps as a sequence: `./101...; ./201...; ./202...; ./203...` I added a VReplication engine check to the `wait_for_healthy_shard` library function.

With the changes in this PR, the workflow ran successfully 10 times in a row in the CI with each workflow run containing 3 subtests: 1 each for consul, etcd, and k8s topos, so the base test really passed 30 times in a row: https://github.com/vitessio/vitess/actions/runs/4347322200

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
