### PR TITLE
adding log statment to vtbackup

### DIFF
--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -346,9 +346,9 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 	var restorePos mysql.Position
 	switch err {
 	case nil:
-		log.Infof("Successfully restored from backup at replication position %v", restorePos)
 		// if err is nil, we expect backupManifest to be non-nil
 		restorePos = backupManifest.Position
+		log.Infof("Successfully restored from backup at replication position %v", restorePos)
 	case mysqlctl.ErrNoBackup:
 		// There is no backup found, but we may be taking the initial backup of a shard
 		if !allowFirstBackup {
@@ -378,6 +378,7 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 		return fmt.Errorf("error starting replication: %v", err)
 	}
 
+	log.Info("get the current primary replication position, and wait until we catch up")
 	// Get the current primary replication position, and wait until we catch up
 	// to that point. We do this instead of looking at ReplicationLag
 	// because that value can
@@ -401,7 +402,7 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 		return nil
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("can't get the primary replication position after all retries: %v", err)
 	}
 
 	// Remember the time when we fetched the primary position, not when we caught
@@ -414,7 +415,7 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return fmt.Errorf("error in replication catch up: %v", ctx.Err())
 		case <-time.After(time.Second):
 		}
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

While auditing the logs I saw the need to add some logging and also corrected a place where we were printing `nil` GTID. 
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
