### PR TITLE
OnlineDDL: Don't Update Migration Started Timestamp on Completion

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -4743,12 +4743,10 @@ func (e *Executor) onSchemaMigrationStatus(ctx context.Context,
 	case schema.OnlineDDLStatusComplete:
 		{
 			progressPct = progressPctFull
-			_ = e.updateMigrationStartedTimestamp(ctx, uuid)
 			err = e.updateMigrationTimestamp(ctx, "completed_timestamp", uuid)
 		}
 	case schema.OnlineDDLStatusFailed:
 		{
-			_ = e.updateMigrationStartedTimestamp(ctx, uuid)
 			err = e.updateMigrationTimestamp(ctx, "completed_timestamp", uuid)
 		}
 	}


### PR DESCRIPTION
## Description

We were updating the migration's *started* timestamp on completion. I believe that's what was causing: https://github.com/vitessio/vitess/issues/12336

You can see where it happened 4 times in a row (the workflow retries a second time and the workflow failed 2 times in a row) here: https://github.com/vitessio/vitess/actions/runs/4370884719/jobs/7646225949

That same test is now being run X times in a row here to see if it is still flaky after this change: https://github.com/vitessio/vitess/actions/runs/4371207016

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/12336

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required