### PR TITLE
CI: extend timeouts in onlineddl_vrepl due to slow CI runners

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -46,8 +46,8 @@ var (
 	onlineDDLThrottlerAppName = "online-ddl"
 	vstreamerThrottlerAppName = "vstreamer"
 
-	normalMigrationWait   = 20 * time.Second
-	extendedMigrationWait = 20 * time.Second
+	normalMigrationWait   = 30 * time.Second
+	extendedMigrationWait = 45 * time.Second
 
 	hostname              = "localhost"
 	keyspaceName          = "ks"


### PR DESCRIPTION

## Description

We're seeing flakiness in `onlineddl_vrepl`, and this time on very basic tests. Example: failure on `successful_online_alter,_vtctl` in https://github.com/vitessio/vitess/actions/runs/4360811846/jobs/7624093912

This is just a very very basic test: submit a migration via `vtctl`, see that it completes. The test failed because after `20sec`, a migration (one out of two shards) was still running.

These migrations take 4-5 seconds on a local dev box. `20sec` used to be enough in CI. But recently, GitHub's CI runners performance is so bad that this is not enough.

This PR just increases some timeouts.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
