### PR TITLE
Auto upgrade the Golang version

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+  pull_request:
 
 jobs:
   update_golang_version:
@@ -20,16 +21,28 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Detect new version and update codebase
-        run:
+        id: detect-and-update
+        run: |
+          if [ ${{github.ref}} == "main" ]; then
+            go run ./go/tools/go-upgrade/go_upgrade.go --main --allow-major-upgrade
+          else
+            go run ./go/tools/go-upgrade/go_upgrade.go
+          fi
+          
+          output=$(git status -s)
+          if [ -z "${output}" ]; then
+            exit 0
+          fi
+          echo "create-pr=true" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
+        if: steps.detect-and-update.outputs.create-pr == 'true'
         uses: peter-evans/create-pull-request@v4
         with:
-          commit-message: "upgrade vitess dependency to latest"
+          commit-message: "Upgrade the Golang version"
           signoff: true
           delete-branch: true
-          title: "Upgrade Vitess Dependency to Latest"
-          body: "Weekly Vitess dependency upgrade running on a cron schedule"
+          title: "Bump the Golang version"
+          body: "test"
           reviewers: |
             frouioui
-            GuptaManan100

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -1,0 +1,35 @@
+name: Update Golang Version
+
+on:
+  # Triggers the workflow every week
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  update_golang_version:
+    name: Update Golang Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.20.2
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Detect new version and update codebase
+        run:
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "upgrade vitess dependency to latest"
+          signoff: true
+          delete-branch: true
+          title: "Upgrade Vitess Dependency to Latest"
+          body: "Weekly Vitess dependency upgrade running on a cron schedule"
+          reviewers: |
+            frouioui
+            GuptaManan100

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -1,7 +1,7 @@
 name: Update Golang Version
 
 on:
-  # Triggers the workflow every week
+  # Triggers the workflow every day
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -44,5 +44,6 @@ jobs:
           delete-branch: true
           title: "Bump the Golang version"
           body: "test"
+          base: "main" # TODO: remove, this is for test purposes
           reviewers: |
             frouioui

--- a/go.mod
+++ b/go.mod
@@ -154,6 +154,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.4.0 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,8 @@ github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2I
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=

--- a/go/tools/go-upgrade/go_upgrade.go
+++ b/go/tools/go-upgrade/go_upgrade.go
@@ -41,7 +41,6 @@ type latestGolangRelease struct {
 }
 
 func main() {
-	failIfNoUpdate := false
 	allowMajorUpgrade := false
 	isMainBranch := true
 
@@ -57,9 +56,6 @@ func main() {
 
 	upgradeTo := chooseNewVersion(currentVersion, availableVersions, allowMajorUpgrade)
 	if upgradeTo == nil {
-		if failIfNoUpdate {
-			os.Exit(1)
-		}
 		return
 	}
 

--- a/go/tools/go-upgrade/go_upgrade.go
+++ b/go/tools/go-upgrade/go_upgrade.go
@@ -40,7 +40,7 @@ type latestGolangRelease struct {
 
 func main() {
 	failIfNoUpdate := false
-	allowMajorUpgrade := false
+	allowMajorUpgrade := true
 
 	currentVersion, err := currentGolangVersion()
 	if err != nil {
@@ -130,10 +130,10 @@ func getLatestStableGolangReleases() (version.Collection, error) {
 func chooseNewVersion(curVersion *version.Version, latestVersions version.Collection, allowMajorUpgrade bool) *version.Version {
 	selectedVersion := curVersion
 	for _, latestVersion := range latestVersions {
-		if !allowMajorUpgrade && latestVersion.Segments()[0] != selectedVersion.Segments()[0] {
+		if !allowMajorUpgrade && !isSameMajorVersion(latestVersion, selectedVersion) {
 			continue
 		}
-		if latestVersion.GreaterThan(curVersion) {
+		if latestVersion.GreaterThan(selectedVersion) {
 			selectedVersion = latestVersion
 		}
 	}
@@ -156,7 +156,7 @@ func replaceGoVersionInCodebase(old, new *version.Version) error {
 		return err
 	}
 
-	if old.Segments()[0] != new.Segments()[0] {
+	if !isSameMajorVersion(old, new) {
 		err = writeNewMajorGolangVersionToGoMod(old, new)
 		if err != nil {
 			return err
@@ -260,4 +260,8 @@ func getListOfFilesWhereGoVersionMustBeUpdated() ([]string, error) {
 		}
 	}
 	return filesToChange, nil
+}
+
+func isSameMajorVersion(a, b *version.Version) bool {
+	return a.Segments()[1] == b.Segments()[1]
 }

--- a/go/tools/go-upgrade/go_upgrade.go
+++ b/go/tools/go-upgrade/go_upgrade.go
@@ -63,10 +63,10 @@ func main() {
 		return
 	}
 
-	// err = replaceGoVersionInCodebase(currentVersion, upgradeTo)
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
+	err = replaceGoVersionInCodebase(currentVersion, upgradeTo)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	currentBootstrapVersionF, err := currentBootstrapVersion()
 	if err != nil {

--- a/go/tools/go-upgrade/go_upgrade.go
+++ b/go/tools/go-upgrade/go_upgrade.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+)
+
+const (
+	goDevAPI = "https://go.dev/dl/?mode=json"
+)
+
+type latestGolangRelease struct {
+	Version string `json:"version"`
+	Stable  bool   `json:"stable"`
+}
+
+func main() {
+	failIfNoUpdate := false
+	allowMajorUpgrade := false
+
+	currentVersion, err := currentGolangVersion()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	availableVersions, err := getLatestStableGolangReleases()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	upgradeTo := chooseNewVersion(currentVersion, availableVersions, allowMajorUpgrade)
+	if upgradeTo == nil {
+		if failIfNoUpdate {
+			os.Exit(1)
+		}
+		return
+	}
+
+	err = replaceGoVersionInCodebase(currentVersion, upgradeTo)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+}
+
+// currentGolangVersion gets the running version of Golang in Vitess
+// and returns it as a *version.Version.
+//
+// The file `./build.env` describes which version of Golang is expected by Vitess.
+// We use this file to detect the current Golang version of our codebase.
+// The file contains `goversion_min 1.20.1`, we will grep `goversion_min` to finally find
+// the precise golang version we're using.
+func currentGolangVersion() (*version.Version, error) {
+	contentRaw, err := os.ReadFile("build.env")
+	if err != nil {
+		return nil, err
+	}
+	content := string(contentRaw)
+	idxBegin := strings.Index(content, "goversion_min") + len("goversion_min") + 1
+	idxFinish := strings.Index(content[idxBegin:], "||") + idxBegin
+	versionStr := strings.TrimSpace(content[idxBegin:idxFinish])
+	return version.NewVersion(versionStr)
+}
+
+// getLatestStableGolangReleases fetches the latest stable releases of Golang from
+// the official website using the goDevAPI URL.
+// Once fetched, the releases are returned as version.Collection.
+func getLatestStableGolangReleases() (version.Collection, error) {
+	resp, err := http.Get(goDevAPI)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var latestGoReleases []latestGolangRelease
+	err = json.Unmarshal(body, &latestGoReleases)
+	if err != nil {
+		return nil, err
+	}
+
+	var versions version.Collection
+	for _, release := range latestGoReleases {
+		if !release.Stable {
+			continue
+		}
+		if !strings.HasPrefix(release.Version, "go") {
+			return nil, fmt.Errorf("golang version malformatted: %s", release.Version)
+		}
+		newVersion, err := version.NewVersion(release.Version[2:])
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, newVersion)
+	}
+	return versions, nil
+}
+
+// chooseNewVersion decides what will be the next version we're going to use in our codebase.
+// Given the current Golang version, the available latest versions and whether we allow major upgrade or not,
+// chooseNewVersion will return either the new version or nil if we cannot/don't need to upgrade.
+func chooseNewVersion(curVersion *version.Version, latestVersions version.Collection, allowMajorUpgrade bool) *version.Version {
+	selectedVersion := curVersion
+	for _, latestVersion := range latestVersions {
+		if !allowMajorUpgrade && latestVersion.Segments()[0] != selectedVersion.Segments()[0] {
+			continue
+		}
+		if latestVersion.GreaterThan(curVersion) {
+			selectedVersion = latestVersion
+		}
+	}
+	// No change detected, return nil meaning that we do not want to have a new Golang version.
+	if selectedVersion.Equal(curVersion) {
+		return nil
+	}
+	return selectedVersion
+}
+
+// replaceGoVersionInCodebase goes through all the files in the codebase where the
+// Golang version must be updated
+func replaceGoVersionInCodebase(old, new *version.Version) error {
+	filesToChange, err := getListOfFilesWhereGoVersionMustBeUpdated()
+	if err != nil {
+		return err
+	}
+	err = writeNewGolangVersionToFiles(old, new, filesToChange)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeNewGolangVersionToFiles goes through all the given file and call
+// writeNewGolangVersionToSingleFile to replace one by one the files with
+// the new Golang version.
+func writeNewGolangVersionToFiles(old, new *version.Version, filesToChange []string) error {
+	for _, fileToChange := range filesToChange {
+		err := writeNewGolangVersionToSingleFile(old, new, fileToChange)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeNewGolangVersionToSingleFile replaces old with new in the given file.
+func writeNewGolangVersionToSingleFile(old *version.Version, new *version.Version, fileToChange string) error {
+	f, err := os.OpenFile(fileToChange, os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+	contentStr := string(content)
+
+	newContent := strings.ReplaceAll(contentStr, old.String(), new.String())
+
+	_, err = f.WriteAt([]byte(newContent), 0)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// getListOfFilesWhereGoVersionMustBeUpdated returns the list of all the files where
+// the Golang version must be updated, excluding go.mod which uses a different format.
+func getListOfFilesWhereGoVersionMustBeUpdated() ([]string, error) {
+	pathsToExplore := []string{
+		"./.github/workflows",
+		"./test/templates",
+		"./build.env",
+		"./docker/bootstrap/Dockerfile.common",
+	}
+
+	var filesToChange []string
+	for _, pathToExplore := range pathsToExplore {
+		stat, err := os.Stat(pathToExplore)
+		if err != nil {
+			return nil, err
+		}
+		if stat.IsDir() {
+			dirEntries, err := os.ReadDir(pathToExplore)
+			if err != nil {
+				return nil, err
+			}
+			for _, entry := range dirEntries {
+				if entry.IsDir() {
+					continue
+				}
+				filesToChange = append(filesToChange, path.Join(pathToExplore, entry.Name()))
+			}
+		} else {
+			filesToChange = append(filesToChange, pathToExplore)
+		}
+	}
+	return filesToChange, nil
+}


### PR DESCRIPTION
## Description

Remake of https://github.com/vitessio/vitess/pull/12575 but on `vitessio/vitess` to have the required CI permissions that are not available on forked repository (`planetscale/vitess`).

WIP

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
