### PR TITLE
v15 backport: CI: increase overall test timeouts for all OnlineDDL tests

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -261,7 +261,7 @@
 		},
 		"onlineddl_ghost": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/ghost"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/ghost", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "onlineddl_ghost",
@@ -270,7 +270,7 @@
 		},
 		"onlineddl_vrepl": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/vrepl"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/vrepl", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "onlineddl_vrepl",
@@ -306,7 +306,7 @@
 		},
 		"onlineddl_revert": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/revert"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/revert", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "onlineddl_revert",
@@ -315,7 +315,7 @@
 		},
 		"onlineddl_revertible": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/revertible"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/revertible", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "onlineddl_revertible",
@@ -324,7 +324,7 @@
 		},
 		"onlineddl_declarative": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/declarative"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/declarative", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "onlineddl_declarative",
@@ -333,7 +333,7 @@
 		},
 		"onlineddl_singleton": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/singleton"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/singleton", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "onlineddl_singleton",
@@ -342,7 +342,7 @@
 		},
 		"onlineddl_scheduler": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/scheduler"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/scheduler", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "onlineddl_scheduler",
@@ -351,7 +351,7 @@
 		},
 		"schemadiff_vrepl": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/schemadiff/vrepl"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/schemadiff/vrepl", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "schemadiff_vrepl",


### PR DESCRIPTION
Manual backport of https://github.com/vitessio/vitess/pull/12584

---

## Description

Due to recent GitHub CI runners slowness, we're seeing some tests time out after `20min` of running. These tests normally run for `5-6 min` on a local dev env, and `20min` used to give good margins. Not anymore.

This PR increases all Online DDL related tests timeouts to `30min`.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
