### PR TITLE
Online DDL: remove artifact entry upon GC

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -3815,7 +3815,10 @@ func (e *Executor) gcArtifacts(ctx context.Context) error {
 			log.Infof("Executor.gcArtifacts: will GC artifact %s for migration %s", artifactTable, uuid)
 			timestampInThePast := timeNow.Add(time.Duration(-i) * time.Second).UTC()
 			toTableName, err := e.gcArtifactTable(ctx, artifactTable, uuid, timestampInThePast)
-			if err != nil {
+			if err == nil {
+				// artifact was renamed away and is gone. There' no need to list it in `artifacts` column.
+				e.clearSingleArtifact(ctx, uuid, artifactTable)
+			} else {
 				return vterrors.Wrapf(err, "in gcArtifacts() for %s", artifactTable)
 			}
 			log.Infof("Executor.gcArtifacts: renamed away artifact %s to %s", artifactTable, toTableName)

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -132,7 +132,7 @@ const (
 			migration_uuid=%a
 	`
 	sqlClearSingleArtifact = `UPDATE _vt.schema_migrations
-			SET artifacts=replace(artifacts, concat(%a, ','), ''), cleanup_timestamp=NULL
+			SET artifacts=replace(artifacts, concat(%a, ','), '')
 		WHERE
 			migration_uuid=%a
 	`


### PR DESCRIPTION
## Description

This PR does better cleanup of `schema_migrations.artifacts` column. As reminder, this column has a concatenated list of all artifact tables created or needed by a migration. Specifically for `ALTER TABLE`, this can include the `_vrepl` table, sentry table (whose cleanup is handled in #12451), "old" table, etc. Once a migration is complete, or failed, and after a predefined duration (`24h`) we read `artifacts` column, and iterate the list of tables to destroy them ("send" them over to GC by renaming them away).

But we'd leave the `artifacts` column intact. A `cleanup_timestamp` indicates we're done, and we'd never look into it again. The reasoning for leaving the column intact was for better debuggability. We'd be able to look up the artifact names in a long-since-completed migration, and then look them up in the logs.

Today, the Online DDL logging is rich enough that IMHO we don't need that. And, as a matter of fact, that column is so bloated (each table at 50+ characters, multiple tables concatenated) that it make it *more difficult* to read the status of `schema_migrations`.

Therefore, in this PR we clear `artifacts` column of each and every entry we send to GC, until it is hopefully left complete.

This PR does not address pre-existing migration entries in `schema_migrations`. Those will not be clears retroactively.



## Related Issue(s)

#6926

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
