### PR TITLE
Use atomic.Bool for fakesqldb behavior flags

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -67,7 +68,7 @@ type DB struct {
 	acceptWG sync.WaitGroup
 
 	// orderMatters is set when the query order matters.
-	orderMatters bool
+	orderMatters atomic.Bool
 
 	// Fields set at runtime.
 
@@ -77,16 +78,16 @@ type DB struct {
 	// Use SetName() to change.
 	name string
 	// isConnFail trigger a panic in the connection handler.
-	isConnFail bool
+	isConnFail atomic.Bool
 	// connDelay causes a sleep in the connection handler
 	connDelay time.Duration
 	// shouldClose, if true, tells ComQuery() to close the connection when
 	// processing the next query. This will trigger a MySQL client error with
 	// errno 2013 ("server lost").
-	shouldClose bool
-	// AllowAll: if set to true, ComQuery returns an empty result
+	shouldClose atomic.Bool
+	// allowAll: if set to true, ComQuery returns an empty result
 	// for all queries. This flag is used for benchmarking.
-	AllowAll bool
+	allowAll atomic.Bool
 
 	// Handler: interface that allows a caller to override the query handling
 	// implementation. By default it points to the DB itself
@@ -122,7 +123,7 @@ type DB struct {
 
 	// if fakesqldb is asked to serve queries or query patterns that it has not been explicitly told about it will
 	// error out by default. However if you set this flag then any unmatched query results in an empty result
-	neverFail bool
+	neverFail atomic.Bool
 }
 
 // QueryHandler is the interface used by the DB to simulate executed queries
@@ -216,12 +217,8 @@ func (db *DB) SetName(name string) *DB {
 }
 
 // OrderMatters sets the orderMatters flag.
-func (db *DB) OrderMatters() *DB {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-
-	db.orderMatters = true
-	return db
+func (db *DB) OrderMatters() {
+	db.orderMatters.Store(true)
 }
 
 // Close closes the Listener and waits for it to stop accepting.
@@ -309,7 +306,7 @@ func (db *DB) NewConnection(c *mysql.Conn) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	if db.isConnFail {
+	if db.isConnFail.Load() {
 		panic(fmt.Errorf("simulating a connection failure"))
 	}
 
@@ -346,11 +343,11 @@ func (db *DB) WarningCount(c *mysql.Conn) uint16 {
 
 // HandleQuery is the default implementation of the QueryHandler interface
 func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
-	if db.AllowAll {
+	if db.allowAll.Load() {
 		return callback(&sqltypes.Result{})
 	}
 
-	if db.orderMatters {
+	if db.orderMatters.Load() {
 		result, err := db.comQueryOrdered(query)
 		if err != nil {
 			return err
@@ -363,7 +360,7 @@ func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.R
 	db.queryCalled[key]++
 	db.querylog = append(db.querylog, key)
 	// Check if we should close the connection and provoke errno 2013.
-	if db.shouldClose {
+	if db.shouldClose.Load() {
 		c.Close()
 
 		//log error
@@ -412,7 +409,7 @@ func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.R
 		}
 	}
 
-	if db.neverFail {
+	if db.neverFail.Load() {
 		return callback(&sqltypes.Result{})
 	}
 	// Nothing matched.
@@ -450,7 +447,7 @@ func (db *DB) comQueryOrdered(query string) (*sqltypes.Result, error) {
 	index := db.expectedExecuteFetchIndex
 
 	if index >= len(db.expectedExecuteFetch) {
-		if db.neverFail {
+		if db.neverFail.Load() {
 			return &sqltypes.Result{}, nil
 		}
 		db.t.Errorf("%v: got unexpected out of bound fetch: %v >= %v", db.name, index, len(db.expectedExecuteFetch))
@@ -465,7 +462,7 @@ func (db *DB) comQueryOrdered(query string) (*sqltypes.Result, error) {
 
 	if strings.HasSuffix(expected, "*") {
 		if !strings.HasPrefix(query, expected[0:len(expected)-1]) {
-			if db.neverFail {
+			if db.neverFail.Load() {
 				return &sqltypes.Result{}, nil
 			}
 			db.t.Errorf("%v: got unexpected query start (index=%v): %v != %v", db.name, index, query, expected)
@@ -473,7 +470,7 @@ func (db *DB) comQueryOrdered(query string) (*sqltypes.Result, error) {
 		}
 	} else {
 		if query != expected {
-			if db.neverFail {
+			if db.neverFail.Load() {
 				return &sqltypes.Result{}, nil
 			}
 			db.t.Errorf("%v: got unexpected query (index=%v): %v != %v", db.name, index, query, expected)
@@ -629,16 +626,12 @@ func (db *DB) ResetQueryLog() {
 
 // EnableConnFail makes connection to this fake DB fail.
 func (db *DB) EnableConnFail() {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-	db.isConnFail = true
+	db.isConnFail.Store(true)
 }
 
 // DisableConnFail makes connection to this fake DB success.
 func (db *DB) DisableConnFail() {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-	db.isConnFail = false
+	db.isConnFail.Store(false)
 }
 
 // SetConnDelay delays connections to this fake DB for the given duration
@@ -650,9 +643,7 @@ func (db *DB) SetConnDelay(d time.Duration) {
 
 // EnableShouldClose closes the connection when processing the next query.
 func (db *DB) EnableShouldClose() {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-	db.shouldClose = true
+	db.shouldClose.Store(true)
 }
 
 //
@@ -757,8 +748,12 @@ func (db *DB) VerifyAllExecutedOrFail() {
 	}
 }
 
+func (db *DB) SetAllowAll(allowAll bool) {
+	db.allowAll.Store(allowAll)
+}
+
 func (db *DB) SetNeverFail(neverFail bool) {
-	db.neverFail = neverFail
+	db.neverFail.Store(neverFail)
 }
 
 func (db *DB) MockQueriesForTable(table string, result *sqltypes.Result) {

--- a/go/vt/vttablet/tabletserver/bench_test.go
+++ b/go/vt/vttablet/tabletserver/bench_test.go
@@ -68,7 +68,7 @@ func BenchmarkExecuteVarBinary(b *testing.B) {
 	}
 
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-	db.AllowAll = true
+	db.SetAllowAll(true)
 	for i := 0; i < b.N; i++ {
 		if _, err := tsv.Execute(context.Background(), &target, benchQuery, bv, 0, 0, nil); err != nil {
 			panic(err)
@@ -93,7 +93,7 @@ func BenchmarkExecuteExpression(b *testing.B) {
 	}
 
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-	db.AllowAll = true
+	db.SetAllowAll(true)
 	for i := 0; i < b.N; i++ {
 		if _, err := tsv.Execute(context.Background(), &target, benchQuery, bv, 0, 0, nil); err != nil {
 			panic(err)


### PR DESCRIPTION
## Description

Recent improvements to character collation logic have surfaced some latent data race issues in tests that use fakedb. S/o @mattlord for finding and debugging some of these races. Matt shared this code w/ me.

## Related Issue(s)

  - Fixes: #12602 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
