### PR TITLE
go/vt/vttablet/tabletserver: temporarily skip flaky consolidation test

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1261,7 +1261,15 @@ func TestReplaceSchemaName(t *testing.T) {
 	}
 }
 
+// TODO(maxeng) This is currently flaky. Skipping for now to avoid slowing down developers.
+//
+// Plans to rework this test.
+// - Use mock consolidator and mock db instead of real consolidator and fakedb.
+// - Run a single query per test case. Simulate concurrent queries through mock
+//   consolidator.
 func TestQueryExecutorShouldConsolidate(t *testing.T) {
+	t.Skip()
+	
 	testcases := []struct {
 		consolidates  []bool
 		executorFlags executorFlags

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1264,12 +1264,12 @@ func TestReplaceSchemaName(t *testing.T) {
 // TODO(maxeng) This is currently flaky. Skipping for now to avoid slowing down developers.
 //
 // Plans to rework this test.
-// - Use mock consolidator and mock db instead of real consolidator and fakedb.
-// - Run a single query per test case. Simulate concurrent queries through mock
-//   consolidator.
+//   - Use mock consolidator and mock db instead of real consolidator and fakedb.
+//   - Run a single query per test case. Simulate concurrent queries through mock
+//     consolidator.
 func TestQueryExecutorShouldConsolidate(t *testing.T) {
 	t.Skip()
-	
+
 	testcases := []struct {
 		consolidates  []bool
 		executorFlags executorFlags


### PR DESCRIPTION
## Description

Temporarily disable this flaky test until it can be re-worked.

## Related Issue(s)

#12602 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
