### PR TITLE
Online DDL: `ready_to_complete` race fix

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -553,7 +553,7 @@ func testScheduler(t *testing.T) {
 			onlineddl.CheckMigrationStatus(t, &vtParams, shards, t1uuid, schema.OnlineDDLStatusRunning)
 			onlineddl.CheckMigrationStatus(t, &vtParams, shards, t2uuid, schema.OnlineDDLStatusQueued, schema.OnlineDDLStatusReady)
 		})
-		t.Run("chech ready to complete (before)", func(t *testing.T) {
+		t.Run("check ready to complete (before)", func(t *testing.T) {
 			for _, uuid := range []string{t1uuid, t2uuid} {
 				rs := onlineddl.ReadMigrations(t, &vtParams, uuid)
 				require.NotNil(t, rs)
@@ -591,7 +591,7 @@ func testScheduler(t *testing.T) {
 			fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 			onlineddl.CheckMigrationStatus(t, &vtParams, shards, t1uuid, schema.OnlineDDLStatusComplete)
 		})
-		t.Run("chech ready to complete (after)", func(t *testing.T) {
+		t.Run("check ready to complete (after)", func(t *testing.T) {
 			for _, uuid := range []string{t1uuid, t2uuid} {
 				rs := onlineddl.ReadMigrations(t, &vtParams, uuid)
 				require.NotNil(t, rs)

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -560,8 +560,7 @@ func testScheduler(t *testing.T) {
 				for _, row := range rs.Named().Rows {
 					readyToComplete := row.AsInt64("ready_to_complete", 0)
 					assert.Equal(t, int64(0), readyToComplete)
-					wasReadyToComplete := row.AsInt64("ready_to_complete_timestamp is not null", 0)
-					assert.Equal(t, int64(0), wasReadyToComplete)
+					assert.True(t, row["ready_to_complete_timestamp"].IsNull())
 				}
 			}
 		})
@@ -599,8 +598,7 @@ func testScheduler(t *testing.T) {
 				for _, row := range rs.Named().Rows {
 					readyToComplete := row.AsInt64("ready_to_complete", 0)
 					assert.Equal(t, int64(1), readyToComplete)
-					wasReadyToComplete := row.AsInt64("ready_to_complete_timestamp is not null", 0)
-					assert.Equal(t, int64(1), wasReadyToComplete)
+					assert.False(t, row["ready_to_complete_timestamp"].IsNull())
 				}
 			}
 		})

--- a/go/vt/sidecardb/schema/onlineddl/schema_migrations.sql
+++ b/go/vt/sidecardb/schema/onlineddl/schema_migrations.sql
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS _vt.schema_migrations
     `cutover_attempts`                int unsigned     NOT NULL DEFAULT '0',
     `is_immediate_operation`          tinyint unsigned NOT NULL DEFAULT '0',
     `reviewed_timestamp`              timestamp        NULL DEFAULT NULL,
+    `ready_to_complete_timestamp`     timestamp        NULL DEFAULT NULL,
     PRIMARY KEY (`id`),
     UNIQUE KEY `uuid_idx` (`migration_uuid`),
     KEY `keyspace_shard_idx` (`keyspace`(64), `shard`(64)),

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -95,8 +95,14 @@ const (
 		WHERE
 			migration_uuid=%a
 	`
-	sqlUpdateMigrationReadyToComplete = `UPDATE _vt.schema_migrations
-			SET ready_to_complete=%a
+	sqlSetMigrationReadyToComplete = `UPDATE _vt.schema_migrations SET
+			ready_to_complete=1,
+			ready_to_complete_timestamp=NOW(6)
+		WHERE
+			migration_uuid=%a
+	`
+	sqlClearMigrationReadyToComplete = `UPDATE _vt.schema_migrations SET
+			ready_to_complete=0
 		WHERE
 			migration_uuid=%a
 	`
@@ -381,6 +387,7 @@ const (
 			retain_artifacts_seconds,
 			is_view,
 			ready_to_complete,
+			ready_to_complete_timestamp is not null as was_ready_to_complete,
 			reverted_uuid,
 			rows_copied,
 			vitess_liveness_indicator,


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/12610

Two main change in this PR:

1. `executeAlterDDLActionMigration()` does not create goroutines in order to execute `vitess`, `gh-ost`, and `pt-osc` migrations. The calls to `ExecuteWithVReplication`, `ExecuteWithGhost`, and `ExecuteWithPTOSC` are now inlined, synchronousely.
  - This means these functions operate under `migrationMutex` acquired by `runNextMigration()`, which calls `isAnyConflictingMigrationRunning()` to determine which migration can be executed that does not conflict with running migrations.
  - As such, the three functions do not need to execute `isAnyConflictingMigrationRunning()` themselves, and that 2nd chcek is removed, trivially solving the race condition reported in #12610.

The reason these migrations were called in a goroutine is historical, and I do not see the need for that anymore.

2. We introduce a new column: `ready_to_complete_timestamp`, in `schema_migrations` table. This column is updated any time the migration is `ready_to_complete`. It defaults `NULL`.

It follows that if the column is `NOT NULL`, then the migration was at some point in the past `read_to_complete`, even if it isn't right now. This condition, `ready_to_complete_timestamp IS NOT NULL`, is read into `WasReadyToComplete`.

In `isAnyConflictingMigrationRunning()`, we replace the `ReadyToComplete` check with a `WasReadyToComplete` check. It is OK to execute a new concurrent `vitess` migration if all existing migrations were at least once ready-to-complete, even if some of them are now not ready to complete. The main thing is that all existing migrations are done with the copy phase and are tailing the logs.
This change is compatible with the behavior of `ready_to_complete` of immediate operations (those are implicitly `ready_to_complete` and thereby their `ready_to_complete_timestamp` is set to a non-`NULL` value).



## Related Issue(s)

- https://github.com/vitessio/vitess/issues/12610
- #6926 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
