### PR TITLE
SQLError: adding some code comments

### DIFF
--- a/go/mysql/sql_error.go
+++ b/go/mysql/sql_error.go
@@ -82,6 +82,17 @@ var errExtract = regexp.MustCompile(`.*\(errno ([0-9]*)\) \(sqlstate ([0-9a-zA-Z
 
 // NewSQLErrorFromError returns a *SQLError from the provided error.
 // If it's not the right type, it still tries to get it from a regexp.
+// Notes about the `error` return type:
+// The function really returns *SQLError or `nil`. Seemingly, the function could just return
+// `*SQLError` type. However, it really must return `error`. The reason is the way `golang`
+// treats `nil` interfaces vs `nil` implementing values.
+// If this function were to return a nil `*SQLError`, the following undesired behavior would happen:
+//
+//	var err error
+//	err = NewSQLErrorFromError(nil) // returns a nil `*SQLError`
+//	if err != nil {
+//	  doSomething() // this actually runs
+//	}
 func NewSQLErrorFromError(err error) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION

## Description

This PR merely adds some code comments for future generations (or future us) about the way `NewSQLErrorFromError()` is implemented.

## Related Issue(s)

Related: https://github.com/vitessio/vitess/pull/12574#issuecomment-1465579958

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
