### PR TITLE
Fix `panic` when executing a prepare statement with over `65,528` parameters

### DIFF
--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -573,7 +573,7 @@ func (c *Conn) parseComStmtExecute(prepareData map[uint32]*PrepareData, data []b
 	}
 
 	if prepare.ParamsCount > 0 {
-		bitMap, pos, ok = readBytes(payload, pos, int((prepare.ParamsCount+7)/8))
+		bitMap, pos, ok = readBytes(payload, pos, (int(prepare.ParamsCount)+7)/8)
 		if !ok {
 			return stmtID, 0, NewSQLError(CRMalformedPacket, SSUnknownSQLState, "reading NULL-bitmap failed")
 		}

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -207,7 +207,7 @@ func TestOuterJoinWithPredicate(t *testing.T) {
 		`[[INT64(0) INT64(0)] [INT64(1) INT64(10)] [INT64(4) INT64(40)]]`)
 }
 
-// This test ensures that we support PREPARE statement with over 65530 parameters.
+// This test ensures that we support PREPARE statement with 65530 parameters.
 // It opens a MySQL connection using the go-mysql driver and execute a select query
 // it then checks the result contains the proper rows and that it's not failing.
 func TestHighNumberOfParams(t *testing.T) {


### PR DESCRIPTION
## Description

There was a panic due to the way we typecasted the size variable used to create our `bitMap` causing https://github.com/vitessio/vitess/issues/12333 to happen.

This PR fixes the issue https://github.com/vitessio/vitess/issues/12333.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/12333

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
