### PR TITLE
Fix transaction throttler ignoring the initial rate

### DIFF
--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -147,7 +147,7 @@ func newThrottlerFromConfig(manager *managerImpl, name, unit string, threadCount
 	if err != nil {
 		return nil, fmt.Errorf("invalid max replication lag config: %w", err)
 	}
-	if maxRateModuleMaxRate >= 0 {
+	if maxRateModuleMaxRate < 0 {
 		return nil, fmt.Errorf("maxRate must be >= 0: %v", maxRateModuleMaxRate)
 	}
 

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -134,6 +134,14 @@ func NewThrottlerFromConfig(name, unit string, threadCount int, maxRateModuleMax
 	return newThrottlerFromConfig(GlobalManager, name, unit, threadCount, maxRateModuleMaxRate, maxReplicationLagModuleConfig, nowFunc)
 }
 
+func newThrottler(manager *managerImpl, name, unit string, threadCount int, maxRate, maxReplicationLag int64, nowFunc func() time.Time) (*Throttler, error) {
+	config := NewMaxReplicationLagModuleConfig(maxReplicationLag)
+	config.MaxReplicationLagSec = maxReplicationLag
+
+	return newThrottlerFromConfig(manager, name, unit, threadCount, maxRate, config, nowFunc)
+
+}
+
 func newThrottlerFromConfig(manager *managerImpl, name, unit string, threadCount int, maxRateModuleMaxRate int64, maxReplicationLagModuleConfig MaxReplicationLagModuleConfig, nowFunc func() time.Time) (*Throttler, error) {
 	err := maxReplicationLagModuleConfig.Verify()
 	if err != nil {
@@ -197,14 +205,6 @@ func newThrottlerFromConfig(manager *managerImpl, name, unit string, threadCount
 	}()
 
 	return t, nil
-}
-
-func newThrottler(manager *managerImpl, name, unit string, threadCount int, maxRate, maxReplicationLag int64, nowFunc func() time.Time) (*Throttler, error) {
-	config := NewMaxReplicationLagModuleConfig(maxReplicationLag)
-	config.MaxReplicationLagSec = maxReplicationLag
-
-	return newThrottlerFromConfig(manager, name, unit, threadCount, maxRate, config, nowFunc)
-
 }
 
 // Throttle returns a backoff duration which specifies for how long "threadId"

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -130,19 +130,23 @@ func NewThrottler(name, unit string, threadCount int, maxRate, maxReplicationLag
 	return newThrottler(GlobalManager, name, unit, threadCount, maxRate, maxReplicationLag, time.Now)
 }
 
-func newThrottler(manager *managerImpl, name, unit string, threadCount int, maxRate, maxReplicationLag int64, nowFunc func() time.Time) (*Throttler, error) {
-	// Verify input parameters.
-	if maxRate < 0 {
-		return nil, fmt.Errorf("maxRate must be >= 0: %v", maxRate)
+func NewThrottlerFromConfig(name, unit string, threadCount int, maxRateModuleMaxRate int64, maxReplicationLagModuleConfig MaxReplicationLagModuleConfig, nowFunc func() time.Time) (*Throttler, error) {
+	return newThrottlerFromConfig(GlobalManager, name, unit, threadCount, maxRateModuleMaxRate, maxReplicationLagModuleConfig, nowFunc)
+}
+
+func newThrottlerFromConfig(manager *managerImpl, name, unit string, threadCount int, maxRateModuleMaxRate int64, maxReplicationLagModuleConfig MaxReplicationLagModuleConfig, nowFunc func() time.Time) (*Throttler, error) {
+	err := maxReplicationLagModuleConfig.Verify()
+	if err != nil {
+		return nil, fmt.Errorf("invalid max replication lag config: %w", err)
 	}
-	if maxReplicationLag < 0 {
-		return nil, fmt.Errorf("maxReplicationLag must be >= 0: %v", maxReplicationLag)
+	if maxRateModuleMaxRate < 0 {
+		return nil, fmt.Errorf("maxRate must be >= 0: %v", maxRateModuleMaxRate)
 	}
 
 	// Enable the configured modules.
-	maxRateModule := NewMaxRateModule(maxRate)
+	maxRateModule := NewMaxRateModule(maxRateModuleMaxRate)
 	actualRateHistory := newAggregatedIntervalHistory(1024, 1*time.Second, threadCount)
-	maxReplicationLagModule, err := NewMaxReplicationLagModule(NewMaxReplicationLagModuleConfig(maxReplicationLag), actualRateHistory, nowFunc)
+	maxReplicationLagModule, err := NewMaxReplicationLagModule(maxReplicationLagModuleConfig, actualRateHistory, nowFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -193,6 +197,13 @@ func newThrottler(manager *managerImpl, name, unit string, threadCount int, maxR
 	}()
 
 	return t, nil
+}
+
+func newThrottler(manager *managerImpl, name, unit string, threadCount int, maxRate, maxReplicationLag int64, nowFunc func() time.Time) (*Throttler, error) {
+	config := NewMaxReplicationLagModuleConfig(maxReplicationLag)
+
+	return newThrottlerFromConfig(manager, name, unit, threadCount, maxRate, config, nowFunc)
+
 }
 
 // Throttle returns a backoff duration which specifies for how long "threadId"

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -201,6 +201,7 @@ func newThrottlerFromConfig(manager *managerImpl, name, unit string, threadCount
 
 func newThrottler(manager *managerImpl, name, unit string, threadCount int, maxRate, maxReplicationLag int64, nowFunc func() time.Time) (*Throttler, error) {
 	config := NewMaxReplicationLagModuleConfig(maxReplicationLag)
+	config.MaxReplicationLagSec = maxReplicationLag
 
 	return newThrottlerFromConfig(manager, name, unit, threadCount, maxRate, config, nowFunc)
 

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -147,7 +147,7 @@ func newThrottlerFromConfig(manager *managerImpl, name, unit string, threadCount
 	if err != nil {
 		return nil, fmt.Errorf("invalid max replication lag config: %w", err)
 	}
-	if maxRateModuleMaxRate < 0 {
+	if maxRateModuleMaxRate >= 0 {
 		return nil, fmt.Errorf("maxRate must be >= 0: %v", maxRateModuleMaxRate)
 	}
 

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -191,7 +191,7 @@ type txThrottlerState struct {
 // in tests to generate mocks.
 type healthCheckFactoryFunc func(topoServer *topo.Server, cell string, cellsToWatch []string) discovery.HealthCheck
 type topologyWatcherFactoryFunc func(topoServer *topo.Server, hc discovery.HealthCheck, cell, keyspace, shard string, refreshInterval time.Duration, topoReadConcurrency int) TopologyWatcherInterface
-type throttlerFactoryFunc func(name, unit string, threadCount int, maxRate int64, maxReplicationLagCondfig throttler.MaxReplicationLagModuleConfig) (ThrottlerInterface, error)
+type throttlerFactoryFunc func(name, unit string, threadCount int, maxRate int64, maxReplicationLagConfig throttler.MaxReplicationLagModuleConfig) (ThrottlerInterface, error)
 
 var (
 	healthCheckFactory     healthCheckFactoryFunc
@@ -210,8 +210,8 @@ func resetTxThrottlerFactories() {
 	topologyWatcherFactory = func(topoServer *topo.Server, hc discovery.HealthCheck, cell, keyspace, shard string, refreshInterval time.Duration, topoReadConcurrency int) TopologyWatcherInterface {
 		return discovery.NewCellTabletsWatcher(context.Background(), topoServer, hc, discovery.NewFilterByKeyspace([]string{keyspace}), cell, refreshInterval, true, topoReadConcurrency)
 	}
-	throttlerFactory = func(name, unit string, threadCount int, maxRate int64, maxReplicationLagCondfig throttler.MaxReplicationLagModuleConfig) (ThrottlerInterface, error) {
-		return throttler.NewThrottlerFromConfig(name, unit, threadCount, maxRate, maxReplicationLagCondfig, time.Now)
+	throttlerFactory = func(name, unit string, threadCount int, maxRate int64, maxReplicationLagConfig throttler.MaxReplicationLagModuleConfig) (ThrottlerInterface, error) {
+		return throttler.NewThrottlerFromConfig(name, unit, threadCount, maxRate, maxReplicationLagConfig, time.Now)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -80,7 +80,7 @@ func TestEnabledThrottler(t *testing.T) {
 	}
 
 	mockThrottler := NewMockThrottlerInterface(mockCtrl)
-	throttlerFactory = func(name, unit string, threadCount int, maxRate int64, maxReplicationLagCondfig throttler.MaxReplicationLagModuleConfig) (ThrottlerInterface, error) {
+	throttlerFactory = func(name, unit string, threadCount int, maxRate int64, maxReplicationLagConfig throttler.MaxReplicationLagModuleConfig) (ThrottlerInterface, error) {
 		assert.Equal(t, 1, threadCount)
 		return mockThrottler, nil
 	}

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -24,6 +24,7 @@ package txthrottler
 import (
 	"testing"
 	"time"
+
 	"vitess.io/vitess/go/vt/throttler"
 
 	"github.com/golang/mock/gomock"

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -24,6 +24,7 @@ package txthrottler
 import (
 	"testing"
 	"time"
+	"vitess.io/vitess/go/vt/throttler"
 
 	"github.com/golang/mock/gomock"
 
@@ -88,7 +89,7 @@ func TestEnabledThrottler(t *testing.T) {
 	}
 
 	mockThrottler := NewMockThrottlerInterface(mockCtrl)
-	throttlerFactory = func(name, unit string, threadCount int, maxRate, maxReplicationLag int64) (ThrottlerInterface, error) {
+	throttlerFactory = func(name, unit string, threadCount int, maxRate int64, maxReplicationLagCondfig throttler.MaxReplicationLagModuleConfig) (ThrottlerInterface, error) {
 		if threadCount != 1 {
 			t.Errorf("want: 1, got: %v", threadCount)
 		}

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -25,12 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/vt/throttler"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/vt/discovery"
+	"vitess.io/vitess/go/vt/throttler"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"


### PR DESCRIPTION
## Description
This PR fixes an issue leading to the transaction throttler ignoring the `initial rate` parameter passed to it.

## Related Issue(s)
https://github.com/vitessio/vitess/issues/12549 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

N/A