### PR TITLE
Table GC: remove spammy log entry

### DIFF
--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -264,7 +264,6 @@ func (collector *TableGC) operate(ctx context.Context) {
 			}
 		case <-purgeRequestsChan:
 			{
-				log.Info("TableGC: purgeRequestsChan")
 				go func() {
 					tableName, err := collector.purge(ctx)
 					if err != nil {


### PR DESCRIPTION

## Description

This PR removes a log entry that logs every `1min` on an interval, with some outliers. It is otherwise not very informative and not needed. It was added in https://github.com/vitessio/vitess/commit/d8f17888aa8561acc0c8b8d88f08b02be5b15446 for better visibility but ended up spamming the logs.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/11972

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
