### PR TITLE
[release-14.0] Fix `panic` when executing a prepare statement with over `65,528` parameters

### DIFF
--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -282,23 +282,23 @@ func (c *Conn) parseRow(data []byte, fields []*querypb.Field, reader func([]byte
 //
 // 1. if the server closes the connection when no command is in flight:
 //
-//   1.1 unix: WriteComQuery will fail with a 'broken pipe', and we'll
-//       return CRServerGone(2006).
+//		1.1 unix: WriteComQuery will fail with a 'broken pipe', and we'll
+//		    return CRServerGone(2006).
 //
-//   1.2 tcp: WriteComQuery will most likely work, but readComQueryResponse
-//       will fail, and we'll return CRServerLost(2013).
+//		1.2 tcp: WriteComQuery will most likely work, but readComQueryResponse
+//		    will fail, and we'll return CRServerLost(2013).
 //
-//       This is because closing a TCP socket on the server side sends
-//       a FIN to the client (telling the client the server is done
-//       writing), but on most platforms doesn't send a RST.  So the
-//       client has no idea it can't write. So it succeeds writing data, which
-//       *then* triggers the server to send a RST back, received a bit
-//       later. By then, the client has already started waiting for
-//       the response, and will just return a CRServerLost(2013).
-//       So CRServerGone(2006) will almost never be seen with TCP.
+//		    This is because closing a TCP socket on the server side sends
+//		    a FIN to the client (telling the client the server is done
+//		    writing), but on most platforms doesn't send a RST.  So the
+//		    client has no idea it can't write. So it succeeds writing data, which
+//		    *then* triggers the server to send a RST back, received a bit
+//		    later. By then, the client has already started waiting for
+//		    the response, and will just return a CRServerLost(2013).
+//		    So CRServerGone(2006) will almost never be seen with TCP.
 //
-// 2. if the server closes the connection when a command is in flight,
-//    readComQueryResponse will fail, and we'll return CRServerLost(2013).
+//	 2. if the server closes the connection when a command is in flight,
+//	    readComQueryResponse will fail, and we'll return CRServerLost(2013).
 func (c *Conn) ExecuteFetch(query string, maxrows int, wantfields bool) (result *sqltypes.Result, err error) {
 	result, _, err = c.ExecuteFetchMulti(query, maxrows, wantfields)
 	return result, err
@@ -576,7 +576,7 @@ func (c *Conn) parseComStmtExecute(prepareData map[uint32]*PrepareData, data []b
 	}
 
 	if prepare.ParamsCount > 0 {
-		bitMap, pos, ok = readBytes(payload, pos, int((prepare.ParamsCount+7)/8))
+		bitMap, pos, ok = readBytes(payload, pos, (int(prepare.ParamsCount)+7)/8)
 		if !ok {
 			return stmtID, 0, NewSQLError(CRMalformedPacket, SSUnknownSQLState, "reading NULL-bitmap failed")
 		}

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -18,11 +18,16 @@ package vtgate
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	_ "github.com/go-sql-driver/mysql"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
@@ -874,4 +879,48 @@ func TestCast(t *testing.T) {
 	utils.AssertMatches(t, conn, "select cast('3.2' as float)", `[[FLOAT32(3.2)]]`)
 	utils.AssertMatches(t, conn, "select cast('3.2' as double)", `[[FLOAT64(3.2)]]`)
 	utils.AssertMatches(t, conn, "select cast('3.2' as unsigned)", `[[UINT64(3)]]`)
+}
+
+// This test ensures that we support PREPARE statement with 65530 parameters.
+// It opens a MySQL connection using the go-mysql driver and execute a select query
+// it then checks the result contains the proper rows and that it's not failing.
+func TestHighNumberOfParams(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	utils.Exec(t, conn, "insert into t1(id1) values (0), (1), (2), (3), (4)")
+
+	paramCount := 65530
+
+	// create the value and argument slices used to build the prepare stmt
+	var vals []any
+	var params []string
+	for i := 0; i < paramCount; i++ {
+		vals = append(vals, strconv.Itoa(i))
+		params = append(params, "?")
+	}
+
+	// connect to the vitess cluster
+	db, err := sql.Open("mysql", fmt.Sprintf("@tcp(%s:%v)/%s", vtParams.Host, vtParams.Port, vtParams.DbName))
+	require.NoError(t, err)
+
+	// run the query
+	r, err := db.Query(fmt.Sprintf("SELECT /*vt+ QUERY_TIMEOUT_MS=10000 */ id1 FROM t1 WHERE id1 in (%s) ORDER BY id1 ASC", strings.Join(params, ", ")), vals...)
+	require.NoError(t, err)
+
+	// check the results we got, we should get 5 rows with each: 0, 1, 2, 3, 4
+	// count is the row number we are currently visiting, also correspond to the
+	// column value we expect.
+	count := 0
+	for r.Next() {
+		j := -1
+		err := r.Scan(&j)
+		require.NoError(t, err)
+		require.Equal(t, j, count)
+		count++
+	}
+	require.Equal(t, 5, count)
 }


### PR DESCRIPTION
## Description

This is a backport of #12614
