### PR TITLE
VStreamer: improve representation of integers in json data types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/kr/text v0.2.0
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
-	github.com/rohit-nayak-ps/ajson v0.7.3
+	github.com/spyzhov/ajson v0.8.0
 	golang.org/x/exp v0.0.0-20230131160201-f062dba9d201
 	modernc.org/sqlite v1.20.3
 )
@@ -216,3 +216,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+replace github.com/spyzhov/ajson v0.8.0 => github.com/rohit-nayak-ps/ajson v0.7.2-0.20230316112806-97deb03d883c

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
-	github.com/spyzhov/ajson v0.7.2
 	github.com/stretchr/testify v1.8.1
 	github.com/tchap/go-patricia v2.3.0+incompatible
 	github.com/tidwall/gjson v1.12.1
@@ -112,6 +111,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/kr/text v0.2.0
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
+	github.com/rohit-nayak-ps/ajson v0.7.3
 	golang.org/x/exp v0.0.0-20230131160201-f062dba9d201
 	modernc.org/sqlite v1.20.3
 )

--- a/go.sum
+++ b/go.sum
@@ -690,6 +690,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rohit-nayak-ps/ajson v0.7.3 h1:dJG+5sWk5Q0tn3tl1ltWPU3V9vA0AAsCKMJ3m/CYN1M=
+github.com/rohit-nayak-ps/ajson v0.7.3/go.mod h1:ApWx7TjNA9X23L+BVqfKKlasFe1Hknqapgz0Ue9uhi8=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -734,8 +736,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.15.0 h1:js3yy885G8xwJa6iOISGFwd+qlUo5AvyXb7CiihdtiU=
 github.com/spf13/viper v1.15.0/go.mod h1:fFcTBJxvhhzSJiZy8n+PeW6t8l+KeT/uTARa0jHOQLA=
-github.com/spyzhov/ajson v0.7.2 h1:kyl+ovUoId/RSBbSbCm31xyQvPixA6Sxgvb0eWyt1Ko=
-github.com/spyzhov/ajson v0.7.2/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -690,8 +690,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rohit-nayak-ps/ajson v0.7.3 h1:dJG+5sWk5Q0tn3tl1ltWPU3V9vA0AAsCKMJ3m/CYN1M=
-github.com/rohit-nayak-ps/ajson v0.7.3/go.mod h1:ApWx7TjNA9X23L+BVqfKKlasFe1Hknqapgz0Ue9uhi8=
+github.com/rohit-nayak-ps/ajson v0.7.2-0.20230316112806-97deb03d883c h1:Y/4qcogoZA2WUtLWMk/yXfJSpaIG3mK3r9Lw4kaARL4=
+github.com/rohit-nayak-ps/ajson v0.7.2-0.20230316112806-97deb03d883c/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/go/mysql/binlog_event_json.go
+++ b/go/mysql/binlog_event_json.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
-	"github.com/rohit-nayak-ps/ajson"
+	"github.com/spyzhov/ajson"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )

--- a/go/mysql/binlog_event_json_test.go
+++ b/go/mysql/binlog_event_json_test.go
@@ -18,50 +18,65 @@ package mysql
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestJSONTypes(t *testing.T) {
+	// most of these test cases have been taken from open source java/python adapters
+	// like https://github.com/shyiko/mysql-binlog-connector-java/pull/119/files
 	testcases := []struct {
+		name     string
 		data     []byte
 		expected string
 		isMap    bool
 	}{{
+		name:     "null",
 		data:     []byte{},
 		expected: `null`,
 	}, {
+		name:     "map, string value",
 		data:     []byte{0, 1, 0, 14, 0, 11, 0, 1, 0, 12, 12, 0, 97, 1, 98},
 		expected: `{"a":"b"}`,
 	}, {
+		name:     "map, int value",
 		data:     []byte{0, 1, 0, 12, 0, 11, 0, 1, 0, 5, 2, 0, 97},
 		expected: `{"a":2}`,
 	}, {
+		name:     "map, object value",
 		data:     []byte{0, 1, 0, 29, 0, 11, 0, 4, 0, 0, 15, 0, 97, 115, 100, 102, 1, 0, 14, 0, 11, 0, 3, 0, 5, 123, 0, 102, 111, 111},
 		expected: `{"asdf":{"foo":123}}`,
 	}, {
+		name:     "list of ints",
 		data:     []byte{2, 2, 0, 10, 0, 5, 1, 0, 5, 2, 0},
 		expected: `[1,2]`,
 	}, {
+		name:     "list of maps",
 		data:     []byte{0, 4, 0, 60, 0, 32, 0, 1, 0, 33, 0, 1, 0, 34, 0, 2, 0, 36, 0, 2, 0, 12, 38, 0, 12, 40, 0, 12, 42, 0, 2, 46, 0, 97, 99, 97, 98, 98, 99, 1, 98, 1, 100, 3, 97, 98, 99, 2, 0, 14, 0, 12, 10, 0, 12, 12, 0, 1, 120, 1, 121},
 		expected: `{"a":"b","c":"d","ab":"abc","bc":["x","y"]}`,
 		isMap:    true,
 	}, {
+		name:     "list with one string",
 		data:     []byte{2, 1, 0, 37, 0, 12, 8, 0, 0, 4, 104, 101, 114, 101},
 		expected: `["here"]`,
 	}, {
+		name:     "list varied",
 		data:     []byte{2, 3, 0, 37, 0, 12, 13, 0, 2, 18, 0, 12, 33, 0, 4, 104, 101, 114, 101, 2, 0, 15, 0, 12, 10, 0, 12, 12, 0, 1, 73, 2, 97, 109, 3, 33, 33, 33},
 		expected: `["here",["I","am"],"!!!"]`,
 	}, {
+		name:     "string",
 		data:     []byte{12, 13, 115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103},
 		expected: `"scalar string"`,
 	}, {
+		name:     "map, long string value",
 		data:     []byte{0, 1, 0, 149, 0, 11, 0, 6, 0, 12, 17, 0, 115, 99, 111, 112, 101, 115, 130, 1, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 66, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 66, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 69, 65, 65, 65, 65, 65, 65, 69, 65, 65, 65, 65, 65, 65, 56, 65, 65, 65, 66, 103, 65, 65, 65, 65, 65, 65, 66, 65, 65, 65, 65, 67, 65, 65, 65, 65, 65, 65, 65, 65, 65, 84, 216, 142, 184},
 		expected: `{"scopes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAEAAAAAAEAAAAAA8AAABgAAAAAABAAAACAAAAAAAAA"}`,
 	}, {
 		// repeat the same string 10 times, to test the case where length of string
 		// requires 2 bytes to store
+		name: "long string",
 		data: []byte{12, 130, 1,
 			115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103,
 			115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103,
@@ -75,89 +90,139 @@ func TestJSONTypes(t *testing.T) {
 			115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103},
 		expected: `"scalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar string"`,
 	}, {
+		name:     "bool true",
 		data:     []byte{4, 1},
 		expected: `true`,
 	}, {
+		name:     "bool false",
 		data:     []byte{4, 2},
 		expected: `false`,
 	}, {
+		name:     "bool null",
 		data:     []byte{4, 0},
 		expected: `null`,
 	}, {
+		name:     "uint16 max",
+		data:     []byte{6, 255, 255},
+		expected: `65535`,
+	}, {
+		name:     "uint32 max",
+		data:     []byte{8, 255, 255, 255, 255},
+		expected: `4294967295`,
+	}, {
+		name:     "uint64 max",
+		data:     []byte{10, 255, 255, 255, 255, 255, 255, 255, 255},
+		expected: `18446744073709551615`,
+	}, {
+		name:     "int16 -1",
 		data:     []byte{5, 255, 255},
 		expected: `-1`,
 	}, {
-		data:     []byte{6, 1, 0},
-		expected: `1`,
+		name:     "int32 -1",
+		data:     []byte{7, 255, 255, 255, 255},
+		expected: `-1`,
 	}, {
+		name:     "int64 -1",
+		data:     []byte{9, 255, 255, 255, 255, 255, 255, 255, 255},
+		expected: `-1`,
+	}, {
+		name:     "int16 max",
 		data:     []byte{5, 255, 127},
 		expected: `32767`,
 	}, {
+		name:     "int32 max",
+		data:     []byte{7, 255, 255, 255, 127},
+		expected: `2147483647`,
+	}, {
+		name:     "int64 max",
+		data:     []byte{9, 255, 255, 255, 255, 255, 255, 255, 127},
+		expected: `9223372036854775807`,
+	}, {
+		name:     "uint16/1",
+		data:     []byte{6, 1, 0},
+		expected: `1`,
+	}, {
+		name:     "int32/32768",
 		data:     []byte{7, 0, 128, 0, 0},
 		expected: `32768`,
 	}, {
+		name:     "int16/neg",
 		data:     []byte{5, 0, 128},
 		expected: `-32768`,
 	}, {
+		name:     "int32/neg",
 		data:     []byte{7, 255, 127, 255, 255},
 		expected: `-32769`,
 	}, {
-		data:     []byte{7, 255, 255, 255, 127},
-		expected: `2.147483647e+09`,
-	}, {
+		name:     "uint32",
 		data:     []byte{8, 0, 128, 0, 0},
 		expected: `32768`,
 	}, {
+		name:     "int64",
 		data:     []byte{9, 0, 0, 0, 128, 0, 0, 0, 0},
-		expected: `2.147483648e+09`,
+		expected: `2147483648`,
 	}, {
+		name:     "int32/neg",
 		data:     []byte{7, 0, 0, 0, 128},
-		expected: `-2.147483648e+09`,
+		expected: `-2147483648`,
 	}, {
+		name:     "int64/neg",
 		data:     []byte{9, 255, 255, 255, 127, 255, 255, 255, 255},
-		expected: `-2.147483649e+09`,
+		expected: `-2147483649`,
 	}, {
+		name:     "uint64",
 		data:     []byte{10, 255, 255, 255, 255, 255, 255, 255, 255},
-		expected: `1.8446744073709552e+19`,
+		expected: `18446744073709551615`,
 	}, {
+		name:     "int64/neg",
 		data:     []byte{9, 0, 0, 0, 0, 0, 0, 0, 128},
-		expected: `-9.223372036854776e+18`,
+		expected: `-9223372036854775808`,
 	}, {
+		name:     "double",
 		data:     []byte{11, 110, 134, 27, 240, 249, 33, 9, 64},
 		expected: `3.14159`,
 	}, {
+		name:     "empty map",
 		data:     []byte{0, 0, 0, 4, 0},
 		expected: `{}`,
 	}, {
+		name:     "empty list",
 		data:     []byte{2, 0, 0, 4, 0},
 		expected: `[]`,
 	}, {
 		// opaque, datetime
+		name:     "datetime",
 		data:     []byte{15, 12, 8, 0, 0, 0, 25, 118, 31, 149, 25},
 		expected: `"2015-01-15 23:24:25.000000"`,
 	}, {
 		// opaque, time
+		name:     "time",
 		data:     []byte{15, 11, 8, 0, 0, 0, 25, 118, 1, 0, 0},
 		expected: `"23:24:25.000000"`,
 	}, {
 		// opaque, time
+		name:     "time2",
 		data:     []byte{15, 11, 8, 192, 212, 1, 25, 118, 1, 0, 0},
 		expected: `"23:24:25.120000"`,
 	}, {
 		// opaque, date
+		name:     "date",
 		data:     []byte{15, 10, 8, 0, 0, 0, 0, 0, 30, 149, 25},
 		expected: `"2015-01-15"`,
 	}, {
 		// opaque, decimal
+		name:     "decimal",
 		data:     []byte{15, 246, 8, 13, 4, 135, 91, 205, 21, 4, 210},
 		expected: `1.234567891234e+08`,
 	}, {
 		// opaque, bit field. Not yet implemented.
+		name:     "bitfield: unimplemented",
 		data:     []byte{15, 16, 2, 202, 254},
 		expected: `opaque type 16 is not supported yet, data [2 202 254]`,
 	}}
 	for _, tc := range testcases {
-		t.Run(tc.expected, func(t *testing.T) {
+		name := fmt.Sprintf("%s (%s)", tc.name, tc.expected)
+		t.Run(name, func(t *testing.T) {
 			val, err := getJSONValue(tc.data)
 			if err != nil {
 				require.Equal(t, tc.expected, err.Error())

--- a/go/test/endtoend/vreplication/unsharded_init_data.sql
+++ b/go/test/endtoend/vreplication/unsharded_init_data.sql
@@ -1,6 +1,6 @@
 insert into customer(cid, name, typ, sport, meta) values(1, 'Jøhn "❤️" Rizzolo',1,'football,baseball','{}');
 insert into customer(cid, name, typ, sport, meta) values(2, 'Paül','soho','cricket',convert(x'7b7d' using utf8mb4));
-insert into customer(cid, name, typ, sport) values(3, 'ringo','enterprise','');
+insert into customer(cid, name, typ, sport, meta) values(3, 'ringo','enterprise','',null);
 insert into merchant(mname, category) values('Monoprice', 'eléctronics');
 insert into merchant(mname, category) values('newegg', 'elec†ronics');
 insert into product(pid, description) values(1, 'keyböard ⌨️');

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -27,13 +27,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spyzhov/ajson"
+	"vitess.io/vitess/go/mysql"
+
+	"github.com/rohit-nayak-ps/ajson"
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/log"
+
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
-	"vitess.io/vitess/go/vt/log"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	qh "vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication/queryhistory"
 )
@@ -1512,21 +1515,21 @@ func TestPlayerTypes(t *testing.T) {
 	}}
 	if enableJSONColumnTesting {
 		testcases = append(testcases, testcase{
-			input: "insert into vitess_json(val1,val2,val3,val4,val5) values (null,'{}','123','{\"a\":[42,100]}', '{\"foo\":\"bar\"}')",
+			input: "insert into vitess_json(val1,val2,val3,val4,val5) values (null,'{}','1629849600','{\"a\":[42,-1,3.1415,-128,127,-9223372036854775808,9223372036854775807,18446744073709551615]}', '{\"foo\":\"bar\"}')",
 			output: "insert into vitess_json(id,val1,val2,val3,val4,val5) values (1," +
-				"convert(null using utf8mb4)," + "convert('{}' using utf8mb4)," + "convert('123' using utf8mb4)," +
-				"convert('{\\\"a\\\":[42,100]}' using utf8mb4)," + "convert('{\\\"foo\\\":\\\"bar\\\"}' using utf8mb4))",
+				"convert(null using utf8mb4)," + "convert('{}' using utf8mb4)," + "convert('1629849600' using utf8mb4)," +
+				"convert('{\\\"a\\\":[42,-1,3.1415,-128,127,-9223372036854775808,9223372036854775807,18446744073709551615]}' using utf8mb4)," + "convert('{\\\"foo\\\":\\\"bar\\\"}' using utf8mb4))",
 			table: "vitess_json",
 			data: [][]string{
-				{"1", "", "{}", "123", `{"a": [42, 100]}`, `{"foo": "bar"}`},
+				{"1", "", "{}", "1629849600", `{"a": [42, -1, 3.1415, -128, 127, -9223372036854775808, 9223372036854775807, 18446744073709551615]}`, `{"foo": "bar"}`},
 			},
 		})
 		testcases = append(testcases, testcase{
-			input:  "update vitess_json set val4 = '{\"a\": [98, 123]}', val5 = convert(x'7b7d' using utf8mb4)",
-			output: "update vitess_json set val1=convert(null using utf8mb4), val2=convert('{}' using utf8mb4), val3=convert('123' using utf8mb4), val4=convert('{\\\"a\\\":[98,123]}' using utf8mb4), val5=convert('{}' using utf8mb4) where id=1",
+			input:  "update vitess_json set val4 = '{\"a\": [-9223372036854775808, -2147483648]}', val5 = convert(x'7b7d' using utf8mb4)",
+			output: "update vitess_json set val1=convert(null using utf8mb4), val2=convert('{}' using utf8mb4), val3=convert('1629849600' using utf8mb4), val4=convert('{\\\"a\\\":[-9223372036854775808,-2147483648]}' using utf8mb4), val5=convert('{}' using utf8mb4) where id=1",
 			table:  "vitess_json",
 			data: [][]string{
-				{"1", "", "{}", "123", `{"a": [98, 123]}`, `{}`},
+				{"1", "", "{}", "1629849600", `{"a": [-9223372036854775808, -2147483648]}`, `{}`},
 			},
 		})
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -29,7 +29,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 
-	"github.com/rohit-nayak-ps/ajson"
+	"github.com/spyzhov/ajson"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/log"


### PR DESCRIPTION
## Description
The binlog parser in vstreamer currently uses the `github.com/spyzhov/ajson` module to decode the value from the binlog image to its json value. However the library only supports a single type Numeric (float64) as a catchall for all numeric types including signed and unsigned integers. As a consequence, the generated JSON represents integers as floats and the string representation in a VEvent can contain decimals or values in scientific notation. So integers can be stored as floats on the target and larger ints sent with scientific notation in VStream events. 

This results in VDiff failures since the json strings stored are different. Also parsing the VEvents sent using the VStream API can result in errors if, for example, the JSON is being parsed by golang. See https://github.com/vitessio/vitess/issues/8686. 

This PR uses a forked version of the library, https://github.com/rohit-nayak-ps/ajson, that adds Integer and UnsignedInteger data type JSON Nodes. Once we submit the related changes  upstream to `github.com/spyzhov/ajson` and they get merged we will switch back to using upstream again.

Minor refactoring is also done as part of this PR.

## Related Issue(s)
  - Fixes: https://github.com/vitessio/vitess/issues/8686

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [x] Documentation was added or is not required
