### PR TITLE
[vtadmin] racy vtexplain

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -73,6 +73,10 @@ type API struct {
 	authz *rbac.Authorizer
 
 	options Options
+
+	// vtexplain is now global again due to stat exporters in the tablet layer
+	// we're not super concerned because we will be deleting vtexplain Soon(TM).
+	vtexplainLock sync.Mutex
 }
 
 // Options wraps the configuration options for different components of the
@@ -1942,6 +1946,16 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 	if !api.authz.IsAuthorized(ctx, c.ID, rbac.VTExplainResource, rbac.GetAction) {
 		return nil, nil
 	}
+
+	lockWaitStart := time.Now()
+
+	api.vtexplainLock.Lock()
+	defer api.vtexplainLock.Unlock()
+
+	lockWaitTime := time.Since(lockWaitStart)
+	log.Infof("vtexplain lock wait time: %s", lockWaitTime)
+
+	span.Annotate("vtexplain_lock_wait_time", lockWaitTime.String())
 
 	tablet, err := c.FindTablet(ctx, func(t *vtadminpb.Tablet) bool {
 		return t.Tablet.Keyspace == req.Keyspace && topo.IsInServingGraph(t.Tablet.Type) && t.Tablet.Type != topodatapb.TabletType_PRIMARY && t.State == vtadminpb.Tablet_SERVING

--- a/go/vt/vtadmin/api_authz_test.go
+++ b/go/vt/vtadmin/api_authz_test.go
@@ -2939,15 +2939,15 @@ func TestVTExplain(t *testing.T) {
 	err := opts.RBAC.Reify()
 	require.NoError(t, err, "failed to reify authorization rules: %+v", opts.RBAC.Rules)
 
-	api := vtadmin.NewAPI(testClusters(t), opts)
-	t.Cleanup(func() {
-		if err := api.Close(); err != nil {
-			t.Logf("api did not close cleanly: %s", err.Error())
-		}
-	})
-
 	t.Run("unauthorized actor", func(t *testing.T) {
 		t.Parallel()
+
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
 
 		actor := &rbac.Actor{Name: "other"}
 		ctx := context.Background()
@@ -2965,6 +2965,13 @@ func TestVTExplain(t *testing.T) {
 
 	t.Run("authorized actor", func(t *testing.T) {
 		t.Parallel()
+
+		api := vtadmin.NewAPI(testClusters(t), opts)
+		t.Cleanup(func() {
+			if err := api.Close(); err != nil {
+				t.Logf("api did not close cleanly: %s", err.Error())
+			}
+		})
 
 		actor := &rbac.Actor{Name: "allowed"}
 		ctx := context.Background()

--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -4601,8 +4601,6 @@ func TestGetWorkflows(t *testing.T) {
 }
 
 func TestVTExplain(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name          string
 		keyspaces     []*vtctldatapb.Keyspace
@@ -4826,8 +4824,6 @@ func TestVTExplain(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			toposerver := memorytopo.NewServer("c0_cell1")
 
 			tmc := testutil.TabletManagerClient{

--- a/go/vt/vtadmin/testutil/authztestgen/config.json
+++ b/go/vt/vtadmin/testutil/authztestgen/config.json
@@ -1736,6 +1736,7 @@
                 }
             ],
             "request": "&vtadminpb.VTExplainRequest{\nCluster: \"test\",\nKeyspace: \"test\",\nSql: \"select id from t1;\",}",
+            "serialize_cases": true,
             "cases": [
                 {
                     "name": "unauthorized actor",


### PR DESCRIPTION
## Description

Two problems here, one cause.

Cause: the old vtexplain code (which we have deprecated and are moving away from) spins up tablets, which do a bunch of things to global state (because you would normally only have one `vttablet` per process), and is therefore not thread safe.

Problem(s):

1. the /vtexplain endpoint is not thread safe => add a lock to the api instance
2. some tests spin up their own api, which makes the above fix insufficient. => we _could_ move the lock off the api instance to its own global, but i don't like that, so i serialized the tests

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/12636

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
