### PR TITLE
Flakes: Handle Non-Determinstic Shard Ordering in VGTID

### DIFF
--- a/go/vt/vtgate/endtoend/vstream_test.go
+++ b/go/vt/vtgate/endtoend/vstream_test.go
@@ -484,7 +484,7 @@ func TestVStreamCopyResume(t *testing.T) {
 					// Validate that the vgtid event the client receives from the vstream copy has a complete TableLastPK proto message.
 					// Also, to ensure that the client can resume properly, make sure that
 					// the Fields value is present in the sqltypes.Result field and not missing.
-					require.Regexp(t, `type:VGTID vgtid:{(shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}}|shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}} shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}})} keyspace:"ks" shard:"(80-|-80)"`, ev.String())
+					require.Regexp(t, `type:VGTID vgtid:{shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+" (table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}})?} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+" (table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}})?} keyspace:"ks" shard:"(80-|-80)"`, ev.String())
 				}
 			}
 			if expectedCatchupEvents == replCatchupEvents && expectedRowCopyEvents == rowCopyEvents {

--- a/go/vt/vtgate/endtoend/vstream_test.go
+++ b/go/vt/vtgate/endtoend/vstream_test.go
@@ -484,7 +484,7 @@ func TestVStreamCopyResume(t *testing.T) {
 					// Validate that the vgtid event the client receives from the vstream copy has a complete TableLastPK proto message.
 					// Also, to ensure that the client can resume properly, make sure that
 					// the Fields value is present in the sqltypes.Result field and not missing.
-					require.Regexp(t, `type:VGTID vgtid:{shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}}} keyspace:"ks" shard:"(80-|-80)"`, ev.String())
+					require.Regexp(t, `type:VGTID vgtid:{(shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}}|shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}} shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}})} keyspace:"ks" shard:"(80-|-80)"`, ev.String())
 				}
 			}
 			if expectedCatchupEvents == replCatchupEvents && expectedRowCopyEvents == rowCopyEvents {

--- a/go/vt/vtgate/endtoend/vstream_test.go
+++ b/go/vt/vtgate/endtoend/vstream_test.go
@@ -372,7 +372,7 @@ func TestVStreamCopyUnspecifiedShardGtid(t *testing.T) {
 						return
 					} else if c.expectedEventNum < len(evs) {
 						printEvents(evs) // for debugging ci failures
-						require.FailNow(t, "len(events)=%v are not expected\n", len(evs))
+						require.FailNow(t, fmt.Sprintf("len(events)=%d are not expected\n", len(evs)))
 					}
 				case io.EOF:
 					log.Infof("stream ended\n")
@@ -481,10 +481,11 @@ func TestVStreamCopyResume(t *testing.T) {
 					printEvents(evs) // for debugging ci failures
 				}
 				if ev.Type == binlogdatapb.VEventType_VGTID {
-					// Validate that the vgtid event the client receives from the vstream copy has a complete TableLastPK proto message.
+					// Validate that the vgtid event the client receives from the vstream copy
+					// has a complete TableLastPK proto message.
 					// Also, to ensure that the client can resume properly, make sure that
 					// the Fields value is present in the sqltypes.Result field and not missing.
-					require.Regexp(t, `type:VGTID vgtid:{shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+" (table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}})?} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+" (table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}})?} keyspace:"ks" shard:"(80-|-80)"`, ev.String())
+					require.Regexp(t, `type:VGTID vgtid:{shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+"( table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}})?} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+"( table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}})?} keyspace:"ks" shard:"(80-|-80)"`, ev.String())
 				}
 			}
 			if expectedCatchupEvents == replCatchupEvents && expectedRowCopyEvents == rowCopyEvents {


### PR DESCRIPTION
## Description

I've noticed that the `TestVStreamCopyResume` test has been flaky lately in the endtoend workflow since we merged https://github.com/vitessio/vitess/pull/12623. You can see an example of it failing 4 times in a row here: https://github.com/vitessio/vitess/actions/runs/4432838267

After investigating the failures, the reason for them is that the order of the shards in the VGTID event is non-deterministic and thus so is which one has the `table_p_ks` field: https://github.com/vitessio/vitess/blob/7afc6e1e1816a820baba841fd4dc38901d40e5a3/go/vt/vtgate/endtoend/vstream_test.go#L483-L488

The regexp would fail if the 80- shard was first in the output. This PR alters the regexp so that it matches regardless of the shard order in the output. 

The test was failing in the CI ~ 50% of the time. With the changes in this PR, it has passed XX times in a row: https://github.com/vitessio/vitess/actions/runs/4434033059/jobs/7779619850

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required