### PR TITLE
Mysqld.GetSchema: tolerate tables being dropped while inspecting schema

### DIFF
--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -110,7 +110,7 @@ func (mysqld *Mysqld) GetSchema(ctx context.Context, dbName string, request *tab
 
 			fields, columns, schema, err := mysqld.collectSchema(ctx, dbName, td.Name, td.Type, request.TableSchemaOnly)
 			if err != nil {
-				// there's a possible race condition: it could happen that a table was dropped in between reading
+				// There's a possible race condition: it could happen that a table was dropped in between reading
 				// the list of tables (collectBasicTableData(), earlier) and the point above where we investigate
 				// the table.
 				// This is fine. We identify the situation and keep the table without any fields/columns/key information


### PR DESCRIPTION
## Description

Identify the two scenarios where a table may be dropped while we're inspecting the schema. Either we get a `(errno 1146)` error code, or the table does not appear in `information_schema` even after it did, before. 

The fix is to silently ignore tables hitting this scenario.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/12640

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
