### PR TITLE
Flakes: Handle Non-Deterministic VStream Event Ordering

### DIFF
--- a/go/vt/vtgate/endtoend/vstream_test.go
+++ b/go/vt/vtgate/endtoend/vstream_test.go
@@ -485,7 +485,7 @@ func TestVStreamCopyResume(t *testing.T) {
 					// has a complete TableLastPK proto message.
 					// Also, to ensure that the client can resume properly, make sure that
 					// the Fields value is present in the sqltypes.Result field and not missing.
-					require.Regexp(t, `type:VGTID vgtid:{shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+"( table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}})?} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+"( table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}})?} keyspace:"ks" shard:"(80-|-80)"`, ev.String())
+					require.Regexp(t, `type:VGTID vgtid:{shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+"( table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}})?} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+"( table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}})?}} keyspace:"ks" shard:"(80-|-80)"`, ev.String())
 				}
 			}
 			if expectedCatchupEvents == replCatchupEvents && expectedRowCopyEvents == rowCopyEvents {

--- a/go/vt/vtgate/endtoend/vstream_test.go
+++ b/go/vt/vtgate/endtoend/vstream_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"sort"
 	"sync"
 	"testing"
@@ -465,7 +466,11 @@ func TestVStreamCopyResume(t *testing.T) {
 		`type:ROW row_event:{table_name:"ks.t1_copy_resume" row_changes:{after:{lengths:1 lengths:2 values:"990"}} keyspace:"ks" shard:"-80"} keyspace:"ks" shard:"-80"`,
 		`type:ROW timestamp:[0-9]+ row_event:{table_name:"ks.t1_copy_resume" row_changes:{before:{lengths:1 lengths:1 values:"99"} after:{lengths:1 lengths:2 values:"990"}} keyspace:"ks" shard:"-80"} current_time:[0-9]+ keyspace:"ks" shard:"-80"`,
 	}
+	redash80 := regexp.MustCompile(`(?i)type:VGTID vgtid:{shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+"}} keyspace:"ks" shard:"(-80|80-)"`)
+	re80dash := regexp.MustCompile(`(?i)type:VGTID vgtid:{shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+"} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}}} keyspace:"ks" shard:"(-80|80-)"`)
+	both := regexp.MustCompile(`(?i)type:VGTID vgtid:{shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+" table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}}}} keyspace:"ks" shard:"(-80|80-)"`)
 	var evs []*binlogdatapb.VEvent
+
 	for {
 		e, err := reader.Recv()
 		switch err {
@@ -485,7 +490,13 @@ func TestVStreamCopyResume(t *testing.T) {
 					// has a complete TableLastPK proto message.
 					// Also, to ensure that the client can resume properly, make sure that
 					// the Fields value is present in the sqltypes.Result field and not missing.
-					require.Regexp(t, `type:VGTID vgtid:{shard_gtids:{keyspace:"ks" shard:"-80" gtid:".+"( table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}})?} shard_gtids:{keyspace:"ks" shard:"80-" gtid:".+"( table_p_ks:{table_name:"t1_copy_resume" lastpk:{fields:{name:"id1" type:INT64} rows:{lengths:1 values:"[0-9]"}}})?}} keyspace:"ks" shard:"(80-|-80)"`, ev.String())
+					// It's not guaranteed that BOTH shards have streamed a row yet as the order
+					// of events in the stream is non-determinstic. So we check to be sure that
+					// at least one shard has copied rows and thus has a full TableLastPK proto
+					// message.
+					eventStr := ev.String()
+					require.True(t, redash80.MatchString(eventStr) || re80dash.MatchString(eventStr) || both.MatchString(eventStr),
+						"VGTID event does not have a complete TableLastPK proto message for either shard; event: %s", eventStr)
 				}
 			}
 			if expectedCatchupEvents == replCatchupEvents && expectedRowCopyEvents == rowCopyEvents {


### PR DESCRIPTION
## Description

Part duex (the [first one](https://github.com/vitessio/vitess/pull/12637) was prematurely merged).

I've noticed that the [`TestVStreamCopyResume` test](https://github.com/vitessio/vitess/blob/7afc6e1e1816a820baba841fd4dc38901d40e5a3/go/vt/vtgate/endtoend/vstream_test.go#L389) has been flaky lately in the [`End-To-End` workflow](https://github.com/vitessio/vitess/blob/7afc6e1e1816a820baba841fd4dc38901d40e5a3/.github/workflows/endtoend.yml) since we merged https://github.com/vitessio/vitess/pull/12623. You can see an example of it failing 4 times in a row here: https://github.com/vitessio/vitess/actions/runs/4432838267

After investigating the failures, the reason for them is that the order of events in the stream are non-deterministic and thus the [`VGtid`](https://pkg.go.dev/vitess.io/vitess/go/vt/proto/binlogdata#VGtid) event contents are also non-deterministic. This meant that one or both of the shard's [`ShardGtid`](https://pkg.go.dev/vitess.io/vitess/go/vt/proto/binlogdata#ShardGtid) values could contain a [`TableLastPK`](https://pkg.go.dev/vitess.io/vitess/go/vt/proto/binlogdata#TableLastPK) proto message: https://github.com/vitessio/vitess/blob/7afc6e1e1816a820baba841fd4dc38901d40e5a3/go/vt/vtgate/endtoend/vstream_test.go#L483-L488

The regexp would only match if BOTH shard's [`ShardGtid`](https://pkg.go.dev/vitess.io/vitess/go/vt/proto/binlogdata#ShardGtid) values had a full [`TableLastPK`](https://pkg.go.dev/vitess.io/vitess/go/vt/proto/binlogdata#TableLastPK) proto message, but that is not guaranteed due to vstream semantics/behavior (even though in local tests that was virtually always the case, the CI is very CPU constrained and it was not the case).

The test was failing in the CI ~ 65% of the time. With the changes in this PR, it has passed 15 times in a row (the workflow failed once, but not because of `TestVStreamCopyResume`): https://github.com/vitessio/vitess/actions/runs/4442832602

## Related Issue(s)

  - Continuation of: https://github.com/vitessio/vitess/pull/12637
  - Follow-up to: https://github.com/vitessio/vitess/pull/12623

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required