### PR TITLE
[Donot Review]Remove VTOrc from backup tests

### DIFF
--- a/go/test/endtoend/backup/vtbackup/main_test.go
+++ b/go/test/endtoend/backup/vtbackup/main_test.go
@@ -137,7 +137,7 @@ func TestMain(m *testing.M) {
 			}
 		}
 
-		if localCluster.VtTabletMajorVersion >= 16 {
+		/*if localCluster.VtTabletMajorVersion >= 16 {
 			// If vttablets are any lower than version 16, then they are running the replication manager.
 			// Running VTOrc and replication manager sometimes creates the situation where VTOrc has set up semi-sync on the primary,
 			// but the replication manager starts replication on the replica without setting semi-sync. This hangs the primary.
@@ -145,7 +145,7 @@ func TestMain(m *testing.M) {
 			if err := localCluster.StartVTOrc(keyspaceName); err != nil {
 				return 1, err
 			}
-		}
+		}*/
 
 		return m.Run(), nil
 	}()


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
