### PR TITLE
Minor Cleanup of SidecarDB Package

### DIFF
--- a/go/vt/sidecardb/identifier_cache.go
+++ b/go/vt/sidecardb/identifier_cache.go
@@ -67,9 +67,8 @@ func NewIdentifierCache(loadFunc func(context.Context, string) (string, error)) 
 func GetIdentifierCache() (*IdentifierCache, error) {
 	if identifierCache.Load() == nil {
 		return nil, vterrors.New(vtrpcpb.Code_INTERNAL, errIdentifierCacheUninitialized)
-	} else {
-		return identifierCache.Load().(*IdentifierCache), nil
 	}
+	return identifierCache.Load().(*IdentifierCache), nil
 }
 
 // Get returns an sqlparser string built from an IdentifierCS using

--- a/go/vt/sidecardb/sidecardb.go
+++ b/go/vt/sidecardb/sidecardb.go
@@ -231,17 +231,17 @@ func GetCreateQuery() string {
 
 // GetDDLCount metric returns the count of sidecardb DDLs that
 // have been run as part of this vttablet's init process.
-func GetDDLCount() int64 {
+func getDDLCount() int64 {
 	return ddlCount.Get()
 }
 
 // GetDDLErrorCount returns the count of sidecardb DDLs that have been errored out as part of this vttablet's init process.
-func GetDDLErrorCount() int64 {
+func getDDLErrorCount() int64 {
 	return ddlErrorCount.Get()
 }
 
 // GetDDLErrorHistory returns the errors encountered as part of this vttablet's init process..
-func GetDDLErrorHistory() []*ddlError {
+func getDDLErrorHistory() []*ddlError {
 	var errors []*ddlError
 	for _, e := range ddlErrorHistory.Records() {
 		ddle, ok := e.(*ddlError)

--- a/go/vt/sidecardb/sidecardb_test.go
+++ b/go/vt/sidecardb/sidecardb_test.go
@@ -83,11 +83,11 @@ func TestInitErrors(t *testing.T) {
 		return conn.ExecuteFetch(query, maxRows, true)
 	}
 
-	require.Equal(t, int64(0), GetDDLCount())
+	require.Equal(t, int64(0), getDDLCount())
 	err = Init(ctx, exec)
 	require.NoError(t, err)
-	require.Equal(t, int64(len(sidecarTables)-len(schemaErrors)), GetDDLCount())
-	require.Equal(t, int64(len(schemaErrors)), GetDDLErrorCount())
+	require.Equal(t, int64(len(sidecarTables)-len(schemaErrors)), getDDLCount())
+	require.Equal(t, int64(len(schemaErrors)), getDDLErrorCount())
 
 	var want []string
 	for _, e := range schemaErrors {
@@ -95,7 +95,7 @@ func TestInitErrors(t *testing.T) {
 	}
 	// sort expected and reported errors for easy comparison
 	sort.Strings(want)
-	got := GetDDLErrorHistory()
+	got := getDDLErrorHistory()
 	sort.Slice(got, func(i, j int) bool {
 		return got[i].tableName < got[j].tableName
 	})
@@ -153,10 +153,10 @@ func TestMiscSidecarDB(t *testing.T) {
 	// tests init on empty db
 	ddlErrorCount.Set(0)
 	ddlCount.Set(0)
-	require.Equal(t, int64(0), GetDDLCount())
+	require.Equal(t, int64(0), getDDLCount())
 	err = Init(ctx, exec)
 	require.NoError(t, err)
-	require.Equal(t, int64(len(sidecarTables)), GetDDLCount())
+	require.Equal(t, int64(len(sidecarTables)), getDDLCount())
 
 	// Include the table DDLs in the expected queries.
 	// This causes them to NOT be created again.
@@ -165,7 +165,7 @@ func TestMiscSidecarDB(t *testing.T) {
 	// tests init on already inited db
 	err = Init(ctx, exec)
 	require.NoError(t, err)
-	require.Equal(t, int64(len(sidecarTables)), GetDDLCount())
+	require.Equal(t, int64(len(sidecarTables)), getDDLCount())
 
 	// tests misc paths not covered above
 	si := &schemaInit{


### PR DESCRIPTION
## Description

This addresses some minor things noticed when doing other work. These things were not caught by the [`golangci-lint` pre-commit hook](https://github.com/vitessio/vitess/blob/main/misc/git/hooks/golangci-lint) as they were caught by `revive` which we disabled in this PR: https://github.com/vitessio/vitess/pull/12286#issuecomment-1423957152

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/12240

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required