### PR TITLE
Fixing backup tests flakiness

### DIFF
--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -400,6 +400,10 @@ type restoreMethod func(t *testing.T, tablet *cluster.Vttablet)
 //  13. verify that don't have the data added after the first backup
 //  14. remove the backups
 func primaryBackup(t *testing.T) {
+	localCluster.DisableVTOrcRecoveries(t)
+	defer func() {
+		localCluster.EnableVTOrcRecoveries(t)
+	}()
 	verifyInitialReplication(t)
 
 	output, err := localCluster.VtctlclientProcess.ExecuteCommandWithOutput("Backup", primary.Alias)
@@ -442,11 +446,6 @@ func primaryBackup(t *testing.T) {
 		"--keyspace_shard", shardKsName,
 		"--new_primary", replica2.Alias)
 	require.Nil(t, err)
-
-	localCluster.DisableVTOrcRecoveries(t)
-	defer func() {
-		localCluster.EnableVTOrcRecoveries(t)
-	}()
 
 	// Delete the current primary tablet (replica2) so that the original primary tablet (primary) can be restored from the
 	// older/first backup w/o it replicating the subsequent insert done after the first backup was taken

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -400,6 +400,10 @@ type restoreMethod func(t *testing.T, tablet *cluster.Vttablet)
 //  13. verify that don't have the data added after the first backup
 //  14. remove the backups
 func primaryBackup(t *testing.T) {
+	// Having the VTOrc in this test causes a lot of flakiness. For example when we delete the tablet `replica2` which
+	// is the current primary and then try to restore from backup the old primary (`primary.Alias`), but before that sometimes the VTOrc
+	// promotes the `replica1` to primary right after we delete the replica2 (current primary).
+	// This can result in unexpected behavior. Therefore, disabling the VTOrc in this test to remove flakiness.
 	localCluster.DisableVTOrcRecoveries(t)
 	defer func() {
 		localCluster.EnableVTOrcRecoveries(t)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 --> 

## Description

Backup Tests `TestBackupMysqlctld/TestPrimaryBackup` is flaky. Here is one such instance of failure

https://github.com/vitessio/vitess/actions/runs/4477008834/jobs/7868010386


The failure is coming from this piece of test code 

```
// Perform PRS to demote the primary tablet (primary) so that we can do a restore there and verify we don't have the
	// data from after the older/first backup
	err = localCluster.VtctlclientProcess.ExecuteCommand("PlannedReparentShard", "--",
		"--keyspace_shard", shardKsName,
		"--new_primary", replica2.Alias)
	require.Nil(t, err)

	// Delete the current primary tablet (replica2) so that the original primary tablet (primary) can be restored from the
	// older/first backup w/o it replicating the subsequent insert done after the first backup was taken
	err = localCluster.VtctlclientProcess.ExecuteCommand("DeleteTablet", "--", "--allow_primary=true", replica2.Alias)
	require.Nil(t, err)
	err = replica2.VttabletProcess.TearDown()
	require.Nil(t, err)

	// Restore the older/first backup -- using the timestamp we saved -- on the original primary tablet (primary)
	err = localCluster.VtctlclientProcess.ExecuteCommand("RestoreFromBackup", "--", "--backup_timestamp", firstBackupTimestamp, primary.Alias)
	require.Nil(t, err)

```

The reason is we have introduced VTOrc in the test which tries to fix Primary when it is down. When we delete the tablet, VTorc tries to elect a new primary. If it elect `replica1` as new primary then we are good but if it elects `primary` as new one then `RestoreFromBackup` fails. 

## Related Issue(s)
closes #12687
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Solution

There were few ways to resolve it.
1. We could have remove VTorc entirely from backup tests
2. We disable VTorc in that specific test which is failing because of VTOrc intervention.
3. We can choose the right replica at the point and use that for restore API. 

I went with option#2, as it looked neat and doesn't result in a lot of changes in code.

## Testing

Ran test few times locally and then on github action. It looked much stable now. 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
