### PR TITLE
evalengine: Implement integer division and modulo

### DIFF
--- a/go/vt/vtgate/evalengine/arena.go
+++ b/go/vt/vtgate/evalengine/arena.go
@@ -60,6 +60,13 @@ func (a *Arena) newEvalDecimal(dec decimal.Decimal, m, d int32) *evalDecimal {
 	return a.newEvalDecimalWithPrec(dec.Clamp(m-d, d), d)
 }
 
+func (a *Arena) newEvalBool(b bool) *evalInt64 {
+	if b {
+		return a.newEvalInt64(1)
+	}
+	return a.newEvalInt64(0)
+}
+
 func (a *Arena) newEvalInt64(i int64) *evalInt64 {
 	if cap(a.aInt64) > len(a.aInt64) {
 		a.aInt64 = a.aInt64[:len(a.aInt64)+1]

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -26,10 +26,15 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/evalengine/internal/decimal"
 )
 
 func dataOutOfRangeError[N1, N2 constraints.Integer | constraints.Float](v1 N1, v2 N2, typ, sign string) error {
 	return vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.DataOutOfRange, "%s value is out of range in '(%v %s %v)'", typ, v1, sign, v2)
+}
+
+func dataOutOfRangeErrorDecimal(v1 decimal.Decimal, v2 decimal.Decimal, typ, sign string) error {
+	return vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.DataOutOfRange, "%s value is out of range in '(%v %s %v)'", typ, v1.String(), sign, v2.String())
 }
 
 func addNumericWithError(left, right eval) (eval, error) {
@@ -127,6 +132,108 @@ func divideNumericWithError(left, right eval, precise bool) (eval, error) {
 	return mathDiv_xx(v1, v2, divPrecisionIncrement)
 }
 
+func integerDivideNumericWithError(left, right eval, precise bool) (eval, error) {
+	v1 := evalToNumeric(left)
+	v2 := evalToNumeric(right)
+	switch v1 := v1.(type) {
+	case *evalInt64:
+		switch v2 := v2.(type) {
+		case *evalInt64:
+			return mathIntDiv_ii(v1, v2)
+		case *evalUint64:
+			return mathIntDiv_iu(v1, v2)
+		case *evalFloat:
+			return mathIntDiv_di(v1.toDecimal(0, 0), v2.toDecimal(0, 0))
+		case *evalDecimal:
+			return mathIntDiv_di(v1.toDecimal(0, 0), v2)
+		}
+	case *evalUint64:
+		switch v2 := v2.(type) {
+		case *evalInt64:
+			return mathIntDiv_ui(v1, v2)
+		case *evalUint64:
+			return mathIntDiv_uu(v1, v2)
+		case *evalFloat:
+			return mathIntDiv_du(v1.toDecimal(0, 0), v2.toDecimal(0, 0))
+		case *evalDecimal:
+			return mathIntDiv_du(v1.toDecimal(0, 0), v2)
+		}
+	case *evalFloat:
+		switch v2 := v2.(type) {
+		case *evalUint64:
+			return mathIntDiv_du(v1.toDecimal(0, 0), v2.toDecimal(0, 0))
+		default:
+			return mathIntDiv_di(v1.toDecimal(0, 0), v2.toDecimal(0, 0))
+		}
+	case *evalDecimal:
+		switch v2 := v2.(type) {
+		case *evalUint64:
+			return mathIntDiv_du(v1, v2.toDecimal(0, 0))
+		default:
+			return mathIntDiv_di(v1, v2.toDecimal(0, 0))
+		}
+	}
+
+	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid arithmetic between: %s %s", evalToSQLValue(v1), evalToSQLValue(v2))
+}
+
+func modNumericWithError(left, right eval, precise bool) (eval, error) {
+	v1 := evalToNumeric(left)
+	v2 := evalToNumeric(right)
+
+	switch v1 := v1.(type) {
+	case *evalInt64:
+		switch v2 := v2.(type) {
+		case *evalInt64:
+			return mathMod_ii(v1, v2)
+		case *evalUint64:
+			return mathMod_iu(v1, v2)
+		case *evalFloat:
+			v1f, ok := v1.toFloat()
+			if !ok {
+				return nil, errDecimalOutOfRange
+			}
+			return mathMod_ff(v1f, v2)
+		case *evalDecimal:
+			return mathMod_dd(v1.toDecimal(0, 0), v2)
+		}
+	case *evalUint64:
+		switch v2 := v2.(type) {
+		case *evalInt64:
+			return mathMod_ui(v1, v2)
+		case *evalUint64:
+			return mathMod_uu(v1, v2)
+		case *evalFloat:
+			v1f, ok := v1.toFloat()
+			if !ok {
+				return nil, errDecimalOutOfRange
+			}
+			return mathMod_ff(v1f, v2)
+		case *evalDecimal:
+			return mathMod_dd(v1.toDecimal(0, 0), v2)
+		}
+	case *evalDecimal:
+		switch v2 := v2.(type) {
+		case *evalFloat:
+			v1f, ok := v1.toFloat()
+			if !ok {
+				return nil, errDecimalOutOfRange
+			}
+			return mathMod_ff(v1f, v2)
+		default:
+			return mathMod_dd(v1, v2.toDecimal(0, 0))
+		}
+	case *evalFloat:
+		v2f, ok := v2.toFloat()
+		if !ok {
+			return nil, errDecimalOutOfRange
+		}
+		return mathMod_ff(v1, v2f)
+	}
+
+	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "invalid arithmetic between: %s %s", evalToSQLValue(v1), evalToSQLValue(v2))
+}
+
 // makeNumericAndPrioritize reorders the input parameters
 // to be Float64, Decimal, Uint64, Int64.
 func makeNumericAndPrioritize(left, right eval) (evalNumeric, evalNumeric) {
@@ -162,44 +269,6 @@ func mathAdd_ii0(v1, v2 int64) (int64, error) {
 	return result, nil
 }
 
-func mathSub_ii(v1, v2 int64) (*evalInt64, error) {
-	result, err := mathSub_ii0(v1, v2)
-	return newEvalInt64(result), err
-}
-
-func mathSub_ii0(v1, v2 int64) (int64, error) {
-	result := v1 - v2
-	if (result < v1) != (v2 > 0) {
-		return 0, dataOutOfRangeError(v1, v2, "BIGINT", "-")
-	}
-	return result, nil
-}
-
-func mathMul_ii(v1, v2 int64) (*evalInt64, error) {
-	result, err := mathMul_ii0(v1, v2)
-	return newEvalInt64(result), err
-}
-
-func mathMul_ii0(v1, v2 int64) (int64, error) {
-	result := v1 * v2
-	if v1 != 0 && result/v1 != v2 {
-		return 0, dataOutOfRangeError(v1, v2, "BIGINT", "*")
-	}
-	return result, nil
-}
-
-func mathSub_iu(v1 int64, v2 uint64) (*evalUint64, error) {
-	result, err := mathSub_iu0(v1, v2)
-	return newEvalUint64(result), err
-}
-
-func mathSub_iu0(v1 int64, v2 uint64) (uint64, error) {
-	if v1 < 0 {
-		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "-")
-	}
-	return mathSub_uu0(uint64(v1), v2)
-}
-
 func mathAdd_ui(v1 uint64, v2 int64) (*evalUint64, error) {
 	result, err := mathAdd_ui0(v1, v2)
 	return newEvalUint64(result), err
@@ -213,37 +282,6 @@ func mathAdd_ui0(v1 uint64, v2 int64) (uint64, error) {
 	return result, nil
 }
 
-func mathSub_ui(v1 uint64, v2 int64) (*evalUint64, error) {
-	result, err := mathSub_ui0(v1, v2)
-	return newEvalUint64(result), err
-}
-
-func mathSub_ui0(v1 uint64, v2 int64) (uint64, error) {
-	if v2 > 0 && v1 < uint64(v2) {
-		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "-")
-	}
-	// uint - (- int) = uint + int
-	if v2 < 0 {
-		return mathAdd_uu0(v1, uint64(-v2))
-	}
-	return mathSub_uu0(v1, uint64(v2))
-}
-
-func mathMul_ui(v1 uint64, v2 int64) (*evalUint64, error) {
-	result, err := mathMul_ui0(v1, v2)
-	return newEvalUint64(result), err
-}
-
-func mathMul_ui0(v1 uint64, v2 int64) (uint64, error) {
-	if v1 == 0 || v2 == 0 {
-		return 0, nil
-	}
-	if v2 < 0 {
-		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "*")
-	}
-	return mathMul_uu0(v1, uint64(v2))
-}
-
 func mathAdd_uu(v1, v2 uint64) (*evalUint64, error) {
 	result, err := mathAdd_uu0(v1, v2)
 	return newEvalUint64(result), err
@@ -253,35 +291,6 @@ func mathAdd_uu0(v1, v2 uint64) (uint64, error) {
 	result := v1 + v2
 	if result < v1 || result < v2 {
 		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "+")
-	}
-	return result, nil
-}
-
-func mathSub_uu(v1, v2 uint64) (*evalUint64, error) {
-	result, err := mathSub_uu0(v1, v2)
-	return newEvalUint64(result), err
-}
-
-func mathSub_uu0(v1, v2 uint64) (uint64, error) {
-	result := v1 - v2
-	if v2 > v1 {
-		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "-")
-	}
-	return result, nil
-}
-
-func mathMul_uu(v1, v2 uint64) (*evalUint64, error) {
-	result, err := mathMul_uu0(v1, v2)
-	return newEvalUint64(result), err
-}
-
-func mathMul_uu0(v1, v2 uint64) (uint64, error) {
-	if v1 == 0 || v2 == 0 {
-		return 0, nil
-	}
-	result := v1 * v2
-	if result < v2 || result < v1 {
-		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "*")
 	}
 	return result, nil
 }
@@ -300,12 +309,152 @@ func mathAdd_ff(v1, v2 float64) *evalFloat {
 	return newEvalFloat(v1 + v2)
 }
 
+func mathAdd_dx(v1 *evalDecimal, v2 evalNumeric) *evalDecimal {
+	return mathAdd_dd(v1, v2.toDecimal(0, 0))
+}
+
+func mathAdd_dd(v1, v2 *evalDecimal) *evalDecimal {
+	return newEvalDecimalWithPrec(v1.dec.Add(v2.dec), maxprec(v1.length, v2.length))
+}
+
+func mathAdd_dd0(v1, v2 *evalDecimal) {
+	v1.dec = v1.dec.Add(v2.dec)
+	v1.length = maxprec(v1.length, v2.length)
+}
+
+func mathSub_ii(v1, v2 int64) (*evalInt64, error) {
+	result, err := mathSub_ii0(v1, v2)
+	return newEvalInt64(result), err
+}
+
+func mathSub_ii0(v1, v2 int64) (int64, error) {
+	result := v1 - v2
+	if (result < v1) != (v2 > 0) {
+		return 0, dataOutOfRangeError(v1, v2, "BIGINT", "-")
+	}
+	return result, nil
+}
+
+func mathSub_iu(v1 int64, v2 uint64) (*evalUint64, error) {
+	result, err := mathSub_iu0(v1, v2)
+	return newEvalUint64(result), err
+}
+
+func mathSub_iu0(v1 int64, v2 uint64) (uint64, error) {
+	if v1 < 0 {
+		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "-")
+	}
+	return mathSub_uu0(uint64(v1), v2)
+}
+
+func mathSub_ui(v1 uint64, v2 int64) (*evalUint64, error) {
+	result, err := mathSub_ui0(v1, v2)
+	return newEvalUint64(result), err
+}
+
+func mathSub_ui0(v1 uint64, v2 int64) (uint64, error) {
+	if v2 > 0 && v1 < uint64(v2) {
+		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "-")
+	}
+	// uint - (- int) = uint + int
+	if v2 < 0 {
+		return mathAdd_uu0(v1, uint64(-v2))
+	}
+	return mathSub_uu0(v1, uint64(v2))
+}
+
+func mathSub_uu(v1, v2 uint64) (*evalUint64, error) {
+	result, err := mathSub_uu0(v1, v2)
+	return newEvalUint64(result), err
+}
+
+func mathSub_uu0(v1, v2 uint64) (uint64, error) {
+	result := v1 - v2
+	if v2 > v1 {
+		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "-")
+	}
+	return result, nil
+}
+
 func mathSub_fx(v1 float64, v2 evalNumeric) (*evalFloat, error) {
 	v2f, ok := v2.toFloat()
 	if !ok {
 		return nil, errDecimalOutOfRange
 	}
 	return mathSub_ff(v1, v2f.f), nil
+}
+
+func mathSub_xf(v1 evalNumeric, v2 float64) (*evalFloat, error) {
+	v1f, ok := v1.toFloat()
+	if !ok {
+		return nil, errDecimalOutOfRange
+	}
+	return mathSub_ff(v1f.f, v2), nil
+}
+
+func mathSub_ff(v1, v2 float64) *evalFloat {
+	return newEvalFloat(v1 - v2)
+}
+
+func mathSub_dx(v1 *evalDecimal, v2 evalNumeric) *evalDecimal {
+	return mathSub_dd(v1, v2.toDecimal(0, 0))
+}
+
+func mathSub_xd(v1 evalNumeric, v2 *evalDecimal) *evalDecimal {
+	return mathSub_dd(v1.toDecimal(0, 0), v2)
+}
+
+func mathSub_dd(v1, v2 *evalDecimal) *evalDecimal {
+	return newEvalDecimalWithPrec(v1.dec.Sub(v2.dec), maxprec(v1.length, v2.length))
+}
+
+func mathSub_dd0(v1, v2 *evalDecimal) {
+	v1.dec = v1.dec.Sub(v2.dec)
+	v1.length = maxprec(v1.length, v2.length)
+}
+
+func mathMul_ii(v1, v2 int64) (*evalInt64, error) {
+	result, err := mathMul_ii0(v1, v2)
+	return newEvalInt64(result), err
+}
+
+func mathMul_ii0(v1, v2 int64) (int64, error) {
+	result := v1 * v2
+	if v1 != 0 && result/v1 != v2 {
+		return 0, dataOutOfRangeError(v1, v2, "BIGINT", "*")
+	}
+	return result, nil
+}
+
+func mathMul_ui(v1 uint64, v2 int64) (*evalUint64, error) {
+	result, err := mathMul_ui0(v1, v2)
+	return newEvalUint64(result), err
+}
+
+func mathMul_ui0(v1 uint64, v2 int64) (uint64, error) {
+	if v1 == 0 || v2 == 0 {
+		return 0, nil
+	}
+	if v2 < 0 {
+		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "*")
+	}
+	return mathMul_uu0(v1, uint64(v2))
+}
+
+func mathMul_uu(v1, v2 uint64) (*evalUint64, error) {
+	result, err := mathMul_uu0(v1, v2)
+	return newEvalUint64(result), err
+}
+
+func mathMul_uu0(v1, v2 uint64) (uint64, error) {
+	if v1 == 0 || v2 == 0 {
+		return 0, nil
+	}
+	result := v1 * v2
+	if result < v2 || result < v1 {
+		return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "*")
+	}
+	return result, nil
 }
 
 func mathMul_fx(v1 float64, v2 evalNumeric) (eval, error) {
@@ -325,36 +474,6 @@ func maxprec(a, b int32) int32 {
 		return a
 	}
 	return b
-}
-
-func mathAdd_dx(v1 *evalDecimal, v2 evalNumeric) *evalDecimal {
-	return mathAdd_dd(v1, v2.toDecimal(0, 0))
-}
-
-func mathAdd_dd(v1, v2 *evalDecimal) *evalDecimal {
-	return newEvalDecimalWithPrec(v1.dec.Add(v2.dec), maxprec(v1.length, v2.length))
-}
-
-func mathAdd_dd0(v1, v2 *evalDecimal) {
-	v1.dec = v1.dec.Add(v2.dec)
-	v1.length = maxprec(v1.length, v2.length)
-}
-
-func mathSub_dx(v1 *evalDecimal, v2 evalNumeric) *evalDecimal {
-	return mathSub_dd(v1, v2.toDecimal(0, 0))
-}
-
-func mathSub_xd(v1 evalNumeric, v2 *evalDecimal) *evalDecimal {
-	return mathSub_dd(v1.toDecimal(0, 0), v2)
-}
-
-func mathSub_dd(v1, v2 *evalDecimal) *evalDecimal {
-	return newEvalDecimalWithPrec(v1.dec.Sub(v2.dec), maxprec(v1.length, v2.length))
-}
-
-func mathSub_dd0(v1, v2 *evalDecimal) {
-	v1.dec = v1.dec.Sub(v2.dec)
-	v1.length = maxprec(v1.length, v2.length)
 }
 
 func mathMul_dx(v1 *evalDecimal, v2 evalNumeric) *evalDecimal {
@@ -413,16 +532,174 @@ func mathDiv_ff0(v1, v2 float64) (float64, error) {
 	return result, nil
 }
 
-func mathSub_xf(v1 evalNumeric, v2 float64) (*evalFloat, error) {
-	v1f, ok := v1.toFloat()
-	if !ok {
-		return nil, errDecimalOutOfRange
+func mathIntDiv_ii(v1, v2 *evalInt64) (eval, error) {
+	if v2.i == 0 {
+		return nil, nil
 	}
-	return mathSub_ff(v1f.f, v2), nil
+	result := v1.i / v2.i
+	return newEvalInt64(result), nil
 }
 
-func mathSub_ff(v1, v2 float64) *evalFloat {
-	return newEvalFloat(v1 - v2)
+func mathIntDiv_iu(v1 *evalInt64, v2 *evalUint64) (eval, error) {
+	if v2.u == 0 {
+		return nil, nil
+	}
+	result, err := mathIntDiv_iu0(v1.i, v2.u)
+	return newEvalUint64(result), err
+}
+
+func mathIntDiv_iu0(v1 int64, v2 uint64) (uint64, error) {
+	if v1 < 0 {
+		if v2 >= math.MaxInt64 {
+			// We know here that v2 is always so large the result
+			// must be 0.
+			return 0, nil
+		}
+		result := v1 / int64(v2)
+		if result < 0 {
+			return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "DIV")
+		}
+		return uint64(result), nil
+
+	}
+	return uint64(v1) / v2, nil
+}
+
+func mathIntDiv_ui(v1 *evalUint64, v2 *evalInt64) (eval, error) {
+	if v2.i == 0 {
+		return nil, nil
+	}
+	result, err := mathIntDiv_ui0(v1.u, v2.i)
+	return newEvalUint64(result), err
+}
+
+func mathIntDiv_ui0(v1 uint64, v2 int64) (uint64, error) {
+	if v2 < 0 {
+		if v1 >= math.MaxInt64 {
+			// We know that v1 is always large here and with v2, the result
+			// must be at least -1 so we can't store this in the available range.
+			return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "DIV")
+		}
+		// Safe to cast since we know it fits in int64 when we get here.
+		result := int64(v1) / v2
+		if result < 0 {
+			return 0, dataOutOfRangeError(v1, v2, "BIGINT UNSIGNED", "DIV")
+		}
+		return uint64(result), nil
+	}
+	return v1 / uint64(v2), nil
+}
+
+func mathIntDiv_uu(v1, v2 *evalUint64) (eval, error) {
+	if v2.u == 0 {
+		return nil, nil
+	}
+	return newEvalUint64(v1.u / v2.u), nil
+}
+
+func mathIntDiv_di(v1, v2 *evalDecimal) (eval, error) {
+	if v2.dec.IsZero() {
+		return nil, nil
+	}
+	result, err := mathIntDiv_di0(v1, v2)
+	return newEvalInt64(result), err
+}
+
+func mathIntDiv_di0(v1, v2 *evalDecimal) (int64, error) {
+	div, _ := v1.dec.QuoRem(v2.dec, 0)
+	result, ok := div.Int64()
+	if !ok {
+		return 0, dataOutOfRangeErrorDecimal(v1.dec, v2.dec, "BIGINT", "DIV")
+	}
+	return result, nil
+}
+
+func mathIntDiv_du(v1, v2 *evalDecimal) (eval, error) {
+	if v2.dec.IsZero() {
+		return nil, nil
+	}
+	result, err := mathIntDiv_du0(v1, v2)
+	return newEvalUint64(result), err
+}
+
+func mathIntDiv_du0(v1, v2 *evalDecimal) (uint64, error) {
+	div, _ := v1.dec.QuoRem(v2.dec, 0)
+	result, ok := div.Uint64()
+	if !ok {
+		return 0, dataOutOfRangeErrorDecimal(v1.dec, v2.dec, "BIGINT UNSIGNED", "DIV")
+	}
+	return result, nil
+}
+
+func mathMod_ii(v1, v2 *evalInt64) (eval, error) {
+	if v2.i == 0 {
+		return nil, nil
+	}
+	return newEvalInt64(v1.i % v2.i), nil
+}
+
+func mathMod_iu(v1 *evalInt64, v2 *evalUint64) (eval, error) {
+	if v2.u == 0 {
+		return nil, nil
+	}
+	return newEvalInt64(mathMod_iu0(v1.i, v2.u)), nil
+}
+
+func mathMod_iu0(v1 int64, v2 uint64) int64 {
+	if v1 == math.MinInt64 && v2 == math.MaxInt64+1 {
+		return 0
+	}
+	if v2 > math.MaxInt64 {
+		return v1
+	}
+	return v1 % int64(v2)
+}
+
+func mathMod_ui(v1 *evalUint64, v2 *evalInt64) (eval, error) {
+	if v2.i == 0 {
+		return nil, nil
+	}
+	result, err := mathMod_ui0(v1.u, v2.i)
+	return newEvalUint64(result), err
+}
+
+func mathMod_ui0(v1 uint64, v2 int64) (uint64, error) {
+	if v2 < 0 {
+		return v1 % uint64(-v2), nil
+	}
+	return v1 % uint64(v2), nil
+}
+
+func mathMod_uu(v1, v2 *evalUint64) (eval, error) {
+	if v2.u == 0 {
+		return nil, nil
+	}
+	return newEvalUint64(v1.u % v2.u), nil
+}
+
+func mathMod_ff(v1, v2 *evalFloat) (eval, error) {
+	if v2.f == 0.0 {
+		return nil, nil
+	}
+	return newEvalFloat(math.Mod(v1.f, v2.f)), nil
+}
+
+func mathMod_dd(v1, v2 *evalDecimal) (eval, error) {
+	if v2.dec.IsZero() {
+		return nil, nil
+	}
+
+	dec, prec := mathMod_dd0(v1, v2)
+	return newEvalDecimalWithPrec(dec, prec), nil
+}
+
+func mathMod_dd0(v1, v2 *evalDecimal) (decimal.Decimal, int32) {
+	length := v1.length
+	if v2.length > length {
+		length = v2.length
+	}
+	_, rem := v1.dec.QuoRem(v2.dec, 0)
+	return rem, length
 }
 
 func parseStringToFloat(str string) float64 {

--- a/go/vt/vtgate/evalengine/compiler.go
+++ b/go/vt/vtgate/evalengine/compiler.go
@@ -316,7 +316,7 @@ func (c *compiler) compileToDecimal(ct ctype, offset int) ctype {
 }
 
 func (c *compiler) compileNullCheck1(ct ctype) *jump {
-	if ct.Flag&flagNullable != 0 {
+	if ct.nullable() {
 		j := c.asm.jumpFrom()
 		c.asm.NullCheck1(j)
 		return j
@@ -325,7 +325,7 @@ func (c *compiler) compileNullCheck1(ct ctype) *jump {
 }
 
 func (c *compiler) compileNullCheck2(lt, rt ctype) *jump {
-	if lt.Flag&flagNullable != 0 || rt.Flag&flagNullable != 0 {
+	if lt.nullable() || rt.nullable() {
 		j := c.asm.jumpFrom()
 		c.asm.NullCheck2(j)
 		return j

--- a/go/vt/vtgate/evalengine/compiler.go
+++ b/go/vt/vtgate/evalengine/compiler.go
@@ -148,6 +148,12 @@ func (c *compiler) compileExpr(expr Expr) (ctype, error) {
 	case *InExpr:
 		return c.compileIn(expr)
 
+	case *NotExpr:
+		return c.compileNot(expr)
+
+	case *LogicalExpr:
+		return c.compileLogical(expr)
+
 	case callable:
 		return c.compileFn(expr)
 

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -363,7 +363,7 @@ func (asm *assembler) BitwiseNot_u() {
 func (asm *assembler) Cmp_eq() {
 	asm.adjustStack(1)
 	asm.emit(func(vm *VirtualMachine) int {
-		vm.stack[vm.sp] = newEvalBool(vm.flags.cmp == 0)
+		vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp == 0)
 		vm.sp++
 		return 1
 	}, "CMPFLAG EQ")
@@ -375,7 +375,7 @@ func (asm *assembler) Cmp_eq_n() {
 		if vm.flags.null {
 			vm.stack[vm.sp] = nil
 		} else {
-			vm.stack[vm.sp] = newEvalBool(vm.flags.cmp == 0)
+			vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp == 0)
 		}
 		vm.sp++
 		return 1
@@ -385,7 +385,7 @@ func (asm *assembler) Cmp_eq_n() {
 func (asm *assembler) Cmp_ge() {
 	asm.adjustStack(1)
 	asm.emit(func(vm *VirtualMachine) int {
-		vm.stack[vm.sp] = newEvalBool(vm.flags.cmp >= 0)
+		vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp >= 0)
 		vm.sp++
 		return 1
 	}, "CMPFLAG GE")
@@ -397,7 +397,7 @@ func (asm *assembler) Cmp_ge_n() {
 		if vm.flags.null {
 			vm.stack[vm.sp] = nil
 		} else {
-			vm.stack[vm.sp] = newEvalBool(vm.flags.cmp >= 0)
+			vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp >= 0)
 		}
 		vm.sp++
 		return 1
@@ -407,7 +407,7 @@ func (asm *assembler) Cmp_ge_n() {
 func (asm *assembler) Cmp_gt() {
 	asm.adjustStack(1)
 	asm.emit(func(vm *VirtualMachine) int {
-		vm.stack[vm.sp] = newEvalBool(vm.flags.cmp > 0)
+		vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp > 0)
 		vm.sp++
 		return 1
 	}, "CMPFLAG GT")
@@ -419,7 +419,7 @@ func (asm *assembler) Cmp_gt_n() {
 		if vm.flags.null {
 			vm.stack[vm.sp] = nil
 		} else {
-			vm.stack[vm.sp] = newEvalBool(vm.flags.cmp > 0)
+			vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp > 0)
 		}
 		vm.sp++
 		return 1
@@ -429,7 +429,7 @@ func (asm *assembler) Cmp_gt_n() {
 func (asm *assembler) Cmp_le() {
 	asm.adjustStack(1)
 	asm.emit(func(vm *VirtualMachine) int {
-		vm.stack[vm.sp] = newEvalBool(vm.flags.cmp <= 0)
+		vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp <= 0)
 		vm.sp++
 		return 1
 	}, "CMPFLAG LE")
@@ -441,7 +441,7 @@ func (asm *assembler) Cmp_le_n() {
 		if vm.flags.null {
 			vm.stack[vm.sp] = nil
 		} else {
-			vm.stack[vm.sp] = newEvalBool(vm.flags.cmp <= 0)
+			vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp <= 0)
 		}
 		vm.sp++
 		return 1
@@ -451,7 +451,7 @@ func (asm *assembler) Cmp_le_n() {
 func (asm *assembler) Cmp_lt() {
 	asm.adjustStack(1)
 	asm.emit(func(vm *VirtualMachine) int {
-		vm.stack[vm.sp] = newEvalBool(vm.flags.cmp < 0)
+		vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp < 0)
 		vm.sp++
 		return 1
 	}, "CMPFLAG LT")
@@ -463,7 +463,7 @@ func (asm *assembler) Cmp_lt_n() {
 		if vm.flags.null {
 			vm.stack[vm.sp] = nil
 		} else {
-			vm.stack[vm.sp] = newEvalBool(vm.flags.cmp < 0)
+			vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp < 0)
 		}
 		vm.sp++
 		return 1
@@ -472,7 +472,7 @@ func (asm *assembler) Cmp_lt_n() {
 func (asm *assembler) Cmp_ne() {
 	asm.adjustStack(1)
 	asm.emit(func(vm *VirtualMachine) int {
-		vm.stack[vm.sp] = newEvalBool(vm.flags.cmp != 0)
+		vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp != 0)
 		vm.sp++
 		return 1
 	}, "CMPFLAG NE")
@@ -484,7 +484,7 @@ func (asm *assembler) Cmp_ne_n() {
 		if vm.flags.null {
 			vm.stack[vm.sp] = nil
 		} else {
-			vm.stack[vm.sp] = newEvalBool(vm.flags.cmp != 0)
+			vm.stack[vm.sp] = vm.arena.newEvalBool(vm.flags.cmp != 0)
 		}
 		vm.sp++
 		return 1
@@ -701,7 +701,7 @@ func (asm *assembler) CmpTupleNullsafe() {
 		var equals bool
 		equals, vm.err = evalCompareTuplesNullSafe(l.t, r.t)
 
-		vm.stack[vm.sp-2] = newEvalBool(equals)
+		vm.stack[vm.sp-2] = vm.arena.newEvalBool(equals)
 		vm.sp -= 1
 		return 1
 	}, "CMP NULLSAFE TUPLE(SP-2), TUPLE(SP-1)")
@@ -719,9 +719,22 @@ func (asm *assembler) Collate(col collations.ID) {
 func (asm *assembler) Convert_bB(offset int) {
 	asm.emit(func(vm *VirtualMachine) int {
 		arg := vm.stack[vm.sp-offset]
-		vm.stack[vm.sp-offset] = newEvalBool(arg != nil && parseStringToFloat(arg.(*evalBytes).string()) != 0.0)
+		vm.stack[vm.sp-offset] = vm.arena.newEvalBool(arg != nil && parseStringToFloat(arg.(*evalBytes).string()) != 0.0)
 		return 1
 	}, "CONV VARBINARY(SP-%d), BOOL", offset)
+}
+
+func (asm *assembler) Convert_jB(offset int) {
+	asm.emit(func(vm *VirtualMachine) int {
+		arg := vm.stack[vm.sp-offset].(*evalJSON)
+		switch arg.Type() {
+		case json.TypeNumber:
+			vm.stack[vm.sp-offset] = vm.arena.newEvalBool(parseStringToFloat(arg.String()) != 0.0)
+		default:
+			vm.stack[vm.sp-offset] = vm.arena.newEvalBool(true)
+		}
+		return 1
+	}, "CONV JSON(SP-%d), BOOL", offset)
 }
 
 func (asm *assembler) Convert_bj(offset int) {
@@ -730,6 +743,14 @@ func (asm *assembler) Convert_bj(offset int) {
 		vm.stack[vm.sp-offset] = evalConvert_bj(arg)
 		return 1
 	}, "CONV VARBINARY(SP-%d), JSON", offset)
+}
+
+func (asm *assembler) ConvertArg_cj(offset int) {
+	asm.emit(func(vm *VirtualMachine) int {
+		arg := vm.stack[vm.sp-offset].(*evalBytes)
+		vm.stack[vm.sp-offset], vm.err = evalConvertArg_cj(arg)
+		return 1
+	}, "CONVA VARCHAR(SP-%d), JSON", offset)
 }
 
 func (asm *assembler) Convert_cj(offset int) {
@@ -743,7 +764,7 @@ func (asm *assembler) Convert_cj(offset int) {
 func (asm *assembler) Convert_dB(offset int) {
 	asm.emit(func(vm *VirtualMachine) int {
 		arg := vm.stack[vm.sp-offset]
-		vm.stack[vm.sp-offset] = newEvalBool(arg != nil && !arg.(*evalDecimal).dec.IsZero())
+		vm.stack[vm.sp-offset] = vm.arena.newEvalBool(arg != nil && !arg.(*evalDecimal).dec.IsZero())
 		return 1
 	}, "CONV DECIMAL(SP-%d), BOOL", offset)
 }
@@ -763,7 +784,7 @@ func (asm *assembler) Convert_dbit(offset int) {
 func (asm *assembler) Convert_fB(offset int) {
 	asm.emit(func(vm *VirtualMachine) int {
 		arg := vm.stack[vm.sp-offset]
-		vm.stack[vm.sp-offset] = newEvalBool(arg != nil && arg.(*evalFloat).f != 0.0)
+		vm.stack[vm.sp-offset] = vm.arena.newEvalBool(arg != nil && arg.(*evalFloat).f != 0.0)
 		return 1
 	}, "CONV FLOAT64(SP-%d), BOOL", offset)
 }
@@ -790,7 +811,7 @@ func (asm *assembler) Convert_hex(offset int) {
 func (asm *assembler) Convert_iB(offset int) {
 	asm.emit(func(vm *VirtualMachine) int {
 		arg := vm.stack[vm.sp-offset]
-		vm.stack[vm.sp-offset] = newEvalBool(arg != nil && arg.(*evalInt64).i != 0)
+		vm.stack[vm.sp-offset] = vm.arena.newEvalBool(arg != nil && arg.(*evalInt64).i != 0)
 		return 1
 	}, "CONV INT64(SP-%d), BOOL", offset)
 }
@@ -848,7 +869,7 @@ func (asm *assembler) Convert_Nj(offset int) {
 func (asm *assembler) Convert_uB(offset int) {
 	asm.emit(func(vm *VirtualMachine) int {
 		arg := vm.stack[vm.sp-offset]
-		vm.stack[vm.sp-offset] = newEvalBool(arg != nil && arg.(*evalUint64).u != 0)
+		vm.stack[vm.sp-offset] = vm.arena.newEvalBool(arg != nil && arg.(*evalUint64).u != 0)
 		return 1
 	}, "CONV UINT64(SP-%d), BOOL", offset)
 }
@@ -1379,7 +1400,7 @@ func (asm *assembler) Fn_COLLATION(col collations.TypedCollation) {
 	}, "FN COLLATION (SP-1)")
 }
 
-func (asm *assembler) Fn_FROM_BASE64() {
+func (asm *assembler) Fn_FROM_BASE64(t sqltypes.Type) {
 	asm.emit(func(vm *VirtualMachine) int {
 		str := vm.stack[vm.sp-1].(*evalBytes)
 
@@ -1390,7 +1411,7 @@ func (asm *assembler) Fn_FROM_BASE64() {
 			vm.stack[vm.sp-1] = nil
 			return 1
 		}
-		str.tt = int16(sqltypes.VarBinary)
+		str.tt = int16(t)
 		str.bytes = decoded[:n]
 		return 1
 	}, "FN FROM_BASE64 VARCHAR(SP-1)")
@@ -1439,7 +1460,7 @@ func (asm *assembler) Fn_JSON_CONTAINS_PATH(match jsonMatch, paths []*json.Path)
 					break
 				}
 			}
-			vm.stack[vm.sp-1] = newEvalBool(matched)
+			vm.stack[vm.sp-1] = vm.arena.newEvalBool(matched)
 			return 1
 		}, "FN JSON_CONTAINS_PATH, SP-1, 'one', [static]")
 	case jsonMatchAll:
@@ -1453,7 +1474,7 @@ func (asm *assembler) Fn_JSON_CONTAINS_PATH(match jsonMatch, paths []*json.Path)
 					break
 				}
 			}
-			vm.stack[vm.sp-1] = newEvalBool(matched)
+			vm.stack[vm.sp-1] = vm.arena.newEvalBool(matched)
 			return 1
 		}, "FN JSON_CONTAINS_PATH, SP-1, 'all', [static]")
 	}
@@ -1812,7 +1833,7 @@ func (asm *assembler) In_table(not bool, table map[vthash.Hash]struct{}) {
 				vm.hash.Reset()
 				lhs.(hashable).Hash(&vm.hash)
 				_, in := table[vm.hash.Sum128()]
-				vm.stack[vm.sp-1] = newEvalBool(!in)
+				vm.stack[vm.sp-1] = vm.arena.newEvalBool(!in)
 			}
 			return 1
 		}, "NOT IN (SP-1), [static table]")
@@ -1823,7 +1844,7 @@ func (asm *assembler) In_table(not bool, table map[vthash.Hash]struct{}) {
 				vm.hash.Reset()
 				lhs.(hashable).Hash(&vm.hash)
 				_, in := table[vm.hash.Sum128()]
-				vm.stack[vm.sp-1] = newEvalBool(in)
+				vm.stack[vm.sp-1] = vm.arena.newEvalBool(in)
 			}
 			return 1
 		}, "IN (SP-1), [static table]")
@@ -1862,9 +1883,147 @@ func (asm *assembler) In_slow(not bool) {
 
 func (asm *assembler) Is(check func(eval) bool) {
 	asm.emit(func(vm *VirtualMachine) int {
-		vm.stack[vm.sp-1] = newEvalBool(check(vm.stack[vm.sp-1]))
+		vm.stack[vm.sp-1] = vm.arena.newEvalBool(check(vm.stack[vm.sp-1]))
 		return 1
 	}, "IS (SP-1), [static]")
+}
+
+func (asm *assembler) Not_i() {
+	asm.emit(func(vm *VirtualMachine) int {
+		arg := vm.stack[vm.sp-1].(*evalInt64)
+		vm.stack[vm.sp-1] = vm.arena.newEvalBool(arg.i == 0)
+		return 1
+	}, "NOT INT64(SP-1)")
+}
+
+func (asm *assembler) Not_u() {
+	asm.emit(func(vm *VirtualMachine) int {
+		arg := vm.stack[vm.sp-1].(*evalUint64)
+		vm.stack[vm.sp-1] = vm.arena.newEvalBool(arg.u == 0)
+		return 1
+	}, "NOT UINT64(SP-1)")
+}
+
+func (asm *assembler) Not_f() {
+	asm.emit(func(vm *VirtualMachine) int {
+		arg := vm.stack[vm.sp-1].(*evalFloat)
+		vm.stack[vm.sp-1] = vm.arena.newEvalBool(arg.f == 0.0)
+		return 1
+	}, "NOT FLOAT64(SP-1)")
+}
+
+func (asm *assembler) Not_d() {
+	asm.emit(func(vm *VirtualMachine) int {
+		arg := vm.stack[vm.sp-1].(*evalDecimal)
+		vm.stack[vm.sp-1] = vm.arena.newEvalBool(arg.dec.IsZero())
+		return 1
+	}, "NOT DECIMAL(SP-1)")
+}
+
+func (asm *assembler) LogicalLeft(opname string) *jump {
+	switch opname {
+	case "AND":
+		j := asm.jumpFrom()
+		asm.emit(func(vm *VirtualMachine) int {
+			left, ok := vm.stack[vm.sp-1].(*evalInt64)
+			if ok && left.i == 0 {
+				return j.offset()
+			}
+			return 1
+		}, "AND CHECK INT64(SP-1)")
+		return j
+	case "OR":
+		j := asm.jumpFrom()
+		asm.emit(func(vm *VirtualMachine) int {
+			left, ok := vm.stack[vm.sp-1].(*evalInt64)
+			if ok && left.i != 0 {
+				left.i = 1
+				return j.offset()
+			}
+			return 1
+		}, "OR CHECK INT64(SP-1)")
+		return j
+	case "XOR":
+		j := asm.jumpFrom()
+		asm.emit(func(vm *VirtualMachine) int {
+			if vm.stack[vm.sp-1] == nil {
+				return j.offset()
+			}
+			return 1
+		}, "XOR CHECK INT64(SP-1)")
+		return j
+	}
+	return nil
+}
+
+func (asm *assembler) LogicalRight(opname string) {
+	asm.adjustStack(-1)
+	switch opname {
+	case "AND":
+		asm.emit(func(vm *VirtualMachine) int {
+			left, lok := vm.stack[vm.sp-2].(*evalInt64)
+			right, rok := vm.stack[vm.sp-1].(*evalInt64)
+
+			isLeft := lok && left.i != 0
+			isRight := rok && right.i != 0
+
+			if isLeft && isRight {
+				left.i = 1
+			} else if rok && !isRight {
+				vm.stack[vm.sp-2] = vm.arena.newEvalBool(false)
+			} else {
+				vm.stack[vm.sp-2] = nil
+			}
+			vm.sp--
+			return 1
+		}, "AND INT64(SP-2), INT64(SP-1)")
+	case "OR":
+		asm.emit(func(vm *VirtualMachine) int {
+			left, lok := vm.stack[vm.sp-2].(*evalInt64)
+			right, rok := vm.stack[vm.sp-1].(*evalInt64)
+
+			isLeft := lok && left.i != 0
+			isRight := rok && right.i != 0
+
+			switch {
+			case !lok:
+				if isRight {
+					vm.stack[vm.sp-2] = vm.arena.newEvalBool(true)
+				}
+			case !rok:
+				vm.stack[vm.sp-2] = nil
+			default:
+				if isLeft || isRight {
+					left.i = 1
+				} else {
+					left.i = 0
+				}
+			}
+			vm.sp--
+			return 1
+		}, "OR INT64(SP-2), INT64(SP-1)")
+	case "XOR":
+		asm.emit(func(vm *VirtualMachine) int {
+			left := vm.stack[vm.sp-2].(*evalInt64)
+			right, rok := vm.stack[vm.sp-1].(*evalInt64)
+
+			isLeft := left.i != 0
+			isRight := rok && right.i != 0
+
+			switch {
+			case !rok:
+				vm.stack[vm.sp-2] = nil
+			default:
+				if isLeft != isRight {
+					left.i = 1
+				} else {
+					left.i = 0
+				}
+			}
+			vm.sp--
+			return 1
+		}, "XOR INT64(SP-2), INT64(SP-1)")
+	}
 }
 
 func (asm *assembler) Like_coerce(expr *LikeExpr, coercion *compiledCoercion) {
@@ -1886,11 +2045,7 @@ func (asm *assembler) Like_coerce(expr *LikeExpr, coercion *compiledCoercion) {
 		}
 
 		match := expr.matchWildcard(bl, br, coercion.col.ID())
-		if match {
-			vm.stack[vm.sp-1] = evalBoolTrue
-		} else {
-			vm.stack[vm.sp-1] = evalBoolFalse
-		}
+		vm.stack[vm.sp-1] = vm.arena.newEvalBool(match)
 		return 1
 	}, "LIKE VARCHAR(SP-2), VARCHAR(SP-1) COERCE AND COLLATE '%s'", coercion.col.Name())
 }
@@ -1904,11 +2059,7 @@ func (asm *assembler) Like_collate(expr *LikeExpr, collation collations.Collatio
 		vm.sp--
 
 		match := expr.matchWildcard(l.bytes, r.bytes, collation.ID())
-		if match {
-			vm.stack[vm.sp-1] = evalBoolTrue
-		} else {
-			vm.stack[vm.sp-1] = evalBoolFalse
-		}
+		vm.stack[vm.sp-1] = vm.arena.newEvalBool(match)
 		return 1
 	}, "LIKE VARCHAR(SP-2), VARCHAR(SP-1) COLLATE '%s'", collation.Name())
 }
@@ -2250,12 +2401,12 @@ func (asm *assembler) PushNull() {
 func (asm *assembler) SetBool(offset int, b bool) {
 	if b {
 		asm.emit(func(vm *VirtualMachine) int {
-			vm.stack[vm.sp-offset] = evalBoolTrue
+			vm.stack[vm.sp-offset] = vm.arena.newEvalBool(true)
 			return 1
 		}, "SET (SP-%d), BOOL(true)", offset)
 	} else {
 		asm.emit(func(vm *VirtualMachine) int {
-			vm.stack[vm.sp-offset] = evalBoolFalse
+			vm.stack[vm.sp-offset] = vm.arena.newEvalBool(false)
 			return 1
 		}, "SET (SP-%d), BOOL(false)", offset)
 	}

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -984,6 +984,203 @@ func (asm *assembler) Div_ff() {
 	}, "DIV FLOAT64(SP-2), FLOAT64(SP-1)")
 }
 
+func (asm *assembler) IntDiv_ii() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalInt64)
+		r := vm.stack[vm.sp-1].(*evalInt64)
+		if r.i == 0 {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			l.i = l.i / r.i
+		}
+		vm.sp--
+		return 1
+	}, "INTDIV INT64(SP-2), INT64(SP-1)")
+}
+
+func (asm *assembler) IntDiv_iu() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalInt64)
+		r := vm.stack[vm.sp-1].(*evalUint64)
+		if r.u == 0 {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			r.u, vm.err = mathIntDiv_iu0(l.i, r.u)
+			vm.stack[vm.sp-2] = r
+		}
+		vm.sp--
+		return 1
+	}, "INTDIV INT64(SP-2), UINT64(SP-1)")
+}
+
+func (asm *assembler) IntDiv_ui() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalUint64)
+		r := vm.stack[vm.sp-1].(*evalInt64)
+		if r.i == 0 {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			l.u, vm.err = mathIntDiv_ui0(l.u, r.i)
+		}
+		vm.sp--
+		return 1
+	}, "INTDIV UINT64(SP-2), INT64(SP-1)")
+}
+
+func (asm *assembler) IntDiv_uu() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalUint64)
+		r := vm.stack[vm.sp-1].(*evalUint64)
+		if r.u == 0 {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			l.u = l.u / r.u
+		}
+		vm.sp--
+		return 1
+	}, "INTDIV UINT64(SP-2), UINT64(SP-1)")
+}
+
+func (asm *assembler) IntDiv_di() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalDecimal)
+		r := vm.stack[vm.sp-1].(*evalDecimal)
+		if r.dec.IsZero() {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			var res int64
+			res, vm.err = mathIntDiv_di0(l, r)
+			vm.stack[vm.sp-2] = vm.arena.newEvalInt64(res)
+		}
+		vm.sp--
+		return 1
+	}, "INTDIV DECIMAL(SP-2), DECIMAL(SP-1)")
+}
+
+func (asm *assembler) IntDiv_du() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalDecimal)
+		r := vm.stack[vm.sp-1].(*evalDecimal)
+		if r.dec.IsZero() {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			var res uint64
+			res, vm.err = mathIntDiv_du0(l, r)
+			vm.stack[vm.sp-2] = vm.arena.newEvalUint64(res)
+		}
+		vm.sp--
+		return 1
+	}, "UINTDIV DECIMAL(SP-2), DECIMAL(SP-1)")
+}
+
+func (asm *assembler) Mod_ii() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalInt64)
+		r := vm.stack[vm.sp-1].(*evalInt64)
+		if r.i == 0 {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			l.i = l.i % r.i
+		}
+		vm.sp--
+		return 1
+	}, "MOD INT64(SP-2), INT64(SP-1)")
+}
+
+func (asm *assembler) Mod_iu() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalInt64)
+		r := vm.stack[vm.sp-1].(*evalUint64)
+		if r.u == 0 {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			l.i = mathMod_iu0(l.i, r.u)
+		}
+		vm.sp--
+		return 1
+	}, "MOD INT64(SP-2), UINT64(SP-1)")
+}
+
+func (asm *assembler) Mod_ui() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalUint64)
+		r := vm.stack[vm.sp-1].(*evalInt64)
+		if r.i == 0 {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			l.u, vm.err = mathMod_ui0(l.u, r.i)
+		}
+		vm.sp--
+		return 1
+	}, "MOD UINT64(SP-2), INT64(SP-1)")
+}
+
+func (asm *assembler) Mod_uu() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalUint64)
+		r := vm.stack[vm.sp-1].(*evalUint64)
+		if r.u == 0 {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			l.u = l.u % r.u
+		}
+		vm.sp--
+		return 1
+	}, "MOD UINT64(SP-2), UINT64(SP-1)")
+}
+
+func (asm *assembler) Mod_ff() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalFloat)
+		r := vm.stack[vm.sp-1].(*evalFloat)
+		if r.f == 0.0 {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			l.f = math.Mod(l.f, r.f)
+		}
+		vm.sp--
+		return 1
+	}, "MOD FLOAT64(SP-2), FLOAT64(SP-1)")
+}
+
+func (asm *assembler) Mod_dd() {
+	asm.adjustStack(-1)
+
+	asm.emit(func(vm *VirtualMachine) int {
+		l := vm.stack[vm.sp-2].(*evalDecimal)
+		r := vm.stack[vm.sp-1].(*evalDecimal)
+		if r.dec.IsZero() {
+			vm.stack[vm.sp-2] = nil
+		} else {
+			l.dec, l.length = mathMod_dd0(l, r)
+		}
+		vm.sp--
+		return 1
+	}, "MOD DECIMAL(SP-2), DECIMAL(SP-1)")
+}
+
 func (asm *assembler) Fn_ASCII() {
 	asm.emit(func(vm *VirtualMachine) int {
 		arg := vm.stack[vm.sp-1].(*evalBytes)

--- a/go/vt/vtgate/evalengine/compiler_compare.go
+++ b/go/vt/vtgate/evalengine/compiler_compare.go
@@ -271,7 +271,7 @@ func (c *compiler) compileLike(expr *LikeExpr) (ctype, error) {
 
 	skip := c.compileNullCheck2(lt, rt)
 
-	if !sqltypes.IsText(lt.Type) && !sqltypes.IsBinary(lt.Type) {
+	if !lt.isTextual() {
 		c.asm.Convert_xc(2, sqltypes.VarChar, c.defaultCollation, 0, false)
 		lt.Col = collations.TypedCollation{
 			Collation:    c.defaultCollation,
@@ -280,7 +280,7 @@ func (c *compiler) compileLike(expr *LikeExpr) (ctype, error) {
 		}
 	}
 
-	if !sqltypes.IsText(rt.Type) && !sqltypes.IsBinary(rt.Type) {
+	if !rt.isTextual() {
 		c.asm.Convert_xc(1, sqltypes.VarChar, c.defaultCollation, 0, false)
 		rt.Col = collations.TypedCollation{
 			Collation:    c.defaultCollation,

--- a/go/vt/vtgate/evalengine/compiler_fn.go
+++ b/go/vt/vtgate/evalengine/compiler_fn.go
@@ -261,16 +261,21 @@ func (c *compiler) compileFn_FROM_BASE64(call *builtinFromBase64) (ctype, error)
 
 	skip := c.compileNullCheck1(str)
 
+	t := sqltypes.VarBinary
+	if str.Type == sqltypes.Blob || str.Type == sqltypes.TypeJSON {
+		t = sqltypes.Blob
+	}
+
 	switch {
 	case sqltypes.IsText(str.Type) || sqltypes.IsBinary(str.Type):
 	default:
-		c.asm.Convert_xc(1, sqltypes.VarBinary, c.defaultCollation, 0, false)
+		c.asm.Convert_xc(1, t, c.defaultCollation, 0, false)
 	}
 
-	c.asm.Fn_FROM_BASE64()
+	c.asm.Fn_FROM_BASE64(t)
 	c.asm.jumpDestination(skip)
 
-	return ctype{Type: sqltypes.VarBinary, Col: collationBinary}, nil
+	return ctype{Type: t, Col: collationBinary}, nil
 }
 
 func (c *compiler) compileFn_CCASE(call *builtinChangeCase) (ctype, error) {

--- a/go/vt/vtgate/evalengine/compiler_fn.go
+++ b/go/vt/vtgate/evalengine/compiler_fn.go
@@ -211,7 +211,7 @@ func (c *compiler) compileFn_REPEAT(expr *builtinRepeat) (ctype, error) {
 	skip := c.compileNullCheck2(str, repeat)
 
 	switch {
-	case sqltypes.IsText(str.Type) || sqltypes.IsBinary(str.Type):
+	case str.isTextual():
 	default:
 		c.asm.Convert_xc(2, sqltypes.VarChar, c.defaultCollation, 0, false)
 	}
@@ -236,7 +236,7 @@ func (c *compiler) compileFn_TO_BASE64(call *builtinToBase64) (ctype, error) {
 	}
 
 	switch {
-	case sqltypes.IsText(str.Type) || sqltypes.IsBinary(str.Type):
+	case str.isTextual():
 	default:
 		c.asm.Convert_xc(1, t, c.defaultCollation, 0, false)
 	}
@@ -267,7 +267,7 @@ func (c *compiler) compileFn_FROM_BASE64(call *builtinFromBase64) (ctype, error)
 	}
 
 	switch {
-	case sqltypes.IsText(str.Type) || sqltypes.IsBinary(str.Type):
+	case str.isTextual():
 	default:
 		c.asm.Convert_xc(1, t, c.defaultCollation, 0, false)
 	}
@@ -287,7 +287,7 @@ func (c *compiler) compileFn_CCASE(call *builtinChangeCase) (ctype, error) {
 	skip := c.compileNullCheck1(str)
 
 	switch {
-	case sqltypes.IsText(str.Type) || sqltypes.IsBinary(str.Type):
+	case str.isTextual():
 	default:
 		c.asm.Convert_xc(1, sqltypes.VarChar, c.defaultCollation, 0, false)
 	}
@@ -307,7 +307,7 @@ func (c *compiler) compileFn_xLENGTH(call callable, asm_ins func()) (ctype, erro
 	skip := c.compileNullCheck1(str)
 
 	switch {
-	case sqltypes.IsText(str.Type) || sqltypes.IsBinary(str.Type):
+	case str.isTextual():
 	default:
 		c.asm.Convert_xc(1, sqltypes.VarChar, c.defaultCollation, 0, false)
 	}
@@ -327,7 +327,7 @@ func (c *compiler) compileFn_ASCII(call *builtinASCII) (ctype, error) {
 	skip := c.compileNullCheck1(str)
 
 	switch {
-	case sqltypes.IsText(str.Type) || sqltypes.IsBinary(str.Type):
+	case str.isTextual():
 	default:
 		c.asm.Convert_xc(1, sqltypes.VarChar, c.defaultCollation, 0, false)
 	}
@@ -360,7 +360,7 @@ func (c *compiler) compileFn_HEX(call *builtinHex) (ctype, error) {
 	switch {
 	case sqltypes.IsNumber(str.Type), sqltypes.IsDecimal(str.Type):
 		c.asm.Fn_HEX_d(col)
-	case sqltypes.IsText(str.Type) || sqltypes.IsBinary(str.Type):
+	case str.isTextual():
 		c.asm.Fn_HEX_c(t, col)
 	default:
 		c.asm.Convert_xc(1, t, c.defaultCollation, 0, false)

--- a/go/vt/vtgate/evalengine/eval.go
+++ b/go/vt/vtgate/evalengine/eval.go
@@ -130,7 +130,22 @@ func evalIsTruthy(e eval) boolean {
 	case *evalDecimal:
 		return makeboolean(!e.dec.IsZero())
 	case *evalBytes:
+		if e.isHexLiteral {
+			hex, ok := e.toNumericHex()
+			if !ok {
+				// overflow
+				return makeboolean(true)
+			}
+			return makeboolean(hex.u != 0)
+		}
 		return makeboolean(parseStringToFloat(e.string()) != 0.0)
+	case *evalJSON:
+		switch e.Type() {
+		case json.TypeNumber:
+			return makeboolean(parseStringToFloat(e.Raw()) != 0.0)
+		default:
+			return makeboolean(true)
+		}
 	default:
 		panic("unhandled case: evalIsTruthy")
 	}

--- a/go/vt/vtgate/evalengine/eval_numeric.go
+++ b/go/vt/vtgate/evalengine/eval_numeric.go
@@ -111,9 +111,9 @@ func evalToNumeric(e eval) evalNumeric {
 	case *evalJSON:
 		switch e.Type() {
 		case json.TypeTrue:
-			return newEvalBool(true)
+			return &evalFloat{f: 1.0}
 		case json.TypeFalse:
-			return newEvalBool(false)
+			return &evalFloat{f: 0.0}
 		case json.TypeNumber, json.TypeString:
 			return &evalFloat{f: parseStringToFloat(e.Raw())}
 		default:

--- a/go/vt/vtgate/evalengine/expr_arithmetic.go
+++ b/go/vt/vtgate/evalengine/expr_arithmetic.go
@@ -53,8 +53,13 @@ var _ opArith = (*opArithIntDiv)(nil)
 var _ opArith = (*opArithMod)(nil)
 
 func (b *ArithmeticExpr) eval(env *ExpressionEnv) (eval, error) {
-	left, right, err := b.arguments(env)
-	if left == nil || right == nil || err != nil {
+	left, err := b.Left.eval(env)
+	if left == nil || err != nil {
+		return nil, err
+	}
+
+	right, err := b.Right.eval(env)
+	if right == nil || err != nil {
 		return nil, err
 	}
 	return b.Op.eval(left, right)

--- a/go/vt/vtgate/evalengine/expr_arithmetic.go
+++ b/go/vt/vtgate/evalengine/expr_arithmetic.go
@@ -35,10 +35,12 @@ type (
 		String() string
 	}
 
-	opArithAdd struct{}
-	opArithSub struct{}
-	opArithMul struct{}
-	opArithDiv struct{}
+	opArithAdd    struct{}
+	opArithSub    struct{}
+	opArithMul    struct{}
+	opArithDiv    struct{}
+	opArithIntDiv struct{}
+	opArithMod    struct{}
 )
 
 var _ Expr = (*ArithmeticExpr)(nil)
@@ -47,6 +49,8 @@ var _ opArith = (*opArithAdd)(nil)
 var _ opArith = (*opArithSub)(nil)
 var _ opArith = (*opArithMul)(nil)
 var _ opArith = (*opArithDiv)(nil)
+var _ opArith = (*opArithIntDiv)(nil)
+var _ opArith = (*opArithMod)(nil)
 
 func (b *ArithmeticExpr) eval(env *ExpressionEnv) (eval, error) {
 	left, right, err := b.arguments(env)
@@ -78,9 +82,22 @@ func (b *ArithmeticExpr) typeof(env *ExpressionEnv) (sqltypes.Type, typeFlag) {
 	switch b.Op.(type) {
 	case *opArithDiv:
 		if t1 == sqltypes.Float64 || t2 == sqltypes.Float64 {
-			return sqltypes.Float64, flags
+			return sqltypes.Float64, flags | flagNullable
 		}
-		return sqltypes.Decimal, flags
+		return sqltypes.Decimal, flags | flagNullable
+	case *opArithIntDiv:
+		if t1 == sqltypes.Uint64 || t2 == sqltypes.Uint64 {
+			return sqltypes.Uint64, flags | flagNullable
+		}
+		return sqltypes.Int64, flags | flagNullable
+	case *opArithMod:
+		if t1 == sqltypes.Float64 || t2 == sqltypes.Float64 {
+			return sqltypes.Float64, flags | flagNullable
+		}
+		if t1 == sqltypes.Decimal || t2 == sqltypes.Decimal {
+			return sqltypes.Decimal, flags | flagNullable
+		}
+		return t1, flags | flagNullable
 	}
 
 	switch t1 {
@@ -121,6 +138,16 @@ func (op *opArithDiv) eval(left, right eval) (eval, error) {
 	return divideNumericWithError(left, right, true)
 }
 func (op *opArithDiv) String() string { return "/" }
+
+func (op *opArithIntDiv) eval(left, right eval) (eval, error) {
+	return integerDivideNumericWithError(left, right, true)
+}
+func (op *opArithIntDiv) String() string { return "DIV" }
+
+func (op *opArithMod) eval(left, right eval) (eval, error) {
+	return modNumericWithError(left, right, true)
+}
+func (op *opArithMod) String() string { return "DIV" }
 
 func (n *NegateExpr) eval(env *ExpressionEnv) (eval, error) {
 	e, err := n.Inner.eval(env)

--- a/go/vt/vtgate/evalengine/expr_bit.go
+++ b/go/vt/vtgate/evalengine/expr_bit.go
@@ -173,8 +173,13 @@ func (o opBitAnd) BitwiseOp() string { return "&" }
 var errBitwiseOperandsLength = vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Binary operands of bitwise operators must be of equal length")
 
 func (bit *BitwiseExpr) eval(env *ExpressionEnv) (eval, error) {
-	l, r, err := bit.arguments(env)
-	if l == nil || r == nil || err != nil {
+	l, err := bit.Left.eval(env)
+	if l == nil || err != nil {
+		return nil, err
+	}
+
+	r, err := bit.Right.eval(env)
+	if r == nil || err != nil {
 		return nil, err
 	}
 

--- a/go/vt/vtgate/evalengine/expr_logical.go
+++ b/go/vt/vtgate/evalengine/expr_logical.go
@@ -25,7 +25,7 @@ import (
 type (
 	LogicalExpr struct {
 		BinaryExpr
-		op     func(left, right boolean) boolean
+		op     func(left, right Expr, env *ExpressionEnv) (boolean, error)
 		opname string
 	}
 
@@ -100,55 +100,100 @@ func (left boolean) not() boolean {
 	}
 }
 
-func (left boolean) and(right boolean) boolean {
+func opAnd(le, re Expr, env *ExpressionEnv) (boolean, error) {
 	// Logical AND.
 	// Evaluates to 1 if all operands are nonzero and not NULL, to 0 if one or more operands are 0, otherwise NULL is returned.
+	l, err := le.eval(env)
+	if err != nil {
+		return boolNULL, err
+	}
+
+	left := evalIsTruthy(l)
+	if left == boolFalse {
+		return boolFalse, nil
+	}
+
+	r, err := re.eval(env)
+	if err != nil {
+		return boolNULL, err
+	}
+	right := evalIsTruthy(r)
+
 	switch {
 	case left == boolTrue && right == boolTrue:
-		return boolTrue
-	case left == boolFalse || right == boolFalse:
-		return boolFalse
+		return boolTrue, nil
+	case right == boolFalse:
+		return boolFalse, nil
 	default:
-		return boolNULL
+		return boolNULL, nil
 	}
 }
 
-func (left boolean) or(right boolean) boolean {
+func opOr(le, re Expr, env *ExpressionEnv) (boolean, error) {
 	// Logical OR. When both operands are non-NULL, the result is 1 if any operand is nonzero, and 0 otherwise.
 	// With a NULL operand, the result is 1 if the other operand is nonzero, and NULL otherwise.
 	// If both operands are NULL, the result is NULL.
+	l, err := le.eval(env)
+	if err != nil {
+		return boolNULL, err
+	}
+
+	left := evalIsTruthy(l)
+	if left == boolTrue {
+		return boolTrue, nil
+	}
+
+	r, err := re.eval(env)
+	if err != nil {
+		return boolNULL, err
+	}
+	right := evalIsTruthy(r)
+
 	switch {
 	case left == boolNULL:
 		if right == boolTrue {
-			return boolTrue
+			return boolTrue, nil
 		}
-		return boolNULL
+		return boolNULL, nil
 
 	case right == boolNULL:
-		if left == boolTrue {
-			return boolTrue
-		}
-		return boolNULL
+		return boolNULL, nil
 
 	default:
-		if left == boolTrue || right == boolTrue {
-			return boolTrue
+		if right == boolTrue {
+			return boolTrue, nil
 		}
-		return boolFalse
+		return boolFalse, nil
 	}
 }
 
-func (left boolean) xor(right boolean) boolean {
+func opXor(le, re Expr, env *ExpressionEnv) (boolean, error) {
 	// Logical XOR. Returns NULL if either operand is NULL.
 	// For non-NULL operands, evaluates to 1 if an odd number of operands is nonzero, otherwise 0 is returned.
+	l, err := le.eval(env)
+	if err != nil {
+		return boolNULL, err
+	}
+
+	left := evalIsTruthy(l)
+	if left == boolNULL {
+		return boolNULL, nil
+	}
+
+	r, err := re.eval(env)
+	if err != nil {
+		return boolNULL, err
+	}
+	right := evalIsTruthy(r)
+
 	switch {
 	case left == boolNULL || right == boolNULL:
-		return boolNULL
+		return boolNULL, nil
 	default:
 		if left != right {
-			return boolTrue
+			return boolTrue, nil
 		}
-		return boolFalse
+		return boolFalse, nil
 	}
 }
 
@@ -162,21 +207,18 @@ func (n *NotExpr) eval(env *ExpressionEnv) (eval, error) {
 
 func (n *NotExpr) typeof(env *ExpressionEnv) (sqltypes.Type, typeFlag) {
 	_, flags := n.Inner.typeof(env)
-	return sqltypes.Uint64, flags
+	return sqltypes.Int64, flags | flagIsBoolean
 }
 
 func (l *LogicalExpr) eval(env *ExpressionEnv) (eval, error) {
-	left, right, err := l.arguments(env)
-	if err != nil {
-		return nil, err
-	}
-	return l.op(evalIsTruthy(left), evalIsTruthy(right)).eval(), nil
+	res, err := l.op(l.Left, l.Right, env)
+	return res.eval(), err
 }
 
 func (l *LogicalExpr) typeof(env *ExpressionEnv) (sqltypes.Type, typeFlag) {
 	_, f1 := l.Left.typeof(env)
 	_, f2 := l.Right.typeof(env)
-	return sqltypes.Uint64, f1 | f2
+	return sqltypes.Int64, f1 | f2 | flagIsBoolean
 }
 
 func (i *IsExpr) eval(env *ExpressionEnv) (eval, error) {

--- a/go/vt/vtgate/evalengine/fn_json.go
+++ b/go/vt/vtgate/evalengine/fn_json.go
@@ -168,7 +168,7 @@ func (call *builtinJSONObject) eval(env *ExpressionEnv) (eval, error) {
 		if err != nil {
 			return nil, err
 		}
-		val1, err := evalToJSON(val)
+		val1, err := argToJSON(val)
 		if err != nil {
 			return nil, err
 		}
@@ -189,7 +189,7 @@ func (call *builtinJSONArray) eval(env *ExpressionEnv) (eval, error) {
 		if err != nil {
 			return nil, err
 		}
-		arg1, err := evalToJSON(arg)
+		arg1, err := argToJSON(arg)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/evalengine/internal/decimal/decimal.go
+++ b/go/vt/vtgate/evalengine/internal/decimal/decimal.go
@@ -362,7 +362,7 @@ func (d Decimal) Div(d2 Decimal, scaleIncr int32) Decimal {
 		scaleIncr = 0
 	}
 	scale := myBigDigits(fracLeft+fracRight+scaleIncr) * 9
-	q, _ := d.quoRem(d2, scale)
+	q, _ := d.QuoRem(d2, scale)
 	return q
 }
 
@@ -372,15 +372,15 @@ func (d Decimal) div(d2 Decimal) Decimal {
 	return d.divRound(d2, int32(divisionPrecision))
 }
 
-// quoRem does division with remainder
-// d.quoRem(d2,precision) returns quotient q and remainder r such that
+// QuoRem does division with remainder
+// d.QuoRem(d2,precision) returns quotient q and remainder r such that
 //
 //	d = d2 * q + r, q an integer multiple of 10^(-precision)
 //	0 <= r < abs(d2) * 10 ^(-precision) if d>=0
 //	0 >= r > -abs(d2) * 10 ^(-precision) if d<0
 //
 // Note that precision<0 is allowed as input.
-func (d Decimal) quoRem(d2 Decimal, precision int32) (Decimal, Decimal) {
+func (d Decimal) QuoRem(d2 Decimal, precision int32) (Decimal, Decimal) {
 	d.ensureInitialized()
 	d2.ensureInitialized()
 	if d2.value.Sign() == 0 {
@@ -389,7 +389,7 @@ func (d Decimal) quoRem(d2 Decimal, precision int32) (Decimal, Decimal) {
 	scale := -precision
 	e := int64(d.exp - d2.exp - scale)
 	if e > math.MaxInt32 || e < math.MinInt32 {
-		panic("overflow in decimal quoRem")
+		panic("overflow in decimal QuoRem")
 	}
 	var aa, bb, expo big.Int
 	var scalerest int32
@@ -428,7 +428,7 @@ func (d Decimal) quoRem(d2 Decimal, precision int32) (Decimal, Decimal) {
 // Note that precision<0 is allowed as input.
 func (d Decimal) divRound(d2 Decimal, precision int32) Decimal {
 	// quoRem already checks initialization
-	q, r := d.quoRem(d2, precision)
+	q, r := d.QuoRem(d2, precision)
 
 	// the actual rounding decision is based on comparing r*10^precision and d2/2
 	// instead compare 2 r 10 ^precision and d2

--- a/go/vt/vtgate/evalengine/internal/decimal/decimal_test.go
+++ b/go/vt/vtgate/evalengine/internal/decimal/decimal_test.go
@@ -746,11 +746,11 @@ func TestDecimal_QuoRem(t *testing.T) {
 		d, _ := NewFromString(inp4.d)
 		d2, _ := NewFromString(inp4.d2)
 		prec := inp4.exp
-		q, r := d.quoRem(d2, prec)
+		q, r := d.QuoRem(d2, prec)
 		expectedQ, _ := NewFromString(inp4.q)
 		expectedR, _ := NewFromString(inp4.r)
 		if !q.Equal(expectedQ) || !r.Equal(expectedR) {
-			t.Errorf("bad quoRem division %s , %s , %d got %v, %v expected %s , %s",
+			t.Errorf("bad QuoRem division %s , %s , %d got %v, %v expected %s , %s",
 				inp4.d, inp4.d2, prec, q, r, inp4.q, inp4.r)
 		}
 		if !d.Equal(d2.mul(q).Add(r)) {
@@ -813,7 +813,7 @@ func TestDecimal_QuoRem2(t *testing.T) {
 		}
 		d2 := tc.d2
 		prec := tc.prec
-		q, r := d.quoRem(d2, prec)
+		q, r := d.QuoRem(d2, prec)
 		// rule 1: d = d2*q +r
 		if !d.Equal(d2.mul(q).Add(r)) {
 			t.Errorf("not fitting, d=%v, d2=%v, prec=%d, q=%v, r=%v",

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -537,7 +537,7 @@ func Types(yield Query) {
 }
 
 func Arithmetic(yield Query) {
-	operators := []string{"+", "-", "*", "/"}
+	operators := []string{"+", "-", "*", "/", "DIV", "%", "MOD"}
 
 	for _, op := range operators {
 		for _, lhs := range inputConversions {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -54,6 +54,8 @@ var Cases = []TestCase{
 	{Run: LikeComparison},
 	{Run: MultiComparisons},
 	{Run: IsStatement},
+	{Run: NotStatement},
+	{Run: LogicalStatement},
 	{Run: TupleComparisons},
 	{Run: Comparisons},
 	{Run: InStatement},
@@ -121,7 +123,7 @@ func JSONObject(yield Query) {
 
 func CharsetConversionOperators(yield Query) {
 	var introducers = []string{
-		"", "_latin1", "_utf8mb4", "_utf8", "_binary",
+		"", "_lat21	in1", "_utf8mb4", "_utf8", "_binary",
 	}
 	var contents = []string{
 		`"foobar"`, `X'4D7953514C'`,
@@ -436,6 +438,12 @@ func BitwiseOperators(yield Query) {
 				yield(fmt.Sprintf("%s %s %s", lhs, op, rhs), nil)
 			}
 		}
+
+		for _, lhs := range inputConversions {
+			for _, rhs := range inputConversions {
+				yield(fmt.Sprintf("%s %s %s", lhs, op, rhs), nil)
+			}
+		}
 	}
 }
 
@@ -720,6 +728,23 @@ func IsStatement(yield Query) {
 	}
 }
 
+func NotStatement(yield Query) {
+	for _, i := range inputConversions {
+		yield(fmt.Sprintf("NOT %s", i), nil)
+	}
+}
+
+func LogicalStatement(yield Query) {
+	var ops = []string{"AND", "OR", "XOR"}
+	for _, op := range ops {
+		for _, l := range inputConversions {
+			for _, r := range inputConversions {
+				yield(fmt.Sprintf("%s %s %s", l, op, r), nil)
+			}
+		}
+	}
+}
+
 func TupleComparisons(yield Query) {
 	var elems = []string{"NULL", "-1", "0", "1"}
 	var operators = []string{"=", "!=", "<=>", "<", "<=", ">", ">="}
@@ -872,5 +897,10 @@ func InStatement(yield Query) {
 		yield(fmt.Sprintf("%s IN (%s, %s)", inputs[2], inputs[1], inputs[0]), nil)
 		yield(fmt.Sprintf("%s IN (%s, %s)", inputs[1], inputs[0], inputs[2]), nil)
 		yield(fmt.Sprintf("%s IN (%s, %s, %s)", inputs[0], inputs[1], inputs[2], inputs[0]), nil)
+
+		yield(fmt.Sprintf("%s NOT IN (%s, %s)", inputs[0], inputs[1], inputs[2]), nil)
+		yield(fmt.Sprintf("%s NOT IN (%s, %s)", inputs[2], inputs[1], inputs[0]), nil)
+		yield(fmt.Sprintf("%s NOT IN (%s, %s)", inputs[1], inputs[0], inputs[2]), nil)
+		yield(fmt.Sprintf("%s NOT IN (%s, %s, %s)", inputs[0], inputs[1], inputs[2], inputs[0]), nil)
 	})
 }

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -123,7 +123,7 @@ func JSONObject(yield Query) {
 
 func CharsetConversionOperators(yield Query) {
 	var introducers = []string{
-		"", "_lat21	in1", "_utf8mb4", "_utf8", "_binary",
+		"", "_latin1", "_utf8mb4", "_utf8", "_binary",
 	}
 	var contents = []string{
 		`"foobar"`, `X'4D7953514C'`,
@@ -729,13 +729,16 @@ func IsStatement(yield Query) {
 }
 
 func NotStatement(yield Query) {
-	for _, i := range inputConversions {
-		yield(fmt.Sprintf("NOT %s", i), nil)
+	var ops = []string{"NOT", "!"}
+	for _, op := range ops {
+		for _, i := range inputConversions {
+			yield(fmt.Sprintf("%s %s", op, i), nil)
+		}
 	}
 }
 
 func LogicalStatement(yield Query) {
-	var ops = []string{"AND", "OR", "XOR"}
+	var ops = []string{"AND", "&&", "OR", "||", "XOR"}
 	for _, op := range ops {
 		for _, l := range inputConversions {
 			for _, r := range inputConversions {

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -97,6 +97,12 @@ var inputConversions = []string{
 	"18446744073709540000e0",
 	"-18446744073709540000e0",
 	"JSON_OBJECT()", "JSON_ARRAY()",
+	"cast(0 as json)", "cast(1 as json)",
+	"cast(true as json)", "cast(false as json)",
+	"cast('{}' as json)", "cast('[]' as json)",
+	"cast('null' as json)", "cast('true' as json)", "cast('false' as json)",
+	"cast('1' as json)", "cast('1.1' as json)", "cast('-1.1' as json)",
+	"cast('\"foo\"' as json)", "cast('invalid' as json)",
 }
 
 const inputPi = "314159265358979323846264338327950288419716939937510582097494459"

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -106,14 +106,14 @@ func (ast *astCompiler) translateLogicalExpr(opname string, left, right sqlparse
 		return nil, err
 	}
 
-	var logic func(l, r boolean) boolean
+	var logic func(l, r Expr, env *ExpressionEnv) (boolean, error)
 	switch opname {
 	case "AND":
-		logic = func(l, r boolean) boolean { return l.and(r) }
+		logic = func(l, r Expr, env *ExpressionEnv) (boolean, error) { return opAnd(l, r, env) }
 	case "OR":
-		logic = func(l, r boolean) boolean { return l.or(r) }
+		logic = func(l, r Expr, env *ExpressionEnv) (boolean, error) { return opOr(l, r, env) }
 	case "XOR":
-		logic = func(l, r boolean) boolean { return l.xor(r) }
+		logic = func(l, r Expr, env *ExpressionEnv) (boolean, error) { return opXor(l, r, env) }
 	default:
 		panic("unexpected logical operator")
 	}

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -234,6 +234,10 @@ func (ast *astCompiler) translateBinaryExpr(binary *sqlparser.BinaryExpr) (Expr,
 		return &ArithmeticExpr{BinaryExpr: binaryExpr, Op: &opArithMul{}}, nil
 	case sqlparser.DivOp:
 		return &ArithmeticExpr{BinaryExpr: binaryExpr, Op: &opArithDiv{}}, nil
+	case sqlparser.IntDivOp:
+		return &ArithmeticExpr{BinaryExpr: binaryExpr, Op: &opArithIntDiv{}}, nil
+	case sqlparser.ModOp:
+		return &ArithmeticExpr{BinaryExpr: binaryExpr, Op: &opArithMod{}}, nil
 	case sqlparser.BitAndOp:
 		return &BitwiseExpr{BinaryExpr: binaryExpr, Op: &opBitAnd{}}, nil
 	case sqlparser.BitOrOp:

--- a/go/vt/vtgate/evalengine/translate_card.go
+++ b/go/vt/vtgate/evalengine/translate_card.go
@@ -134,6 +134,8 @@ func (ast *astCompiler) cardExpr(expr Expr) error {
 		return ast.cardUnary(expr.Inner)
 	case *BitwiseNotExpr:
 		return ast.cardUnary(expr.Inner)
+	case *NotExpr:
+		return ast.cardUnary(expr.Inner)
 	case *ArithmeticExpr:
 		return ast.cardBinary(expr.Left, expr.Right)
 	case *LogicalExpr:


### PR DESCRIPTION
As follow up on #12369, this implements additional missing arithmetic support for `DIV`, `%` (and the `MOD` alias). 

It also adds support to the compiler for `NOT`, `AND`, `OR` and `XOR` which was missing as well. 

## Related Issue(s)

Implements part of the items listed in #9647 as well.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required