### PR TITLE
Refactor: go/vt/vtgate/engine/opcode to reduce `semantics` package dependencies

### DIFF
--- a/go/vt/vtgate/engine/concatenate.go
+++ b/go/vt/vtgate/engine/concatenate.go
@@ -82,8 +82,8 @@ func formatTwoOptionsNicely(a, b string) string {
 	return a + "_" + b
 }
 
-// ErrWrongNumberOfColumnsInSelect is an error
-var ErrWrongNumberOfColumnsInSelect = vterrors.NewErrorf(vtrpcpb.Code_FAILED_PRECONDITION, vterrors.WrongNumberOfColumnsInSelect, "The used SELECT statements have a different number of columns")
+// errWrongNumberOfColumnsInSelect is an error
+var errWrongNumberOfColumnsInSelect = vterrors.NewErrorf(vtrpcpb.Code_FAILED_PRECONDITION, vterrors.WrongNumberOfColumnsInSelect, "The used SELECT statements have a different number of columns")
 
 // TryExecute performs a non-streaming exec.
 func (c *Concatenate) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
@@ -106,7 +106,7 @@ func (c *Concatenate) TryExecute(ctx context.Context, vcursor VCursor, bindVars 
 		if len(rows) > 0 &&
 			len(r.Rows) > 0 &&
 			len(rows[0]) != len(r.Rows[0]) {
-			return nil, ErrWrongNumberOfColumnsInSelect
+			return nil, errWrongNumberOfColumnsInSelect
 		}
 
 		rows = append(rows, r.Rows...)
@@ -350,7 +350,7 @@ func (c *Concatenate) description() PrimitiveDescription {
 
 func (c *Concatenate) compareFields(fields1 []*querypb.Field, fields2 []*querypb.Field) error {
 	if len(fields1) != len(fields2) {
-		return ErrWrongNumberOfColumnsInSelect
+		return errWrongNumberOfColumnsInSelect
 	}
 	for i, field1 := range fields1 {
 		if _, found := c.NoNeedToTypeCheck[i]; found {

--- a/go/vt/vtgate/engine/opcode/constants.go
+++ b/go/vt/vtgate/engine/opcode/constants.go
@@ -1,0 +1,97 @@
+package opcode
+
+import (
+	"fmt"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+// PulloutOpcode is a number representing the opcode
+// for the PulloutSubquery primitive.
+type PulloutOpcode int
+
+// This is the list of PulloutOpcode values.
+const (
+	PulloutValue = PulloutOpcode(iota)
+	PulloutIn
+	PulloutNotIn
+	PulloutExists
+)
+
+var pulloutName = map[PulloutOpcode]string{
+	PulloutValue:  "PulloutValue",
+	PulloutIn:     "PulloutIn",
+	PulloutNotIn:  "PulloutNotIn",
+	PulloutExists: "PulloutExists",
+}
+
+func (code PulloutOpcode) String() string {
+	return pulloutName[code]
+}
+
+// MarshalJSON serializes the PulloutOpcode as a JSON string.
+// It's used for testing and diagnostics.
+func (code PulloutOpcode) MarshalJSON() ([]byte, error) {
+	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
+}
+
+// AggregateOpcode is the aggregation Opcode.
+type AggregateOpcode int
+
+// These constants list the possible aggregate opcodes.
+const (
+	AggregateUnassigned = AggregateOpcode(iota)
+	AggregateCount
+	AggregateSum
+	AggregateMin
+	AggregateMax
+	AggregateCountDistinct
+	AggregateSumDistinct
+	AggregateGtid
+	AggregateRandom
+	AggregateCountStar
+)
+
+var (
+	// OpcodeType keeps track of the known output types for different aggregate functions
+	OpcodeType = map[AggregateOpcode]querypb.Type{
+		AggregateCountDistinct: sqltypes.Int64,
+		AggregateCount:         sqltypes.Int64,
+		AggregateCountStar:     sqltypes.Int64,
+		AggregateSumDistinct:   sqltypes.Decimal,
+		AggregateSum:           sqltypes.Decimal,
+		AggregateGtid:          sqltypes.VarChar,
+	}
+)
+
+// SupportedAggregates maps the list of supported aggregate
+// functions to their opcodes.
+var SupportedAggregates = map[string]AggregateOpcode{
+	"count": AggregateCount,
+	"sum":   AggregateSum,
+	"min":   AggregateMin,
+	"max":   AggregateMax,
+	// These functions don't exist in mysql, but are used
+	// to display the plan.
+	"count_distinct": AggregateCountDistinct,
+	"sum_distinct":   AggregateSumDistinct,
+	"vgtid":          AggregateGtid,
+	"count_star":     AggregateCountStar,
+	"random":         AggregateRandom,
+}
+
+func (code AggregateOpcode) String() string {
+	for k, v := range SupportedAggregates {
+		if v == code {
+			return k
+		}
+	}
+	return "ERROR"
+}
+
+// MarshalJSON serializes the AggregateOpcode as a JSON string.
+// It's used for testing and diagnostics.
+func (code AggregateOpcode) MarshalJSON() ([]byte, error) {
+	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
+}

--- a/go/vt/vtgate/engine/opcode/constants.go
+++ b/go/vt/vtgate/engine/opcode/constants.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package opcode
 
 import (

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -26,10 +26,18 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/sqltypes"
+	. "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+var (
+	// Some predefined values
+	countZero = sqltypes.MakeTrusted(sqltypes.Int64, []byte("0"))
+	countOne  = sqltypes.MakeTrusted(sqltypes.Int64, []byte("1"))
+	sumZero   = sqltypes.MakeTrusted(sqltypes.Decimal, []byte("0"))
 )
 
 var _ Primitive = (*OrderedAggregate)(nil)
@@ -137,70 +145,6 @@ func (ap *AggregateParams) String() string {
 		return fmt.Sprintf("%s%s(%s) AS %s", ap.Opcode.String(), dispOrigOp, keyCol, ap.Alias)
 	}
 	return fmt.Sprintf("%s%s(%s)", ap.Opcode.String(), dispOrigOp, keyCol)
-}
-
-// AggregateOpcode is the aggregation Opcode.
-type AggregateOpcode int
-
-// These constants list the possible aggregate opcodes.
-const (
-	AggregateUnassigned = AggregateOpcode(iota)
-	AggregateCount
-	AggregateSum
-	AggregateMin
-	AggregateMax
-	AggregateCountDistinct
-	AggregateSumDistinct
-	AggregateGtid
-	AggregateRandom
-	AggregateCountStar
-)
-
-var (
-	// OpcodeType keeps track of the known output types for different aggregate functions
-	OpcodeType = map[AggregateOpcode]querypb.Type{
-		AggregateCountDistinct: sqltypes.Int64,
-		AggregateCount:         sqltypes.Int64,
-		AggregateCountStar:     sqltypes.Int64,
-		AggregateSumDistinct:   sqltypes.Decimal,
-		AggregateSum:           sqltypes.Decimal,
-		AggregateGtid:          sqltypes.VarChar,
-	}
-	// Some predefined values
-	countZero = sqltypes.MakeTrusted(sqltypes.Int64, []byte("0"))
-	countOne  = sqltypes.MakeTrusted(sqltypes.Int64, []byte("1"))
-	sumZero   = sqltypes.MakeTrusted(sqltypes.Decimal, []byte("0"))
-)
-
-// SupportedAggregates maps the list of supported aggregate
-// functions to their opcodes.
-var SupportedAggregates = map[string]AggregateOpcode{
-	"count": AggregateCount,
-	"sum":   AggregateSum,
-	"min":   AggregateMin,
-	"max":   AggregateMax,
-	// These functions don't exist in mysql, but are used
-	// to display the plan.
-	"count_distinct": AggregateCountDistinct,
-	"sum_distinct":   AggregateSumDistinct,
-	"vgtid":          AggregateGtid,
-	"count_star":     AggregateCountStar,
-	"random":         AggregateRandom,
-}
-
-func (code AggregateOpcode) String() string {
-	for k, v := range SupportedAggregates {
-		if v == code {
-			return k
-		}
-	}
-	return "ERROR"
-}
-
-// MarshalJSON serializes the AggregateOpcode as a JSON string.
-// It's used for testing and diagnostics.
-func (code AggregateOpcode) MarshalJSON() ([]byte, error) {
-	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
 }
 
 // RouteType returns a description of the query routing type used by the primitive

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -32,6 +32,7 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/servenv"
+	. "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 )
 
 var collationEnv *collations.Environment

--- a/go/vt/vtgate/engine/pullout_subquery.go
+++ b/go/vt/vtgate/engine/pullout_subquery.go
@@ -18,10 +18,10 @@ package engine
 
 import (
 	"context"
-	"fmt"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vterrors"
+	. "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -188,33 +188,4 @@ func (ps *PulloutSubquery) description() PrimitiveDescription {
 		Variant:      ps.Opcode.String(),
 		Other:        other,
 	}
-}
-
-// PulloutOpcode is a number representing the opcode
-// for the PulloutSubquery primitive.
-type PulloutOpcode int
-
-// This is the list of PulloutOpcode values.
-const (
-	PulloutValue = PulloutOpcode(iota)
-	PulloutIn
-	PulloutNotIn
-	PulloutExists
-)
-
-var pulloutName = map[PulloutOpcode]string{
-	PulloutValue:  "PulloutValue",
-	PulloutIn:     "PulloutIn",
-	PulloutNotIn:  "PulloutNotIn",
-	PulloutExists: "PulloutExists",
-}
-
-func (code PulloutOpcode) String() string {
-	return pulloutName[code]
-}
-
-// MarshalJSON serializes the PulloutOpcode as a JSON string.
-// It's used for testing and diagnostics.
-func (code PulloutOpcode) MarshalJSON() ([]byte, error) {
-	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
 }

--- a/go/vt/vtgate/engine/pullout_subquery_test.go
+++ b/go/vt/vtgate/engine/pullout_subquery_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
-
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	. "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 )
 
 func TestPulloutSubqueryValueGood(t *testing.T) {

--- a/go/vt/vtgate/engine/scalar_aggregation.go
+++ b/go/vt/vtgate/engine/scalar_aggregation.go
@@ -25,6 +25,7 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
+	. "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 )
 
 var _ Primitive = (*ScalarAggregate)(nil)

--- a/go/vt/vtgate/engine/scalar_aggregation_test.go
+++ b/go/vt/vtgate/engine/scalar_aggregation_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
+	. "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 )
 
 func TestEmptyRows(outer *testing.T) {

--- a/go/vt/vtgate/planbuilder/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/aggregation_pushing.go
@@ -22,7 +22,7 @@ import (
 
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vtgate/engine"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 )
@@ -231,7 +231,7 @@ func countStarAggr() *operators.Aggr {
 
 	return &operators.Aggr{
 		Original: &sqlparser.AliasedExpr{Expr: f},
-		OpCode:   engine.AggregateCountStar,
+		OpCode:   popcode.AggregateCountStar,
 		Alias:    "count(*)",
 	}
 }
@@ -420,17 +420,17 @@ func (hp *horizonPlanning) filteredPushAggregation(
 	return newplan, groupingOffsets, outputAggrs, pushed, nil
 }
 
-func isMinOrMax(in engine.AggregateOpcode) bool {
+func isMinOrMax(in popcode.AggregateOpcode) bool {
 	switch in {
-	case engine.AggregateMin, engine.AggregateMax:
+	case popcode.AggregateMin, popcode.AggregateMax:
 		return true
 	default:
 		return false
 	}
 }
 
-func isRandom(in engine.AggregateOpcode) bool {
-	return in == engine.AggregateRandom
+func isRandom(in popcode.AggregateOpcode) bool {
+	return in == popcode.AggregateRandom
 }
 
 func splitAggregationsToLeftAndRight(

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -20,10 +20,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"vitess.io/vitess/go/vt/vterrors"
-
 	"vitess.io/vitess/go/vt/sqlparser"
-	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vterrors"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
@@ -144,7 +143,7 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr, reservedVars *sqlpar
 		if !ok {
 			// (subquery) -> :_sq
 			expr = sqlparser.ReplaceExpr(expr, sqi.ast, sqlparser.NewArgument(sqName))
-			pullouts = append(pullouts, newPulloutSubquery(engine.PulloutValue, sqName, hasValues, sqi.plan))
+			pullouts = append(pullouts, newPulloutSubquery(popcode.PulloutValue, sqName, hasValues, sqi.plan))
 			continue
 		}
 		switch construct := construct.(type) {
@@ -166,7 +165,7 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr, reservedVars *sqlpar
 					Right: right,
 				}
 				expr = sqlparser.ReplaceExpr(expr, construct, newExpr)
-				pullouts = append(pullouts, newPulloutSubquery(engine.PulloutIn, sqName, hasValues, sqi.plan))
+				pullouts = append(pullouts, newPulloutSubquery(popcode.PulloutIn, sqName, hasValues, sqi.plan))
 			} else {
 				// a not in (subquery) -> (:__sq_has_values = 0 or (a not in ::__sq))
 				left := &sqlparser.ComparisonExpr{
@@ -184,12 +183,12 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr, reservedVars *sqlpar
 					Right: right,
 				}
 				expr = sqlparser.ReplaceExpr(expr, construct, newExpr)
-				pullouts = append(pullouts, newPulloutSubquery(engine.PulloutNotIn, sqName, hasValues, sqi.plan))
+				pullouts = append(pullouts, newPulloutSubquery(popcode.PulloutNotIn, sqName, hasValues, sqi.plan))
 			}
 		case *sqlparser.ExistsExpr:
 			// exists (subquery) -> :__sq_has_values
 			expr = sqlparser.ReplaceExpr(expr, construct, sqlparser.NewArgument(hasValues))
-			pullouts = append(pullouts, newPulloutSubquery(engine.PulloutExists, sqName, hasValues, sqi.plan))
+			pullouts = append(pullouts, newPulloutSubquery(popcode.PulloutExists, sqName, hasValues, sqi.plan))
 		}
 	}
 	return pullouts, highestOrigin, expr, nil

--- a/go/vt/vtgate/planbuilder/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/horizon_planning.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"vitess.io/vitess/go/sqltypes"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 
@@ -423,11 +424,11 @@ func generateAggregateParams(aggrs []operators.Aggr, aggrParamOffsets [][]offset
 			offset = incomingOffset
 		}
 
-		opcode := engine.AggregateSum
+		opcode := popcode.AggregateSum
 		switch aggr.OpCode {
-		case engine.AggregateMin, engine.AggregateMax, engine.AggregateRandom:
+		case popcode.AggregateMin, popcode.AggregateMax, popcode.AggregateRandom:
 			opcode = aggr.OpCode
-		case engine.AggregateCount, engine.AggregateCountStar, engine.AggregateCountDistinct, engine.AggregateSumDistinct:
+		case popcode.AggregateCount, popcode.AggregateCountStar, popcode.AggregateCountDistinct, popcode.AggregateSumDistinct:
 			if !pushed {
 				opcode = aggr.OpCode
 			}

--- a/go/vt/vtgate/planbuilder/operators/operator_test.go
+++ b/go/vt/vtgate/planbuilder/operators/operator_test.go
@@ -25,17 +25,14 @@ import (
 	"strings"
 	"testing"
 
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-
-	"vitess.io/vitess/go/vt/vtgate/engine"
-
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/sqlparser"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
 type lineCountingReader struct {
@@ -134,7 +131,7 @@ func testString(op interface{}) string { // TODO
 	case *SubQuery:
 		var inners []string
 		for _, sqOp := range op.Inner {
-			subquery := fmt.Sprintf("{\n\tType: %s", engine.PulloutOpcode(sqOp.ExtractedSubquery.OpCode).String())
+			subquery := fmt.Sprintf("{\n\tType: %s", popcode.PulloutOpcode(sqOp.ExtractedSubquery.OpCode).String())
 			if sqOp.ExtractedSubquery.GetArgName() != "" {
 				subquery += fmt.Sprintf("\n\tArgName: %s", sqOp.ExtractedSubquery.GetArgName())
 			}

--- a/go/vt/vtgate/planbuilder/operators/sharded_routing.go
+++ b/go/vt/vtgate/planbuilder/operators/sharded_routing.go
@@ -25,6 +25,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
@@ -600,10 +601,10 @@ func makeEvalEngineExpr(ctx *plancontext.PlanningContext, n sqlparser.Expr) eval
 			if extractedSubquery == nil {
 				continue
 			}
-			switch engine.PulloutOpcode(extractedSubquery.OpCode) {
-			case engine.PulloutIn, engine.PulloutNotIn:
+			switch popcode.PulloutOpcode(extractedSubquery.OpCode) {
+			case popcode.PulloutIn, popcode.PulloutNotIn:
 				expr = sqlparser.NewListArg(extractedSubquery.GetArgName())
-			case engine.PulloutValue, engine.PulloutExists:
+			case popcode.PulloutValue, popcode.PulloutExists:
 				expr = sqlparser.NewArgument(extractedSubquery.GetArgName())
 			}
 		}

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -20,6 +20,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/rewrite"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
@@ -61,7 +62,7 @@ func optimizeSubQuery(ctx *plancontext.PlanningContext, op *SubQuery, ts semanti
 			continue
 		}
 
-		if inner.ExtractedSubquery.OpCode == int(engine.PulloutExists) {
+		if inner.ExtractedSubquery.OpCode == int(popcode.PulloutExists) {
 			correlatedTree, err := createCorrelatedSubqueryOp(ctx, innerOp, outer, preds, inner.ExtractedSubquery)
 			if err != nil {
 				return nil, rewrite.SameTree, err
@@ -456,7 +457,7 @@ func createCorrelatedSubqueryOp(
 func canMergeSubqueryOnColumnSelection(ctx *plancontext.PlanningContext, a, b *Route, predicate *sqlparser.ExtractedSubquery) bool {
 	left := predicate.OtherSide
 	opCode := predicate.OpCode
-	if opCode != int(engine.PulloutValue) && opCode != int(engine.PulloutIn) {
+	if opCode != int(popcode.PulloutValue) && opCode != int(popcode.PulloutIn) {
 		return false
 	}
 

--- a/go/vt/vtgate/planbuilder/project.go
+++ b/go/vt/vtgate/planbuilder/project.go
@@ -24,6 +24,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"
 )
 
@@ -74,7 +75,7 @@ func planProjection(pb *primitiveBuilder, in logicalPlan, expr *sqlparser.Aliase
 		// the rows be correctly ordered.
 	case *orderedAggregate:
 		if aggrFunc, isAggregate := expr.Expr.(sqlparser.AggrFunc); isAggregate {
-			if _, ok := engine.SupportedAggregates[strings.ToLower(aggrFunc.AggrName())]; ok {
+			if _, ok := popcode.SupportedAggregates[strings.ToLower(aggrFunc.AggrName())]; ok {
 				rc, colNumber, err := node.pushAggr(pb, expr, origin)
 				if err != nil {
 					return nil, nil, 0, err

--- a/go/vt/vtgate/planbuilder/projection_pushing.go
+++ b/go/vt/vtgate/planbuilder/projection_pushing.go
@@ -22,6 +22,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
@@ -138,7 +139,7 @@ func pushProjectionIntoOA(ctx *plancontext.PlanningContext, expr *sqlparser.Alia
 		return 0, false, err
 	}
 	node.aggregates = append(node.aggregates, &engine.AggregateParams{
-		Opcode:   engine.AggregateRandom,
+		Opcode:   popcode.AggregateRandom,
 		Col:      offset,
 		Alias:    expr.ColumnName(),
 		Expr:     expr.Expr,

--- a/go/vt/vtgate/planbuilder/pullout_subquery.go
+++ b/go/vt/vtgate/planbuilder/pullout_subquery.go
@@ -20,6 +20,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 )
@@ -37,7 +38,7 @@ type pulloutSubquery struct {
 }
 
 // newPulloutSubquery builds a new pulloutSubquery.
-func newPulloutSubquery(opcode engine.PulloutOpcode, sqName, hasValues string, subquery logicalPlan) *pulloutSubquery {
+func newPulloutSubquery(opcode popcode.PulloutOpcode, sqName, hasValues string, subquery logicalPlan) *pulloutSubquery {
 	return &pulloutSubquery{
 		subquery: subquery,
 		eSubquery: &engine.PulloutSubquery{

--- a/go/vt/vtgate/planbuilder/rewrite.go
+++ b/go/vt/vtgate/planbuilder/rewrite.go
@@ -19,7 +19,7 @@ package planbuilder
 import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vtgate/engine"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 )
 
@@ -131,7 +131,7 @@ func rewriteSubquery(cursor *sqlparser.Cursor, r *rewriter, node *sqlparser.Subq
 	if err != nil {
 		return err
 	}
-	if semTableSQ.GetArgName() != "" || engine.PulloutOpcode(semTableSQ.OpCode) != engine.PulloutValue {
+	if semTableSQ.GetArgName() != "" || popcode.PulloutOpcode(semTableSQ.OpCode) != popcode.PulloutValue {
 		return nil
 	}
 	r.inSubquery++

--- a/go/vt/vtgate/planbuilder/show.go
+++ b/go/vt/vtgate/planbuilder/show.go
@@ -22,22 +22,20 @@ import (
 	"sort"
 	"strings"
 
-	"vitess.io/vitess/go/vt/log"
-	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
-	"vitess.io/vitess/go/vt/sidecardb"
-
 	"vitess.io/vitess/go/mysql/collations"
-	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
-
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
-
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/sidecardb"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	popcode "vitess.io/vitess/go/vt/vtgate/engine/opcode"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
 const (
@@ -568,7 +566,7 @@ func buildShowVGtidPlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) 
 		PreProcess: true,
 		Aggregates: []*engine.AggregateParams{
 			{
-				Opcode: engine.AggregateGtid,
+				Opcode: popcode.AggregateGtid,
 				Col:    1,
 				Alias:  "global vgtid_executed",
 			},

--- a/go/vt/vtgate/planbuilder/subquery_op.go
+++ b/go/vt/vtgate/planbuilder/subquery_op.go
@@ -19,6 +19,7 @@ package planbuilder
 import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 )
@@ -41,7 +42,7 @@ func transformSubQueryPlan(ctx *plancontext.PlanningContext, op *operators.SubQu
 	if merged != nil {
 		return merged, nil
 	}
-	plan := newPulloutSubquery(engine.PulloutOpcode(op.Extracted.OpCode), argName, hasValuesArg, innerPlan)
+	plan := newPulloutSubquery(opcode.PulloutOpcode(op.Extracted.OpCode), argName, hasValuesArg, innerPlan)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -20,13 +20,12 @@ import (
 	"fmt"
 	"testing"
 
-	"vitess.io/vitess/go/vt/vtgate/engine"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
@@ -528,32 +527,32 @@ func TestScopeForSubqueries(t *testing.T) {
 func TestSubqueriesMappingWhereClause(t *testing.T) {
 	tcs := []struct {
 		sql           string
-		opCode        engine.PulloutOpcode
+		opCode        opcode.PulloutOpcode
 		otherSideName string
 	}{
 		{
 			sql:           "select id from t1 where id in (select uid from t2)",
-			opCode:        engine.PulloutIn,
+			opCode:        opcode.PulloutIn,
 			otherSideName: "id",
 		},
 		{
 			sql:           "select id from t1 where id not in (select uid from t2)",
-			opCode:        engine.PulloutNotIn,
+			opCode:        opcode.PulloutNotIn,
 			otherSideName: "id",
 		},
 		{
 			sql:           "select id from t where col1 = (select uid from t2 order by uid desc limit 1)",
-			opCode:        engine.PulloutValue,
+			opCode:        opcode.PulloutValue,
 			otherSideName: "col1",
 		},
 		{
 			sql:           "select id from t where exists (select uid from t2 where uid = 42)",
-			opCode:        engine.PulloutExists,
+			opCode:        opcode.PulloutExists,
 			otherSideName: "",
 		},
 		{
 			sql:           "select id from t where col1 >= (select uid from t2 where uid = 42)",
-			opCode:        engine.PulloutValue,
+			opCode:        opcode.PulloutValue,
 			otherSideName: "col1",
 		},
 	}
@@ -608,7 +607,7 @@ func TestSubqueriesMappingSelectExprs(t *testing.T) {
 			extractedSubq := semTable.SubqueryRef[subq]
 			assert.True(t, sqlparser.Equals.Expr(extractedSubq.Subquery, subq))
 			assert.True(t, sqlparser.Equals.Expr(extractedSubq.Original, subq))
-			assert.EqualValues(t, engine.PulloutValue, extractedSubq.OpCode)
+			assert.EqualValues(t, opcode.PulloutValue, extractedSubq.OpCode)
 		})
 	}
 }

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -19,7 +19,7 @@ package semantics
 import (
 	"strings"
 
-	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 )
@@ -211,16 +211,16 @@ func (b *binder) createExtractedSubquery(cursor *sqlparser.Cursor, currScope *sc
 	sq := &sqlparser.ExtractedSubquery{
 		Subquery: subq,
 		Original: subq,
-		OpCode:   int(engine.PulloutValue),
+		OpCode:   int(opcode.PulloutValue),
 	}
 
 	switch par := cursor.Parent().(type) {
 	case *sqlparser.ComparisonExpr:
 		switch par.Operator {
 		case sqlparser.InOp:
-			sq.OpCode = int(engine.PulloutIn)
+			sq.OpCode = int(opcode.PulloutIn)
 		case sqlparser.NotInOp:
-			sq.OpCode = int(engine.PulloutNotIn)
+			sq.OpCode = int(opcode.PulloutNotIn)
 		}
 		subq, exp := GetSubqueryAndOtherSide(par)
 		sq.Original = &sqlparser.ComparisonExpr{
@@ -230,7 +230,7 @@ func (b *binder) createExtractedSubquery(cursor *sqlparser.Cursor, currScope *sc
 		}
 		sq.OtherSide = exp
 	case *sqlparser.ExistsExpr:
-		sq.OpCode = int(engine.PulloutExists)
+		sq.OpCode = int(opcode.PulloutExists)
 		sq.Original = par
 	}
 	return sq, nil

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -21,7 +21,6 @@ import (
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vtgate/engine"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 )
@@ -212,7 +211,7 @@ func (s *scoper) createSpecialScopePostProjection(parent sqlparser.SQLNode) erro
 			}
 			thisTableInfo := createVTableInfoForExpressions(sel.SelectExprs, nil /*needed for star expressions*/, s.org)
 			if len(tableInfo.cols) != len(thisTableInfo.cols) {
-				return engine.ErrWrongNumberOfColumnsInSelect
+				return vterrors.NewErrorf(vtrpcpb.Code_FAILED_PRECONDITION, vterrors.WrongNumberOfColumnsInSelect, "The used SELECT statements have a different number of columns")
 			}
 			for i, col := range tableInfo.cols {
 				// at this stage, we don't store the actual dependencies, we only store the expressions.

--- a/go/vt/vtgate/semantics/typer.go
+++ b/go/vt/vtgate/semantics/typer.go
@@ -23,7 +23,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
-	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
 )
 
 // typer is responsible for setting the type for expressions
@@ -62,9 +62,9 @@ func (t *typer) up(cursor *sqlparser.Cursor) error {
 			t.exprTypes[node] = floatval
 		}
 	case sqlparser.AggrFunc:
-		code, ok := engine.SupportedAggregates[strings.ToLower(node.AggrName())]
+		code, ok := opcode.SupportedAggregates[strings.ToLower(node.AggrName())]
 		if ok {
-			typ, ok := engine.OpcodeType[code]
+			typ, ok := opcode.OpcodeType[code]
 			if ok {
 				t.exprTypes[node] = Type{Type: typ}
 			}

--- a/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
@@ -26,6 +26,7 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
 )
 
 type tablePlan struct {
@@ -99,7 +100,7 @@ func (td *tableDiffer) buildTablePlan() (*tablePlan, error) {
 					// but will need to be revisited when we add such support to vreplication
 					aggregateFuncType := "sum"
 					aggregates = append(aggregates, &engine.AggregateParams{
-						Opcode: engine.SupportedAggregates[aggregateFuncType],
+						Opcode: opcode.SupportedAggregates[aggregateFuncType],
 						Col:    len(sourceSelect.SelectExprs) - 1,
 					})
 				}

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -33,6 +33,7 @@ import (
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
 )
 
 func TestBuildPlanSuccess(t *testing.T) {
@@ -418,10 +419,10 @@ func TestBuildPlanSuccess(t *testing.T) {
 				Direction: sqlparser.AscOrder,
 			}},
 			aggregates: []*engine.AggregateParams{{
-				Opcode: engine.AggregateSum,
+				Opcode: opcode.AggregateSum,
 				Col:    2,
 			}, {
-				Opcode: engine.AggregateSum,
+				Opcode: opcode.AggregateSum,
 				Col:    3,
 			}},
 		},

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -46,6 +46,7 @@ import (
 	"vitess.io/vitess/go/vt/vtctl/workflow"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vttablet/tabletconn"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
@@ -576,7 +577,7 @@ func (df *vdiff) buildTablePlan(table *tabletmanagerdatapb.TableDefinition, quer
 					// but will need to be revisited when we add such support to vreplication
 					aggregateFuncType := "sum"
 					aggregates = append(aggregates, &engine.AggregateParams{
-						Opcode: engine.SupportedAggregates[aggregateFuncType],
+						Opcode: opcode.SupportedAggregates[aggregateFuncType],
 						Col:    len(sourceSelect.SelectExprs) - 1,
 					})
 				}

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -25,6 +25,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
 
 	"context"
 
@@ -395,10 +396,10 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive: &engine.OrderedAggregate{
 				Aggregates: []*engine.AggregateParams{{
-					Opcode: engine.AggregateSum,
+					Opcode: opcode.AggregateSum,
 					Col:    2,
 				}, {
-					Opcode: engine.AggregateSum,
+					Opcode: opcode.AggregateSum,
 					Col:    3,
 				}},
 				GroupByKeys: []*engine.GroupByParams{{KeyCol: 0, WeightStringCol: -1}},


### PR DESCRIPTION

## Description

This is an internal refactor PR, that creates a new package: `go/vt/vtgate/engine/opcode`. With this new package, we can remove `go/vt/vtgate/semantics`'s dependency on `go/vt/vtgate/engine`. Now both `semantics` and `engine` use the new `opcode` package.

This decoupling was found necessary in https://github.com/vitessio/vitess/pull/12565#issuecomment-1475805681, and helps to untangle https://github.com/vitessio/vitess/pull/12565

## Related Issue(s)

https://github.com/vitessio/vitess/pull/12565

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
