### PR TITLE
Cherry pick v14: Mysqld.GetSchema: tolerate tables being dropped while inspecting schema

### DIFF
--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -109,6 +110,15 @@ func (mysqld *Mysqld) GetSchema(ctx context.Context, dbName string, tables, excl
 
 			fields, columns, schema, err := mysqld.collectSchema(ctx, dbName, td.Name, td.Type)
 			if err != nil {
+				// There's a possible race condition: it could happen that a table was dropped in between reading
+				// the list of tables (collectBasicTableData(), earlier) and the point above where we investigate
+				// the table.
+				// This is fine. We identify the situation and keep the table without any fields/columns/key information
+				sqlErr, isSQLErr := mysql.NewSQLErrorFromError(err).(*mysql.SQLError)
+				if isSQLErr && sqlErr != nil && sqlErr.Number() == mysql.ERNoSuchTable {
+					return
+				}
+
 				allErrors.RecordError(err)
 				cancel()
 				return
@@ -121,6 +131,8 @@ func (mysqld *Mysqld) GetSchema(ctx context.Context, dbName string, tables, excl
 	}
 
 	// Get primary columns concurrently.
+	// The below runs a single query on `INFORMATION_SCHEMA` and does not interact with the actual tables.
+	// It is therefore safe to run even if some tables are dropped in the interim.
 	colMap := map[string][]string{}
 	if len(tableNames) > 0 {
 		wg.Add(1)


### PR DESCRIPTION
Cherry pick of https://github.com/vitessio/vitess/pull/12641 for `release-14.0`

--

## Description

Identify the two scenarios where a table may be dropped while we're inspecting the schema. Either we get a `(errno 1146)` error code, or the table does not appear in `information_schema` even after it did, before. 

The fix is to silently ignore tables hitting this scenario.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/12640

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
