### PR TITLE
[planner bugfix] add expressions to HAVING

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -1005,10 +1005,8 @@ func (node *Select) AddHaving(expr Expr) {
 		}
 		return
 	}
-	node.Having.Expr = &AndExpr{
-		Left:  node.Having.Expr,
-		Right: expr,
-	}
+	exprs := SplitAndExpression(nil, node.Having.Expr)
+	node.Having.Expr = AndExpressions(append(exprs, expr)...)
 }
 
 // AddGroupBy adds a grouping expression, unless it's already present

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -57,32 +57,22 @@ func TestSelect(t *testing.T) {
 	sel.AddWhere(expr)
 	buf := NewTrackedBuffer(nil)
 	sel.Where.Format(buf)
-	want := " where a = 1"
-	if buf.String() != want {
-		t.Errorf("where: %q, want %s", buf.String(), want)
-	}
+	assert.Equal(t, " where a = 1", buf.String())
 	sel.AddWhere(expr)
 	buf = NewTrackedBuffer(nil)
 	sel.Where.Format(buf)
-	want = " where a = 1"
-	if buf.String() != want {
-		t.Errorf("where: %q, want %s", buf.String(), want)
-	}
+	assert.Equal(t, " where a = 1", buf.String())
+
 	sel = &Select{}
 	sel.AddHaving(expr)
 	buf = NewTrackedBuffer(nil)
 	sel.Having.Format(buf)
-	want = " having a = 1"
-	if buf.String() != want {
-		t.Errorf("having: %q, want %s", buf.String(), want)
-	}
+	assert.Equal(t, " having a = 1", buf.String())
+
 	sel.AddHaving(expr)
 	buf = NewTrackedBuffer(nil)
 	sel.Having.Format(buf)
-	want = " having a = 1 and a = 1"
-	if buf.String() != want {
-		t.Errorf("having: %q, want %s", buf.String(), want)
-	}
+	assert.Equal(t, " having a = 1", buf.String())
 
 	tree, err = Parse("select * from t where a = 1 or b = 1")
 	require.NoError(t, err)
@@ -91,18 +81,14 @@ func TestSelect(t *testing.T) {
 	sel.AddWhere(expr)
 	buf = NewTrackedBuffer(nil)
 	sel.Where.Format(buf)
-	want = " where a = 1 or b = 1"
-	if buf.String() != want {
-		t.Errorf("where: %q, want %s", buf.String(), want)
-	}
+	assert.Equal(t, " where a = 1 or b = 1", buf.String())
+
 	sel = &Select{}
 	sel.AddHaving(expr)
 	buf = NewTrackedBuffer(nil)
 	sel.Having.Format(buf)
-	want = " having a = 1 or b = 1"
-	if buf.String() != want {
-		t.Errorf("having: %q, want %s", buf.String(), want)
-	}
+	assert.Equal(t, " having a = 1 or b = 1", buf.String())
+
 }
 
 func TestUpdate(t *testing.T) {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -5004,5 +5004,42 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "when pushing predicates into derived tables, make sure to put them in HAVING when they contain aggregations",
+    "query": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as count from user_extra where localDate > :v1 group by user_id, flowId order by null) as t1 where count >= :v2",
+    "v3-plan": {
+      "QueryType": "SELECT",
+      "Original": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as count from user_extra where localDate > :v1 group by user_id, flowId order by null) as t1 where count >= :v2",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as `count` from user_extra where 1 != 1 group by user_id, flowId) as t1 where 1 != 1",
+        "Query": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as `count` from user_extra where localDate > :v1 group by user_id, flowId order by null) as t1 where `count` >= :v2",
+        "Table": "user_extra"
+      }
+    },
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as count from user_extra where localDate > :v1 group by user_id, flowId order by null) as t1 where count >= :v2",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as `count` from user_extra where 1 != 1 group by user_id, flowId) as t1 where 1 != 1",
+        "Query": "select t1.portalId, t1.flowId from (select portalId, flowId, count(*) as `count` from user_extra where localDate > :v1 group by user_id, flowId having count(*) >= :v2 order by null) as t1",
+        "Table": "user_extra"
+      },
+      "TablesUsed": [
+        "user.user_extra"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description
When planning derived tables, we were pushing down predicates into the WHERE clause instead of the HAVING clause, even when the predicate contains aggregation.

## Related Issue(s)
Fixes #12550

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
