### PR TITLE
Use a left join to make sure that tables with tablespace=innodb_system are included in the schema

### DIFF
--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -363,7 +363,7 @@ const TablesWithSize80 = `SELECT t.table_name,
 	SUM(i.file_size),
 	SUM(i.allocated_size)
 FROM information_schema.tables t
-INNER JOIN information_schema.innodb_tablespaces i
+LEFT JOIN information_schema.innodb_tablespaces i
 	ON i.name LIKE CONCAT(database(), '/%') AND (i.name = CONCAT(t.table_schema, '/', t.table_name) OR i.name LIKE CONCAT(t.table_schema, '/', t.table_name, '#p#%'))
 WHERE t.table_schema = database()
 GROUP BY t.table_name, t.table_type, t.create_time, t.table_comment`

--- a/go/test/endtoend/vreplication/vstream_test.go
+++ b/go/test/endtoend/vreplication/vstream_test.go
@@ -190,7 +190,7 @@ const vschemaUnsharded = `
 }
 `
 const schemaSharded = `
-create table customer(cid int, name varbinary(128), primary key(cid))  CHARSET=utf8mb4;
+create table customer(cid int, name varbinary(128), primary key(cid)) TABLESPACE innodb_system CHARSET=utf8mb4;
 `
 const vschemaSharded = `
 {


### PR DESCRIPTION
## Description

To make sure the behaviour of the schema engine is the same for 5.7 and 8.0 in terms of handling of tables that have innodb tablespace set to innodb_system (those are not included in `information_schema.innodb_tablespaces`). This should make sure that vstreamer works as expected when some of the tables in a keyspace have been created with `tablespace innodb_system` option (because of https://bugs.mysql.com/bug.php?id=110383 or some other reason).

This issue exists in 14.x and the fix needs backporting AFAIU.

## Related Issue(s)

Fixes #12669

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation is not required
