### PR TITLE
Reset the current lag when closing the replication lag reader.

### DIFF
--- a/go/vt/vttablet/tabletserver/repltracker/reader.go
+++ b/go/vt/vttablet/tabletserver/repltracker/reader.go
@@ -123,6 +123,9 @@ func (r *heartbeatReader) Close() {
 	}
 	r.ticks.Stop()
 	r.pool.Close()
+
+	currentLagNs.Set(0)
+
 	r.isOpen = false
 	log.Info("Heartbeat Reader: closed")
 }

--- a/go/vt/vttablet/tabletserver/repltracker/writer_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer_test.go
@@ -30,18 +30,12 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
-var (
-	now         = time.Now()
-	mockNowFunc = func() time.Time {
-		return now
-	}
-)
-
 func TestWriteHeartbeat(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 
-	tw := newTestWriter(db, mockNowFunc)
+	now := time.Now()
+	tw := newTestWriter(db, &now)
 	upsert := fmt.Sprintf("INSERT INTO %s.heartbeat (ts, tabletUid, keyspaceShard) VALUES (%d, %d, '%s') ON DUPLICATE KEY UPDATE ts=VALUES(ts), tabletUid=VALUES(tabletUid)",
 		"_vt", now.UnixNano(), tw.tabletAlias.Uid, tw.keyspaceShard)
 	db.AddQuery(upsert, &sqltypes.Result{})
@@ -58,7 +52,8 @@ func TestWriteHeartbeatError(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 
-	tw := newTestWriter(db, mockNowFunc)
+	now := time.Now()
+	tw := newTestWriter(db, &now)
 
 	writes.Reset()
 	writeErrors.Reset()
@@ -68,7 +63,7 @@ func TestWriteHeartbeatError(t *testing.T) {
 	assert.Equal(t, int64(1), writeErrors.Get())
 }
 
-func newTestWriter(db *fakesqldb.DB, nowFunc func() time.Time) *heartbeatWriter {
+func newTestWriter(db *fakesqldb.DB, frozenTime *time.Time) *heartbeatWriter {
 	config := tabletenv.NewDefaultConfig()
 	config.ReplicationTracker.Mode = tabletenv.Heartbeat
 	config.ReplicationTracker.HeartbeatIntervalSeconds = 1
@@ -79,7 +74,13 @@ func newTestWriter(db *fakesqldb.DB, nowFunc func() time.Time) *heartbeatWriter 
 
 	tw := newHeartbeatWriter(tabletenv.NewEnv(config, "WriterTest"), &topodatapb.TabletAlias{Cell: "test", Uid: 1111})
 	tw.keyspaceShard = "test:0"
-	tw.now = nowFunc
+
+	if frozenTime != nil {
+		tw.now = func() time.Time {
+			return *frozenTime
+		}
+	}
+
 	tw.appPool.Open(dbc.AppWithDB())
 	tw.allPrivsPool.Open(dbc.AllPrivsWithDB())
 


### PR DESCRIPTION
## Description

Reset the current replication lag on the replication lag reader when closing it.

Co-authored with @arthurschreiber.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/12682.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

N/A.
