### PR TITLE
evalengine: misc. cleanups

### DIFF
--- a/go/vt/vtgate/evalengine/compiler.go
+++ b/go/vt/vtgate/evalengine/compiler.go
@@ -324,6 +324,15 @@ func (c *compiler) compileNullCheck1(ct ctype) *jump {
 	return nil
 }
 
+func (c *compiler) compileNullCheck1r(ct ctype) *jump {
+	if ct.nullable() {
+		j := c.asm.jumpFrom()
+		c.asm.NullCheck1r(j)
+		return j
+	}
+	return nil
+}
+
 func (c *compiler) compileNullCheck2(lt, rt ctype) *jump {
 	if lt.nullable() || rt.nullable() {
 		j := c.asm.jumpFrom()

--- a/go/vt/vtgate/evalengine/compiler_arithmetic.go
+++ b/go/vt/vtgate/evalengine/compiler_arithmetic.go
@@ -108,7 +108,8 @@ func (c *compiler) compileArithmeticAdd(left, right Expr) (ctype, error) {
 	}
 
 	swap := false
-	skip2 := c.compileNullCheck2(lt, rt)
+	skip2 := c.compileNullCheck1r(rt)
+
 	lt = c.compileToNumeric(lt, 2)
 	rt = c.compileToNumeric(rt, 1)
 	lt, rt, swap = c.compileNumericPriority(lt, rt)
@@ -145,8 +146,7 @@ func (c *compiler) compileArithmeticAdd(left, right Expr) (ctype, error) {
 		sumtype = sqltypes.Float64
 	}
 
-	c.asm.jumpDestination(skip1)
-	c.asm.jumpDestination(skip2)
+	c.asm.jumpDestination(skip1, skip2)
 	return ctype{Type: sumtype, Col: collationNumeric}, nil
 }
 
@@ -162,7 +162,7 @@ func (c *compiler) compileArithmeticSub(left, right Expr) (ctype, error) {
 		return ctype{}, err
 	}
 
-	skip2 := c.compileNullCheck2(lt, rt)
+	skip2 := c.compileNullCheck1r(rt)
 	lt = c.compileToNumeric(lt, 2)
 	rt = c.compileToNumeric(rt, 1)
 
@@ -224,8 +224,7 @@ func (c *compiler) compileArithmeticSub(left, right Expr) (ctype, error) {
 		panic("did not compile?")
 	}
 
-	c.asm.jumpDestination(skip1)
-	c.asm.jumpDestination(skip2)
+	c.asm.jumpDestination(skip1, skip2)
 	return ctype{Type: subtype, Col: collationNumeric}, nil
 }
 
@@ -242,7 +241,7 @@ func (c *compiler) compileArithmeticMul(left, right Expr) (ctype, error) {
 	}
 
 	swap := false
-	skip2 := c.compileNullCheck2(lt, rt)
+	skip2 := c.compileNullCheck1r(rt)
 	lt = c.compileToNumeric(lt, 2)
 	rt = c.compileToNumeric(rt, 1)
 	lt, rt, swap = c.compileNumericPriority(lt, rt)
@@ -279,8 +278,7 @@ func (c *compiler) compileArithmeticMul(left, right Expr) (ctype, error) {
 		multype = sqltypes.Decimal
 	}
 
-	c.asm.jumpDestination(skip1)
-	c.asm.jumpDestination(skip2)
+	c.asm.jumpDestination(skip1, skip2)
 	return ctype{Type: multype, Col: collationNumeric}, nil
 }
 
@@ -295,7 +293,7 @@ func (c *compiler) compileArithmeticDiv(left, right Expr) (ctype, error) {
 	if err != nil {
 		return ctype{}, err
 	}
-	skip2 := c.compileNullCheck2(lt, rt)
+	skip2 := c.compileNullCheck1r(rt)
 
 	lt = c.compileToNumeric(lt, 2)
 	rt = c.compileToNumeric(rt, 1)
@@ -312,8 +310,7 @@ func (c *compiler) compileArithmeticDiv(left, right Expr) (ctype, error) {
 		c.compileToDecimal(rt, 1)
 		c.asm.Div_dd()
 	}
-	c.asm.jumpDestination(skip1)
-	c.asm.jumpDestination(skip2)
+	c.asm.jumpDestination(skip1, skip2)
 	return ct, nil
 }
 
@@ -329,7 +326,7 @@ func (c *compiler) compileArithmeticIntDiv(left, right Expr) (ctype, error) {
 		return ctype{}, err
 	}
 
-	skip2 := c.compileNullCheck2(lt, rt)
+	skip2 := c.compileNullCheck1r(rt)
 	lt = c.compileToNumeric(lt, 2)
 	rt = c.compileToNumeric(rt, 1)
 
@@ -393,8 +390,7 @@ func (c *compiler) compileArithmeticIntDiv(left, right Expr) (ctype, error) {
 			c.asm.IntDiv_di()
 		}
 	}
-	c.asm.jumpDestination(skip1)
-	c.asm.jumpDestination(skip2)
+	c.asm.jumpDestination(skip1, skip2)
 	return ct, nil
 }
 
@@ -410,7 +406,7 @@ func (c *compiler) compileArithmeticMod(left, right Expr) (ctype, error) {
 		return ctype{}, err
 	}
 
-	skip2 := c.compileNullCheck2(lt, rt)
+	skip2 := c.compileNullCheck1r(rt)
 	lt = c.compileToNumeric(lt, 2)
 	rt = c.compileToNumeric(rt, 1)
 
@@ -465,7 +461,6 @@ func (c *compiler) compileArithmeticMod(left, right Expr) (ctype, error) {
 		c.asm.Mod_ff()
 	}
 
-	c.asm.jumpDestination(skip1)
-	c.asm.jumpDestination(skip2)
+	c.asm.jumpDestination(skip1, skip2)
 	return ct, nil
 }

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -53,9 +53,11 @@ func (asm *assembler) jumpFrom() *jump {
 	return &jump{from: len(asm.ins)}
 }
 
-func (asm *assembler) jumpDestination(j *jump) {
-	if j != nil {
-		j.to = len(asm.ins)
+func (asm *assembler) jumpDestination(jumps ...*jump) {
+	for _, j := range jumps {
+		if j != nil {
+			j.to = len(asm.ins)
+		}
 	}
 }
 
@@ -2191,6 +2193,17 @@ func (asm *assembler) NullCheck1(j *jump) {
 		}
 		return 1
 	}, "NULLCHECK SP-1")
+}
+
+func (asm *assembler) NullCheck1r(j *jump) {
+	asm.emit(func(vm *VirtualMachine) int {
+		if vm.stack[vm.sp-1] == nil {
+			vm.stack[vm.sp-2] = nil
+			vm.sp--
+			return j.offset()
+		}
+		return 1
+	}, "NULLCHECK SP-1, SP-2")
 }
 
 func (asm *assembler) NullCheck2(j *jump) {

--- a/go/vt/vtgate/evalengine/compiler_bit.go
+++ b/go/vt/vtgate/evalengine/compiler_bit.go
@@ -48,13 +48,12 @@ func (c *compiler) compileBitwiseOp(left Expr, right Expr, asm_ins_bb, asm_ins_u
 		return ctype{}, err
 	}
 
-	skip2 := c.compileNullCheck2(lt, rt)
+	skip2 := c.compileNullCheck1r(rt)
 
 	if lt.Type == sqltypes.VarBinary && rt.Type == sqltypes.VarBinary {
 		if !lt.isHexOrBitLiteral() || !rt.isHexOrBitLiteral() {
 			asm_ins_bb()
-			c.asm.jumpDestination(skip1)
-			c.asm.jumpDestination(skip2)
+			c.asm.jumpDestination(skip1, skip2)
 			return ctype{Type: sqltypes.VarBinary, Col: collationBinary}, nil
 		}
 	}
@@ -63,8 +62,7 @@ func (c *compiler) compileBitwiseOp(left Expr, right Expr, asm_ins_bb, asm_ins_u
 	rt = c.compileToBitwiseUint64(rt, 1)
 
 	asm_ins_uu()
-	c.asm.jumpDestination(skip1)
-	c.asm.jumpDestination(skip2)
+	c.asm.jumpDestination(skip1, skip2)
 	return ctype{Type: sqltypes.Uint64, Col: collationNumeric}, nil
 }
 
@@ -81,7 +79,7 @@ func (c *compiler) compileBitwiseShift(left Expr, right Expr, i int) (ctype, err
 		return ctype{}, err
 	}
 
-	skip2 := c.compileNullCheck2(lt, rt)
+	skip2 := c.compileNullCheck1r(rt)
 
 	if lt.Type == sqltypes.VarBinary && !lt.isHexOrBitLiteral() {
 		_ = c.compileToUint64(rt, 1)
@@ -90,8 +88,7 @@ func (c *compiler) compileBitwiseShift(left Expr, right Expr, i int) (ctype, err
 		} else {
 			c.asm.BitShiftRight_bu()
 		}
-		c.asm.jumpDestination(skip1)
-		c.asm.jumpDestination(skip2)
+		c.asm.jumpDestination(skip1, skip2)
 		return ctype{Type: sqltypes.VarBinary, Col: collationBinary}, nil
 	}
 
@@ -104,8 +101,7 @@ func (c *compiler) compileBitwiseShift(left Expr, right Expr, i int) (ctype, err
 		c.asm.BitShiftRight_uu()
 	}
 
-	c.asm.jumpDestination(skip1)
-	c.asm.jumpDestination(skip2)
+	c.asm.jumpDestination(skip1, skip2)
 	return ctype{Type: sqltypes.Uint64, Col: collationNumeric}, nil
 }
 


### PR DESCRIPTION
## Description

Some minor cleanups to the evalengine code.

- Reduce the surface of null checks with a `NullCheck1r` so we don't have to compare the left-most argument twice in most short-circuited operations.
- Cleanup jump destinations using var-args
- De-duplicate the rounding math methods
- Use direct comparison against `sqltypes` for more math methods (@dbussink: I think it's important to always use `sqltypes` constants directly in the compiler because methods like `IsInteger()` can mask bugs: the compiler should never handle any of the intermediate integral types that `IsInteger` does handle).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
