### PR TITLE
Fix fullstatus test for backward compat

### DIFF
--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -418,7 +418,8 @@ func TestFullStatus(t *testing.T) {
 	primaryStatusString, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("GetFullStatus", primaryTablet.Alias)
 	require.NoError(t, err)
 	primaryStatus := &replicationdatapb.FullStatus{}
-	err = protojson.Unmarshal([]byte(primaryStatusString), primaryStatus)
+	opt := protojson.UnmarshalOptions{DiscardUnknown: true}
+	err = opt.Unmarshal([]byte(primaryStatusString), primaryStatus)
 	require.NoError(t, err)
 	assert.NotEmpty(t, primaryStatus.ServerUuid)
 	assert.NotEmpty(t, primaryStatus.ServerId)
@@ -458,7 +459,8 @@ func TestFullStatus(t *testing.T) {
 	replicaStatusString, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("GetFullStatus", replicaTablet.Alias)
 	require.NoError(t, err)
 	replicaStatus := &replicationdatapb.FullStatus{}
-	err = protojson.Unmarshal([]byte(replicaStatusString), replicaStatus)
+	opt = protojson.UnmarshalOptions{DiscardUnknown: true}
+	err = opt.Unmarshal([]byte(replicaStatusString), replicaStatus)
 	require.NoError(t, err)
 	assert.NotEmpty(t, replicaStatus.ServerUuid)
 	assert.NotEmpty(t, replicaStatus.ServerId)
@@ -511,7 +513,8 @@ func getFullStatus(t *testing.T, clusterInstance *cluster.LocalProcessCluster, t
 	statusString, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("GetFullStatus", tablet.Alias)
 	require.NoError(t, err)
 	status := &replicationdatapb.FullStatus{}
-	err = protojson.Unmarshal([]byte(statusString), status)
+	opt := protojson.UnmarshalOptions{DiscardUnknown: true}
+	err = opt.Unmarshal([]byte(statusString), status)
 	require.NoError(t, err)
 	return status
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Downgrad/Upgrade test (Reparent New Vtctl) is failing on v16.0 (https://github.com/vitessio/vitess/actions/runs/4466836285/jobs/7865121597) 

In #12206 we added an additional field "super_read_only" to FullStatus message, with upgrade downgrade test we use N+1 (17) version of Vtctl along with N (v16) version of VTTablet. Since the test code does not have updated proto definition of FullStatus message (replicationdata.proto), it fails to Unmarshal the message object.



## Solution:
1- If I use
```
opt := protojson.UnmarshalOptions{DiscardUnknown: true} 
err = opt.Unmarshal([]byte(primaryStatusString), primaryStatus)
```
then this will disregard the missing fields ...

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
