### PR TITLE
Fix handling of table information for missing column

### DIFF
--- a/go/vt/vterrors/code.go
+++ b/go/vt/vterrors/code.go
@@ -41,9 +41,9 @@ var (
 	VT03016 = errorWithoutState("VT03016", vtrpcpb.Code_INVALID_ARGUMENT, "unknown vindex column: '%s'", "The given column is unknown in the vindex table.")
 	VT03017 = errorWithState("VT03017", vtrpcpb.Code_INVALID_ARGUMENT, SyntaxError, "where clause can only be of the type 'pos > <value>'", "This vstream where clause can only be a greater than filter.")
 	VT03018 = errorWithoutState("VT03018", vtrpcpb.Code_INVALID_ARGUMENT, "NEXT used on a non-sequence table", "You cannot use the NEXT syntax on a table that is not a sequence table.")
-	VT03019 = errorWithoutState("VT03019", vtrpcpb.Code_INVALID_ARGUMENT, "symbol %s not found", "The given symbol was not found or is not available.")
-	VT03020 = errorWithoutState("VT03020", vtrpcpb.Code_INVALID_ARGUMENT, "symbol %s not found in subquery", "The given symbol was not found in the subquery.")
-	VT03021 = errorWithoutState("VT03021", vtrpcpb.Code_INVALID_ARGUMENT, "ambiguous symbol reference: %v", "The given symbol is ambiguous. You can use a table qualifier to make it unambiguous.")
+	VT03019 = errorWithoutState("VT03019", vtrpcpb.Code_INVALID_ARGUMENT, "column %s not found", "The given column was not found or is not available.")
+	VT03020 = errorWithoutState("VT03020", vtrpcpb.Code_INVALID_ARGUMENT, "column %s not found in subquery", "The given column was not found in the subquery.")
+	VT03021 = errorWithoutState("VT03021", vtrpcpb.Code_INVALID_ARGUMENT, "ambiguous column reference: %v", "The given column is ambiguous. You can use a table qualifier to make it unambiguous.")
 	VT03022 = errorWithoutState("VT03022", vtrpcpb.Code_INVALID_ARGUMENT, "column %v not found in %v", "The given column cannot be found.")
 	VT03023 = errorWithoutState("VT03023", vtrpcpb.Code_INVALID_ARGUMENT, "INSERT not supported when targeting a key range: %s", "When targeting a range of shards, Vitess does not know which shard to send the INSERT to.")
 

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -4255,7 +4255,7 @@
   {
     "comment": "select (select 1 from user u having count(ue.col) > 10) from user_extra ue",
     "query": "select (select 1 from user u having count(ue.col) > 10) from user_extra ue",
-    "v3-plan": "VT03020: symbol ue.col not found in subquery",
+    "v3-plan": "VT03020: column ue.col not found in subquery",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select (select 1 from user u having count(ue.col) > 10) from user_extra ue",
@@ -4386,7 +4386,7 @@
   {
     "comment": "scatter aggregate symtab lookup error",
     "query": "select id, b as id, count(*) from user order by id",
-    "v3-plan": "VT03021: ambiguous symbol reference: id",
+    "v3-plan": "VT03021: ambiguous column reference: id",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select id, b as id, count(*) from user order by id",

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -2916,8 +2916,8 @@
   {
     "comment": "unresolved symbol in inner subquery.",
     "query": "select id from user where id = :a and user.col in (select user_extra.col from user_extra where user_extra.user_id = :a and foo.id = 1)",
-    "v3-plan": "VT03019: symbol foo.id not found",
-    "gen4-plan": "symbol foo.id not found"
+    "v3-plan": "VT03019: column foo.id not found",
+    "gen4-plan": "column 'foo.id' not found"
   },
   {
     "comment": "outer and inner subquery route by same outermost column value",

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -2701,7 +2701,7 @@
         "Table": "`user`, user_extra"
       }
     },
-    "gen4-plan": "symbol t.col not found"
+    "gen4-plan": "column 't.col' not found"
   },
   {
     "comment": "routing rules for derived table where the constraint is in the outer query",
@@ -2766,7 +2766,7 @@
         "Table": "`user`"
       }
     },
-    "gen4-plan": "symbol t.id not found"
+    "gen4-plan": "column 'id' not found in table 't'"
   },
   {
     "comment": "push predicate on joined derived tables",
@@ -4587,8 +4587,8 @@
   {
     "comment": "verify ',' vs JOIN precedence",
     "query": "select u1.a from unsharded u1, unsharded u2 join unsharded u3 on u1.a = u2.a",
-    "v3-plan": "VT03019: symbol u1.a not found",
-    "gen4-plan": "symbol u1.a not found"
+    "v3-plan": "VT03019: column u1.a not found",
+    "gen4-plan": "column 'u1.a' not found"
   },
   {
     "comment": "first expression fails for ',' join (code coverage: ensure error is returned)",
@@ -4598,8 +4598,8 @@
   {
     "comment": "table names should be case-sensitive",
     "query": "select unsharded.id from unsharded where Unsharded.val = 1",
-    "v3-plan": "VT03019: symbol Unsharded.val not found",
-    "gen4-plan": "symbol Unsharded.val not found"
+    "v3-plan": "VT03019: column Unsharded.val not found",
+    "gen4-plan": "column 'Unsharded.val' not found"
   },
   {
     "comment": "implicit table reference for sharded keyspace",

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -74,7 +74,7 @@
   {
     "comment": "information schema join",
     "query": "select tables.TABLE_SCHEMA, files.`STATUS` from information_schema.tables join information_schema.files",
-    "v3-plan": "VT03019: symbol `tables`.TABLE_SCHEMA not found",
+    "v3-plan": "VT03019: column `tables`.TABLE_SCHEMA not found",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select tables.TABLE_SCHEMA, files.`STATUS` from information_schema.tables join information_schema.files",
@@ -734,7 +734,7 @@
   {
     "comment": "subquery of information_schema with itself",
     "query": "select TABLES.CHECKSUM from information_schema.`TABLES` where `TABLE_NAME` in (select `TABLE_NAME` from information_schema.`COLUMNS`)",
-    "v3-plan": "VT03019: symbol `TABLES`.`CHECKSUM` not found",
+    "v3-plan": "VT03019: column `TABLES`.`CHECKSUM` not found",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select TABLES.CHECKSUM from information_schema.`TABLES` where `TABLE_NAME` in (select `TABLE_NAME` from information_schema.`COLUMNS`)",

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -74,7 +74,7 @@
   {
     "comment": "information schema join",
     "query": "select tables.TABLE_SCHEMA, files.`STATUS` from information_schema.tables join information_schema.files",
-    "v3-plan": "VT03019: symbol `tables`.TABLE_SCHEMA not found",
+    "v3-plan": "VT03019: column `tables`.TABLE_SCHEMA not found",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select tables.TABLE_SCHEMA, files.`STATUS` from information_schema.tables join information_schema.files",
@@ -816,7 +816,7 @@
   {
     "comment": "subquery of information_schema with itself",
     "query": "select TABLES.CHECKSUM from information_schema.`TABLES` where `TABLE_NAME` in (select `TABLE_NAME` from information_schema.`COLUMNS`)",
-    "v3-plan": "VT03019: symbol `TABLES`.`CHECKSUM` not found",
+    "v3-plan": "VT03019: column `TABLES`.`CHECKSUM` not found",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select TABLES.CHECKSUM from information_schema.`TABLES` where `TABLE_NAME` in (select `TABLE_NAME` from information_schema.`COLUMNS`)",

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -39,7 +39,7 @@
   {
     "comment": "ambiguous symbol reference",
     "query": "select user.col1, user_extra.col1 from user join user_extra having col1 = 2",
-    "v3-plan": "VT03021: ambiguous symbol reference: col1",
+    "v3-plan": "VT03021: ambiguous column reference: col1",
     "gen4-plan": "Column 'col1' in field list is ambiguous"
   },
   {
@@ -1612,7 +1612,7 @@
   {
     "comment": "Order by, verify outer symtab is searched according to its own context.",
     "query": "select u.id from user u having u.id in (select col2 from user where user.id = u.id order by u.col)",
-    "v3-plan": "VT03020: symbol u.col not found in subquery",
+    "v3-plan": "VT03020: column u.col not found in subquery",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select u.id from user u having u.id in (select col2 from user where user.id = u.id order by u.col)",
@@ -1635,8 +1635,8 @@
   {
     "comment": "Order by, qualified '*' expression, name mismatched.",
     "query": "select user.* from user where id = 5 order by e.col",
-    "v3-plan": "VT03019: symbol e.col not found",
-    "gen4-plan": "symbol e.col not found"
+    "v3-plan": "VT03019: column e.col not found",
+    "gen4-plan": "column 'e.col' not found"
   },
   {
     "comment": "Order by, invalid column number",
@@ -2783,7 +2783,7 @@
   {
     "comment": "join order by with ambiguous column reference ; valid in MySQL",
     "query": "select name, name from user, music order by name",
-    "v3-plan": "VT03021: ambiguous symbol reference: `name`",
+    "v3-plan": "VT03021: ambiguous column reference: `name`",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select name, name from user, music order by name",
@@ -2827,7 +2827,7 @@
   {
     "comment": "order by with ambiguous column reference ; valid in MySQL",
     "query": "select id, id from user order by id",
-    "v3-plan": "VT03021: ambiguous symbol reference: id",
+    "v3-plan": "VT03021: ambiguous column reference: id",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select id, id from user order by id",
@@ -3030,7 +3030,7 @@
   {
     "comment": "Distinct with same column",
     "query": "select distinct a, a from user",
-    "v3-plan": "generating ORDER BY clause: VT03021: ambiguous symbol reference: a",
+    "v3-plan": "generating ORDER BY clause: VT03021: ambiguous column reference: a",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select distinct a, a from user",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -796,7 +796,7 @@
   {
     "comment": "Cannot auto-resolve for cross-shard joins",
     "query": "select col from user join user_extra",
-    "v3-plan": "VT03019: symbol col not found",
+    "v3-plan": "VT03019: column col not found",
     "gen4-plan": "Column 'col' in field list is ambiguous"
   },
   {
@@ -2372,8 +2372,8 @@
   {
     "comment": "non-existent symbol in cross-shard derived table",
     "query": "select t.col from (select user.id from user join user_extra) as t",
-    "v3-plan": "VT03019: symbol t.col not found",
-    "gen4-plan": "symbol t.col not found"
+    "v3-plan": "VT03019: column t.col not found",
+    "gen4-plan": "column 't.col' not found"
   },
   {
     "comment": "union with the same target shard",
@@ -7900,34 +7900,34 @@
     "comment": "query with a derived table and dual table in unsharded keyspace",
     "query": "SELECT * FROM unsharded_a AS t1  JOIN (SELECT trim((SELECT MAX(name) FROM unsharded_a)) AS name) AS t2 WHERE t1.name >= t2.name ORDER BY t1.name ASC LIMIT 1;",
     "v3-plan": {
+      "QueryType": "SELECT",
+      "Original": "SELECT * FROM unsharded_a AS t1  JOIN (SELECT trim((SELECT MAX(name) FROM unsharded_a)) AS name) AS t2 WHERE t1.name >= t2.name ORDER BY t1.name ASC LIMIT 1;",
       "Instructions": {
-        "FieldQuery": "select * from unsharded_a as t1 join (select trim((select max(`name`) from unsharded_a where 1 != 1)) as `name` from dual where 1 != 1) as t2 where 1 != 1",
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
         "Keyspace": {
           "Name": "main",
           "Sharded": false
         },
-        "OperatorType": "Route",
+        "FieldQuery": "select * from unsharded_a as t1 join (select trim((select max(`name`) from unsharded_a where 1 != 1)) as `name` from dual where 1 != 1) as t2 where 1 != 1",
         "Query": "select * from unsharded_a as t1 join (select trim((select max(`name`) from unsharded_a)) as `name` from dual) as t2 where t1.`name` >= t2.`name` order by t1.`name` asc limit 1",
-        "Table": "unsharded_a, dual",
-        "Variant": "Unsharded"
-      },
-      "Original": "SELECT * FROM unsharded_a AS t1  JOIN (SELECT trim((SELECT MAX(name) FROM unsharded_a)) AS name) AS t2 WHERE t1.name >= t2.name ORDER BY t1.name ASC LIMIT 1;",
-      "QueryType": "SELECT"
+        "Table": "unsharded_a, dual"
+      }
     },
     "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "SELECT * FROM unsharded_a AS t1  JOIN (SELECT trim((SELECT MAX(name) FROM unsharded_a)) AS name) AS t2 WHERE t1.name >= t2.name ORDER BY t1.name ASC LIMIT 1;",
       "Instructions": {
-        "FieldQuery": "select * from unsharded_a as t1 join (select trim((select max(`name`) from unsharded_a where 1 != 1)) as `name` from dual where 1 != 1) as t2 where 1 != 1",
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
         "Keyspace": {
           "Name": "main",
           "Sharded": false
         },
-        "OperatorType": "Route",
+        "FieldQuery": "select * from unsharded_a as t1 join (select trim((select max(`name`) from unsharded_a where 1 != 1)) as `name` from dual where 1 != 1) as t2 where 1 != 1",
         "Query": "select * from unsharded_a as t1 join (select trim((select max(`name`) from unsharded_a)) as `name` from dual) as t2 where t1.`name` >= t2.`name` order by t1.`name` asc limit 1",
-        "Table": "dual, unsharded_a",
-        "Variant": "Unsharded"
+        "Table": "dual, unsharded_a"
       },
-      "Original": "SELECT * FROM unsharded_a AS t1  JOIN (SELECT trim((SELECT MAX(name) FROM unsharded_a)) AS name) AS t2 WHERE t1.name >= t2.name ORDER BY t1.name ASC LIMIT 1;",
-      "QueryType": "SELECT",
       "TablesUsed": [
         "main.dual",
         "main.unsharded_a"

--- a/go/vt/vtgate/planbuilder/testdata/symtab_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/symtab_cases.json
@@ -84,7 +84,7 @@
   {
     "comment": "predef1 is in both user and unsharded. So, it's ambiguous.",
     "query": "select predef1, predef3 from user join unsharded on predef1 = predef3",
-    "v3-plan": "VT03019: symbol predef1 not found",
+    "v3-plan": "VT03019: column predef1 not found",
     "gen4-plan": "Column 'predef1' in field list is ambiguous"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -8,7 +8,7 @@
   {
     "comment": "TPC-H query 2",
     "query": "select s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment from part, supplier, partsupp, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and p_size = 15 and p_type like '%BRASS' and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'EUROPE' and ps_supplycost = ( select min(ps_supplycost) from partsupp, supplier, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'EUROPE' ) order by s_acctbal desc, n_name, s_name, p_partkey limit 10",
-    "v3-plan": "VT03019: symbol p_partkey not found",
+    "v3-plan": "VT03019: column p_partkey not found",
     "gen4-plan": "VT12001: unsupported: cross-shard correlated subquery"
   },
   {
@@ -134,7 +134,7 @@
   {
     "comment": "TPC-H query 4",
     "query": "select o_orderpriority, count(*) as order_count from orders where o_orderdate >= date('1993-07-01') and o_orderdate < date('1993-07-01') + interval '3' month and exists ( select * from lineitem where l_orderkey = o_orderkey and l_commitdate < l_receiptdate ) group by o_orderpriority order by o_orderpriority",
-    "v3-plan": "VT03019: symbol o_orderkey not found",
+    "v3-plan": "VT03019: column o_orderkey not found",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select o_orderpriority, count(*) as order_count from orders where o_orderdate >= date('1993-07-01') and o_orderdate < date('1993-07-01') + interval '3' month and exists ( select * from lineitem where l_orderkey = o_orderkey and l_commitdate < l_receiptdate ) group by o_orderpriority order by o_orderpriority",
@@ -1124,7 +1124,7 @@
   {
     "comment": "TPC-H query 17",
     "query": "select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and l_quantity < ( select 0.2 * avg(l_quantity) from lineitem where l_partkey = p_partkey )",
-    "v3-plan": "VT03019: symbol p_partkey not found",
+    "v3-plan": "VT03019: column p_partkey not found",
     "gen4-plan": "VT12001: unsupported: cross-shard correlated subquery"
   },
   {
@@ -1340,7 +1340,7 @@
   {
     "comment": "TPC-H query 20",
     "query": "select s_name, s_address from supplier, nation where s_suppkey in ( select ps_suppkey from partsupp where ps_partkey in ( select p_partkey from part where p_name like 'forest%' ) and ps_availqty > ( select 0.5 * sum(l_quantity) from lineitem where l_partkey = ps_partkey and l_suppkey = ps_suppkey and l_shipdate >= date('1994-01-01') and l_shipdate < date('1994-01-01') + interval '1' year ) ) and s_nationkey = n_nationkey and n_name = 'CANADA' order by s_name",
-    "v3-plan": "VT03019: symbol ps_partkey not found",
+    "v3-plan": "VT03019: column ps_partkey not found",
     "gen4-plan": "VT12001: unsupported: cross-shard correlated subquery"
   },
   {
@@ -1489,7 +1489,7 @@
   {
     "comment": "TPC-H query 22",
     "query": "select cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal from ( select substring(c_phone from 1 for 2) as cntrycode, c_acctbal from customer where substring(c_phone from 1 for 2) in ('13', '31', '23', '29', '30', '18', '17') and c_acctbal > ( select avg(c_acctbal) from customer where c_acctbal > 0.00 and substring(c_phone from 1 for 2) in ('13', '31', '23', '29', '30', '18', '17') ) and not exists ( select * from orders where o_custkey = c_custkey ) ) as custsale group by cntrycode order by cntrycode",
-    "v3-plan": "VT03019: symbol c_custkey not found",
+    "v3-plan": "VT03019: column c_custkey not found",
     "gen4-plan": "VT12001: unsupported: EXISTS sub-queries are only supported with AND clause"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -2398,7 +2398,7 @@
   {
     "comment": "systable union query in derived table with constraint on outside (star projection)",
     "query": "select * from (select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `constraint_name` = 'primary'",
-    "v3-plan": "VT03019: symbol constraint_name not found",
+    "v3-plan": "VT03019: column constraint_name not found",
     "gen4-plan": {
       "QueryType": "SELECT",
       "Original": "select * from (select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `constraint_name` = 'primary'",

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -372,7 +372,7 @@
   {
     "comment": "create view with Cannot auto-resolve for cross-shard joins",
     "query": "create view user.view_a as select col from user join user_extra",
-    "v3-plan": "VT03019: symbol col not found",
+    "v3-plan": "VT03019: column col not found",
     "gen4-plan": "Column 'col' in field list is ambiguous"
   },
   {
@@ -414,7 +414,7 @@
   {
     "comment": "scatter aggregate with ambiguous aliases",
     "query": "select distinct a, b as a from user",
-    "v3-plan": "generating ORDER BY clause: VT03021: ambiguous symbol reference: a",
+    "v3-plan": "generating ORDER BY clause: VT03021: ambiguous column reference: a",
     "gen4-plan": "VT13001: [BUG] generating ORDER BY clause: ambiguous symbol reference: a"
   },
   {

--- a/go/vt/vtgate/planbuilder/testdata/vindex_func_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/vindex_func_cases.json
@@ -723,7 +723,7 @@
   {
     "comment": "select none from user_index where id = :id",
     "query": "select none from user_index where id = :id",
-    "v3-plan": "VT03019: symbol `none` not found",
-    "gen4-plan": "symbol user_index.`none` not found"
+    "v3-plan": "VT03019: column `none` not found",
+    "gen4-plan": "column '`none`' not found in table 'user_index'"
   }
 ]

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -125,7 +125,7 @@ func TestBindingSingleTableNegative(t *testing.T) {
 			require.NoError(t, err)
 			_, err = Analyze(parse, "d", &FakeSI{})
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "symbol")
+			require.Contains(t, err.Error(), "column")
 			require.Contains(t, err.Error(), "not found")
 		})
 	}
@@ -311,7 +311,7 @@ func TestMissingTable(t *testing.T) {
 			parse, _ := sqlparser.Parse(query)
 			_, err := Analyze(parse, "", &FakeSI{})
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "symbol t.col not found")
+			require.Contains(t, err.Error(), "column 't.col' not found")
 		})
 	}
 }
@@ -462,7 +462,7 @@ func TestScoping(t *testing.T) {
 	}{
 		{
 			query:        "select 1 from u1, u2 left join u3 on u1.a = u2.a",
-			errorMessage: "symbol u1.a not found",
+			errorMessage: "column 'u1.a' not found",
 		},
 	}
 	for _, query := range queries {
@@ -916,10 +916,10 @@ func TestInvalidQueries(t *testing.T) {
 		err: &JSONTablesError{},
 	}, {
 		sql:  "select does_not_exist from t1",
-		serr: "symbol t1.does_not_exist not found",
+		serr: "column 'does_not_exist' not found in table 't1'",
 	}, {
 		sql:  "select t1.does_not_exist from t1, t2",
-		serr: "symbol t1.does_not_exist not found",
+		serr: "column 't1.does_not_exist' not found",
 	}}
 
 	for _, tc := range tcases {
@@ -985,7 +985,7 @@ func TestScopingWDerivedTables(t *testing.T) {
 			expectation:          T2,
 		}, {
 			query:        "select t.id2 from (select foo as id from user) as t",
-			errorMessage: "symbol t.id2 not found",
+			errorMessage: "column 't.id2' not found",
 		}, {
 			query:                "select id from (select 42 as id) as t",
 			recursiveExpectation: T0,
@@ -996,7 +996,7 @@ func TestScopingWDerivedTables(t *testing.T) {
 			expectation:          T2,
 		}, {
 			query:        "select ks.t.id from (select 42 as id) as t",
-			errorMessage: "symbol ks.t.id not found",
+			errorMessage: "column 'ks.t.id' not found",
 		}, {
 			query:        "select * from (select id, id from user) as t",
 			errorMessage: "Duplicate column name 'id'",
@@ -1022,13 +1022,13 @@ func TestScopingWDerivedTables(t *testing.T) {
 			recursiveExpectation: T2,
 		}, {
 			query:        "select uu.test from (select id from t1) uu",
-			errorMessage: "symbol uu.test not found",
+			errorMessage: "column 'uu.test' not found",
 		}, {
 			query:        "select uu.id from (select id as col from t1) uu",
-			errorMessage: "symbol uu.id not found",
+			errorMessage: "column 'uu.id' not found",
 		}, {
 			query:        "select uu.id from (select id as col from t1) uu",
-			errorMessage: "symbol uu.id not found",
+			errorMessage: "column 'uu.id' not found",
 		}, {
 			query:                "select uu.id from (select id from t1) as uu where exists (select * from t2 as uu where uu.id = uu.uid)",
 			expectation:          T2,

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -239,6 +239,7 @@ func (b *binder) createExtractedSubquery(cursor *sqlparser.Cursor, currScope *sc
 func (b *binder) resolveColumn(colName *sqlparser.ColName, current *scope, allowMulti bool) (dependency, error) {
 	var thisDeps dependencies
 	first := true
+	var tableName *sqlparser.TableName
 	for current != nil {
 		var err error
 		thisDeps, err = b.resolveColumnInScope(current, colName, allowMulti)
@@ -266,13 +267,13 @@ func (b *binder) resolveColumn(colName *sqlparser.ColName, current *scope, allow
 			// This is just used for a clearer error message
 			name, err := current.tables[0].Name()
 			if err == nil {
-				colName.Qualifier = name
+				tableName = &name
 			}
 		}
 		first = false
 		current = current.parent
 	}
-	return dependency{}, &ColumnNotFoundError{Column: colName}
+	return dependency{}, &ColumnNotFoundError{Column: colName, Table: tableName}
 }
 
 func (b *binder) resolveColumnInScope(current *scope, expr *sqlparser.ColName, allowMulti bool) (dependencies, error) {

--- a/go/vt/vtgate/semantics/errors.go
+++ b/go/vt/vtgate/semantics/errors.go
@@ -235,10 +235,14 @@ func (e *BuggyError) bug() {}
 // ColumnNotFoundError
 type ColumnNotFoundError struct {
 	Column *sqlparser.ColName
+	Table  *sqlparser.TableName
 }
 
 func (e *ColumnNotFoundError) Error() string {
-	return eprintf(e, "symbol %s not found", sqlparser.String(e.Column))
+	if e.Table == nil {
+		return eprintf(e, "column '%s' not found", sqlparser.String(e.Column))
+	}
+	return eprintf(e, "column '%s' not found in table '%s'", sqlparser.String(e.Column), sqlparser.String(e.Table))
 }
 
 func (e *ColumnNotFoundError) ErrorCode() vtrpcpb.Code {


### PR DESCRIPTION
The change in https://github.com/vitessio/vitess/pull/12572 introduced a subtle bug. When we clone a parsed SQL statement, we don't clone the column information since that's used in the semantic analyzer as a by pointer value.

This means that semantic analysis also is not allowed to update / change this column information because it would modify also a previously cloned statement.

So we need to introduce an explicit field reference to the table. This also updates the terminology to use column instead of symbol as that's a more common term and also what MySQL uses in it's error messages.

## Related Issue(s)

Issue introduced in https://github.com/vitessio/vitess/pull/12572

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required