### PR TITLE
Fix the returned schema object for broken views

### DIFF
--- a/go/vt/schemadiff/schema_test.go
+++ b/go/vt/schemadiff/schema_test.go
@@ -114,9 +114,12 @@ func TestNewSchemaFromQueriesUnresolved(t *testing.T) {
 	queries := append(createQueries,
 		"create view v7 as select * from v8, t2",
 	)
-	_, err := NewSchemaFromQueries(queries)
+	schema, err := NewSchemaFromQueries(queries)
 	assert.Error(t, err)
 	assert.EqualError(t, err, (&ViewDependencyUnresolvedError{View: "v7"}).Error())
+	v := schema.sorted[len(schema.sorted)-1]
+	assert.IsType(t, &CreateViewEntity{}, v)
+	assert.Equal(t, "CREATE VIEW `v7` AS SELECT * FROM `v8`, `t2`", v.Create().CanonicalStatementString())
 }
 
 func TestNewSchemaFromQueriesUnresolvedAlias(t *testing.T) {


### PR DESCRIPTION
The logic added in https://github.com/vitessio/vitess/pull/12675 has a small issue. When a view is found that has an error, it's not present anymore when a subsequent `.ToSQL()` call happens, so it looks like the view disappears.

We should never have a view disappear since that could potentially break things and lead to unexpected results.

## Related Issue(s)

Issue introduced in https://github.com/vitessio/vitess/pull/12675

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required