### PR TITLE
[planner fix 14.0] make unknown column an error only for sharded queries

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -3474,7 +3474,22 @@
   {
     "comment": "verify ',' vs JOIN precedence",
     "query": "select u1.a from unsharded u1, unsharded u2 join unsharded u3 on u1.a = u2.a",
-    "plan": "symbol u1.a not found"
+    "v3-plan": "symbol u1.a not found",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select u1.a from unsharded u1, unsharded u2 join unsharded u3 on u1.a = u2.a",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select u1.a from unsharded as u1, unsharded as u2 join unsharded as u3 on u1.a = u2.a where 1 != 1",
+        "Query": "select u1.a from unsharded as u1, unsharded as u2 join unsharded as u3 on u1.a = u2.a",
+        "Table": "unsharded"
+      }
+    }
   },
   {
     "comment": "first expression fails for ',' join (code coverage: ensure error is returned)",
@@ -3484,7 +3499,22 @@
   {
     "comment": "table names should be case-sensitive",
     "query": "select unsharded.id from unsharded where Unsharded.val = 1",
-    "plan": "symbol Unsharded.val not found"
+    "v3-plan": "symbol Unsharded.val not found",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select unsharded.id from unsharded where Unsharded.val = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
+        "Query": "select unsharded.id from unsharded where Unsharded.val = 1",
+        "Table": "unsharded"
+      }
+    }
   },
   {
     "comment": "implicit table reference for sharded keyspace",
@@ -4762,5 +4792,30 @@
         ]
       }
     }
+  },
+  {
+    "comment": "missing and ambiguous column info is OK as long as we can send the query to a single unsharded keyspace",
+    "query": "select missing_column from unsharded, unsharded_a",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select missing_column from unsharded, unsharded_a",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select missing_column from unsharded, unsharded_a where 1 != 1",
+        "Query": "select missing_column from unsharded, unsharded_a",
+        "Table": "unsharded, unsharded_a"
+      }
+    }
+  },
+  {
+    "comment": "missing and ambiguous column info is not valid when we have two different unsharded keyspaces in the query",
+    "query": "select missing_column from unsharded, unsharded_tab",
+    "v3-plan": "symbol missing_column not found",
+    "gen4-plan": "Column 'missing_column' in field list is ambiguous"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -1916,5 +1916,24 @@
         ]
       }
     }
+  },
+  {
+    "comment": "unknown columns are OK as long as the whole query is unsharded",
+    "query": "(SELECT * FROM (SELECT * FROM unsharded WHERE branchId = 203622 AND buildNumber <= 113893 AND state = 'FAILED' ORDER BY buildNumber DESC LIMIT 1) AS last_failed) UNION ALL (SELECT * FROM (SELECT * FROM unsharded WHERE branchId = 203622 AND buildNumber <= 113893 AND state = 'SUCCEEDED' ORDER BY buildNumber DESC LIMIT 1) AS last_succeeded) ORDER BY buildNumber DESC LIMIT 1",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "(SELECT * FROM (SELECT * FROM unsharded WHERE branchId = 203622 AND buildNumber <= 113893 AND state = 'FAILED' ORDER BY buildNumber DESC LIMIT 1) AS last_failed) UNION ALL (SELECT * FROM (SELECT * FROM unsharded WHERE branchId = 203622 AND buildNumber <= 113893 AND state = 'SUCCEEDED' ORDER BY buildNumber DESC LIMIT 1) AS last_succeeded) ORDER BY buildNumber DESC LIMIT 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select * from (select * from unsharded where 1 != 1) as last_failed where 1 != 1 union all select * from (select * from unsharded where 1 != 1) as last_succeeded where 1 != 1",
+        "Query": "select * from (select * from unsharded where branchId = 203622 and buildNumber <= 113893 and state = 'FAILED' order by buildNumber desc limit 1) as last_failed union all select * from (select * from unsharded where branchId = 203622 and buildNumber <= 113893 and state = 'SUCCEEDED' order by buildNumber desc limit 1) as last_succeeded order by buildNumber desc limit 1",
+        "Table": "unsharded"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -105,7 +105,7 @@ func (a *analyzer) setError(err error) {
 	switch err := err.(type) {
 	case ProjError:
 		a.projErr = err.Inner
-	case UnshardedError:
+	case ShardedError:
 		a.unshardedErr = err.Inner
 	default:
 		if a.inProjection > 0 && vterrors.ErrState(err) == vterrors.NonUniqError {
@@ -204,8 +204,8 @@ func checkUnionColumns(union *sqlparser.Union) error {
 }
 
 /*
-	errors that happen when we are evaluating SELECT expressions are saved until we know
-	if we can merge everything into a single route or not
+errors that happen when we are evaluating SELECT expressions are saved until we know
+if we can merge everything into a single route or not
 */
 func (a *analyzer) enterProjection(cursor *sqlparser.Cursor) {
 	_, ok := cursor.Node().(sqlparser.SelectExprs)
@@ -256,11 +256,11 @@ func (a *analyzer) checkForInvalidConstructs(cursor *sqlparser.Cursor) error {
 	switch node := cursor.Node().(type) {
 	case *sqlparser.Update:
 		if len(node.TableExprs) != 1 {
-			return UnshardedError{Inner: vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: multiple tables in update")}
+			return ShardedError{Inner: vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: multiple tables in update")}
 		}
 		alias, isAlias := node.TableExprs[0].(*sqlparser.AliasedTableExpr)
 		if !isAlias {
-			return UnshardedError{Inner: vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: multiple tables in update")}
+			return ShardedError{Inner: vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: multiple tables in update")}
 		}
 		_, isDerived := alias.Expr.(*sqlparser.DerivedTable)
 		if isDerived {
@@ -362,12 +362,12 @@ func (p ProjError) Error() string {
 	return p.Inner.Error()
 }
 
-// UnshardedError is used to mark an error as something that should only be returned
+// ShardedError is used to mark an error as something that should only be returned
 // if the query is not unsharded
-type UnshardedError struct {
+type ShardedError struct {
 	Inner error
 }
 
-func (p UnshardedError) Error() string {
+func (p ShardedError) Error() string {
 	return p.Inner.Error()
 }

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -113,10 +113,10 @@ func TestBindingSingleTableNegative(t *testing.T) {
 		t.Run(query, func(t *testing.T) {
 			parse, err := sqlparser.Parse(query)
 			require.NoError(t, err)
-			_, err = Analyze(parse.(sqlparser.SelectStatement), "d", &FakeSI{})
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "symbol")
-			require.Contains(t, err.Error(), "not found")
+			st, err := Analyze(parse.(sqlparser.SelectStatement), "d", &FakeSI{})
+			require.NoError(t, err)
+			require.ErrorContains(t, st.NotUnshardedErr, "symbol")
+			require.ErrorContains(t, st.NotUnshardedErr, "not found")
 		})
 	}
 }
@@ -133,12 +133,13 @@ func TestBindingSingleAliasedTableNegative(t *testing.T) {
 		t.Run(query, func(t *testing.T) {
 			parse, err := sqlparser.Parse(query)
 			require.NoError(t, err)
-			_, err = Analyze(parse.(sqlparser.SelectStatement), "", &FakeSI{
+			st, err := Analyze(parse.(sqlparser.SelectStatement), "", &FakeSI{
 				Tables: map[string]*vindexes.Table{
 					"t": {Name: sqlparser.NewTableIdent("t")},
 				},
 			})
-			require.Error(t, err)
+			require.NoError(t, err)
+			require.Error(t, st.NotUnshardedErr)
 		})
 	}
 }
@@ -299,9 +300,9 @@ func TestMissingTable(t *testing.T) {
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
 			parse, _ := sqlparser.Parse(query)
-			_, err := Analyze(parse.(sqlparser.SelectStatement), "", &FakeSI{})
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "symbol t.col not found")
+			st, err := Analyze(parse.(sqlparser.SelectStatement), "", &FakeSI{})
+			require.NoError(t, err)
+			require.ErrorContains(t, st.NotUnshardedErr, "symbol t.col not found")
 		})
 	}
 }
@@ -459,16 +460,13 @@ func TestScoping(t *testing.T) {
 		t.Run(query.query, func(t *testing.T) {
 			parse, err := sqlparser.Parse(query.query)
 			require.NoError(t, err)
-			_, err = Analyze(parse.(sqlparser.SelectStatement), "user", &FakeSI{
+			st, err := Analyze(parse.(sqlparser.SelectStatement), "user", &FakeSI{
 				Tables: map[string]*vindexes.Table{
 					"t": {Name: sqlparser.NewTableIdent("t")},
 				},
 			})
-			if query.errorMessage == "" {
-				require.NoError(t, err)
-			} else {
-				require.EqualError(t, err, query.errorMessage)
-			}
+			require.NoError(t, err)
+			require.EqualError(t, st.NotUnshardedErr, query.errorMessage)
 		})
 	}
 }
@@ -857,8 +855,9 @@ func TestUnionOrderByRewrite(t *testing.T) {
 
 func TestInvalidQueries(t *testing.T) {
 	tcases := []struct {
-		sql string
-		err string
+		sql        string
+		err        string
+		shardedErr string
 	}{{
 		sql: "select t1.id, t1.col1 from t1 union select t2.uid from t2",
 		err: "The used SELECT statements have a different number of columns",
@@ -886,15 +885,37 @@ func TestInvalidQueries(t *testing.T) {
 	}, {
 		sql: "select (select sql_calc_found_rows id from a) as t",
 		err: "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'",
+	}, {
+		sql: "select id from t1 natural join t2",
+		err: "unsupported: natural join",
+	}, {
+		sql: "select * from music where user_id IN (select sql_calc_found_rows * from music limit 10)",
+		err: "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'",
+	}, {
+		sql: "select is_free_lock('xyz') from user",
+		err: "is_free_lock('xyz') allowed only with dual",
+	}, {
+		sql: "SELECT * FROM JSON_TABLE('[ {\"c1\": null} ]','$[*]' COLUMNS( c1 INT PATH '$.c1' ERROR ON ERROR )) as jt",
+		err: "unsupported: json_table expressions",
+	}, {
+		sql:        "select does_not_exist from t1",
+		shardedErr: "symbol does_not_exist not found",
+	}, {
+		sql:        "select t1.does_not_exist from t1, t2",
+		shardedErr: "symbol t1.does_not_exist not found",
 	}}
 	for _, tc := range tcases {
 		t.Run(tc.sql, func(t *testing.T) {
 			parse, err := sqlparser.Parse(tc.sql)
 			require.NoError(t, err)
 
-			_, err = Analyze(parse.(sqlparser.SelectStatement), "dbName", fakeSchemaInfo())
-			require.Error(t, err)
-			require.Equal(t, tc.err, err.Error())
+			st, err := Analyze(parse.(sqlparser.SelectStatement), "dbName", fakeSchemaInfo())
+			if tc.err != "" {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err, tc.err)
+				require.EqualError(t, st.NotUnshardedErr, tc.shardedErr)
+			}
 		})
 	}
 }
@@ -1007,9 +1028,13 @@ func TestScopingWDerivedTables(t *testing.T) {
 					"t": {Name: sqlparser.NewTableIdent("t")},
 				},
 			})
-			if query.errorMessage != "" {
+
+			switch {
+			case query.errorMessage != "" && err != nil:
 				require.EqualError(t, err, query.errorMessage)
-			} else {
+			case query.errorMessage != "":
+				require.EqualError(t, st.NotUnshardedErr, query.errorMessage)
+			default:
 				require.NoError(t, err)
 				sel := parse.(*sqlparser.Select)
 				assert.Equal(t, query.recursiveExpectation, st.RecursiveDeps(extract(sel, 0)), "RecursiveDeps")

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -258,7 +258,7 @@ func (b *binder) resolveColumn(colName *sqlparser.ColName, current *scope, allow
 		}
 		current = current.parent
 	}
-	return dependency{}, vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.BadFieldError, "symbol %s not found", sqlparser.String(colName))
+	return dependency{}, ShardedError{Inner: vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.BadFieldError, "symbol %s not found", sqlparser.String(colName))}
 }
 
 func (b *binder) resolveColumnInScope(current *scope, expr *sqlparser.ColName, allowMulti bool) (dependencies, error) {


### PR DESCRIPTION
## Description
Backport of #12704

In earlier releases, the vtgate planner would be lenient with unknown columns, letting the underlying MySQL if there was a real problem.

This PR re-introduces this behaviour. On queries that only touch a single unsharded keyspace, the gen4 planner will allow missing column information.

## Related Issue(s)
Fixes #12548