### PR TITLE
vtgate: use collation when hashing query plans

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1018,7 +1018,7 @@ func (e *Executor) getPlan(ctx context.Context, vcursor *vcursorImpl, sql string
 	return e.cacheAndBuildStatement(ctx, vcursor, query, statement, qo, logStats, stmt, reservedVars, bindVarNeeds)
 }
 
-func (e *Executor) cacheAndBuildStatement(ctx context.Context, vcursor *vcursorImpl, query string, statement sqlparser.Statement, qo iQueryOption, logStats *logstats.LogStats, stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, bindVarNeeds *sqlparser.BindVarNeeds) (*engine.Plan, sqlparser.Statement, error) {
+func (e *Executor) hashPlan(ctx context.Context, vcursor *vcursorImpl, query string) string {
 	planHash := sha256.New()
 
 	{
@@ -1028,8 +1028,11 @@ func (e *Executor) cacheAndBuildStatement(ctx context.Context, vcursor *vcursorI
 		buf.Flush()
 	}
 
-	planKey := hex.EncodeToString(planHash.Sum(nil))
+	return hex.EncodeToString(planHash.Sum(nil))
+}
 
+func (e *Executor) cacheAndBuildStatement(ctx context.Context, vcursor *vcursorImpl, query string, statement sqlparser.Statement, qo iQueryOption, logStats *logstats.LogStats, stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, bindVarNeeds *sqlparser.BindVarNeeds) (*engine.Plan, sqlparser.Statement, error) {
+	planKey := e.hashPlan(ctx, vcursor, query)
 	if sqlparser.CachePlan(statement) && qo.cachePlan() {
 		if plan, ok := e.plans.Get(planKey); ok {
 			logStats.CachedPlan = true
@@ -1084,15 +1087,6 @@ func prepareSetVarComment(vcursor *vcursorImpl, stmt sqlparser.Statement) (strin
 		res.WriteString(fmt.Sprintf("SET_VAR(%s = %s) ", k, v))
 	})
 	return strings.TrimSpace(res.String()), nil
-}
-
-func (e *Executor) debugGetPlan(planKey string) (*engine.Plan, bool) {
-	planHash := sha256.Sum256([]byte(planKey))
-	planHex := hex.EncodeToString(planHash[:])
-	if plan, ok := e.plans.Get(planHex); ok {
-		return plan.(*engine.Plan), true
-	}
-	return nil, false
 }
 
 type cacheItem struct {

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -35,7 +36,6 @@ import (
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/cache"
-	"vitess.io/vitess/go/hack"
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
@@ -1020,9 +1020,14 @@ func (e *Executor) getPlan(ctx context.Context, vcursor *vcursorImpl, sql string
 
 func (e *Executor) cacheAndBuildStatement(ctx context.Context, vcursor *vcursorImpl, query string, statement sqlparser.Statement, qo iQueryOption, logStats *logstats.LogStats, stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, bindVarNeeds *sqlparser.BindVarNeeds) (*engine.Plan, sqlparser.Statement, error) {
 	planHash := sha256.New()
-	_, _ = planHash.Write([]byte(vcursor.planPrefixKey(ctx)))
-	_, _ = planHash.Write([]byte{':'})
-	_, _ = planHash.Write(hack.StringBytes(query))
+
+	{
+		// use a bufio.Writer to accumulate writes instead of writing directly to the hasher
+		buf := bufio.NewWriter(planHash)
+		vcursor.keyForPlan(ctx, query, buf)
+		buf.Flush()
+	}
+
 	planKey := hex.EncodeToString(planHash.Sum(nil))
 
 	if sqlparser.CachePlan(statement) && qo.cachePlan() {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1624,10 +1624,7 @@ func TestGetPlanUnnormalized(t *testing.T) {
 	if plan1 != plan2 {
 		t.Errorf("getPlan(query1): plans must be equal: %p %p", plan1, plan2)
 	}
-	want := []string{
-		"@unknown:" + query1,
-	}
-	assertCacheContains(t, r, want)
+	assertCacheContains(t, r, emptyvc, query1)
 	if logStats2.SQL != wantSQL {
 		t.Errorf("logstats sql want \"%s\" got \"%s\"", wantSQL, logStats2.SQL)
 	}
@@ -1642,11 +1639,8 @@ func TestGetPlanUnnormalized(t *testing.T) {
 	if plan3 != plan4 {
 		t.Errorf("getPlan(query1, ks): plans must be equal: %p %p", plan3, plan4)
 	}
-	want = []string{
-		KsTestUnsharded + "@unknown:" + query1,
-		"@unknown:" + query1,
-	}
-	assertCacheContains(t, r, want)
+	assertCacheContains(t, r, emptyvc, query1)
+	assertCacheContains(t, r, unshardedvc, query1)
 	if logStats4.SQL != wantSQL {
 		t.Errorf("logstats sql want \"%s\" got \"%s\"", wantSQL, logStats4.SQL)
 	}
@@ -1664,13 +1658,26 @@ func assertCacheSize(t *testing.T, c cache.Cache, expected int) {
 	}
 }
 
-func assertCacheContains(t *testing.T, e *Executor, want []string) {
+func assertCacheContains(t *testing.T, e *Executor, vc *vcursorImpl, sql string) *engine.Plan {
 	t.Helper()
-	for _, wantKey := range want {
-		if _, ok := e.debugGetPlan(wantKey); !ok {
-			t.Errorf("missing key in plan cache: %v", wantKey)
+
+	var plan *engine.Plan
+	if vc == nil {
+		e.plans.ForEach(func(x any) bool {
+			p := x.(*engine.Plan)
+			if p.Original == sql {
+				plan = p
+			}
+			return true
+		})
+	} else {
+		h := e.hashPlan(context.Background(), vc, sql)
+		if p, ok := e.plans.Get(h); ok {
+			plan = p.(*engine.Plan)
 		}
 	}
+	require.Truef(t, plan != nil, "plan not found for query: %s", sql)
+	return plan
 }
 
 func getPlanCached(t *testing.T, e *Executor, vcursor *vcursorImpl, sql string, comments sqlparser.MarginComments, bindVars map[string]*querypb.BindVariable, skipQueryPlanCache bool) (*engine.Plan, *logstats.LogStats) {
@@ -1782,10 +1789,7 @@ func TestGetPlanNormalized(t *testing.T) {
 	plan2, logStats2 := getPlanCached(t, r, emptyvc, query1, makeComments(" /* comment 2 */"), map[string]*querypb.BindVariable{}, false)
 
 	assert.Equal(t, plan1, plan2)
-	want := []string{
-		"@unknown:" + normalized,
-	}
-	assertCacheContains(t, r, want)
+	assertCacheContains(t, r, emptyvc, normalized)
 
 	wantSQL := normalized + " /* comment 1 */"
 	assert.Equal(t, wantSQL, logStats1.SQL)
@@ -1810,15 +1814,13 @@ func TestGetPlanNormalized(t *testing.T) {
 
 	plan4, _ = getPlanCached(t, r, unshardedvc, query1, makeComments(" /* comment 6 */"), map[string]*querypb.BindVariable{}, false)
 	assert.Equal(t, plan1, plan4)
-	want = []string{
-		KsTestUnsharded + "@unknown:" + normalized,
-		"@unknown:" + normalized,
-	}
-	assertCacheContains(t, r, want)
+	assertCacheContains(t, r, emptyvc, normalized)
+	assertCacheContains(t, r, unshardedvc, normalized)
 
 	_, _, err := r.getPlan(context.Background(), emptyvc, "syntax", makeComments(""), map[string]*querypb.BindVariable{}, nil, nil)
 	assert.EqualError(t, err, "syntax error at position 7 near 'syntax'")
-	assertCacheContains(t, r, want)
+	assertCacheContains(t, r, emptyvc, normalized)
+	assertCacheContains(t, r, unshardedvc, normalized)
 }
 
 func TestPassthroughDDL(t *testing.T) {

--- a/go/vt/vtgate/queryz_test.go
+++ b/go/vt/vtgate/queryz_test.go
@@ -44,10 +44,7 @@ func TestQueryzHandler(t *testing.T) {
 	_, err := executorExec(executor, sql, nil)
 	require.NoError(t, err)
 	executor.plans.Wait()
-	plan1, ok := executor.debugGetPlan("@primary:" + sql)
-	if !ok {
-		t.Fatalf("couldn't get plan from cache")
-	}
+	plan1 := assertCacheContains(t, executor, nil, sql)
 	plan1.ExecTime = uint64(1 * time.Millisecond)
 
 	// scatter
@@ -55,10 +52,7 @@ func TestQueryzHandler(t *testing.T) {
 	_, err = executorExec(executor, sql, nil)
 	require.NoError(t, err)
 	executor.plans.Wait()
-	plan2, ok := executor.debugGetPlan("@primary:" + sql)
-	if !ok {
-		t.Fatalf("couldn't get plan from cache")
-	}
+	plan2 := assertCacheContains(t, executor, nil, sql)
 	plan2.ExecTime = uint64(1 * time.Second)
 
 	sql = "insert into user (id, name) values (:id, :name)"
@@ -68,14 +62,10 @@ func TestQueryzHandler(t *testing.T) {
 	})
 	require.NoError(t, err)
 	executor.plans.Wait()
-	plan3, ok := executor.debugGetPlan("@primary:" + sql)
-	if !ok {
-		t.Fatalf("couldn't get plan from cache")
-	}
+	plan3 := assertCacheContains(t, executor, nil, sql)
 
 	// vindex insert from above execution
-	plan4, ok := executor.debugGetPlan("@primary:" + "insert into name_user_map(name, user_id) values(:name_0, :user_id_0)")
-	require.True(t, ok, "couldn't get plan from cache")
+	plan4 := assertCacheContains(t, executor, nil, "insert into name_user_map(name, user_id) values(:name_0, :user_id_0)")
 
 	// same query again should add query counts to existing plans
 	sql = "insert into user (id, name) values (:id, :name)"

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -998,10 +998,10 @@ func parseDestinationTarget(targetString string, vschema *vindexes.VSchema) (str
 }
 
 func (vc *vcursorImpl) keyForPlan(ctx context.Context, query string, buf io.StringWriter) {
-	buf.WriteString(vc.keyspace)
-	buf.WriteString(vindexes.TabletTypeSuffix[vc.tabletType])
-	buf.WriteString("+Collate:")
-	buf.WriteString(vc.collation.Get().Name())
+	_, _ = buf.WriteString(vc.keyspace)
+	_, _ = buf.WriteString(vindexes.TabletTypeSuffix[vc.tabletType])
+	_, _ = buf.WriteString("+Collate:")
+	_, _ = buf.WriteString(vc.collation.Get().Name())
 
 	if vc.destination != nil {
 		switch vc.destination.(type) {
@@ -1014,21 +1014,21 @@ func (vc *vcursorImpl) keyForPlan(ctx context.Context, query string, buf io.Stri
 				}
 				sort.Strings(shards)
 
-				buf.WriteString("+KsIDsResolved:")
+				_, _ = buf.WriteString("+KsIDsResolved:")
 				for i, s := range shards {
 					if i > 0 {
-						buf.WriteString(",")
+						_, _ = buf.WriteString(",")
 					}
-					buf.WriteString(s)
+					_, _ = buf.WriteString(s)
 				}
 			}
 		default:
-			buf.WriteString("+")
-			buf.WriteString(vc.destination.String())
+			_, _ = buf.WriteString("+")
+			_, _ = buf.WriteString(vc.destination.String())
 		}
 	}
-	buf.WriteString("+Query:")
-	buf.WriteString(query)
+	_, _ = buf.WriteString("+Query:")
+	_, _ = buf.WriteString(query)
 }
 
 func (vc *vcursorImpl) GetKeyspace() string {

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -19,6 +19,7 @@ package vtgate
 import (
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -996,7 +997,12 @@ func parseDestinationTarget(targetString string, vschema *vindexes.VSchema) (str
 	return destKeyspace, destTabletType, dest, err
 }
 
-func (vc *vcursorImpl) planPrefixKey(ctx context.Context) string {
+func (vc *vcursorImpl) keyForPlan(ctx context.Context, query string, buf io.StringWriter) {
+	buf.WriteString(vc.keyspace)
+	buf.WriteString(vindexes.TabletTypeSuffix[vc.tabletType])
+	buf.WriteString("+Collate:")
+	buf.WriteString(vc.collation.Get().Name())
+
 	if vc.destination != nil {
 		switch vc.destination.(type) {
 		case key.DestinationKeyspaceID, key.DestinationKeyspaceIDs:
@@ -1007,14 +1013,22 @@ func (vc *vcursorImpl) planPrefixKey(ctx context.Context) string {
 					shards[i] = resolved[i].Target.GetShard()
 				}
 				sort.Strings(shards)
-				return fmt.Sprintf("%s%sKsIDsResolved(%s)", vc.keyspace, vindexes.TabletTypeSuffix[vc.tabletType], strings.Join(shards, ","))
+
+				buf.WriteString("+KsIDsResolved:")
+				for i, s := range shards {
+					if i > 0 {
+						buf.WriteString(",")
+					}
+					buf.WriteString(s)
+				}
 			}
 		default:
-			// use destination string (out of the switch)
+			buf.WriteString("+")
+			buf.WriteString(vc.destination.String())
 		}
-		return fmt.Sprintf("%s%s%s", vc.keyspace, vindexes.TabletTypeSuffix[vc.tabletType], vc.destination.String())
 	}
-	return fmt.Sprintf("%s%s", vc.keyspace, vindexes.TabletTypeSuffix[vc.tabletType])
+	buf.WriteString("+Query:")
+	buf.WriteString(query)
 }
 
 func (vc *vcursorImpl) GetKeyspace() string {


### PR DESCRIPTION
## Description

This PR changes the contents of the key used when caching Query Plans in the VTGate to include the VCursor's current collation (which defaults to the user's connection collation).

Right now, there are two places in the `evalengine` where this collation is considered:

1. When first translating a SQL expression (passed as an argument to `Translate`)
2. When executing a SQL expression (passed as a field in `ExpressionEnv`).

This behavior is not consistent and can lead to buggy evaluation when an user with a specific collation first performs a query, the query's plan is cached, and then separate request with a different connection collation re-uses the same cached plan.

The WIP PR https://github.com/vitessio/vitess/pull/12724 removes the usage of (2) so that the only place where connection collation is taken into account is during initial translation, but we also need this change to ensure that connections with a non-default collation won't be able to access the wrong plan in the plan cache.

As part of this refactoring, I've cleaned up and optimized the way we generate these keys. The new code allocates less memory and should be easier to follow!

cc @systay @harshit-gangal 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
