### PR TITLE
[Work In Progress] VReplicating JSON Columns: fix data loss with large NUMERIC and DECIMAL values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
-	github.com/spyzhov/ajson v0.7.2
+	github.com/spyzhov/ajson v0.8.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tchap/go-patricia v2.3.0+incompatible
 	github.com/tidwall/gjson v1.12.1
@@ -113,6 +113,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/kr/text v0.2.0
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
+	github.com/shopspring/decimal v1.3.1
 	golang.org/x/exp v0.0.0-20230131160201-f062dba9d201
 	golang.org/x/sync v0.1.0
 	modernc.org/sqlite v1.20.3
@@ -218,3 +219,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+replace github.com/spyzhov/ajson v0.8.0 => /home/rohit/ajson-upstream

--- a/go.sum
+++ b/go.sum
@@ -702,6 +702,8 @@ github.com/secure-systems-lab/go-securesystemslib v0.3.1/go.mod h1:o8hhjkbNl2gOa
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -735,8 +737,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.15.0 h1:js3yy885G8xwJa6iOISGFwd+qlUo5AvyXb7CiihdtiU=
 github.com/spf13/viper v1.15.0/go.mod h1:fFcTBJxvhhzSJiZy8n+PeW6t8l+KeT/uTARa0jHOQLA=
-github.com/spyzhov/ajson v0.7.2 h1:kyl+ovUoId/RSBbSbCm31xyQvPixA6Sxgvb0eWyt1Ko=
-github.com/spyzhov/ajson v0.7.2/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go/mysql/binlog_event_json.go
+++ b/go/mysql/binlog_event_json.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/shopspring/decimal"
+
 	"vitess.io/vitess/go/vt/log"
 
 	"github.com/spyzhov/ajson"
@@ -472,11 +474,12 @@ func (oh opaquePlugin) getNode(typ jsonDataType, data []byte, pos int) (node *aj
 		if err != nil {
 			return nil, err
 		}
-		float, err := val.ToFloat64()
+		decimalValue, err := decimal.NewFromString(val.ToString())
+
 		if err != nil {
 			return nil, err
 		}
-		node = ajson.NumericNode("", float)
+		node = ajson.DecimalNode("", decimalValue)
 	default:
 		return nil, fmt.Errorf("opaque type %d is not supported yet, data %v", dataType, data[2:])
 	}

--- a/go/mysql/binlog_event_json_test.go
+++ b/go/mysql/binlog_event_json_test.go
@@ -150,7 +150,7 @@ func TestJSONTypes(t *testing.T) {
 	}, {
 		// opaque, decimal
 		data:     []byte{15, 246, 8, 13, 4, 135, 91, 205, 21, 4, 210},
-		expected: `1.234567891234e+08`,
+		expected: `123456789.1234`,
 	}, {
 		// opaque, bit field. Not yet implemented.
 		data:     []byte{15, 16, 2, 202, 254},

--- a/go/test/endtoend/vreplication/unsharded_init_data.sql
+++ b/go/test/endtoend/vreplication/unsharded_init_data.sql
@@ -1,4 +1,4 @@
-insert into customer(cid, name, typ, sport, meta) values(1, 'Jøhn "❤️" Rizzolo',1,'football,baseball','{}');
+insert into customer(cid, name, typ, sport, meta) values(1, 'Jøhn2 "❤️" Rizzolo',1,'football,baseball', '{"a": 1}');
 insert into customer(cid, name, typ, sport, meta) values(2, 'Paül','soho','cricket',convert(x'7b7d' using utf8mb4));
 insert into customer(cid, name, typ, sport) values(3, 'ringo','enterprise','');
 insert into merchant(mname, category) values('Monoprice', 'eléctronics');

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -587,6 +587,7 @@ func TestCellAliasVreplicationWorkflow(t *testing.T) {
 	verifyClusterHealth(t, vc)
 
 	insertInitialData(t)
+
 	t.Run("VStreamFrom", func(t *testing.T) {
 		testVStreamFrom(t, keyspace, 2)
 	})
@@ -749,9 +750,10 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 
 		query := "select cid from customer"
 		require.True(t, validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "product", query, query))
-		insertQuery1 := "insert into customer(cid, name) values(1001, 'tempCustomer1')"
-		matchInsertQuery1 := "insert into customer(cid, `name`) values (:vtg1, :vtg2)"
-		require.True(t, validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "product", insertQuery1, matchInsertQuery1))
+		insertQuery1 := "insert into customer(cid, name, meta) values(1001, 'tempCustomer1', '{\"a\": 1629849600, \"b\": 930701976723823, \"c\": 123456789012345678901234567890}')"
+
+		matchInsertQuery1 := "insert into customer(cid, `name`, meta) values (:vtg1, :vtg2, :vtg3)"
+		validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "product", insertQuery1, matchInsertQuery1)
 
 		// confirm that the backticking of table names in the routing rules works
 		tbls := []string{"Lead", "Lead-1"}


### PR DESCRIPTION
## Description

### Motivation
Large fixed point `NUMERIC` and `DECIMAL` values in JSON Objects are not correctly vreplicated today. Such numbers are converted to a `float64` by the binlog json parser. 

So a json value like `{"a": 12345678901234567890123456789012345678901234567890123456789012345678901234567890, "b": 987654321.012345678901234567890}` on the source gets replicated like ` {"a": 1.2345678901234573e79, "b": 987654321.0123456}`

### Approach

#### VStreamer
The VStreamer needs to deserialize the binlog values exactly. This is done by  adding support for fixed type integers and decimals in `ajson`, the library we use today to define a json value in an ast and stringify it while creating the correspondig VEvent.

#### VPlayer
The VPlayer needs to generate mysql queries so that MySQL retains precision.MySQL will only keep the true value of fixed point values if they are specified in a `json_object()` while inserting or updating. If they are just specified as a string representation, the mysql parser will convert it to a float and lose precision. Same holds for json arrays. 

The snippets below illustrate the issue:

```
insert into jsontest values 
('{"a": 12345678901234567890123456789012345678901234567890123456789012345678901234567890,
 "b": 987654321.012345678901234567890}');

insert into jsontest values 
(json_object("a",12345678901234567890123456789012345678901234567890123456789012345678901234567890, 
"b", 987654321.012345678901234567890)); 

select * from jsontest;
+-------------------------------------------------------------------------------------------------------------------------------+
| j                                                                                                                             |
+-------------------------------------------------------------------------------------------------------------------------------+
| {"a": 1.2345678901234573e79, "b": 987654321.0123456}                                                                          |
| {"a": 12345678901234567890123456789012345678901234567890123456789012345678901234567890, "b": 987654321.012345678901234567890} |
+-------------------------------------------------------------------------------------------------------------------------------+

```

So we need to also generate `json_object()`s  and `json_array()`s while inserting json (dictionary) objects and arrays so as to replicate the exact value. 

## Status

* VStreamer now generates data correctly for DECIMALS with a local change to ajson which has not yet been pushed to our ajson fork. https://github.com/vitessio/vitess/pull/12630 already fixed issues with large integers like `930701976723823` which would get vreplicated as  `9.30701976723823e+14` and `1234567890` which would get vreplicated as  `1234567890.0` .

* TODO: 
* 
## Related Issue(s)

https://github.com/vitessio/vitess/issues/8686

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
