### PR TITLE
Update topo {Get,Create}Keyspace to prevent invalid keyspace names

### DIFF
--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -5,6 +5,7 @@
 - **[Major Changes](#major-changes)**
   - **[Breaking Changes](#breaking-changes)**
     - [Dedicated stats for VTGate Prepare operations](#dedicated-vtgate-prepare-stats)
+    - [Keyspace name validation in TopoServer](#keyspace-name-validation)
   - **[New command line flags and behavior](#new-flag)**
     - [Builtin backup: read buffering flags](#builtin-backup-read-buffering-flags)
   - **[New stats](#new-stats)**
@@ -48,6 +49,16 @@ Here is a (condensed) example of stats output:
   }
 }
 ```
+
+
+#### <a id="keyspace-name-validation"> Keyspace name validation in TopoServer
+
+Prior to v17, it was possible to create a keyspace with invalid characters, which would then be inaccessible to various cluster management operations.
+
+Now, the TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given an invalid name.
+
+Keyspace names may no longer contain the following characters:
+- Forward slash ("/").
 
 ### <a id="new-flag"/> New command line flags and behavior
 

--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -57,8 +57,7 @@ Prior to v17, it was possible to create a keyspace with invalid characters, whic
 
 Now, the TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given an invalid name.
 
-Keyspace names may no longer contain the following characters:
-- Forward slash ("/").
+Keyspace names may now only contain alphanumerics, dashes (`-`), and underscores (`_`), and must begin with an alphabetical character.
 
 ### <a id="new-flag"/> New command line flags and behavior
 

--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -55,10 +55,7 @@ Here is a (condensed) example of stats output:
 
 Prior to v17, it was possible to create a keyspace with invalid characters, which would then be inaccessible to various cluster management operations.
 
-Now, the TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given an invalid name.
-
-Keyspace names may no longer contain the following characters:
-- Forward slash ("/").
+Keyspace names may no longer contain the forward slash ("/") character, and TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given such a name.
 
 ### <a id="new-flag"/> New command line flags and behavior
 

--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -57,7 +57,8 @@ Prior to v17, it was possible to create a keyspace with invalid characters, whic
 
 Now, the TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given an invalid name.
 
-Keyspace names may now only contain alphanumerics, dashes (`-`), and underscores (`_`), and must begin with an alphabetical character.
+Keyspace names may no longer contain the following characters:
+- Forward slash ("/").
 
 ### <a id="new-flag"/> New command line flags and behavior
 

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -18,7 +18,7 @@ package topo
 
 import (
 	"path"
-	"strings"
+	"regexp"
 
 	"context"
 
@@ -54,15 +54,15 @@ func (ki *KeyspaceInfo) SetKeyspaceName(name string) {
 	ki.keyspace = name
 }
 
-var invalidKeyspaceNameChars = "/"
+var keyspaceNameRegexp = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_-]*$")
 
 // ValidateKeyspaceNames checks if the provided name is a valid name for a
 // keyspace.
 //
 // As of v17, "all invalid characters" is just the forward slash ("/").
 func ValidateKeyspaceName(name string) error {
-	if strings.ContainsAny(name, invalidKeyspaceNameChars) {
-		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "keyspace name %s contains invalid characters; may not contain any of the following: %+v", name, strings.Split(invalidKeyspaceNameChars, ""))
+	if !keyspaceNameRegexp.MatchString(name) {
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "keyspace name %s contains invalid characters; may only contain alphanumerics, dashes and underscores", name)
 	}
 
 	return nil

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -18,7 +18,7 @@ package topo
 
 import (
 	"path"
-	"regexp"
+	"strings"
 
 	"context"
 
@@ -54,15 +54,15 @@ func (ki *KeyspaceInfo) SetKeyspaceName(name string) {
 	ki.keyspace = name
 }
 
-var keyspaceNameRegexp = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_-]*$")
+var invalidKeyspaceNameChars = "/"
 
 // ValidateKeyspaceNames checks if the provided name is a valid name for a
 // keyspace.
 //
 // As of v17, "all invalid characters" is just the forward slash ("/").
 func ValidateKeyspaceName(name string) error {
-	if !keyspaceNameRegexp.MatchString(name) {
-		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "keyspace name %s contains invalid characters; may only contain alphanumerics, dashes and underscores", name)
+	if strings.ContainsAny(name, invalidKeyspaceNameChars) {
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "keyspace name %s contains invalid characters; may not contain any of the following: %+v", name, strings.Split(invalidKeyspaceNameChars, ""))
 	}
 
 	return nil

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -56,7 +56,7 @@ func (ki *KeyspaceInfo) SetKeyspaceName(name string) {
 
 var invalidKeyspaceNameChars = "/"
 
-// ValidateKeyspaceNames checks if the provided name is a valid name for a
+// ValidateKeyspaceName checks if the provided name is a valid name for a
 // keyspace.
 //
 // As of v17, "all invalid characters" is just the forward slash ("/").

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -56,6 +56,14 @@ func (ki *KeyspaceInfo) SetKeyspaceName(name string) {
 
 var ksNameReplacer = strings.NewReplacer("/", "")
 
+// ValidateKeyspaceNames checks if the provided name is a valid name for a
+// keyspace.
+//
+// If it is valid, the original name is returned with no error. If it is
+// invalid, the name with all invalid characters removed is returned, along
+// with an error.
+//
+// As of v17, "all invalid characters" is just the forward slash ("/").
 func ValidateKeyspaceName(name string) (string, error) {
 	if validated := ksNameReplacer.Replace(name); name != validated {
 		return validated, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "keyspace name %s contains invalid characters; expected %s instead", name, validated)

--- a/go/vt/topo/keyspace_test.go
+++ b/go/vt/topo/keyspace_test.go
@@ -20,8 +20,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
@@ -175,51 +173,5 @@ func TestComputeCellServedFrom(t *testing.T) {
 		},
 	}) {
 		t.Fatalf("c2 failed: %v", m)
-	}
-}
-
-func TestValidateKeyspaceName(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name  string
-		valid bool
-	}{
-		{
-			name:  "testks",
-			valid: true,
-		},
-		{
-			name:  "alphnum_ks1-with_a_dash",
-			valid: true,
-		},
-		{
-			name:  "no/slashes/allowed",
-			valid: false,
-		},
-		{
-			name:  "wë!rd ch@r@ct3r$",
-			valid: false,
-		},
-		{
-			name:  "0_cant-start_with-a-number",
-			valid: false,
-		},
-	}
-
-	for _, tcase := range cases {
-		tcase := tcase
-		t.Run(tcase.name, func(t *testing.T) {
-			t.Parallel()
-
-			var assertion func(t assert.TestingT, err error, msgAndArgs ...any) bool
-			if tcase.valid {
-				assertion = assert.NoError
-			} else {
-				assertion = assert.Error
-			}
-
-			assertion(t, ValidateKeyspaceName(tcase.name))
-		})
 	}
 }

--- a/go/vt/topo/topotests/keyspace_test.go
+++ b/go/vt/topo/topotests/keyspace_test.go
@@ -30,9 +30,6 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
-// TODO: add copyright
-// TODO: test valid vs invalid ks names
-
 func TestCreateKeyspace(t *testing.T) {
 	ts := memorytopo.NewServer("zone1")
 	ctx := context.Background()

--- a/go/vt/topo/topotests/keyspace_test.go
+++ b/go/vt/topo/topotests/keyspace_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topotests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/vterrors"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
+)
+
+// TODO: add copyright
+// TODO: test valid vs invalid ks names
+
+func TestCreateKeyspace(t *testing.T) {
+	ts := memorytopo.NewServer("zone1")
+	ctx := context.Background()
+
+	t.Run("valid name", func(t *testing.T) {
+		err := ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{})
+		require.NoError(t, err)
+	})
+	t.Run("invalid name", func(t *testing.T) {
+		err := ts.CreateKeyspace(ctx, "no/slashes/allowed", &topodatapb.Keyspace{})
+		assert.Error(t, err)
+		assert.Equal(t, vtrpc.Code_INVALID_ARGUMENT, vterrors.Code(err), "%+v", err)
+	})
+}
+
+func TestGetKeyspace(t *testing.T) {
+	ts := memorytopo.NewServer("zone1")
+	ctx := context.Background()
+
+	t.Run("valid name", func(t *testing.T) {
+		// First, create the keyspace.
+		err := ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{})
+		require.NoError(t, err)
+
+		// Now, get it.
+		ks, err := ts.GetKeyspace(ctx, "ks")
+		require.NoError(t, err)
+		assert.NotNil(t, ks)
+	})
+
+	t.Run("invalid name", func(t *testing.T) {
+		// We can't create the keyspace (because we can't create a keyspace
+		// with an invalid name), so we'll validate the error we get is *not*
+		// NOT_FOUND.
+		ks, err := ts.GetKeyspace(ctx, "no/slashes/allowed")
+		assert.Error(t, err)
+		assert.Equal(t, vtrpc.Code_INVALID_ARGUMENT, vterrors.Code(err), "%+v", err)
+		assert.Nil(t, ks)
+	})
+}

--- a/go/vt/vtorc/inst/keyspace_dao.go
+++ b/go/vt/vtorc/inst/keyspace_dao.go
@@ -30,7 +30,7 @@ var ErrKeyspaceNotFound = errors.New("keyspace not found")
 
 // ReadKeyspace reads the vitess keyspace record.
 func ReadKeyspace(keyspaceName string) (*topo.KeyspaceInfo, error) {
-	if _, err := topo.ValidateKeyspaceName(keyspaceName); err != nil {
+	if err := topo.ValidateKeyspaceName(keyspaceName); err != nil {
 		return nil, err
 	}
 

--- a/go/vt/vtorc/inst/keyspace_dao.go
+++ b/go/vt/vtorc/inst/keyspace_dao.go
@@ -30,6 +30,10 @@ var ErrKeyspaceNotFound = errors.New("keyspace not found")
 
 // ReadKeyspace reads the vitess keyspace record.
 func ReadKeyspace(keyspaceName string) (*topo.KeyspaceInfo, error) {
+	if _, err := topo.ValidateKeyspaceName(keyspaceName); err != nil {
+		return nil, err
+	}
+
 	query := `
 		select
 			keyspace_type,


### PR DESCRIPTION
## Description

What it says on the tin. Note that any method that calls `GetKeyspace` will be affected by this ([almost a good search](https://github.com/search?q=repo%3Avitessio%2Fvitess+language%3AGo+%2F%5C.GetKeyspace%2F+%28path%3Ago%2Fvt%2Ftopo%2F+OR+path%3Ago%2Fvt%2Fvtctl%29&type=code&l=Go))

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/12738

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
