### PR TITLE
Implement logic to handle more JSON conversion

### DIFF
--- a/go/vt/vtgate/evalengine/api_literal.go
+++ b/go/vt/vtgate/evalengine/api_literal.go
@@ -18,7 +18,9 @@ package evalengine
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math"
+	"math/big"
 	"strconv"
 	"unicode/utf8"
 
@@ -154,6 +156,15 @@ func parseHexNumber(val []byte) ([]byte, error) {
 	return parseHexLiteral(val[1:])
 }
 
+func parseBitLiteral(val []byte) ([]byte, error) {
+	var i big.Int
+	_, ok := i.SetString(string(val), 2)
+	if !ok {
+		return nil, fmt.Errorf("invalid bit literal: %s", string(val))
+	}
+	return i.Bytes(), nil
+}
+
 func NewLiteralBinary(val []byte) *Literal {
 	return &Literal{newEvalBinary(val)}
 }
@@ -172,6 +183,14 @@ func NewLiteralBinaryFromHexNum(val []byte) (*Literal, error) {
 		return nil, err
 	}
 	return &Literal{newEvalBytesHex(raw)}, nil
+}
+
+func NewLiteralBinaryFromBit(val []byte) (*Literal, error) {
+	raw, err := parseBitLiteral(val)
+	if err != nil {
+		return nil, err
+	}
+	return &Literal{newEvalBytesBit(raw)}, nil
 }
 
 // NewBindVar returns a bind variable

--- a/go/vt/vtgate/evalengine/api_literal.go
+++ b/go/vt/vtgate/evalengine/api_literal.go
@@ -18,7 +18,6 @@ package evalengine
 
 import (
 	"encoding/hex"
-	"fmt"
 	"math"
 	"math/big"
 	"strconv"
@@ -160,7 +159,7 @@ func parseBitLiteral(val []byte) ([]byte, error) {
 	var i big.Int
 	_, ok := i.SetString(string(val), 2)
 	if !ok {
-		return nil, fmt.Errorf("invalid bit literal: %s", string(val))
+		panic("malformed bit literal from parser")
 	}
 	return i.Bytes(), nil
 }

--- a/go/vt/vtgate/evalengine/compare.go
+++ b/go/vt/vtgate/evalengine/compare.go
@@ -17,6 +17,8 @@ limitations under the License.
 package evalengine
 
 import (
+	"bytes"
+	"fmt"
 	"time"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -24,6 +26,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/evalengine/internal/decimal"
+	"vitess.io/vitess/go/vt/vtgate/evalengine/internal/json"
 )
 
 func compareNumeric(left, right eval) (int, error) {
@@ -199,4 +202,118 @@ func compareStrings(l, r eval) (int, error) {
 		panic("unknown collation after coercion")
 	}
 	return collation.Collate(l.(*evalBytes).bytes, r.(*evalBytes).bytes, false), nil
+}
+
+func compareJSON(l, r eval) (int, error) {
+	lj, err := argToJSON(l)
+	if err != nil {
+		return 0, err
+	}
+
+	rj, err := argToJSON(r)
+	if err != nil {
+		return 0, err
+	}
+
+	return compareJSONValue(lj, rj)
+}
+
+// compareJSONValue compares two JSON values.
+// See https://dev.mysql.com/doc/refman/8.0/en/json.html#json-comparison for all the rules.
+func compareJSONValue(lj, rj *json.Value) (int, error) {
+	cmp := int(lj.Type()) - int(rj.Type())
+	if cmp != 0 {
+		return cmp, nil
+	}
+
+	switch lj.Type() {
+	case json.TypeNull:
+		return 0, nil
+	case json.TypeNumber:
+		ld, ok := lj.Decimal()
+		if !ok {
+			return 0, fmt.Errorf("JSON number is out of range")
+		}
+		rd, ok := rj.Decimal()
+		if !ok {
+			return 0, fmt.Errorf("JSON number is out of range")
+		}
+		return ld.Cmp(rd), nil
+	case json.TypeString:
+		return collationJSON.Collation.Get().Collate(lj.ToRawBytes(), rj.ToRawBytes(), false), nil
+	case json.TypeBlob, json.TypeBit, json.TypeOpaque:
+		return bytes.Compare(lj.ToUnencodedBytes(), rj.ToUnencodedBytes()), nil
+	case json.TypeBoolean:
+		if lj == rj {
+			return 0, nil
+		}
+		if lj == json.ValueFalse {
+			return -1, nil
+		}
+		return 1, nil
+	case json.TypeDate:
+		ld, _ := lj.Date()
+		rd, _ := rj.Date()
+		return ld.Compare(rd), nil
+	case json.TypeDateTime:
+		ld, _ := lj.DateTime()
+		rd, _ := rj.DateTime()
+		return ld.Compare(rd), nil
+	case json.TypeTime:
+		ld, _ := lj.Time()
+		rd, _ := rj.Time()
+		return ld.Compare(rd), nil
+	case json.TypeArray:
+		la, _ := lj.Array()
+		ra, _ := rj.Array()
+		until := len(la)
+		if len(la) > len(ra) {
+			until = len(ra)
+		}
+		for i := 0; i < until; i++ {
+			cmp, err := compareJSONValue(la[i], ra[i])
+			if err != nil {
+				return 0, err
+			}
+			if cmp != 0 {
+				return cmp, nil
+			}
+		}
+		return len(la) - len(ra), nil
+	case json.TypeObject:
+		// These rules are not documented but this is the so far
+		// best effort reverse engineered implementation based on
+		// what MySQL returns in our tests.
+		lo, _ := lj.Object()
+		ro, _ := rj.Object()
+
+		if lo.Len() != ro.Len() {
+			return lo.Len() - ro.Len(), nil
+		}
+
+		rks := ro.Keys()
+		lks := lo.Keys()
+
+		for i := 0; i < len(lks); i++ {
+			if lks[i] < rks[i] {
+				return -1, nil
+			}
+			if lks[i] > rks[i] {
+				return 1, nil
+			}
+		}
+
+		for i := 0; i < len(lks); i++ {
+			cmp, err := compareJSONValue(lo.Get(lks[i]), ro.Get(rks[i]))
+			if err != nil {
+				return 0, err
+			}
+			if cmp != 0 {
+				return cmp, nil
+			}
+		}
+		return 0, nil
+	}
+
+	return cmp, nil
 }

--- a/go/vt/vtgate/evalengine/compare.go
+++ b/go/vt/vtgate/evalengine/compare.go
@@ -18,7 +18,6 @@ package evalengine
 
 import (
 	"bytes"
-	"fmt"
 	"time"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -232,11 +231,11 @@ func compareJSONValue(lj, rj *json.Value) (int, error) {
 	case json.TypeNumber:
 		ld, ok := lj.Decimal()
 		if !ok {
-			return 0, fmt.Errorf("JSON number is out of range")
+			return 0, vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.DataOutOfRange, "DECIMAL value is out of range")
 		}
 		rd, ok := rj.Decimal()
 		if !ok {
-			return 0, fmt.Errorf("JSON number is out of range")
+			return 0, vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.DataOutOfRange, "DECIMAL value is out of range")
 		}
 		return ld.Cmp(rd), nil
 	case json.TypeString:

--- a/go/vt/vtgate/evalengine/compiler_compare.go
+++ b/go/vt/vtgate/evalengine/compiler_compare.go
@@ -59,6 +59,13 @@ func (c *compiler) compileComparison(expr *ComparisonExpr) (ctype, error) {
 		return ctype{}, err
 	}
 
+	var skip1 *jump
+	switch expr.Op.(type) {
+	case compareNullSafeEQ:
+	default:
+		skip1 = c.compileNullCheck1(lt)
+	}
+
 	rt, err := c.compileExpr(expr.Right)
 	if err != nil {
 		return ctype{}, err
@@ -72,14 +79,14 @@ func (c *compiler) compileComparison(expr *ComparisonExpr) (ctype, error) {
 	}
 
 	swapped := false
-	var skip *jump
+	var skip2 *jump
 
 	switch expr.Op.(type) {
 	case compareNullSafeEQ:
-		skip = c.asm.jumpFrom()
-		c.asm.Cmp_nullsafe(skip)
+		skip2 = c.asm.jumpFrom()
+		c.asm.Cmp_nullsafe(skip2)
 	default:
-		skip = c.compileNullCheck2(lt, rt)
+		skip2 = c.compileNullCheck1r(rt)
 	}
 
 	switch {
@@ -93,6 +100,11 @@ func (c *compiler) compileComparison(expr *ComparisonExpr) (ctype, error) {
 
 	case compareAsDates(lt.Type, rt.Type) || compareAsDateAndString(lt.Type, rt.Type) || compareAsDateAndNumeric(lt.Type, rt.Type):
 		return ctype{}, c.unsupported(expr)
+
+	case compareAsJSON(lt.Type, rt.Type):
+		if err := c.compareAsJSON(lt, rt); err != nil {
+			return ctype{}, err
+		}
 
 	default:
 		lt = c.compileToFloat(lt, 2)
@@ -132,7 +144,7 @@ func (c *compiler) compileComparison(expr *ComparisonExpr) (ctype, error) {
 			c.asm.Cmp_ge()
 		}
 	case compareNullSafeEQ:
-		c.asm.jumpDestination(skip)
+		c.asm.jumpDestination(skip2)
 		c.asm.Cmp_eq()
 		return cmptype, nil
 
@@ -140,7 +152,7 @@ func (c *compiler) compileComparison(expr *ComparisonExpr) (ctype, error) {
 		panic("unexpected comparison operator")
 	}
 
-	c.asm.jumpDestination(skip)
+	c.asm.jumpDestination(skip1, skip2)
 	return cmptype, nil
 }
 
@@ -235,6 +247,25 @@ func (c *compiler) compareAsStrings(lt ctype, rt ctype) error {
 			right: coerceRight,
 		})
 	}
+	return nil
+}
+
+func (c *compiler) compareAsJSON(lt ctype, rt ctype) error {
+	if lt.Type != sqltypes.TypeJSON {
+		_, err := c.compileArgToJSON(lt, 2)
+		if err != nil {
+			return err
+		}
+	}
+
+	if rt.Type != sqltypes.TypeJSON {
+		_, err := c.compileArgToJSON(rt, 1)
+		if err != nil {
+			return err
+		}
+	}
+	c.asm.CmpJSON()
+
 	return nil
 }
 

--- a/go/vt/vtgate/evalengine/compiler_compare.go
+++ b/go/vt/vtgate/evalengine/compiler_compare.go
@@ -251,18 +251,14 @@ func (c *compiler) compareAsStrings(lt ctype, rt ctype) error {
 }
 
 func (c *compiler) compareAsJSON(lt ctype, rt ctype) error {
-	if lt.Type != sqltypes.TypeJSON {
-		_, err := c.compileArgToJSON(lt, 2)
-		if err != nil {
-			return err
-		}
+	_, err := c.compileArgToJSON(lt, 2)
+	if err != nil {
+		return err
 	}
 
-	if rt.Type != sqltypes.TypeJSON {
-		_, err := c.compileArgToJSON(rt, 1)
-		if err != nil {
-			return err
-		}
+	_, err = c.compileArgToJSON(rt, 1)
+	if err != nil {
+		return err
 	}
 	c.asm.CmpJSON()
 

--- a/go/vt/vtgate/evalengine/compiler_json.go
+++ b/go/vt/vtgate/evalengine/compiler_json.go
@@ -60,6 +60,12 @@ func (c *compiler) compileToJSON(doct ctype, offset int) (ctype, error) {
 		c.asm.Convert_bj(offset)
 	case sqltypes.Null:
 		c.asm.Convert_Nj(offset)
+	case sqltypes.Date:
+		c.asm.Convert_dj(offset)
+	case sqltypes.Datetime, sqltypes.Timestamp:
+		c.asm.Convert_dtj(offset)
+	case sqltypes.Time:
+		c.asm.Convert_tj(offset)
 	default:
 		return ctype{}, vterrors.Errorf(vtrpc.Code_UNIMPLEMENTED, "Unsupported type conversion: %s AS JSON", doct.Type)
 	}
@@ -80,6 +86,14 @@ func (c *compiler) compileArgToJSON(doct ctype, offset int) (ctype, error) {
 		c.asm.Convert_bj(offset)
 	case sqltypes.Null:
 		c.asm.Convert_Nj(offset)
+	case sqltypes.Date:
+		c.asm.Convert_dj(offset)
+	case sqltypes.Datetime:
+		c.asm.Convert_dtj(offset)
+	case sqltypes.Timestamp:
+		c.asm.Convert_dtj(offset)
+	case sqltypes.Time:
+		c.asm.Convert_tj(offset)
 	default:
 		return ctype{}, vterrors.Errorf(vtrpc.Code_UNIMPLEMENTED, "Unsupported type conversion: %s AS JSON", doct.Type)
 	}

--- a/go/vt/vtgate/evalengine/eval.go
+++ b/go/vt/vtgate/evalengine/eval.go
@@ -142,7 +142,20 @@ func evalIsTruthy(e eval) boolean {
 	case *evalJSON:
 		switch e.Type() {
 		case json.TypeNumber:
-			return makeboolean(parseStringToFloat(e.Raw()) != 0.0)
+			switch e.NumberType() {
+			case json.NumberTypeInteger:
+				if i, ok := e.Int64(); ok {
+					return makeboolean(i != 0)
+				}
+
+				d, _ := e.Decimal()
+				return makeboolean(!d.IsZero())
+			case json.NumberTypeDouble:
+				d, _ := e.Float64()
+				return makeboolean(d != 0.0)
+			default:
+				return makeboolean(parseStringToFloat(e.Raw()) != 0.0)
+			}
 		default:
 			return makeboolean(true)
 		}

--- a/go/vt/vtgate/evalengine/eval_bytes.go
+++ b/go/vt/vtgate/evalengine/eval_bytes.go
@@ -49,6 +49,13 @@ func newEvalBytesHex(raw []byte) eval {
 	return &evalBytes{tt: int16(sqltypes.VarBinary), isHexLiteral: true, col: collationBinary, bytes: raw}
 }
 
+// newEvalBytesBit creates a new evalBytes for a bit literal.
+// Turns out that a bit literal is not actually typed with
+// sqltypes.Bit, but with sqltypes.VarBinary.
+func newEvalBytesBit(raw []byte) eval {
+	return &evalBytes{tt: int16(sqltypes.VarBinary), isBitLiteral: true, col: collationBinary, bytes: raw}
+}
+
 func newEvalBinary(raw []byte) *evalBytes {
 	return newEvalRaw(sqltypes.VarBinary, raw, collationBinary)
 }

--- a/go/vt/vtgate/evalengine/eval_json.go
+++ b/go/vt/vtgate/evalengine/eval_json.go
@@ -18,7 +18,6 @@ package evalengine
 
 import (
 	"bytes"
-	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -65,12 +64,10 @@ func intoJSONPath(e eval) (*json.Path, error) {
 }
 
 func evalConvert_bj(e *evalBytes) *evalJSON {
-	const prefix = "base64:type15:"
-
-	dst := make([]byte, len(prefix)+mysqlBase64.EncodedLen(len(e.bytes)))
-	copy(dst, prefix)
-	base64.StdEncoding.Encode(dst[len(prefix):], e.bytes)
-	return json.NewString(dst)
+	if e.tt == int16(sqltypes.Bit) {
+		return json.NewBit(e.bytes)
+	}
+	return json.NewBlob(e.bytes)
 }
 
 func evalConvert_fj(e *evalFloat) *evalJSON {
@@ -108,6 +105,18 @@ func evalConvertArg_cj(e *evalBytes) (*evalJSON, error) {
 	return json.NewString(jsonText), nil
 }
 
+func evalConvert_dj(e *evalBytes) *evalJSON {
+	return json.NewDate(e.bytes)
+}
+
+func evalConvert_dtj(e *evalBytes) *evalJSON {
+	return json.NewDateTime(e.bytes)
+}
+
+func evalConvert_tj(e *evalBytes) *evalJSON {
+	return json.NewTime(e.bytes)
+}
+
 func evalToJSON(e eval) (*evalJSON, error) {
 	switch e := e.(type) {
 	case nil:
@@ -119,7 +128,14 @@ func evalToJSON(e eval) (*evalJSON, error) {
 	case evalNumeric:
 		return evalConvert_nj(e), nil
 	case *evalBytes:
-		if sqltypes.IsBinary(e.SQLType()) {
+		switch {
+		case e.SQLType() == sqltypes.Date:
+			return evalConvert_dj(e), nil
+		case e.SQLType() == sqltypes.Datetime, e.SQLType() == sqltypes.Timestamp:
+			return evalConvert_dtj(e), nil
+		case e.SQLType() == sqltypes.Time:
+			return evalConvert_tj(e), nil
+		case sqltypes.IsBinary(e.SQLType()):
 			return evalConvert_bj(e), nil
 		}
 		return evalConvert_cj(e)
@@ -139,7 +155,14 @@ func argToJSON(e eval) (*evalJSON, error) {
 	case evalNumeric:
 		return evalConvert_nj(e), nil
 	case *evalBytes:
-		if sqltypes.IsBinary(e.SQLType()) {
+		switch {
+		case e.SQLType() == sqltypes.Date:
+			return evalConvert_dj(e), nil
+		case e.SQLType() == sqltypes.Datetime, e.SQLType() == sqltypes.Timestamp:
+			return evalConvert_dtj(e), nil
+		case e.SQLType() == sqltypes.Time:
+			return evalConvert_tj(e), nil
+		case sqltypes.IsBinary(e.SQLType()):
 			return evalConvert_bj(e), nil
 		}
 		return evalConvertArg_cj(e)

--- a/go/vt/vtgate/evalengine/eval_numeric.go
+++ b/go/vt/vtgate/evalengine/eval_numeric.go
@@ -110,11 +110,27 @@ func evalToNumeric(e eval) evalNumeric {
 		return &evalFloat{f: parseStringToFloat(e.string())}
 	case *evalJSON:
 		switch e.Type() {
-		case json.TypeTrue:
-			return &evalFloat{f: 1.0}
-		case json.TypeFalse:
+		case json.TypeBoolean:
+			if e == json.ValueTrue {
+				return &evalFloat{f: 1.0}
+			}
 			return &evalFloat{f: 0.0}
-		case json.TypeNumber, json.TypeString:
+		case json.TypeNumber:
+			switch e.NumberType() {
+			case json.NumberTypeInteger:
+				i, ok := e.Int64()
+				if ok {
+					return &evalInt64{i: i}
+				}
+				d, _ := e.Decimal()
+				return newEvalDecimalWithPrec(d, 0)
+			case json.NumberTypeDouble:
+				f, _ := e.Float64()
+				return &evalFloat{f: f}
+			default:
+				panic("unsupported")
+			}
+		case json.TypeString:
 			return &evalFloat{f: parseStringToFloat(e.Raw())}
 		default:
 			return &evalFloat{f: 0}

--- a/go/vt/vtgate/evalengine/fn_base64.go
+++ b/go/vt/vtgate/evalengine/fn_base64.go
@@ -35,7 +35,35 @@ type (
 var _ Expr = (*builtinToBase64)(nil)
 var _ Expr = (*builtinFromBase64)(nil)
 
-var mysqlBase64 = base64.StdEncoding
+// MySQL wraps every 76 characters with a newline. That maps
+// to a 57 byte input. So we encode here in blocks of 57 bytes
+// with then each a newline.
+var mysqlBase64OutLineLength = 76
+var mysqlBase64InLineLength = (mysqlBase64OutLineLength / 4) * 3
+
+func mysqlBase64Encode(in []byte) []byte {
+	newlines := len(in) / mysqlBase64InLineLength
+	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(in))+newlines)
+	out := encoded
+	for len(in) > mysqlBase64InLineLength {
+		base64.StdEncoding.Encode(out, in[:mysqlBase64InLineLength])
+		in = in[mysqlBase64InLineLength:]
+		out[mysqlBase64OutLineLength] = '\n'
+		out = out[mysqlBase64OutLineLength+1:]
+	}
+	base64.StdEncoding.Encode(out, in)
+	return encoded
+}
+
+func mysqlBase64Decode(in []byte) ([]byte, error) {
+	decoded := make([]byte, base64.StdEncoding.DecodedLen(len(in)))
+
+	n, err := base64.StdEncoding.Decode(decoded, in)
+	if err != nil {
+		return nil, err
+	}
+	return decoded[:n], nil
+}
 
 func (call *builtinToBase64) eval(env *ExpressionEnv) (eval, error) {
 	arg, err := call.arg1(env)
@@ -47,8 +75,7 @@ func (call *builtinToBase64) eval(env *ExpressionEnv) (eval, error) {
 	}
 
 	b := evalToBinary(arg)
-	encoded := make([]byte, mysqlBase64.EncodedLen(len(b.bytes)))
-	mysqlBase64.Encode(encoded, b.bytes)
+	encoded := mysqlBase64Encode(b.bytes)
 
 	if arg.SQLType() == sqltypes.Blob || arg.SQLType() == sqltypes.TypeJSON {
 		return newEvalRaw(sqltypes.Text, encoded, env.collation()), nil
@@ -74,14 +101,14 @@ func (call *builtinFromBase64) eval(env *ExpressionEnv) (eval, error) {
 	}
 
 	b := evalToBinary(arg)
-	decoded := make([]byte, mysqlBase64.DecodedLen(len(b.bytes)))
-	if n, err := mysqlBase64.Decode(decoded, b.bytes); err == nil {
-		if arg.SQLType() == sqltypes.Text || arg.SQLType() == sqltypes.TypeJSON {
-			return newEvalRaw(sqltypes.Blob, decoded[:n], collationBinary), nil
-		}
-		return newEvalBinary(decoded[:n]), nil
+	decoded, err := mysqlBase64Decode(b.bytes)
+	if err != nil {
+		return nil, nil
 	}
-	return nil, nil
+	if arg.SQLType() == sqltypes.Text || arg.SQLType() == sqltypes.TypeJSON {
+		return newEvalRaw(sqltypes.Blob, decoded, collationBinary), nil
+	}
+	return newEvalBinary(decoded), nil
 }
 
 func (call *builtinFromBase64) typeof(env *ExpressionEnv) (sqltypes.Type, typeFlag) {

--- a/go/vt/vtgate/evalengine/internal/json/helpers.go
+++ b/go/vt/vtgate/evalengine/internal/json/helpers.go
@@ -32,6 +32,10 @@ func (v *Value) ToRawBytes() []byte {
 	return v.MarshalTo(nil)
 }
 
+func (v *Value) ToUnencodedBytes() []byte {
+	return []byte(v.s)
+}
+
 func (v *Value) SQLType() sqltypes.Type {
 	return sqltypes.TypeJSON
 }
@@ -61,6 +65,41 @@ func NewString(raw []byte) *Value {
 	return &Value{
 		s: string(raw),
 		t: TypeString,
+	}
+}
+
+func NewBlob(raw []byte) *Value {
+	return &Value{
+		s: string(raw),
+		t: TypeBlob,
+	}
+}
+
+func NewBit(raw []byte) *Value {
+	return &Value{
+		s: string(raw),
+		t: TypeBit,
+	}
+}
+
+func NewDate(raw []byte) *Value {
+	return &Value{
+		s: string(raw),
+		t: TypeDate,
+	}
+}
+
+func NewDateTime(raw []byte) *Value {
+	return &Value{
+		s: string(raw),
+		t: TypeDateTime,
+	}
+}
+
+func NewTime(raw []byte) *Value {
+	return &Value{
+		s: string(raw),
+		t: TypeTime,
 	}
 }
 

--- a/go/vt/vtgate/evalengine/internal/json/parser.go
+++ b/go/vt/vtgate/evalengine/internal/json/parser.go
@@ -18,12 +18,17 @@ limitations under the License.
 package json
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf16"
 
 	"golang.org/x/exp/slices"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/evalengine/internal/decimal"
 
 	"vitess.io/vitess/go/hack"
 )
@@ -493,6 +498,14 @@ func (o *Object) reset() {
 	o.kvs = o.kvs[:0]
 }
 
+func (o *Object) Keys() []string {
+	keys := make([]string, 0, len(o.kvs))
+	for _, kv := range o.kvs {
+		keys = append(keys, kv.k)
+	}
+	return keys
+}
+
 // MarshalTo appends marshaled o to dst and returns the result.
 func (o *Object) MarshalTo(dst []byte) []byte {
 	dst = append(dst, '{')
@@ -605,6 +618,11 @@ type Value struct {
 	a []*Value
 	s string
 	t Type
+	// Flag to indicate if we have an arbitrary sized integer type
+	// or a floating point value if we have a number type. MySQL
+	// makes this distinction as well and keeps track of this type
+	// through JSON operations.
+	i bool
 }
 
 // MarshalTo appends marshaled v to dst and returns the result.
@@ -629,11 +647,58 @@ func (v *Value) MarshalTo(dst []byte) []byte {
 		return dst
 	case TypeString:
 		return escapeString(dst, v.s)
+	case TypeDate:
+		t, _ := v.Date()
+		return escapeString(dst, t.Format("2006-01-02"))
+	case TypeDateTime:
+		t, _ := v.DateTime()
+		return escapeString(dst, t.Format("2006-01-02 15:04:05.000000"))
+	case TypeTime:
+		now := time.Now()
+		year, month, day := now.Date()
+
+		t, _ := v.Time()
+		diff := t.Sub(time.Date(year, month, day, 0, 0, 0, 0, time.UTC))
+		var neg bool
+		if diff < 0 {
+			diff = -diff
+			neg = true
+		}
+
+		b := strings.Builder{}
+		if neg {
+			b.WriteByte('-')
+		}
+
+		hours := (diff / time.Hour)
+		diff -= hours * time.Hour
+		// For some reason MySQL wraps this around and loses data
+		// if it's more than 32 hours.
+		fmt.Fprintf(&b, "%02d", hours%32)
+		minutes := (diff / time.Minute)
+		fmt.Fprintf(&b, ":%02d", minutes)
+		diff -= minutes * time.Minute
+		seconds := (diff / time.Second)
+		fmt.Fprintf(&b, ":%02d", seconds)
+		diff -= seconds * time.Second
+		fmt.Fprintf(&b, ".%06d", diff)
+		return escapeString(dst, b.String())
+	case TypeBlob, TypeBit:
+		const prefix = "base64:type15:"
+
+		size := 2 + len(prefix) + base64.StdEncoding.EncodedLen(len(v.s))
+		dst := make([]byte, size)
+		dst[0] = '"'
+		copy(dst[1:], prefix)
+		base64.StdEncoding.Encode(dst[len(prefix)+1:], []byte(v.s))
+		dst[size-1] = '"'
+		return dst
 	case TypeNumber:
 		return append(dst, v.s...)
-	case TypeTrue:
-		return append(dst, "true"...)
-	case TypeFalse:
+	case TypeBoolean:
+		if v == ValueTrue {
+			return append(dst, "true"...)
+		}
 		return append(dst, "false"...)
 	case TypeNull:
 		return append(dst, "null"...)
@@ -657,31 +722,55 @@ func (v *Value) String() string {
 }
 
 // Type represents JSON type.
-type Type int
+type Type int32
 
+// See https://dev.mysql.com/doc/refman/8.0/en/json.html#json-comparison for the ordering here
 const (
 	// TypeNull is JSON null.
-	TypeNull Type = 0
-
-	// TypeObject is JSON object type.
-	TypeObject Type = 1
-
-	// TypeArray is JSON array type.
-	TypeArray Type = 2
-
-	// TypeString is JSON string type.
-	TypeString Type = 3
+	TypeNull Type = iota
 
 	// TypeNumber is JSON number type.
-	TypeNumber Type = 4
+	TypeNumber
 
-	// TypeTrue is JSON true.
-	TypeTrue Type = 5
+	// TypeString is JSON string type.
+	TypeString
 
-	// TypeFalse is JSON false.
-	TypeFalse Type = 6
+	// TypeObject is JSON object type.
+	TypeObject
 
-	typeRawString Type = 7
+	// TypeArray is JSON array type.
+	TypeArray
+
+	// TypeTrue is JSON boolean.
+	TypeBoolean
+
+	// TypeDate is JSON date.
+	TypeDate
+
+	// TypeTime is JSON time.
+	TypeTime
+
+	// TypeDateTime is JSON time.
+	TypeDateTime
+
+	// TypeOpaque is JSON opaque type.
+	TypeOpaque
+
+	// TypeBit is JSON bit string.
+	TypeBit
+
+	// TypeBlob is JSON blob.
+	TypeBlob
+
+	typeRawString
+)
+
+type NumberType int32
+
+const (
+	NumberTypeUnknown NumberType = iota
+	NumberTypeInteger
+	NumberTypeDouble
 )
 
 // String returns string representation of t.
@@ -695,10 +784,20 @@ func (t Type) String() string {
 		return "string"
 	case TypeNumber:
 		return "number"
-	case TypeTrue:
-		return "true"
-	case TypeFalse:
-		return "false"
+	case TypeBoolean:
+		return "boolean"
+	case TypeBlob:
+		return "blob"
+	case TypeBit:
+		return "bit"
+	case TypeDate:
+		return "date"
+	case TypeTime:
+		return "time"
+	case TypeDateTime:
+		return "datetime"
+	case TypeOpaque:
+		return "opaque"
 	case TypeNull:
 		return "null"
 
@@ -719,6 +818,39 @@ func (v *Value) Type() Type {
 		v.t = TypeString
 	}
 	return v.t
+}
+
+func (v *Value) Date() (time.Time, bool) {
+	if v.t != TypeDate {
+		return time.Time{}, false
+	}
+	t, err := sqlparser.ParseDate(v.s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+func (v *Value) DateTime() (time.Time, bool) {
+	if v.t != TypeDateTime {
+		return time.Time{}, false
+	}
+	t, err := sqlparser.ParseDateTime(v.s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+func (v *Value) Time() (time.Time, bool) {
+	if v.t != TypeTime {
+		return time.Time{}, false
+	}
+	t, err := sqlparser.ParseTime(v.s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
 }
 
 // Object returns the underlying JSON object for the v.
@@ -749,21 +881,61 @@ func (v *Value) Raw() string {
 	return v.s
 }
 
+func (v *Value) NumberType() NumberType {
+	if v.t != TypeNumber {
+		return NumberTypeUnknown
+	}
+	if v.i {
+		return NumberTypeInteger
+	}
+	return NumberTypeDouble
+}
+
+func (v *Value) Int64() (int64, bool) {
+	str := strings.TrimSpace(v.s)
+	i, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return i, true
+}
+
+func (v *Value) Float64() (float64, bool) {
+	str := strings.TrimSpace(v.s)
+	// We only care to parse as many of the initial float characters of the
+	// string as possible. This functionality is implemented in the `strconv` package
+	// of the standard library, but not exposed, so we hook into it.
+	val, _, err := hack.ParseFloatPrefix(str, 64)
+	if err != nil {
+		return 0.0, false
+	}
+	return val, true
+}
+
+func (v *Value) Decimal() (decimal.Decimal, bool) {
+	str := strings.TrimSpace(v.s)
+	dec, err := decimal.NewFromString(str)
+	if err != nil {
+		return decimal.Zero, false
+	}
+	return dec, true
+}
+
 // Bool returns the underlying JSON bool for the v.
 //
 // Use GetBool if you don't need error handling.
 func (v *Value) Bool() (bool, bool) {
-	if v.t == TypeTrue {
+	if v == ValueTrue {
 		return true, true
 	}
-	if v.t == TypeFalse {
+	if v == ValueFalse {
 		return false, true
 	}
 	return false, false
 }
 
 var (
-	ValueTrue  = &Value{t: TypeTrue}
-	ValueFalse = &Value{t: TypeFalse}
+	ValueTrue  = &Value{t: TypeBoolean}
+	ValueFalse = &Value{t: TypeBoolean}
 	ValueNull  = &Value{t: TypeNull}
 )

--- a/go/vt/vtgate/evalengine/internal/json/parser_test.go
+++ b/go/vt/vtgate/evalengine/internal/json/parser_test.go
@@ -470,8 +470,7 @@ func TestParserParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("cannot parse true: %s", err)
 		}
-		tp := v.Type()
-		if tp != TypeTrue || tp.String() != "true" {
+		if v != ValueTrue {
 			t.Fatalf("unexpected value obtained for true: %#v", v)
 		}
 		b, ok := v.Bool()
@@ -492,8 +491,7 @@ func TestParserParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("cannot parse false: %s", err)
 		}
-		tp := v.Type()
-		if tp != TypeFalse || tp.String() != "false" {
+		if v != ValueFalse {
 			t.Fatalf("unexpected value obtained for false: %#v", v)
 		}
 		b, ok := v.Bool()

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -769,9 +769,15 @@ func TupleComparisons(yield Query) {
 func Comparisons(yield Query) {
 	var operators = []string{"=", "!=", "<=>", "<", "<=", ">", ">="}
 	for _, op := range operators {
-		for i := 0; i < len(inputComparisonElement); i++ {
-			for j := 0; j < len(inputComparisonElement); j++ {
-				yield(fmt.Sprintf("%s %s %s", inputComparisonElement[i], op, inputComparisonElement[j]), nil)
+		for _, l := range inputComparisonElement {
+			for _, r := range inputComparisonElement {
+				yield(fmt.Sprintf("%s %s %s", l, op, r), nil)
+			}
+		}
+
+		for _, l := range inputConversions {
+			for _, r := range inputConversions {
+				yield(fmt.Sprintf("%s %s %s", l, op, r), nil)
 			}
 		}
 	}

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -101,8 +101,25 @@ var inputConversions = []string{
 	"cast(true as json)", "cast(false as json)",
 	"cast('{}' as json)", "cast('[]' as json)",
 	"cast('null' as json)", "cast('true' as json)", "cast('false' as json)",
-	"cast('1' as json)", "cast('1.1' as json)", "cast('-1.1' as json)",
-	"cast('\"foo\"' as json)", "cast('invalid' as json)",
+	// JSON numbers
+	"cast('1' as json)", "cast('2' as json)", "cast('1.1' as json)", "cast('-1.1' as json)",
+	// JSON strings
+	"cast('\"foo\"' as json)", "cast('\"bar\"' as json)", "cast('invalid' as json)",
+	// JSON binary values
+	"cast(_binary' \"foo\"' as json)", "cast(_binary '\"bar\"' as json)",
+	"cast(0xFF666F6F626172FF as json)", "cast(0x666F6F626172FF as json)",
+	"cast(0b01 as json)", "cast(0b001 as json)",
+	// JSON arrays
+	"cast('[\"a\"]' as json)", "cast('[\"ab\"]' as json)",
+	"cast('[\"ab\", \"cd\", \"ef\"]' as json)", "cast('[\"ab\", \"ef\"]' as json)",
+	// JSON objects
+	"cast('{\"a\": 1, \"b\": 2}' as json)", "cast('{\"b\": 2, \"a\": 1}' as json)",
+	"cast('{\"c\": 1, \"b\": 2}' as json)", "cast('{\"b\": 2, \"c\": 1}' as json)",
+	"cast(' \"b\": 2}' as json)", "cast('\"a\": 1' as json)",
+	// JSON date, datetime & time
+	"cast(date '2000-01-01' as json)", "cast(date '2000-01-02' as json)",
+	"cast(timestamp '2000-01-01 12:34:58' as json)",
+	"cast(time '12:34:56' as json)", "cast(time '12:34:58' as json)", "cast(time '5 12:34:58' as json)",
 }
 
 const inputPi = "314159265358979323846264338327950288419716939937510582097494459"

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -200,6 +200,8 @@ func (ast *astCompiler) translateLiteral(lit *sqlparser.Literal) (*Literal, erro
 		return NewLiteralBinaryFromHexNum(lit.Bytes())
 	case sqlparser.HexVal:
 		return NewLiteralBinaryFromHex(lit.Bytes())
+	case sqlparser.BitVal:
+		return NewLiteralBinaryFromBit(lit.Bytes())
 	case sqlparser.DateVal:
 		return NewLiteralDateFromBytes(lit.Bytes())
 	case sqlparser.TimeVal:


### PR DESCRIPTION
This extends the evalengine support to better convert existing types to JSON as appropriate.

It also implements the comparison according to https://dev.mysql.com/doc/refman/8.0/en/json.html.

## Related Issue(s)

Extends the work started in https://github.com/vitessio/vitess/pull/12369.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required