### PR TITLE
[release-16.0] Port two flaky test fixes #12603 and #12546

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -67,7 +68,7 @@ type DB struct {
 	acceptWG sync.WaitGroup
 
 	// orderMatters is set when the query order matters.
-	orderMatters bool
+	orderMatters atomic.Bool
 
 	// Fields set at runtime.
 
@@ -77,16 +78,16 @@ type DB struct {
 	// Use SetName() to change.
 	name string
 	// isConnFail trigger a panic in the connection handler.
-	isConnFail bool
+	isConnFail atomic.Bool
 	// connDelay causes a sleep in the connection handler
 	connDelay time.Duration
 	// shouldClose, if true, tells ComQuery() to close the connection when
 	// processing the next query. This will trigger a MySQL client error with
 	// errno 2013 ("server lost").
-	shouldClose bool
-	// AllowAll: if set to true, ComQuery returns an empty result
+	shouldClose atomic.Bool
+	// allowAll: if set to true, ComQuery returns an empty result
 	// for all queries. This flag is used for benchmarking.
-	AllowAll bool
+	allowAll atomic.Bool
 
 	// Handler: interface that allows a caller to override the query handling
 	// implementation. By default it points to the DB itself
@@ -122,7 +123,7 @@ type DB struct {
 
 	// if fakesqldb is asked to serve queries or query patterns that it has not been explicitly told about it will
 	// error out by default. However if you set this flag then any unmatched query results in an empty result
-	neverFail bool
+	neverFail atomic.Bool
 }
 
 // QueryHandler is the interface used by the DB to simulate executed queries
@@ -216,12 +217,8 @@ func (db *DB) SetName(name string) *DB {
 }
 
 // OrderMatters sets the orderMatters flag.
-func (db *DB) OrderMatters() *DB {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-
-	db.orderMatters = true
-	return db
+func (db *DB) OrderMatters() {
+	db.orderMatters.Store(true)
 }
 
 // Close closes the Listener and waits for it to stop accepting.
@@ -309,7 +306,7 @@ func (db *DB) NewConnection(c *mysql.Conn) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	if db.isConnFail {
+	if db.isConnFail.Load() {
 		panic(fmt.Errorf("simulating a connection failure"))
 	}
 
@@ -346,11 +343,11 @@ func (db *DB) WarningCount(c *mysql.Conn) uint16 {
 
 // HandleQuery is the default implementation of the QueryHandler interface
 func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
-	if db.AllowAll {
+	if db.allowAll.Load() {
 		return callback(&sqltypes.Result{})
 	}
 
-	if db.orderMatters {
+	if db.orderMatters.Load() {
 		result, err := db.comQueryOrdered(query)
 		if err != nil {
 			return err
@@ -363,7 +360,7 @@ func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.R
 	db.queryCalled[key]++
 	db.querylog = append(db.querylog, key)
 	// Check if we should close the connection and provoke errno 2013.
-	if db.shouldClose {
+	if db.shouldClose.Load() {
 		c.Close()
 
 		//log error
@@ -412,7 +409,7 @@ func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.R
 		}
 	}
 
-	if db.neverFail {
+	if db.neverFail.Load() {
 		return callback(&sqltypes.Result{})
 	}
 	// Nothing matched.
@@ -450,7 +447,7 @@ func (db *DB) comQueryOrdered(query string) (*sqltypes.Result, error) {
 	index := db.expectedExecuteFetchIndex
 
 	if index >= len(db.expectedExecuteFetch) {
-		if db.neverFail {
+		if db.neverFail.Load() {
 			return &sqltypes.Result{}, nil
 		}
 		db.t.Errorf("%v: got unexpected out of bound fetch: %v >= %v", db.name, index, len(db.expectedExecuteFetch))
@@ -465,7 +462,7 @@ func (db *DB) comQueryOrdered(query string) (*sqltypes.Result, error) {
 
 	if strings.HasSuffix(expected, "*") {
 		if !strings.HasPrefix(query, expected[0:len(expected)-1]) {
-			if db.neverFail {
+			if db.neverFail.Load() {
 				return &sqltypes.Result{}, nil
 			}
 			db.t.Errorf("%v: got unexpected query start (index=%v): %v != %v", db.name, index, query, expected)
@@ -473,7 +470,7 @@ func (db *DB) comQueryOrdered(query string) (*sqltypes.Result, error) {
 		}
 	} else {
 		if query != expected {
-			if db.neverFail {
+			if db.neverFail.Load() {
 				return &sqltypes.Result{}, nil
 			}
 			db.t.Errorf("%v: got unexpected query (index=%v): %v != %v", db.name, index, query, expected)
@@ -629,16 +626,12 @@ func (db *DB) ResetQueryLog() {
 
 // EnableConnFail makes connection to this fake DB fail.
 func (db *DB) EnableConnFail() {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-	db.isConnFail = true
+	db.isConnFail.Store(true)
 }
 
 // DisableConnFail makes connection to this fake DB success.
 func (db *DB) DisableConnFail() {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-	db.isConnFail = false
+	db.isConnFail.Store(false)
 }
 
 // SetConnDelay delays connections to this fake DB for the given duration
@@ -650,9 +643,7 @@ func (db *DB) SetConnDelay(d time.Duration) {
 
 // EnableShouldClose closes the connection when processing the next query.
 func (db *DB) EnableShouldClose() {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-	db.shouldClose = true
+	db.shouldClose.Store(true)
 }
 
 //
@@ -757,8 +748,12 @@ func (db *DB) VerifyAllExecutedOrFail() {
 	}
 }
 
+func (db *DB) SetAllowAll(allowAll bool) {
+	db.allowAll.Store(allowAll)
+}
+
 func (db *DB) SetNeverFail(neverFail bool) {
-	db.neverFail = neverFail
+	db.neverFail.Store(neverFail)
 }
 
 func (db *DB) MockQueriesForTable(table string, result *sqltypes.Result) {

--- a/go/vt/log/log.go
+++ b/go/vt/log/log.go
@@ -22,6 +22,10 @@ limitations under the License.
 package log
 
 import (
+	"fmt"
+	"strconv"
+	"sync/atomic"
+
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 )
@@ -78,5 +82,32 @@ var (
 // calls this function, or call this function directly before parsing
 // command-line arguments.
 func RegisterFlags(fs *pflag.FlagSet) {
-	fs.Uint64Var(&glog.MaxSize, "log_rotate_max_size", glog.MaxSize, "size in bytes at which logs are rotated (glog.MaxSize)")
+	flagVal := logRotateMaxSize{
+		val: fmt.Sprintf("%d", atomic.LoadUint64(&glog.MaxSize)),
+	}
+	fs.Var(&flagVal, "log_rotate_max_size", "size in bytes at which logs are rotated (glog.MaxSize)")
+}
+
+// logRotateMaxSize implements pflag.Value and is used to
+// try and provide thread-safe access to glog.MaxSize.
+type logRotateMaxSize struct {
+	val string
+}
+
+func (lrms *logRotateMaxSize) Set(s string) error {
+	maxSize, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	atomic.StoreUint64(&glog.MaxSize, maxSize)
+	lrms.val = s
+	return nil
+}
+
+func (lrms *logRotateMaxSize) String() string {
+	return lrms.val
+}
+
+func (lrms *logRotateMaxSize) Type() string {
+	return "uint64"
 }

--- a/go/vt/vtctl/vdiff2_test.go
+++ b/go/vt/vtctl/vdiff2_test.go
@@ -35,7 +35,7 @@ var (
 )
 
 func TestVDiff2Unsharded(t *testing.T) {
-	env := newTestVDiffEnv([]string{"0"}, []string{"0"}, "", nil)
+	env := newTestVDiffEnv(t, []string{"0"}, []string{"0"}, "", nil)
 	defer env.close()
 
 	UUID := uuid.New().String()
@@ -275,7 +275,7 @@ func TestVDiff2Unsharded(t *testing.T) {
 }
 
 func TestVDiff2Sharded(t *testing.T) {
-	env := newTestVDiffEnv([]string{"-40", "40-"}, []string{"-80", "80-"}, "", map[string]string{
+	env := newTestVDiffEnv(t, []string{"-40", "40-"}, []string{"-80", "80-"}, "", map[string]string{
 		"-80": "MySQL56/0e45e704-7cb9-11ed-a1eb-0242ac120002:1-890",
 		"80-": "MySQL56/1497ddb0-7cb9-11ed-a1eb-0242ac120002:1-891",
 	})

--- a/go/vt/vttablet/tabletserver/bench_test.go
+++ b/go/vt/vttablet/tabletserver/bench_test.go
@@ -68,7 +68,7 @@ func BenchmarkExecuteVarBinary(b *testing.B) {
 	}
 
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-	db.AllowAll = true
+	db.SetAllowAll(true)
 	for i := 0; i < b.N; i++ {
 		if _, err := tsv.Execute(context.Background(), &target, benchQuery, bv, 0, 0, nil); err != nil {
 			panic(err)
@@ -93,7 +93,7 @@ func BenchmarkExecuteExpression(b *testing.B) {
 	}
 
 	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
-	db.AllowAll = true
+	db.SetAllowAll(true)
 	for i := 0; i < b.N; i++ {
 		if _, err := tsv.Execute(context.Background(), &target, benchQuery, bv, 0, 0, nil); err != nil {
 			panic(err)

--- a/go/vt/wrangler/vdiff_env_test.go
+++ b/go/vt/wrangler/vdiff_env_test.go
@@ -19,7 +19,9 @@ package wrangler
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
+	"testing"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -62,25 +64,10 @@ type testVDiffEnv struct {
 	tablets map[int]*testVDiffTablet
 }
 
-// vdiffEnv has to be a global for RegisterDialer to work.
-var vdiffEnv *testVDiffEnv
-
-func init() {
-	tabletconn.RegisterDialer("VDiffTest", func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
-		vdiffEnv.mu.Lock()
-		defer vdiffEnv.mu.Unlock()
-		if qs, ok := vdiffEnv.tablets[int(tablet.Alias.Uid)]; ok {
-			return qs, nil
-		}
-		return nil, fmt.Errorf("tablet %d not found", tablet.Alias.Uid)
-	})
-}
-
 //----------------------------------------------
 // testVDiffEnv
 
-func newTestVDiffEnv(sourceShards, targetShards []string, query string, positions map[string]string) *testVDiffEnv {
-	tabletconntest.SetProtocol("go.vt.wrangler.vdiff_env_test", "VDiffTest")
+func newTestVDiffEnv(t testing.TB, sourceShards, targetShards []string, query string, positions map[string]string) *testVDiffEnv {
 	env := &testVDiffEnv{
 		workflow:   "vdiffTest",
 		tablets:    make(map[int]*testVDiffTablet),
@@ -90,6 +77,18 @@ func newTestVDiffEnv(sourceShards, targetShards []string, query string, position
 		tmc:        newTestVDiffTMClient(),
 	}
 	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc)
+
+	// Generate a unique dialer name.
+	dialerName := fmt.Sprintf("VDiffTest-%s-%d", t.Name(), rand.Intn(1000000000))
+	tabletconn.RegisterDialer(dialerName, func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
+		env.mu.Lock()
+		defer env.mu.Unlock()
+		if qs, ok := env.tablets[int(tablet.Alias.Uid)]; ok {
+			return qs, nil
+		}
+		return nil, fmt.Errorf("tablet %d not found", tablet.Alias.Uid)
+	})
+	tabletconntest.SetProtocol("go.vt.wrangler.vdiff_env_test", dialerName)
 
 	tabletID := 100
 	for _, shard := range sourceShards {
@@ -167,7 +166,6 @@ func newTestVDiffEnv(sourceShards, targetShards []string, query string, position
 
 		tabletID += 10
 	}
-	vdiffEnv = env
 	return env
 }
 

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -490,7 +490,7 @@ func TestVDiffPlanFailure(t *testing.T) {
 }
 
 func TestVDiffUnsharded(t *testing.T) {
-	env := newTestVDiffEnv([]string{"0"}, []string{"0"}, "", nil)
+	env := newTestVDiffEnv(t, []string{"0"}, []string{"0"}, "", nil)
 	defer env.close()
 
 	schm := &tabletmanagerdatapb.SchemaDefinition{
@@ -767,7 +767,7 @@ func TestVDiffUnsharded(t *testing.T) {
 func TestVDiffSharded(t *testing.T) {
 	// Also test that highest position ""MariaDB/5-456-892" will be used
 	// if lower positions are found.
-	env := newTestVDiffEnv([]string{"-40", "40-"}, []string{"-80", "80-"}, "", map[string]string{
+	env := newTestVDiffEnv(t, []string{"-40", "40-"}, []string{"-80", "80-"}, "", map[string]string{
 		"-40-80": "MariaDB/5-456-890",
 		"40-80-": "MariaDB/5-456-891",
 	})
@@ -838,7 +838,7 @@ func TestVDiffSharded(t *testing.T) {
 }
 
 func TestVDiffAggregates(t *testing.T) {
-	env := newTestVDiffEnv([]string{"-40", "40-"}, []string{"-80", "80-"}, "select c1, count(*) c2, sum(c3) c3 from t group by c1", nil)
+	env := newTestVDiffEnv(t, []string{"-40", "40-"}, []string{"-80", "80-"}, "select c1, count(*) c2, sum(c3) c3 from t group by c1", nil)
 	defer env.close()
 
 	schm := &tabletmanagerdatapb.SchemaDefinition{
@@ -905,7 +905,7 @@ func TestVDiffAggregates(t *testing.T) {
 }
 
 func TestVDiffDefaults(t *testing.T) {
-	env := newTestVDiffEnv([]string{"0"}, []string{"0"}, "", nil)
+	env := newTestVDiffEnv(t, []string{"0"}, []string{"0"}, "", nil)
 	defer env.close()
 
 	schm := &tabletmanagerdatapb.SchemaDefinition{
@@ -958,7 +958,7 @@ func TestVDiffDefaults(t *testing.T) {
 }
 
 func TestVDiffReplicationWait(t *testing.T) {
-	env := newTestVDiffEnv([]string{"0"}, []string{"0"}, "", nil)
+	env := newTestVDiffEnv(t, []string{"0"}, []string{"0"}, "", nil)
 	defer env.close()
 
 	schm := &tabletmanagerdatapb.SchemaDefinition{

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -36,7 +36,7 @@ func TestVExec(t *testing.T) {
 	workflow := "wrWorkflow"
 	keyspace := "target"
 	query := "update _vt.vreplication set state = 'Running'"
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, time.Now().Unix())
+	env := newWranglerTestEnv(t, []string{"0"}, []string{"-80", "80-"}, "", nil, time.Now().Unix())
 	defer env.close()
 	var logger = logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc)
@@ -180,7 +180,7 @@ func TestWorkflowListStreams(t *testing.T) {
 	ctx := context.Background()
 	workflow := "wrWorkflow"
 	keyspace := "target"
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, 1234)
+	env := newWranglerTestEnv(t, []string{"0"}, []string{"-80", "80-"}, "", nil, 1234)
 	defer env.close()
 	logger := logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc)
@@ -353,7 +353,7 @@ func TestWorkflowListAll(t *testing.T) {
 	ctx := context.Background()
 	keyspace := "target"
 	workflow := "wrWorkflow"
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, 0)
+	env := newWranglerTestEnv(t, []string{"0"}, []string{"-80", "80-"}, "", nil, 0)
 	defer env.close()
 	logger := logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc)
@@ -373,7 +373,7 @@ func TestVExecValidations(t *testing.T) {
 	workflow := "wf"
 	keyspace := "ks"
 	query := ""
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, 0)
+	env := newWranglerTestEnv(t, []string{"0"}, []string{"-80", "80-"}, "", nil, 0)
 	defer env.close()
 
 	wr := New(logutil.NewConsoleLogger(), env.topoServ, env.tmc)

--- a/go/vt/wrangler/wrangler_env_test.go
+++ b/go/vt/wrangler/wrangler_env_test.go
@@ -19,7 +19,9 @@ package wrangler
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
+	"testing"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -53,39 +55,35 @@ type testWranglerEnv struct {
 	tabletType topodatapb.TabletType
 	tmc        *testWranglerTMClient
 	mu         sync.Mutex
-	tablets    map[int]*testWranglerTablet
-}
-
-// wranglerEnv has to be a global for RegisterDialer to work.
-var wranglerEnv *testWranglerEnv
-
-func init() {
-	tabletconn.RegisterDialer("WranglerTest", func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
-		wranglerEnv.mu.Lock()
-		defer wranglerEnv.mu.Unlock()
-		if qs, ok := wranglerEnv.tablets[int(tablet.Alias.Uid)]; ok {
-			return qs, nil
-		}
-		// some tests don't require the query service. Earlier we were returning an error for such cases but the tablet picker
-		// now logs a warning and spams the logs. Hence we return a fake service instead
-		return newFakeTestWranglerTablet(), nil
-	})
 }
 
 //----------------------------------------------
 // testWranglerEnv
 
-func newWranglerTestEnv(sourceShards, targetShards []string, query string, positions map[string]string, timeUpdated int64) *testWranglerEnv {
-	tabletconntest.SetProtocol("go.vt.wrangler.vdiff_env_test", "WranglerTest")
+func newWranglerTestEnv(t testing.TB, sourceShards, targetShards []string, query string, positions map[string]string, timeUpdated int64) *testWranglerEnv {
 	env := &testWranglerEnv{
 		workflow:   "wrWorkflow",
-		tablets:    make(map[int]*testWranglerTablet),
 		topoServ:   memorytopo.NewServer("zone1"),
 		cell:       "zone1",
 		tabletType: topodatapb.TabletType_REPLICA,
 		tmc:        newTestWranglerTMClient(),
 	}
 	env.wr = New(logutil.NewConsoleLogger(), env.topoServ, env.tmc)
+	env.tmc.tablets = make(map[int]*testWranglerTablet)
+
+	// Generate a unique dialer name.
+	dialerName := fmt.Sprintf("WranglerTest-%s-%d", t.Name(), rand.Intn(1000000000))
+	tabletconn.RegisterDialer(dialerName, func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
+		env.mu.Lock()
+		defer env.mu.Unlock()
+		if qs, ok := env.tmc.tablets[int(tablet.Alias.Uid)]; ok {
+			return qs, nil
+		}
+		// some tests don't require the query service. Earlier we were returning an error for such cases but the tablet picker
+		// now logs a warning and spams the logs. Hence we return a fake service instead
+		return newFakeTestWranglerTablet(), nil
+	})
+	tabletconntest.SetProtocol("go.vt.wrangler.wrangler_env_test", dialerName)
 
 	tabletID := 100
 	for _, shard := range sourceShards {
@@ -198,17 +196,16 @@ func newWranglerTestEnv(sourceShards, targetShards []string, query string, posit
 		"wrWorkflow", "wrWorkflow2",
 	)
 	env.tmc.setVRResults(primary.tablet, "select distinct workflow from _vt.vreplication where db_name = 'vt_target2'", result)
-	wranglerEnv = env
 	return env
 }
 
 func (env *testWranglerEnv) close() {
 	env.mu.Lock()
 	defer env.mu.Unlock()
-	for _, t := range env.tablets {
+	for _, t := range env.tmc.tablets {
 		env.topoServ.DeleteTablet(context.Background(), t.tablet.Alias)
 	}
-	env.tablets = nil
+	env.tmc.tablets = nil
 }
 
 func newFakeTestWranglerTablet() *testWranglerTablet {
@@ -245,7 +242,7 @@ func (env *testWranglerEnv) addTablet(id int, keyspace, shard string, tabletType
 			"test": int32(id),
 		},
 	}
-	env.tablets[id] = newTestWranglerTablet(tablet)
+	env.tmc.tablets[id] = newTestWranglerTablet(tablet)
 	if err := env.wr.TopoServer().InitTablet(context.Background(), tablet, false /* allowPrimaryOverride */, true /* createShardAndKeyspace */, false /* allowUpdate */); err != nil {
 		panic(err)
 	}
@@ -258,8 +255,8 @@ func (env *testWranglerEnv) addTablet(id int, keyspace, shard string, tabletType
 			panic(err)
 		}
 	}
-	env.tablets[id].queryResults = make(map[string]*querypb.QueryResult)
-	return env.tablets[id]
+	env.tmc.tablets[id].queryResults = make(map[string]*querypb.QueryResult)
+	return env.tmc.tablets[id]
 }
 
 //----------------------------------------------
@@ -296,6 +293,7 @@ func (tvt *testWranglerTablet) StreamHealth(ctx context.Context, callback func(*
 
 type testWranglerTMClient struct {
 	tmclient.TabletManagerClient
+	tablets   map[int]*testWranglerTablet
 	schema    *tabletmanagerdatapb.SchemaDefinition
 	vrQueries map[int]map[string]*querypb.QueryResult
 	waitpos   map[int]string
@@ -334,7 +332,7 @@ func (tmc *testWranglerTMClient) VReplicationExec(ctx context.Context, tablet *t
 }
 
 func (tmc *testWranglerTMClient) ExecuteFetchAsApp(ctx context.Context, tablet *topodatapb.Tablet, usePool bool, req *tabletmanagerdatapb.ExecuteFetchAsAppRequest) (*querypb.QueryResult, error) {
-	t := wranglerEnv.tablets[int(tablet.Alias.Uid)]
+	t := tmc.tablets[int(tablet.Alias.Uid)]
 	t.gotQueries = append(t.gotQueries, string(req.Query))
 	result, ok := t.queryResults[string(req.Query)]
 	if !ok {


### PR DESCRIPTION
## Description

* Use atomic.Bool for fakesqldb behavior flags #12603
* Flakes: Address Common Unit Test Races #12546

## Related issues

#12603
#12546

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

