### PR TITLE
[gen4 planner] Move more horizon planning to operators

### DIFF
--- a/go/slices2/slices.go
+++ b/go/slices2/slices.go
@@ -37,3 +37,11 @@ func Any[T any](s []T, fn func(T) bool) bool {
 	}
 	return false
 }
+
+func Map[From, To any](in []From, f func(From) To) []To {
+	result := make([]To, len(in))
+	for i, col := range in {
+		result[i] = f(col)
+	}
+	return result
+}

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -59,6 +59,18 @@ func transformToLogicalPlan(ctx *plancontext.PlanningContext, op ops.Operator, i
 		return transformCorrelatedSubQueryPlan(ctx, op)
 	case *operators.Derived:
 		return transformDerivedPlan(ctx, op)
+	case *operators.SimpleProjection:
+		src, err := transformToLogicalPlan(ctx, op.Source, false)
+		if err != nil {
+			return nil, err
+		}
+
+		return &simpleProjection{
+			logicalPlanCommon: newBuilderCommon(src),
+			eSimpleProj: &engine.SimpleProjection{
+				Cols: op.Columns,
+			},
+		}, nil
 	case *operators.Filter:
 		plan, err := transformToLogicalPlan(ctx, op.Source, false)
 		if err != nil {

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -60,49 +60,57 @@ func transformToLogicalPlan(ctx *plancontext.PlanningContext, op ops.Operator, i
 	case *operators.Derived:
 		return transformDerivedPlan(ctx, op)
 	case *operators.SimpleProjection:
-		src, err := transformToLogicalPlan(ctx, op.Source, false)
-		if err != nil {
-			return nil, err
-		}
-
-		return &simpleProjection{
-			logicalPlanCommon: newBuilderCommon(src),
-			eSimpleProj: &engine.SimpleProjection{
-				Cols: op.Columns,
-			},
-		}, nil
+		return transformSimpleProjection(ctx, op)
 	case *operators.Filter:
-		plan, err := transformToLogicalPlan(ctx, op.Source, false)
-		if err != nil {
-			return nil, err
-		}
-
-		predicate := op.FinalPredicate
-		ast := ctx.SemTable.AndExpressions(op.Predicates...)
-
-		// this might already have been done on the operators
-		if predicate == nil {
-			predicate, err = evalengine.Translate(ast, &evalengine.Config{
-				ResolveColumn: resolveFromPlan(ctx, plan, true),
-				Collation:     ctx.SemTable.Collation,
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		return &filter{
-			logicalPlanCommon: newBuilderCommon(plan),
-			efilter: &engine.Filter{
-				Predicate:    predicate,
-				ASTPredicate: ast,
-			},
-		}, nil
+		return transformFilter(ctx, op)
 	case *operators.Horizon:
 		return transformHorizon(ctx, op, isRoot)
 	}
 
 	return nil, vterrors.VT13001(fmt.Sprintf("unknown type encountered: %T (transformToLogicalPlan)", op))
+}
+
+func transformFilter(ctx *plancontext.PlanningContext, op *operators.Filter) (logicalPlan, error) {
+	plan, err := transformToLogicalPlan(ctx, op.Source, false)
+	if err != nil {
+		return nil, err
+	}
+
+	predicate := op.FinalPredicate
+	ast := ctx.SemTable.AndExpressions(op.Predicates...)
+
+	// this might already have been done on the operators
+	if predicate == nil {
+		predicate, err = evalengine.Translate(ast, &evalengine.Config{
+			ResolveColumn: resolveFromPlan(ctx, plan, true),
+			Collation:     ctx.SemTable.Collation,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &filter{
+		logicalPlanCommon: newBuilderCommon(plan),
+		efilter: &engine.Filter{
+			Predicate:    predicate,
+			ASTPredicate: ast,
+		},
+	}, nil
+}
+
+func transformSimpleProjection(ctx *plancontext.PlanningContext, op *operators.SimpleProjection) (logicalPlan, error) {
+	src, err := transformToLogicalPlan(ctx, op.Source, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return &simpleProjection{
+		logicalPlanCommon: newBuilderCommon(src),
+		eSimpleProj: &engine.SimpleProjection{
+			Cols: op.Columns,
+		},
+	}, nil
 }
 
 func transformHorizon(ctx *plancontext.PlanningContext, op *operators.Horizon, isRoot bool) (logicalPlan, error) {

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -64,13 +64,19 @@ func transformToLogicalPlan(ctx *plancontext.PlanningContext, op ops.Operator, i
 		if err != nil {
 			return nil, err
 		}
+
+		predicate := op.FinalPredicate
 		ast := ctx.SemTable.AndExpressions(op.Predicates...)
-		predicate, err := evalengine.Translate(ast, &evalengine.Config{
-			ResolveColumn: resolveFromPlan(ctx, plan, true),
-			Collation:     ctx.SemTable.Collation,
-		})
-		if err != nil {
-			return nil, err
+
+		// this might already have been done on the operators
+		if predicate == nil {
+			predicate, err = evalengine.Translate(ast, &evalengine.Config{
+				ResolveColumn: resolveFromPlan(ctx, plan, true),
+				Collation:     ctx.SemTable.Collation,
+			})
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return &filter{

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -141,7 +141,7 @@ func (a *ApplyJoin) AddJoinPredicate(ctx *plancontext.PlanningContext, expr sqlp
 }
 
 func (a *ApplyJoin) pushColLeft(ctx *plancontext.PlanningContext, e *sqlparser.AliasedExpr) (int, error) {
-	newLHS, offset, err := a.LHS.AddColumn(ctx, e)
+	newLHS, offset, err := a.LHS.AddColumn(ctx, e, true)
 	if err != nil {
 		return 0, err
 	}
@@ -149,7 +149,7 @@ func (a *ApplyJoin) pushColLeft(ctx *plancontext.PlanningContext, e *sqlparser.A
 	return offset, nil
 }
 func (a *ApplyJoin) pushColRight(ctx *plancontext.PlanningContext, e *sqlparser.AliasedExpr) (int, error) {
-	newRHS, offset, err := a.RHS.AddColumn(ctx, e)
+	newRHS, offset, err := a.RHS.AddColumn(ctx, e, true)
 	if err != nil {
 		return 0, err
 	}
@@ -157,9 +157,12 @@ func (a *ApplyJoin) pushColRight(ctx *plancontext.PlanningContext, e *sqlparser.
 	return offset, nil
 }
 
-func (a *ApplyJoin) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (ops.Operator, int, error) {
+func (a *ApplyJoin) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
 	// first check if we already are passing through this expression
 	for i, existing := range a.ColumnsAST {
+		if !reuseCol {
+			break
+		}
 		if ctx.SemTable.EqualsExpr(existing, expr.Expr) {
 			return a, i, nil
 		}

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -159,12 +159,11 @@ func (a *ApplyJoin) pushColRight(ctx *plancontext.PlanningContext, e *sqlparser.
 
 func (a *ApplyJoin) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
 	// first check if we already are passing through this expression
-	for i, existing := range a.ColumnsAST {
-		if !reuseCol {
-			break
-		}
-		if ctx.SemTable.EqualsExpr(existing, expr.Expr) {
-			return a, i, nil
+	if reuseCol {
+		for i, existing := range a.ColumnsAST {
+			if ctx.SemTable.EqualsExpr(existing, expr.Expr) {
+				return a, i, nil
+			}
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -157,6 +157,10 @@ func (a *ApplyJoin) pushColRight(ctx *plancontext.PlanningContext, e *sqlparser.
 	return offset, nil
 }
 
+func (a *ApplyJoin) GetColumns() ([]sqlparser.Expr, error) {
+	return a.ColumnsAST, nil
+}
+
 func (a *ApplyJoin) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
 	// first check if we already are passing through this expression
 	if reuseCol {

--- a/go/vt/vtgate/planbuilder/operators/derived.go
+++ b/go/vt/vtgate/planbuilder/operators/derived.go
@@ -132,8 +132,8 @@ func (d *Derived) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.
 	return d, nil
 }
 
-func (d *Derived) AddColumn(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (int, error) {
-	col, ok := expr.(*sqlparser.ColName)
+func (d *Derived) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error) {
+	col, ok := expr.Expr.(*sqlparser.ColName)
 	if !ok {
 		return 0, vterrors.VT13001("cannot push non-colname expression to a derived table")
 	}
@@ -148,7 +148,7 @@ func (d *Derived) AddColumn(ctx *plancontext.PlanningContext, expr sqlparser.Exp
 	d.Columns = append(d.Columns, col)
 	// add it to the source if we were not already passing it through
 	if i <= -1 {
-		_, err := d.Source.AddColumn(ctx, sqlparser.NewColName(col.Name.String()))
+		_, err := d.Source.AddColumn(ctx, aeWrap(sqlparser.NewColName(col.Name.String())))
 		if err != nil {
 			return 0, err
 		}

--- a/go/vt/vtgate/planbuilder/operators/derived.go
+++ b/go/vt/vtgate/planbuilder/operators/derived.go
@@ -132,15 +132,15 @@ func (d *Derived) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.
 	return d, nil
 }
 
-func (d *Derived) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error) {
+func (d *Derived) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (ops.Operator, int, error) {
 	col, ok := expr.Expr.(*sqlparser.ColName)
 	if !ok {
-		return 0, vterrors.VT13001("cannot push non-colname expression to a derived table")
+		return nil, 0, vterrors.VT13001("cannot push non-colname expression to a derived table")
 	}
 
 	i, err := d.findOutputColumn(col)
 	if err != nil {
-		return 0, err
+		return nil, 0, err
 	}
 	var pos int
 	d.ColumnsOffset, pos = addToIntSlice(d.ColumnsOffset, i)
@@ -148,12 +148,13 @@ func (d *Derived) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.Al
 	d.Columns = append(d.Columns, col)
 	// add it to the source if we were not already passing it through
 	if i <= -1 {
-		_, err := d.Source.AddColumn(ctx, aeWrap(sqlparser.NewColName(col.Name.String())))
+		newSrc, _, err := d.Source.AddColumn(ctx, aeWrap(sqlparser.NewColName(col.Name.String())))
 		if err != nil {
-			return 0, err
+			return nil, 0, err
 		}
+		d.Source = newSrc
 	}
-	return pos, nil
+	return d, pos, nil
 }
 
 func addToIntSlice(columnOffset []int, valToAdd int) ([]int, int) {

--- a/go/vt/vtgate/planbuilder/operators/derived.go
+++ b/go/vt/vtgate/planbuilder/operators/derived.go
@@ -19,6 +19,8 @@ package operators
 import (
 	"golang.org/x/exp/slices"
 
+	"vitess.io/vitess/go/slices2"
+
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -163,6 +165,10 @@ func (d *Derived) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.Al
 		d.Source = newSrc
 	}
 	return d, pos, nil
+}
+
+func (d *Derived) GetColumns() ([]sqlparser.Expr, error) {
+	return slices2.Map(d.Columns, colNameToExpr), nil
 }
 
 func addToIntSlice(columnOffset []int, valToAdd int) ([]int, int) {

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -77,8 +77,13 @@ func (f *Filter) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.E
 	return f, nil
 }
 
-func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error) {
-	return f.Source.AddColumn(ctx, expr)
+func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (ops.Operator, int, error) {
+	newSrc, offset, err := f.Source.AddColumn(ctx, expr)
+	if err != nil {
+		return nil, 0, err
+	}
+	f.Source = newSrc
+	return f, offset, nil
 }
 
 func (f *Filter) Compact(*plancontext.PlanningContext) (ops.Operator, rewrite.TreeIdentity, error) {

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -77,7 +77,7 @@ func (f *Filter) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.E
 	return f, nil
 }
 
-func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (int, error) {
+func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error) {
 	return f.Source.AddColumn(ctx, expr)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -77,8 +77,8 @@ func (f *Filter) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.E
 	return f, nil
 }
 
-func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (ops.Operator, int, error) {
-	newSrc, offset, err := f.Source.AddColumn(ctx, expr)
+func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
+	newSrc, offset, err := f.Source.AddColumn(ctx, expr, reuseCol)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -18,6 +18,7 @@ package operators
 
 import (
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/rewrite"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
@@ -27,6 +28,10 @@ import (
 type Filter struct {
 	Source     ops.Operator
 	Predicates []sqlparser.Expr
+
+	// FinalPredicate is the evalengine expression that will finally be used.
+	// It contains the ANDed predicates in Predicates, with ColName:s replaced by Offset:s
+	FinalPredicate evalengine.Expr
 }
 
 var _ ops.PhysicalOperator = (*Filter)(nil)

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -91,6 +91,10 @@ func (f *Filter) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.Ali
 	return f, offset, nil
 }
 
+func (f *Filter) GetColumns() ([]sqlparser.Expr, error) {
+	return f.Source.GetColumns()
+}
+
 func (f *Filter) Compact(*plancontext.PlanningContext) (ops.Operator, rewrite.TreeIdentity, error) {
 	if len(f.Predicates) == 0 {
 		return f.Source, rewrite.NewTree, nil

--- a/go/vt/vtgate/planbuilder/operators/helpers.go
+++ b/go/vt/vtgate/planbuilder/operators/helpers.go
@@ -35,7 +35,7 @@ func Compact(ctx *plancontext.PlanningContext, op ops.Operator) (ops.Operator, e
 		Compact(ctx *plancontext.PlanningContext) (ops.Operator, rewrite.TreeIdentity, error)
 	}
 
-	newOp, err := rewrite.BottomUpAll(op, TableID, func(_ semantics.TableSet, op ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
+	newOp, err := rewrite.BottomUpAll(op, TableID, func(op ops.Operator, _ semantics.TableSet) (ops.Operator, rewrite.TreeIdentity, error) {
 		newOp, ok := op.(compactable)
 		if !ok {
 			return op, rewrite.SameTree, nil

--- a/go/vt/vtgate/planbuilder/operators/helpers.go
+++ b/go/vt/vtgate/planbuilder/operators/helpers.go
@@ -35,7 +35,7 @@ func Compact(ctx *plancontext.PlanningContext, op ops.Operator) (ops.Operator, e
 		Compact(ctx *plancontext.PlanningContext) (ops.Operator, rewrite.TreeIdentity, error)
 	}
 
-	newOp, err := rewrite.BottomUp(op, semantics.EmptyTableSet(), TableID, func(_ semantics.TableSet, op ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
+	newOp, err := rewrite.BottomUpAll(op, TableID, func(_ semantics.TableSet, op ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
 		newOp, ok := op.(compactable)
 		if !ok {
 			return op, rewrite.SameTree, nil

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -23,7 +23,8 @@ import (
 )
 
 // Horizon is an operator that allows us to postpone planning things like SELECT/GROUP BY/ORDER BY/LIMIT until later.
-// It contains information about the planning we have to do after deciding how we will send the query to the tablets.	// If we are able to push down the Horizon under a route, we don't have to plan these things separately and can
+// It contains information about the planning we have to do after deciding how we will send the query to the tablets.
+// If we are able to push down the Horizon under a route, we don't have to plan these things separately and can
 // just copy over the AST constructs to the query being sent to a tablet.
 // If we are not able to push it down, this operator needs to be split up into smaller
 // Project/Aggregate/Sort/Limit operations, some which can be pushed down,

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -22,8 +22,12 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 )
 
-// Horizon is an operator we use until we decide how to handle the source to the horizon.
-// It contains information about the planning we have to do after deciding how we will send the query to the tablets.
+// Horizon is an operator that allows us to postpone planning things like SELECT/GROUP BY/ORDER BY/LIMIT until later.
+// It contains information about the planning we have to do after deciding how we will send the query to the tablets.	// If we are able to push down the Horizon under a route, we don't have to plan these things separately and can
+// just copy over the AST constructs to the query being sent to a tablet.
+// If we are not able to push it down, this operator needs to be split up into smaller
+// Project/Aggregate/Sort/Limit operations, some which can be pushed down,
+// and some that have to be evaluated at the vtgate level.
 type Horizon struct {
 	Source ops.Operator
 	Select sqlparser.SelectStatement

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -76,3 +76,7 @@ func planSingleRoute(rb *Route, horizon *Horizon) (ops.Operator, rewrite.VisitRu
 	rb.Source, horizon.Source = horizon, rb.Source
 	return rb, rewrite.SkipChildren, nil
 }
+
+func aeWrap(e sqlparser.Expr) *sqlparser.AliasedExpr {
+	return &sqlparser.AliasedExpr{Expr: e}
+}

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -33,7 +33,7 @@ func planColumns(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Opera
 		_, isRoute := operator.(*Route)
 		return rewrite.VisitRule(!isRoute)
 	}
-	visitor := func(id semantics.TableSet, in ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
+	visitor := func(in ops.Operator, _ semantics.TableSet) (ops.Operator, rewrite.TreeIdentity, error) {
 		switch in := in.(type) {
 		case *Horizon:
 			op, err := planHorizon(ctx, in, in == root)
@@ -46,6 +46,7 @@ func planColumns(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Opera
 			}
 			return op, rewrite.NewTree, nil
 		case *Derived, *Filter:
+			// TODO we need to do column planning on these
 			return nil, rewrite.SameTree, errNotHorizonPlanned
 		default:
 			return in, rewrite.SameTree, nil

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -21,33 +21,44 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/rewrite"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/semantics"
 
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
 )
 
 var errNotHorizonPlanned = vterrors.VT12001("query cannot be fully operator planned")
 
-func planHorizons(ctx *plancontext.PlanningContext, in ops.Operator) (ops.Operator, error) {
-	return rewrite.TopDown(in, func(in ops.Operator) (ops.Operator, rewrite.TreeIdentity, rewrite.VisitRule, error) {
+func planColumns(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Operator, error) {
+	stopAtRoute := func(operator ops.Operator) rewrite.VisitRule {
+		_, isRoute := operator.(*Route)
+		return rewrite.VisitRule(!isRoute)
+	}
+	visitor := func(id semantics.TableSet, in ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
 		switch in := in.(type) {
 		case *Horizon:
-			op, visit, err := planHorizon(ctx, in)
+			op, err := planHorizon(ctx, in, in == root)
 			if err != nil {
-				return nil, rewrite.SameTree, rewrite.SkipChildren, err
+				if vterr, ok := err.(*vterrors.VitessError); ok && vterr.ID == "VT13001" {
+					// we encountered a bug. let's try to back out
+					return nil, rewrite.SameTree, errNotHorizonPlanned
+				}
+				return nil, rewrite.SameTree, err
 			}
-			return op, rewrite.NewTree, visit, nil
-		case *Route:
-			return in, rewrite.SameTree, rewrite.SkipChildren, nil
+			return op, rewrite.NewTree, nil
+		case *Derived, *Filter:
+			return nil, rewrite.SameTree, errNotHorizonPlanned
 		default:
-			return in, rewrite.SameTree, rewrite.VisitChildren, nil
+			return in, rewrite.SameTree, nil
 		}
-	})
+	}
+	return rewrite.BottomUp(root, TableID, visitor, stopAtRoute)
 }
 
-func planHorizon(ctx *plancontext.PlanningContext, in *Horizon) (ops.Operator, rewrite.VisitRule, error) {
+func planHorizon(ctx *plancontext.PlanningContext, in *Horizon, isRoot bool) (ops.Operator, error) {
 	rb, isRoute := in.Source.(*Route)
-	if !isRoute {
-		return in, rewrite.VisitChildren, nil
+	if !isRoute && ctx.SemTable.NotSingleRouteErr != nil {
+		// If we got here, we don't have a single shard plan
+		return nil, ctx.SemTable.NotSingleRouteErr
 	}
 	if isRoute && rb.IsSingleShard() && in.Select.GetLimit() == nil {
 		return planSingleRoute(rb, in)
@@ -55,26 +66,55 @@ func planHorizon(ctx *plancontext.PlanningContext, in *Horizon) (ops.Operator, r
 
 	sel, isSel := in.Select.(*sqlparser.Select)
 	if !isSel {
-		return nil, rewrite.VisitChildren, errNotHorizonPlanned
+		return nil, errNotHorizonPlanned
 	}
 
 	qp, err := CreateQPFromSelect(ctx, sel)
 	if err != nil {
-		return nil, rewrite.VisitChildren, err
+		return nil, err
 	}
 
 	needsOrdering := len(qp.OrderExprs) > 0
 	canShortcut := isRoute && sel.Having == nil && !needsOrdering
+	_, isDerived := in.Source.(*Derived)
 
-	if !qp.NeedsAggregation() && sel.Having == nil && canShortcut && !needsOrdering && !qp.NeedsDistinct() && in.Select.GetLimit() == nil {
+	// if we are at the root, we have to return the columns the user asked for. in all other levels, we reuse as much as possible
+	canReuseCols := !isRoot
+
+	switch {
+	case qp.NeedsAggregation() || sel.Having != nil || sel.Limit != nil || isDerived || needsOrdering || qp.NeedsDistinct():
+		return nil, errNotHorizonPlanned
+	case canShortcut:
 		return planSingleRoute(rb, in)
+	default:
+		src := in.Source
+		for idx, e := range qp.SelectExprs {
+			expr, err := e.GetAliasedExpr()
+			if err != nil {
+				return nil, err
+			}
+			if !expr.As.IsEmpty() {
+				// we are not handling column names correct yet, so let's fail here for now
+				return nil, errNotHorizonPlanned
+			}
+			var offset int
+			src, offset, err = src.AddColumn(ctx, expr, canReuseCols)
+			if err != nil {
+				return nil, err
+			}
+			if idx != offset && isRoot {
+				// if we are returning something different from what the user asked for,
+				// we need to add an operator on top to clean up the output
+				return nil, errNotHorizonPlanned
+			}
+		}
+		return src, nil
 	}
-	return nil, rewrite.VisitChildren, errNotHorizonPlanned
 }
 
-func planSingleRoute(rb *Route, horizon *Horizon) (ops.Operator, rewrite.VisitRule, error) {
+func planSingleRoute(rb *Route, horizon *Horizon) (ops.Operator, error) {
 	rb.Source, horizon.Source = horizon, rb.Source
-	return rb, rewrite.SkipChildren, nil
+	return rb, nil
 }
 
 func aeWrap(e sqlparser.Expr) *sqlparser.AliasedExpr {

--- a/go/vt/vtgate/planbuilder/operators/operator.go
+++ b/go/vt/vtgate/planbuilder/operators/operator.go
@@ -88,7 +88,7 @@ func (noInputs) Inputs() []ops.Operator {
 }
 
 // AddColumn implements the Operator interface
-func (noColumns) AddColumn(*plancontext.PlanningContext, sqlparser.Expr) (int, error) {
+func (noColumns) AddColumn(*plancontext.PlanningContext, *sqlparser.AliasedExpr) (int, error) {
 	return 0, vterrors.VT13001("the noColumns operator cannot accept columns")
 }
 

--- a/go/vt/vtgate/planbuilder/operators/operator.go
+++ b/go/vt/vtgate/planbuilder/operators/operator.go
@@ -88,8 +88,8 @@ func (noInputs) Inputs() []ops.Operator {
 }
 
 // AddColumn implements the Operator interface
-func (noColumns) AddColumn(*plancontext.PlanningContext, *sqlparser.AliasedExpr) (int, error) {
-	return 0, vterrors.VT13001("the noColumns operator cannot accept columns")
+func (noColumns) AddColumn(*plancontext.PlanningContext, *sqlparser.AliasedExpr) (ops.Operator, int, error) {
+	return nil, 0, vterrors.VT13001("the noColumns operator cannot accept columns")
 }
 
 // AddPredicate implements the Operator interface

--- a/go/vt/vtgate/planbuilder/operators/operator.go
+++ b/go/vt/vtgate/planbuilder/operators/operator.go
@@ -92,6 +92,10 @@ func (noColumns) AddColumn(*plancontext.PlanningContext, *sqlparser.AliasedExpr,
 	return nil, 0, vterrors.VT13001("the noColumns operator cannot accept columns")
 }
 
+func (noColumns) GetColumns() ([]sqlparser.Expr, error) {
+	return nil, vterrors.VT13001("the noColumns operator cannot accept columns")
+}
+
 // AddPredicate implements the Operator interface
 func (noPredicates) AddPredicate(*plancontext.PlanningContext, sqlparser.Expr) (ops.Operator, error) {
 	return nil, vterrors.VT13001("the noColumns operator cannot accept predicates")

--- a/go/vt/vtgate/planbuilder/operators/operator.go
+++ b/go/vt/vtgate/planbuilder/operators/operator.go
@@ -68,7 +68,7 @@ func PlanQuery(ctx *plancontext.PlanningContext, selStmt sqlparser.Statement) (o
 
 	backup := Clone(op)
 
-	op, err = planHorizons(ctx, op)
+	op, err = planColumns(ctx, op)
 	if err == errNotHorizonPlanned {
 		op = backup
 	} else if err != nil {
@@ -88,7 +88,7 @@ func (noInputs) Inputs() []ops.Operator {
 }
 
 // AddColumn implements the Operator interface
-func (noColumns) AddColumn(*plancontext.PlanningContext, *sqlparser.AliasedExpr) (ops.Operator, int, error) {
+func (noColumns) AddColumn(*plancontext.PlanningContext, *sqlparser.AliasedExpr, bool) (ops.Operator, int, error) {
 	return nil, 0, vterrors.VT13001("the noColumns operator cannot accept columns")
 }
 

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -39,7 +39,7 @@ type (
 
 		// AddColumn tells an operator to also output an additional column specified.
 		// The offset to the column is returned.
-		AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error)
+		AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (Operator, int, error)
 	}
 
 	// PhysicalOperator means that this operator is ready to be turned into a logical plan

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -39,7 +39,7 @@ type (
 
 		// AddColumn tells an operator to also output an additional column specified.
 		// The offset to the column is returned.
-		AddColumn(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (int, error)
+		AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error)
 	}
 
 	// PhysicalOperator means that this operator is ready to be turned into a logical plan

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -39,7 +39,7 @@ type (
 
 		// AddColumn tells an operator to also output an additional column specified.
 		// The offset to the column is returned.
-		AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (Operator, int, error)
+		AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (Operator, int, error)
 	}
 
 	// PhysicalOperator means that this operator is ready to be turned into a logical plan

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -40,6 +40,8 @@ type (
 		// AddColumn tells an operator to also output an additional column specified.
 		// The offset to the column is returned.
 		AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (Operator, int, error)
+
+		GetColumns() ([]sqlparser.Expr, error)
 	}
 
 	// PhysicalOperator means that this operator is ready to be turned into a logical plan

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -517,8 +517,8 @@ func (r *Route) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Ex
 	return r, err
 }
 
-func (r *Route) AddColumn(ctx *plancontext.PlanningContext, e sqlparser.Expr) (int, error) {
-	return r.Source.AddColumn(ctx, e)
+func (r *Route) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error) {
+	return r.Source.AddColumn(ctx, expr)
 }
 
 // TablesUsed returns tables used by MergedWith routes, which are not included

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -517,8 +517,13 @@ func (r *Route) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Ex
 	return r, err
 }
 
-func (r *Route) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error) {
-	return r.Source.AddColumn(ctx, expr)
+func (r *Route) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (ops.Operator, int, error) {
+	newSrc, offset, err := r.Source.AddColumn(ctx, expr)
+	if err != nil {
+		return nil, 0, err
+	}
+	r.Source = newSrc
+	return r, offset, nil
 }
 
 // TablesUsed returns tables used by MergedWith routes, which are not included

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -526,6 +526,10 @@ func (r *Route) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.Alia
 	return r, offset, nil
 }
 
+func (r *Route) GetColumns() ([]sqlparser.Expr, error) {
+	return r.Source.GetColumns()
+}
+
 // TablesUsed returns tables used by MergedWith routes, which are not included
 // in Inputs() and thus not a part of the operator tree
 func (r *Route) TablesUsed() []string {

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -517,8 +517,8 @@ func (r *Route) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Ex
 	return r, err
 }
 
-func (r *Route) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (ops.Operator, int, error) {
-	newSrc, offset, err := r.Source.AddColumn(ctx, expr)
+func (r *Route) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
+	newSrc, offset, err := r.Source.AddColumn(ctx, expr, reuseCol)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -50,7 +50,7 @@ type (
 // Here we try to merge query parts into the same route primitives. At the end of this process,
 // all the operators in the tree are guaranteed to be PhysicalOperators
 func transformToPhysical(ctx *plancontext.PlanningContext, in ops.Operator) (ops.Operator, error) {
-	op, err := rewrite.BottomUpAll(in, TableID, func(ts semantics.TableSet, operator ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
+	op, err := rewrite.BottomUpAll(in, TableID, func(operator ops.Operator, ts semantics.TableSet) (ops.Operator, rewrite.TreeIdentity, error) {
 		switch op := operator.(type) {
 		case *QueryGraph:
 			return optimizeQueryGraph(ctx, op)

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -115,7 +115,7 @@ func optimizeDerived(ctx *plancontext.PlanningContext, op *Derived) (ops.Operato
 func optimizeJoin(ctx *plancontext.PlanningContext, op *Join) (ops.Operator, rewrite.TreeIdentity, error) {
 	join, err := mergeOrJoin(ctx, op.LHS, op.RHS, sqlparser.SplitAndExpression(nil, op.Predicate), !op.LeftJoin)
 	if err != nil {
-		return nil, rewrite.SameTree, err
+		return nil, false, err
 	}
 	return join, rewrite.NewTree, nil
 }

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -50,7 +50,7 @@ type (
 // Here we try to merge query parts into the same route primitives. At the end of this process,
 // all the operators in the tree are guaranteed to be PhysicalOperators
 func transformToPhysical(ctx *plancontext.PlanningContext, in ops.Operator) (ops.Operator, error) {
-	op, err := rewrite.BottomUp(in, semantics.EmptyTableSet(), TableID, func(ts semantics.TableSet, operator ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
+	op, err := rewrite.BottomUpAll(in, TableID, func(ts semantics.TableSet, operator ops.Operator) (ops.Operator, rewrite.TreeIdentity, error) {
 		switch op := operator.(type) {
 		case *QueryGraph:
 			return optimizeQueryGraph(ctx, op)

--- a/go/vt/vtgate/planbuilder/operators/simpleProjection.go
+++ b/go/vt/vtgate/planbuilder/operators/simpleProjection.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"golang.org/x/exp/slices"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+)
+
+type SimpleProjection struct {
+	Source     ops.Operator
+	Columns    []int
+	ASTColumns []*sqlparser.AliasedExpr
+}
+
+var _ ops.PhysicalOperator = (*SimpleProjection)(nil)
+
+func newSimpleProjection(src ops.Operator) *SimpleProjection {
+	return &SimpleProjection{
+		Source: src,
+	}
+}
+
+func (s *SimpleProjection) IPhysical() {}
+
+func (s *SimpleProjection) Clone(inputs []ops.Operator) ops.Operator {
+	return &SimpleProjection{
+		Source:     inputs[0],
+		Columns:    slices.Clone(s.Columns),
+		ASTColumns: slices.Clone(s.ASTColumns),
+	}
+}
+
+func (s *SimpleProjection) Inputs() []ops.Operator {
+	return []ops.Operator{s.Source}
+}
+
+func (s *SimpleProjection) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SimpleProjection) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
+	// TODO implement me
+	panic("implement me")
+}

--- a/go/vt/vtgate/planbuilder/operators/simpleProjection.go
+++ b/go/vt/vtgate/planbuilder/operators/simpleProjection.go
@@ -55,12 +55,12 @@ func (s *SimpleProjection) Inputs() []ops.Operator {
 
 func (s *SimpleProjection) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
 	// TODO implement me
-	panic("implement me")
+	return nil, errNotHorizonPlanned
 }
 
 func (s *SimpleProjection) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
 	// TODO implement me
-	panic("implement me")
+	return nil, 0, errNotHorizonPlanned
 }
 
 func exprFromAliasedExpr(from *sqlparser.AliasedExpr) sqlparser.Expr { return from.Expr }

--- a/go/vt/vtgate/planbuilder/operators/simpleProjection.go
+++ b/go/vt/vtgate/planbuilder/operators/simpleProjection.go
@@ -19,6 +19,7 @@ package operators
 import (
 	"golang.org/x/exp/slices"
 
+	"vitess.io/vitess/go/slices2"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
@@ -60,4 +61,10 @@ func (s *SimpleProjection) AddPredicate(ctx *plancontext.PlanningContext, expr s
 func (s *SimpleProjection) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
 	// TODO implement me
 	panic("implement me")
+}
+
+func exprFromAliasedExpr(from *sqlparser.AliasedExpr) sqlparser.Expr { return from.Expr }
+
+func (s *SimpleProjection) GetColumns() ([]sqlparser.Expr, error) {
+	return slices2.Map(s.ASTColumns, exprFromAliasedExpr), nil
 }

--- a/go/vt/vtgate/planbuilder/operators/simple_projection.go
+++ b/go/vt/vtgate/planbuilder/operators/simple_projection.go
@@ -25,6 +25,9 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 )
 
+// SimpleProjection is used to be selective about which columns to pass through
+// All it does is to map through columns from the input
+// It's used to limit the number of columns to hide result from the user that was not requested
 type SimpleProjection struct {
 	Source     ops.Operator
 	Columns    []int

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -361,7 +361,7 @@ func rewriteColumnsInSubqueryOpForJoin(
 			return true
 		}
 		// if it does not exist, then push this as an output column there and add it to the joinVars
-		newInnerOp, offset, err := resultInnerOp.AddColumn(ctx, aeWrap(node))
+		newInnerOp, offset, err := resultInnerOp.AddColumn(ctx, aeWrap(node), true)
 		if err != nil {
 			rewriteError = err
 			return false
@@ -427,7 +427,7 @@ func createCorrelatedSubqueryOp(
 			bindVars[node] = bindVar
 
 			// if it does not exist, then push this as an output column in the outerOp and add it to the joinVars
-			newOuterOp, offset, err := resultOuterOp.AddColumn(ctx, aeWrap(node))
+			newOuterOp, offset, err := resultOuterOp.AddColumn(ctx, aeWrap(node), true)
 			if err != nil {
 				rewriteError = err
 				return true

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -361,11 +361,12 @@ func rewriteColumnsInSubqueryOpForJoin(
 			return true
 		}
 		// if it does not exist, then push this as an output column there and add it to the joinVars
-		offset, err := resultInnerOp.AddColumn(ctx, aeWrap(node))
+		newInnerOp, offset, err := resultInnerOp.AddColumn(ctx, aeWrap(node))
 		if err != nil {
 			rewriteError = err
 			return false
 		}
+		resultInnerOp = newInnerOp
 		outerTree.Vars[bindVar] = offset
 		return true
 	})
@@ -426,11 +427,12 @@ func createCorrelatedSubqueryOp(
 			bindVars[node] = bindVar
 
 			// if it does not exist, then push this as an output column in the outerOp and add it to the joinVars
-			offset, err := resultOuterOp.AddColumn(ctx, aeWrap(node))
+			newOuterOp, offset, err := resultOuterOp.AddColumn(ctx, aeWrap(node))
 			if err != nil {
 				rewriteError = err
 				return true
 			}
+			resultOuterOp = newOuterOp
 			lhsCols = append(lhsCols, node)
 			vars[bindVar] = offset
 			return true

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -44,7 +44,7 @@ func optimizeSubQuery(ctx *plancontext.PlanningContext, op *SubQuery, ts semanti
 		}
 		merged, err := tryMergeSubQueryOp(ctx, outer, innerOp, newInner, preds, newSubQueryMerge(ctx, newInner), ts)
 		if err != nil {
-			return nil, rewrite.SameTree, err
+			return nil, false, err
 		}
 
 		if merged != nil {
@@ -65,13 +65,13 @@ func optimizeSubQuery(ctx *plancontext.PlanningContext, op *SubQuery, ts semanti
 		if inner.ExtractedSubquery.OpCode == int(popcode.PulloutExists) {
 			correlatedTree, err := createCorrelatedSubqueryOp(ctx, innerOp, outer, preds, inner.ExtractedSubquery)
 			if err != nil {
-				return nil, rewrite.SameTree, err
+				return nil, false, err
 			}
 			outer = correlatedTree
 			continue
 		}
 
-		return nil, rewrite.SameTree, vterrors.VT12001("cross-shard correlated subquery")
+		return nil, false, vterrors.VT12001("cross-shard correlated subquery")
 	}
 
 	for _, tree := range unmerged {

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -361,7 +361,7 @@ func rewriteColumnsInSubqueryOpForJoin(
 			return true
 		}
 		// if it does not exist, then push this as an output column there and add it to the joinVars
-		offset, err := resultInnerOp.AddColumn(ctx, node)
+		offset, err := resultInnerOp.AddColumn(ctx, aeWrap(node))
 		if err != nil {
 			rewriteError = err
 			return false
@@ -426,7 +426,7 @@ func createCorrelatedSubqueryOp(
 			bindVars[node] = bindVar
 
 			// if it does not exist, then push this as an output column in the outerOp and add it to the joinVars
-			offset, err := resultOuterOp.AddColumn(ctx, node)
+			offset, err := resultOuterOp.AddColumn(ctx, aeWrap(node))
 			if err != nil {
 				rewriteError = err
 				return true

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -67,8 +67,8 @@ func (to *Table) AddPredicate(_ *plancontext.PlanningContext, expr sqlparser.Exp
 	return newFilter(to, expr), nil
 }
 
-func (to *Table) AddColumn(_ *plancontext.PlanningContext, e sqlparser.Expr) (int, error) {
-	return addColumn(to, e)
+func (to *Table) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error) {
+	return addColumn(to, expr.Expr)
 }
 
 func (to *Table) GetColumns() []*sqlparser.ColName {

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -67,8 +67,13 @@ func (to *Table) AddPredicate(_ *plancontext.PlanningContext, expr sqlparser.Exp
 	return newFilter(to, expr), nil
 }
 
-func (to *Table) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error) {
-	return addColumn(to, expr.Expr)
+func (to *Table) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (ops.Operator, int, error) {
+	offset, err := addColumn(to, expr.Expr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return to, offset, nil
 }
 
 func (to *Table) GetColumns() []*sqlparser.ColName {

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -68,8 +68,8 @@ func (to *Table) AddPredicate(_ *plancontext.PlanningContext, expr sqlparser.Exp
 	return newFilter(to, expr), nil
 }
 
-func (to *Table) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
-	offset, err := addColumn(to, expr.Expr, reuseCol)
+func (to *Table) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
+	offset, err := addColumn(ctx, to, expr.Expr, reuseCol)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -95,19 +95,15 @@ func (to *Table) TablesUsed() []string {
 	return SingleQualifiedIdentifier(to.VTable.Keyspace, to.VTable.Name)
 }
 
-func addColumn(op ColNameColumns, e sqlparser.Expr, reuseCol bool) (int, error) {
+func addColumn(ctx *plancontext.PlanningContext, op ColNameColumns, e sqlparser.Expr, reuseCol bool) (int, error) {
 	col, ok := e.(*sqlparser.ColName)
 	if !ok {
 		return 0, vterrors.VT13001("cannot push this expression to a table/vindex")
 	}
 	sqlparser.RemoveKeyspaceFromColName(col)
 	cols := op.GetColNames()
-	if reuseCol {
-		for idx, column := range cols {
-			if col.Name.Equal(column.Name) {
-				return idx, nil
-			}
-		}
+	if offset, found := canReuseColumn(ctx, reuseCol, cols, e); found {
+		return offset, nil
 	}
 	offset := len(cols)
 	op.AddCol(col)

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -66,8 +66,8 @@ func (v *Vindex) Clone([]ops.Operator) ops.Operator {
 
 var _ ops.PhysicalOperator = (*Vindex)(nil)
 
-func (v *Vindex) AddColumn(_ *plancontext.PlanningContext, expr sqlparser.Expr) (int, error) {
-	return addColumn(v, expr)
+func (v *Vindex) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error) {
+	return addColumn(v, expr.Expr)
 }
 
 func (v *Vindex) GetColumns() []*sqlparser.ColName {
@@ -77,7 +77,6 @@ func (v *Vindex) AddCol(col *sqlparser.ColName) {
 	v.Columns = append(v.Columns, col)
 }
 
-// checkValid implements the Operator interface
 func (v *Vindex) CheckValid() error {
 	if len(v.Table.Predicates) == 0 {
 		return vterrors.VT12001(VindexUnsupported + " (where clause missing)")

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -66,8 +66,14 @@ func (v *Vindex) Clone([]ops.Operator) ops.Operator {
 
 var _ ops.PhysicalOperator = (*Vindex)(nil)
 
-func (v *Vindex) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (int, error) {
-	return addColumn(v, expr.Expr)
+func (v *Vindex) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (ops.Operator, int, error) {
+	offset, err := addColumn(v, expr.Expr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return v, offset, nil
+
 }
 
 func (v *Vindex) GetColumns() []*sqlparser.ColName {

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -17,6 +17,7 @@ limitations under the License.
 package operators
 
 import (
+	"vitess.io/vitess/go/slices2"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
@@ -76,7 +77,13 @@ func (v *Vindex) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.Alias
 
 }
 
-func (v *Vindex) GetColumns() []*sqlparser.ColName {
+func colNameToExpr(c *sqlparser.ColName) sqlparser.Expr { return c }
+
+func (v *Vindex) GetColumns() ([]sqlparser.Expr, error) {
+	return slices2.Map(v.Columns, colNameToExpr), nil
+}
+
+func (v *Vindex) GetColNames() []*sqlparser.ColName {
 	return v.Columns
 }
 func (v *Vindex) AddCol(col *sqlparser.ColName) {

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -66,8 +66,8 @@ func (v *Vindex) Clone([]ops.Operator) ops.Operator {
 
 var _ ops.PhysicalOperator = (*Vindex)(nil)
 
-func (v *Vindex) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (ops.Operator, int, error) {
-	offset, err := addColumn(v, expr.Expr)
+func (v *Vindex) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
+	offset, err := addColumn(v, expr.Expr, reuseCol)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -67,14 +67,13 @@ func (v *Vindex) Clone([]ops.Operator) ops.Operator {
 
 var _ ops.PhysicalOperator = (*Vindex)(nil)
 
-func (v *Vindex) AddColumn(_ *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
-	offset, err := addColumn(v, expr.Expr, reuseCol)
+func (v *Vindex) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, reuseCol bool) (ops.Operator, int, error) {
+	offset, err := addColumn(ctx, v, expr.Expr, reuseCol)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	return v, offset, nil
-
 }
 
 func colNameToExpr(c *sqlparser.ColName) sqlparser.Expr { return c }

--- a/go/vt/vtgate/planbuilder/simple_projection.go
+++ b/go/vt/vtgate/planbuilder/simple_projection.go
@@ -35,7 +35,6 @@ var _ logicalPlan = (*simpleProjection)(nil)
 // a new route that keeps the subquery in the FROM
 // clause, because a route is more versatile than
 // a simpleProjection.
-// this should not be used by the gen4 planner
 type simpleProjection struct {
 	logicalPlanCommon
 	resultColumns []*resultColumn

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -3158,7 +3158,7 @@
       "Instructions": {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "L:0",
+        "JoinColumnIndexes": "L:1",
         "JoinVars": {
           "t_col1": 0,
           "t_id": 1
@@ -3166,41 +3166,32 @@
         "TableName": "`user`_user_extra_unsharded",
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": [
-              1,
-              0
-            ],
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "L:0,L:1",
+            "TableName": "`user`_user_extra",
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1",
-                "TableName": "`user`_user_extra",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select `user`.id, `user`.col1 from `user` where 1 != 1",
-                    "Query": "select `user`.id, `user`.col1 from `user`",
-                    "Table": "`user`"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select 1 from user_extra",
-                    "Table": "user_extra"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select `user`.id, `user`.col1 from `user` where 1 != 1",
+                "Query": "select `user`.id, `user`.col1 from `user`",
+                "Table": "`user`"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra",
+                "Table": "user_extra"
               }
             ]
           },
@@ -3392,7 +3383,7 @@
       "Instructions": {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "R:0",
+        "JoinColumnIndexes": "R:1",
         "TableName": "unsharded_a_`user`_user_extra",
         "Inputs": [
           {
@@ -3407,40 +3398,32 @@
             "Table": "unsharded_a"
           },
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": [
-              1
-            ],
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "L:0,L:1",
+            "TableName": "`user`_user_extra",
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1",
-                "TableName": "`user`_user_extra",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select `user`.id, `user`.col1 from `user` where 1 != 1",
-                    "Query": "select `user`.id, `user`.col1 from `user`",
-                    "Table": "`user`"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select 1 from user_extra",
-                    "Table": "user_extra"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select `user`.id, `user`.col1 from `user` where 1 != 1",
+                "Query": "select `user`.id, `user`.col1 from `user`",
+                "Table": "`user`"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra",
+                "Table": "user_extra"
               }
             ]
           }
@@ -3463,7 +3446,7 @@
       "Instructions": {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "R:0",
+        "JoinColumnIndexes": "R:1",
         "JoinVars": {
           "ua_id": 0
         },
@@ -3481,44 +3464,36 @@
             "Table": "unsharded_a"
           },
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": [
-              1
-            ],
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "L:0,L:1",
+            "TableName": "`user`_user_extra",
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1",
-                "TableName": "`user`_user_extra",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "EqualUnique",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select `user`.id, `user`.col1 from `user` where 1 != 1",
-                    "Query": "select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id",
-                    "Table": "`user`",
-                    "Values": [
-                      ":ua_id"
-                    ],
-                    "Vindex": "user_index"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select 1 from user_extra",
-                    "Table": "user_extra"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select `user`.id, `user`.col1 from `user` where 1 != 1",
+                "Query": "select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id",
+                "Table": "`user`",
+                "Values": [
+                  ":ua_id"
+                ],
+                "Vindex": "user_index"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra",
+                "Table": "user_extra"
               }
             ]
           }

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -129,6 +129,16 @@ func (st *SemTable) CopyDependencies(from, to sqlparser.Expr) {
 	st.Direct[to] = st.DirectDeps(from)
 }
 
+// CopyDependencies copies the dependencies from one expression into the other
+func (st *SemTable) Cloned(from, to sqlparser.SQLNode) {
+	f, fromOK := from.(sqlparser.Expr)
+	t, toOK := to.(sqlparser.Expr)
+	if !(fromOK && toOK) {
+		return
+	}
+	st.CopyDependencies(f, t)
+}
+
 // EmptySemTable creates a new empty SemTable
 func EmptySemTable() *SemTable {
 	return &SemTable{


### PR DESCRIPTION
## Description
While planning, we use two important types of data structures - logical plans and operators. We are moving more and more logic over to the operators. This PR moves planning of projections over to the operators. 

Still to do is: ordering, limit, distinct and aggregation.

## Related Issue(s)

Tracking issue: https://github.com/vitessio/vitess/issues/11626

Other PRs in this series: #11622, #11680, #12506
