### PR TITLE
Fix incorrect path during release notes generation

### DIFF
--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -512,7 +512,7 @@ func main() {
 	// Define the path to the release notes folder
 	majorVersion := versionMatch[1] + "." + versionMatch[2]
 	patchVersion := versionMatch[0]
-	releaseNotesPath = path.Join(releaseNotesPath, majorVersion, patchVersion)
+	releaseNotesPath = path.Join(releaseNotesPath, majorVersion, patchVersion[1:])
 
 	err := os.MkdirAll(releaseNotesPath, os.ModePerm)
 	if err != nil {

--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -511,8 +511,8 @@ func main() {
 
 	// Define the path to the release notes folder
 	majorVersion := versionMatch[1] + "." + versionMatch[2]
-	patchVersion := versionMatch[0]
-	releaseNotesPath = path.Join(releaseNotesPath, majorVersion, patchVersion[1:])
+	patchVersion := versionMatch[1] + "." + versionMatch[2] + "." + versionMatch[3]
+	releaseNotesPath = path.Join(releaseNotesPath, majorVersion, patchVersion)
 
 	err := os.MkdirAll(releaseNotesPath, os.ModePerm)
 	if err != nil {


### PR DESCRIPTION
## Description

As witnessed in the recent Release Pull Requests (https://github.com/vitessio/vitess/pull/12766/commits/0b41ed2fd2bd41b46f479cf08d192dd76b1c8554 in https://github.com/vitessio/vitess/pull/12766) the generated folder for the release notes was incorrect. There was an extra `v`. This pull request fixes this issue.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
