### PR TITLE
go/{stats,vt}: publish VReplicationStreamState to prometheus backend

### DIFF
--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -10,6 +10,7 @@
   - **[New stats](#new-stats)**
     - [Detailed backup and restore stats](#detailed-backup-and-restore-stats)
     - [VTtablet Error count with code ](#vttablet-error-count-with-code)
+    - [VReplication stream status for Prometheus](#vreplication-stream-status-for-prometheus)
   - **[Deprecations and Deletions](#deprecations-and-deletions)**
     - [Deprecated Stats](#deprecated-stats)
   - **[VTTablet](#vttablet)**
@@ -193,6 +194,24 @@ Some notes to help understand these metrics:
 
 We are introducing new error counter `QueryErrorCountsWithCode` for VTTablet. It is similar to existing [QueryErrorCounts](https://github.com/vitessio/vitess/blob/main/go/vt/vttablet/tabletserver/query_engine.go#L174) except it contains errorCode as additional dimension.
 We will deprecate `QueryErrorCounts` in v18.
+
+#### <a id="vreplication-stream-status-for-prometheus"/> VReplication stream status for Prometheus
+
+VReplication publishes the `VReplicationStreamState` status which reports the state of VReplication streams. For example, here's what it looks like in the local cluster example after the MoveTables step:
+
+```
+"VReplicationStreamState": {
+  "commerce2customer.1": "Running"
+}
+```
+
+Prior to v17, this data was not available via the Prometheus backend. In v17, workflow states are also published as a Prometheus gauge with a `state` label and a value of `1.0`. For example:
+
+```
+# HELP vttablet_v_replication_stream_state State of vreplication workflow
+# TYPE vttablet_v_replication_stream_state gauge
+vttablet_v_replication_stream_state{counts="1",state="Running",workflow="commerce2customer"} 1
+```
 
 ## <a id="deprecations-and-deletions"/> Deprecations and Deletions
 

--- a/go/stats/export.go
+++ b/go/stats/export.go
@@ -121,6 +121,60 @@ func Publish(name string, v expvar.Var) {
 	publish(name, v)
 }
 
+// StringMapFuncWithMultiLabels is a multidimensional string map publisher.
+//
+// Map keys are compound names made with joining multiple strings with '.',
+// and are named by corresponding key labels.
+//
+// Map values are any string, and are named by the value label.
+//
+// Since the map is returned by the function, we assume it's in the right
+// format (meaning each key is of the form 'aaa.bbb.ccc' with as many elements
+// as there are in Labels).
+//
+// Backends which need to provide a numeric value can set a constant value of 1
+// (or whatever is appropriate for the backend) for each key-value pair present
+// in the map.
+type StringMapFuncWithMultiLabels struct {
+	StringMapFunc
+	help       string
+	keyLabels  []string
+	valueLabel string
+}
+
+// Help returns the descriptive help message.
+func (s StringMapFuncWithMultiLabels) Help() string {
+	return s.help
+}
+
+// KeyLabels returns the list of key labels.
+func (s StringMapFuncWithMultiLabels) KeyLabels() []string {
+	return s.keyLabels
+}
+
+// ValueLabel returns the value label labels.
+func (s StringMapFuncWithMultiLabels) ValueLabel() string {
+	return s.valueLabel
+}
+
+// NewStringMapFuncWithMultiLabels creates a new StringMapFuncWithMultiLabels,
+// mapping to the provided function. The key labels correspond with components
+// of map keys. The value label names the map values.
+func NewStringMapFuncWithMultiLabels(name, help string, keyLabels []string, valueLabel string, f func() map[string]string) *StringMapFuncWithMultiLabels {
+	t := &StringMapFuncWithMultiLabels{
+		StringMapFunc: StringMapFunc(f),
+		help:          help,
+		keyLabels:     keyLabels,
+		valueLabel:    valueLabel,
+	}
+
+	if name != "" {
+		publish(name, t)
+	}
+
+	return t
+}
+
 func publish(name string, v expvar.Var) {
 	defaultVarGroup.publish(name, v)
 }

--- a/go/stats/export.go
+++ b/go/stats/export.go
@@ -152,7 +152,7 @@ func (s StringMapFuncWithMultiLabels) KeyLabels() []string {
 	return s.keyLabels
 }
 
-// ValueLabel returns the value label labels.
+// ValueLabel returns the value label.
 func (s StringMapFuncWithMultiLabels) ValueLabel() string {
 	return s.valueLabel
 }

--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -85,6 +85,8 @@ func (be PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 		newMultiTimingsCollector(st, be.buildPromName(name))
 	case *stats.Histogram:
 		newHistogramCollector(st, be.buildPromName(name))
+	case *stats.StringMapFuncWithMultiLabels:
+		newStringMapFuncWithMultiLabelsCollector(st, be.buildPromName(name))
 	case *stats.String, stats.StringFunc, stats.StringMapFunc, *stats.Rates, *stats.RatesFunc:
 		// Silently ignore these types since they don't make sense to
 		// export to Prometheus' data model.


### PR DESCRIPTION
## Description

In order to make it easier to monitor VReplication workflow status, expose the existing `VReplicationStreamState` as a 1-valued Prometheus gauge. S/o @mcrauwel for the idea.

## Related Issue(s)

  - Fixes: #12770

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required