### PR TITLE
go/vt/vttablet/tabletmanager: include workflow type in vreplication stats

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -57,6 +57,7 @@ type controller struct {
 
 	id           int32
 	workflow     string
+	workflowType string
 	source       *binlogdatapb.BinlogSource
 	stopPos      string
 	tabletPicker *discovery.TabletPicker
@@ -95,6 +96,16 @@ func newController(ctx context.Context, params map[string]string, dbClientFactor
 	}
 	ct.id = int32(id)
 	ct.workflow = params["workflow"]
+	ct.workflowType = "Unknown"
+	if typeS, ok := params["workflow_type"]; ok {
+		typeI, err := strconv.ParseInt(typeS, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		if name, ok := binlogdatapb.VReplicationWorkflowType_name[int32(typeI)]; ok {
+			ct.workflowType = name
+		}
+	}
 	ct.lastWorkflowError = vterrors.NewLastError(fmt.Sprintf("VReplication controller %d for workflow %q", ct.id, ct.workflow), maxTimeToRetryError)
 
 	state := params["state"]

--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -77,13 +77,13 @@ func (st *vrStats) register() {
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationLagSeconds",
 		"vreplication seconds behind primary per stream",
-		[]string{"source_keyspace", "source_shard", "workflow", "counts"},
+		[]string{"source_keyspace", "source_shard", "workflow_type", "workflow", "counts"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()
 			result := make(map[string]int64, len(st.controllers))
 			for _, ct := range st.controllers {
-				result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)] = ct.blpStats.ReplicationLagSeconds.Load()
+				result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflowType+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)] = ct.blpStats.ReplicationLagSeconds.Load()
 			}
 			return result
 		})
@@ -166,14 +166,14 @@ func (st *vrStats) register() {
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationPhaseTimings",
 		"vreplication per phase timings per stream",
-		[]string{"source_keyspace", "source_shard", "workflow", "counts", "phase"},
+		[]string{"source_keyspace", "source_shard", "workflow_type", "workflow", "counts", "phase"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()
 			result := make(map[string]int64, len(st.controllers))
 			for _, ct := range st.controllers {
 				for phase, t := range ct.blpStats.PhaseTimings.Histograms() {
-					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+phase] = t.Total()
+					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflowType+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+phase] = t.Total()
 				}
 			}
 			return result
@@ -196,14 +196,14 @@ func (st *vrStats) register() {
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationPhaseTimingsCounts",
 		"vreplication per phase count of timings per stream",
-		[]string{"source_keyspace", "source_shard", "workflow", "counts", "phase"},
+		[]string{"source_keyspace", "source_shard", "workflow_type", "workflow", "counts", "phase"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()
 			result := make(map[string]int64, len(st.controllers))
 			for _, ct := range st.controllers {
 				for phase, t := range ct.blpStats.PhaseTimings.Counts() {
-					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+phase] = t
+					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflowType+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+phase] = t
 				}
 			}
 			return result
@@ -212,7 +212,7 @@ func (st *vrStats) register() {
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationQueryCount",
 		"vreplication query counts per stream",
-		[]string{"source_keyspace", "source_shard", "workflow", "counts", "phase"},
+		[]string{"source_keyspace", "source_shard", "workflow_type", "workflow", "counts", "phase"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()
@@ -222,7 +222,7 @@ func (st *vrStats) register() {
 					if label == "" {
 						continue
 					}
-					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+label] = count
+					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflowType+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+label] = count
 				}
 			}
 			return result
@@ -246,7 +246,7 @@ func (st *vrStats) register() {
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationNoopQueryCount",
 		"vreplication noop query counts per stream",
-		[]string{"source_keyspace", "source_shard", "workflow", "counts", "phase"},
+		[]string{"source_keyspace", "source_shard", "workflow_type", "workflow", "counts", "phase"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()
@@ -256,7 +256,7 @@ func (st *vrStats) register() {
 					if label == "" {
 						continue
 					}
-					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+label] = count
+					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflowType+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+label] = count
 				}
 			}
 			return result
@@ -279,13 +279,13 @@ func (st *vrStats) register() {
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationCopyRowCount",
 		"vreplication rows copied in copy phase per stream",
-		[]string{"source_keyspace", "source_shard", "workflow", "counts"},
+		[]string{"source_keyspace", "source_shard", "workflow_type", "workflow", "counts"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()
 			result := make(map[string]int64, len(st.controllers))
 			for _, ct := range st.controllers {
-				result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)] = ct.blpStats.CopyRowCount.Get()
+				result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflowType+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)] = ct.blpStats.CopyRowCount.Get()
 			}
 			return result
 		})
@@ -306,13 +306,13 @@ func (st *vrStats) register() {
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationCopyLoopCount",
 		"Number of times the copy phase looped per stream",
-		[]string{"source_keyspace", "source_shard", "workflow", "counts"},
+		[]string{"source_keyspace", "source_shard", "workflow_type", "workflow", "counts"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()
 			result := make(map[string]int64, len(st.controllers))
 			for _, ct := range st.controllers {
-				result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)] = ct.blpStats.CopyLoopCount.Get()
+				result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflowType+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)] = ct.blpStats.CopyLoopCount.Get()
 			}
 			return result
 		})
@@ -347,13 +347,13 @@ func (st *vrStats) register() {
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationHeartbeat",
 		"Time when last heartbeat was received from a vstreamer",
-		[]string{"source_keyspace", "source_shard", "workflow", "time"},
+		[]string{"source_keyspace", "source_shard", "workflow_type", "workflow", "time"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()
 			result := make(map[string]int64, len(st.controllers))
 			for _, ct := range st.controllers {
-				result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)] = ct.blpStats.Heartbeat()
+				result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflowType+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)] = ct.blpStats.Heartbeat()
 			}
 			return result
 		})
@@ -361,7 +361,7 @@ func (st *vrStats) register() {
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationTableCopyRowCounts",
 		"vreplication rows copied in copy phase per table per stream",
-		[]string{"source_keyspace", "source_shard", "workflow", "counts", "table"},
+		[]string{"source_keyspace", "source_shard", "workflow_type", "workflow", "counts", "table"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()
@@ -371,7 +371,7 @@ func (st *vrStats) register() {
 					if table == "" {
 						continue
 					}
-					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+table] = count
+					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflowType+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+table] = count
 				}
 			}
 			return result
@@ -379,14 +379,14 @@ func (st *vrStats) register() {
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationTableCopyTimings",
 		"vreplication copy phase timings per table per stream",
-		[]string{"source_keyspace", "source_shard", "workflow", "counts", "table"},
+		[]string{"source_keyspace", "source_shard", "workflow_type", "workflow", "counts", "table"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()
 			result := make(map[string]int64, len(st.controllers))
 			for _, ct := range st.controllers {
 				for table, t := range ct.blpStats.TableCopyTimings.Histograms() {
-					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+table] = t.Total()
+					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflowType+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+table] = t.Total()
 				}
 			}
 			return result


### PR DESCRIPTION
## Description

In order to make it easier to monitor VReplication workflow status, include `workflow_type` in some existing VReplication stats. S/o @shlomi for the idea.

## Related Issue(s)

Addresses #12770.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required