### PR TITLE
Remove `nvm use` from vtadmin-up.sh script

### DIFF
--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -67,9 +67,7 @@ fi
 source "$NVM_DIR/nvm.sh"
 
 output "\nConfiguring Node.js $NODE_VERSION\n"
-nvm install "$NODE_VERSION" || fail "Could not install nvm $NODE_VERSION."
-nvm use "$NODE_VERSION" || fail "Could not use nvm $NODE_VERSION."
-nvm use "$NODE_VERSION" || fail "Could not use nvm $NODE_VERSION."
+nvm install "$NODE_VERSION" || fail "Could not install and use nvm $NODE_VERSION."
 
 # As a TODO, it'd be nice to make the assumption that vtadmin-web is already
 # installed and built (since we assume that `make` has already been run for


### PR DESCRIPTION
## Description
This PR removes the `nvm use` lines in `vtadmin-up.sh` script, since `nvm install` will also execute `nvm use`:
```
➜  vitess git:(main) nvm install 16
v16.20.0 is already installed.
Now using node v16.20.0 (npm v8.19.4)
```

## Related Issue(s)

N/A
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported **Not needed**
-   [x] Tests were added or are not required **Not needed**
-   [x] Did the new or modified tests pass consistently locally and on the CI **No new tests**
-   [x] Documentation was added or is not required **Not needed**

## Deployment Notes

N/A