### PR TITLE
Remove TODO from e2e upgrade test

### DIFF
--- a/go/test/endtoend/versionupgrade/upgrade_test.go
+++ b/go/test/endtoend/versionupgrade/upgrade_test.go
@@ -106,9 +106,6 @@ func TestMain(m *testing.M) {
 			return 1, err
 		}
 
-		// TODO: remove this once we upgrade to v12
-		// setting the planner version to 0, so the vtgate binary's default is used
-		clusterInstance.VtGatePlannerVersion = 0
 		vtgateInstance := clusterInstance.NewVtgateInstance()
 		// Start vtgate
 		if err := vtgateInstance.Setup(); err != nil {


### PR DESCRIPTION
## Description

We're well-past v12 😊 

## Related Issue(s)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
