### PR TITLE
[vtadmin-api] standardize cluster ids

### DIFF
--- a/go/vt/vtadmin/http/api_test.go
+++ b/go/vt/vtadmin/http/api_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeprecateQueryParam(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in       map[string][]string
+		oldName  string
+		newName  string
+		expected []string
+	}{
+		{
+			in: map[string][]string{
+				"foo":     {"1", "2"},
+				"old_bar": {"one", "two"},
+			},
+			oldName:  "old_bar",
+			newName:  "bar",
+			expected: []string{"one", "two"},
+		},
+		{
+			in: map[string][]string{
+				"foo": {"1", "2"},
+				"bar": {"one", "two"},
+			},
+			oldName:  "old_bar",
+			newName:  "bar",
+			expected: []string{"one", "two"},
+		},
+		{
+			in: map[string][]string{
+				"foo":     {"1", "2"},
+				"old_bar": {"one", "three"},
+				"bar":     {"one", "two"},
+			},
+			oldName:  "old_bar",
+			newName:  "bar",
+			expected: []string{"one", "two", "three"},
+		},
+		{
+			in: map[string][]string{
+				"foo": {"1", "2"},
+			},
+			oldName:  "old_bar",
+			newName:  "bar",
+			expected: nil,
+		},
+	}
+
+	for _, tcase := range cases {
+		tcase := tcase
+		t.Run("", func(t *testing.T) {
+			query := url.Values(tcase.in)
+
+			r := http.Request{
+				URL: &url.URL{RawQuery: query.Encode()},
+			}
+
+			deprecateQueryParam(&r, tcase.newName, tcase.oldName)
+
+			assert.False(t, r.URL.Query().Has(tcase.oldName), "old query param (%s) should not be in transformed query", tcase.oldName)
+			assert.Equal(t, tcase.expected, r.URL.Query()[tcase.newName])
+		})
+	}
+}

--- a/go/vt/vtadmin/http/backups.go
+++ b/go/vt/vtadmin/http/backups.go
@@ -25,7 +25,7 @@ import (
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
 )
 
-// GetBackups implements the http wrapper for /backups[?cluster=[&cluster=]].
+// GetBackups implements the http wrapper for /backups[?cluster_id=[&cluster_id=]].
 func GetBackups(ctx context.Context, r Request, api *API) *JSONResponse {
 	query := r.URL.Query()
 
@@ -51,7 +51,7 @@ func GetBackups(ctx context.Context, r Request, api *API) *JSONResponse {
 	}
 
 	backups, err := api.server.GetBackups(ctx, &vtadminpb.GetBackupsRequest{
-		ClusterIds:     query["cluster"],
+		ClusterIds:     query["cluster_id"],
 		Keyspaces:      query["keyspace"],
 		KeyspaceShards: query["keyspace_shard"],
 		RequestOptions: &vtctldatapb.GetBackupsRequest{

--- a/go/vt/vtadmin/http/cells.go
+++ b/go/vt/vtadmin/http/cells.go
@@ -23,7 +23,7 @@ import (
 )
 
 // GetCellInfos implements the http wrapper for the
-// /cells[?cluster=[&cluster=...]?cell=[&cell=...]&names_only=(true|false)] route.
+// /cells[?cluster=[&cluster_id=...]?cell=[&cell=...]&names_only=(true|false)] route.
 func GetCellInfos(ctx context.Context, r Request, api *API) *JSONResponse {
 	namesOnly, err := r.ParseQueryParamAsBool("names_only", false)
 	if err != nil {
@@ -31,7 +31,7 @@ func GetCellInfos(ctx context.Context, r Request, api *API) *JSONResponse {
 	}
 
 	cellInfos, err := api.server.GetCellInfos(ctx, &vtadminpb.GetCellInfosRequest{
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 		Cells:      r.URL.Query()["cell"],
 		NamesOnly:  namesOnly,
 	})
@@ -39,10 +39,10 @@ func GetCellInfos(ctx context.Context, r Request, api *API) *JSONResponse {
 }
 
 // GetCellsAliases implements the http wrapper for the
-// /cells_aliases[?cluster=[&cluster=]] route.
+// /cells_aliases[?cluster_id=[&cluster_id=]] route.
 func GetCellsAliases(ctx context.Context, r Request, api *API) *JSONResponse {
 	cellsAliases, err := api.server.GetCellsAliases(ctx, &vtadminpb.GetCellsAliasesRequest{
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(cellsAliases, err)

--- a/go/vt/vtadmin/http/experimental/tablets.go
+++ b/go/vt/vtadmin/http/experimental/tablets.go
@@ -42,7 +42,7 @@ func TabletDebugVarsPassthrough(ctx context.Context, r vtadminhttp.Request, api 
 
 	tablet, err := api.Server().GetTablet(ctx, &vtadminpb.GetTabletRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	if err != nil {

--- a/go/vt/vtadmin/http/gates.go
+++ b/go/vt/vtadmin/http/gates.go
@@ -22,10 +22,10 @@ import (
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
 
-// GetGates implements the http wrapper for /gates[?cluster=[&cluster=]].
+// GetGates implements the http wrapper for /gates[?cluster_id=[&cluster_id=]].
 func GetGates(ctx context.Context, r Request, api *API) *JSONResponse {
 	gates, err := api.server.GetGates(ctx, &vtadminpb.GetGatesRequest{
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(gates, err)

--- a/go/vt/vtadmin/http/keyspaces.go
+++ b/go/vt/vtadmin/http/keyspaces.go
@@ -78,10 +78,10 @@ func GetKeyspace(ctx context.Context, r Request, api *API) *JSONResponse {
 	return NewJSONResponse(keyspace, err)
 }
 
-// GetKeyspaces implements the http wrapper for /keyspaces[?cluster=[&cluster=]].
+// GetKeyspaces implements the http wrapper for /keyspaces[?cluster_id=[&cluster_id=]].
 func GetKeyspaces(ctx context.Context, r Request, api *API) *JSONResponse {
 	keyspaces, err := api.server.GetKeyspaces(ctx, &vtadminpb.GetKeyspacesRequest{
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(keyspaces, err)

--- a/go/vt/vtadmin/http/replication.go
+++ b/go/vt/vtadmin/http/replication.go
@@ -24,14 +24,14 @@ import (
 
 // GetShardReplicationPositions implements the http wrapper for /shard_replication_positions.
 // Query params:
-//   - cluster: repeated, cluster ID
+//   - cluster_id: repeated, cluster ID
 //   - keyspace: repeated, keyspace names
 //   - keyspace_shard: repeated, keyspace shard names
 func GetShardReplicationPositions(ctx context.Context, r Request, api *API) *JSONResponse {
 	query := r.URL.Query()
 
 	resp, err := api.server.GetShardReplicationPositions(ctx, &vtadminpb.GetShardReplicationPositionsRequest{
-		ClusterIds:     query["cluster"],
+		ClusterIds:     query["cluster_id"],
 		Keyspaces:      query["keyspace"],
 		KeyspaceShards: query["keyspace_shard"],
 	})

--- a/go/vt/vtadmin/http/schemas.go
+++ b/go/vt/vtadmin/http/schemas.go
@@ -27,7 +27,7 @@ import (
 )
 
 // FindSchema implements the http wrapper for the
-// /schema/{table}[?cluster=[&cluster=]] route.
+// /schema/{table}[?cluster_id=[&cluster_id=]] route.
 func FindSchema(ctx context.Context, r Request, api *API) *JSONResponse {
 	vars := r.Vars()
 	query := r.URL.Query()
@@ -39,7 +39,7 @@ func FindSchema(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	schema, err := api.server.FindSchema(ctx, &vtadminpb.FindSchemaRequest{
 		Table:            vars["table"],
-		ClusterIds:       query["cluster"],
+		ClusterIds:       query["cluster_id"],
 		TableSizeOptions: sizeOpts,
 	})
 
@@ -66,7 +66,7 @@ func GetSchema(ctx context.Context, r Request, api *API) *JSONResponse {
 	return NewJSONResponse(schema, err)
 }
 
-// GetSchemas implements the http wrapper for the /schemas[?cluster=[&cluster=]
+// GetSchemas implements the http wrapper for the /schemas[?cluster_id=[&cluster_id=]
 // route.
 func GetSchemas(ctx context.Context, r Request, api *API) *JSONResponse {
 	sizeOpts, err := getTableSizeOpts(r)
@@ -75,7 +75,7 @@ func GetSchemas(ctx context.Context, r Request, api *API) *JSONResponse {
 	}
 
 	schemas, err := api.server.GetSchemas(ctx, &vtadminpb.GetSchemasRequest{
-		ClusterIds:       r.URL.Query()["cluster"],
+		ClusterIds:       r.URL.Query()["cluster_id"],
 		TableSizeOptions: sizeOpts,
 	})
 
@@ -134,14 +134,14 @@ func ReloadSchemas(ctx context.Context, r Request, api *API) *JSONResponse {
 		Concurrency:    concurrency,
 		IncludePrimary: includePrimary,
 		WaitPosition:   q.Get("wait_position"),
-		ClusterIds:     q["cluster"],
+		ClusterIds:     q["cluster_id"],
 	})
 	return NewJSONResponse(resp, err)
 }
 
 // ReloadTabletSchema implements the http wrapper for /tablets/{tablet}/reload_schema.
 //
-// Note that all query parameters that apply to ReloadSchemas, except for `cluster`,
+// Note that all query parameters that apply to ReloadSchemas, except for `cluster_id`,
 // are ignored.
 func ReloadTabletSchema(ctx context.Context, r Request, api *API) *JSONResponse {
 	alias, err := r.Vars().GetTabletAlias("tablet")
@@ -151,7 +151,7 @@ func ReloadTabletSchema(ctx context.Context, r Request, api *API) *JSONResponse 
 
 	resp, err := api.server.ReloadSchemas(ctx, &vtadminpb.ReloadSchemasRequest{
 		Tablets:    []*topodatapb.TabletAlias{alias},
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 	return NewJSONResponse(resp, err)
 }

--- a/go/vt/vtadmin/http/shards.go
+++ b/go/vt/vtadmin/http/shards.go
@@ -70,7 +70,7 @@ func DeleteShards(ctx context.Context, r Request, api *API) *JSONResponse {
 	}
 
 	shardList := r.URL.Query()["keyspace_shard"]
-	shardList = sets.List(sets.New[string](shardList...))
+	shardList = sets.List(sets.New(shardList...))
 	shards := make([]*vtctldatapb.Shard, len(shardList))
 	for i, kss := range shardList {
 		ks, shard, err := topoproto.ParseKeyspaceShard(kss)

--- a/go/vt/vtadmin/http/srvkeyspaces.go
+++ b/go/vt/vtadmin/http/srvkeyspaces.go
@@ -30,7 +30,7 @@ func GetSrvKeyspaces(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	sks, err := api.server.GetSrvKeyspaces(ctx, &vtadminpb.GetSrvKeyspacesRequest{
 		Cells:      query["cell"],
-		ClusterIds: query["cluster"],
+		ClusterIds: query["cluster_id"],
 	})
 
 	return NewJSONResponse(sks, err)

--- a/go/vt/vtadmin/http/srvvschemas.go
+++ b/go/vt/vtadmin/http/srvvschemas.go
@@ -40,7 +40,7 @@ func GetSrvVSchemas(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	svs, err := api.server.GetSrvVSchemas(ctx, &vtadminpb.GetSrvVSchemasRequest{
 		Cells:      query["cell"],
-		ClusterIds: query["cluster"],
+		ClusterIds: query["cluster_id"],
 	})
 
 	return NewJSONResponse(svs, err)

--- a/go/vt/vtadmin/http/tablets.go
+++ b/go/vt/vtadmin/http/tablets.go
@@ -31,7 +31,7 @@ func GetFullStatus(ctx context.Context, r Request, api *API) *JSONResponse {
 		return NewJSONResponse(nil, err)
 	}
 	status, err := api.server.GetFullStatus(ctx, &vtadminpb.GetFullStatusRequest{
-		ClusterId: r.URL.Query()["cluster"][0],
+		ClusterId: r.URL.Query()["cluster_id"][0],
 		Alias:     alias,
 	})
 
@@ -41,7 +41,7 @@ func GetFullStatus(ctx context.Context, r Request, api *API) *JSONResponse {
 // GetTablets implements the http wrapper for /tablets[?cluster=[&cluster=]].
 func GetTablets(ctx context.Context, r Request, api *API) *JSONResponse {
 	tablets, err := api.server.GetTablets(ctx, &vtadminpb.GetTabletsRequest{
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(tablets, err)
@@ -58,7 +58,7 @@ func GetTablet(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	tablet, err := api.server.GetTablet(ctx, &vtadminpb.GetTabletRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(tablet, err)
@@ -80,7 +80,7 @@ func DeleteTablet(ctx context.Context, r Request, api *API) *JSONResponse {
 	deleted, err := api.server.DeleteTablet(ctx, &vtadminpb.DeleteTabletRequest{
 		Alias:        alias,
 		AllowPrimary: allowPrimary,
-		ClusterIds:   r.URL.Query()["cluster"],
+		ClusterIds:   r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(deleted, err)
@@ -97,7 +97,7 @@ func PingTablet(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	ping, err := api.server.PingTablet(ctx, &vtadminpb.PingTabletRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(ping, err)
@@ -114,7 +114,7 @@ func RefreshState(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	result, err := api.server.RefreshState(ctx, &vtadminpb.RefreshStateRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(result, err)
@@ -124,7 +124,7 @@ func RefreshState(ctx context.Context, r Request, api *API) *JSONResponse {
 // PUT /tablet/{tablet}/refresh_replication_source.
 //
 // Query params:
-//   - cluster: repeatable, list of cluster IDs to restrict to when searching fo
+//   - cluster_id: repeatable, list of cluster IDs to restrict to when searching fo
 //     a tablet with that alias.
 //
 // PUT body is unused; this endpoint takes no additional options.
@@ -138,7 +138,7 @@ func RefreshTabletReplicationSource(ctx context.Context, r Request, api *API) *J
 
 	result, err := api.server.RefreshTabletReplicationSource(ctx, &vtadminpb.RefreshTabletReplicationSourceRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(result, err)
@@ -155,7 +155,7 @@ func RunHealthCheck(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	result, err := api.server.RunHealthCheck(ctx, &vtadminpb.RunHealthCheckRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(result, err)
@@ -172,7 +172,7 @@ func SetReadOnly(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	result, err := api.server.SetReadOnly(ctx, &vtadminpb.SetReadOnlyRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(result, err)
@@ -189,7 +189,7 @@ func SetReadWrite(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	result, err := api.server.SetReadWrite(ctx, &vtadminpb.SetReadWriteRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(result, err)
@@ -206,7 +206,7 @@ func StartReplication(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	result, err := api.server.StartReplication(ctx, &vtadminpb.StartReplicationRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(result, err)
@@ -223,7 +223,7 @@ func StopReplication(ctx context.Context, r Request, api *API) *JSONResponse {
 
 	result, err := api.server.StopReplication(ctx, &vtadminpb.StopReplicationRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(result, err)
@@ -233,7 +233,7 @@ func StopReplication(ctx context.Context, r Request, api *API) *JSONResponse {
 // POST /tablet/{tablet}/tablet_externally_promoted.
 //
 // Query params:
-// - `cluster`: repeated list of clusterIDs to limit the request to.
+// - `cluster_id`: repeated list of clusterIDs to limit the request to.
 //
 // POST body is unused; this endpoint takes no additional options.
 func TabletExternallyPromoted(ctx context.Context, r Request, api *API) *JSONResponse {
@@ -246,7 +246,7 @@ func TabletExternallyPromoted(ctx context.Context, r Request, api *API) *JSONRes
 
 	result, err := api.server.TabletExternallyPromoted(ctx, &vtadminpb.TabletExternallyPromotedRequest{
 		Alias:      alias,
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 	return NewJSONResponse(result, err)
 }

--- a/go/vt/vtadmin/http/vschemas.go
+++ b/go/vt/vtadmin/http/vschemas.go
@@ -36,10 +36,10 @@ func GetVSchema(ctx context.Context, r Request, api *API) *JSONResponse {
 }
 
 // GetVSchemas implements the http wrapper for the
-// /vschemas[?cluster=[&cluster=]] route.
+// /vschemas[?cluster_id=[&cluster_id=]] route.
 func GetVSchemas(ctx context.Context, r Request, api *API) *JSONResponse {
 	vschemas, err := api.server.GetVSchemas(ctx, &vtadminpb.GetVSchemasRequest{
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(vschemas, err)

--- a/go/vt/vtadmin/http/vtctlds.go
+++ b/go/vt/vtadmin/http/vtctlds.go
@@ -22,10 +22,10 @@ import (
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
 
-// GetVtctlds implements the http wrapper for /vtctlds[?cluster=[&cluster=]].
+// GetVtctlds implements the http wrapper for /vtctlds[?cluster_id=[&cluster_id=]].
 func GetVtctlds(ctx context.Context, r Request, api *API) *JSONResponse {
 	vtctlds, err := api.server.GetVtctlds(ctx, &vtadminpb.GetVtctldsRequest{
-		ClusterIds: r.URL.Query()["cluster"],
+		ClusterIds: r.URL.Query()["cluster_id"],
 	})
 
 	return NewJSONResponse(vtctlds, err)

--- a/go/vt/vtadmin/http/vtexplain.go
+++ b/go/vt/vtadmin/http/vtexplain.go
@@ -22,11 +22,11 @@ import (
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
 
-// VTExplain implements the http wrapper for /vtexplain?cluster=&keyspace=&sql=
+// VTExplain implements the http wrapper for /vtexplain?cluster_id=&keyspace=&sql=
 func VTExplain(ctx context.Context, r Request, api *API) *JSONResponse {
 	query := r.URL.Query()
 	res, err := api.server.VTExplain(ctx, &vtadminpb.VTExplainRequest{
-		Cluster:  query.Get("cluster"),
+		Cluster:  query.Get("cluster_id"),
 		Keyspace: query.Get("keyspace"),
 		Sql:      query.Get("sql"),
 	})

--- a/go/vt/vtadmin/http/workflows.go
+++ b/go/vt/vtadmin/http/workflows.go
@@ -48,7 +48,7 @@ func GetWorkflow(ctx context.Context, r Request, api *API) *JSONResponse {
 // method.
 //
 // Its route is /workflows, with query params:
-// - cluster: repeated, cluster IDs
+// - cluster_id: repeated, cluster IDs
 // - active_only
 // - keyspace: repeated
 // - ignore_keyspace: repeated
@@ -61,7 +61,7 @@ func GetWorkflows(ctx context.Context, r Request, api *API) *JSONResponse {
 	}
 
 	workflows, err := api.server.GetWorkflows(ctx, &vtadminpb.GetWorkflowsRequest{
-		ClusterIds:      query["cluster"],
+		ClusterIds:      query["cluster_id"],
 		Keyspaces:       query["keyspace"],
 		IgnoreKeyspaces: query["ignore_keyspace"],
 		ActiveOnly:      activeOnly,


### PR DESCRIPTION
## Description

This does the API portion of #12729 by introducing a step in the `http.Adapt` function that turns any request with a `cluster` query param into a `cluster_id` query param, logging a warning if it needed to make that transformation.

### Testing

<details><summary>test requests</summary>

```
➜  local git:(andrew/vtadmin-standardize-cluster_ids) ✗ curl "localhost:14200/api/keyspaces?cluster=local"
{"result":{"keyspaces":[{"cluster":{"id":"local","name":"local"},"keyspace":{"name":"commerce","keyspace":{"durability_policy":"semi_sync","sidecar_db_name":"_vt"}},"shards":{"0":{"keyspace":"commerce","name":"0","shard":{"primary_alias":{"cell":"zone1","uid":100},"primary_term_start_time":{"seconds":1680373482,"nanoseconds":17317000},"is_primary_serving":true}}}}]},"ok":true}%             
➜  local git:(andrew/vtadmin-standardize-cluster_ids) ✗ 
curl "localhost:14200/api/keyspaces?cluster_id=local"
{"result":{"keyspaces":[{"cluster":{"id":"local","name":"local"},"keyspace":{"name":"commerce","keyspace":{"durability_policy":"semi_sync","sidecar_db_name":"_vt"}},"shards":{"0":{"keyspace":"commerce","name":"0","shard":{"primary_alias":{"cell":"zone1","uid":100},"primary_term_start_time":{"seconds":1680373482,"nanoseconds":17317000},"is_primary_serving":true}}}}]},"ok":true}%  
```
</details>

<details><summary>logs</summary>

```
➜  local git:(andrew/vtadmin-standardize-cluster_ids) ✗ tail -f ./vtdataroot/tmp/vtadmin-api.out 
W0401 15:29:18.294365   79759 api.go:110] query param cluster is deprecated in favor of cluster_id. support for cluster will be dropped in the next version


just me typing to separate the logs



okay hereeeeee we go


```
</details>

## Related Issue(s)

#12729 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required: :eyes:  => https://github.com/vitessio/website/pull/1431

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
