### PR TITLE
evalengine: Implement CRC32 & CONV

### DIFF
--- a/go/mysql/json/fastparse/fastparse_test.go
+++ b/go/mysql/json/fastparse/fastparse_test.go
@@ -24,83 +24,131 @@ import (
 func TestParseInt64(t *testing.T) {
 	testcases := []struct {
 		input    string
+		base     int
 		expected int64
 		err      string
 	}{
 		{
 			input:    "0",
+			base:     10,
 			expected: 0,
 		},
 		{
 			input:    "1",
+			base:     10,
 			expected: 1,
 		},
 		{
+			input:    "1",
+			base:     2,
+			expected: 1,
+		},
+		{
+			input:    "10",
+			base:     2,
+			expected: 2,
+		},
+		{
 			input:    "9223372036854775807",
+			base:     10,
 			expected: 9223372036854775807,
 		},
 		{
+			input:    "7fffffffffffffff",
+			base:     16,
+			expected: 9223372036854775807,
+		},
+		{
+			input:    "7FFFFFFFFFFFFFFF",
+			base:     16,
+			expected: 9223372036854775807,
+		},
+		{
+			input:    "8000000000000000",
+			base:     16,
+			expected: 9223372036854775807,
+			err:      `cannot parse int64 from "8000000000000000": overflow`,
+		},
+		{
+			input:    "80.1",
+			base:     16,
+			expected: 128,
+			err:      `unparsed tail left after parsing int64 from "80.1": ".1"`,
+		},
+		{
 			input:    "9223372036854775807trailing",
+			base:     10,
 			expected: 9223372036854775807,
 			err:      `unparsed tail left after parsing int64 from "9223372036854775807trailing": "trailing"`,
 		},
 		{
 			input:    "9223372036854775808",
+			base:     10,
 			expected: 9223372036854775807,
-			err:      `cannot parse int64 from "9223372036854775808"`,
+			err:      `cannot parse int64 from "9223372036854775808": overflow`,
 		},
 		{
 			input:    "9223372036854775808trailing",
+			base:     10,
 			expected: 9223372036854775807,
-			err:      `cannot parse int64 from "9223372036854775808trailing"`,
+			err:      `cannot parse int64 from "9223372036854775808trailing": overflow`,
 		},
 		{
 			input:    "-9223372036854775807",
+			base:     10,
 			expected: -9223372036854775807,
 		},
 		{
 			input:    "-9223372036854775807.1",
+			base:     10,
 			expected: -9223372036854775807,
 			err:      `unparsed tail left after parsing int64 from "-9223372036854775807.1": ".1"`,
 		},
 		{
 			input:    "-9223372036854775808",
+			base:     10,
 			expected: -9223372036854775808,
 		},
 		{
 			input:    "-9223372036854775808.1",
+			base:     10,
 			expected: -9223372036854775808,
 			err:      `unparsed tail left after parsing int64 from "-9223372036854775808.1": ".1"`,
 		},
 		{
 			input:    "-9223372036854775809",
+			base:     10,
 			expected: -9223372036854775808,
-			err:      `cannot parse int64 from "-9223372036854775809"`,
+			err:      `cannot parse int64 from "-9223372036854775809": overflow`,
 		},
 		{
 			input:    "18446744073709551615",
+			base:     10,
 			expected: 9223372036854775807,
-			err:      `cannot parse int64 from "18446744073709551615"`,
+			err:      `cannot parse int64 from "18446744073709551615": overflow`,
 		},
 		{
 			input:    "18446744073709551616",
+			base:     10,
 			expected: 9223372036854775807,
-			err:      `cannot parse int64 from "18446744073709551616"`,
+			err:      `cannot parse int64 from "18446744073709551616": overflow`,
 		},
 		{
 			input:    "1.1",
+			base:     10,
 			expected: 1,
 			err:      `unparsed tail left after parsing int64 from "1.1": ".1"`,
 		},
 		{
 			input:    "-1.1",
+			base:     10,
 			expected: -1,
 			err:      `unparsed tail left after parsing int64 from "-1.1": ".1"`,
 		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.input, func(t *testing.T) {
-			val, err := ParseInt64(tc.input)
+			val, err := ParseInt64(tc.input, tc.base)
 			if tc.err == "" {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, val)
@@ -115,58 +163,95 @@ func TestParseInt64(t *testing.T) {
 func TestParseUint64(t *testing.T) {
 	testcases := []struct {
 		input    string
+		base     int
 		expected uint64
 		err      string
 	}{
 		{
 			input:    "0",
+			base:     10,
 			expected: 0,
 		},
 		{
 			input:    "1",
+			base:     10,
 			expected: 1,
 		},
 		{
+			input:    "1",
+			base:     2,
+			expected: 1,
+		},
+		{
+			input:    "10",
+			base:     2,
+			expected: 2,
+		},
+		{
 			input:    "9223372036854775807",
+			base:     10,
 			expected: 9223372036854775807,
 		},
 		{
 			input:    "9223372036854775807trailing",
+			base:     10,
 			expected: 9223372036854775807,
 			err:      `unparsed tail left after parsing uint64 from "9223372036854775807trailing": "trailing"`,
 		},
 		{
 			input:    "9223372036854775808",
+			base:     10,
 			expected: 9223372036854775808,
 		},
 		{
 			input:    "9223372036854775808trailing",
+			base:     10,
 			expected: 9223372036854775808,
 			err:      `unparsed tail left after parsing uint64 from "9223372036854775808trailing": "trailing"`,
 		},
 		{
 			input:    "18446744073709551615",
+			base:     10,
+			expected: 18446744073709551615,
+		},
+		{
+			input:    "ffffffffffffffff",
+			base:     16,
+			expected: 18446744073709551615,
+		},
+		{
+			input:    "FFFFFFFFFFFFFFFF",
+			base:     16,
 			expected: 18446744073709551615,
 		},
 		{
 			input:    "18446744073709551615.1",
+			base:     10,
 			expected: 18446744073709551615,
 			err:      `unparsed tail left after parsing uint64 from "18446744073709551615.1": ".1"`,
 		},
 		{
+			input:    "ff.1",
+			base:     16,
+			expected: 255,
+			err:      `unparsed tail left after parsing uint64 from "ff.1": ".1"`,
+		},
+		{
 			input:    "18446744073709551616",
+			base:     10,
 			expected: 18446744073709551615,
-			err:      `cannot parse uint64 from "18446744073709551616"`,
+			err:      `cannot parse uint64 from "18446744073709551616": overflow`,
 		},
 		{
 			input:    "1.1",
+			base:     10,
 			expected: 1,
 			err:      `unparsed tail left after parsing uint64 from "1.1": ".1"`,
 		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.input, func(t *testing.T) {
-			val, err := ParseUint64(tc.input)
+			val, err := ParseUint64(tc.input, tc.base)
 			if tc.err == "" {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, val)

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -501,6 +501,18 @@ func (cached *builtinCollation) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinConv) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinCos) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -514,6 +526,18 @@ func (cached *builtinCos) CachedSize(alloc bool) int64 {
 	return size
 }
 func (cached *builtinCot) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
+func (cached *builtinCrc32) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
 	}

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -969,6 +969,18 @@ func (cached *builtinUser) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinUtcDate) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinVersion) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler.go
+++ b/go/vt/vtgate/evalengine/compiler.go
@@ -350,3 +350,12 @@ func (c *compiler) compileNullCheck2(lt, rt ctype) *jump {
 	}
 	return nil
 }
+
+func (c *compiler) compileNullCheck3(arg1, arg2, arg3 ctype) *jump {
+	if arg1.nullable() || arg2.nullable() || arg3.nullable() {
+		j := c.asm.jumpFrom()
+		c.asm.NullCheck3(j)
+		return j
+	}
+	return nil
+}

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -18,6 +18,7 @@ package evalengine
 
 import (
 	"bytes"
+	"hash/crc32"
 	"math"
 	"math/bits"
 	"strconv"
@@ -1850,6 +1851,14 @@ func (asm *assembler) Fn_TRUNCATE_d() {
 		env.vm.sp--
 		return 1
 	}, "FN TRUNCATE DECIMAL(SP-2) INT64(SP-1)")
+}
+
+func (asm *assembler) Fn_CRC32() {
+	asm.emit(func(env *ExpressionEnv) int {
+		b := env.vm.stack[env.vm.sp-1].(*evalBytes)
+		env.vm.stack[env.vm.sp-1] = env.vm.arena.newEvalUint64(uint64(crc32.ChecksumIEEE(b.bytes)))
+		return 1
+	}, "FN CRC32 BINARY(SP-1)")
 }
 
 func (asm *assembler) Fn_COLLATION(col collations.TypedCollation) {

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -2948,6 +2948,18 @@ func (asm *assembler) Fn_Curdate() {
 	}, "FN CURDATE")
 }
 
+func (asm *assembler) Fn_UtcDate() {
+	asm.adjustStack(1)
+	asm.emit(func(env *ExpressionEnv) int {
+		val := env.vm.arena.newEvalBytesEmpty()
+		val.tt = int16(sqltypes.Date)
+		val.bytes = formatDate.Format(env.time(true))
+		env.vm.stack[env.vm.sp] = val
+		env.vm.sp++
+		return 1
+	}, "FN UTC_DATE")
+}
+
 func (asm *assembler) Fn_User() {
 	asm.adjustStack(1)
 	asm.emit(func(env *ExpressionEnv) int {

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -1919,16 +1919,16 @@ func (asm *assembler) Fn_CONV_uc(t sqltypes.Type, col collations.TypedCollation)
 			return 1
 		}
 
-		var out string
+		var out []byte
 		if base.i < 0 {
-			out = strconv.FormatInt(int64(u), -int(base.i))
+			out = strconv.AppendInt(out, int64(u), -int(base.i))
 		} else {
-			out = strconv.FormatUint(u, int(base.i))
+			out = strconv.AppendUint(out, u, int(base.i))
 		}
 
 		res := env.vm.arena.newEvalBytesEmpty()
 		res.tt = int16(t)
-		res.bytes = []byte(strings.ToUpper(out))
+		res.bytes = upcaseASCII(out)
 		res.col = col
 
 		env.vm.stack[env.vm.sp-3] = res

--- a/go/vt/vtgate/evalengine/compiler_asm_push.go
+++ b/go/vt/vtgate/evalengine/compiler_asm_push.go
@@ -29,7 +29,7 @@ import (
 
 func push_i(env *ExpressionEnv, raw []byte) int {
 	var ival int64
-	ival, env.vm.err = fastparse.ParseInt64(hack.String(raw))
+	ival, env.vm.err = fastparse.ParseInt64(hack.String(raw), 10)
 	env.vm.stack[env.vm.sp] = env.vm.arena.newEvalInt64(ival)
 	env.vm.sp++
 	return 1
@@ -254,7 +254,7 @@ func (asm *assembler) PushBVar_text(key string, col collations.TypedCollation) {
 
 func push_u(env *ExpressionEnv, raw []byte) int {
 	var uval uint64
-	uval, env.vm.err = fastparse.ParseUint64(hack.String(raw))
+	uval, env.vm.err = fastparse.ParseUint64(hack.String(raw), 10)
 	env.vm.stack[env.vm.sp] = env.vm.arena.newEvalUint64(uval)
 	env.vm.sp++
 	return 1

--- a/go/vt/vtgate/evalengine/compiler_fn.go
+++ b/go/vt/vtgate/evalengine/compiler_fn.go
@@ -112,6 +112,8 @@ func (c *compiler) compileFn(call callable) (ctype, error) {
 		return c.compileFn_ROUND(call)
 	case *builtinTruncate:
 		return c.compileFn_TRUNCATE(call)
+	case *builtinCrc32:
+		return c.compileFn_CRC32(call)
 	case *builtinWeightString:
 		return c.compileFn_WEIGHT_STRING(call)
 	case *builtinNow:
@@ -680,6 +682,25 @@ func (c *compiler) compileFn_TRUNCATE(expr callable) (ctype, error) {
 	}
 
 	c.asm.jumpDestination(skip1, skip2)
+	return arg, nil
+}
+
+func (c *compiler) compileFn_CRC32(expr callable) (ctype, error) {
+	arg, err := c.compileExpr(expr.callable()[0])
+	if err != nil {
+		return ctype{}, err
+	}
+
+	skip := c.compileNullCheck1(arg)
+
+	switch {
+	case arg.isTextual():
+	default:
+		c.asm.Convert_xb(1, sqltypes.Binary, 0, false)
+	}
+
+	c.asm.Fn_CRC32()
+	c.asm.jumpDestination(skip)
 	return arg, nil
 }
 

--- a/go/vt/vtgate/evalengine/compiler_fn.go
+++ b/go/vt/vtgate/evalengine/compiler_fn.go
@@ -114,6 +114,8 @@ func (c *compiler) compileFn(call callable) (ctype, error) {
 		return c.compileFn_TRUNCATE(call)
 	case *builtinCrc32:
 		return c.compileFn_CRC32(call)
+	case *builtinConv:
+		return c.compileFn_CONV(call)
 	case *builtinWeightString:
 		return c.compileFn_WEIGHT_STRING(call)
 	case *builtinNow:
@@ -702,6 +704,56 @@ func (c *compiler) compileFn_CRC32(expr callable) (ctype, error) {
 	c.asm.Fn_CRC32()
 	c.asm.jumpDestination(skip)
 	return arg, nil
+}
+
+func (c *compiler) compileFn_CONV(expr callable) (ctype, error) {
+	n, err := c.compileExpr(expr.callable()[0])
+	if err != nil {
+		return ctype{}, err
+	}
+
+	from, err := c.compileExpr(expr.callable()[1])
+	if err != nil {
+		return ctype{}, err
+	}
+
+	to, err := c.compileExpr(expr.callable()[2])
+	if err != nil {
+		return ctype{}, err
+	}
+
+	skip := c.compileNullCheck3(n, from, to)
+
+	_ = c.compileToInt64(from, 2)
+	_ = c.compileToInt64(to, 1)
+
+	t := sqltypes.VarChar
+	if n.Type == sqltypes.Blob || n.Type == sqltypes.TypeJSON {
+		t = sqltypes.Text
+	}
+
+	switch {
+	case n.isTextual():
+	default:
+		c.asm.Convert_xb(3, t, 0, false)
+	}
+
+	if n.isHexOrBitLiteral() {
+		c.asm.Fn_CONV_hu(3, 2)
+	} else {
+		c.asm.Fn_CONV_bu(3, 2)
+	}
+
+	col := collations.TypedCollation{
+		Collation:    c.cfg.Collation,
+		Coercibility: collations.CoerceCoercible,
+		Repertoire:   collations.RepertoireASCII,
+	}
+
+	c.asm.Fn_CONV_uc(t, col)
+	c.asm.jumpDestination(skip)
+
+	return ctype{Type: t, Col: col, Flag: flagNullable}, nil
 }
 
 func (c *compiler) compileFn_WEIGHT_STRING(call *builtinWeightString) (ctype, error) {

--- a/go/vt/vtgate/evalengine/compiler_fn.go
+++ b/go/vt/vtgate/evalengine/compiler_fn.go
@@ -122,6 +122,8 @@ func (c *compiler) compileFn(call callable) (ctype, error) {
 		return c.compileFn_Now(call)
 	case *builtinCurdate:
 		return c.compileFn_Curdate(call)
+	case *builtinUtcDate:
+		return c.compileFn_UtcDate(call)
 	case *builtinSysdate:
 		return c.compileFn_Sysdate(call)
 	case *builtinUser:
@@ -800,6 +802,11 @@ func (c *compiler) compileFn_Now(call *builtinNow) (ctype, error) {
 
 func (c *compiler) compileFn_Curdate(*builtinCurdate) (ctype, error) {
 	c.asm.Fn_Curdate()
+	return ctype{Type: sqltypes.Date, Col: collationBinary}, nil
+}
+
+func (c *compiler) compileFn_UtcDate(*builtinUtcDate) (ctype, error) {
+	c.asm.Fn_UtcDate()
 	return ctype{Type: sqltypes.Date, Col: collationBinary}, nil
 }
 

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -282,6 +282,18 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `NULL AND 1`,
 			result:     `NULL`,
 		},
+		{
+			expression: `CONV(-1.5e0, 1.5e0, 1.5e0)`,
+			result:     `VARCHAR("1111111111111111111111111111111111111111111111111111111111111111")`,
+		},
+		{
+			expression: `CONV(9223372036854775810.4, 13, 7)`,
+			result:     `VARCHAR("45012021522523134134601")`,
+		},
+		{
+			expression: `CONV(-9223372036854775809, 13e0, 13e0)`,
+			result:     `VARCHAR("0")`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/go/vt/vtgate/evalengine/eval_numeric.go
+++ b/go/vt/vtgate/evalengine/eval_numeric.go
@@ -210,7 +210,7 @@ func evalToInt64(e eval) *evalInt64 {
 			i, _ := strconv.ParseInt(strings.ReplaceAll(n, ":", ""), 10, 64)
 			return newEvalInt64(i)
 		}
-		i, _ := fastparse.ParseInt64(e.string())
+		i, _ := fastparse.ParseInt64(e.string(), 10)
 		return newEvalInt64(i)
 	case *evalJSON:
 		switch e.Type() {
@@ -238,7 +238,7 @@ func evalToInt64(e eval) *evalInt64 {
 				panic("unsupported")
 			}
 		case json.TypeString:
-			i, _ := fastparse.ParseInt64(e.Raw())
+			i, _ := fastparse.ParseInt64(e.Raw(), 10)
 			return newEvalInt64(i)
 		default:
 			return newEvalInt64(0)

--- a/go/vt/vtgate/evalengine/fn_time.go
+++ b/go/vt/vtgate/evalengine/fn_time.go
@@ -42,11 +42,16 @@ type (
 	builtinCurdate struct {
 		CallExpr
 	}
+
+	builtinUtcDate struct {
+		CallExpr
+	}
 )
 
 var _ Expr = (*builtinNow)(nil)
 var _ Expr = (*builtinSysdate)(nil)
 var _ Expr = (*builtinCurdate)(nil)
+var _ Expr = (*builtinUtcDate)(nil)
 
 var (
 	formatTime     [7]*datetime.Strftime
@@ -117,5 +122,18 @@ func (call *builtinCurdate) typeof(_ *ExpressionEnv, _ []*querypb.Field) (sqltyp
 }
 
 func (call *builtinCurdate) constant() bool {
+	return false
+}
+
+func (call *builtinUtcDate) eval(env *ExpressionEnv) (eval, error) {
+	now := env.time(true)
+	return newEvalRaw(sqltypes.Date, formatDate.Format(now), collationBinary), nil
+}
+
+func (call *builtinUtcDate) typeof(_ *ExpressionEnv, _ []*querypb.Field) (sqltypes.Type, typeFlag) {
+	return sqltypes.Date, 0
+}
+
+func (call *builtinUtcDate) constant() bool {
 	return false
 }

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -95,6 +95,7 @@ var Cases = []TestCase{
 	{Run: FnRound},
 	{Run: FnTruncate},
 	{Run: FnCrc32},
+	{Run: FnConv},
 }
 
 func JSONPathOperations(yield Query) {
@@ -557,6 +558,41 @@ func FnCrc32(yield Query) {
 
 	for _, num := range inputConversions {
 		yield(fmt.Sprintf("CRC32(%s)", num), nil)
+	}
+}
+
+func FnConv(yield Query) {
+	for _, num1 := range radianInputs {
+		for _, num2 := range radianInputs {
+			for _, num3 := range radianInputs {
+				yield(fmt.Sprintf("CONV(%s, %s, %s)", num1, num2, num3), nil)
+			}
+			for _, num3 := range inputBitwise {
+				yield(fmt.Sprintf("CONV(%s, %s, %s)", num1, num2, num3), nil)
+			}
+		}
+	}
+
+	for _, num1 := range radianInputs {
+		for _, num2 := range inputBitwise {
+			for _, num3 := range radianInputs {
+				yield(fmt.Sprintf("CONV(%s, %s, %s)", num1, num2, num3), nil)
+			}
+			for _, num3 := range inputBitwise {
+				yield(fmt.Sprintf("CONV(%s, %s, %s)", num1, num2, num3), nil)
+			}
+		}
+	}
+
+	for _, num1 := range inputBitwise {
+		for _, num2 := range inputBitwise {
+			for _, num3 := range radianInputs {
+				yield(fmt.Sprintf("CONV(%s, %s, %s)", num1, num2, num3), nil)
+			}
+			for _, num3 := range inputBitwise {
+				yield(fmt.Sprintf("CONV(%s, %s, %s)", num1, num2, num3), nil)
+			}
+		}
 	}
 }
 

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -1168,6 +1168,7 @@ func FnNow(yield Query) {
 		"UTC_TIMESTAMP(1)",
 		"CURDATE()", "CURRENT_DATE()", "CURRENT_DATE",
 		"UTC_TIME()", "UTC_TIME",
+		"UTC_DATE()", "UTC_DATE",
 		"UTC_TIME(1)",
 		"CURTIME()", "CURRENT_TIME()", "CURRENT_TIME",
 		"CURTIME(1)", "CURRENT_TIME(1)",

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -94,6 +94,7 @@ var Cases = []TestCase{
 	{Run: FnSqrt},
 	{Run: FnRound},
 	{Run: FnTruncate},
+	{Run: FnCrc32},
 }
 
 func JSONPathOperations(yield Query) {
@@ -542,6 +543,20 @@ func FnTruncate(yield Query) {
 		for _, num2 := range inputBitwise {
 			yield(fmt.Sprintf("TRUNCATE(%s, %s)", num1, num2), nil)
 		}
+	}
+}
+
+func FnCrc32(yield Query) {
+	for _, num := range radianInputs {
+		yield(fmt.Sprintf("CRC32(%s)", num), nil)
+	}
+
+	for _, num := range inputBitwise {
+		yield(fmt.Sprintf("CRC32(%s)", num), nil)
+	}
+
+	for _, num := range inputConversions {
+		yield(fmt.Sprintf("CRC32(%s)", num), nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -238,6 +238,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (Expr, error) 
 			return nil, argError(method)
 		}
 		return &builtinTruncate{CallExpr: call}, nil
+	case "crc32":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		return &builtinCrc32{CallExpr: call}, nil
 	case "lower", "lcase":
 		if len(args) != 1 {
 			return nil, argError(method)

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -310,6 +310,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (Expr, error) 
 			return nil, argError(method)
 		}
 		return &builtinCurdate{CallExpr: call}, nil
+	case "utc_date":
+		if len(args) != 0 {
+			return nil, argError(method)
+		}
+		return &builtinUtcDate{CallExpr: call}, nil
 	case "user", "current_user", "session_user", "system_user":
 		if len(args) != 0 {
 			return nil, argError(method)

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -243,6 +243,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (Expr, error) 
 			return nil, argError(method)
 		}
 		return &builtinCrc32{CallExpr: call}, nil
+	case "conv":
+		if len(args) != 3 {
+			return nil, argError(method)
+		}
+		return &builtinConv{CallExpr: call, collate: ast.cfg.Collation}, nil
 	case "lower", "lcase":
 		if len(args) != 1 {
 			return nil, argError(method)


### PR DESCRIPTION
This implements the `CRC32`, `CONV` & `UTC_DATE` functions in the evalengine.

## Related Issue(s)

Part of #9647 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required