### PR TITLE
Do not fail build on incorrect Go version

### DIFF
--- a/build.env
+++ b/build.env
@@ -17,7 +17,7 @@
 source ./tools/shell_functions.inc
 
 go version >/dev/null 2>&1 || fail "Go is not installed or is not in \$PATH. See https://vitess.io/contributing/build-from-source for install instructions."
-goversion_min 1.20.2 || fail "Go version reported: `go version`. Version 1.20.2+ required. See https://vitess.io/contributing/build-from-source for install instructions."
+goversion_min 1.20.2 || echo "Go version reported: `go version`. Version 1.20.2+ required. See https://vitess.io/contributing/build-from-source for install instructions."
 
 mkdir -p dist
 mkdir -p bin


### PR DESCRIPTION
## Description

Following the recent Golang upgrade on main (https://github.com/vitessio/vitess/pull/12706) we want to let developers choose whatever Golang version they want, and thus not fail the build if the version is not exactly what we expect.

There are several places where the Golang version has to be exactly how we expect it to be:
- In the Docker images
- In the CI workflows

With the new automated process to upgrade the Golang version in the repository we now have more trusts that the two places listed above will always contain valid values.

If the version is not what we expect, we print a warning.

## Related Issue(s)

- Website docs change: https://github.com/vitessio/website/pull/1433

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
