### PR TITLE
fakesqldb: Guard query log usage with lock

### DIFF
--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -93,6 +93,6 @@ jobs:
 
     - name: unit_race
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.unit_tests == 'true'
-      timeout-minutes: 30
+      timeout-minutes: 45
       run: |
         eatmydata -- make unit_test_race

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -616,11 +616,15 @@ func (db *DB) GetQueryCalledNum(query string) int {
 
 // QueryLog returns the query log in a semicomma separated string
 func (db *DB) QueryLog() string {
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	return strings.Join(db.querylog, ";")
 }
 
 // ResetQueryLog resets the query log
 func (db *DB) ResetQueryLog() {
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	db.querylog = nil
 }
 

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -4255,7 +4255,9 @@ func (s *VtctldServer) ValidateVersionShard(ctx context.Context, req *vtctldatap
 		}
 
 		wg.Add(1)
-		go s.diffVersion(ctx, primaryVersion.Version, shard.PrimaryAlias, alias, &wg, &er)
+		go func(alias *topodatapb.TabletAlias) {
+			s.diffVersion(ctx, primaryVersion.Version, shard.PrimaryAlias, alias, &wg, &er)
+		}(alias)
 	}
 
 	wg.Wait()

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -2707,7 +2707,7 @@ func TestDeleteShards(t *testing.T) {
 				defer func() {
 					topofactory.SetError(nil)
 
-					actualShards := []*vtctldatapb.Shard{}
+					var actualShards []*vtctldatapb.Shard
 
 					keyspaces, err := ts.GetKeyspaces(ctx)
 					require.NoError(t, err, "cannot get keyspace names to check remaining shards")


### PR DESCRIPTION
This lock is used around adding to the query log, but it means we also need to use the lock when reading from it or when resetting it.

We've seen this cause race test failures which look like this:

```
$ go test -trimpath -race -v -count=1000 ./go/vt/vttablet/tabletserver -run TestReserveExecute_WithTx
=== RUN   TestReserveExecute_WithTx
E0403 15:54:57.850444    4408 server.go:418] Query not found: set @@session.sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
E0403 15:54:57.854239    4408 server.go:418] Query not found: show full tables like '\_vt\_%'
==================
WARNING: DATA RACE
Write at 0x00c000556460 by goroutine 363:
  vitess.io/vitess/go/mysql/fakesqldb.(*DB).ResetQueryLog()
      vitess.io/vitess/go/mysql/fakesqldb/server.go:624 +0x1d8
  vitess.io/vitess/go/vt/vttablet/tabletserver.TestReserveExecute_WithTx()
      vitess.io/vitess/go/vt/vttablet/tabletserver/tabletserver_test.go:1899 +0x1cc
  testing.tRunner()
      testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      testing/testing.go:1629 +0x40

Previous write at 0x00c000556460 by goroutine 414:
  vitess.io/vitess/go/mysql/fakesqldb.(*DB).HandleQuery()
      vitess.io/vitess/go/mysql/fakesqldb/server.go:361 +0x2d4
  vitess.io/vitess/go/mysql/fakesqldb.(*DB).ComQuery()
      vitess.io/vitess/go/mysql/fakesqldb/server.go:336 +0x68
  vitess.io/vitess/go/mysql.(*Conn).execQuery()
      vitess.io/vitess/go/mysql/conn.go:1359 +0x1a4
  vitess.io/vitess/go/mysql.(*Conn).handleComQuery()
      vitess.io/vitess/go/mysql/conn.go:1344 +0x364
  vitess.io/vitess/go/mysql.(*Conn).handleNextCommand()
      vitess.io/vitess/go/mysql/conn.go:910 +0x184
  vitess.io/vitess/go/mysql.(*Listener).handle()
      vitess.io/vitess/go/mysql/server.go:527 +0x1460
  vitess.io/vitess/go/mysql.(*Listener).Accept.func1()
      vitess.io/vitess/go/mysql/server.go:331 +0x1a0

Goroutine 363 (running) created at:
  testing.(*T).Run()
      testing/testing.go:1629 +0x5b4
  testing.runTests.func1()
      testing/testing.go:2036 +0x80
  testing.tRunner()
      testing/testing.go:1576 +0x180
  testing.runTests()
      testing/testing.go:2034 +0x6a8
  testing.(*M).Run()
      testing/testing.go:1906 +0x8e0
  main.main()
      _testmain.go:435 +0x2b8

Goroutine 414 (running) created at:
  vitess.io/vitess/go/mysql.(*Listener).Accept()
      vitess.io/vitess/go/mysql/server.go:322 +0x48
  vitess.io/vitess/go/mysql/fakesqldb.New.func1()
      vitess.io/vitess/go/mysql/fakesqldb/server.go:194 +0x74
==================
W0403 15:54:57.855201    4408 tabletserver.go:1557] Code: ABORTED
transaction 1680530097843343001: ended at 2023-04-03 15:54:57.855 CEST (release connection)
: Sql: "", BindVars: {}
    testing.go:1446: race detected during execution of test
--- FAIL: TestReserveExecute_WithTx (0.02s)
```

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
