### PR TITLE
Fix `TestGatewayBufferingWhileReparenting` flakiness

### DIFF
--- a/go/vt/discovery/keyspace_events.go
+++ b/go/vt/discovery/keyspace_events.go
@@ -454,6 +454,7 @@ func (kew *KeyspaceEventWatcher) TargetIsBeingResharded(target *query.Target) bo
 // The shard state keeps track of the current primary and the last externally reparented time, which we can use
 // to determine that there was a serving primary which now became non serving. This is only possible in a DemotePrimary
 // RPC which are only called from ERS and PRS. So buffering will stop when these operations succeed.
+// We return the tablet alias of the primary if it is serving.
 func (kew *KeyspaceEventWatcher) PrimaryIsNotServing(target *query.Target) (*topodatapb.TabletAlias, bool) {
 	if target.TabletType != topodatapb.TabletType_PRIMARY {
 		return nil, false

--- a/go/vt/discovery/keyspace_events.go
+++ b/go/vt/discovery/keyspace_events.go
@@ -454,19 +454,19 @@ func (kew *KeyspaceEventWatcher) TargetIsBeingResharded(target *query.Target) bo
 // The shard state keeps track of the current primary and the last externally reparented time, which we can use
 // to determine that there was a serving primary which now became non serving. This is only possible in a DemotePrimary
 // RPC which are only called from ERS and PRS. So buffering will stop when these operations succeed.
-func (kew *KeyspaceEventWatcher) PrimaryIsNotServing(target *query.Target) bool {
+func (kew *KeyspaceEventWatcher) PrimaryIsNotServing(target *query.Target) (*topodatapb.TabletAlias, bool) {
 	if target.TabletType != topodatapb.TabletType_PRIMARY {
-		return false
+		return nil, false
 	}
 	ks := kew.getKeyspaceStatus(target.Keyspace)
 	if ks == nil {
-		return false
+		return nil, false
 	}
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
 	if state, ok := ks.shards[target.Shard]; ok {
 		// If the primary tablet was present then externallyReparented will be non-zero and currentPrimary will be not nil
-		return !state.serving && !ks.consistent && state.externallyReparented != 0 && state.currentPrimary != nil
+		return state.currentPrimary, !state.serving && !ks.consistent && state.externallyReparented != 0 && state.currentPrimary != nil
 	}
-	return false
+	return nil, false
 }

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -301,8 +301,14 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, "current keyspace is being resharded")
 					continue
 				}
-				if kev.PrimaryIsNotServing(target) {
+				primary, serving := kev.PrimaryIsNotServing(target)
+				if serving {
 					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, "primary is not serving, there is a reparent operation in progress")
+					continue
+				}
+				// if primary is serving, but we initially found no tablet, we're in an inconsistent state
+				// we then retry the entire loop
+				if primary != nil {
 					continue
 				}
 			}


### PR DESCRIPTION
## Description

This Pull Request fixes the test `TestGatewayBufferingWhileReparenting` which was found to be flaky.

To quote @GuptaManan100:

> I found a race that is causing this failure. I believe it's not the test, but a race in the code itself. Consider these operations:
>
> - PRS has started and the primary tablet has published itself as not-serving.
> - This causes the call `tablets := gw.hc.GetHealthyTabletStats(target)` to not return any tablets.
> - We end up going into the if condition block, which is going to check for potential problems with the shard.
> - Before that code runs, let's assume the new primary succeeds and publishes itself as serving.
> - Now the code in the condition check is going to say that there is nothing wrong with the cluster, and we get the error no healthy tablet available for....
> - In the tests, I can reproduce this consistently by adding some strategically placed sleeps, but in real-time these failures are totally possible even if unlikely.

The fix for this flaky test was to detect that our data is stale, and decide to `continue` the retry loop one more time.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
