### PR TITLE
evalengine: Try to reduce test flakyness around time

### DIFF
--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -480,6 +480,11 @@ func (v Value) IsDateTime() bool {
 	return v.typ == querypb.Type_DATETIME
 }
 
+// IsTime returns true if Value is time.
+func (v Value) IsTime() bool {
+	return v.typ == querypb.Type_TIME
+}
+
 // IsDecimal returns true if Value is a decimal.
 func (v Value) IsDecimal() bool {
 	return IsDecimal(v.typ)

--- a/go/vt/vtgate/evalengine/integration/comparison_test.go
+++ b/go/vt/vtgate/evalengine/integration/comparison_test.go
@@ -178,8 +178,8 @@ func compareRemoteExprEnv(t *testing.T, env *evalengine.ExpressionEnv, conn *mys
 		}
 	}
 
-	if diff := compareResult(localErr, remoteErr, localVal, remoteVal, localCollation, remoteCollation, decimals); diff != "" {
-		t.Errorf("%s\nquery: %s (SIMPLIFY=%v)\nrow: %v", diff, localQuery, debugSimplify, env.Row)
+	if err := compareResult(localErr, remoteErr, localVal, remoteVal, localCollation, remoteCollation, decimals); err != nil {
+		t.Errorf("%s\nquery: %s (SIMPLIFY=%v)\nrow: %v", err, localQuery, debugSimplify, env.Row)
 	} else if debugPrintAll {
 		t.Logf("local=%s mysql=%s\nquery: %s\nrow: %v", localVal.String(), remoteVal.String(), localQuery, env.Row)
 	}

--- a/go/vt/vtgate/evalengine/integration/fuzz_test.go
+++ b/go/vt/vtgate/evalengine/integration/fuzz_test.go
@@ -330,24 +330,24 @@ func closeDatetime(a, b time.Time, diff time.Duration) bool {
 	return d <= diff
 }
 
-func compareResult(localErr, remoteErr error, localVal, remoteVal sqltypes.Value, localCollation, remoteCollation collations.ID, decimals uint32) string {
+func compareResult(localErr, remoteErr error, localVal, remoteVal sqltypes.Value, localCollation, remoteCollation collations.ID, decimals uint32) error {
 	if localErr != nil {
 		if remoteErr == nil {
-			return fmt.Sprintf("%v; mysql response: %s", localErr, remoteVal)
+			return fmt.Errorf("%w: mysql response: %s", localErr, remoteVal)
 		}
 		if !errorsMatch(remoteErr, localErr) {
-			return fmt.Sprintf("mismatch in errors: eval=%s; mysql response: %s", localErr.Error(), remoteErr.Error())
+			return fmt.Errorf("mismatch in errors: eval=%w; mysql response: %w", localErr, remoteErr)
 		}
-		return ""
+		return nil
 	}
 
 	if remoteErr != nil {
 		for _, ke := range knownErrors {
 			if ke.MatchString(remoteErr.Error()) {
-				return ""
+				return nil
 			}
 		}
-		return fmt.Sprintf("%v; mysql failed with: %s", localVal, remoteErr.Error())
+		return fmt.Errorf("%v; mysql failed with: %w", localVal, remoteErr)
 	}
 
 	var localCollationName string
@@ -362,55 +362,55 @@ func compareResult(localErr, remoteErr error, localVal, remoteVal sqltypes.Value
 	if localVal.IsFloat() && remoteVal.IsFloat() {
 		localFloat, err := localVal.ToFloat64()
 		if err != nil {
-			return fmt.Sprintf("error converting local value to float: %v", err)
+			return fmt.Errorf("error converting local value to float: %w", err)
 		}
 		remoteFloat, err := remoteVal.ToFloat64()
 		if err != nil {
-			return fmt.Sprintf("error converting remote value to float: %v", err)
+			return fmt.Errorf("error converting remote value to float: %w", err)
 		}
 		if !closeFloat(localFloat, remoteFloat, decimals) {
-			return fmt.Sprintf("different results: %s; mysql response: %s (local collation: %s; mysql collation: %s)",
+			return fmt.Errorf("different results: %s; mysql response: %s (local collation: %s; mysql collation: %s)",
 				localVal.String(), remoteVal.String(), localCollationName, remoteCollationName)
 		}
 	} else if localVal.IsDateTime() && remoteVal.IsDateTime() {
 		localDatetime, err := time.Parse("2006-01-02 15:04:05.999999", localVal.ToString())
 		if err != nil {
-			return fmt.Sprintf("error converting local value to datetime: %v", err)
+			return fmt.Errorf("error converting local value to datetime: %w", err)
 		}
 		remoteDatetime, err := time.Parse("2006-01-02 15:04:05.999999", remoteVal.ToString())
 		if err != nil {
-			return fmt.Sprintf("error converting remote value to datetime: %v", err)
+			return fmt.Errorf("error converting remote value to datetime: %w", err)
 		}
 		if !closeDatetime(localDatetime, remoteDatetime, 1*time.Second) {
-			return fmt.Sprintf("different results: %s; mysql response: %s (local collation: %s; mysql collation: %s)",
+			return fmt.Errorf("different results: %s; mysql response: %s (local collation: %s; mysql collation: %s)",
 				localVal.String(), remoteVal.String(), localCollationName, remoteCollationName)
 		}
 	} else if localVal.IsTime() && remoteVal.IsTime() {
 		localTime, err := time.Parse("15:04:05.999999", localVal.ToString())
 		if err != nil {
-			return fmt.Sprintf("error converting local value to time: %v", err)
+			return fmt.Errorf("error converting local value to time: %w", err)
 		}
 		remoteTime, err := time.Parse("15:04:05.999999", remoteVal.ToString())
 		if err != nil {
-			return fmt.Sprintf("error converting remote value to time: %v", err)
+			return fmt.Errorf("error converting remote value to time: %w", err)
 		}
 		if !closeDatetime(localTime, remoteTime, 1*time.Second) {
-			return fmt.Sprintf("different results: %s; mysql response: %s (local collation: %s; mysql collation: %s)",
+			return fmt.Errorf("different results: %s; mysql response: %s (local collation: %s; mysql collation: %s)",
 				localVal.String(), remoteVal.String(), localCollationName, remoteCollationName)
 		}
 	} else if localVal.String() != remoteVal.String() {
-		return fmt.Sprintf("different results: %s; mysql response: %s (local collation: %s; mysql collation: %s)",
+		return fmt.Errorf("different results: %s; mysql response: %s (local collation: %s; mysql collation: %s)",
 			localVal.String(), remoteVal.String(), localCollationName, remoteCollationName)
 	}
 	if localCollation != remoteCollation {
-		return fmt.Sprintf("different collations: %s; mysql response: %s (local result: %s; mysql result: %s)",
+		return fmt.Errorf("different collations: %s; mysql response: %s (local result: %s; mysql result: %s)",
 			localCollationName, remoteCollationName, localVal.String(), remoteVal.String(),
 		)
 	}
 
-	return ""
+	return nil
 }
 
 func (cr *mismatch) Error() string {
-	return compareResult(cr.localErr, cr.remoteErr, cr.localVal, cr.remoteVal, collations.Unknown, collations.Unknown, 0)
+	return compareResult(cr.localErr, cr.remoteErr, cr.localVal, cr.remoteVal, collations.Unknown, collations.Unknown, 0).Error()
 }


### PR DESCRIPTION
Looks like Actions sometimes runs slow enough that 100ms is not enough buffer, so increase it to 1 second and allow the limit value itself as well. This is useful if things are rounded to seconds already.

Also compare `TIME` objects in a similar way to allow for differences.

## Related Issue(s)

See failure output like https://github.com/vitessio/vitess/actions/runs/4597420941/jobs/8125168911

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required