### PR TITLE
Flaky test fix: OnlineDDL: convert time->unix->TIMESTAMP in golang space

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -3524,7 +3524,7 @@ func (e *Executor) reviewRunningMigrations(ctx context.Context) (countRunnning i
 					_ = e.updateRowsCopied(ctx, uuid, s.rowsCopied)
 					_ = e.updateMigrationProgressByRowsCopied(ctx, uuid, s.rowsCopied)
 					_ = e.updateMigrationETASecondsByProgress(ctx, uuid)
-					_ = e.updateMigrationLastThrottled(ctx, uuid, s.timeThrottled, s.componentThrottled)
+					_ = e.updateMigrationLastThrottled(ctx, uuid, time.Unix(s.timeThrottled, 0), s.componentThrottled)
 
 					isReady, err := e.isVReplMigrationReadyToCutOver(ctx, s)
 					if err != nil {
@@ -4201,9 +4201,9 @@ func (e *Executor) updateMigrationETASecondsByProgress(ctx context.Context, uuid
 	return err
 }
 
-func (e *Executor) updateMigrationLastThrottled(ctx context.Context, uuid string, lastThrottledUnixTime int64, throttledCompnent string) error {
+func (e *Executor) updateMigrationLastThrottled(ctx context.Context, uuid string, lastThrottledTime time.Time, throttledCompnent string) error {
 	query, err := sqlparser.ParseAndBind(sqlUpdateLastThrottled,
-		sqltypes.Int64BindVariable(lastThrottledUnixTime),
+		sqltypes.StringBindVariable(lastThrottledTime.Format(sqltypes.TimestampFormat)),
 		sqltypes.StringBindVariable(throttledCompnent),
 		sqltypes.StringBindVariable(uuid),
 	)

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -233,7 +233,7 @@ const (
 			migration_uuid=%a
 	`
 	sqlUpdateLastThrottled = `UPDATE _vt.schema_migrations
-			SET last_throttled_timestamp=FROM_UNIXTIME(%a), component_throttled=%a
+			SET last_throttled_timestamp=%a, component_throttled=%a
 		WHERE
 			migration_uuid=%a
 	`


### PR DESCRIPTION
## Description

This PR attempts to fix https://github.com/vitessio/vitess/issues/12336. ~~I'll keep it in `Draft` and run `onlineddl_vrepl` test a few times in CI, before asking for review.~~

https://github.com/vitessio/vitess/issues/12336 presents a very weird situation, where the `_vt.vreplication.time_throttled` value, recorded by `vreplication` components, ends up being _earlier_ than a migration's `started_timestamp`, which shouldn't possibly happen, as we only ever start looking at the migration's throttler state _after it starts_.

The one thing that caught my eye is that `vreplication` grabs current time and extracts it to Unix time:

https://github.com/vitessio/vitess/blob/a6529e1df6ea6e4e7b7ecfa65f985f5f1db0803d/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go#L534-L535

But then, as we write this value to `_vt.schema_migrations.throttled_timestamp`, we ask MySQL to convert it from Unix time to `TIMESTAMP`:

https://github.com/vitessio/vitess/blob/a6529e1df6ea6e4e7b7ecfa65f985f5f1db0803d/go/vt/vttablet/onlineddl/schema.go#L113-L117

So my current conjecture, which we experiment in this PR, is that the two do not agree with each other. Maybe one has a different `leap year` evaluation. At any case, it makes complete sense to have `golang` do both conversions, and that's what this PR does.


## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/12336
- https://github.com/planetscale/vitess-private/issues/1663

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
