### PR TITLE
evalengine: Improve the timezone parsing logic

### DIFF
--- a/go/mysql/datetime/time_zone.go
+++ b/go/mysql/datetime/time_zone.go
@@ -1,0 +1,63 @@
+package datetime
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+func unknownTimeZone(tz string) error {
+	return vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.UnknownTimeZone, "Unknown or incorrect time zone: '%s'", tz)
+}
+
+func ParseTimeZone(tz string) (*time.Location, error) {
+	// Needs to be checked first since time.LoadLocation("") returns UTC.
+	if tz == "" {
+		return nil, unknownTimeZone(tz)
+	}
+	loc, err := time.LoadLocation(tz)
+	if err == nil {
+		return loc, nil
+	}
+
+	// MySQL also handles timezone formats in the form of the
+	// offset from UTC, so we'll try that if the above fails.
+	// This format is always something in the form of +HH:MM or -HH:MM.
+	if len(tz) != 6 {
+		return nil, unknownTimeZone(tz)
+	}
+	if tz[0] != '+' && tz[0] != '-' {
+		return nil, unknownTimeZone(tz)
+	}
+	if tz[3] != ':' {
+		return nil, unknownTimeZone(tz)
+	}
+	neg := tz[0] == '-'
+	hours, err := strconv.ParseUint(tz[1:3], 10, 4)
+	if err != nil {
+		return nil, unknownTimeZone(tz)
+	}
+	minutes, err := strconv.ParseUint(tz[4:], 10, 6)
+	if err != nil {
+		return nil, unknownTimeZone(tz)
+	}
+	if minutes > 59 {
+		return nil, unknownTimeZone(tz)
+	}
+
+	// MySQL only supports timezones in the range of -13:59 to +14:00.
+	if neg && hours > 13 {
+		return nil, unknownTimeZone(tz)
+	}
+	if !neg && (hours > 14 || hours == 14 && minutes > 0) {
+		return nil, unknownTimeZone(tz)
+	}
+	offset := int(hours)*60*60 + int(minutes)*60
+	if neg {
+		offset = -offset
+	}
+	return time.FixedZone(fmt.Sprintf("UTC%s", tz), offset), nil
+}

--- a/go/mysql/datetime/time_zone.go
+++ b/go/mysql/datetime/time_zone.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package datetime
 
 import (

--- a/go/mysql/datetime/time_zone_test.go
+++ b/go/mysql/datetime/time_zone_test.go
@@ -1,0 +1,61 @@
+package datetime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTimeZone(t *testing.T) {
+	testCases := []struct {
+		tz   string
+		want string
+	}{
+		{
+			tz:   "Europe/Amsterdam",
+			want: "Europe/Amsterdam",
+		},
+		{
+			tz:   "",
+			want: "Unknown or incorrect time zone: ''",
+		},
+		{
+			tz:   "+02:00",
+			want: "UTC+02:00",
+		},
+		{
+			tz:   "+14:00",
+			want: "UTC+14:00",
+		},
+		{
+			tz:   "+14:01",
+			want: "Unknown or incorrect time zone: '+14:01'",
+		},
+		{
+			tz:   "-13:59",
+			want: "UTC-13:59",
+		},
+		{
+			tz:   "-14:00",
+			want: "Unknown or incorrect time zone: '-14:00'",
+		},
+		{
+			tz:   "-15:00",
+			want: "Unknown or incorrect time zone: '-15:00'",
+		},
+		{
+			tz:   "foo",
+			want: "Unknown or incorrect time zone: 'foo'",
+		},
+	}
+
+	for _, tc := range testCases {
+
+		zone, err := ParseTimeZone(tc.tz)
+		if err != nil {
+			assert.Equal(t, tc.want, err.Error())
+		} else {
+			assert.Equal(t, tc.want, zone.String())
+		}
+	}
+}

--- a/go/mysql/datetime/time_zone_test.go
+++ b/go/mysql/datetime/time_zone_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package datetime
 
 import (

--- a/go/mysql/sql_error.go
+++ b/go/mysql/sql_error.go
@@ -210,6 +210,7 @@ var stateToMysqlCode = map[vterrors.State]mysqlCode{
 	vterrors.NoSuchSession:                {num: ERUnknownComError, state: SSNetError},
 	vterrors.OperandColumns:               {num: EROperandColumns, state: SSWrongNumberOfColumns},
 	vterrors.WrongValueCountOnRow:         {num: ERWrongValueCountOnRow, state: SSWrongValueCountOnRow},
+	vterrors.UnknownTimeZone:              {num: ERUnknownTimeZone, state: SSUnknownSQLState},
 }
 
 func getStateToMySQLState(state vterrors.State) mysqlCode {

--- a/go/vt/vterrors/state.go
+++ b/go/vt/vterrors/state.go
@@ -83,6 +83,9 @@ const (
 	// server not available
 	ServerNotAvailable
 
+	// unknown timezone
+	UnknownTimeZone
+
 	// No state should be added below NumOfStates
 	NumOfStates
 )

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -25,6 +25,8 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"vitess.io/vitess/go/mysql/datetime"
+
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/sysvars"
@@ -553,9 +555,9 @@ func (session *SafeSession) TimeZone() *time.Location {
 	session.mu.Unlock()
 
 	if !ok {
-		return time.Local
+		return nil
 	}
-	loc, _ := time.LoadLocation(tz)
+	loc, _ := datetime.ParseTimeZone(tz)
 	return loc
 }
 


### PR DESCRIPTION
While looking at supporting `CONVERT_TZ` in the evalengine, it was clear that our current timezone parsing didn't suffice. MySQL also supports direct UTC offsets to be used as a timezone identifier which `time.LoadLocation` doesn't handle.

This adds support for parsing this style of timezone offsets and a bunch of tests for this as well. It adds a separate parsing function with error so in the future we can use that in `CONVERT_TZ` which returns `NULL` on invalid timezone definitions.

## Related Issue(s)

Part of implementing #9647 and something that was missed in #12742

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required