### PR TITLE
Fix backup flaky tests

### DIFF
--- a/go/test/endtoend/cluster/cluster_util.go
+++ b/go/test/endtoend/cluster/cluster_util.go
@@ -43,7 +43,7 @@ var (
 	dbCredentialFile         string
 	InsertTabletTemplateKsID = `insert into %s (id, msg) values (%d, '%s') /* id:%d */`
 	defaultOperationTimeout  = 60 * time.Second
-	defeaultRetryDelay       = 1 * time.Second
+	defaultRetryDelay        = 1 * time.Second
 )
 
 // Restart restarts vttablet and mysql.
@@ -54,15 +54,17 @@ func (tablet *Vttablet) Restart() error {
 
 	if tablet.MysqlctlProcess.TabletUID > 0 {
 		tablet.MysqlctlProcess.Stop()
+		tablet.MysqlctldProcess.WaitForMysqlctldShutdown(tablet)
 		tablet.VttabletProcess.TearDown()
-		os.RemoveAll(tablet.VttabletProcess.Directory)
+		tablet.MysqlctldProcess.CleanupFiles(tablet.TabletUID)
 
 		return tablet.MysqlctlProcess.Start()
 	}
 
 	tablet.MysqlctldProcess.Stop()
+	tablet.MysqlctldProcess.WaitForMysqlctldShutdown(tablet)
 	tablet.VttabletProcess.TearDown()
-	os.RemoveAll(tablet.VttabletProcess.Directory)
+	tablet.MysqlctldProcess.CleanupFiles(tablet.TabletUID)
 
 	return tablet.MysqlctldProcess.Start()
 }
@@ -441,6 +443,6 @@ func WaitForHealthyShard(vtctldclient *VtctldClientProcess, keyspace, shard stri
 		default:
 		}
 
-		time.Sleep(defeaultRetryDelay)
+		time.Sleep(defaultRetryDelay)
 	}
 }

--- a/go/test/endtoend/cluster/cluster_util.go
+++ b/go/test/endtoend/cluster/cluster_util.go
@@ -54,7 +54,7 @@ func (tablet *Vttablet) Restart() error {
 
 	if tablet.MysqlctlProcess.TabletUID > 0 {
 		tablet.MysqlctlProcess.Stop()
-		tablet.MysqlctldProcess.WaitForMysqlctldShutdown(tablet)
+		tablet.MysqlctldProcess.WaitForMysqlCtldShutdown()
 		tablet.VttabletProcess.TearDown()
 		tablet.MysqlctldProcess.CleanupFiles(tablet.TabletUID)
 
@@ -62,7 +62,7 @@ func (tablet *Vttablet) Restart() error {
 	}
 
 	tablet.MysqlctldProcess.Stop()
-	tablet.MysqlctldProcess.WaitForMysqlctldShutdown(tablet)
+	tablet.MysqlctldProcess.WaitForMysqlCtldShutdown()
 	tablet.VttabletProcess.TearDown()
 	tablet.MysqlctldProcess.CleanupFiles(tablet.TabletUID)
 

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -222,6 +222,7 @@ func (mysqlctl *MysqlctlProcess) CleanupFiles(tabletUID int) {
 	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/tmp", tabletUID)))
 	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/bin-logs", tabletUID)))
 	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/innodb", tabletUID)))
+	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d", tabletUID)))
 }
 
 // Connect returns a new connection to the underlying MySQL server

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -217,11 +217,6 @@ func (mysqlctl *MysqlctlProcess) BinaryLogsPath() string {
 
 // CleanupFiles clean the mysql files to make sure we can start the same process again
 func (mysqlctl *MysqlctlProcess) CleanupFiles(tabletUID int) {
-	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/data", tabletUID)))
-	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/relay-logs", tabletUID)))
-	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/tmp", tabletUID)))
-	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/bin-logs", tabletUID)))
-	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/innodb", tabletUID)))
 	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d", tabletUID)))
 }
 

--- a/go/test/endtoend/cluster/mysqlctld_process.go
+++ b/go/test/endtoend/cluster/mysqlctld_process.go
@@ -139,11 +139,6 @@ func (mysqlctld *MysqlctldProcess) Stop() error {
 
 // CleanupFiles clean the mysql files to make sure we can start the same process again
 func (mysqlctld *MysqlctldProcess) CleanupFiles(tabletUID int) {
-	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/data", tabletUID)))
-	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/relay-logs", tabletUID)))
-	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/tmp", tabletUID)))
-	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/bin-logs", tabletUID)))
-	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/innodb", tabletUID)))
 	os.RemoveAll(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d", tabletUID)))
 }
 
@@ -179,11 +174,11 @@ func (mysqlctld *MysqlctldProcess) hasShutdown() bool {
 	return mysqlctld.process == nil
 }
 
-func (mysqlctld *MysqlctldProcess) WaitForMysqlctldShutdown(tablet *Vttablet) bool {
+func (mysqlctld *MysqlctldProcess) WaitForMysqlCtldShutdown() bool {
 	tmr := time.NewTimer(defaultOperationTimeout)
 	defer tmr.Stop()
 	for {
-		if tablet.MysqlctldProcess.hasShutdown() {
+		if mysqlctld.hasShutdown() {
 			return true
 		}
 		select {

--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -138,7 +138,7 @@ func TestRestart(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	err := primaryTablet.MysqlctldProcess.Stop()
 	require.Nil(t, err)
-	require.Truef(t, primaryTablet.MysqlctldProcess.WaitForMysqlctldShutdown(primaryTablet), "Mysqlctld has not stopped...")
+	require.Truef(t, primaryTablet.MysqlctldProcess.WaitForMysqlCtldShutdown(), "Mysqlctld has not stopped...")
 	primaryTablet.MysqlctldProcess.CleanupFiles(primaryTablet.TabletUID)
 	err = primaryTablet.MysqlctldProcess.Start()
 	require.Nil(t, err)

--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -135,30 +134,11 @@ func initCluster(shardNames []string, totalTabletsRequired int) error {
 	return nil
 }
 
-const defaultOperationTimeout = 300 * time.Second
-const defaultRetryDelay = 3 * time.Second
-
-func waitForMysqlctldShutdown(t *testing.T, tab *cluster.Vttablet) bool {
-	tmr := time.NewTimer(defaultOperationTimeout)
-	defer tmr.Stop()
-	for {
-		if tab.MysqlctldProcess.HasShutdown() {
-			return true
-		}
-		select {
-		case <-tmr.C:
-			return false
-		default:
-		}
-		time.Sleep(defaultRetryDelay)
-	}
-}
-
 func TestRestart(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	err := primaryTablet.MysqlctldProcess.Stop()
 	require.Nil(t, err)
-	require.Truef(t, waitForMysqlctldShutdown(t, primaryTablet), "Mysqlctld has not stopped after %s", defaultOperationTimeout)
+	require.Truef(t, primaryTablet.MysqlctldProcess.WaitForMysqlctldShutdown(primaryTablet), "Mysqlctld has not stopped...")
 	primaryTablet.MysqlctldProcess.CleanupFiles(primaryTablet.TabletUID)
 	err = primaryTablet.MysqlctldProcess.Start()
 	require.Nil(t, err)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

## Description

Backup tests are flaky. One such example is 

Cluster 21 --> https://github.com/vitessio/vitess/actions/runs/4620105525/jobs/8169754027

During mysql Teardown, it is observed that sometimes mysql is not able to stop, clean and restart properly. I saw there was a fix done for similar issue by @rohit-nayak-ps (https://github.com/vitessio/vitess/pull/12799). So I refactored his code and added some additional enhancement.


## Testing

Ran test in CI few times to make sure, it is no longer flaky
https://github.com/vitessio/vitess/actions/runs/4614501474

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
