### PR TITLE
fix: vtadmin vttablet url protocol

### DIFF
--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -21,7 +21,7 @@ vtadmin \
   --alsologtostderr \
   --rbac \
   --rbac-config="${script_dir}/../vtadmin/rbac.yaml" \
-  --cluster "id=${cluster_name},name=${cluster_name},discovery=staticfile,discovery-staticfile-path=${script_dir}/../vtadmin/discovery.json,tablet-fqdn-tmpl={{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
+  --cluster "id=${cluster_name},name=${cluster_name},discovery=staticfile,discovery-staticfile-path=${script_dir}/../vtadmin/discovery.json,tablet-fqdn-tmpl=http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
   > "${log_dir}/vtadmin-api.out" 2>&1 &
 
 vtadmin_api_pid=$!

--- a/web/vtadmin/.gitignore
+++ b/web/vtadmin/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .eslintcache
+.env

--- a/web/vtadmin/README.md
+++ b/web/vtadmin/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [node](https://nodejs.org) >= 16.13.0 LTS
+- [node](https://nodejs.org) >= 16.19.0 LTS
 	- _Note_: If you are using Node >= 17.x.y, you may see errors like `Error: error:0308010C:digital envelope routines::unsupported` when running `npm run build`. This is due to node dropping support for older versions of `openssl`. A workaround was added in [nodejs/node#40455](https://github.com/nodejs/node/issues/40455), allowing you to `export NODE_OPTIONS="--openssl-legacy-provider"` before running `npm run build`.
 - npm >= 8.1.0 (comes with node)
 

--- a/web/vtadmin/src/components/links/ExternalTabletLink.tsx
+++ b/web/vtadmin/src/components/links/ExternalTabletLink.tsx
@@ -25,7 +25,7 @@ export const ExternalTabletLink: React.FunctionComponent<Props> = ({ children, c
     }
 
     return (
-        <a className={className} href={`//${fqdn}`} rel="noreferrer" target="_blank">
+        <a className={className} href={`${fqdn}`} rel="noreferrer" target="_blank">
             {children}
         </a>
     );

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -96,7 +96,7 @@ export const Tablets = () => {
                     </DataCell>
 
                     <DataCell>
-                        <ExternalTabletLink fqdn={`//${t._raw.FQDN}`}>{t.hostname}</ExternalTabletLink>
+                        <ExternalTabletLink fqdn={`${t._raw.FQDN}`}>{t.hostname}</ExternalTabletLink>
                     </DataCell>
 
                     <ReadOnlyGate>

--- a/web/vtadmin/src/components/routes/shard/ShardTablets.tsx
+++ b/web/vtadmin/src/components/routes/shard/ShardTablets.tsx
@@ -95,7 +95,7 @@ export const ShardTablets: React.FunctionComponent<Props> = (props) => {
                     </DataCell>
 
                     <DataCell>
-                        <ExternalTabletLink fqdn={`//${t.fqdn}`}>{t.hostname}</ExternalTabletLink>
+                        <ExternalTabletLink fqdn={`${t.fqdn}`}>{t.hostname}</ExternalTabletLink>
                     </DataCell>
                 </tr>
             );


### PR DESCRIPTION
## Issue

https://github.com/vitessio/vitess/issues/12837

## Description

Following our [Slack discussion](https://vitess.slack.com/archives/C01H307F68J/p1680076925636199) we saw that there are four slashes in front of vttablet links (like: `////10.95.196.20:15000/debug/status`) preventing user to specify the protocol (http/https). 

This fix aims to remove those / and allow user to specify the protocol they want to use.

Before the fix: 
<img width="789" alt="image" src="https://user-images.githubusercontent.com/4710495/230035311-84eae57b-434c-4571-9c43-9147032308a2.png">

After the fix:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/4710495/230035384-9c64a8f1-be77-4768-9f53-8226a1a7cb44.png">



## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
