### PR TITLE
Small fixes to the auto-upgrade golang tool

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -39,12 +39,19 @@ jobs:
           if [ -z "${output}" ]; then
             exit 0
           fi
-          echo "create-pr=true" >> $GITHUB_OUTPUT
-
+          
           go_version=$(go run ./go/tools/go-upgrade/go-upgrade.go get go-version)
           bootstrap_version=$(go run ./go/tools/go-upgrade/go-upgrade.go get bootstrap-version)
           echo "go-version=${go_version}" >> $GITHUB_OUTPUT
           echo "bootstrap-version=${bootstrap_version}" >> $GITHUB_OUTPUT
+
+          # Check if the PR already exists, if it does then do not create new PR.
+          gh pr list -S "is:open [${{ matrix.branch }}] Upgrade the Golang version to go${go_version}" | grep "OPEN"
+          if [ $? -eq 0 ]; then
+            exit 0
+          fi
+
+          echo "create-pr=true" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         if: steps.detect-and-update.outputs.create-pr == 'true'

--- a/go/tools/go-upgrade/go-upgrade.go
+++ b/go/tools/go-upgrade/go-upgrade.go
@@ -45,7 +45,7 @@ type (
 	}
 
 	bootstrapVersion struct {
-		major, minor int
+		major, minor int // when minor == -1, it means there are no minor version
 	}
 )
 
@@ -279,9 +279,13 @@ func currentBootstrapVersion() (bootstrapVersion, error) {
 	if err != nil {
 		return bootstrapVersion{}, err
 	}
-	minor, err := strconv.Atoi(vs[1])
-	if err != nil {
-		return bootstrapVersion{}, err
+
+	minor := -1
+	if len(vs) > 1 {
+		minor, err = strconv.Atoi(vs[1])
+		if err != nil {
+			return bootstrapVersion{}, err
+		}
 	}
 
 	return bootstrapVersion{
@@ -524,5 +528,8 @@ func replaceInFile(oldexps []*regexp.Regexp, new []string, fileToChange string) 
 }
 
 func (b bootstrapVersion) toString() string {
+	if b.minor == -1 {
+		return fmt.Sprintf("%d", b.major)
+	}
 	return fmt.Sprintf("%d.%d", b.major, b.minor)
 }

--- a/go/tools/go-upgrade/go-upgrade.go
+++ b/go/tools/go-upgrade/go-upgrade.go
@@ -38,10 +38,16 @@ const (
 	goDevAPI = "https://go.dev/dl/?mode=json"
 )
 
-type latestGolangRelease struct {
-	Version string `json:"version"`
-	Stable  bool   `json:"stable"`
-}
+type (
+	latestGolangRelease struct {
+		Version string `json:"version"`
+		Stable  bool   `json:"stable"`
+	}
+
+	bootstrapVersion struct {
+		major, minor int
+	}
+)
 
 var (
 	workflowUpdate    = true
@@ -151,7 +157,7 @@ func runGetBootstrapCmd(_ *cobra.Command, _ []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(currentVersion)
+	fmt.Println(currentVersion.toString())
 }
 
 func runUpgradeWorkflowsCmd(_ *cobra.Command, _ []string) {
@@ -218,11 +224,11 @@ func upgradePath(allowMajorUpgrade, workflowUpdate, isMainBranch bool) error {
 	}
 	nextBootstrapVersionF := currentBootstrapVersionF
 	if isMainBranch {
-		nextBootstrapVersionF += 1
+		nextBootstrapVersionF.major += 1
 	} else {
-		nextBootstrapVersionF += 0.1
+		nextBootstrapVersionF.minor += 1
 	}
-	err = updateBootstrapVersionInCodebase(currentBootstrapVersionF, nextBootstrapVersionF, upgradeTo)
+	err = updateBootstrapVersionInCodebase(currentBootstrapVersionF.toString(), nextBootstrapVersionF.toString(), upgradeTo)
 	if err != nil {
 		return err
 	}
@@ -251,23 +257,37 @@ func currentGolangVersion() (*version.Version, error) {
 	return version.NewVersion(versionStr[1])
 }
 
-func currentBootstrapVersion() (float64, error) {
+func currentBootstrapVersion() (bootstrapVersion, error) {
 	contentRaw, err := os.ReadFile("Makefile")
 	if err != nil {
-		return 0, err
+		return bootstrapVersion{}, err
 	}
 	content := string(contentRaw)
 
 	versre := regexp.MustCompile("(?i).*BOOTSTRAP_VERSION[[:space:]]*=[[:space:]]*([0-9.]+).*")
 	versionStr := versre.FindStringSubmatch(content)
 	if len(versionStr) != 2 {
-		return 0, fmt.Errorf("malformatted error, got: %v", versionStr)
+		return bootstrapVersion{}, fmt.Errorf("malformatted error, got: %v", versionStr)
 	}
-	f, err := strconv.ParseFloat(versionStr[1], 64)
+	_, err = strconv.ParseFloat(versionStr[1], 64)
 	if err != nil {
-		return 0, err
+		return bootstrapVersion{}, err
 	}
-	return f, nil
+
+	vs := strings.Split(versionStr[1], ".")
+	major, err := strconv.Atoi(vs[0])
+	if err != nil {
+		return bootstrapVersion{}, err
+	}
+	minor, err := strconv.Atoi(vs[1])
+	if err != nil {
+		return bootstrapVersion{}, err
+	}
+
+	return bootstrapVersion{
+		major: major,
+		minor: minor,
+	}, nil
 }
 
 // getLatestStableGolangReleases fetches the latest stable releases of Golang from
@@ -371,7 +391,7 @@ func replaceGoVersionInCodebase(old, new *version.Version, workflowUpdate bool) 
 	return nil
 }
 
-func updateBootstrapVersionInCodebase(old, new float64, newGoVersion *version.Version) error {
+func updateBootstrapVersionInCodebase(old, new string, newGoVersion *version.Version) error {
 	if old == new {
 		return nil
 	}
@@ -394,8 +414,8 @@ func updateBootstrapVersionInCodebase(old, new float64, newGoVersion *version.Ve
 				regexp.MustCompile(`BOOTSTRAP_VERSION[[:space:]]*=[[:space:]]*[0-9.]+`),                // Makefile
 			},
 			[]string{
-				fmt.Sprintf("ARG bootstrap_version=%-1g", new), // Dockerfile
-				fmt.Sprintf("BOOTSTRAP_VERSION=%-1g", new),     // Makefile
+				fmt.Sprintf("ARG bootstrap_version=%s", new), // Dockerfile
+				fmt.Sprintf("BOOTSTRAP_VERSION=%s", new),     // Makefile
 			},
 			file,
 		)
@@ -406,7 +426,7 @@ func updateBootstrapVersionInCodebase(old, new float64, newGoVersion *version.Ve
 
 	err = replaceInFile(
 		[]*regexp.Regexp{regexp.MustCompile(`\"bootstrap-version\",[[:space:]]*\"([0-9.]+)\"`)},
-		[]string{fmt.Sprintf("\"bootstrap-version\", \"%-1g\"", new)},
+		[]string{fmt.Sprintf("\"bootstrap-version\", \"%s\"", new)},
 		"./test.go",
 	)
 	if err != nil {
@@ -421,7 +441,7 @@ func updateBootstrapVersionInCodebase(old, new float64, newGoVersion *version.Ve
 	return nil
 }
 
-func updateBootstrapChangelog(new float64, goVersion *version.Version) error {
+func updateBootstrapChangelog(new string, goVersion *version.Version) error {
 	file, err := os.OpenFile("./docker/bootstrap/CHANGELOG.md", os.O_RDWR, 0600)
 	if err != nil {
 		return err
@@ -434,7 +454,7 @@ func updateBootstrapChangelog(new float64, goVersion *version.Version) error {
 	}
 	newContent := fmt.Sprintf(`
 
-## [%-1g] - %s
+## [%s] - %s
 ### Changes
 - Update build to golang %s`, new, time.Now().Format(time.DateOnly), goVersion.String())
 
@@ -501,4 +521,8 @@ func replaceInFile(oldexps []*regexp.Regexp, new []string, fileToChange string) 
 		return err
 	}
 	return nil
+}
+
+func (b bootstrapVersion) toString() string {
+	return fmt.Sprintf("%d.%d", b.major, b.minor)
 }


### PR DESCRIPTION
## Description

We could see two issues in the previous golang upgrade auto Pull Requests:
- The bootstrap version was `14.2999999..` instead of `14.3`. This is because the summing operations of two float can give different results if there are some gaps in the mantissa. 
- The bot would re-create the Pull Request on top of the already existing one.

These two issues are now fixed in this PR.
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
