### PR TITLE
VDiff: cleanup test log output

### DIFF
--- a/go/cache/ristretto/bloom/bbloom_test.go
+++ b/go/cache/ristretto/bloom/bbloom_test.go
@@ -2,9 +2,11 @@ package bloom
 
 import (
 	"crypto/rand"
-	"fmt"
 	"os"
 	"testing"
+
+	_flag "vitess.io/vitess/go/internal/flag"
+	"vitess.io/vitess/go/vt/log"
 
 	"vitess.io/vitess/go/hack"
 )
@@ -16,14 +18,15 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	// hack to get rid of an "ERROR: logging before flag.Parse"
+	_flag.TrickGlog()
 	wordlist1 = make([][]byte, n)
 	for i := range wordlist1 {
 		b := make([]byte, 32)
 		_, _ = rand.Read(b)
 		wordlist1[i] = b
 	}
-	fmt.Println("\n###############\nbbloom_test.go")
-	fmt.Print("Benchmarks relate to 2**16 OP. --> output/65536 op/ns\n###############\n\n")
+	log.Info("Benchmarks relate to 2**16 OP. --> output/65536 op/ns")
 
 	os.Exit(m.Run())
 }
@@ -38,7 +41,7 @@ func TestM_NumberOfWrongs(t *testing.T) {
 			cnt++
 		}
 	}
-	fmt.Printf("Bloomfilter New(7* 2**16, 7) (-> size=%v bit): \n            Check for 'false positives': %v wrong positive 'Has' results on 2**16 entries => %v %%\n", len(bf.bitset)<<6, cnt, float64(cnt)/float64(n))
+	log.Infof("Bloomfilter New(7* 2**16, 7) (-> size=%v bit): \n            Check for 'false positives': %v wrong positive 'Has' results on 2**16 entries => %v %%", len(bf.bitset)<<6, cnt, float64(cnt)/float64(n))
 
 }
 

--- a/go/cache/ristretto/cache_test.go
+++ b/go/cache/ristretto/cache_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/log"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -97,7 +99,7 @@ func TestCacheMaxCost(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(time.Second)
 		cacheCost := c.Metrics.CostAdded() - c.Metrics.CostEvicted()
-		t.Logf("total cache cost: %d\n", cacheCost)
+		log.Infof("total cache cost: %d", cacheCost)
 		require.True(t, float64(cacheCost) <= float64(1e6*1.05))
 	}
 	for i := 0; i < 8; i++ {

--- a/go/cache/ristretto/sketch_test.go
+++ b/go/cache/ristretto/sketch_test.go
@@ -20,6 +20,8 @@ package ristretto
 import (
 	"testing"
 
+	"vitess.io/vitess/go/vt/log"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,9 +81,9 @@ func TestNext2Power(t *testing.T) {
 	sz := 12 << 30
 	szf := float64(sz) * 0.01
 	val := int64(szf)
-	t.Logf("szf = %.2f val = %d\n", szf, val)
+	log.Infof("szf = %.2f val = %d\n", szf, val)
 	pow := next2Power(val)
-	t.Logf("pow = %d. mult 4 = %d\n", pow, pow*4)
+	log.Infof("pow = %d. mult 4 = %d\n", pow, pow*4)
 }
 
 func BenchmarkSketchIncrement(b *testing.B) {

--- a/go/vt/wrangler/fake_dbclient_test.go
+++ b/go/vt/wrangler/fake_dbclient_test.go
@@ -91,9 +91,6 @@ func newFakeDBClient(name string) *fakeDBClient {
 func (dc *fakeDBClient) addQuery(query string, result *sqltypes.Result, err error) {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
-	if testMode == "debug" {
-		log.Infof("%s::addQuery %s\n\n", dc.id(), query)
-	}
 	dbr := &dbResult{result: result, err: err}
 	if dbrs, ok := dc.queries[query]; ok {
 		dbrs.results = append(dbrs.results, dbr)
@@ -105,9 +102,6 @@ func (dc *fakeDBClient) addQuery(query string, result *sqltypes.Result, err erro
 func (dc *fakeDBClient) addQueryRE(query string, result *sqltypes.Result, err error) {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
-	if testMode == "debug" {
-		log.Infof("%s::addQueryRE %s\n\n", dc.id(), query)
-	}
 	dbr := &dbResult{result: result, err: err}
 	if dbrs, ok := dc.queriesRE[query]; ok {
 		dbrs.results = append(dbrs.results, dbr)
@@ -126,9 +120,6 @@ func (dc *fakeDBClient) getInvariant(query string) *sqltypes.Result {
 func (dc *fakeDBClient) addInvariant(query string, result *sqltypes.Result) {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
-	if testMode == "debug" {
-		log.Infof("%s::addInvariant %s\n\n", dc.id(), query)
-	}
 	dc.invariants[query] = result
 }
 
@@ -170,9 +161,6 @@ func (dc *fakeDBClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Resul
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 	qr, err := dc.executeFetch(query, maxrows)
-	if testMode == "debug" {
-		log.Infof("%s::ExecuteFetch for >>>%s<<< returns >>>%v<<< error >>>%+v<<< ", dc.id(), query, qr, err)
-	}
 	return qr, err
 }
 

--- a/go/vt/wrangler/resharder_env_test.go
+++ b/go/vt/wrangler/resharder_env_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"runtime/debug"
 	"strings"
 	"sync"
 	"testing"
@@ -50,10 +49,6 @@ type testResharderEnv struct {
 	cell     string
 	tmc      *testResharderTMClient
 }
-
-var (
-	testMode = "" // "debug"
-)
 
 //----------------------------------------------
 // testResharderEnv
@@ -217,14 +212,8 @@ func (tmc *testResharderTMClient) expectVRQuery(tabletID int, query string, resu
 func (tmc *testResharderTMClient) VReplicationExec(ctx context.Context, tablet *topodatapb.Tablet, query string) (*querypb.QueryResult, error) {
 	tmc.mu.Lock()
 	defer tmc.mu.Unlock()
-	if testMode == "debug" {
-		fmt.Printf("Got: %d:%s\n", tablet.Alias.Uid, query)
-	}
 	qrs := tmc.vrQueries[int(tablet.Alias.Uid)]
 	if len(qrs) == 0 {
-		if testMode == "debug" {
-			fmt.Printf("Want: %d:%s, Stack:\n%v\n", tablet.Alias.Uid, query, debug.Stack())
-		}
 		return nil, fmt.Errorf("tablet %v does not expect any more queries: %s", tablet, query)
 	}
 	matched := false

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -110,6 +110,7 @@ func newTestTableMigraterCustom(ctx context.Context, t *testing.T, sourceShards,
 	tme.sourceShards = sourceShards
 	tme.targetShards = targetShards
 	tme.tmeDB = fakesqldb.New(t)
+	expectVDiffQueries(tme.tmeDB)
 	tabletID := 10
 	for _, shard := range sourceShards {
 		tme.sourcePrimaries = append(tme.sourcePrimaries, newFakeTablet(t, tme.wr, "cell1", uint32(tabletID), topodatapb.TabletType_PRIMARY, tme.tmeDB, TabletKeyspaceShard(t, "ks1", shard)))
@@ -269,6 +270,7 @@ func newTestShardMigrater(ctx context.Context, t *testing.T, sourceShards, targe
 	tme.sourceShards = sourceShards
 	tme.targetShards = targetShards
 	tme.tmeDB = fakesqldb.New(t)
+	expectVDiffQueries(tme.tmeDB)
 	tme.wr.sem = semaphore.NewWeighted(1)
 
 	tabletID := 10

--- a/go/vt/wrangler/vdiff_env_test.go
+++ b/go/vt/wrangler/vdiff_env_test.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"testing"
 
+	"vitess.io/vitess/go/mysql/fakesqldb"
+
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/logutil"
@@ -340,4 +342,19 @@ func (tmc *testVDiffTMClient) PrimaryPosition(ctx context.Context, tablet *topod
 		return "", fmt.Errorf("no primary position for %d", tablet.Alias.Uid)
 	}
 	return pos, nil
+}
+
+func expectVDiffQueries(db *fakesqldb.DB) {
+	res := &sqltypes.Result{}
+	queries := []string{
+		"USE `vt_ks`",
+		"USE `vt_ks1`",
+		"USE `vt_ks2`",
+		"optimize table _vt.copy_state",
+		"alter table _vt.copy_state auto_increment = 1",
+	}
+	for _, query := range queries {
+		db.AddQuery(query, res)
+	}
+	db.AddQueryPattern("delete from vd, vdt, vdl.*", res)
 }


### PR DESCRIPTION
## Description

* VDiff unit tests had not setup fakedb to expect some queries and they were being excessively logged in the unit/e2e test workflows
* Removed old debug code in vreplication 
* Other minor fixes

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
