### PR TITLE
Remove misleading message in `build.env`

### DIFF
--- a/build.env
+++ b/build.env
@@ -17,7 +17,7 @@
 source ./tools/shell_functions.inc
 
 go version >/dev/null 2>&1 || fail "Go is not installed or is not in \$PATH. See https://vitess.io/contributing/build-from-source for install instructions."
-goversion_min 1.20.2 || echo "Go version reported: `go version`. Version 1.20.2+ required. See https://vitess.io/contributing/build-from-source for install instructions."
+goversion_min 1.20.2 || echo "Go version reported: `go version`. Version 1.20.2+ recommended. See https://vitess.io/contributing/build-from-source for install instructions."
 
 mkdir -p dist
 mkdir -p bin


### PR DESCRIPTION
## Description

This Pull Request is a follow-up of https://github.com/vitessio/vitess/pull/12809, it fixes a misleading sentence that @deepthi noticed in https://github.com/vitessio/vitess/pull/12809#discussion_r1158746593.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
