### PR TITLE
[topo] Disallow the slash character in shard names

### DIFF
--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -6,6 +6,7 @@
   - **[Breaking Changes](#breaking-changes)**
     - [Dedicated stats for VTGate Prepare operations](#dedicated-vtgate-prepare-stats)
     - [Keyspace name validation in TopoServer](#keyspace-name-validation)
+    - [Shard name validation in TopoServer](#shard-name-validation)
   - **[New command line flags and behavior](#new-flag)**
     - [Builtin backup: read buffering flags](#builtin-backup-read-buffering-flags)
   - **[New stats](#new-stats)**
@@ -57,6 +58,12 @@ Here is a (condensed) example of stats output:
 Prior to v17, it was possible to create a keyspace with invalid characters, which would then be inaccessible to various cluster management operations.
 
 Keyspace names may no longer contain the forward slash ("/") character, and TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given such a name.
+
+#### <a id="shard-name-validation"> Shard name validation in TopoServer
+
+Prior to v17, it was possible to create a shard name with invalid characters, which would then be inaccessible to various cluster management operations.
+
+Shard names may no longer contain the forward slash ("/") character, and TopoServer's `CreateShard` and method returns an error if given such a name.
 
 ### <a id="new-flag"/> New command line flags and behavior
 

--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -63,7 +63,7 @@ Keyspace names may no longer contain the forward slash ("/") character, and Topo
 
 Prior to v17, it was possible to create a shard name with invalid characters, which would then be inaccessible to various cluster management operations.
 
-Shard names may no longer contain the forward slash ("/") character, and TopoServer's `CreateShard` and method returns an error if given such a name.
+Shard names may no longer contain the forward slash ("/") character, and TopoServer's `CreateShard` method returns an error if given such a name.
 
 ### <a id="new-flag"/> New command line flags and behavior
 

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -121,6 +121,10 @@ func IsShardUsingRangeBasedSharding(shard string) bool {
 // ValidateShardName takes a shard name and sanitizes it, and also returns
 // the KeyRange.
 func ValidateShardName(shard string) (string, *topodatapb.KeyRange, error) {
+	if strings.Contains(shard, "/") {
+		return "", nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid shardId, may not contain '-': %v", shard)
+	}
+
 	if !IsShardUsingRangeBasedSharding(shard) {
 		return shard, nil, nil
 	}

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -122,7 +122,7 @@ func IsShardUsingRangeBasedSharding(shard string) bool {
 // the KeyRange.
 func ValidateShardName(shard string) (string, *topodatapb.KeyRange, error) {
 	if strings.Contains(shard, "/") {
-		return "", nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid shardId, may not contain '-': %v", shard)
+		return "", nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid shardId, may not contain '/': %v", shard)
 	}
 
 	if !IsShardUsingRangeBasedSharding(shard) {


### PR DESCRIPTION
## Description

Gives echos of https://github.com/vitessio/vitess/pull/12732

"demo" of this erroring out in vtadmin:

<img width="319" alt="Screen Shot 2023-04-05 at 2 01 52 PM" src="https://user-images.githubusercontent.com/4276638/230170075-636f9be3-cbd2-40e8-815a-d78252a4befd.png">


## Related Issue(s)

Fixes #12842.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
