### PR TITLE
[vtadmin] log response errors

### DIFF
--- a/go/vt/vtadmin/http/response.go
+++ b/go/vt/vtadmin/http/response.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtadmin/errors"
 )
 
@@ -44,6 +45,8 @@ type errorBody struct {
 // 500 unknown.
 func NewJSONResponse(value any, err error) *JSONResponse {
 	if err != nil {
+		log.Errorf(err.Error())
+
 		switch e := err.(type) {
 		case errors.TypedError:
 			return typedErrorJSONResponse(e)


### PR DESCRIPTION
## Description

This installs middleware ("ish" in the case of the http side) layers to both the HTTP and gRPC APIs for vtadmin to ensure that any methods that ultimately return an error log that error at the ERROR level to facilitate better debugging

### Testing

After creating a bogus shard as described in #12842, trying to load the keyspace page now shows in the logs as:

```
E0405 14:32:48.115084   20808 response.go:48] FindAllShardsInKeyspace(cluster = local, keyspace = commerce) failed: rpc error: code = Unknown desc = uncaught panic: runtime error: invalid memory address or nil pointer dereference
E0405 14:32:49.139644   20808 response.go:48] FindAllShardsInKeyspace(cluster = local, keyspace = commerce) failed: rpc error: code = Unknown desc = uncaught panic: runtime error: invalid memory address or nil pointer dereference
E0405 14:32:50.023643   20808 response.go:48] FindAllShardsInKeyspace(cluster = local, keyspace = commerce) failed: rpc error: code = Unknown desc = uncaught panic: runtime error: invalid memory address or nil pointer dereference
```

## Related Issue(s)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
