### PR TITLE
[release-15.0] Add timeout to golangci-lint and bump its version (#12852)

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Install golangci-lint
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 
       - name: Clean Env
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
@@ -170,7 +170,7 @@ jobs:
 
       - name: Run golangci-lint
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
-        run: $(go env GOPATH)/bin/golangci-lint run go/... || exit 1
+        run: $(go env GOPATH)/bin/golangci-lint run go/... --timeout 10m || exit 1
 
       - name: Run go mod tidy
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -158,4 +158,4 @@ issues:
 
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.50.1 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.52.2 # use the fixed version to not introduce new linters unexpectedly


### PR DESCRIPTION
## Description

This is a backport of #12852.