### PR TITLE
Add panic recovery handler to vtadmin http middleware

### DIFF
--- a/go/vt/vtadmin/http/handlers/panic_recovery.go
+++ b/go/vt/vtadmin/http/handlers/panic_recovery.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"vitess.io/vitess/go/vt/log"
+)
+
+// PanicRecoveryHandler is a mux.MiddlewareFunc which recovers from any uncaught
+// `panic`s further down the middleware chain.
+//
+// If it recovers from a panic, it returns a 500 to the caller, and logs the
+// route name along with the panicking error.
+// name, as set by (mux.*Route).Name(), embeds it in the request context, and invokes
+// the next middleware in the chain.
+func PanicRecoveryHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := mux.CurrentRoute(r).GetName()
+		defer func() {
+			if err := recover(); err != nil {
+				log.Errorf("uncaught panic in %s: %s", name, err)
+				http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)
+			}
+		}()
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/go/vt/vtadmin/http/handlers/panic_recovery_test.go
+++ b/go/vt/vtadmin/http/handlers/panic_recovery_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPanicRecoveryHandler(t *testing.T) {
+	m := mux.NewRouter()
+	m.HandleFunc("/panic", func(w http.ResponseWriter, r *http.Request) { panic("test") })
+	m.HandleFunc("/nopanic", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok\n"))
+	})
+
+	m.Use(PanicRecoveryHandler)
+	serv := httptest.NewServer(m)
+	defer serv.Close()
+
+	cases := []struct {
+		route   string
+		code    int
+		message string
+	}{
+		{
+			route:   "/panic",
+			code:    http.StatusInternalServerError,
+			message: "test\n",
+		},
+		{
+			route:   "/nopanic",
+			code:    http.StatusOK,
+			message: "ok\n",
+		},
+	}
+
+	for _, tcase := range cases {
+		tcase := tcase
+		t.Run(tcase.route, func(t *testing.T) {
+			rec := httptest.ResponseRecorder{
+				Body: bytes.NewBuffer(nil),
+			}
+
+			m.ServeHTTP(&rec, httptest.NewRequest("GET", tcase.route, nil))
+			assert.Equal(t, tcase.code, rec.Code)
+			assert.Equal(t, tcase.message, rec.Body.String())
+		})
+	}
+}


### PR DESCRIPTION
## Description

What it says on the tin.

## Related Issue(s)

Closes #12863 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
