### PR TITLE
Update fossa check for Node deprecation

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run FOSSA scan and upload build data
         if: steps.skip-workflow.outputs.skip-workflow == 'false'
-        uses: fossa-contrib/fossa-action@v1
+        uses: fossa-contrib/fossa-action@v2
         with:
           fossa-api-key: 76d7483ea206d530d9452e44bffe7ba8
 


### PR DESCRIPTION
This ensures we run it on Node 16, fixing the current deprecation message it shows.

## Related Issue(s)

See for example the output at https://github.com/vitessio/vitess/actions/runs/4664825536

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required