### PR TITLE
tools/build_version_flags: allow configurable `build time`

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -29,6 +29,9 @@ ARG BUILD_GIT_BRANCH
 # Allows docker builds to set the BUILD_GIT_REV
 ARG BUILD_GIT_REV
 
+# Allows docker builds to set the BUILD_TIME
+ARG BUILD_TIME
+
 # Re-copy sources from working tree
 COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
 

--- a/docker/base/Dockerfile.mysql57
+++ b/docker/base/Dockerfile.mysql57
@@ -29,6 +29,9 @@ ARG BUILD_GIT_BRANCH
 # Allows docker builds to set the BUILD_GIT_REV
 ARG BUILD_GIT_REV
 
+# Allows docker builds to set the BUILD_TIME
+ARG BUILD_TIME
+
 # Re-copy sources from working tree
 COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
 

--- a/docker/base/Dockerfile.percona57
+++ b/docker/base/Dockerfile.percona57
@@ -29,6 +29,9 @@ ARG BUILD_GIT_BRANCH
 # Allows docker builds to set the BUILD_GIT_REV
 ARG BUILD_GIT_REV
 
+# Allows docker builds to set the BUILD_TIME
+ARG BUILD_TIME
+
 # Re-copy sources from working tree
 COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
 

--- a/docker/base/Dockerfile.percona80
+++ b/docker/base/Dockerfile.percona80
@@ -29,6 +29,9 @@ ARG BUILD_GIT_BRANCH
 # Allows docker builds to set the BUILD_GIT_REV
 ARG BUILD_GIT_REV
 
+# Allows docker builds to set the BUILD_TIME
+ARG BUILD_TIME
+
 # Re-copy sources from working tree
 COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
 

--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -23,12 +23,13 @@ source $DIR/shell_functions.inc
 # this information instead.
 DEFAULT_BUILD_GIT_REV=$(git rev-parse HEAD)
 DEFAULT_BUILD_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+DEFAULT_BUILD_TIME=$(LC_ALL=C date)
 
 echo "\
   -X 'vitess.io/vitess/go/vt/servenv.buildHost=$(hostname)' \
   -X 'vitess.io/vitess/go/vt/servenv.buildUser=$(whoami)' \
   -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=${BUILD_GIT_REV:-$DEFAULT_BUILD_GIT_REV}' \
   -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=${BUILD_GIT_BRANCH:-$DEFAULT_BUILD_GIT_BRANCH}' \
-  -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(LC_ALL=C date)' \
+  -X 'vitess.io/vitess/go/vt/servenv.buildTime=${BUILD_TIME:-$DEFAULT_BUILD_TIME}' \
   -X 'vitess.io/vitess/go/vt/servenv.jenkinsBuildNumberStr=${BUILD_NUMBER}' \
 "


### PR DESCRIPTION
This PR allows us to configure the build time via Docker build-args. By
default nothing changes, but it'll allow us to pass down the
build-time from a CI environment. It's useful for cases when you want to
store the same build time of a binary also in a different environment
for logging purposes.

Signed-off-by: Fatih Arslan <fatih@planetscale.com>
