### PR TITLE
planner fix: scoping rules for JOIN ON expression inside a subquery

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -7935,7 +7935,7 @@
     }
   },
   {
-    "comment": "Add your test case here for debugging and run go test -run=One.",
+    "comment": "subquery having join table on clause, using column reference of outer select table",
     "query": "select (select 1 from user u1 join user u2 on u1.id = u2.id and u1.id = u3.id) subquery from user u3 where u3.id = 1",
     "v3-plan": "VT03019: column u3.id not found",
     "gen4-plan": {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -7933,5 +7933,32 @@
         "main.unsharded_a"
       ]
     }
+  },
+  {
+    "comment": "Add your test case here for debugging and run go test -run=One.",
+    "query": "select (select 1 from user u1 join user u2 on u1.id = u2.id and u1.id = u3.id) subquery from user u3 where u3.id = 1",
+    "v3-plan": "VT03019: column u3.id not found",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select (select 1 from user u1 join user u2 on u1.id = u2.id and u1.id = u3.id) subquery from user u3 where u3.id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select (select 1 from `user` as u1 join `user` as u2 on u1.id = u2.id and u1.id = u3.id where 1 != 1) as subquery from `user` as u3 where 1 != 1",
+        "Query": "select (select 1 from `user` as u1 join `user` as u2 on u1.id = u2.id and u1.id = u3.id) as subquery from `user` as u3 where u3.id = 1",
+        "Table": "`user`",
+        "Values": [
+          "INT64(1)"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -1494,6 +1494,25 @@ func TestUpdateErrors(t *testing.T) {
 	}
 }
 
+func TestScopingSubQueryJoinClause(t *testing.T) {
+	query := "select (select 1 from u1 join u2 on u1.id = u2.id and u2.id = u3.id) x from u3"
+
+	parse, err := sqlparser.Parse(query)
+	require.NoError(t, err)
+
+	st, err := Analyze(parse, "user", &FakeSI{
+		Tables: map[string]*vindexes.Table{
+			"t": {Name: sqlparser.NewIdentifierCS("t")},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, st.NotUnshardedErr)
+
+	tb := st.DirectDeps(parse.(*sqlparser.Select).SelectExprs[0].(*sqlparser.AliasedExpr).Expr.(*sqlparser.Subquery).Select.(*sqlparser.Select).From[0].(*sqlparser.JoinTableExpr).Condition.On)
+	require.Equal(t, 3, tb.NumberOfTables())
+
+}
+
 var ks1 = &vindexes.Keyspace{
 	Name:    "ks1",
 	Sharded: false,

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -1494,6 +1494,9 @@ func TestUpdateErrors(t *testing.T) {
 	}
 }
 
+// TestScopingSubQueryJoinClause tests the scoping behavior of a subquery containing a join clause.
+// The test ensures that the scoping analysis correctly identifies and handles the relationships
+// between the tables involved in the join operation with the outer query.
 func TestScopingSubQueryJoinClause(t *testing.T) {
 	query := "select (select 1 from u1 join u2 on u1.id = u2.id and u2.id = u3.id) x from u3"
 

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -180,6 +180,9 @@ func TestExpandStar(t *testing.T) {
 			require.True(t, isSelectStatement, "analyzer expects a select statement")
 			st, err := Analyze(selectStatement, cDB, schemaInfo)
 			if tcase.expErr == "" {
+				require.NoError(t, err)
+				require.NoError(t, st.NotUnshardedErr)
+				require.NoError(t, st.NotSingleRouteErr)
 				found := 0
 			outer:
 				for _, selExpr := range selectStatement.SelectExprs {
@@ -204,9 +207,6 @@ func TestExpandStar(t *testing.T) {
 				} else {
 					require.Equal(t, tcase.colExpandedNumber, found)
 				}
-				require.NoError(t, err)
-				require.NoError(t, st.NotUnshardedErr)
-				require.NoError(t, st.NotSingleRouteErr)
 				assert.Equal(t, tcase.expSQL, sqlparser.String(selectStatement))
 			} else {
 				require.EqualError(t, err, tcase.expErr)

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -45,6 +45,7 @@ type (
 		tables    []TableInfo
 		isUnion   bool
 		joinUsing map[string]TableSet
+		stmtScope bool
 	}
 )
 
@@ -61,11 +62,13 @@ func (s *scoper) down(cursor *sqlparser.Cursor) error {
 	switch node := node.(type) {
 	case *sqlparser.Update, *sqlparser.Delete:
 		currScope := newScope(s.currentScope())
+		currScope.stmtScope = true
 		s.push(currScope)
 
 		currScope.stmt = node.(sqlparser.Statement)
 	case *sqlparser.Select:
 		currScope := newScope(s.currentScope())
+		currScope.stmtScope = true
 		s.push(currScope)
 
 		// Needed for order by with Literal to find the Expression.
@@ -76,14 +79,10 @@ func (s *scoper) down(cursor *sqlparser.Cursor) error {
 	case sqlparser.TableExpr:
 		if isParentSelect(cursor) {
 			// when checking the expressions used in JOIN conditions, special rules apply where the ON expression
-			// can only see the two tables involved in the JOIN, and no other tables.
-			// To create this special context, we create a special scope here that is then merged with
-			// the surrounding scope when we come back out from the JOIN
-			var parenScope *scope
-			if len(s.scopes) >= 2 {
-				parenScope = s.scopes[len(s.scopes)-2]
-			}
-			nScope := newScope(parenScope)
+			// can only see the two tables involved in the JOIN, and no other tables of that select statement.
+			// They are allowed to see the tables of the outer select query.
+			// To create this special context, we will find the parent scope of the select statement involved.
+			nScope := newScope(s.currentScope().findParentScopeOfStatement())
 			nScope.stmt = cursor.Parent().(*sqlparser.Select)
 			s.push(nScope)
 		}
@@ -291,4 +290,15 @@ func (s *scope) prepareUsingMap() (result map[TableSet]map[string]TableSet) {
 		}
 	}
 	return
+}
+
+// findParentScopeOfStatement finds the scope that belongs to a statement.
+func (s *scope) findParentScopeOfStatement() *scope {
+	if s.stmtScope {
+		return s.parent
+	}
+	if s.parent == nil {
+		return nil
+	}
+	return s.parent.findParentScopeOfStatement()
 }

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -79,7 +79,11 @@ func (s *scoper) down(cursor *sqlparser.Cursor) error {
 			// can only see the two tables involved in the JOIN, and no other tables.
 			// To create this special context, we create a special scope here that is then merged with
 			// the surrounding scope when we come back out from the JOIN
-			nScope := newScope(nil)
+			var parenScope *scope
+			if len(s.scopes) >= 2 {
+				parenScope = s.scopes[len(s.scopes)-2]
+			}
+			nScope := newScope(parenScope)
 			nScope.stmt = cursor.Parent().(*sqlparser.Select)
 			s.push(nScope)
 		}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR updates the scoping rules for expressions involved in join table ON clauses, allowing them to use the scope of the SELECT statement's parent scope.

In MySQL 5.7, this scoping rule is not supported. However, MySQL 8.0 and later versions do support this functionality.

For example, consider the following query:

```sql
SELECT 1, (SELECT foo FROM t1 JOIN t2 ON t1.col = t2.col AND t1.id = t3.id) subquery FROM t3;
```

With the updated scoping rules, the join condition between t1 and t2 can now reference columns from t3, essentially allowing access to all columns available from the outer query.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
