### PR TITLE
datetime: Add week number formatting

### DIFF
--- a/go/mysql/datetime/format_test.go
+++ b/go/mysql/datetime/format_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestFormattingFromMySQL(t *testing.T) {
-	const FormatString = `%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r %S %s %T %W %w %Y %y %%`
+	const FormatString = `%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r %S %s %T %U %u %V %v %W %w %X %x %Y %y %%`
 
 	var cases = []struct {
 		timestamp string
@@ -31,11 +31,15 @@ func TestFormattingFromMySQL(t *testing.T) {
 	}{
 		{
 			`1999-12-31 23:59:58.999`,
-			`Fri Dec 12 31st 31 31 999000 23 11 11 59 365 23 11 December 12 PM 11:59:58 PM 58 58 23:59:58 Friday 5 1999 99 %`,
+			`Fri Dec 12 31st 31 31 999000 23 11 11 59 365 23 11 December 12 PM 11:59:58 PM 58 58 23:59:58 52 52 52 52 Friday 5 1999 1999 1999 99 %`,
 		},
 		{
 			`2000-01-02 03:04:05`,
-			`Sun Jan 1 2nd 02 2 000000 03 03 03 04 002 3 3 January 01 AM 03:04:05 AM 05 05 03:04:05 Sunday 0 2000 00 %`,
+			`Sun Jan 1 2nd 02 2 000000 03 03 03 04 002 3 3 January 01 AM 03:04:05 AM 05 05 03:04:05 01 00 01 52 Sunday 0 2000 1999 2000 00 %`,
+		},
+		{
+			`2001-01-01 01:04:05`,
+			`Mon Jan 1 1st 01 1 000000 01 01 01 04 001 1 1 January 01 AM 01:04:05 AM 05 05 01:04:05 00 01 53 01 Monday 1 2000 2001 2001 01 %`,
 		},
 	}
 
@@ -49,21 +53,5 @@ func TestFormattingFromMySQL(t *testing.T) {
 
 			require.Equal(t, tc.output, string(eval))
 		})
-	}
-}
-
-func TestUnsupportedFormatting(t *testing.T) {
-	var Unsupported = []string{
-		"%U",
-		"%u",
-		"%V",
-		"%v",
-		"%X",
-		"%x",
-	}
-
-	for _, fmt := range Unsupported {
-		_, err := Format(fmt, DateTime{}, 6)
-		require.Error(t, err)
 	}
 }

--- a/go/mysql/datetime/formats.go
+++ b/go/mysql/datetime/formats.go
@@ -38,14 +38,14 @@ var DefaultMySQLStrftime = map[byte]Spec{
 	'S': fmtSecond{true, false},
 	's': fmtSecond{true, false},
 	'T': fmtFullTime24{},
-	'U': nil, // fmtWeek0{}, // TODO
-	'u': nil, // fmtWeek1{}, // TODO
-	'V': nil, // fmtWeek2{}, // TODO
-	'v': nil, // fmtWeek3{}, // TODO
+	'U': fmtWeek0{},
+	'u': fmtWeek1{},
+	'V': fmtWeek2{},
+	'v': fmtWeek3{},
 	'W': fmtWeekdayName{},
 	'w': fmtWeekday{},
-	'X': nil, // fmtYearForWeek2{}, // TODO
-	'x': nil, // fmtYearForWeek3{}, // TODO
+	'X': fmtYearForWeek2{},
+	'x': fmtYearForWeek3{},
 	'Y': fmtYearLong{},
 	'y': fmtYearShort{},
 }

--- a/go/mysql/datetime/spec.go
+++ b/go/mysql/datetime/spec.go
@@ -355,7 +355,11 @@ func (t2 fmtFullTime24) parse(t *timeparts, bytes string) (string, bool) {
 type fmtWeek0 struct{}
 
 func (fmtWeek0) format(dst []byte, t DateTime, prec uint8) []byte {
-	panic("TODO")
+	year, week := t.Date.SundayWeek()
+	if year < t.Date.Year() {
+		week = 0
+	}
+	return appendInt(dst, week, 2)
 }
 
 func (u fmtWeek0) parse(t *timeparts, bytes string) (string, bool) {
@@ -366,7 +370,11 @@ func (u fmtWeek0) parse(t *timeparts, bytes string) (string, bool) {
 type fmtWeek1 struct{}
 
 func (fmtWeek1) format(dst []byte, t DateTime, prec uint8) []byte {
-	panic("TODO")
+	year, week := t.Date.ISOWeek()
+	if year < t.Date.Year() {
+		week = 0
+	}
+	return appendInt(dst, week, 2)
 }
 
 func (u fmtWeek1) parse(t *timeparts, bytes string) (string, bool) {
@@ -377,7 +385,8 @@ func (u fmtWeek1) parse(t *timeparts, bytes string) (string, bool) {
 type fmtWeek2 struct{}
 
 func (fmtWeek2) format(dst []byte, t DateTime, prec uint8) []byte {
-	panic("TODO")
+	_, week := t.Date.SundayWeek()
+	return appendInt(dst, week, 2)
 }
 
 func (v fmtWeek2) parse(t *timeparts, bytes string) (string, bool) {
@@ -388,8 +397,8 @@ func (v fmtWeek2) parse(t *timeparts, bytes string) (string, bool) {
 type fmtWeek3 struct{}
 
 func (fmtWeek3) format(dst []byte, t DateTime, prec uint8) []byte {
-	//TODO implement me
-	panic("implement me")
+	_, week := t.Date.ISOWeek()
+	return appendInt(dst, week, 2)
 }
 
 func (v fmtWeek3) parse(t *timeparts, bytes string) (string, bool) {
@@ -420,7 +429,8 @@ func (w fmtWeekday) parse(t *timeparts, bytes string) (string, bool) {
 type fmtYearForWeek2 struct{}
 
 func (fmtYearForWeek2) format(dst []byte, t DateTime, prec uint8) []byte {
-	panic("TODO")
+	year, _ := t.Date.SundayWeek()
+	return appendInt(dst, year, 4)
 }
 func (x fmtYearForWeek2) parse(t *timeparts, bytes string) (string, bool) {
 	//TODO implement me
@@ -430,8 +440,8 @@ func (x fmtYearForWeek2) parse(t *timeparts, bytes string) (string, bool) {
 type fmtYearForWeek3 struct{}
 
 func (fmtYearForWeek3) format(dst []byte, t DateTime, prec uint8) []byte {
-	//TODO implement me
-	panic("implement me")
+	year, _ := t.Date.ISOWeek()
+	return appendInt(dst, year, 4)
 }
 func (x fmtYearForWeek3) parse(t *timeparts, bytes string) (string, bool) {
 	//TODO implement me

--- a/go/mysql/datetime/types.go
+++ b/go/mysql/datetime/types.go
@@ -197,7 +197,19 @@ func (dt Date) Yearday() int {
 }
 
 func (d Date) ISOWeek() (int, int) {
-	return 0, 0
+	return d.ToStdTime(time.Local).ISOWeek()
+}
+
+// SundayWeek returns the year and week number of the current
+// date, when week numbers are defined by starting on the first
+// Sunday of the year.
+func (d Date) SundayWeek() (int, int) {
+	t := d.ToStdTime(time.Local)
+	// Since the week numbers always start on a Sunday, we can look
+	// at the week number of Sunday itself. So we shift back to last
+	// Sunday we saw and compute the week number based on that.
+	sun := t.Add(-time.Duration(t.Weekday()) * 24 * time.Hour)
+	return sun.Year(), (sun.YearDay()-1)/7 + 1
 }
 
 func (dt DateTime) IsZero() bool {

--- a/go/vt/vtgate/evalengine/mysql_test.go
+++ b/go/vt/vtgate/evalengine/mysql_test.go
@@ -136,6 +136,6 @@ func TestMySQLGolden(t *testing.T) {
 
 func TestDebug1(t *testing.T) {
 	// Debug
-	eval, err := testSingle(t, `SELECT DATE_FORMAT(TIMESTAMP '1999-12-31 23:59:58.999', "%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r %S %s %T %W %w %Y %y %% ")`)
+	eval, err := testSingle(t, `SELECT DATE_FORMAT(TIMESTAMP '1999-12-31 23:59:58.999', "%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r %S %s %T %U %u %V %v %W %w %X %x %Y %y %%")`)
 	t.Logf("eval=%s err=%v coll=%s", eval.String(), err, eval.Collation().Get().Name())
 }


### PR DESCRIPTION
One of the things we punted on in #12815 was formatting week numbers. This adds support for those formats as well.

## Related Issue(s)

Follow-up to #12815

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required