### PR TITLE
evalengine: unset Type for NewColumnWithCollation

### DIFF
--- a/go/vt/vtgate/evalengine/api_literal.go
+++ b/go/vt/vtgate/evalengine/api_literal.go
@@ -222,7 +222,7 @@ func NewColumn(offset int) *Column {
 }
 
 func NewColumnWithCollation(offset int, coll collations.TypedCollation) *Column {
-	return &Column{Offset: offset, Collation: coll}
+	return &Column{Offset: offset, Type: -1, Collation: coll}
 }
 
 // NewTupleExpr returns a tuple expression


### PR DESCRIPTION
## Description

This is a small fix that makes the creation of `Column` entities in the evalengine consistent. The `Type` of the column must be initialized to -1 to mark it as "unset", because the zero value for `Type` is actually `sqltypes.Null`, which is a valid type for a column to have.

cc @dbussink 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
