### PR TITLE
evalengine: Add CONVERT_TZ function

### DIFF
--- a/go/mysql/datetime/spec.go
+++ b/go/mysql/datetime/spec.go
@@ -114,12 +114,14 @@ func (fmtMonthDaySuffix) format(dst []byte, t DateTime, prec uint8) []byte {
 	d := t.Date.Day()
 	dst = appendInt(dst, d, 0)
 
-	switch d % 10 {
-	case 1:
+	switch {
+	case d >= 11 && d < 20:
+		return append(dst, "th"...)
+	case d%10 == 1:
 		return append(dst, "st"...)
-	case 2:
+	case d%10 == 2:
 		return append(dst, "nd"...)
-	case 3:
+	case d%10 == 3:
 		return append(dst, "rd"...)
 	default:
 		return append(dst, "th"...)

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -513,6 +513,18 @@ func (cached *builtinConv) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinConvertTz) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinCos) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/eval_temporal.go
+++ b/go/vt/vtgate/evalengine/eval_temporal.go
@@ -224,11 +224,32 @@ func evalToDateTime(e eval) *evalTemporal {
 		if d, _ := datetime.ParseDate(e.string()); !d.IsZero() {
 			return newEvalDateTime(datetime.DateTime{Date: d})
 		}
-	case evalNumeric:
-		if t, ok := datetime.ParseDateTimeInt64(e.toInt64().i); ok {
+	case *evalInt64:
+		if t, ok := datetime.ParseDateTimeInt64(e.i); ok {
 			return newEvalDateTime(t)
 		}
-		if d, ok := datetime.ParseDateInt64(e.toInt64().i); ok {
+		if d, ok := datetime.ParseDateInt64(e.i); ok {
+			return newEvalDateTime(datetime.DateTime{Date: d})
+		}
+	case *evalUint64:
+		if t, ok := datetime.ParseDateTimeInt64(int64(e.u)); ok {
+			return newEvalDateTime(t)
+		}
+		if d, ok := datetime.ParseDateInt64(int64(e.u)); ok {
+			return newEvalDateTime(datetime.DateTime{Date: d})
+		}
+	case *evalFloat:
+		if t, ok := datetime.ParseDateTimeFloat(e.f); ok {
+			return newEvalDateTime(t)
+		}
+		if d, ok := datetime.ParseDateFloat(e.f); ok {
+			return newEvalDateTime(datetime.DateTime{Date: d})
+		}
+	case *evalDecimal:
+		if t, ok := datetime.ParseDateTimeDecimal(e.dec); ok {
+			return newEvalDateTime(t)
+		}
+		if d, ok := datetime.ParseDateDecimal(e.dec); ok {
 			return newEvalDateTime(datetime.DateTime{Date: d})
 		}
 	case *evalJSON:

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -101,6 +101,7 @@ var Cases = []TestCase{
 	{Run: FnSHA2},
 	{Run: FnRandomBytes},
 	{Run: FnDateFormat},
+	{Run: FnConvertTz},
 }
 
 func JSONPathOperations(yield Query) {
@@ -1299,11 +1300,6 @@ func FnDateFormat(yield Query) {
 		{'%', ""},
 	}
 
-	dates := []string{
-		`TIMESTAMP '1999-12-31 23:59:58.999'`,
-		`TIMESTAMP '2000-01-02 03:04:05'`,
-	}
-
 	var buf strings.Builder
 	for _, f := range formats {
 		buf.WriteByte('%')
@@ -1312,7 +1308,35 @@ func FnDateFormat(yield Query) {
 	}
 	format := buf.String()
 
-	for _, d := range dates {
+	for _, d := range inputConversions {
 		yield(fmt.Sprintf("DATE_FORMAT(%s, %q)", d, format), nil)
+	}
+}
+
+func FnConvertTz(yield Query) {
+	timezoneInputs := []string{
+		"UTC",
+		"GMT",
+		"America/New_York",
+		"America/Los_Angeles",
+		"Europe/London",
+		"Europe/Amsterdam",
+		"+00:00",
+		"-00:00",
+		"+01:00",
+		"-01:00",
+		"+02:00",
+		"-02:00",
+		"+14:00",
+		"-13:00",
+		"bogus",
+	}
+	for _, num1 := range inputConversions {
+		for _, tzFrom := range timezoneInputs {
+			for _, tzTo := range timezoneInputs {
+				q := fmt.Sprintf("CONVERT_TZ(%s, '%s', '%s')", num1, tzFrom, tzTo)
+				yield(q, nil)
+			}
+		}
 	}
 }

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -172,5 +172,5 @@ var inputConversionTypes = []string{
 	"DECIMAL", "DECIMAL(0, 4)", "DECIMAL(12, 0)", "DECIMAL(12, 4)", "DECIMAL(60)",
 	"DOUBLE", "REAL",
 	"SIGNED", "UNSIGNED", "SIGNED INTEGER", "UNSIGNED INTEGER", "JSON",
-	"DATE", "DATETIME", "TIME",
+	"DATE", "DATETIME", "TIME", "DATETIME(6)", "TIME(6)",
 }

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -355,6 +355,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (Expr, error) 
 			return nil, argError(method)
 		}
 		return &builtinSHA2{CallExpr: call, collate: ast.cfg.Collation}, nil
+	case "convert_tz":
+		if len(args) != 3 {
+			return nil, argError(method)
+		}
+		return &builtinConvertTz{CallExpr: call}, nil
 	default:
 		return nil, translateExprNotSupported(fn)
 	}


### PR DESCRIPTION
This adds the CONVERT_TZ function to convert between different timezones. It assumes that the timezone tables are loaded in MySQL as well and always has these functions working.

It also fixes a number of issues found in the DATE_FORMAT logic where it would for example panic on invalid timestamps. We also need to be able to parse the fractional part of decimals or floats for timestamp conversions.

## Related Issue(s)

Follow up https://github.com/vitessio/vitess/pull/12815 and part of #9647 

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required