### PR TITLE
refactor: clean up and simplify the semantics package

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -1008,12 +1008,12 @@ func (node *Select) GetColumns() SelectExprs {
 	return node.SelectExprs
 }
 
-// SetComments implements the SelectStatement interface
+// SetComments implements the Commented interface
 func (node *Select) SetComments(comments Comments) {
 	node.Comments = comments.Parsed()
 }
 
-// GetComments implements the SelectStatement interface
+// GetParsedComments implements the Commented interface
 func (node *Select) GetParsedComments() *ParsedComments {
 	return node.Comments
 }

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -18,10 +18,8 @@ package semantics
 
 import (
 	"vitess.io/vitess/go/mysql/collations"
-	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
-
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 // analyzer controls the flow of the analysis.
@@ -109,7 +107,6 @@ func (a *analyzer) newSemTable(statement sqlparser.Statement, coll collations.ID
 		Direct:            a.binder.direct,
 		ExprTypes:         a.typer.exprTypes,
 		Tables:            a.tables.Tables,
-		selectScope:       a.scoper.rScope,
 		NotSingleRouteErr: a.projErr,
 		NotUnshardedErr:   a.unshardedErr,
 		Warning:           a.warning,
@@ -118,7 +115,6 @@ func (a *analyzer) newSemTable(statement sqlparser.Statement, coll collations.ID
 		SubqueryRef:       a.binder.subqueryRef,
 		ColumnEqualities:  map[columnName][]sqlparser.Expr{},
 		Collation:         coll,
-		ExpandedColumns:   a.rewriter.expandedColumns,
 	}
 }
 
@@ -270,95 +266,6 @@ func (a *analyzer) depsForExpr(expr sqlparser.Expr) (direct, recursive TableSet,
 func (a *analyzer) analyze(statement sqlparser.Statement) error {
 	_ = sqlparser.Rewrite(statement, a.analyzeDown, a.analyzeUp)
 	return a.err
-}
-
-func (a *analyzer) checkForInvalidConstructs(cursor *sqlparser.Cursor) error {
-	switch node := cursor.Node().(type) {
-	case *sqlparser.Update:
-		if len(node.TableExprs) != 1 {
-			return ShardedError{Inner: &UnsupportedMultiTablesInUpdateError{ExprCount: len(node.TableExprs)}}
-		}
-		alias, isAlias := node.TableExprs[0].(*sqlparser.AliasedTableExpr)
-		if !isAlias {
-			return ShardedError{Inner: &UnsupportedMultiTablesInUpdateError{NotAlias: true}}
-		}
-		_, isDerived := alias.Expr.(*sqlparser.DerivedTable)
-		if isDerived {
-			return &TableNotUpdatableError{Table: alias.As.String()}
-		}
-	case *sqlparser.Select:
-		parent := cursor.Parent()
-		if _, isUnion := parent.(*sqlparser.Union); isUnion && node.SQLCalcFoundRows {
-			return &UnionWithSQLCalcFoundRowsError{}
-		}
-		if _, isRoot := parent.(*sqlparser.RootNode); !isRoot && node.SQLCalcFoundRows {
-			return &SQLCalcFoundRowsUsageError{}
-		}
-		errMsg := "INTO"
-		nextVal := false
-		if len(node.SelectExprs) == 1 {
-			if _, isNextVal := node.SelectExprs[0].(*sqlparser.Nextval); isNextVal {
-				nextVal = true
-				errMsg = "NEXT"
-			}
-		}
-		if !nextVal && node.Into == nil {
-			return nil
-		}
-		if a.scoper.currentScope().parent != nil {
-			return &CantUseOptionHereError{Msg: errMsg}
-		}
-	case *sqlparser.Nextval:
-		currScope := a.scoper.currentScope()
-		if currScope.parent != nil {
-			// This is defensively checking that we are not inside a subquery or derived table
-			// Will probably already have been checked on the SELECT level
-			return &CantUseOptionHereError{Msg: "INTO"}
-		}
-		if len(currScope.tables) != 1 {
-			// This is defensively checking that we don't have too many tables.
-			// Hard to check this with unit tests, since the parser does not accept these queries
-			return &NextWithMultipleTablesError{CountTables: len(currScope.tables)}
-		}
-		vindexTbl := currScope.tables[0].GetVindexTable()
-		if vindexTbl == nil {
-			return &MissingInVSchemaError{
-				Table: currScope.tables[0],
-			}
-		}
-		if vindexTbl.Type != vindexes.TypeSequence {
-			return &NotSequenceTableError{Table: vindexTbl.Name.String()}
-		}
-	case *sqlparser.JoinTableExpr:
-		if node.Join == sqlparser.NaturalJoinType || node.Join == sqlparser.NaturalRightJoinType || node.Join == sqlparser.NaturalLeftJoinType {
-			return &UnsupportedNaturalJoinError{JoinExpr: node}
-		}
-	case *sqlparser.LockingFunc:
-		return &LockOnlyWithDualError{Node: node}
-	case *sqlparser.Union:
-		err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-			switch node := node.(type) {
-			case *sqlparser.ColName:
-				if !node.Qualifier.IsEmpty() {
-					return false, &QualifiedOrderInUnionError{Table: node.Qualifier.Name.String()}
-				}
-			case *sqlparser.Subquery:
-				return false, nil
-			}
-			return true, nil
-		}, node.OrderBy)
-		if err != nil {
-			return err
-		}
-		err = checkUnionColumns(node)
-		if err != nil {
-			return err
-		}
-	case *sqlparser.JSONTableExpr:
-		return &JSONTablesError{}
-	}
-
-	return nil
 }
 
 func (a *analyzer) shouldContinue() bool {

--- a/go/vt/vtgate/semantics/check_invalid.go
+++ b/go/vt/vtgate/semantics/check_invalid.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package semantics
+
+import (
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+func (a *analyzer) checkForInvalidConstructs(cursor *sqlparser.Cursor) error {
+	switch node := cursor.Node().(type) {
+	case *sqlparser.Update:
+		return checkUpdate(node)
+	case *sqlparser.Select:
+		return a.checkSelect(cursor, node)
+	case *sqlparser.Nextval:
+		return a.checkNextVal()
+	case *sqlparser.JoinTableExpr:
+		return a.checkJoin(node)
+	case *sqlparser.LockingFunc:
+		return &LockOnlyWithDualError{Node: node}
+	case *sqlparser.Union:
+		return checkUnion(node)
+	case *sqlparser.JSONTableExpr:
+		return &JSONTablesError{}
+	}
+
+	return nil
+}
+
+func checkUnion(node *sqlparser.Union) error {
+	err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		switch node := node.(type) {
+		case *sqlparser.ColName:
+			if !node.Qualifier.IsEmpty() {
+				return false, &QualifiedOrderInUnionError{Table: node.Qualifier.Name.String()}
+			}
+		case *sqlparser.Subquery:
+			return false, nil
+		}
+		return true, nil
+	}, node.OrderBy)
+	if err != nil {
+		return err
+	}
+	err = checkUnionColumns(node)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *analyzer) checkJoin(j *sqlparser.JoinTableExpr) error {
+	if j.Join == sqlparser.NaturalJoinType || j.Join == sqlparser.NaturalRightJoinType || j.Join == sqlparser.NaturalLeftJoinType {
+		return &UnsupportedNaturalJoinError{JoinExpr: j}
+	}
+	return nil
+}
+func (a *analyzer) checkNextVal() error {
+	currScope := a.scoper.currentScope()
+	if currScope.parent != nil {
+		// This is defensively checking that we are not inside a subquery or derived table
+		// Will probably already have been checked on the SELECT level
+		return &CantUseOptionHereError{Msg: "INTO"}
+	}
+	if len(currScope.tables) != 1 {
+		// This is defensively checking that we don't have too many tables.
+		// Hard to check this with unit tests, since the parser does not accept these queries
+		return &NextWithMultipleTablesError{CountTables: len(currScope.tables)}
+	}
+	vindexTbl := currScope.tables[0].GetVindexTable()
+	if vindexTbl == nil {
+		return &MissingInVSchemaError{
+			Table: currScope.tables[0],
+		}
+	}
+	if vindexTbl.Type != vindexes.TypeSequence {
+		return &NotSequenceTableError{Table: vindexTbl.Name.String()}
+	}
+	return nil
+}
+
+func (a *analyzer) checkSelect(cursor *sqlparser.Cursor, node *sqlparser.Select) error {
+	parent := cursor.Parent()
+	if _, isUnion := parent.(*sqlparser.Union); isUnion && node.SQLCalcFoundRows {
+		return &UnionWithSQLCalcFoundRowsError{}
+	}
+	if _, isRoot := parent.(*sqlparser.RootNode); !isRoot && node.SQLCalcFoundRows {
+		return &SQLCalcFoundRowsUsageError{}
+	}
+	errMsg := "INTO"
+	nextVal := false
+	if len(node.SelectExprs) == 1 {
+		if _, isNextVal := node.SelectExprs[0].(*sqlparser.Nextval); isNextVal {
+			nextVal = true
+			errMsg = "NEXT"
+		}
+	}
+	if !nextVal && node.Into == nil {
+		return nil
+	}
+	if a.scoper.currentScope().parent != nil {
+		return &CantUseOptionHereError{Msg: errMsg}
+	}
+	return nil
+}
+
+func checkUpdate(node *sqlparser.Update) error {
+	if len(node.TableExprs) != 1 {
+		return ShardedError{Inner: &UnsupportedMultiTablesInUpdateError{ExprCount: len(node.TableExprs)}}
+	}
+	alias, isAlias := node.TableExprs[0].(*sqlparser.AliasedTableExpr)
+	if !isAlias {
+		return ShardedError{Inner: &UnsupportedMultiTablesInUpdateError{NotAlias: true}}
+	}
+	_, isDerived := alias.Expr.(*sqlparser.DerivedTable)
+	if isDerived {
+		return &TableNotUpdatableError{Table: alias.As.String()}
+	}
+	return nil
+}

--- a/go/vt/vtgate/semantics/check_invalid.go
+++ b/go/vt/vtgate/semantics/check_invalid.go
@@ -18,6 +18,7 @@ package semantics
 
 import (
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
@@ -37,8 +38,17 @@ func (a *analyzer) checkForInvalidConstructs(cursor *sqlparser.Cursor) error {
 		return checkUnion(node)
 	case *sqlparser.JSONTableExpr:
 		return &JSONTablesError{}
+	case *sqlparser.DerivedTable:
+		return checkDerived(node)
 	}
 
+	return nil
+}
+
+func checkDerived(node *sqlparser.DerivedTable) error {
+	if node.Lateral {
+		return vterrors.VT12001("lateral derived tables")
+	}
 	return nil
 }
 

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -183,30 +183,6 @@ func TestExpandStar(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, st.NotUnshardedErr)
 				require.NoError(t, st.NotSingleRouteErr)
-				found := 0
-			outer:
-				for _, selExpr := range selectStatement.SelectExprs {
-					aliasedExpr, isAliased := selExpr.(*sqlparser.AliasedExpr)
-					if !isAliased {
-						continue
-					}
-					for _, tbl := range st.ExpandedColumns {
-						for _, col := range tbl {
-							if sqlparser.Equals.Expr(aliasedExpr.Expr, col) {
-								found++
-								continue outer
-							}
-						}
-					}
-				}
-				if tcase.colExpandedNumber == 0 {
-					for _, tbl := range st.ExpandedColumns {
-						found -= len(tbl)
-					}
-					require.Zero(t, found)
-				} else {
-					require.Equal(t, tcase.colExpandedNumber, found)
-				}
 				assert.Equal(t, tcase.expSQL, sqlparser.String(selectStatement))
 			} else {
 				require.EqualError(t, err, tcase.expErr)

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -68,40 +68,45 @@ type (
 
 	// SemTable contains semantic analysis information about the query.
 	SemTable struct {
+		// Tables stores information about the tables in the query, including derived tables
 		Tables []TableInfo
+		// Comments stores any comments of the /* vt+ */ type in the query
+		Comments *sqlparser.ParsedComments
+		// Warning stores any warnings generated during semantic analysis.
+		Warning string
+		// Collation represents the default collation for the query, usually inherited
+		// from the connection's default collation.
+		Collation collations.ID
+		// ExprTypes maps expressions to their respective types in the query.
+		ExprTypes map[sqlparser.Expr]Type
 
-		// NotSingleRouteErr stores any errors that have to be generated if the query cannot be planned as a single route.
+		// NotSingleRouteErr stores errors related to missing schema information.
+		// This typically occurs when a column's existence is uncertain.
+		// Instead of failing early, the query is allowed to proceed, possibly
+		// succeeding once it reaches MySQL.
 		NotSingleRouteErr error
-		// NotUnshardedErr stores any errors that have to be generated if the query is not unsharded.
+
+		// NotUnshardedErr stores errors that occur if the query isn't planned as a single route
+		// targeting an unsharded keyspace. This typically arises when information is missing, but
+		// for unsharded tables, the code operates in a passthrough mode, relying on the underlying
+		// MySQL engine to handle errors appropriately.
 		NotUnshardedErr error
 
-		// Recursive contains the dependencies from the expression to the actual tables
-		// in the query (i.e. not including derived tables). If an expression is a column on a derived table,
-		// this map will contain the accumulated dependencies for the column expression inside the derived table
+		// Recursive contains dependencies from the expression to the actual tables
+		// in the query (excluding derived tables). For columns in derived tables,
+		// this map holds the accumulated dependencies for the column expression.
 		Recursive ExprDependencies
-
-		// Direct keeps information about the closest dependency for an expression.
-		// It does not recurse inside derived tables and the like to find the original dependencies
+		// Direct stores information about the closest dependency for an expression.
+		// It doesn't recurse inside derived tables to find the original dependencies.
 		Direct ExprDependencies
 
-		ExprTypes   map[sqlparser.Expr]Type
-		selectScope map[*sqlparser.Select]*scope
-		Comments    *sqlparser.ParsedComments
+		// SubqueryMap holds extracted subqueries for each statement.
 		SubqueryMap map[sqlparser.Statement][]*sqlparser.ExtractedSubquery
+		// SubqueryRef maps subquery pointers to their extracted subquery.
 		SubqueryRef map[*sqlparser.Subquery]*sqlparser.ExtractedSubquery
 
-		// ColumnEqualities is used to enable transitive closures
-		// if a == b and b == c then a == c
+		// ColumnEqualities is used for transitive closures (e.g., if a == b and b == c, then a == c).
 		ColumnEqualities map[columnName][]sqlparser.Expr
-
-		// DefaultCollation is the default collation for this query, which is usually
-		// inherited from the connection's default collation.
-		Collation collations.ID
-
-		Warning string
-
-		// ExpandedColumns is a map of all the added columns for a given table.
-		ExpandedColumns map[sqlparser.TableName][]*sqlparser.ColName
 
 		comparator *sqlparser.Comparator
 	}
@@ -129,7 +134,7 @@ func (st *SemTable) CopyDependencies(from, to sqlparser.Expr) {
 	st.Direct[to] = st.DirectDeps(from)
 }
 
-// CopyDependencies copies the dependencies from one expression into the other
+// Cloned copies the dependencies from one expression into the other
 func (st *SemTable) Cloned(from, to sqlparser.SQLNode) {
 	f, fromOK := from.(sqlparser.Expr)
 	t, toOK := to.(sqlparser.Expr)
@@ -224,12 +229,6 @@ func (st *SemTable) GetExprAndEqualities(expr sqlparser.Expr) []sqlparser.Expr {
 // Careful: this only works for expressions that have a single table dependency
 func (st *SemTable) TableInfoForExpr(expr sqlparser.Expr) (TableInfo, error) {
 	return st.TableInfoFor(st.Direct.dependencies(expr))
-}
-
-// GetSelectTables returns the table in the select.
-func (st *SemTable) GetSelectTables(node *sqlparser.Select) []TableInfo {
-	scope := st.selectScope[node]
-	return scope.tables
 }
 
 // AddExprs adds new select exprs to the SemTable.


### PR DESCRIPTION
## Description
Refactoring of the semantics package. I searched for methods with high cognitive complexity, and worked on them to simplify. In the process, I found dead code that could be removed.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
