### PR TITLE
remove tablet server's ACL check on the /healthz HTTP api route

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1725,10 +1725,6 @@ func (tsv *TabletServer) registerHealthzHealthHandler() {
 }
 
 func (tsv *TabletServer) healthzHandler(w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {
-		acl.SendError(w, err)
-		return
-	}
 	if (tsv.sm.wantState == StateServing || tsv.sm.wantState == StateNotConnected) && !tsv.sm.IsServing() {
 		http.Error(w, "500 internal server error: vttablet is not serving", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Description

This PR removes the ACL check on the tablet server's HTTP API `/healthz` endpoint. Currently if `security_policy` is set to something like `deny-all` the `/healthz` endpoint is restricted which interferes with the ability to use it as a liveness/readiness probe check in Kubernetes. The `/healthz` endpoint doesn't return any sensitive information as it returns either a 200 OK or 500 error if the tablet is unhealthy (i.e not serving or high replication lag). 

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/12896

- https://vitess.slack.com/archives/C0PQY0PTK/p1681400286098069

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

None
