### PR TITLE
skip dbddl plugin test

### DIFF
--- a/go/test/endtoend/vtgate/createdb_plugin/main_test.go
+++ b/go/test/endtoend/vtgate/createdb_plugin/main_test.go
@@ -81,6 +81,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestDBDDLPlugin(t *testing.T) {
+	t.Skip("this feature is not used and with recent changes to how vttablets starts, it is broken")
 	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	vtParams := mysql.ConnParams{

--- a/test/config.json
+++ b/test/config.json
@@ -837,15 +837,6 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
-		"vtgate_dbddlplugin": {
-			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/createdb_plugin"],
-			"Command": [],
-			"Manual": false,
-			"Shard": "vtgate_general_heavy",
-			"RetryMax": 1,
-			"Tags": []
-		},
 		"vtgate_gen4": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/gen4"],


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

The creation of database from vitess with a use of plugin was done as experimental. The recent changes to vttablet has let to consistent failure of this test. Marking this as skipped and removing from the CI run. We can revive it based on the interest.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [X] Tests were added or are not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
