### PR TITLE
[release-15.0] Remove recent golangci-lint version bump

### DIFF
--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Install golangci-lint
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
 
       - name: Clean Env
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.go_files == 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -158,4 +158,4 @@ issues:
 
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.52.2 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.46.2 # use the fixed version to not introduce new linters unexpectedly


### PR DESCRIPTION
## Description

This reverts the golangci-lint version upgrade that was done in #12853