### PR TITLE
evalengine: Implement additional week modes

### DIFF
--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -325,6 +325,18 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `CAST(-235959.995 AS TIME(2))`,
 			result:     `TIME("-24:00:00.00")`,
 		},
+		{
+			expression: `WEEK('2000-01-02', 6)`,
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `WEEK(date '2000-01-01', 4)`,
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `WEEK(date '2023-04-11', 6)`,
+			result:     `INT64(15)`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -1302,16 +1302,14 @@ func FnDateFormat(yield Query) {
 		{'S', "LPAD(SECOND(t),2,0)"},
 		{'s', "LPAD(SECOND(t),2,0)"},
 		{'T', ""},
-		// TODO
-		// {'U', "LPAD(WEEK(d,0),2,0)"},
-		// {'u', "LPAD(WEEK(d,1),2,0)"},
-		// {'V', "RIGHT(YEARWEEK(d,2),2)"},
-		// {'v', "RIGHT(YEARWEEK(d,3),2)"},
+		{'U', "LPAD(WEEK(d,0),2,0)"},
+		{'u', "LPAD(WEEK(d,1),2,0)"},
+		{'V', "RIGHT(YEARWEEK(d,2),2)"},
+		{'v', "RIGHT(YEARWEEK(d,3),2)"},
 		{'W', "DAYNAME(d)"},
 		{'w', "DAYOFWEEK(d)-1"},
-		// TODO
-		// {'X', "LEFT(YEARWEEK(d,2),4)"},
-		// {'x', "LEFT(YEARWEEK(d,3),4)"},
+		{'X', "LEFT(YEARWEEK(d,2),4)"},
+		{'x', "LEFT(YEARWEEK(d,3),4)"},
 		{'Y', "YEAR(d)"},
 		{'y', "RIGHT(YEAR(d),2)"},
 		{'%', ""},
@@ -1432,7 +1430,7 @@ func FnTime(yield Query) {
 }
 
 func FnWeek(yield Query) {
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 16; i++ {
 		for _, d := range inputConversions {
 			yield(fmt.Sprintf("WEEK(%s, %d)", d, i), nil)
 		}


### PR DESCRIPTION
In #12907 the focus was first on adding a lot of the new functions but we didn't add the additional week formats that `WEEK` supports but `DATE_FORMAT` doesn't.

This adds those week formats as well.

## Related Issue(s)

Follow up to #12907 and part of #9647

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required