### PR TITLE
topo: Move to allow list for invalid names

### DIFF
--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -79,7 +79,7 @@ Keyspace names are restricted to using only ASCII characters, digits and `_` and
 
 Prior to v17, it was possible to create a shard name with invalid characters, which would then be inaccessible to various cluster management operations.
 
-Shard names are restricted to using only ASCII characters, digits and `_` and `-`. TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given an invalid name.
+Shard names are restricted to using only ASCII characters, digits and `_` and `-`. TopoServer's `GetShard` and `CreateShard` methods return an error if given an invalid name.
 
 #### <a id="VtctldClient-RestoreFromBackup"> VtctldClient command RestoreFromBackup will now use the correct context
 

--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -73,13 +73,13 @@ Previously, VTAdmin web used the Create React App framework to test, build, and 
 
 Prior to v17, it was possible to create a keyspace with invalid characters, which would then be inaccessible to various cluster management operations.
 
-Keyspace names may no longer contain the forward slash ("/") character, and TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given such a name.
+Keyspace names are restricted to using only ASCII characters, digits and `_` and `-`. TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given an invalid name.
 
 #### <a id="shard-name-validation"> Shard name validation in TopoServer
 
 Prior to v17, it was possible to create a shard name with invalid characters, which would then be inaccessible to various cluster management operations.
 
-Shard names may no longer contain the forward slash ("/") character, and TopoServer's `CreateShard` method returns an error if given such a name.
+Shard names are restricted to using only ASCII characters, digits and `_` and `-`. TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given an invalid name.
 
 #### <a id="VtctldClient-RestoreFromBackup"> VtctldClient command RestoreFromBackup will now use the correct context
 

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -17,10 +17,8 @@ limitations under the License.
 package topo
 
 import (
-	"path"
-	"strings"
-
 	"context"
+	"path"
 
 	"vitess.io/vitess/go/vt/sidecardb"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -54,18 +52,10 @@ func (ki *KeyspaceInfo) SetKeyspaceName(name string) {
 	ki.keyspace = name
 }
 
-var invalidKeyspaceNameChars = "/"
-
 // ValidateKeyspaceName checks if the provided name is a valid name for a
 // keyspace.
-//
-// As of v17, "all invalid characters" is just the forward slash ("/").
 func ValidateKeyspaceName(name string) error {
-	if strings.ContainsAny(name, invalidKeyspaceNameChars) {
-		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "keyspace name %s contains invalid characters; may not contain any of the following: %+v", name, strings.Split(invalidKeyspaceNameChars, ""))
-	}
-
-	return nil
+	return validateObjectName(name)
 }
 
 // GetServedFrom returns a Keyspace_ServedFrom record if it exists.

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -121,8 +121,8 @@ func IsShardUsingRangeBasedSharding(shard string) bool {
 // ValidateShardName takes a shard name and sanitizes it, and also returns
 // the KeyRange.
 func ValidateShardName(shard string) (string, *topodatapb.KeyRange, error) {
-	if strings.Contains(shard, "/") {
-		return "", nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid shardId, may not contain '/': %v", shard)
+	if err := validateObjectName(shard); err != nil {
+		return "", nil, err
 	}
 
 	if !IsShardUsingRangeBasedSharding(shard) {

--- a/go/vt/topo/validator.go
+++ b/go/vt/topo/validator.go
@@ -1,0 +1,30 @@
+package topo
+
+import (
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+// ValidateObjectName checks that the name is a valid object name.
+// Object names are used for things like keyspace and shard names
+// and must match specific constraints.
+// They are only allowed to use ASCII letters or digits, - and _.
+// No spaces or special characters are allowed.
+func validateObjectName(name string) error {
+	if name == "" {
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "empty name")
+	}
+
+	for _, c := range name {
+		switch {
+		case 'a' <= c && c <= 'z':
+		case 'A' <= c && c <= 'Z':
+		case '0' <= c && c <= '9':
+		case c == '-' || c == '_':
+		default:
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid character %v in name %v", c, name)
+		}
+	}
+
+	return nil
+}

--- a/go/vt/topo/validator.go
+++ b/go/vt/topo/validator.go
@@ -15,6 +15,10 @@ func validateObjectName(name string) error {
 		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "empty name")
 	}
 
+	if len(name) > 64 {
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "name %v is too long", name)
+	}
+
 	for _, c := range name {
 		switch {
 		case 'a' <= c && c <= 'z':
@@ -22,7 +26,7 @@ func validateObjectName(name string) error {
 		case '0' <= c && c <= '9':
 		case c == '-' || c == '_':
 		default:
-			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid character %v in name %v", c, name)
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid character %s in name %v", string(c), name)
 		}
 	}
 

--- a/go/vt/topo/validator_test.go
+++ b/go/vt/topo/validator_test.go
@@ -1,0 +1,46 @@
+package topo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateObjectName(t *testing.T) {
+	cases := []struct {
+		name string
+		err  string
+	}{
+		{
+			name: "valid",
+			err:  "",
+		},
+		{
+			name: "validdigits1321",
+			err:  "",
+		},
+		{
+			name: "valid-with-dashes",
+			err:  "",
+		},
+		{
+			name: "very-long-keyspace-name-that-is-even-too-long-for-mysql-to-handle",
+			err:  "name very-long-keyspace-name-that-is-even-too-long-for-mysql-to-handle is too long",
+		},
+		{
+			name: "with<invalid>chars",
+			err:  "invalid character < in name with<invalid>chars",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateObjectName(c.name)
+			if c.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, c.err)
+			}
+		})
+	}
+}

--- a/go/vt/wrangler/tablet_test.go
+++ b/go/vt/wrangler/tablet_test.go
@@ -40,7 +40,8 @@ func TestInitTabletShardConversion(t *testing.T) {
 			Cell: cell,
 			Uid:  1,
 		},
-		Shard: "80-C0",
+		Keyspace: "test",
+		Shard:    "80-C0",
 	}
 
 	if err := wr.TopoServer().InitTablet(context.Background(), tablet, false /*allowPrimaryOverride*/, true /*createShardAndKeyspace*/, false /*allowUpdate*/); err != nil {
@@ -70,7 +71,8 @@ func TestDeleteTabletBasic(t *testing.T) {
 			Cell: cell,
 			Uid:  1,
 		},
-		Shard: "0",
+		Shard:    "0",
+		Keyspace: "test",
 	}
 
 	if err := wr.TopoServer().InitTablet(context.Background(), tablet, false /*allowPrimaryOverride*/, true /*createShardAndKeyspace*/, false /*allowUpdate*/); err != nil {


### PR DESCRIPTION
Today we explicit disallow only specific characters like `/`. We should move here to an allow list approach though, explicitly allowing specific characters.

The reason is that a block list approach is bound to end up in a game of whack-a-mole where we keep having to add characters. Instead an allow list approach of safe characters is a fundamentally better method moving forward that provides security.

The biggest potential downside is that there's people we don't know about that are using names we would disallow with the current restrictions.

From a security perspective though, it's better that we start off here and then allow more known safe things if necessary and try to get feedback from the community for when things are too restricted.

## Related Issue(s)

Followup to https://github.com/vitessio/vitess/pull/12843 & https://github.com/vitessio/vitess/pull/12732 where we added the first validations. This is the more fundamental fix for #12738

I have also marked it for backporting as we've backported the previous changes as well and classified them as a security issue.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required