### PR TITLE
schemadiff: rich `ImpossibleApplyDiffOrderError`

### DIFF
--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -19,6 +19,7 @@ package schemadiff
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"vitess.io/vitess/go/sqlescape"
 )
@@ -30,8 +31,23 @@ var (
 	ErrUnexpectedTableSpec            = errors.New("unexpected table spec")
 	ErrExpectedCreateTable            = errors.New("expected a CREATE TABLE statement")
 	ErrExpectedCreateView             = errors.New("expected a CREATE VIEW statement")
-	ErrImpossibleDiffOrder            = errors.New("Impossible diff sequence")
 )
+
+type ImpossibleApplyDiffOrderError struct {
+	UnorderedDiffs        []EntityDiff
+	ConflictingDiffs      []EntityDiff
+	ConflictingStatements []string
+}
+
+func (e *ImpossibleApplyDiffOrderError) Error() string {
+	var b strings.Builder
+	b.WriteString("no valid applicable order for diffs. Diffs found conflicting:")
+	for _, diff := range e.ConflictingStatements {
+		b.WriteString("\n")
+		b.WriteString(diff)
+	}
+	return b.String()
+}
 
 type UnsupportedEntityError struct {
 	Entity    string

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -34,19 +34,25 @@ var (
 )
 
 type ImpossibleApplyDiffOrderError struct {
-	UnorderedDiffs        []EntityDiff
-	ConflictingDiffs      []EntityDiff
-	ConflictingStatements []string
+	UnorderedDiffs   []EntityDiff
+	ConflictingDiffs []EntityDiff
 }
 
 func (e *ImpossibleApplyDiffOrderError) Error() string {
 	var b strings.Builder
 	b.WriteString("no valid applicable order for diffs. Diffs found conflicting:")
-	for _, diff := range e.ConflictingStatements {
+	for _, s := range e.ConflictingStatements() {
 		b.WriteString("\n")
-		b.WriteString(diff)
+		b.WriteString(s)
 	}
 	return b.String()
+}
+
+func (e *ImpossibleApplyDiffOrderError) ConflictingStatements() (result []string) {
+	for _, diff := range e.ConflictingDiffs {
+		result = append(result, diff.CanonicalStatementString())
+	}
+	return result
 }
 
 type UnsupportedEntityError struct {

--- a/go/vt/schemadiff/schema_diff.go
+++ b/go/vt/schemadiff/schema_diff.go
@@ -251,7 +251,11 @@ func (d *SchemaDiff) OrderedDiffs() ([]EntityDiff, error) {
 		})
 		if !foundValidPathForClass {
 			// In this equivalence class, there is no valid permutation. We cannot linearize the diffs.
-			return nil, ErrImpossibleDiffOrder
+			return nil, &ImpossibleApplyDiffOrderError{
+				UnorderedDiffs:        d.UnorderedDiffs(),
+				ConflictingDiffs:      classDiffs,
+				ConflictingStatements: m[class],
+			}
 		}
 		// Done taking care of this equivalence class.
 	}

--- a/go/vt/schemadiff/schema_diff.go
+++ b/go/vt/schemadiff/schema_diff.go
@@ -252,9 +252,8 @@ func (d *SchemaDiff) OrderedDiffs() ([]EntityDiff, error) {
 		if !foundValidPathForClass {
 			// In this equivalence class, there is no valid permutation. We cannot linearize the diffs.
 			return nil, &ImpossibleApplyDiffOrderError{
-				UnorderedDiffs:        d.UnorderedDiffs(),
-				ConflictingDiffs:      classDiffs,
-				ConflictingStatements: m[class],
+				UnorderedDiffs:   d.UnorderedDiffs(),
+				ConflictingDiffs: classDiffs,
 			}
 		}
 		// Done taking care of this equivalence class.

--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -164,14 +164,14 @@ func TestSchemaDiff(t *testing.T) {
 		}
 	)
 	tt := []struct {
-		name            string
-		fromQueries     []string
-		toQueries       []string
-		expectDiffs     int
-		expectDeps      int
-		sequential      bool
-		impossibleOrder bool
-		entityOrder     []string // names of tables/views in expected diff order
+		name             string
+		fromQueries      []string
+		toQueries        []string
+		expectDiffs      int
+		expectDeps       int
+		sequential       bool
+		conflictingDiffs int
+		entityOrder      []string // names of tables/views in expected diff order
 	}{
 		{
 			name:        "no change",
@@ -287,10 +287,10 @@ func TestSchemaDiff(t *testing.T) {
 				"create table t2 (id int primary key, ts timestamp);",
 				"create view v1 as select the_id from t1",
 			},
-			expectDiffs:     2,
-			expectDeps:      1,
-			entityOrder:     []string{"t1", "v1"},
-			impossibleOrder: true,
+			expectDiffs:      2,
+			expectDeps:       1,
+			entityOrder:      []string{"t1", "v1"},
+			conflictingDiffs: 2,
 		},
 		{
 			name: "alter table, add view",
@@ -450,9 +450,9 @@ func TestSchemaDiff(t *testing.T) {
 				"create table t1 (id int primary key, newcol int not null);",
 				"create view v1 as select id, newcol from t1",
 			},
-			expectDiffs:     2,
-			expectDeps:      1,
-			impossibleOrder: true,
+			expectDiffs:      2,
+			expectDeps:       1,
+			conflictingDiffs: 2,
 		},
 
 		// FKs
@@ -644,10 +644,10 @@ func TestSchemaDiff(t *testing.T) {
 				"create table t1 (id int primary key, q int, key q_idx (q));",
 				"create table t2 (id int primary key, q int, key q_idx (q), foreign key (q) references t1 (q) on delete no action);",
 			},
-			expectDiffs:     2,
-			expectDeps:      1,
-			sequential:      true,
-			impossibleOrder: true,
+			expectDiffs:      2,
+			expectDeps:       1,
+			sequential:       true,
+			conflictingDiffs: 2,
 		},
 	}
 	hints := &DiffHints{RangeRotationStrategy: RangeRotationDistinctStatements}
@@ -683,9 +683,13 @@ func TestSchemaDiff(t *testing.T) {
 			assert.Equal(t, tc.sequential, schemaDiff.HasSequentialExecutionDeps())
 
 			orderedDiffs, err := schemaDiff.OrderedDiffs()
-			if tc.impossibleOrder {
+			if tc.conflictingDiffs > 0 {
+				require.Greater(t, tc.conflictingDiffs, 1) // self integrity. If there's a conflict, then obviously there's at least two conflicting diffs (a single diff has nothing to conflict with)
 				assert.Error(t, err)
-				assert.Equal(t, ErrImpossibleDiffOrder, err)
+				impossibleOrderErr, ok := err.(*ImpossibleApplyDiffOrderError)
+				assert.True(t, ok)
+				assert.Equal(t, tc.conflictingDiffs, len(impossibleOrderErr.ConflictingDiffs))
+				assert.Equal(t, tc.conflictingDiffs, len(impossibleOrderErr.ConflictingStatements))
 			} else {
 				require.NoError(t, err)
 			}
@@ -693,7 +697,7 @@ func TestSchemaDiff(t *testing.T) {
 			for _, diff := range orderedDiffs {
 				diffStatementStrings = append(diffStatementStrings, diff.CanonicalStatementString())
 			}
-			if !tc.impossibleOrder {
+			if tc.conflictingDiffs == 0 {
 				// validate that the order of diffs is as expected (we don't check for the full diff statement,
 				// just for the order of affected tables/views)
 				require.NotNil(t, tc.entityOrder) // making sure we explicitly specified expected order

--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -689,7 +689,6 @@ func TestSchemaDiff(t *testing.T) {
 				impossibleOrderErr, ok := err.(*ImpossibleApplyDiffOrderError)
 				assert.True(t, ok)
 				assert.Equal(t, tc.conflictingDiffs, len(impossibleOrderErr.ConflictingDiffs))
-				assert.Equal(t, tc.conflictingDiffs, len(impossibleOrderErr.ConflictingStatements))
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION

## Description

Continuing https://github.com/vitessio/vitess/pull/12551 and https://github.com/vitessio/vitess/pull/12885, this PR offers a strongly typed and rich `ImpossibleApplyDiffOrderError`.

This error indicates the total diffs for which no valid ordering is found, as well as a subset of diffs that causes the conflict. From there' we can generate the statements, or extract the effected entities.

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/12551
- https://github.com/vitessio/vitess/pull/12885
- #10203 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
