### PR TITLE
Add limit planning to operators

### DIFF
--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -67,6 +67,8 @@ func transformToLogicalPlan(ctx *plancontext.PlanningContext, op ops.Operator, i
 		return transformHorizon(ctx, op, isRoot)
 	case *operators.Projection:
 		return transformProjection(ctx, op)
+	case *operators.Limit:
+		return transformLimit(ctx, op)
 	}
 
 	return nil, vterrors.VT13001(fmt.Sprintf("unknown type encountered: %T (transformToLogicalPlan)", op))
@@ -687,6 +689,15 @@ func transformDerivedPlan(ctx *plancontext.PlanningContext, op *operators.Derive
 		SelectExprs: selectExprs,
 	}
 	return plan, nil
+}
+
+func transformLimit(ctx *plancontext.PlanningContext, op *operators.Limit) (logicalPlan, error) {
+	plan, err := transformToLogicalPlan(ctx, op.Source, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return createLimit(plan, op.AST)
 }
 
 type subQReplacer struct {

--- a/go/vt/vtgate/planbuilder/operators/limit.go
+++ b/go/vt/vtgate/planbuilder/operators/limit.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+)
+
+type Limit struct {
+	Source ops.Operator
+	AST    *sqlparser.Limit
+
+	// Pushed marks whether the limit has been pushed down to the inputs but still need to keep the operator around.
+	// For example, `select * from user order by id limit 10`. Even after we push the limit to the route, we need a limit on top
+	// since it is a scatter.
+	Pushed bool
+}
+
+func (l *Limit) Clone(inputs []ops.Operator) ops.Operator {
+	return &Limit{
+		Source: inputs[0],
+		AST:    sqlparser.CloneRefOfLimit(l.AST),
+	}
+}
+
+func (l *Limit) Inputs() []ops.Operator {
+	return []ops.Operator{l.Source}
+}
+
+func (l *Limit) SetInputs(operators []ops.Operator) {
+	l.Source = operators[0]
+}
+
+func (l *Limit) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (ops.Operator, error) {
+	newSrc, err := l.Source.AddPredicate(ctx, expr)
+	if err != nil {
+		return nil, err
+	}
+	l.Source = newSrc
+	return l, nil
+}
+
+func (l *Limit) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (ops.Operator, int, error) {
+	newSrc, offset, err := l.Source.AddColumn(ctx, expr)
+	if err != nil {
+		return nil, 0, err
+	}
+	l.Source = newSrc
+	return l, offset, nil
+}
+
+func (l *Limit) GetColumns() ([]sqlparser.Expr, error) {
+	return l.Source.GetColumns()
+}
+
+func (l *Limit) IPhysical() {}

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -295,6 +295,14 @@ func TestOne(t *testing.T) {
 	testFile(t, "onecase.json", "", vschema, false)
 }
 
+func TestOneTPCC(t *testing.T) {
+	vschema := &vschemaWrapper{
+		v: loadSchema(t, "vschemas/tpcc_schema.json", true),
+	}
+
+	testFile(t, "onecase.json", "", vschema, false)
+}
+
 func TestOneWithMainAsDefault(t *testing.T) {
 	vschema := &vschemaWrapper{
 		v: loadSchema(t, "vschemas/schema.json", true),

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -5848,40 +5848,32 @@
             "TableName": "`user`_user_extra_user_extra",
             "Inputs": [
               {
-                "OperatorType": "SimpleProjection",
-                "Columns": [
-                  0
-                ],
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "L:0",
+                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
-                    "OperatorType": "Join",
-                    "Variant": "Join",
-                    "JoinColumnIndexes": "L:0",
-                    "TableName": "`user`_user_extra",
-                    "Inputs": [
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                        "Query": "select `user`.col from `user`",
-                        "Table": "`user`"
-                      },
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select 1 from user_extra where 1 != 1",
-                        "Query": "select 1 from user_extra",
-                        "Table": "user_extra"
-                      }
-                    ]
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select `user`.col from `user` where 1 != 1",
+                    "Query": "select `user`.col from `user`",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select 1 from user_extra where 1 != 1",
+                    "Query": "select 1 from user_extra",
+                    "Table": "user_extra"
                   }
                 ]
               },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -7580,27 +7580,19 @@
         "TableName": "user_extra_`user`",
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": [
-              0
-            ],
+            "OperatorType": "Limit",
+            "Count": "INT64(10)",
             "Inputs": [
               {
-                "OperatorType": "Limit",
-                "Count": "INT64(10)",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select user_id from user_extra where 1 != 1",
-                    "Query": "select user_id from user_extra limit :__upper_limit",
-                    "Table": "user_extra"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select user_id from user_extra where 1 != 1",
+                "Query": "select user_id from user_extra limit :__upper_limit",
+                "Table": "user_extra"
               }
             ]
           },

--- a/go/vt/vtgate/planbuilder/testdata/wireup_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/wireup_cases.json
@@ -1069,9 +1069,9 @@
           {
             "OperatorType": "Join",
             "Variant": "Join",
-            "JoinColumnIndexes": "L:1,R:0",
+            "JoinColumnIndexes": "L:0,R:0",
             "JoinVars": {
-              "u_col": 0
+              "u_col": 1
             },
             "TableName": "`user`_user_extra",
             "Inputs": [
@@ -1082,8 +1082,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select u.col, u.id from `user` as u where 1 != 1",
-                "Query": "select u.col, u.id from `user` as u",
+                "FieldQuery": "select u.id, u.col from `user` as u where 1 != 1",
+                "Query": "select u.id, u.col from `user` as u",
                 "Table": "`user`"
               },
               {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds the functionality to do the limit planning on operators and not on the logical plan

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #11626 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
