### PR TITLE
Deprecate `durability_policy` flag in vtctld

### DIFF
--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -267,7 +267,7 @@ The flag `schema_change_check_interval` used to accept either a Go duration valu
 This behavior was deprecated in v15.0.0 and has been removed.
 `schema_change_check_interval` now **only** accepts Go duration values.
 
-The flag `durability_policy` is no longer used by vtctld. Instead it reads the durability policy from the keyspace information for all the keyspaces.
+The flag `durability_policy` is no longer used by vtctld. Instead it reads the durability policies for all keyspaces from the topology server.
 
 ### <a id="vttablet"/> VTTablet
 #### <a id="vttablet-initialization"/> Initializing all replicas with super_read_only

--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -267,6 +267,8 @@ The flag `schema_change_check_interval` used to accept either a Go duration valu
 This behavior was deprecated in v15.0.0 and has been removed.
 `schema_change_check_interval` now **only** accepts Go duration values.
 
+The flag `durability_policy` is no longer used by vtctld. Instead it reads the durability policy from the keyspace information for all the keyspaces.
+
 ### <a id="vttablet"/> VTTablet
 #### <a id="vttablet-initialization"/> Initializing all replicas with super_read_only
 In order to prevent SUPER privileged users like `root` or `vt_dba` from producing errant GTIDs on replicas, all the replica MySQL servers are initialized with the MySQL

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -24,7 +24,6 @@ Usage of vtctld:
       --datadog-agent-host string                                        host to send spans to. if empty, no tracing will be done
       --datadog-agent-port string                                        port to send spans to. if empty, no tracing will be done
       --disable_active_reparents                                         if set, do not allow active reparents. Use this to protect a cluster using external reparents.
-      --durability_policy string                                         type of durability to enforce. Default is none. Other values are dictated by registered plugins (default "none")
       --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
       --external-compressor string                                       command with arguments to use when compressing a backup.
       --external-compressor-extension string                             extension to use when using an external compressor.

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -46,6 +46,7 @@ func init() {
 
 func registerVtctldFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&durabilityPolicy, "durability_policy", durabilityPolicy, "type of durability to enforce. Default is none. Other values are dictated by registered plugins")
+	fs.MarkDeprecated("durability_policy", "Set the correct durability policy in the keyspace information instead.")
 	fs.BoolVar(&sanitizeLogMessages, "vtctld_sanitize_log_messages", sanitizeLogMessages, "When true, vtctld sanitizes logging.")
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR deprecates the `durability_policy` flag in vtctld, the working of which was changed a long time ago. Vtctld now reads the durability policy from the keyspace information for all the keyspaces and doesn't rely on the flag.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #8975 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
