### PR TITLE
datetime: Fix weekday calculation for DST changes

### DIFF
--- a/go/mysql/datetime/types.go
+++ b/go/mysql/datetime/types.go
@@ -241,7 +241,7 @@ func (d Date) SundayWeek() (int, int) {
 	// Since the week numbers always start on a Sunday, we can look
 	// at the week number of Sunday itself. So we shift back to last
 	// Sunday we saw and compute the week number based on that.
-	sun := t.Add(-time.Duration(t.Weekday()) * 24 * time.Hour)
+	sun := t.AddDate(0, 0, -int(t.Weekday()))
 	return sun.Year(), (sun.YearDay()-1)/7 + 1
 }
 
@@ -254,7 +254,7 @@ func (d Date) MondayWeek() (int, int) {
 	// at the week number of Monday itself. So we shift back to last
 	// Monday we saw and compute the week number based on that.
 	wd := (t.Weekday() + 6) % 7
-	mon := t.Add(-time.Duration(wd) * 24 * time.Hour)
+	mon := t.AddDate(0, 0, -int(wd))
 	return mon.Year(), (mon.YearDay()-1)/7 + 1
 }
 
@@ -276,9 +276,9 @@ func (d Date) Sunday4DayWeek() (int, int) {
 	case wd == 3:
 		wed = t
 	case wd < 3:
-		wed = t.Add(time.Duration(3-t.Weekday()) * 24 * time.Hour)
+		wed = t.AddDate(0, 0, int(3-t.Weekday()))
 	case wd > 3:
-		wed = t.Add(-time.Duration(t.Weekday()-3) * 24 * time.Hour)
+		wed = t.AddDate(0, 0, -int(t.Weekday()-3))
 	}
 
 	return wed.Year(), (wed.YearDay()-1)/7 + 1

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -334,8 +334,11 @@ func TestCompilerSingle(t *testing.T) {
 			result:     `INT64(0)`,
 		},
 		{
-			expression: `WEEK(date '2023-04-11', 6)`,
-			result:     `INT64(15)`,
+			// This is the day of DST change in Europe/Amsterdam when
+			// the year started on a Wednesday. Regression test for
+			// using 24 hour time diffing instead of days.
+			expression: `WEEK(date '2014-10-26', 6)`,
+			result:     `INT64(44)`,
 		},
 	}
 


### PR DESCRIPTION
It's not safe to add multiples of 24 hours to `time.Time` instances to try and move things a certain number of days since some days might have DST changes and more or less than 24 hours in one day.

Instead use the proper function to add a specific number of days to a `time.Time`.

## Related Issue(s)

Introduced in #12916 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required