### PR TITLE
evalengine: Implement `MAKEDATE` and `MAKETIME`.

### DIFF
--- a/go/mysql/datetime/parse.go
+++ b/go/mysql/datetime/parse.go
@@ -291,10 +291,10 @@ func ParseTimeInt64(i int64) (t Time, ok bool) {
 		return t, false
 	}
 
-	t.hour = uint16(i % 100)
-	if i/100 != 0 {
+	if i > 838 {
 		return t, false
 	}
+	t.hour = uint16(i)
 	if neg {
 		t.hour |= negMask
 	}

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -897,6 +897,30 @@ func (cached *builtinMD5) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinMakedate) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
+func (cached *builtinMaketime) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinMicrosecond) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -340,6 +340,14 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `WEEK(date '2014-10-26', 6)`,
 			result:     `INT64(44)`,
 		},
+		{
+			expression: `MAKEDATE(cast('invalid' as json), NULL)`,
+			result:     `NULL`,
+		},
+		{
+			expression: `MAKETIME(NULL, '', cast('invalid' as json))`,
+			result:     `NULL`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -108,6 +108,8 @@ var Cases = []TestCase{
 	{Run: FnDayOfYear},
 	{Run: FnFromUnixtime},
 	{Run: FnHour},
+	{Run: FnMakedate},
+	{Run: FnMaketime},
 	{Run: FnMicroSecond},
 	{Run: FnMinute},
 	{Run: FnMonth},
@@ -1368,6 +1370,29 @@ func FnFromUnixtime(yield Query) {
 func FnHour(yield Query) {
 	for _, d := range inputConversions {
 		yield(fmt.Sprintf("HOUR(%s)", d), nil)
+	}
+}
+
+func FnMakedate(yield Query) {
+	for _, y := range inputConversions {
+		for _, d := range inputConversions {
+			yield(fmt.Sprintf("MAKEDATE(%s, %s)", y, d), nil)
+		}
+	}
+}
+
+func FnMaketime(yield Query) {
+	// Don't use inputConversions for minutes as those are simplest
+	// and otherwise we explode in test runtime.
+	minutes := []string{
+		"''", "0", "'3'", "59", "60", "0xFF666F6F626172FF", "18446744073709551615",
+	}
+	for _, h := range inputConversions {
+		for _, m := range minutes {
+			for _, s := range inputConversions {
+				yield(fmt.Sprintf("MAKETIME(%s, %s, %s)", h, m, s), nil)
+			}
+		}
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -352,6 +352,16 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (Expr, error) 
 			return nil, argError(method)
 		}
 		return &builtinHour{CallExpr: call}, nil
+	case "makedate":
+		if len(args) != 2 {
+			return nil, argError(method)
+		}
+		return &builtinMakedate{CallExpr: call}, nil
+	case "maketime":
+		if len(args) != 3 {
+			return nil, argError(method)
+		}
+		return &builtinMaketime{CallExpr: call}, nil
 	case "microsecond":
 		if len(args) != 1 {
 			return nil, argError(method)


### PR DESCRIPTION
This adds the `MAKEDATE` and `MAKETIME` functions. As always, this also uncovers some other small issues in how we parse things. This time it's that we don't allow the full range of valid values for hours when parsing the integer representation for a `time` type.

## Related Issue(s)

Follow up to https://github.com/vitessio/vitess/pull/12907 and part of https://github.com/vitessio/vitess/issues/9647

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required