### PR TITLE
topo: Remove unused templating code

### DIFF
--- a/go/vt/topo/topoproto/shard.go
+++ b/go/vt/topo/topoproto/shard.go
@@ -17,13 +17,8 @@ limitations under the License.
 package topoproto
 
 import (
-	"encoding/hex"
 	"fmt"
-	"html/template"
 	"strings"
-
-	"vitess.io/vitess/go/vt/key"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 // KeyspaceShardString returns a "keyspace/shard" string taking
@@ -43,24 +38,4 @@ func ParseKeyspaceShard(param string) (string, string, error) {
 		}
 	}
 	return keySpaceShard[0], keySpaceShard[1], nil
-}
-
-// SourceShardString returns a printable view of a SourceShard.
-func SourceShardString(source *topodatapb.Shard_SourceShard) string {
-	return fmt.Sprintf("SourceShard(%v,%v/%v)", source.Uid, source.Keyspace, source.Shard)
-}
-
-// SourceShardAsHTML returns a HTML version of the object.
-func SourceShardAsHTML(source *topodatapb.Shard_SourceShard) template.HTML {
-	result := fmt.Sprintf("<b>Uid</b>: %v</br>\n<b>Source</b>: %v/%v</br>\n", source.Uid, source.Keyspace, source.Shard)
-	if key.KeyRangeIsPartial(source.KeyRange) {
-		result += fmt.Sprintf("<b>KeyRange</b>: %v-%v</br>\n",
-			hex.EncodeToString(source.KeyRange.Start),
-			hex.EncodeToString(source.KeyRange.End))
-	}
-	if len(source.Tables) > 0 {
-		result += fmt.Sprintf("<b>Tables</b>: %v</br>\n",
-			strings.Join(source.Tables, " "))
-	}
-	return template.HTML(result)
 }

--- a/go/vt/topo/topoproto/shard_test.go
+++ b/go/vt/topo/topoproto/shard_test.go
@@ -18,8 +18,6 @@ package topoproto
 
 import (
 	"testing"
-
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 func TestParseKeyspaceShard(t *testing.T) {
@@ -42,25 +40,5 @@ func TestParseKeyspaceShard(t *testing.T) {
 		if s != shard {
 			t.Errorf("shard parsed from keyspace%sshard pair %s is %s, but expect %s", delim, keyspaceShard, s, shard)
 		}
-	}
-}
-
-func TestSourceShardAsHTML(t *testing.T) {
-	s := &topodatapb.Shard_SourceShard{
-		Uid:      123,
-		Keyspace: "source_keyspace",
-		Shard:    "source_shard",
-		KeyRange: &topodatapb.KeyRange{
-			Start: []byte{0x80},
-		},
-		Tables: []string{"table1", "table2"},
-	}
-	got := string(SourceShardAsHTML(s))
-	expected := "<b>Uid</b>: 123</br>\n" +
-		"<b>Source</b>: source_keyspace/source_shard</br>\n" +
-		"<b>KeyRange</b>: 80-</br>\n" +
-		"<b>Tables</b>: table1 table2</br>\n"
-	if got != expected {
-		t.Errorf("got wrong SourceShardAsHTML output, got:\n%vexpected:\n%v", got, expected)
 	}
 }


### PR DESCRIPTION
This code seems to be entirely unused and only referenced from tests. We can therefore safely clean this up.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required