### PR TITLE
template: Move all HTML templates to safehtml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 
 require (
 	github.com/bndr/gotabulate v1.1.2
+	github.com/google/safehtml v0.1.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kr/pretty v0.3.1
 	github.com/kr/text v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -392,6 +392,8 @@ github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 h1:Xim43kblpZXfIBQsbuBVKCudVG457BR2GZFIz3uw3hQ=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/safehtml v0.1.0 h1:EwLKo8qawTKfsi0orxcQAZzu07cICaBeFMegAU9eaT8=
+github.com/google/safehtml v0.1.0/go.mod h1:L4KWwDsUJdECRAEpZoBn3O64bQaywRscowZjJAzjHnU=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -19,7 +19,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"html/template"
 	"os"
 	"os/exec"
 	"path"
@@ -27,6 +26,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/callinfo/callinfo.go
+++ b/go/vt/callinfo/callinfo.go
@@ -19,9 +19,9 @@ limitations under the License.
 package callinfo
 
 import (
-	"html/template"
-
 	"context"
+
+	"github.com/google/safehtml"
 )
 
 // CallInfo is the extra data stored in the Context
@@ -36,7 +36,7 @@ type CallInfo interface {
 	Text() string
 
 	// HTML represents this rpc call connection in a web-friendly way.
-	HTML() template.HTML
+	HTML() safehtml.HTML
 }
 
 // internal type and value
@@ -57,8 +57,8 @@ func FromContext(ctx context.Context) (CallInfo, bool) {
 
 // HTMLFromContext returns that value of HTML() from the context, or "" if we're
 // not able to recover one
-func HTMLFromContext(ctx context.Context) template.HTML {
-	var h template.HTML
+func HTMLFromContext(ctx context.Context) safehtml.HTML {
+	var h safehtml.HTML
 	ci, ok := FromContext(ctx)
 	if ok {
 		return ci.HTML()

--- a/go/vt/callinfo/fakecallinfo/fakecallinfo.go
+++ b/go/vt/callinfo/fakecallinfo/fakecallinfo.go
@@ -18,7 +18,8 @@ package fakecallinfo
 
 import (
 	"fmt"
-	"html/template"
+
+	"github.com/google/safehtml"
 )
 
 // FakeCallInfo gives a fake Callinfo usable in callinfo
@@ -26,7 +27,7 @@ type FakeCallInfo struct {
 	Remote string
 	Method string
 	User   string
-	Html   string
+	Html   safehtml.HTML
 }
 
 // RemoteAddr returns the remote address.
@@ -45,6 +46,6 @@ func (fci *FakeCallInfo) Text() string {
 }
 
 // HTML returns the html.
-func (fci *FakeCallInfo) HTML() template.HTML {
-	return template.HTML(fci.Html)
+func (fci *FakeCallInfo) HTML() safehtml.HTML {
+	return fci.Html
 }

--- a/go/vt/callinfo/plugin_grpc.go
+++ b/go/vt/callinfo/plugin_grpc.go
@@ -19,11 +19,11 @@ package callinfo
 // This file implements the CallInfo interface for gRPC contexts.
 
 import (
-	"fmt"
-	"html/template"
-
 	"context"
+	"fmt"
 
+	"github.com/google/safehtml"
+	"github.com/google/safehtml/template"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 )
@@ -64,6 +64,18 @@ func (gci *gRPCCallInfoImpl) Text() string {
 	return fmt.Sprintf("%s:%s(gRPC)", gci.remoteAddr, gci.method)
 }
 
-func (gci *gRPCCallInfoImpl) HTML() template.HTML {
-	return template.HTML("<b>Method:</b> " + gci.method + " <b>Remote Addr:</b> " + gci.remoteAddr)
+var grpcTmpl = template.Must(template.New("tcs").Parse("<b>Method:</b> {{.Method}} <b>Remote Addr:</b> {{.RemoteAddr}}"))
+
+func (gci *gRPCCallInfoImpl) HTML() safehtml.HTML {
+	html, err := grpcTmpl.ExecuteToHTML(struct {
+		Method     string
+		RemoteAddr string
+	}{
+		Method:     gci.method,
+		RemoteAddr: gci.remoteAddr,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return html
 }

--- a/go/vt/callinfo/plugin_mysql.go
+++ b/go/vt/callinfo/plugin_mysql.go
@@ -19,10 +19,11 @@ package callinfo
 // This file implements the CallInfo interface for Mysql contexts.
 
 import (
-	"fmt"
-	"html/template"
-
 	"context"
+	"fmt"
+
+	"github.com/google/safehtml"
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/mysql"
 )
@@ -53,6 +54,18 @@ func (mci *mysqlCallInfoImpl) Text() string {
 	return fmt.Sprintf("%s@%s(Mysql)", mci.user, mci.remoteAddr)
 }
 
-func (mci *mysqlCallInfoImpl) HTML() template.HTML {
-	return template.HTML("<b>MySQL User:</b> " + mci.user + " <b>Remote Addr:<b> " + mci.remoteAddr)
+var mysqlTmpl = template.Must(template.New("tcs").Parse("<b>MySQL User:</b> {{.MySQLUser}} <b>Remote Addr:</b> {{.RemoteAddr}}"))
+
+func (mci *mysqlCallInfoImpl) HTML() safehtml.HTML {
+	html, err := mysqlTmpl.ExecuteToHTML(struct {
+		MySQLUser  string
+		RemoteAddr string
+	}{
+		MySQLUser:  mci.user,
+		RemoteAddr: mci.remoteAddr,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return html
 }

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"html/template"
 	"io"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/safehtml/template"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -19,8 +19,6 @@ package servenv
 import (
 	"bytes"
 	"fmt"
-	"html"
-	"html/template"
 	"io"
 	"net"
 	"net/http"
@@ -31,6 +29,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/safehtml"
+	"github.com/google/safehtml/template"
+	"github.com/google/safehtml/template/uncheckedconversions"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"
@@ -260,7 +262,7 @@ func (sp *statusPage) reparse(sections []section) (*template.Template, error) {
 	io.WriteString(&buf, statusHTML)
 
 	for i, sec := range sections {
-		fmt.Fprintf(&buf, "<h1>%s</h1>\n", html.EscapeString(sec.Banner))
+		fmt.Fprintf(&buf, "<h1>%s</h1>\n", safehtml.HTMLEscaped(sec.Banner))
 		fmt.Fprintf(&buf, "{{$sec := index .Sections %d}}\n", i)
 		fmt.Fprintf(&buf, `{{template "sec-%d" call $sec.F}}`+"\n", i)
 	}
@@ -270,7 +272,7 @@ func (sp *statusPage) reparse(sections []section) (*template.Template, error) {
 	for i, sec := range sections {
 		fmt.Fprintf(&buf, `{{define "sec-%d"}}%s{{end}}\n`, i, sec.Fragment)
 	}
-	return template.New("").Funcs(sp.funcMap).Parse(buf.String())
+	return template.New("").Funcs(sp.funcMap).ParseFromTrustedTemplate(uncheckedconversions.TrustedTemplateFromStringKnownToSatisfyTypeContract(buf.String()))
 }
 
 // Toggle the block profile rate to/from 100%, unless specific rate is passed in

--- a/go/vt/servenv/status_test.go
+++ b/go/vt/servenv/status_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package servenv
 
 import (
-	"html/template"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -25,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/safehtml/template"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -20,12 +20,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"html/template"
 	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/vt/key"
 

--- a/go/vt/throttler/throttlerlogz.go
+++ b/go/vt/throttler/throttlerlogz.go
@@ -18,12 +18,12 @@ package throttler
 
 import (
 	"fmt"
-	"html/template"
 	"io"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/google/safehtml/template"
 	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/vt/logz"

--- a/go/vt/throttler/throttlerz.go
+++ b/go/vt/throttler/throttlerz.go
@@ -17,10 +17,10 @@ limitations under the License.
 package throttler
 
 import (
-	"html/template"
 	"net/http"
 	"strings"
 
+	"github.com/google/safehtml/template"
 	"golang.org/x/exp/slices"
 
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vtgate/executor_scatter_stats.go
+++ b/go/vt/vtgate/executor_scatter_stats.go
@@ -18,10 +18,11 @@ package vtgate
 
 import (
 	"fmt"
-	"html/template"
 	"net/http"
 	"sync/atomic"
 	"time"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/vt/logz"
 

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -21,13 +21,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/vt/vtgate/logstats"
 

--- a/go/vt/vtgate/logstats/logstats.go
+++ b/go/vt/vtgate/logstats/logstats.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"io"
 	"net/url"
 	"time"
+
+	"github.com/google/safehtml"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"
@@ -99,7 +100,7 @@ func (stats *LogStats) TotalTime() time.Duration {
 // ContextHTML returns the HTML version of the context that was used, or "".
 // This is a method on LogStats instead of a field so that it doesn't need
 // to be passed by value everywhere.
-func (stats *LogStats) ContextHTML() template.HTML {
+func (stats *LogStats) ContextHTML() safehtml.HTML {
 	return callinfo.HTMLFromContext(stats.Ctx)
 }
 

--- a/go/vt/vtgate/logstats/logstats_test.go
+++ b/go/vt/vtgate/logstats/logstats_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/safehtml/testconversions"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -194,12 +195,12 @@ func TestLogStatsRowThreshold(t *testing.T) {
 func TestLogStatsContextHTML(t *testing.T) {
 	html := "HtmlContext"
 	callInfo := &fakecallinfo.FakeCallInfo{
-		Html: html,
+		Html: testconversions.MakeHTMLForTest(html),
 	}
 	ctx := callinfo.NewContext(context.Background(), callInfo)
 	logStats := NewLogStats(ctx, "test", "sql1", "", map[string]*querypb.BindVariable{})
-	if string(logStats.ContextHTML()) != html {
-		t.Fatalf("expect to get html: %s, but got: %s", html, string(logStats.ContextHTML()))
+	if logStats.ContextHTML().String() != html {
+		t.Fatalf("expect to get html: %s, but got: %s", html, logStats.ContextHTML().String())
 	}
 }
 

--- a/go/vt/vtgate/queryz.go
+++ b/go/vt/vtgate/queryz.go
@@ -18,10 +18,11 @@ package vtgate
 
 import (
 	"fmt"
-	"html/template"
 	"net/http"
 	"sort"
 	"time"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vtgate/status_test.go
+++ b/go/vt/vtgate/status_test.go
@@ -18,10 +18,11 @@ package vtgate
 
 import (
 	"bytes"
-	"html/template"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/safehtml/template"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )

--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -484,7 +484,7 @@ type ControllerStatus struct {
 	TableCopyTimings      map[string]int64
 }
 
-var vreplicationTemplate = `
+const vreplicationTemplate = `
 {{if .IsOpen}}VReplication state: Open</br>
 <table>
   <tr>

--- a/go/vt/vttablet/tabletmanager/vreplication/stats_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats_test.go
@@ -18,11 +18,11 @@ package vreplication
 
 import (
 	"bytes"
-	"html/template"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/safehtml/template"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"

--- a/go/vt/vttablet/tabletserver/livequeryz.go
+++ b/go/vt/vttablet/tabletserver/livequeryz.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"text/template"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletserver/query_list.go
+++ b/go/vt/vttablet/tabletserver/query_list.go
@@ -18,10 +18,11 @@ package tabletserver
 
 import (
 	"context"
-	"html/template"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/google/safehtml"
 
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callinfo"
@@ -128,7 +129,7 @@ func (ql *QueryList) TerminateAll() {
 type QueryDetailzRow struct {
 	Type              string
 	Query             string
-	ContextHTML       template.HTML
+	ContextHTML       safehtml.HTML
 	Start             time.Time
 	Duration          time.Duration
 	ConnID            int64

--- a/go/vt/vttablet/tabletserver/queryz.go
+++ b/go/vt/vttablet/tabletserver/queryz.go
@@ -18,10 +18,11 @@ package tabletserver
 
 import (
 	"fmt"
-	"html/template"
 	"net/http"
 	"sort"
 	"time"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletserver/schema/schemaz.go
+++ b/go/vt/vttablet/tabletserver/schema/schemaz.go
@@ -17,9 +17,10 @@ limitations under the License.
 package schema
 
 import (
-	"html/template"
 	"net/http"
 	"sort"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletserver/status.go
+++ b/go/vt/vttablet/tabletserver/status.go
@@ -36,7 +36,7 @@ const (
 	unhappyClass   = "unhappy"
 )
 
-var (
+const (
 	// This template is a slight duplicate of the one in go/cmd/vttablet/status.go.
 	headerTemplate = `
 <style>

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -17,14 +17,14 @@ limitations under the License.
 package tabletenv
 
 import (
+	"context"
 	"fmt"
-	"html/template"
 	"io"
 	"net/url"
 	"strings"
 	"time"
 
-	"context"
+	"github.com/google/safehtml"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"
@@ -153,7 +153,7 @@ func (stats *LogStats) FmtQuerySources() string {
 // ContextHTML returns the HTML version of the context that was used, or "".
 // This is a method on LogStats instead of a field so that it doesn't need
 // to be passed by value everywhere.
-func (stats *LogStats) ContextHTML() template.HTML {
+func (stats *LogStats) ContextHTML() safehtml.HTML {
 	return callinfo.HTMLFromContext(stats.Ctx)
 }
 

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/safehtml/testconversions"
+
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callinfo"
@@ -204,12 +206,12 @@ func TestLogStatsFormatQuerySources(t *testing.T) {
 func TestLogStatsContextHTML(t *testing.T) {
 	html := "HtmlContext"
 	callInfo := &fakecallinfo.FakeCallInfo{
-		Html: html,
+		Html: testconversions.MakeHTMLForTest(html),
 	}
 	ctx := callinfo.NewContext(context.Background(), callInfo)
 	logStats := NewLogStats(ctx, "test")
-	if string(logStats.ContextHTML()) != html {
-		t.Fatalf("expect to get html: %s, but got: %s", html, string(logStats.ContextHTML()))
+	if logStats.ContextHTML().String() != html {
+		t.Fatalf("expect to get html: %s, but got: %s", html, logStats.ContextHTML().String())
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/twopcz.go
+++ b/go/vt/vttablet/tabletserver/twopcz.go
@@ -19,8 +19,9 @@ package tabletserver
 import (
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"net/http"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 

--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -18,10 +18,11 @@ package tabletserver
 
 import (
 	"fmt"
-	"html/template"
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/streamlog"

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"html/template"
 	"sync"
+	"text/template"
 	"time"
 
 	"vitess.io/vitess/go/vt/concurrency"


### PR DESCRIPTION
`html/template` is very easy to misuse and to create accidental potential XSS cases. We have a bunch of places where we manually construct HTML today that isn't done in a safe way. There's no immediate XSS possible here that I can see since all values are not something that arbitrary data could be injected into.

But that is still hard to reason about and too easy to make a mistake with. Therefore we really should switch to proper templating everywhere so that any bound values get escaped.

This uses `safehtml` now instead of `html/template` since it's much harder to make a mistake with that package. See also https://blogtitle.github.io/go-safe-html/ for the additional rationale behind why it's better than `html/template` (and created by the maintainer of `html/template`).

Depends on #12939 which cleans up a bunch of other stuff and together with these changes all direct `template.HTML`

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required