### PR TITLE
Optionally truncate queries that are written to logs

### DIFF
--- a/go/vt/sqlparser/truncate_query.go
+++ b/go/vt/sqlparser/truncate_query.go
@@ -30,6 +30,8 @@ var (
 	truncateErrLen = 0
 )
 
+const TruncationText = "[TRUNCATED]"
+
 func registerQueryTruncationFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&truncateUILen, "sql-max-length-ui", truncateUILen, "truncate queries in debug UIs to the given length (default 512)")
 	fs.IntVar(&truncateErrLen, "sql-max-length-errors", truncateErrLen, "truncate queries in error logs to the given length (default unlimited)")
@@ -69,7 +71,7 @@ func truncateQuery(query string, max int) string {
 		return comments.Leading + sql + comments.Trailing
 	}
 
-	return comments.Leading + sql[:max-12] + " [TRUNCATED]" + comments.Trailing
+	return comments.Leading + sql[:max-(len(TruncationText)+1)] + " " + TruncationText + comments.Trailing
 }
 
 // TruncateForUI is used when displaying queries on various Vitess status pages

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -740,7 +740,7 @@ func (qre *QueryExecutor) verifyRowCount(count, maxrows int64) error {
 	if warnThreshold > 0 && count > warnThreshold {
 		callerID := callerid.ImmediateCallerIDFromContext(qre.ctx)
 		qre.tsv.Stats().Warnings.Add("ResultsExceeded", 1)
-		log.Warningf("caller id: %s row count %v exceeds warning threshold %v: %q", callerID.Username, count, warnThreshold, queryAsString(qre.plan.FullQuery.Query, qre.bindVars, qre.tsv.Config().SanitizeLogMessages))
+		log.Warningf("caller id: %s row count %v exceeds warning threshold %v: %q", callerID.Username, count, warnThreshold, queryAsString(qre.plan.FullQuery.Query, qre.bindVars, qre.tsv.Config().SanitizeLogMessages, true))
 	}
 	return nil
 }

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -2034,9 +2034,9 @@ func queryAsString(sql string, bindVariables map[string]*querypb.BindVariable, s
 	maxLen := sqlparser.GetTruncateErrLen()
 	if truncateForLog && maxLen > 0 && len(bv) > maxLen {
 		if maxLen <= 12 {
-			bv = "[TRUNCATED]"
+			bv = sqlparser.TruncationText
 		} else {
-			bv = bv[:maxLen-12] + " [TRUNCATED]"
+			bv = bv[:maxLen-(len(sqlparser.TruncationText)+1)] + " " + sqlparser.TruncationText
 		}
 	}
 

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1439,10 +1439,10 @@ func TestHandlePanicAndSendLogStatsMessageTruncation(t *testing.T) {
 
 	defer func() {
 		err := logStats.Error
-		want := "TODO"
+		want := "Uncaught panic for Sql: \"select * from test_table_loooooooooooooooooooooooooooooooooooong\", BindVars: {bv1: \"type:INT64 value:\\\"1111111111\\\"\"bv2: \"type:INT64 value:\\\"2222222222\\\"\"bv3: \"type:INT64 value:\\\"3333333333\\\"\"bv4: \"type:INT64 value:\\\"4444444444\\\"\"}"
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), want)
-		want = "TODO"
+		want = "Uncaught panic for Sql: \"select * from test_t [TRUNCATED]\", BindVars: {bv1: \"typ [TRUNCATED]"
 		if !strings.Contains(tl.getLog(0), want) {
 			t.Errorf("error log %s, want '%s'", tl.getLog(0), want)
 		}
@@ -1465,19 +1465,19 @@ func TestQueryAsString(t *testing.T) {
 	defer sqlparser.SetTruncateErrLen(origTruncateErrLen)
 
 	query := queryAsString(longSql, longBv, true, true)
-	want := "TODO"
+	want := "Sql: \"select * from test_t [TRUNCATED]\", BindVars: {[REDACTED]}"
 	assert.Equal(t, want, query)
 
 	query = queryAsString(longSql, longBv, true, false)
-	want = "TODO"
+	want = "Sql: \"select * from test_table_loooooooooooooooooooooooooooooooooooong\", BindVars: {[REDACTED]}"
 	assert.Equal(t, want, query)
 
 	query = queryAsString(longSql, longBv, false, true)
-	want = "TODO"
+	want = "Sql: \"select * from test_t [TRUNCATED]\", BindVars: {bv1: \"typ [TRUNCATED]"
 	assert.Equal(t, want, query)
 
 	query = queryAsString(longSql, longBv, false, false)
-	want = "TODO"
+	want = "Sql: \"select * from test_table_loooooooooooooooooooooooooooooooooooong\", BindVars: {bv1: \"type:INT64 value:\\\"1111111111\\\"\"bv2: \"type:INT64 value:\\\"2222222222\\\"\"bv3: \"type:INT64 value:\\\"3333333333\\\"\"bv4: \"type:INT64 value:\\\"4444444444\\\"\"}"
 	assert.Equal(t, want, query)
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Vttablet has a flag:
```
--sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
```

This flag is supposed to truncate queries that are logged, because logging a very long query can fill up disk space if the query is being logged frequently enough. There were a few logging callsites where we were not truncating the query.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13059

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
