### PR TITLE
go/vt/mysqlctl: fix dup open/close backup stats

### DIFF
--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -39,8 +39,8 @@ import (
 )
 
 var (
-	// BackupEngineImplementation is the implementation to use for BackupEngine
-	backupEngineImplementation = BuiltinBackupEngineName
+	// backupEngineImplementation is the implementation to use for BackupEngine
+	backupEngineImplementation = builtinBackupEngineName
 )
 
 // BackupEngine is the interface to take a backup with a given engine.
@@ -197,7 +197,7 @@ func GetRestoreEngine(ctx context.Context, backup backupstorage.BackupHandle) (R
 	engine := manifest.BackupMethod
 	if engine == "" {
 		// The builtin engine is the only one that ever left BackupMethod unset.
-		engine = BuiltinBackupEngineName
+		engine = builtinBackupEngineName
 	}
 	re, ok := BackupRestoreEngineMap[engine]
 	if !ok {

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	// BackupEngineImplementation is the implementation to use for BackupEngine
-	backupEngineImplementation = builtinBackupEngineName
+	backupEngineImplementation = BuiltinBackupEngineName
 )
 
 // BackupEngine is the interface to take a backup with a given engine.
@@ -197,7 +197,7 @@ func GetRestoreEngine(ctx context.Context, backup backupstorage.BackupHandle) (R
 	engine := manifest.BackupMethod
 	if engine == "" {
 		// The builtin engine is the only one that ever left BackupMethod unset.
-		engine = builtinBackupEngineName
+		engine = BuiltinBackupEngineName
 	}
 	re, ok := BackupRestoreEngineMap[engine]
 	if !ok {

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -51,7 +51,7 @@ import (
 )
 
 const (
-	BuiltinBackupEngineName = "builtin"
+	builtinBackupEngineName = "builtin"
 	autoIncrementalFromPos  = "auto"
 	dataDictionaryFile      = "mysql.ibd"
 )
@@ -573,7 +573,7 @@ func (be *BuiltinBackupEngine) backupFiles(
 	bm := &builtinBackupManifest{
 		// Common base fields
 		BackupManifest: BackupManifest{
-			BackupMethod:   BuiltinBackupEngineName,
+			BackupMethod:   builtinBackupEngineName,
 			Position:       replicationPosition,
 			PurgedPosition: purgedPosition,
 			FromPosition:   fromPosition,

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -51,7 +51,7 @@ import (
 )
 
 const (
-	builtinBackupEngineName = "builtin"
+	BuiltinBackupEngineName = "builtin"
 	autoIncrementalFromPos  = "auto"
 	dataDictionaryFile      = "mysql.ibd"
 )
@@ -573,7 +573,7 @@ func (be *BuiltinBackupEngine) backupFiles(
 	bm := &builtinBackupManifest{
 		// Common base fields
 		BackupManifest: BackupManifest{
-			BackupMethod:   builtinBackupEngineName,
+			BackupMethod:   BuiltinBackupEngineName,
 			Position:       replicationPosition,
 			PurgedPosition: purgedPosition,
 			FromPosition:   fromPosition,
@@ -779,17 +779,13 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 	}
 
 	// Close the backupPipe to finish writing on destination.
-	closeWriterAt := time.Now()
 	if err = bw.Close(); err != nil {
 		return vterrors.Wrapf(err, "cannot flush destination: %v", name)
 	}
-	params.Stats.Scope(stats.Operation("Destination:Close")).TimedIncrement(time.Since(closeWriterAt))
 
-	closeReaderAt := time.Now()
 	if err := br.Close(); err != nil {
 		return vterrors.Wrap(err, "failed to close the source reader")
 	}
-	params.Stats.Scope(stats.Operation("Source:Close")).TimedIncrement(time.Since(closeReaderAt))
 
 	// Save the hash.
 	fe.Hash = bw.HashString()
@@ -1044,17 +1040,13 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, params RestorePa
 	}
 
 	// Flush the buffer.
-	closeDestAt := time.Now()
 	if err := bufferedDest.Flush(); err != nil {
 		return vterrors.Wrap(err, "failed to flush destination buffer")
 	}
-	params.Stats.Scope(stats.Operation("Destination:Close")).TimedIncrement(time.Since(closeDestAt))
 
-	closeSourceAt := time.Now()
 	if err := br.Close(); err != nil {
 		return vterrors.Wrap(err, "failed to close the source reader")
 	}
-	params.Stats.Scope(stats.Operation("Source:Close")).TimedIncrement(time.Since(closeSourceAt))
 
 	return nil
 }


### PR DESCRIPTION
## Description

Found a silly bug (in code I wrote) where the `Destination:Close` and `Source:Close` stats are being reported multiple times. Removing the duplications and adding a test.

## Related Issue(s)

Fixes #12946 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
