### PR TITLE
evalengine: Skip integration tests under race detector

### DIFF
--- a/go/vt/vtgate/evalengine/integration/comparison_test.go
+++ b/go/vt/vtgate/evalengine/integration/comparison_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Vitess Authors.
 

--- a/go/vt/vtgate/evalengine/integration/fuzz_test.go
+++ b/go/vt/vtgate/evalengine/integration/fuzz_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Vitess Authors.
 


### PR DESCRIPTION
These are running at least 4x slower than without the race detector and they are hitting timeouts.

The race detector is not that useful for these tests as they're all serial functions that we're testing, so let's disable these under the race detector to speed up CI times.

See also
https://github.com/vitessio/vitess/actions/runs/4764430794/jobs/8469017735 for an example CI failure when it was hitting individual test timeouts.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
