### PR TITLE
Throttled transactions return MySQL error code 1041 ER_OUT_OF_RESOURCES

### DIFF
--- a/go/mysql/sql_error_test.go
+++ b/go/mysql/sql_error_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDumuxResourceExhaustedErrors(t *testing.T) {
+func TestDemuxResourceExhaustedErrors(t *testing.T) {
 	type testCase struct {
 		msg  string
 		want ErrorCode
@@ -43,6 +43,7 @@ func TestDumuxResourceExhaustedErrors(t *testing.T) {
 		// This should be explicitly handled by returning ERNetPacketTooLarge from the execturo directly
 		// and therefore shouldn't need to be teased out of another error.
 		{"in-memory row count exceeded allowed limit of 13", ERTooManyUserConnections},
+		{"rpc error: code = ResourceExhausted desc = Transaction throttled", EROutOfResources},
 	}
 
 	for _, c := range cases {
@@ -166,6 +167,11 @@ func TestNewSQLErrorFromError(t *testing.T) {
 			err: vterrors.Wrapf(fmt.Errorf("Column 'val' cannot be null (errno 1048) (sqlstate 23000) during query: insert into _edf4846d_ab65_11ed_abb1_0a43f95f28a3_20230213061619_vrepl(id,val,ts) values (1,2,'2023-02-13 04:46:16'), (2,3,'2023-02-13 04:46:16'), (3,null,'2023-02-13 04:46:16')"), "task error: %d", 17),
 			num: ERBadNullError,
 			ss:  SSConstraintViolation,
+		},
+		{
+			err: vterrors.Errorf(vtrpc.Code_RESOURCE_EXHAUSTED, "vttablet: rpc error: code = ResourceExhausted desc = Transaction throttled"),
+			num: EROutOfResources,
+			ss:  SSUnknownSQLState,
 		},
 	}
 


### PR DESCRIPTION
## Description
This PR causes transactions throttled by the Transaction Throttler to return MySQL error code 1041 ER_OUT_OF_RESOURCES. This error code seems better suited to represent the fact that transactions
are being throttled by the server due to some form of resource contention than the current code 1203 ER_TOO_MANY_USER_CONNECTIONS.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/12958

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

N/A