### PR TITLE
debug: add ToString to operators to make it easier to debug

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/apply_join.go
+++ b/go/vt/vtgate/planbuilder/operators/apply_join.go
@@ -278,6 +278,17 @@ func (a *ApplyJoin) addOffset(offset int) {
 	a.Columns = append(a.Columns, offset)
 }
 
+func (a *ApplyJoin) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "Join",
+		Variant:      "Apply",
+		Other: map[string]any{
+			"Predicate":     sqlparser.String(a.Predicate),
+			"OutputColumns": a.Columns,
+		},
+	}
+}
+
 func (jc JoinColumn) IsPureLeft() bool {
 	return jc.RHSExpr == nil
 }

--- a/go/vt/vtgate/planbuilder/operators/correlated_subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/correlated_subquery.go
@@ -72,6 +72,13 @@ func (s *SubQueryOp) SetInputs(ops []ops.Operator) {
 	s.Outer, s.Inner = ops[0], ops[1]
 }
 
+func (s *SubQueryOp) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "SubQuery",
+		Variant:      "Apply",
+	}
+}
+
 // IPhysical implements the PhysicalOperator interface
 func (c *CorrelatedSubQueryOp) IPhysical() {}
 
@@ -102,4 +109,11 @@ func (c *CorrelatedSubQueryOp) Inputs() []ops.Operator {
 // SetInputs implements the Operator interface
 func (c *CorrelatedSubQueryOp) SetInputs(ops []ops.Operator) {
 	c.Outer, c.Inner = ops[0], ops[1]
+}
+
+func (c *CorrelatedSubQueryOp) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "SubQuery",
+		Variant:      "Correlated",
+	}
 }

--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -60,3 +60,9 @@ func (d *Delete) TablesUsed() []string {
 	}
 	return nil
 }
+
+func (d *Delete) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "Delete",
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/derived.go
+++ b/go/vt/vtgate/planbuilder/operators/derived.go
@@ -229,3 +229,9 @@ func (d *Derived) selectStatement() sqlparser.SelectStatement {
 func (d *Derived) src() ops.Operator {
 	return d.Source
 }
+
+func (d *Derived) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "Derived",
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -137,3 +137,12 @@ func (f *Filter) planOffsets(ctx *plancontext.PlanningContext) error {
 	f.FinalPredicate = eexpr
 	return nil
 }
+
+func (f *Filter) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "Filter",
+		Other: map[string]any{
+			"Predicate": sqlparser.String(sqlparser.AndExpressions(f.Predicates...)),
+		},
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -87,3 +87,9 @@ func (h *Horizon) selectStatement() sqlparser.SelectStatement {
 func (h *Horizon) src() ops.Operator {
 	return h.Source
 }
+
+func (h *Horizon) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "Horizon",
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/join.go
+++ b/go/vt/vtgate/planbuilder/operators/join.go
@@ -154,3 +154,12 @@ func (j *Join) AddJoinPredicate(ctx *plancontext.PlanningContext, expr sqlparser
 	j.Predicate = ctx.SemTable.AndExpressions(j.Predicate, expr)
 	return nil
 }
+
+func (j *Join) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "Join",
+		Other: map[string]any{
+			"Predicate": sqlparser.String(j.Predicate),
+		},
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/limit.go
+++ b/go/vt/vtgate/planbuilder/operators/limit.go
@@ -70,3 +70,17 @@ func (l *Limit) GetColumns() ([]sqlparser.Expr, error) {
 }
 
 func (l *Limit) IPhysical() {}
+
+func (l *Limit) Description() ops.OpDescription {
+	other := map[string]any{}
+	if l.AST.Offset != nil {
+		other["Offset"] = sqlparser.String(l.AST.Offset)
+	}
+	if l.AST.Rowcount != nil {
+		other["RowCount"] = sqlparser.String(l.AST.Rowcount)
+	}
+	return ops.OpDescription{
+		OperatorType: "Limit",
+		Other:        other,
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/ops/op.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/op.go
@@ -48,11 +48,22 @@ type (
 		AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr) (Operator, int, error)
 
 		GetColumns() ([]sqlparser.Expr, error)
+
+		Description() OpDescription
 	}
 
 	// PhysicalOperator means that this operator is ready to be turned into a logical plan
 	PhysicalOperator interface {
 		Operator
 		IPhysical()
+	}
+
+	OpDescription struct {
+		OperatorType string
+		Variant      string
+		Other        map[string]any
+
+		// This field will be filled in by the JSON producer. No need to set it manually
+		Inputs []OpDescription
 	}
 )

--- a/go/vt/vtgate/planbuilder/operators/ops/to_json.go
+++ b/go/vt/vtgate/planbuilder/operators/ops/to_json.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ops
+
+import "encoding/json"
+
+// ToJSON is a debug only function. It can panic, so do not use this in production code
+func ToJSON(op Operator) string {
+	descr := buildDescriptionTree(op)
+	out, err := json.MarshalIndent(descr, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+func buildDescriptionTree(op Operator) OpDescription {
+	descr := op.Description()
+	for _, in := range op.Inputs() {
+		descr.Inputs = append(descr.Inputs, buildDescriptionTree(in))
+	}
+	return descr
+}

--- a/go/vt/vtgate/planbuilder/operators/projection.go
+++ b/go/vt/vtgate/planbuilder/operators/projection.go
@@ -133,3 +133,12 @@ func (p *Projection) AllOffsets() (cols []int) {
 	}
 	return
 }
+
+func (p *Projection) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "Projection",
+		Other: map[string]any{
+			"OutputColumns": p.ColumnNames,
+		},
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/querygraph.go
+++ b/go/vt/vtgate/planbuilder/operators/querygraph.go
@@ -215,3 +215,15 @@ func (qt *QueryTable) Clone() *QueryTable {
 		IsInfSchema: qt.IsInfSchema,
 	}
 }
+
+func (qg *QueryGraph) Description() ops.OpDescription {
+	var tables []string
+	for _, table := range qg.Tables {
+		tables = append(tables, sqlparser.String(table.Table))
+	}
+
+	return ops.OpDescription{
+		OperatorType: "QueryGraph",
+		Other:        map[string]any{"Tables": tables},
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -583,3 +583,14 @@ func (r *Route) TablesUsed() []string {
 	}
 	return collect()
 }
+
+func (r *Route) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "Route",
+		Other: map[string]any{
+			"OpCode":   r.Routing.OpCode(),
+			"Cost":     r.Routing.Cost(),
+			"Keyspace": r.Routing.Keyspace(),
+		},
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -118,3 +118,14 @@ func createSubqueryFromStatement(ctx *plancontext.PlanningContext, stmt sqlparse
 	}
 	return subq, nil
 }
+
+func (s *SubQuery) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "SubQuery",
+	}
+}
+func (s *SubQueryInner) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "SubQueryInner",
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -110,3 +110,14 @@ func addColumn(ctx *plancontext.PlanningContext, op ColNameColumns, e sqlparser.
 	op.AddCol(col)
 	return offset, nil
 }
+
+func (to *Table) Description() ops.OpDescription {
+	var columns []string
+	for _, col := range to.Columns {
+		columns = append(columns, sqlparser.String(col))
+	}
+	return ops.OpDescription{
+		OperatorType: "Table",
+		Other:        map[string]any{"Columns": columns},
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -194,3 +194,9 @@ func (u *Union) Compact(*plancontext.PlanningContext) (ops.Operator, rewrite.App
 }
 
 func (u *Union) NoLHSTableSet() {}
+
+func (u *Union) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "Union",
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -65,3 +65,9 @@ func (u *Update) TablesUsed() []string {
 	}
 	return nil
 }
+
+func (u *Update) Description() ops.OpDescription {
+	return ops.OpDescription{
+		OperatorType: "Update",
+	}
+}

--- a/go/vt/vtgate/planbuilder/operators/vindex.go
+++ b/go/vt/vtgate/planbuilder/operators/vindex.go
@@ -145,3 +145,7 @@ func (v *Vindex) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.E
 func (v *Vindex) TablesUsed() []string {
 	return []string{v.Table.Table.Name.String()}
 }
+
+func (v *Vindex) Description() ops.OpDescription {
+	return ops.OpDescription{OperatorType: "Vindex"}
+}


### PR DESCRIPTION
## Description
We are moving most of the logic around planning to the operators data structures, but we don't have good introspection support for these. This PR adds a rudimentary `ToJSON` support to the operators to make it easier to debug and understand what is going on.

## Related Issue(s)
Tracking issue: #11626

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
