### PR TITLE
update v16 release notes about VTGate Advertised MySQL Version

### DIFF
--- a/changelog/16.0/16.0.0/release_notes.md
+++ b/changelog/16.0/16.0.0/release_notes.md
@@ -109,6 +109,8 @@ or
 Since [Pull Request #11989](https://github.com/vitessio/vitess/pull/11989), VTGate advertises MySQL version 8.0.30. This is a breaking change for clients that rely on the VTGate advertised MySQL version and still use MySQL 5.7.
 The users can set the `mysql_server_version` flag to advertise the correct version.
 
+It's worth noting that [the feature to avoid using reserved connections](https://vitess.io/docs/16.0/reference/query-serving/reserved-conn/#avoiding-the-use-of-reserved-connections) depends on the `mysql_server_version`, which has been changed from `5.7.9-vitess` to `8.0.30-Vitess` as the default value from now on. In conclusion, we recommend that users running MySQL 5.7 set vtgate's `mysql_server_version` to `5.7.9-vitess` to prevent the queries from being unexpectedly rewritten.
+
 #### <a id="default-mysql-version"/>Default MySQL version on Docker
 
 The default major MySQL version used by our `vitess/lite:latest` image is going from `5.7` to `8.0`. Additionally, the patch version of MySQL80 has been upgraded from `8.0.23` to `8.0.30`.

--- a/changelog/16.0/16.0.0/release_notes.md
+++ b/changelog/16.0/16.0.0/release_notes.md
@@ -109,7 +109,7 @@ or
 Since [Pull Request #11989](https://github.com/vitessio/vitess/pull/11989), VTGate advertises MySQL version 8.0.30. This is a breaking change for clients that rely on the VTGate advertised MySQL version and still use MySQL 5.7.
 The users can set the `mysql_server_version` flag to advertise the correct version.
 
-It's worth noting that [the feature to avoid using reserved connections](https://vitess.io/docs/16.0/reference/query-serving/reserved-conn/#avoiding-the-use-of-reserved-connections) depends on the `mysql_server_version`, which has been changed from `5.7.9-vitess` to `8.0.30-Vitess` as the default value from now on. In conclusion, we recommend that users running MySQL 5.7 set vtgate's `mysql_server_version` to `5.7.9-vitess` to prevent the queries from being unexpectedly rewritten.
+It is worth noting that [the feature to avoid using reserved connections](https://vitess.io/docs/16.0/reference/query-serving/reserved-conn/#avoiding-the-use-of-reserved-connections) depends on the `mysql_server_version` CLI flag, which default value has been changed from `5.7.9-vitess` to `8.0.30-vitess`. We recommend that users running MySQL 5.7 set vtgate's `mysql_server_version` CLI flag to `5.7.9-vitess` to prevent the queries from being unexpectedly rewritten.
 
 #### <a id="default-mysql-version"/>Default MySQL version on Docker
 

--- a/changelog/16.0/16.0.0/summary.md
+++ b/changelog/16.0/16.0.0/summary.md
@@ -108,7 +108,7 @@ or
 Since [Pull Request #11989](https://github.com/vitessio/vitess/pull/11989), VTGate advertises MySQL version 8.0.30. This is a breaking change for clients that rely on the VTGate advertised MySQL version and still use MySQL 5.7.
 The users can set the `mysql_server_version` flag to advertise the correct version.
 
-It's worth noting that [the feature to avoid using reserved connections](https://vitess.io/docs/16.0/reference/query-serving/reserved-conn/#avoiding-the-use-of-reserved-connections) depends on the `mysql_server_version`, which has been changed from `5.7.9-vitess` to `8.0.30-Vitess` as the default value from now on. In conclusion, we recommend that users running MySQL 5.7 set vtgate's `mysql_server_version` to `5.7.9-vitess` to prevent the queries from being unexpectedly rewritten.
+It is worth noting that [the feature to avoid using reserved connections](https://vitess.io/docs/16.0/reference/query-serving/reserved-conn/#avoiding-the-use-of-reserved-connections) depends on the `mysql_server_version` CLI flag, which default value has been changed from `5.7.9-vitess` to `8.0.30-vitess`. We recommend that users running MySQL 5.7 set vtgate's `mysql_server_version` CLI flag to `5.7.9-vitess` to prevent the queries from being unexpectedly rewritten.
 
 #### <a id="default-mysql-version"/>Default MySQL version on Docker
 

--- a/changelog/16.0/16.0.0/summary.md
+++ b/changelog/16.0/16.0.0/summary.md
@@ -108,6 +108,8 @@ or
 Since [Pull Request #11989](https://github.com/vitessio/vitess/pull/11989), VTGate advertises MySQL version 8.0.30. This is a breaking change for clients that rely on the VTGate advertised MySQL version and still use MySQL 5.7.
 The users can set the `mysql_server_version` flag to advertise the correct version.
 
+It's worth noting that [the feature to avoid using reserved connections](https://vitess.io/docs/16.0/reference/query-serving/reserved-conn/#avoiding-the-use-of-reserved-connections) depends on the `mysql_server_version`, which has been changed from `5.7.9-vitess` to `8.0.30-Vitess` as the default value from now on. In conclusion, we recommend that users running MySQL 5.7 set vtgate's `mysql_server_version` to `5.7.9-vitess` to prevent the queries from being unexpectedly rewritten.
+
 #### <a id="default-mysql-version"/>Default MySQL version on Docker
 
 The default major MySQL version used by our `vitess/lite:latest` image is going from `5.7` to `8.0`. Additionally, the patch version of MySQL80 has been upgraded from `8.0.23` to `8.0.30`.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR provides a better warning regarding the v16 upgrade: `VTGate Advertised MySQL Version is a breaking change for MySQL 5.7 users.`

Discussion on Slack: https://vitess.slack.com/archives/C0PQY0PTK/p1682067776047289

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Follow up to https://github.com/vitessio/vitess/pull/11989

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
