### PR TITLE
vtgate : Disable Automatically setting immediateCallerID to user from static authentication context 

### DIFF
--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -34,6 +34,7 @@ Usage of vtgate:
       --gate_query_cache_size int                                        gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a cache. This config controls the expected amount of unique entries in the cache. (default 5000)
       --gateway_initial_tablet_timeout duration                          At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type (default 30s)
       --grpc-use-effective-groups                                        If set, and SSL is not used, will set the immediate caller's security groups from the effective caller id's groups.
+      --grpc-use-static-authentication-callerid                          If set, will set the immediate caller id to the username authenticated by the static auth plugin.
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.

--- a/go/test/endtoend/vtgate/grpc_server_acls/acls_test.go
+++ b/go/test/endtoend/vtgate/grpc_server_acls/acls_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpcserverauthstatic
+package grpc_server_acls
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"vitess.io/vitess/go/vt/callerid"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,11 +51,11 @@ var (
 	grpcServerAuthStaticJSON = `
 		[
 		  {
-			"Username": "user_with_access",
+			"Username": "some_other_user",
 			"Password": "test_password"
 		  },
 		  {
-			"Username": "user_no_access",
+			"Username": "another_unrelated_user",
 			"Password": "test_password"
 		  }
 		]
@@ -109,7 +110,7 @@ func TestMain(m *testing.M) {
 		clusterInstance.VtGateExtraArgs = []string{
 			"--grpc_auth_mode", "static",
 			"--grpc_auth_static_password_file", grpcServerAuthStaticPath,
-			"--grpc-use-static-authentication-callerid", "true",
+			"--grpc-use-static-authentication-callerid", "false",
 		}
 
 		// Configure vttablet to use table ACL
@@ -140,12 +141,12 @@ func TestMain(m *testing.M) {
 	os.Exit(exitcode)
 }
 
-// TestAuthenticatedUserWithAccess verifies that an authenticated gRPC static user with ACL access can execute queries
+// TestAuthenticatedUserWithAccess verifies that an authenticated gRPC static user with an effectiveCallerID that has ACL access can execute queries
 func TestAuthenticatedUserWithAccess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	vtgateConn, err := dialVTGate(ctx, t, "user_with_access", "test_password")
+	vtgateConn, err := dialVTGate(ctx, t, "some_other_user", "test_password")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,16 +154,17 @@ func TestAuthenticatedUserWithAccess(t *testing.T) {
 
 	session := vtgateConn.Session(keyspaceName+"@primary", nil)
 	query := "SELECT id FROM test_table"
+	ctx = callerid.NewContext(ctx, callerid.NewEffectiveCallerID("user_with_access", "", ""), nil)
 	_, err = session.Execute(ctx, query, nil)
 	assert.NoError(t, err)
 }
 
-// TestAuthenticatedUserNoAccess verifies that an authenticated gRPC static user with no ACL access cannot execute queries
+// TestAuthenticatedUserNoAccess verifies that an authenticated gRPC static user without an effectiveCallerID that has ACL access cannot execute queries
 func TestAuthenticatedUserNoAccess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	vtgateConn, err := dialVTGate(ctx, t, "user_no_access", "test_password")
+	vtgateConn, err := dialVTGate(ctx, t, "another_unrelated_user", "test_password")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,6 +172,7 @@ func TestAuthenticatedUserNoAccess(t *testing.T) {
 
 	session := vtgateConn.Session(keyspaceName+"@primary", nil)
 	query := "SELECT id FROM test_table"
+	ctx = callerid.NewContext(ctx, callerid.NewEffectiveCallerID("user_no_access", "", ""), nil)
 	_, err = session.Execute(ctx, query, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Select command denied to user")

--- a/go/test/endtoend/vtgate/grpc_server_acls/acls_test.go
+++ b/go/test/endtoend/vtgate/grpc_server_acls/acls_test.go
@@ -112,7 +112,8 @@ func TestMain(m *testing.M) {
 		clusterInstance.VtGateExtraArgs = []string{
 			"--grpc_auth_mode", "static",
 			"--grpc_auth_static_password_file", grpcServerAuthStaticPath,
-			"--grpc-use-static-authentication-callerid", "false",
+			"--grpc_use_effective_callerid",
+			"--grpc-use-static-authentication-callerid",
 		}
 
 		// Configure vttablet to use table ACL
@@ -143,8 +144,8 @@ func TestMain(m *testing.M) {
 	os.Exit(exitcode)
 }
 
-// TestAuthenticatedUserWithAccess verifies that an authenticated gRPC static user with an effectiveCallerID that has ACL access can execute queries
-func TestAuthenticatedUserWithAccess(t *testing.T) {
+// TestEffectiveCallerIDWithAccess verifies that an authenticated gRPC static user with an effectiveCallerID that has ACL access can execute queries
+func TestEffectiveCallerIDWithAccess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -161,8 +162,8 @@ func TestAuthenticatedUserWithAccess(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestAuthenticatedUserNoAccess verifies that an authenticated gRPC static user without an effectiveCallerID that has ACL access cannot execute queries
-func TestAuthenticatedUserNoAccess(t *testing.T) {
+// TestEffectiveCallerIDWithNoAccess verifies that an authenticated gRPC static user without an effectiveCallerID that has ACL access cannot execute queries
+func TestEffectiveCallerIDWithNoAccess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -179,24 +180,6 @@ func TestAuthenticatedUserNoAccess(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Select command denied to user")
 	assert.Contains(t, err.Error(), "for table 'test_table' (ACL check error)")
-}
-
-// TestUnauthenticatedUser verifies that an unauthenticated gRPC user cannot execute queries
-func TestUnauthenticatedUser(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	vtgateConn, err := dialVTGate(ctx, t, "", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer vtgateConn.Close()
-
-	session := vtgateConn.Session(keyspaceName+"@primary", nil)
-	query := "SELECT id FROM test_table"
-	_, err = session.Execute(ctx, query, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid credentials")
 }
 
 func dialVTGate(ctx context.Context, t *testing.T, username string, password string) (*vtgateconn.VTGateConn, error) {

--- a/go/test/endtoend/vtgate/grpc_server_acls/acls_test.go
+++ b/go/test/endtoend/vtgate/grpc_server_acls/acls_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"testing"
+
 	"vitess.io/vitess/go/vt/callerid"
 
 	"github.com/stretchr/testify/assert"
@@ -76,6 +77,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
+
 	defer cluster.PanicHandler(nil)
 	flag.Parse()
 

--- a/go/test/endtoend/vtgate/grpc_server_auth_static/main_test.go
+++ b/go/test/endtoend/vtgate/grpc_server_auth_static/main_test.go
@@ -109,7 +109,7 @@ func TestMain(m *testing.M) {
 		clusterInstance.VtGateExtraArgs = []string{
 			"--grpc_auth_mode", "static",
 			"--grpc_auth_static_password_file", grpcServerAuthStaticPath,
-			"--grpc-use-static-authentication-callerid", "true",
+			"--grpc-use-static-authentication-callerid",
 		}
 
 		// Configure vttablet to use table ACL

--- a/go/vt/vtgate/grpcvtgateservice/server.go
+++ b/go/vt/vtgate/grpcvtgateservice/server.go
@@ -46,13 +46,15 @@ const (
 )
 
 var (
-	useEffective       bool
-	useEffectiveGroups bool
+	useEffective                    bool
+	useEffectiveGroups              bool
+	useStaticAuthenticationIdentity bool
 )
 
 func registerFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&useEffective, "grpc_use_effective_callerid", false, "If set, and SSL is not used, will set the immediate caller id from the effective caller id's principal.")
 	fs.BoolVar(&useEffectiveGroups, "grpc-use-effective-groups", false, "If set, and SSL is not used, will set the immediate caller's security groups from the effective caller id's groups.")
+	fs.BoolVar(&useStaticAuthenticationIdentity, "grpc-use-static-authentication-callerid", false, "If set, will set the immediate caller id to the username authenticated by the static auth plugin.")
 }
 
 func init() {
@@ -95,8 +97,10 @@ func immediateCallerIDFromCert(ctx context.Context) (string, []string) {
 }
 
 func immediateCallerID(ctx context.Context) (string, []string) {
-	if immediate := servenv.StaticAuthUsernameFromContext(ctx); immediate != "" {
-		return immediate, nil
+	if useStaticAuthenticationIdentity {
+		if immediate := servenv.StaticAuthUsernameFromContext(ctx); immediate != "" {
+			return immediate, nil
+		}
 	}
 	return immediateCallerIDFromCert(ctx)
 }

--- a/go/vt/vtgate/grpcvtgateservice/server.go
+++ b/go/vt/vtgate/grpcvtgateservice/server.go
@@ -96,25 +96,35 @@ func immediateCallerIDFromCert(ctx context.Context) (string, []string) {
 	return cert.Subject.CommonName, cert.DNSNames
 }
 
-func immediateCallerID(ctx context.Context) (string, []string) {
-	if useStaticAuthenticationIdentity {
-		if immediate := servenv.StaticAuthUsernameFromContext(ctx); immediate != "" {
-			return immediate, nil
-		}
+// immediateCallerIdFromStaticAuthentication extracts the username of the current
+// static authentication context and returns that to the caller.
+func immediateCallerIdFromStaticAuthentication(ctx context.Context) (string, []string) {
+	if immediate := servenv.StaticAuthUsernameFromContext(ctx); immediate != "" {
+		return immediate, nil
 	}
-	return immediateCallerIDFromCert(ctx)
+
+	return "", nil
 }
 
 // withCallerIDContext creates a context that extracts what we need
 // from the incoming call and can be forwarded for use when talking to vttablet.
 func withCallerIDContext(ctx context.Context, effectiveCallerID *vtrpcpb.CallerID) context.Context {
-	immediate, securityGroups := immediateCallerID(ctx)
+	// The client cert common name (if using mTLS)
+	immediate, securityGroups := immediateCallerIDFromCert(ctx)
+
+	// The effective caller id (if --grpc_use_effective_callerid=true)
 	if immediate == "" && useEffective && effectiveCallerID != nil {
 		immediate = effectiveCallerID.Principal
 		if useEffectiveGroups && len(effectiveCallerID.Groups) > 0 {
 			securityGroups = effectiveCallerID.Groups
 		}
 	}
+
+	// The static auth username (if --grpc-use-static-authentication-callerid=true)
+	if immediate == "" && useStaticAuthenticationIdentity {
+		immediate, securityGroups = immediateCallerIdFromStaticAuthentication(ctx)
+	}
+
 	if immediate == "" {
 		immediate = unsecureClient
 	}

--- a/test/config.json
+++ b/test/config.json
@@ -878,7 +878,16 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/grpc_server_auth_static"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "vtgate_general_heavy",
+			"Shard": "vtgate_general_acls",
+			"RetryMax": 1,
+			"Tags": []
+		},
+		"vtgate_grpc_server_acls": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/grpc_server_acls"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_general_acls",
 			"RetryMax": 1,
 			"Tags": []
 		},

--- a/test/config.json
+++ b/test/config.json
@@ -878,7 +878,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/grpc_server_auth_static"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "vtgate_general_acls",
+			"Shard": "vtgate_general_heavy",
 			"RetryMax": 1,
 			"Tags": []
 		},
@@ -887,7 +887,7 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/grpc_server_acls"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "vtgate_general_acls",
+			"Shard": "vtgate_general_heavy",
 			"RetryMax": 1,
 			"Tags": []
 		},


### PR DESCRIPTION
## Description

Fixes https://github.com/vitessio/vitess/issues/12970 

This PR adds a new flag grpc-use-static-authentication-callerid to gate the behavior introduced in https://github.com/vitessio/vitess/pull/12050


While I reviewed this PR, I didn't catch the issue where the username from static authentication context **would completely override the immediate callerID** for all `Execute` calls to vtgate. 

PlanetScale's usage of vtgate static auth and ACLs system is a bit unique in that we don't handle authentication for user queries in vtgate. We do that in our own query front-end service.
VTGate static authentication is configured for service-to-service authentication between the query front-end and vtgate, ACL system is configured to pass through user roles from our credential store to vtgate.

We do this by setting the effectiveCallerID on requests made to the vtgate gRPC service and having the same names reflected in the acl config file for a given vttablet.

With the change in the referenced PR, all ACL checks for a database will fail since it will use the static authentication username, and not the effectiveCallerID from the `ExecuteRequest` call. 


The precedence of assigning the immediate Caller ID is now : 

``` bash
The client cert common name (if using mTLS)
The effective caller id (if --grpc_use_effective_callerid=true)
The static auth username (if --grpc-use-static-authentication-callerid=true)
```

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required
