### PR TITLE
Tablet throttler: adding log entries

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -338,7 +338,7 @@ func (throttler *Throttler) applyThrottlerConfig(ctx context.Context, throttlerC
 	if !throttlerConfigViaTopo {
 		return
 	}
-	log.Infof("Throttler: applying topo config")
+	log.Infof("Throttler: applying topo config: %+v", srvks.ThrottlerConfig)
 	if throttlerConfig.CustomQuery == "" {
 		throttler.metricsQuery.Store(sqlparser.BuildParsedQuery(defaultReplicationLagQuery, sidecardb.GetIdentifier()).Query)
 	} else {

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -310,6 +310,7 @@ func (throttler *Throttler) normalizeThrottlerConfig(thottlerConfig *topodatapb.
 }
 
 func (throttler *Throttler) WatchSrvKeyspaceCallback(srvks *topodatapb.SrvKeyspace, err error) bool {
+	log.Infof("Throttler: WatchSrvKeyspaceCallback")
 	if err != nil {
 		log.Errorf("WatchSrvKeyspaceCallback error: %v", err)
 		return false
@@ -320,6 +321,7 @@ func (throttler *Throttler) WatchSrvKeyspaceCallback(srvks *topodatapb.SrvKeyspa
 		// Throttler is running and we should apply the config change through Operate()
 		// or else we get into race conditions.
 		go func() {
+			log.Infof("Throttler: submitting a throttler config apply message")
 			throttler.throttlerConfigChan <- throttlerConfig
 		}()
 	} else {
@@ -336,6 +338,7 @@ func (throttler *Throttler) applyThrottlerConfig(ctx context.Context, throttlerC
 	if !throttlerConfigViaTopo {
 		return
 	}
+	log.Infof("Throttler: applying topo config")
 	if throttlerConfig.CustomQuery == "" {
 		throttler.metricsQuery.Store(sqlparser.BuildParsedQuery(defaultReplicationLagQuery, sidecardb.GetIdentifier()).Query)
 	} else {
@@ -361,8 +364,10 @@ func (throttler *Throttler) Enable(ctx context.Context) bool {
 	defer throttler.enableMutex.Unlock()
 
 	if throttler.IsEnabled() {
+		log.Infof("Throttler: already enabled")
 		return false
 	}
+	log.Infof("Throttler: enabling")
 	atomic.StoreInt64(&throttler.isEnabled, 1)
 
 	ctx, throttler.cancelEnableContext = context.WithCancel(ctx)
@@ -382,8 +387,10 @@ func (throttler *Throttler) Disable(ctx context.Context) bool {
 	defer throttler.enableMutex.Unlock()
 
 	if !throttler.IsEnabled() {
+		log.Infof("Throttler: already disabled")
 		return false
 	}
+	log.Infof("Throttler: disabling")
 	// _ = throttler.updateConfig(ctx, false, throttler.MetricsThreshold.Get()) // TODO(shlomi)
 	atomic.StoreInt64(&throttler.isEnabled, 0)
 
@@ -398,12 +405,15 @@ func (throttler *Throttler) Disable(ctx context.Context) bool {
 
 // Open opens database pool and initializes the schema
 func (throttler *Throttler) Open() error {
+	log.Infof("Throttler: started execution of Open. Acquiring initMutex lock")
 	throttler.initMutex.Lock()
 	defer throttler.initMutex.Unlock()
 	if atomic.LoadInt64(&throttler.isOpen) > 0 {
 		// already open
+		log.Infof("Throttler: throttler is already open")
 		return nil
 	}
+	log.Infof("Throttler: opening")
 	ctx := context.Background()
 	// The query needs to be dynamically built because the sidecar database name
 	// is not known when the TabletServer is created, which in turn creates the
@@ -419,6 +429,7 @@ func (throttler *Throttler) Open() error {
 	throttler.ThrottleApp("always-throttled-app", time.Now().Add(time.Hour*24*365*10), defaultThrottleRatio)
 
 	if throttlerConfigViaTopo {
+		log.Infof("Throttler: throttler-config-via-topo detected")
 		// We want to read throttler config from topo and apply it.
 		// But also, we're in an Open() function, which blocks state manager's operation, and affects
 		// opening of all other components. We thus read the throttler config in the background.

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -321,7 +321,7 @@ func (throttler *Throttler) WatchSrvKeyspaceCallback(srvks *topodatapb.SrvKeyspa
 		// Throttler is running and we should apply the config change through Operate()
 		// or else we get into race conditions.
 		go func() {
-			log.Infof("Throttler: submitting a throttler config apply message with: %+v", srvks.ThrottlerConfig)
+			log.Infof("Throttler: submitting a throttler config apply message with: %+v", throttlerConfig)
 			throttler.throttlerConfigChan <- throttlerConfig
 		}()
 	} else {
@@ -338,7 +338,7 @@ func (throttler *Throttler) applyThrottlerConfig(ctx context.Context, throttlerC
 	if !throttlerConfigViaTopo {
 		return
 	}
-	log.Infof("Throttler: applying topo config: %+v", srvks.ThrottlerConfig)
+	log.Infof("Throttler: applying topo config: %+v", throttlerConfig)
 	if throttlerConfig.CustomQuery == "" {
 		throttler.metricsQuery.Store(sqlparser.BuildParsedQuery(defaultReplicationLagQuery, sidecardb.GetIdentifier()).Query)
 	} else {

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -321,7 +321,7 @@ func (throttler *Throttler) WatchSrvKeyspaceCallback(srvks *topodatapb.SrvKeyspa
 		// Throttler is running and we should apply the config change through Operate()
 		// or else we get into race conditions.
 		go func() {
-			log.Infof("Throttler: submitting a throttler config apply message")
+			log.Infof("Throttler: submitting a throttler config apply message with: %+v", srvks.ThrottlerConfig)
 			throttler.throttlerConfigChan <- throttlerConfig
 		}()
 	} else {

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -310,7 +310,7 @@ func (throttler *Throttler) normalizeThrottlerConfig(thottlerConfig *topodatapb.
 }
 
 func (throttler *Throttler) WatchSrvKeyspaceCallback(srvks *topodatapb.SrvKeyspace, err error) bool {
-	log.Infof("Throttler: WatchSrvKeyspaceCallback")
+	log.Infof("Throttler: WatchSrvKeyspaceCallback called with: %+v", srvks)
 	if err != nil {
 		log.Errorf("WatchSrvKeyspaceCallback error: %v", err)
 		return false


### PR DESCRIPTION

## Description

This Pr adds much required log entries at key points of the tablet's lag throttler's operation; namely around `Open()`, `Enable()`, `Disable()` and a bit more. All of these entries are quiet, ie only log at startup/promotion/demotion/config update. These will not spam the logs.

## Related Issue(s)

-

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
