### PR TITLE
Use the newer `v2.7.5` vitess-operator version in the examples

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -5432,7 +5432,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: planetscale/vitess-operator:v2.7.4
+          image: planetscale/vitess-operator:v2.7.5
           name: vitess-operator
           resources:
             limits:


### PR DESCRIPTION
## Description

This is a follow-up of the recent `2.7.5` vitess-operator release. This PR updates the example to use that newer version.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
