### PR TITLE
vtgr: Remove unused code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,12 +15,10 @@ require (
 	github.com/aws/aws-sdk-go v1.44.192
 	github.com/buger/jsonparser v1.1.1
 	github.com/cespare/xxhash/v2 v2.2.0
-	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
 	github.com/corpix/uarand v0.1.1 // indirect
 	github.com/dave/jennifer v1.6.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fsnotify/fsnotify v1.6.0
-	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/golang/glog v1.0.0
 	github.com/golang/mock v1.6.0
@@ -36,7 +34,6 @@ require (
 	github.com/hashicorp/consul/api v1.18.0
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/serf v0.10.1 // indirect
-	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef
 	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
-github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
-github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
@@ -253,8 +251,6 @@ github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab h1:xveKWz2iaueeTaUgdetzel+U7exyigDYBryyVfV/rZk=
-github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -475,8 +471,6 @@ github.com/hashicorp/memberlist v0.5.0 h1:EtYPN8DpAURiapus508I4n9CzHs2W+8NZGbmmR
 github.com/hashicorp/memberlist v0.5.0/go.mod h1:yvyXLpo0QaGE59Y7hDTsTzDD25JYBZ4mHgHUZ8lrOI0=
 github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
-github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
-github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/go/vt/vtgr/ssl/ssl.go
+++ b/go/vt/vtgr/ssl/ssl.go
@@ -3,34 +3,15 @@ package ssl
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/pem"
 	"errors"
-	"fmt"
-	nethttp "net/http"
 	"os"
-	"strings"
 
 	"vitess.io/vitess/go/vt/log"
-
-	"github.com/go-martini/martini"
-	"github.com/howeyc/gopass"
-
-	"vitess.io/vitess/go/vt/vtgr/config"
 )
 
 /*
 	This file has been copied over from VTOrc package
 */
-
-// Determine if a string element is in a string array
-func HasString(elem string, arr []string) bool {
-	for _, s := range arr {
-		if s == elem {
-			return true
-		}
-	}
-	return false
-}
 
 // NewTLSConfig returns an initialized TLS configuration suitable for client
 // authentication. If caFile is non-empty, it will be loaded.
@@ -69,40 +50,6 @@ func ReadCAFile(caFile string) (*x509.CertPool, error) {
 	return caCertPool, nil
 }
 
-// Verify that the OU of the presented client certificate matches the list
-// of Valid OUs
-func Verify(r *nethttp.Request, validOUs []string) error {
-	if strings.Contains(r.URL.String(), config.Config.StatusEndpoint) && !config.Config.StatusOUVerify {
-		return nil
-	}
-	if r.TLS == nil {
-		return errors.New("No TLS")
-	}
-	for _, chain := range r.TLS.VerifiedChains {
-		s := chain[0].Subject.OrganizationalUnit
-		log.Infof("All OUs:", strings.Join(s, " "))
-		for _, ou := range s {
-			log.Infof("Client presented OU:", ou)
-			if HasString(ou, validOUs) {
-				log.Infof("Found valid OU:", ou)
-				return nil
-			}
-		}
-	}
-	log.Error("No valid OUs found")
-	return errors.New("Invalid OU")
-}
-
-// TODO: make this testable?
-func VerifyOUs(validOUs []string) martini.Handler {
-	return func(res nethttp.ResponseWriter, req *nethttp.Request, c martini.Context) {
-		log.Infof("Verifying client OU")
-		if err := Verify(req, validOUs); err != nil {
-			nethttp.Error(res, err.Error(), nethttp.StatusUnauthorized)
-		}
-	}
-}
-
 // AppendKeyPair loads the given TLS key pair and appends it to
 // tlsConfig.Certificates.
 func AppendKeyPair(tlsConfig *tls.Config, certFile string, keyFile string) error {
@@ -112,97 +59,4 @@ func AppendKeyPair(tlsConfig *tls.Config, certFile string, keyFile string) error
 	}
 	tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 	return nil
-}
-
-// Read in a keypair where the key is password protected
-func AppendKeyPairWithPassword(tlsConfig *tls.Config, certFile string, keyFile string, pemPass []byte) error {
-
-	// Certificates aren't usually password protected, but we're kicking the password
-	// along just in case.  It won't be used if the file isn't encrypted
-	certData, err := ReadPEMData(certFile, pemPass)
-	if err != nil {
-		return err
-	}
-	keyData, err := ReadPEMData(keyFile, pemPass)
-	if err != nil {
-		return err
-	}
-	cert, err := tls.X509KeyPair(certData, keyData)
-	if err != nil {
-		return err
-	}
-	tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
-	return nil
-}
-
-// Read a PEM file and ask for a password to decrypt it if needed
-func ReadPEMData(pemFile string, pemPass []byte) ([]byte, error) {
-	pemData, err := os.ReadFile(pemFile)
-	if err != nil {
-		return pemData, err
-	}
-
-	// We should really just get the pem.Block back here, if there's other
-	// junk on the end, warn about it.
-	pemBlock, rest := pem.Decode(pemData)
-	if len(rest) > 0 {
-		log.Warning("Didn't parse all of", pemFile)
-	}
-
-	if x509.IsEncryptedPEMBlock(pemBlock) { //nolint SA1019
-		// Decrypt and get the ASN.1 DER bytes here
-		pemData, err = x509.DecryptPEMBlock(pemBlock, pemPass) //nolint SA1019
-		if err != nil {
-			return pemData, err
-		}
-		log.Infof("Decrypted %v successfully", pemFile)
-		// Shove the decrypted DER bytes into a new pem Block with blank headers
-		var newBlock pem.Block
-		newBlock.Type = pemBlock.Type
-		newBlock.Bytes = pemData
-		// This is now like reading in an uncrypted key from a file and stuffing it
-		// into a byte stream
-		pemData = pem.EncodeToMemory(&newBlock)
-	}
-	return pemData, nil
-}
-
-// Print a password prompt on the terminal and collect a password
-func GetPEMPassword(pemFile string) []byte {
-	fmt.Printf("Password for %s: ", pemFile)
-	pass, err := gopass.GetPasswd()
-	if err != nil {
-		// We'll error with an incorrect password at DecryptPEMBlock
-		return []byte("")
-	}
-	return pass
-}
-
-// Determine if PEM file is encrypted
-func IsEncryptedPEM(pemFile string) bool {
-	pemData, err := os.ReadFile(pemFile)
-	if err != nil {
-		return false
-	}
-	pemBlock, _ := pem.Decode(pemData)
-	if len(pemBlock.Bytes) == 0 {
-		return false
-	}
-	return x509.IsEncryptedPEMBlock(pemBlock) //nolint SA1019
-}
-
-// ListenAndServeTLS acts identically to http.ListenAndServeTLS, except that it
-// expects TLS configuration.
-// TODO: refactor so this is testable?
-func ListenAndServeTLS(addr string, handler nethttp.Handler, tlsConfig *tls.Config) error {
-	if addr == "" {
-		// On unix Listen calls getaddrinfo to parse the port, so named ports are fine as long
-		// as they exist in /etc/services
-		addr = ":https"
-	}
-	l, err := tls.Listen("tcp", addr, tlsConfig)
-	if err != nil {
-		return err
-	}
-	return nethttp.Serve(l, handler)
 }


### PR DESCRIPTION
While digging into something else, I ran into this code which seems entirely unused.

This cleanup also removes a bunch of deprecated APIs for encrypted PEM files which aren't very secure and custom certificate validation logic, so that's a double win.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
