### PR TITLE
fix: deflake TestGetSchemaRPC test

### DIFF
--- a/go/vt/vttablet/endtoend/views_test.go
+++ b/go/vt/vttablet/endtoend/views_test.go
@@ -269,6 +269,7 @@ func TestViewAndTableUnique(t *testing.T) {
 func TestGetSchemaRPC(t *testing.T) {
 	client := framework.NewClient()
 
+	client.Execute("delete from _vt.views", nil)
 	viewSchemaDef, err := client.GetSchema(querypb.SchemaTableType_VIEWS)
 	require.NoError(t, err)
 	require.Zero(t, len(viewSchemaDef))


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds cleanup query before start of `TestGetSchemaRPC` test. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
- 
## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
