### PR TITLE
gen4 planner: Derived table handling on operators

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -920,8 +920,12 @@ func containEscapableChars(s string, at AtCount) bool {
 }
 
 func formatID(buf *TrackedBuffer, original string, at AtCount) {
+	if buf.escape == EscapeNoIdentifiers {
+		buf.WriteString(original)
+		return
+	}
 	_, isKeyword := keywordLookupTable.LookupString(original)
-	if buf.escape || isKeyword || containEscapableChars(original, at) {
+	if buf.escape == escapeAllIdentifiers || isKeyword || containEscapableChars(original, at) {
 		writeEscapedString(buf, original)
 	} else {
 		buf.WriteString(original)

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -920,7 +920,7 @@ func containEscapableChars(s string, at AtCount) bool {
 }
 
 func formatID(buf *TrackedBuffer, original string, at AtCount) {
-	if buf.escape == EscapeNoIdentifiers {
+	if buf.escape == escapeNoIdentifiers {
 		buf.WriteString(original)
 		return
 	}

--- a/go/vt/sqlparser/tracked_buffer.go
+++ b/go/vt/sqlparser/tracked_buffer.go
@@ -45,9 +45,9 @@ type TrackedBuffer struct {
 type escapeType int
 
 const (
-	EscapeKeywords escapeType = iota
+	escapeKeywords escapeType = iota
 	escapeAllIdentifiers
-	EscapeNoIdentifiers
+	escapeNoIdentifiers
 )
 
 // NewTrackedBuffer creates a new TrackedBuffer.
@@ -100,7 +100,7 @@ func (buf *TrackedBuffer) SetEscapeAllIdentifiers() {
 // Enabling this option will prevent the optimized fastFormat routines from running.
 func (buf *TrackedBuffer) SetEscapeNoIdentifier() {
 	buf.fast = false
-	buf.escape = EscapeNoIdentifiers
+	buf.escape = escapeNoIdentifiers
 }
 
 // WriteNode function, initiates the writing of a single SQLNode tree by passing

--- a/go/vt/sqlparser/tracked_buffer.go
+++ b/go/vt/sqlparser/tracked_buffer.go
@@ -37,9 +37,18 @@ type TrackedBuffer struct {
 	bindLocations []bindLocation
 	nodeFormatter NodeFormatter
 	literal       func(string) (int, error)
-	escape        bool
 	fast          bool
+
+	escape escapeType
 }
+
+type escapeType int
+
+const (
+	EscapeKeywords escapeType = iota
+	escapeAllIdentifiers
+	EscapeNoIdentifiers
+)
 
 // NewTrackedBuffer creates a new TrackedBuffer.
 func NewTrackedBuffer(nodeFormatter NodeFormatter) *TrackedBuffer {
@@ -81,9 +90,17 @@ func (buf *TrackedBuffer) SetUpperCase(enable bool) {
 // and escaped. By default, identifiers are only escaped if they match the name of a SQL keyword or they
 // contain characters that must be escaped.
 // Enabling this option will prevent the optimized fastFormat routines from running.
-func (buf *TrackedBuffer) SetEscapeAllIdentifiers(enable bool) {
+func (buf *TrackedBuffer) SetEscapeAllIdentifiers() {
 	buf.fast = false
-	buf.escape = enable
+	buf.escape = escapeAllIdentifiers
+}
+
+// SetEscapeNoIdentifier sets whether NO identifiers in the serialized SQL query should be quoted and escaped.
+// Warning: this can lead to query output that is not valid SQL
+// Enabling this option will prevent the optimized fastFormat routines from running.
+func (buf *TrackedBuffer) SetEscapeNoIdentifier() {
+	buf.fast = false
+	buf.escape = EscapeNoIdentifiers
 }
 
 // WriteNode function, initiates the writing of a single SQLNode tree by passing
@@ -304,6 +321,19 @@ func String(node SQLNode) string {
 	return buf.String()
 }
 
+// UnescapedString will return a string where no identifiers have been escaped.
+func UnescapedString(node SQLNode) string {
+	if node == nil {
+		return "" // do not return '<nil>', which is Go syntax.
+	}
+
+	buf := NewTrackedBuffer(nil)
+	buf.SetEscapeNoIdentifier()
+	node.Format(buf)
+	return buf.String()
+
+}
+
 // CanonicalString returns a canonical string representation of an SQLNode where all identifiers
 // are always escaped and all SQL syntax is in uppercase. This matches the canonical output from MySQL.
 func CanonicalString(node SQLNode) string {
@@ -313,7 +343,7 @@ func CanonicalString(node SQLNode) string {
 
 	buf := NewTrackedBuffer(nil)
 	buf.SetUpperCase(true)
-	buf.SetEscapeAllIdentifiers(true)
+	buf.SetEscapeAllIdentifiers()
 	node.Format(buf)
 	return buf.String()
 }

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -371,6 +371,8 @@ func buildProjection(op *Projection, qb *queryBuilder) error {
 	}
 
 	qb.clearProjections()
+
+	// we are creating the select here
 	for i, column := range op.Columns {
 		ae := &sqlparser.AliasedExpr{Expr: column.GetExpr()}
 		if op.ColumnNames[i] != "" {
@@ -378,6 +380,17 @@ func buildProjection(op *Projection, qb *queryBuilder) error {
 		}
 		qb.addProjection(ae)
 	}
+
+	// if the projection is on derived table, we use the select we have
+	// created above and transform it into a derived table
+	if op.TableID != nil {
+		sel := qb.sel.(*sqlparser.Select)
+		qb.sel = nil
+		qb.addTableExpr(op.Alias, op.Alias, TableID(op), &sqlparser.DerivedTable{
+			Select: sel,
+		}, nil, nil)
+	}
+
 	return nil
 }
 

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -372,7 +372,6 @@ func buildProjection(op *Projection, qb *queryBuilder) error {
 
 	qb.clearProjections()
 
-	// we are creating the select here
 	for i, column := range op.Columns {
 		ae := &sqlparser.AliasedExpr{Expr: column.GetExpr()}
 		if op.ColumnNames[i] != "" {

--- a/go/vt/vtgate/planbuilder/operators/derived.go
+++ b/go/vt/vtgate/planbuilder/operators/derived.go
@@ -253,6 +253,7 @@ func (d *Derived) getQP(ctx *plancontext.PlanningContext) (*QueryProjection, err
 	d.QP = qp
 	return d.QP, nil
 }
+
 func (d *Derived) setQP(qp *QueryProjection) {
 	d.QP = qp
 }

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -104,6 +104,7 @@ func (h *Horizon) getQP(ctx *plancontext.PlanningContext) (*QueryProjection, err
 	h.QP = qp
 	return h.QP, nil
 }
+
 func (h *Horizon) setQP(qp *QueryProjection) {
 	h.QP = qp
 }

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -155,71 +155,17 @@ func pushDownProjectionInApplyJoin(
 	lhs, rhs := &projector{}, &projector{}
 
 	src.ColumnsAST = nil
-	// Iterate through each column in the Projection's columns.
 	for idx := 0; idx < len(p.Columns); idx++ {
-		in := p.Columns[idx]
-		expr := in.GetExpr()
-
-		// Check if the current expression can reuse an existing column in the ApplyJoin.
-		if _, found := canReuseColumn(ctx, src.ColumnsAST, expr, joinColumnToExpr); found {
-			continue
-		}
-
-		// Get a JoinColumn for the current expression.
-		colName := p.ColumnNames[idx]
-		col, err := src.getJoinColumnFor(ctx, &sqlparser.AliasedExpr{Expr: expr, As: sqlparser.NewIdentifierCI(colName)})
+		err := splitProjectionAcrossJoin(ctx, src, lhs, rhs, p.Columns[idx], p.ColumnNames[idx])
 		if err != nil {
 			return nil, false, err
 		}
-
-		// Update the left and right child columns and names based on the JoinColumn type.
-		switch {
-		case col.IsPureLeft():
-			lhs.add(in, colName)
-		case col.IsPureRight():
-			rhs.add(in, colName)
-		case col.IsMixedLeftAndRight():
-			for _, lhsExpr := range col.LHSExprs {
-				lhs.add(&Expr{E: lhsExpr}, "")
-			}
-			rhs.add(&Expr{E: col.RHSExpr}, colName)
-		}
-
-		// Add the new JoinColumn to the ApplyJoin's ColumnsAST.
-		src.ColumnsAST = append(src.ColumnsAST, col)
 	}
 
 	if p.TableID != nil {
-		derivedTbl, err := ctx.SemTable.TableInfoFor(*p.TableID)
+		err := exposeColumnsThroughDerivedTable(ctx, p, src, lhs)
 		if err != nil {
 			return nil, false, err
-		}
-		derivedTblName, err := derivedTbl.Name()
-		if err != nil {
-			return nil, false, err
-		}
-		for _, predicate := range src.JoinPredicates {
-			for idx, expr := range predicate.LHSExprs {
-				tbl, err := ctx.SemTable.TableInfoForExpr(expr)
-				if err != nil {
-					return nil, false, err
-				}
-				tblExpr := tbl.GetExpr()
-				tblName, err := tblExpr.TableName()
-				if err != nil {
-					return nil, false, err
-				}
-
-				expr = semantics.RewriteDerivedTableExpression(expr, derivedTbl)
-				out, err := prefixColNames(tblName, expr)
-				if err != nil {
-					return nil, false, err
-				}
-
-				alias := sqlparser.UnescapedString(out)
-				predicate.LHSExprs[idx] = sqlparser.NewColNameWithQualifier(alias, derivedTblName)
-				lhs.add(&Expr{E: out}, alias)
-			}
 		}
 	}
 
@@ -239,6 +185,95 @@ func pushDownProjectionInApplyJoin(
 	return src, rewrite.NewTree, nil
 }
 
+// splitProjectionAcrossJoin creates JoinColumns for all projections,
+// and pushes down columns as needed between the LHS and RHS of a join
+func splitProjectionAcrossJoin(
+	ctx *plancontext.PlanningContext,
+	join *ApplyJoin,
+	lhs, rhs *projector,
+	in ProjExpr,
+	colName string,
+) error {
+	expr := in.GetExpr()
+
+	// Check if the current expression can reuse an existing column in the ApplyJoin.
+	if _, found := canReuseColumn(ctx, join.ColumnsAST, expr, joinColumnToExpr); found {
+		return nil
+	}
+
+	// Get a JoinColumn for the current expression.
+	col, err := join.getJoinColumnFor(ctx, &sqlparser.AliasedExpr{Expr: expr, As: sqlparser.NewIdentifierCI(colName)})
+	if err != nil {
+		return err
+	}
+
+	// Update the left and right child columns and names based on the JoinColumn type.
+	switch {
+	case col.IsPureLeft():
+		lhs.add(in, colName)
+	case col.IsPureRight():
+		rhs.add(in, colName)
+	case col.IsMixedLeftAndRight():
+		for _, lhsExpr := range col.LHSExprs {
+			lhs.add(&Expr{E: lhsExpr}, "")
+		}
+		rhs.add(&Expr{E: col.RHSExpr}, colName)
+	}
+
+	// Add the new JoinColumn to the ApplyJoin's ColumnsAST.
+	join.ColumnsAST = append(join.ColumnsAST, col)
+	return nil
+}
+
+// exposeColumnsThroughDerivedTable rewrites expressions within a join that is inside a derived table
+// in order to make them accessible outside the derived table. This is necessary when swapping the
+// positions of the derived table and join operation.
+//
+// For example, consider the input query:
+// select ... from (select T1.foo from T1 join T2 on T1.id = T2.id) as t
+// If we push the derived table under the join, with T1 on the LHS of the join, we need to expose
+// the values of T1.id through the derived table, or they will not be accessible on the RHS.
+//
+// The function iterates through each join predicate, rewriting the expressions in the predicate's
+// LHS expressions to include the derived table. This allows the expressions to be accessed outside
+// the derived table.
+func exposeColumnsThroughDerivedTable(ctx *plancontext.PlanningContext, p *Projection, src *ApplyJoin, lhs *projector) error {
+	derivedTbl, err := ctx.SemTable.TableInfoFor(*p.TableID)
+	if err != nil {
+		return err
+	}
+	derivedTblName, err := derivedTbl.Name()
+	if err != nil {
+		return err
+	}
+	for _, predicate := range src.JoinPredicates {
+		for idx, expr := range predicate.LHSExprs {
+			tbl, err := ctx.SemTable.TableInfoForExpr(expr)
+			if err != nil {
+				return err
+			}
+			tblExpr := tbl.GetExpr()
+			tblName, err := tblExpr.TableName()
+			if err != nil {
+				return err
+			}
+
+			expr = semantics.RewriteDerivedTableExpression(expr, derivedTbl)
+			out, err := prefixColNames(tblName, expr)
+			if err != nil {
+				return err
+			}
+
+			alias := sqlparser.UnescapedString(out)
+			predicate.LHSExprs[idx] = sqlparser.NewColNameWithQualifier(alias, derivedTblName)
+			lhs.add(&Expr{E: out}, alias)
+		}
+	}
+	return nil
+}
+
+// prefixColNames adds qualifier prefixes to all ColName:s.
+// We want to be more explicit than the user was to make sure we never produce invalid SQL
 func prefixColNames(tblName sqlparser.TableName, e sqlparser.Expr) (out sqlparser.Expr, err error) {
 	out = sqlparser.CopyOnRewrite(e, nil, func(cursor *sqlparser.CopyOnWriteCursor) {
 		col, ok := cursor.Node().(*sqlparser.ColName)

--- a/go/vt/vtgate/planbuilder/operators/logical.go
+++ b/go/vt/vtgate/planbuilder/operators/logical.go
@@ -270,7 +270,6 @@ func getOperatorFromAliasedTableExpr(ctx *plancontext.PlanningContext, tableExpr
 	tableID := ctx.SemTable.TableSetFor(tableExpr)
 	switch tbl := tableExpr.Expr.(type) {
 	case sqlparser.TableName:
-		tableID := tableID
 		tableInfo, err := ctx.SemTable.TableInfoFor(tableID)
 		if err != nil {
 			return nil, err

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -3166,41 +3166,32 @@
         "TableName": "`user`_user_extra_unsharded",
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": [
-              1,
-              0
-            ],
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "L:0,L:1",
+            "TableName": "`user`_user_extra",
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1",
-                "TableName": "`user`_user_extra",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select `user`.id, `user`.col1 from `user` where 1 != 1",
-                    "Query": "select `user`.id, `user`.col1 from `user`",
-                    "Table": "`user`"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select 1 from user_extra",
-                    "Table": "user_extra"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select t.col1, t.id from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
+                "Query": "select t.col1, t.id from (select `user`.id, `user`.col1 from `user`) as t",
+                "Table": "`user`"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra",
+                "Table": "user_extra"
               }
             ]
           },
@@ -3276,43 +3267,35 @@
       "QueryType": "SELECT",
       "Original": "select t.id from (select user.id, user.col1 from user join user_extra on user_extra.col = user.col) as t",
       "Instructions": {
-        "OperatorType": "SimpleProjection",
-        "Columns": [
-          0
-        ],
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0",
+        "JoinVars": {
+          "user_col": 1
+        },
+        "TableName": "`user`_user_extra",
         "Inputs": [
           {
-            "OperatorType": "Join",
-            "Variant": "Join",
-            "JoinColumnIndexes": "L:1,L:2",
-            "JoinVars": {
-              "user_col": 0
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
             },
-            "TableName": "`user`_user_extra",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `user`.col, `user`.id, `user`.col1 from `user` where 1 != 1",
-                "Query": "select `user`.col, `user`.id, `user`.col1 from `user`",
-                "Table": "`user`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra where user_extra.col = :user_col",
-                "Table": "user_extra"
-              }
-            ]
+            "FieldQuery": "select t.id, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id, t.`user.col` from (select `user`.id, `user`.col1, `user`.col as `user.col` from `user`) as t",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from user_extra where 1 != 1",
+            "Query": "select 1 from user_extra where user_extra.col = :user_col",
+            "Table": "user_extra"
           }
         ]
       },
@@ -3407,40 +3390,32 @@
             "Table": "unsharded_a"
           },
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": [
-              1
-            ],
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "L:0",
+            "TableName": "`user`_user_extra",
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1",
-                "TableName": "`user`_user_extra",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select `user`.id, `user`.col1 from `user` where 1 != 1",
-                    "Query": "select `user`.id, `user`.col1 from `user`",
-                    "Table": "`user`"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select 1 from user_extra",
-                    "Table": "user_extra"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
+                "Query": "select t.col1 from (select `user`.id, `user`.col1 from `user`) as t",
+                "Table": "`user`"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra",
+                "Table": "user_extra"
               }
             ]
           }
@@ -3481,44 +3456,36 @@
             "Table": "unsharded_a"
           },
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": [
-              1
-            ],
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "L:0",
+            "TableName": "`user`_user_extra",
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1",
-                "TableName": "`user`_user_extra",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "EqualUnique",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select `user`.id, `user`.col1 from `user` where 1 != 1",
-                    "Query": "select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id",
-                    "Table": "`user`",
-                    "Values": [
-                      ":ua_id"
-                    ],
-                    "Vindex": "user_index"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select 1 from user_extra where 1 != 1",
-                    "Query": "select 1 from user_extra",
-                    "Table": "user_extra"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select t.col1 from (select `user`.id, `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
+                "Query": "select t.col1 from (select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id) as t",
+                "Table": "`user`",
+                "Values": [
+                  ":ua_id"
+                ],
+                "Vindex": "user_index"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra",
+                "Table": "user_extra"
               }
             ]
           }
@@ -4298,41 +4265,32 @@
       "QueryType": "SELECT",
       "Original": "select id, t.id from (select user.id from user join user_extra) as t",
       "Instructions": {
-        "OperatorType": "SimpleProjection",
-        "Columns": [
-          0,
-          0
-        ],
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0,L:0",
+        "TableName": "`user`_user_extra",
         "Inputs": [
           {
-            "OperatorType": "Join",
-            "Variant": "Join",
-            "JoinColumnIndexes": "L:0",
-            "TableName": "`user`_user_extra",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `user`.id from `user` where 1 != 1",
-                "Query": "select `user`.id from `user`",
-                "Table": "`user`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
-              }
-            ]
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from (select `user`.id from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select id from (select `user`.id from `user`) as t",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from user_extra where 1 != 1",
+            "Query": "select 1 from user_extra",
+            "Table": "user_extra"
           }
         ]
       },
@@ -5013,44 +4971,36 @@
       "QueryType": "SELECT",
       "Original": "select id from (select user.id, user.col from user join user_extra) as t where id=5",
       "Instructions": {
-        "OperatorType": "SimpleProjection",
-        "Columns": [
-          0
-        ],
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0",
+        "TableName": "`user`_user_extra",
         "Inputs": [
           {
-            "OperatorType": "Join",
-            "Variant": "Join",
-            "JoinColumnIndexes": "L:0,L:1",
-            "TableName": "`user`_user_extra",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "EqualUnique",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `user`.id, `user`.col from `user` where 1 != 1",
-                "Query": "select `user`.id, `user`.col from `user` where `user`.id = 5",
-                "Table": "`user`",
-                "Values": [
-                  "INT64(5)"
-                ],
-                "Vindex": "user_index"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
-              }
-            ]
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select id from (select `user`.id, `user`.col from `user` where `user`.id = 5) as t",
+            "Table": "`user`",
+            "Values": [
+              "INT64(5)"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from user_extra where 1 != 1",
+            "Query": "select 1 from user_extra",
+            "Table": "user_extra"
           }
         ]
       },
@@ -5068,40 +5018,32 @@
       "QueryType": "SELECT",
       "Original": "select id+1 from (select user.id, user.col from user join user_extra) as t",
       "Instructions": {
-        "OperatorType": "SimpleProjection",
-        "Columns": [
-          2
-        ],
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0",
+        "TableName": "`user`_user_extra",
         "Inputs": [
           {
-            "OperatorType": "Join",
-            "Variant": "Join",
-            "JoinColumnIndexes": "L:0,L:1,L:2",
-            "TableName": "`user`_user_extra",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `user`.id, `user`.col, `user`.id + 1 from `user` where 1 != 1",
-                "Query": "select `user`.id, `user`.col, `user`.id + 1 from `user`",
-                "Table": "`user`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select 1 from user_extra where 1 != 1",
-                "Query": "select 1 from user_extra",
-                "Table": "user_extra"
-              }
-            ]
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id + 1 from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select id + 1 from (select `user`.id, `user`.col from `user`) as t",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from user_extra where 1 != 1",
+            "Query": "select 1 from user_extra",
+            "Table": "user_extra"
           }
         ]
       },
@@ -5499,48 +5441,39 @@
       "Instructions": {
         "OperatorType": "Join",
         "Variant": "Join",
-        "JoinColumnIndexes": "L:1",
+        "JoinColumnIndexes": "L:0",
         "JoinVars": {
-          "t_col1": 0
+          "t_col1": 1
         },
         "TableName": "`user`_unsharded_unsharded",
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": [
-              0,
-              1
-            ],
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "L:0,L:1",
+            "TableName": "`user`_unsharded",
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1",
-                "TableName": "`user`_unsharded",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select `user`.col1, 0 from `user` where 1 != 1",
-                    "Query": "select `user`.col1, 0 from `user`",
-                    "Table": "`user`"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Unsharded",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select 1 from unsharded where 1 != 1",
-                    "Query": "select 1 from unsharded",
-                    "Table": "unsharded"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 0, t.col1 from (select `user`.col1 from `user` where 1 != 1) as t where 1 != 1",
+                "Query": "select 0, t.col1 from (select `user`.col1 from `user`) as t",
+                "Table": "`user`"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1 from unsharded where 1 != 1",
+                "Query": "select 1 from unsharded",
+                "Table": "unsharded"
               }
             ]
           },
@@ -5882,40 +5815,32 @@
             "TableName": "`user`_user_extra_user_extra",
             "Inputs": [
               {
-                "OperatorType": "SimpleProjection",
-                "Columns": [
-                  0
-                ],
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "L:0",
+                "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
-                    "OperatorType": "Join",
-                    "Variant": "Join",
-                    "JoinColumnIndexes": "L:0",
-                    "TableName": "`user`_user_extra",
-                    "Inputs": [
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select `user`.col from `user` where 1 != 1",
-                        "Query": "select `user`.col from `user`",
-                        "Table": "`user`"
-                      },
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select 1 from user_extra where 1 != 1",
-                        "Query": "select 1 from user_extra",
-                        "Table": "user_extra"
-                      }
-                    ]
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select u.col from (select `user`.col from `user` where 1 != 1) as u where 1 != 1",
+                    "Query": "select u.col from (select `user`.col from `user`) as u",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select 1 from user_extra where 1 != 1",
+                    "Query": "select 1 from user_extra",
+                    "Table": "user_extra"
                   }
                 ]
               },

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.json
@@ -494,22 +494,20 @@
       "QueryType": "SELECT",
       "Original": "select id from (select user.id, user.col from user join user_extra) as t order by id",
       "Instructions": {
-        "OperatorType": "Sort",
-        "Variant": "Memory",
-        "OrderBy": "(0|1) ASC",
-        "ResultColumns": 1,
+        "OperatorType": "SimpleProjection",
+        "Columns": [
+          0
+        ],
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": [
-              0,
-              2
-            ],
+            "OperatorType": "Sort",
+            "Variant": "Memory",
+            "OrderBy": "(0|1) ASC",
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "L:0,L:1,L:2",
+                "JoinColumnIndexes": "L:0,L:1",
                 "TableName": "`user`_user_extra",
                 "Inputs": [
                   {
@@ -519,8 +517,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select `user`.id, `user`.col, weight_string(`user`.id) from `user` where 1 != 1",
-                    "Query": "select `user`.id, `user`.col, weight_string(`user`.id) from `user`",
+                    "FieldQuery": "select id, weight_string(id) from (select `user`.id, `user`.col from `user` where 1 != 1) as t where 1 != 1",
+                    "Query": "select id, weight_string(id) from (select `user`.id, `user`.col from `user`) as t",
                     "Table": "`user`"
                   },
                   {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -2319,41 +2319,32 @@
       "QueryType": "SELECT",
       "Original": "select * from (select user.id id1, user_extra.id id2 from user join user_extra) as t",
       "Instructions": {
-        "OperatorType": "SimpleProjection",
-        "Columns": [
-          0,
-          1
-        ],
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0,R:0",
+        "TableName": "`user`_user_extra",
         "Inputs": [
           {
-            "OperatorType": "Join",
-            "Variant": "Join",
-            "JoinColumnIndexes": "L:0,R:0",
-            "TableName": "`user`_user_extra",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `user`.id as id1 from `user` where 1 != 1",
-                "Query": "select `user`.id as id1 from `user`",
-                "Table": "`user`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select user_extra.id as id2 from user_extra where 1 != 1",
-                "Query": "select user_extra.id as id2 from user_extra",
-                "Table": "user_extra"
-              }
-            ]
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select t.id1 from (select `user`.id as id1 from `user` where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id1 from (select `user`.id as id1 from `user`) as t",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select t.id2 from (select user_extra.id as id2 from user_extra where 1 != 1) as t where 1 != 1",
+            "Query": "select t.id2 from (select user_extra.id as id2 from user_extra) as t",
+            "Table": "user_extra"
           }
         ]
       },
@@ -7580,27 +7571,19 @@
         "TableName": "user_extra_`user`",
         "Inputs": [
           {
-            "OperatorType": "SimpleProjection",
-            "Columns": [
-              0
-            ],
+            "OperatorType": "Limit",
+            "Count": "INT64(10)",
             "Inputs": [
               {
-                "OperatorType": "Limit",
-                "Count": "INT64(10)",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select user_id from user_extra where 1 != 1",
-                    "Query": "select user_id from user_extra limit :__upper_limit",
-                    "Table": "user_extra"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select ue.user_id from (select user_id from user_extra where 1 != 1) as ue where 1 != 1",
+                "Query": "select ue.user_id from (select user_id from user_extra) as ue limit :__upper_limit",
+                "Table": "user_extra"
               }
             ]
           },

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -129,7 +129,7 @@ func (b *binder) bindCountStar(node *sqlparser.CountStar) {
 				}
 			}
 		default:
-			expr := tbl.getExpr()
+			expr := tbl.GetExpr()
 			if expr != nil {
 				setFor := b.tc.tableSetFor(expr)
 				ts = ts.Merge(setFor)
@@ -150,7 +150,7 @@ func (b *binder) rewriteJoinUsingColName(deps dependency, node *sqlparser.ColNam
 	if err != nil {
 		return dependency{}, err
 	}
-	alias := infoFor.getExpr().As
+	alias := infoFor.GetExpr().As
 	if alias.IsEmpty() {
 		name, err := infoFor.Name()
 		if err != nil {

--- a/go/vt/vtgate/semantics/derived_table.go
+++ b/go/vt/vtgate/semantics/derived_table.go
@@ -105,7 +105,7 @@ func (dt *DerivedTable) Name() (sqlparser.TableName, error) {
 	return dt.ASTNode.TableName()
 }
 
-func (dt *DerivedTable) getExpr() *sqlparser.AliasedTableExpr {
+func (dt *DerivedTable) GetExpr() *sqlparser.AliasedTableExpr {
 	return dt.ASTNode
 }
 

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -553,7 +553,7 @@ type expanderState struct {
 // addColumn adds columns to the expander state. If we have vschema info about the query,
 // we also store which columns were expanded
 func (e *expanderState) addColumn(col ColumnInfo, tbl TableInfo, tblName sqlparser.TableName) {
-	tableAliased := !tbl.getExpr().As.IsEmpty()
+	tableAliased := !tbl.GetExpr().As.IsEmpty()
 	withQualifier := e.needsQualifier || tableAliased
 	var colName *sqlparser.ColName
 	var alias sqlparser.IdentifierCI
@@ -578,7 +578,7 @@ func (e *expanderState) createAliasedExpr(
 	tbl TableInfo,
 	tblName sqlparser.TableName,
 ) *sqlparser.AliasedExpr {
-	tableAliased := !tbl.getExpr().As.IsEmpty()
+	tableAliased := !tbl.GetExpr().As.IsEmpty()
 	withQualifier := e.needsQualifier || tableAliased
 	var colName *sqlparser.ColName
 	var alias sqlparser.IdentifierCI

--- a/go/vt/vtgate/semantics/real_table.go
+++ b/go/vt/vtgate/semantics/real_table.go
@@ -73,7 +73,7 @@ func (r *RealTable) getColumns() []ColumnInfo {
 }
 
 // GetExpr implements the TableInfo interface
-func (r *RealTable) getExpr() *sqlparser.AliasedTableExpr {
+func (r *RealTable) GetExpr() *sqlparser.AliasedTableExpr {
 	return r.ASTNode
 }
 

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -125,7 +125,7 @@ func newVindexTable(t sqlparser.IdentifierCS) *vindexes.Table {
 // The code lives in this file since it is only touching tableCollector data
 func (tc *tableCollector) tableSetFor(t *sqlparser.AliasedTableExpr) TableSet {
 	for i, t2 := range tc.Tables {
-		if t == t2.getExpr() {
+		if t == t2.GetExpr() {
 			return SingleTableSet(i)
 		}
 	}

--- a/go/vt/vtgate/semantics/vindex_table.go
+++ b/go/vt/vtgate/semantics/vindex_table.go
@@ -67,8 +67,8 @@ func (v *VindexTable) Name() (sqlparser.TableName, error) {
 }
 
 // GetExpr implements the TableInfo interface
-func (v *VindexTable) getExpr() *sqlparser.AliasedTableExpr {
-	return v.Table.getExpr()
+func (v *VindexTable) GetExpr() *sqlparser.AliasedTableExpr {
+	return v.Table.GetExpr()
 }
 
 // GetColumns implements the TableInfo interface

--- a/go/vt/vtgate/semantics/vtable.go
+++ b/go/vt/vtgate/semantics/vtable.go
@@ -70,7 +70,7 @@ func (v *vTableInfo) Name() (sqlparser.TableName, error) {
 	return sqlparser.TableName{}, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "oh noes")
 }
 
-func (v *vTableInfo) getExpr() *sqlparser.AliasedTableExpr {
+func (v *vTableInfo) GetExpr() *sqlparser.AliasedTableExpr {
 	return nil
 }
 


### PR DESCRIPTION
## Description
As part of the ongoing effort to improve the Vitess query planner and transition more planner logic to the operator model, this PR focuses on enhancing the handling of derived tables.

Previously, derived tables were only managed effectively if they could be pushed down under a Route. With this update, the query planner is now able to handle situations where derived tables need to be split into multiple operators under the Route. This improvement enables the queries sent to MySQL to more closely resemble the user's original query, retaining the derived table in the query being sent down.

By maintaining the derived table in the query, the result is easier for users to understand, as it better reflects their initial input. This enhancement aligns with the overall goal of simplifying the query planning process, allowing developers to better comprehend the optimization steps and create more efficient and optimized queries for their applications.

## Related Issue(s)
Tracking issue #11626

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
