### PR TITLE
Flakes: Wait for throttler to open in throttler custom config test

### DIFF
--- a/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
@@ -148,15 +148,7 @@ func TestMain(m *testing.M) {
 }
 
 func throttleCheck(tablet *cluster.Vttablet) (*http.Response, error) {
-	read := func() (*http.Response, error) {
-		return httpClient.Get(fmt.Sprintf("http://localhost:%d/%s", tablet.HTTPPort, checkAPIPath))
-	}
-	resp, err := read()
-	// Retry one time if we got an ephemeral 500 error.
-	if resp.StatusCode == http.StatusInternalServerError {
-		resp.Body.Close()
-		return read()
-	}
+	resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/%s", tablet.HTTPPort, checkAPIPath))
 	return resp, err
 }
 

--- a/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
@@ -77,8 +77,9 @@ var (
 )
 
 const (
-	testThreshold   = 5
-	applyConfigWait = 15 * time.Second // time after which we're sure the throttler has refreshed config and tablets
+	testThreshold     = 5
+	applyConfigWait   = 15 * time.Second // time after which we're sure the throttler has refreshed config and tablets
+	statusWaitTimeout = 30 * time.Second
 )
 
 func TestMain(m *testing.M) {
@@ -147,8 +148,38 @@ func TestMain(m *testing.M) {
 }
 
 func throttleCheck(tablet *cluster.Vttablet) (*http.Response, error) {
-	resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/%s", tablet.HTTPPort, checkAPIPath))
+	read := func() (*http.Response, error) {
+		return httpClient.Get(fmt.Sprintf("http://localhost:%d/%s", tablet.HTTPPort, checkAPIPath))
+	}
+	resp, err := read()
+	// Retry one time if we got an ephemeral 500 error.
+	if resp.StatusCode == http.StatusInternalServerError {
+		resp.Body.Close()
+		return read()
+	}
 	return resp, err
+}
+
+func waitForThrottlerStatus(tablet *cluster.Vttablet, status int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), statusWaitTimeout)
+	defer cancel()
+	tkr := time.NewTicker(100 * time.Millisecond)
+	defer tkr.Stop()
+
+	for {
+		resp, _ := throttleCheck(tablet)
+		seenStatus := resp.StatusCode
+		resp.Body.Close()
+		if seenStatus == status {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for expected throttler status %d after %v; last seen value: %d",
+				status, statusWaitTimeout, seenStatus)
+		case <-tkr.C:
+		}
+	}
 }
 
 func throttleCheckSelf(tablet *cluster.Vttablet) (*http.Response, error) {
@@ -159,10 +190,10 @@ func TestThrottlerThresholdOK(t *testing.T) {
 	defer cluster.PanicHandler(t)
 
 	t.Run("immediately", func(t *testing.T) {
-		resp, err := throttleCheck(primaryTablet)
+		// The tablet throttler can still be initializing so we wait for
+		// the status to be OK.
+		err := waitForThrottlerStatus(primaryTablet, http.StatusOK)
 		require.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 	t.Run("after long wait", func(t *testing.T) {
 		time.Sleep(applyConfigWait)


### PR DESCRIPTION
## Description

We have seen that the [`tabletmanager_throttler_custom_config` workflow](https://github.com/vitessio/vitess/blob/main/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml) has been somewhat flaky, with the seen failures revolving around what seem to be ephemeral 500 errors ([runs can be seen here](https://github.com/vitessio/vitess/actions/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml)). 

All of the failures that I've seen were this ([example](https://github.com/vitessio/vitess/actions/runs/4791103225/jobs/8521102542)):
```
=== RUN   TestThrottlerThresholdOK/immediately
    throttler_test.go:165: 
        	Error Trace:	/home/runner/work/vitess/vitess/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go:165
        	Error:      	Not equal: 
        	            	expected: 200
        	            	actual  : 500
        	Test:       	TestThrottlerThresholdOK/immediately
```

This can happen because `http.InternalServerError` (500) is returned from the throttler's `/check*` http endpoints any time there is an error. In this case, the throttler initialization is asynchronous and only started during tablet init. So when the CI is severely constrained and experiencing pauses, the throttler is not yet open and ready so it returns an error in the check. So it can be expected when you check the status immediately after starting the process if you don't first wait until the `/status` endpoint tells you that it's open and ready. We are now checking for that in the `throttler_topo` tests, but I didn't bother adding it to this one as the tablet flag based config and its associated tests here will be going away in favor of the new keyspace level topo based config in a future release.

This PR addresses the issue by using a wait on the initial status check after tablet initialization.

Test runs after the changes can be seen here, where it passed 20 times in a row: https://github.com/vitessio/vitess/actions/runs/4811169288/jobs/8564810642?pr=12980

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required