### PR TITLE
Fix bug in `SwitchTraffic` that wasn't respecting `--dry_run` for readonly and replica tablets during a resharding event

### DIFF
--- a/go/test/endtoend/vreplication/vreplication_test_env.go
+++ b/go/test/endtoend/vreplication/vreplication_test_env.go
@@ -85,3 +85,9 @@ var dryRunResultsSwitchWritesM2m3 = []string{
 	"       Keyspace merchant-type, Shard c0-, Tablet 1800, Workflow m2m3, DbName vt_merchant-type",
 	"Unlock keyspace merchant-type",
 }
+
+var dryRunResultsSwitchReadM2m3 = []string{
+	"Lock keyspace merchant-type",
+	"Switch reads from keyspace merchant-type to keyspace merchant-type for shards -80,80- to shards -40,40-c0,c0-",
+	"Unlock keyspace merchant-type",
+}

--- a/go/test/endtoend/vreplication/vstream_test.go
+++ b/go/test/endtoend/vreplication/vstream_test.go
@@ -372,7 +372,7 @@ func testVStreamStopOnReshardFlag(t *testing.T, stopOnReshard bool, baseTabletID
 		switch tickCount {
 		case 1:
 			reshard(t, "sharded", "customer", "vstreamStopOnReshard", "-80,80-",
-				"-40,40-", baseTabletID+400, nil, nil, nil, defaultCellName, 1)
+				"-40,40-", baseTabletID+400, nil, nil, nil, nil, defaultCellName, 1)
 		case 60:
 			done = true
 		}
@@ -502,7 +502,7 @@ func testVStreamCopyMultiKeyspaceReshard(t *testing.T, baseTabletID int) numEven
 		tickCount++
 		switch tickCount {
 		case 1:
-			reshard(t, "sharded", "customer", "vstreamCopyMultiKeyspaceReshard", "-80,80-", "-40,40-", baseTabletID+400, nil, nil, nil, defaultCellName, 1)
+			reshard(t, "sharded", "customer", "vstreamCopyMultiKeyspaceReshard", "-80,80-", "-40,40-", baseTabletID+400, nil, nil, nil, nil, defaultCellName, 1)
 			reshardDone = true
 		case 60:
 			done = true

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -397,7 +397,7 @@ func (wr *Wrangler) SwitchReads(ctx context.Context, targetKeyspace, workflowNam
 		return sw.logs(), nil
 	}
 	wr.Logger().Infof("About to switchShardReads: %+v, %+v, %+v", cells, servedTypes, direction)
-	if err := ts.switchShardReads(ctx, cells, servedTypes, direction); err != nil {
+	if err := sw.switchShardReads(ctx, cells, servedTypes, direction); err != nil {
 		ts.Logger().Errorf("switchShardReads failed: %v", err)
 		return nil, err
 	}


### PR DESCRIPTION
## Description

There's a bug when resharding and switching traffic that makes it so it does not respect the `--dry_run` flag.

#### ❌ does not respect `--dry_run` _without_ the fix in `traffic_switcher.go`

> **Note the `no locksInfo` error**

```bash
vtctlclient Reshard -- --tablet_types=rdonly,replica SwitchTraffic --dry_run customer.cust2cust

I0426 14:42:58.221613    9828 main.go:96] I0426 14:42:58.221425 traffic_switcher.go:399] About to switchShardReads: [], [RDONLY REPLICA], 0
E0426 14:42:58.223739    9828 main.go:96] E0426 14:42:58.223117 traffic_switcher.go:401] switchShardReads failed: Code: INVALID_ARGUMENT
keyspace customer is not locked (no locksInfo)
E0426 14:42:58.224562    9828 main.go:96] E0426 14:42:58.223567 vtctl.go:2264] 
keyspace customer is not locked (no locksInfo)
I0426 14:42:58.236510    9828 main.go:96] I0426 14:42:58.236337 vtctl.go:2266] Workflow Status: Reads Not Switched. Writes Not Switched

Following vreplication streams are running for workflow customer.cust2cust:

id=1 on -80/zone1-0000000301: Status: Running. VStream Lag: 0s.
id=1 on 80-/zone1-0000000400: Status: Running. VStream Lag: 0s.

Reshard Error: rpc error: code = Unknown desc = keyspace customer is not locked (no locksInfo)
E0426 14:42:58.251351    9828 main.go:105] remote error: rpc error: code = Unknown desc = keyspace customer is not locked (no locksInfo)
```

#### ✅ does respect `--dry_run` _with_ the fix in `traffic_switcher.go`

> **Note no more `locksInfo` error**

```bash
vtctlclient Reshard -- --tablet_types=rdonly,replica SwitchTraffic --dry_run customer.cust2cust
...
Dry Run results for SwitchTraffic run at 26 Apr 23 15:14 UTC
Parameters: --tablet_types=rdonly,replica SwitchTraffic --dry_run customer.cust2cust

Lock keyspace customer
Switch reads from keyspace customer to keyspace customer for shards 0 to shards -80,80-
Unlock keyspace customer
```

## testing on the primary 

On v15 I wasn't able to replicate the issue with the primary tablets going to `NOT SERVING` because `SwitchTraffic` did [respect the dry run flag when dealing with the primary](https://github.com/Shopify/vitess/blob/main/go/vt/wrangler/traffic_switcher.go#L459).

```bash
# without the fix
vtctlclient Reshard -- --tablet_types=primary SwitchTraffic --dry_run customer.cust2cust
...
Dry Run results for SwitchTraffic run at 26 Apr 23 15:15 UTC
Parameters: --tablet_types=primary SwitchTraffic --dry_run customer.cust2cust

Lock keyspace customer
Stop writes on keyspace customer, tables [/.*]:
        Keyspace customer, Shard 0 at Position MySQL56/83376623-e444-11ed-87cb-4201f0803195:1-151
Wait for VReplication on stopped streams to catchup for upto 30s
Create reverse replication workflow cust2cust_reverse
Create journal entries on source databases
Enable writes on keyspace customer tables [/.*]
Switch routing from keyspace customer to keyspace customer
IsPrimaryServing will be set to false for:
        Shard 0, Tablet 200
IsPrimaryServing will be set to true for:
        Shard -80, Tablet 301
        Shard 80-, Tablet 400
SwitchWrites completed, freeze and delete vreplication streams on:
        tablet 301
        tablet 400
Start reverse replication streams on:
        tablet 200
Mark vreplication streams frozen on:
        Keyspace customer, Shard -80, Tablet 301, Workflow cust2cust, DbName vt_customer
        Keyspace customer, Shard 80-, Tablet 400, Workflow cust2cust, DbName vt_customer
Unlock keyspace customer
```

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/6480
- [previously unmerged PR](https://github.com/vitessio/vitess/pull/6497) with fix + some QoL improvements

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

None
