### PR TITLE
Use vitess-operator `v2.8.4` in the examples

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -5615,7 +5615,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: planetscale/vitess-operator:v2.8.3
+          image: planetscale/vitess-operator:v2.8.4
           name: vitess-operator
           resources:
             limits:


### PR DESCRIPTION
## Description

This is a follow-up of the recent [vitess-operator v2.8.4](https://github.com/planetscale/vitess-operator/releases/tag/v2.8.4) release. It updates the examples to use the proper version.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
