### PR TITLE
Add minimal token permissions (continued)

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -13,7 +13,8 @@ jobs:
   build:
     name: Create Release
     runs-on: ubuntu-22.04
-    permissions: write-all
+    permissions:
+      contents: write
     steps:
 
     - name: Set up Go

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -5,8 +5,13 @@ on:
     - cron: "0 0 * * *" # Runs every day at midnight UTC
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   update_golang_version:
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       matrix:
         branch: [ main, release-16.0, release-15.0, release-14.0 ]


### PR DESCRIPTION
Fixes #12717.

This is a continuation of #12718. `create_release.yml` came out with job-level `permissions: write-all` (as mentioned in #12718, it only needed `contents: write`, but forgot to update that 🤷‍♂️) and just making the new `update_golang_version.yml` consistent with the other workflows.