### PR TITLE
Do not rewrite `last_insert_id` function calls with arguments.

### DIFF
--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -571,10 +571,17 @@ func (er *astRewriter) funcRewrite(cursor *Cursor, node *FuncExpr) {
 	if !found || (bindVar == DBVarName && !er.shouldRewriteDatabaseFunc) {
 		return
 	}
+
+	// Don't rewrite `last_insert_id` function call if an argument is given
+	if len(node.Exprs) > 0 && node.Name.Lowered() == "last_insert_id" {
+		return
+	}
+
 	if len(node.Exprs) > 0 {
 		er.err = vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "Argument to %s() not supported", node.Name.Lowered())
 		return
 	}
+
 	cursor.Replace(bindVarExpression(bindVar))
 	er.bindVars.AddFuncResult(bindVar)
 }

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -68,6 +68,9 @@ func TestRewrites(in *testing.T) {
 		expected:                    "SELECT :__vtenable_system_settings as `@@enable_system_settings`",
 		sessionEnableSystemSettings: true,
 	}, {
+		in:       "SELECT last_insert_id(10)",
+		expected: "SELECT last_insert_id(10)",
+	}, {
 		in:       "SELECT last_insert_id()",
 		expected: "SELECT :__lastInsertId as `last_insert_id()`",
 		liid:     true,


### PR DESCRIPTION
## Description

With Vitess v16, the rewriting behaviour of `last_insert_id` and other function calls became more strict. It explicitly returns an error now when `last_insert_id` is called with an argument, whereas before it would just not perform any rewriting and pass the function call to MySQL as-is.

This change restores the previous behaviour of not rewriting `last_insert_id` funciton calls that have arguments.

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

N/A