### PR TITLE
evalengine: Fix wrong coercion into float

### DIFF
--- a/go/vt/vtgate/evalengine/eval.go
+++ b/go/vt/vtgate/evalengine/eval.go
@@ -241,7 +241,7 @@ func valueToEvalCast(v sqltypes.Value, typ sqltypes.Type) (eval, error) {
 			dec = decimal.NewFromFloat(fval)
 		case v.IsText() || v.IsBinary():
 			fval, _ := fastparse.ParseFloat64(v.RawStr())
-			return newEvalFloat(fval), nil
+			dec = decimal.NewFromFloat(fval)
 		default:
 			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "coercion should not try to coerce this value to a decimal: %v", v)
 		}


### PR DESCRIPTION
This was a likely copy-paste bug introduced in
https://github.com/vitessio/vitess/pull/12979/files#diff-4e6fe1f65ff81fe967668629b6d6b978309e3ad20ba5f81ae95612c98b7c3cfcR244

Instead of converting properly into a decimal, it was returning a float instance. This adds some additional test to ensure we catch this case and improves the random test generator to cover decimals too.

## Related Issue(s)

Broken in https://github.com/vitessio/vitess/pull/12979/files#diff-4e6fe1f65ff81fe967668629b6d6b978309e3ad20ba5f81ae95612c98b7c3cfcR244

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required