### PR TITLE
Materialize Workflows: Periodically send copy state for workflows which are heavily filtered

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -99,6 +99,8 @@ type Stats struct {
 	ErrorCounts    *stats.CountersWithMultiLabels
 	NoopQueryCount *stats.CountersWithSingleLabel
 
+	FilteredRowsCopyStateSyncCount *stats.Counter
+
 	VReplicationLags     *stats.Timings
 	VReplicationLagRates *stats.Rates
 
@@ -169,6 +171,7 @@ func NewStats() *Stats {
 	bps.TableCopyTimings = stats.NewTimings("", "", "Table")
 	bps.PartialQueryCacheSize = stats.NewCountersWithMultiLabels("", "", []string{"type"})
 	bps.PartialQueryCount = stats.NewCountersWithMultiLabels("", "", []string{"type"})
+	bps.FilteredRowsCopyStateSyncCount = stats.NewCounter("", "")
 	return bps
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -324,7 +324,7 @@ func (st *vrStats) register() {
 		})
 	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationFilteredRowsCopyStateSyncCount",
-		"Number of times the last pk was sent when a set of previous rows were filtered",
+		"Number of times only the last pk was sent without any rows in the copy phase per stream",
 		[]string{"source_keyspace", "source_shard", "workflow", "counts"},
 		func() map[string]int64 {
 			st.mu.Lock()

--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -322,7 +322,19 @@ func (st *vrStats) register() {
 			}
 			return result
 		})
-
+	stats.NewGaugesFuncWithMultiLabels(
+		"VReplicationFilteredRowsCopyStateSyncCount",
+		"Number of times the last pk was sent when a set of previous rows were filtered",
+		[]string{"source_keyspace", "source_shard", "workflow", "counts"},
+		func() map[string]int64 {
+			st.mu.Lock()
+			defer st.mu.Unlock()
+			result := make(map[string]int64, len(st.controllers))
+			for _, ct := range st.controllers {
+				result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)] = ct.blpStats.FilteredRowsCopyStateSyncCount.Get()
+			}
+			return result
+		})
 	stats.NewCounterFunc(
 		"VReplicationCopyLoopCountTotal",
 		"Number of times the copy phase looped aggregated across streams",

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -41,8 +41,8 @@ import (
 var (
 	rowStreamertHeartbeatInterval = 10 * time.Second
 	// If the rowstreamer filters rowStreamerMaxFilteredRowsBeforeLastPK without sending a response, send the lastPK.
-	// Otherwise, materialize workflows which filter out a large number of rows, for example can stall because they
-	// reach the copy timeout before they receive any response.
+	// Otherwise, materialize workflows which filter out a large number of rows can stall because they
+	// reach the copy timeout before receiving any response.
 	rowStreamerMaxFilteredRowsBeforeLastPK = 10000
 )
 
@@ -343,6 +343,7 @@ func (rs *rowStreamer) streamQuery(conn *snapshotConn, send func(*binlogdatapb.V
 	var rows []*querypb.Row
 	var rowCount int
 	var mysqlrow []sqltypes.Value
+
 	filteredRows := 0
 	mustSendLastPK := false
 	filtered := make([]sqltypes.Value, len(rs.plan.ColExprs))


### PR DESCRIPTION
## Description

We have an edge case where, if a `materialize` workflow is set up such that only very few rows match the filter, it is possible, during the copy phase, that no row is sent for an entire `copyPhaseDuration` either because there is no match or we never reach the packet size. Then the workflow will restart on the target without the copy state being updated and hence the workflow will never make progress.

This PR sends a sync response when a particular number of rows are filtered out without any response being sent. 

Currently, the threshold is set to 10000 rows. It is probably a bit low and ideally it should be sent with time periodicity rather than row count periodicity, but since the `copyPhaseDuration` is set by the target, the source has no idea of what the duration is.  A flag would make this configurable, but we are trying to get away a profusion of flags and enforce sensible defaults where possible. 

We also add a per-workflow stat `VReplicationFilteredRowsCopyStateSyncCount` to keep track of the number of such sync responses sent.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/12937

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required
