### PR TITLE
topo: Move to allow list for invalid names (#12917)

### DIFF
--- a/changelog/16.0/16.0.2/summary.md
+++ b/changelog/16.0/16.0.2/summary.md
@@ -1,7 +1,13 @@
 ## Summary
 
+### Keyspace name validation in TopoServer
+
+Prior to 16.0.2, it was possible to create a keyspace with invalid characters, which would then be inaccessible to various cluster management operations.
+
+Keyspace names are restricted to using only ASCII characters, digits and `_` and `-`. TopoServer's `GetKeyspace` and `CreateKeyspace` methods return an error if given an invalid name.
+
 ### Shard name validation in TopoServer
 
-Prior to v16.0.2, it was possible to create a shard name with invalid characters, which would then be inaccessible to various cluster management operations.
+Prior to 16.0.2, it was possible to create a shard name with invalid characters, which would then be inaccessible to various cluster management operations.
 
-Shard names may no longer contain the forward slash ("/") character, and TopoServer's `CreateShard` method returns an error if given such a name.
+Shard names are restricted to using only ASCII characters, digits and `_` and `-`. TopoServer's `GetShard` and `CreateShard` methods return an error if given an invalid name.

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -17,12 +17,10 @@ limitations under the License.
 package topo
 
 import (
+	"context"
 	"path"
-	"strings"
 
 	"google.golang.org/protobuf/proto"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -55,18 +53,10 @@ func (ki *KeyspaceInfo) SetKeyspaceName(name string) {
 	ki.keyspace = name
 }
 
-var invalidKeyspaceNameChars = "/"
-
 // ValidateKeyspaceName checks if the provided name is a valid name for a
 // keyspace.
-//
-// As of v16.0.1, "all invalid characters" is just the forward slash ("/").
 func ValidateKeyspaceName(name string) error {
-	if strings.ContainsAny(name, invalidKeyspaceNameChars) {
-		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "keyspace name %s contains invalid characters; may not contain any of the following: %+v", name, strings.Split(invalidKeyspaceNameChars, ""))
-	}
-
-	return nil
+	return validateObjectName(name)
 }
 
 // GetServedFrom returns a Keyspace_ServedFrom record if it exists.

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -120,8 +120,8 @@ func IsShardUsingRangeBasedSharding(shard string) bool {
 // ValidateShardName takes a shard name and sanitizes it, and also returns
 // the KeyRange.
 func ValidateShardName(shard string) (string, *topodatapb.KeyRange, error) {
-	if strings.Contains(shard, "/") {
-		return "", nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid shardId, may not contain '/': %v", shard)
+	if err := validateObjectName(shard); err != nil {
+		return "", nil, err
 	}
 
 	if !IsShardUsingRangeBasedSharding(shard) {
@@ -199,6 +199,14 @@ func (si *ShardInfo) SetPrimaryTermStartTime(t time.Time) {
 // GetShard is a high level function to read shard data.
 // It generates trace spans.
 func (ts *Server) GetShard(ctx context.Context, keyspace, shard string) (*ShardInfo, error) {
+	if err := ValidateKeyspaceName(keyspace); err != nil {
+		return nil, err
+	}
+
+	if _, _, err := ValidateShardName(shard); err != nil {
+		return nil, err
+	}
+
 	span, ctx := trace.NewSpan(ctx, "TopoServer.GetShard")
 	span.Annotate("keyspace", keyspace)
 	span.Annotate("shard", shard)
@@ -283,18 +291,22 @@ func (ts *Server) UpdateShardFields(ctx context.Context, keyspace, shard string,
 // This will lock the Keyspace, as we may be looking at other shard servedTypes.
 // Using GetOrCreateShard is probably a better idea for most use cases.
 func (ts *Server) CreateShard(ctx context.Context, keyspace, shard string) (err error) {
-	// Lock the keyspace, because we'll be looking at ServedTypes.
-	ctx, unlock, lockErr := ts.LockKeyspace(ctx, keyspace, "CreateShard")
-	if lockErr != nil {
-		return lockErr
+	if err := ValidateKeyspaceName(keyspace); err != nil {
+		return err
 	}
-	defer unlock(&err)
 
 	// validate parameters
 	_, keyRange, err := ValidateShardName(shard)
 	if err != nil {
 		return err
 	}
+
+	// Lock the keyspace, because we'll be looking at ServedTypes.
+	ctx, unlock, lockErr := ts.LockKeyspace(ctx, keyspace, "CreateShard")
+	if lockErr != nil {
+		return lockErr
+	}
+	defer unlock(&err)
 
 	value := &topodatapb.Shard{
 		KeyRange: keyRange,

--- a/go/vt/topo/validator.go
+++ b/go/vt/topo/validator.go
@@ -1,0 +1,34 @@
+package topo
+
+import (
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+// ValidateObjectName checks that the name is a valid object name.
+// Object names are used for things like keyspace and shard names
+// and must match specific constraints.
+// They are only allowed to use ASCII letters or digits, - and _.
+// No spaces or special characters are allowed.
+func validateObjectName(name string) error {
+	if name == "" {
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "empty name")
+	}
+
+	if len(name) > 64 {
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "name %v is too long", name)
+	}
+
+	for _, c := range name {
+		switch {
+		case 'a' <= c && c <= 'z':
+		case 'A' <= c && c <= 'Z':
+		case '0' <= c && c <= '9':
+		case c == '-' || c == '_':
+		default:
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid character %s in name %v", string(c), name)
+		}
+	}
+
+	return nil
+}

--- a/go/vt/topo/validator_test.go
+++ b/go/vt/topo/validator_test.go
@@ -1,0 +1,46 @@
+package topo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateObjectName(t *testing.T) {
+	cases := []struct {
+		name string
+		err  string
+	}{
+		{
+			name: "valid",
+			err:  "",
+		},
+		{
+			name: "validdigits1321",
+			err:  "",
+		},
+		{
+			name: "valid-with-dashes",
+			err:  "",
+		},
+		{
+			name: "very-long-keyspace-name-that-is-even-too-long-for-mysql-to-handle",
+			err:  "name very-long-keyspace-name-that-is-even-too-long-for-mysql-to-handle is too long",
+		},
+		{
+			name: "with<invalid>chars",
+			err:  "invalid character < in name with<invalid>chars",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateObjectName(c.name)
+			if c.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, c.err)
+			}
+		})
+	}
+}

--- a/go/vt/wrangler/tablet_test.go
+++ b/go/vt/wrangler/tablet_test.go
@@ -40,7 +40,8 @@ func TestInitTabletShardConversion(t *testing.T) {
 			Cell: cell,
 			Uid:  1,
 		},
-		Shard: "80-C0",
+		Keyspace: "test",
+		Shard:    "80-C0",
 	}
 
 	if err := wr.TopoServer().InitTablet(context.Background(), tablet, false /*allowPrimaryOverride*/, true /*createShardAndKeyspace*/, false /*allowUpdate*/); err != nil {
@@ -70,7 +71,8 @@ func TestDeleteTabletBasic(t *testing.T) {
 			Cell: cell,
 			Uid:  1,
 		},
-		Shard: "0",
+		Shard:    "0",
+		Keyspace: "test",
 	}
 
 	if err := wr.TopoServer().InitTablet(context.Background(), tablet, false /*allowPrimaryOverride*/, true /*createShardAndKeyspace*/, false /*allowUpdate*/); err != nil {


### PR DESCRIPTION
Today we explicit disallow only specific characters like `/`. We should move here to an allow list approach though, explicitly allowing specific characters.

The reason is that a block list approach is bound to end up in a game of whack-a-mole where we keep having to add characters. Instead an allow list approach of safe characters is a fundamentally better method moving forward that provides security.

The biggest potential downside is that there's people we don't know about that are using names we would disallow with the current restrictions.

From a security perspective though, it's better that we start off here and then allow more known safe things if necessary and try to get feedback from the community for when things are too restricted.

## Related Issue(s)

Backport of #12917 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
