### PR TITLE
Generated Invisible Primary Keys: add vreplication test cases 

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -1406,6 +1406,9 @@ func TestPlayerCopyTablesGIPK(t *testing.T) {
 }
 
 func testPlayerCopyTablesGIPK(t *testing.T) {
+	if !env.HasCapability(testenv.ServerCapabilityGeneratedInvisiblePrimaryKey) {
+		t.Skip("skipping test as server does not support invisible primary keys")
+	}
 	defer deleteTablet(addTablet(100))
 
 	execStatements(t, []string{

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -1418,6 +1418,7 @@ func testPlayerCopyTablesGIPK(t *testing.T) {
 		fmt.Sprintf("create table %s.dst1(my_row_id int, val varbinary(128), primary key(my_row_id))", vrepldb),
 	})
 	defer execStatements(t, []string{
+		"SET sql_generate_invisible_primary_key=OFF;",
 		"drop table src1",
 		fmt.Sprintf("drop table %s.dst1", vrepldb),
 	})

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -1412,13 +1412,13 @@ func testPlayerCopyTablesGIPK(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	execStatements(t, []string{
-		"SET sql_generate_invisible_primary_key=ON;",
+		"SET @@session.sql_generate_invisible_primary_key=ON;",
 		"create table src1(val varbinary(128))",
+		"SET @@session.sql_generate_invisible_primary_key=OFF;",
 		"insert into src1 values('aaa'), ('bbb')",
 		fmt.Sprintf("create table %s.dst1(my_row_id int, val varbinary(128), primary key(my_row_id))", vrepldb),
 	})
 	defer execStatements(t, []string{
-		"SET sql_generate_invisible_primary_key=OFF;",
 		"drop table src1",
 		fmt.Sprintf("drop table %s.dst1", vrepldb),
 	})

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -1399,15 +1399,16 @@ func testPlayerCopyTablesStopAfterCopy(t *testing.T) {
 }
 
 // TestPlayerCopyTablesGIPK tests the flow when the source table has a generated invisible primary key.
-// The target table needs to explicitly define the `my_row_id` column as the primary key since we will be copying the
-// rows from the source table into the target table. The test also confirms that the copy_state has the gipk.
+// The target table needs to explicitly define the `my_row_id` column as the primary key since we will
+// be copying the rows from the source table into the target table.
+// The test also confirms that the copy_state has the gipk.
 func TestPlayerCopyTablesGIPK(t *testing.T) {
 	testVcopierTestCases(t, testPlayerCopyTablesGIPK, commonVcopierTestCases())
 }
 
 func testPlayerCopyTablesGIPK(t *testing.T) {
 	if !env.HasCapability(testenv.ServerCapabilityGeneratedInvisiblePrimaryKey) {
-		t.Skip("skipping test as server does not support invisible primary keys")
+		t.Skip("skipping test as server does not support generated invisible primary keys")
 	}
 	defer deleteTablet(addTablet(100))
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -23,12 +23,13 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/testenv"
+
 	"vitess.io/vitess/go/vt/vttablet"
 
-	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/mysqlctl"
-
 	"context"
+
+	"vitess.io/vitess/go/vt/log"
 
 	"github.com/stretchr/testify/require"
 
@@ -1725,8 +1726,7 @@ func testCopyTablesWithInvalidDates(t *testing.T) {
 }
 
 func supportsInvisibleColumns() bool {
-	if env.DBType == string(mysqlctl.FlavorMySQL) && env.DBMajorVersion >= 8 &&
-		(env.DBMinorVersion > 0 || env.DBPatchVersion >= 23) {
+	if env.HasCapability(testenv.ServerCapabilityInvisibleColumn) {
 		return true
 	}
 	log.Infof("invisible columns not supported in %d.%d.%d", env.DBMajorVersion, env.DBMinorVersion, env.DBPatchVersion)

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -1397,6 +1397,83 @@ func testPlayerCopyTablesStopAfterCopy(t *testing.T) {
 	})
 }
 
+// TestPlayerCopyTablesGIPK tests the flow when the source table has a generated invisible primary key.
+// The target table needs to explicitly define the `my_row_id` column as the primary key since we will be copying the
+// rows from the source table into the target table. The test also confirms that the copy_state has the gipk.
+func TestPlayerCopyTablesGIPK(t *testing.T) {
+	testVcopierTestCases(t, testPlayerCopyTablesGIPK, commonVcopierTestCases())
+}
+
+func testPlayerCopyTablesGIPK(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+
+	execStatements(t, []string{
+		"SET sql_generate_invisible_primary_key=ON;",
+		"create table src1(val varbinary(128))",
+		"insert into src1 values('aaa'), ('bbb')",
+		fmt.Sprintf("create table %s.dst1(my_row_id int, val varbinary(128), primary key(my_row_id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table src1",
+		fmt.Sprintf("drop table %s.dst1", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "dst1",
+			Filter: "select * from src1",
+		}},
+	}
+
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace:      env.KeyspaceName,
+		Shard:         env.ShardName,
+		Filter:        filter,
+		OnDdl:         binlogdatapb.OnDDLAction_IGNORE,
+		StopAfterCopy: true,
+	}
+	query := binlogplayer.CreateVReplicationState("test", bls, "", binlogplayer.VReplicationInit, playerEngine.dbName, 0, 0)
+	qr, err := playerEngine.Exec(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		query := fmt.Sprintf("delete from _vt.vreplication where id = %d", qr.InsertID)
+		if _, err := playerEngine.Exec(query); err != nil {
+			t.Fatal(err)
+		}
+		expectDeleteQueries(t)
+	}()
+
+	expectDBClientQueries(t, qh.Expect(
+		"/insert into _vt.vreplication",
+		"/update _vt.vreplication set message='Picked source tablet.*",
+		// Create the list of tables to copy and transition to Copying state.
+		"begin",
+		"/insert into _vt.copy_state",
+		"/update _vt.vreplication set state='Copying'",
+		"commit",
+		// The first fast-forward has no starting point. So, it just saves the current position.
+		"/update _vt.vreplication set pos=",
+	).Then(qh.Eventually(
+		"begin",
+		"insert into dst1(my_row_id,val) values (1,'aaa'), (2,'bbb')",
+		`/insert into _vt.copy_state \(lastpk, vrepl_id, table_name\) values \('fields:{name:\\"my_row_id\\" type:UINT64} rows:{lengths:1 values:\\"2\\"}'.*`,
+		"commit",
+	)).Then(qh.Immediately(
+		// copy of dst1 is done: delete from copy_state.
+		"/delete cs, pca from _vt.copy_state as cs left join _vt.post_copy_action as pca on cs.vrepl_id=pca.vrepl_id and cs.table_name=pca.table_name.*dst1",
+		// All tables copied. Stop vreplication because we requested it.
+		"/update _vt.vreplication set state='Stopped'",
+	)))
+
+	expectData(t, "dst1", [][]string{
+		{"1", "aaa"},
+		{"2", "bbb"},
+	})
+}
+
 func TestPlayerCopyTableCancel(t *testing.T) {
 	testVcopierTestCases(t, testPlayerCopyTableCancel, commonVcopierTestCases())
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -54,6 +54,7 @@ func TestPlayerGeneratedInvisiblePrimaryKey(t *testing.T) {
 		fmt.Sprintf("create table %s.t1(my_row_id int, val varbinary(128), primary key(my_row_id))", vrepldb),
 	})
 	defer execStatements(t, []string{
+		"SET sql_generate_invisible_primary_key=OFF;",
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/testenv"
+
 	"vitess.io/vitess/go/vt/vttablet"
 
 	"github.com/nsf/jsondiff"
@@ -39,6 +41,73 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	qh "vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication/queryhistory"
 )
+
+func TestPlayerGeneratedInvisiblePrimaryKey(t *testing.T) {
+	if !env.HasCapability(testenv.ServerCapabilityGeneratedInvisiblePrimaryKey) {
+		t.Skip("skipping test as server does not support invisible primary keys")
+	}
+	defer deleteTablet(addTablet(100))
+
+	execStatements(t, []string{
+		"SET sql_generate_invisible_primary_key=ON;",
+		"create table t1(val varbinary(128))",
+		fmt.Sprintf("create table %s.t1(my_row_id int, val varbinary(128), primary key(my_row_id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t1",
+		fmt.Sprintf("drop table %s.t1", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "t1",
+			Filter: "select * from t1",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	cancel, _ := startVReplication(t, bls, "")
+	defer cancel()
+
+	testcases := []struct {
+		input       string
+		output      string
+		table       string
+		data        [][]string
+		query       string
+		queryResult [][]string
+	}{{
+		input:  "insert into t1(val) values ('aaa')",
+		output: "insert into t1(my_row_id,val) values (1,'aaa')",
+		table:  "t1",
+		data: [][]string{
+			{"1", "aaa"},
+		},
+		query: "select my_row_id, val from t1",
+		queryResult: [][]string{
+			{"1", "aaa"},
+		},
+	}}
+
+	for _, tcases := range testcases {
+		execStatements(t, []string{tcases.input})
+		output := qh.Expect(tcases.output)
+		expectNontxQueries(t, output)
+		time.Sleep(1 * time.Second)
+		log.Flush()
+		if tcases.table != "" {
+			expectData(t, tcases.table, tcases.data)
+		}
+		if tcases.query != "" {
+			expectQueryResult(t, tcases.query, tcases.queryResult)
+		}
+	}
+}
 
 func TestPlayerInvisibleColumns(t *testing.T) {
 	if !supportsInvisibleColumns() {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -49,12 +49,12 @@ func TestPlayerGeneratedInvisiblePrimaryKey(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	execStatements(t, []string{
-		"SET sql_generate_invisible_primary_key=ON;",
+		"SET @@session.sql_generate_invisible_primary_key=ON;",
 		"create table t1(val varbinary(128))",
+		"SET @@session.sql_generate_invisible_primary_key=OFF;",
 		fmt.Sprintf("create table %s.t1(my_row_id int, val varbinary(128), primary key(my_row_id))", vrepldb),
 	})
 	defer execStatements(t, []string{
-		"SET sql_generate_invisible_primary_key=OFF;",
 		"drop table t1",
 		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -42,9 +42,10 @@ import (
 	qh "vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication/queryhistory"
 )
 
+// TestPlayerGeneratedInvisiblePrimaryKey confirms that the gipk column is replicated by vplayer.
 func TestPlayerGeneratedInvisiblePrimaryKey(t *testing.T) {
 	if !env.HasCapability(testenv.ServerCapabilityGeneratedInvisiblePrimaryKey) {
-		t.Skip("skipping test as server does not support invisible primary keys")
+		t.Skip("skipping test as server does not support generated invisible primary keys")
 	}
 	defer deleteTablet(addTablet(100))
 
@@ -99,8 +100,6 @@ func TestPlayerGeneratedInvisiblePrimaryKey(t *testing.T) {
 		execStatements(t, []string{tcases.input})
 		output := qh.Expect(tcases.output)
 		expectNontxQueries(t, output)
-		time.Sleep(1 * time.Second)
-		log.Flush()
 		if tcases.table != "" {
 			expectData(t, tcases.table, tcases.data)
 		}

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -190,3 +190,25 @@ func (te *Env) RemoveAnyDeprecatedDisplayWidths(orig string) string {
 	}
 	return adjusted
 }
+
+type ServerCapability int32
+
+const (
+	ServerCapabilityInvisibleColumn              ServerCapability = 1
+	ServerCapabilityGeneratedInvisiblePrimaryKey ServerCapability = 2
+)
+
+// HasCapability returns true if the server has the given capability.
+// Used to skip tests that require a certain version of MySQL.
+func (te *Env) HasCapability(cap ServerCapability) bool {
+	if te.DBType != string(mysqlctl.FlavorMySQL) || te.DBMajorVersion < 8 {
+		return false
+	}
+	switch cap {
+	case ServerCapabilityInvisibleColumn:
+		return te.DBMinorVersion > 0 || te.DBPatchVersion >= 23
+	case ServerCapabilityGeneratedInvisiblePrimaryKey:
+		return te.DBMinorVersion > 0 || te.DBPatchVersion >= 30
+	}
+	return false
+}

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -191,6 +191,8 @@ func (te *Env) RemoveAnyDeprecatedDisplayWidths(orig string) string {
 	return adjusted
 }
 
+// ServerCapability is used to define capabilities for which we want to optionally run tests
+// if the underlying mysql server supports them.
 type ServerCapability int32
 
 const (

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
@@ -2114,7 +2114,7 @@ func TestGeneratedColumns(t *testing.T) {
 // TestGeneratedInvisiblePrimaryKey validates that generated invisible primary keys are sent in row events.
 func TestGeneratedInvisiblePrimaryKey(t *testing.T) {
 	if !env.HasCapability(testenv.ServerCapabilityGeneratedInvisiblePrimaryKey) {
-		t.Skip("skipping test as server does not support invisible primary keys")
+		t.Skip("skipping test as server does not support generated invisible primary keys")
 	}
 	execStatements(t, []string{
 		"SET @@session.sql_generate_invisible_primary_key=ON;",

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
@@ -2117,11 +2117,11 @@ func TestGeneratedInvisiblePrimaryKey(t *testing.T) {
 		t.Skip("skipping test as server does not support invisible primary keys")
 	}
 	execStatements(t, []string{
-		"SET sql_generate_invisible_primary_key=ON;",
+		"SET @@session.sql_generate_invisible_primary_key=ON;",
 		"create table t1(val varbinary(6))",
+		"SET @@session.sql_generate_invisible_primary_key=OFF;",
 	})
 	defer execStatements(t, []string{
-		"SET sql_generate_invisible_primary_key=OFF;",
 		"drop table t1",
 	})
 	engine.se.Reload(context.Background())

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
@@ -2121,6 +2121,7 @@ func TestGeneratedInvisiblePrimaryKey(t *testing.T) {
 		"create table t1(val varbinary(6))",
 	})
 	defer execStatements(t, []string{
+		"SET sql_generate_invisible_primary_key=OFF;",
 		"drop table t1",
 	})
 	engine.se.Reload(context.Background())

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/testenv"
+
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/vt/log"
@@ -2111,6 +2113,9 @@ func TestGeneratedColumns(t *testing.T) {
 
 // TestGeneratedInvisiblePrimaryKey validates that generated invisible primary keys are sent in row events.
 func TestGeneratedInvisiblePrimaryKey(t *testing.T) {
+	if !env.HasCapability(testenv.ServerCapabilityGeneratedInvisiblePrimaryKey) {
+		t.Skip("skipping test as server does not support invisible primary keys")
+	}
 	execStatements(t, []string{
 		"SET sql_generate_invisible_primary_key=ON;",
 		"create table t1(val varbinary(6))",


### PR DESCRIPTION
## Description

This PR only adds unit tests to vstreamer, vcopier and vplayer to illustrate how generated invisible private keys are used in vreplication workflows.

`MoveTables` will retain the GIPK on the table in the target keyspace. However, while that works when the target keyspace is unsharded, for sharded keyspaces we would use [sequences](https://vitess.io/docs/15.0/reference/features/vitess-sequences/) instead. This is similar to how we would deal with regular autoincrement Primary Keys in Vitess. 

When the source table has a GIPK, the schema of the sharded target table will have to define `my_row_id` as the column name for the PK column, in line with MySQL's internal implementation.

Reference: https://dev.mysql.com/doc/refman/8.0/en/create-table-gipks.html

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required
