### PR TITLE
goyacc: don't import "unsafe" if not used

### DIFF
--- a/go/vt/sqlparser/goyacc/goyacc.go
+++ b/go/vt/sqlparser/goyacc/goyacc.go
@@ -3051,12 +3051,12 @@ func others() {
 
 	if allowFastAppend {
 		fastAppendHelper := strings.Replace(fastAppendHelperText, "$$", prefix, -1)
-		fmt.Fprintf(ftable, fastAppendHelper)
+		fmt.Fprint(ftable, fastAppendHelper)
 	}
 
 	// copy yaccpar
 	if !lflag {
-		fmt.Fprintf(ftable, "\n//line yaccpar:1\n")
+		fmt.Fprint(ftable, "\n//line yaccpar:1\n")
 	}
 
 	parts := strings.SplitN(yaccpar, prefix+"run()", 2)

--- a/go/vt/sqlparser/goyacc/goyacc.go
+++ b/go/vt/sqlparser/goyacc/goyacc.go
@@ -1206,7 +1206,9 @@ func emitcode(code []rune, lineno int) {
 		if !writtenImports && isPackageClause(line) {
 			fmt.Fprintln(ftable, `import (`)
 			fmt.Fprintln(ftable, `__yyfmt__ "fmt"`)
-			fmt.Fprintln(ftable, `__yyunsafe__ "unsafe"`)
+			if allowFastAppend {
+				fmt.Fprintln(ftable, `__yyunsafe__ "unsafe"`)
+			}
 			fmt.Fprintln(ftable, `)`)
 			if !lflag {
 				fmt.Fprintf(ftable, "//line %v:%v\n\t\t", infile, lineno+i)
@@ -3047,6 +3049,11 @@ func others() {
 		ch = getrune(finput)
 	}
 
+	if allowFastAppend {
+		fastAppendHelper := strings.Replace(fastAppendHelperText, "$$", prefix, -1)
+		fmt.Fprintf(ftable, fastAppendHelper)
+	}
+
 	// copy yaccpar
 	if !lflag {
 		fmt.Fprintf(ftable, "\n//line yaccpar:1\n")
@@ -3344,10 +3351,7 @@ func gofmt() {
 	os.WriteFile(oflag, src, 0666)
 }
 
-var yaccpar string // will be processed version of yaccpartext: s/$$/prefix/g
-var yaccpartext = `
-/*	parser for yacc output	*/
-
+const fastAppendHelperText = `
 func $$Iaddr(v any) __yyunsafe__.Pointer {
 	type h struct {
 		t __yyunsafe__.Pointer
@@ -3355,6 +3359,11 @@ func $$Iaddr(v any) __yyunsafe__.Pointer {
 	}
 	return (*h)(__yyunsafe__.Pointer(&v)).p
 }
+`
+
+var yaccpar string // will be processed version of yaccpartext: s/$$/prefix/g
+const yaccpartext = `
+/*	parser for yacc output	*/
 
 var (
 	$$Debug        = 0

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -9169,10 +9169,6 @@ var yyErrorMessages = [...]struct {
 	msg   string
 }{}
 
-//line yaccpar:1
-
-/*	parser for yacc output	*/
-
 func yyIaddr(v any) __yyunsafe__.Pointer {
 	type h struct {
 		t __yyunsafe__.Pointer
@@ -9180,6 +9176,10 @@ func yyIaddr(v any) __yyunsafe__.Pointer {
 	}
 	return (*h)(__yyunsafe__.Pointer(&v)).p
 }
+
+//line yaccpar:1
+
+/*	parser for yacc output	*/
 
 var (
 	yyDebug        = 0


### PR DESCRIPTION
## Description

Avoids importing "unsafe" (and emitting the `*Iaddr` helper function that uses it) if the `--fast-append` flag is not used. When this flag is not used, the `*Iaddr` helper function is never used. To maximize code portability (since there are some niche runtimes that do not support unsafe), we want to avoid the "unsafe" import if we can.

## Related Issue(s)

Fixes #13006 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

I did some manual testing with a yacc grammar I have. The change excluded the import and the unused helper function as expected. When I added the `-f` flag, they were present (along with a few calls to the `*Iaddr` function).

This still leaves some potential room for improvement: instead of gating this only on the `--fast-append` flag, we could also see if the token type actually includes any slice fields. If not, we could omit this. Counter-argument: it might be weird if the "unsafe" import magically appears just from adding a new field to the union type in the grammar. 🤷 

## Deployment Notes

N/A
