### PR TITLE
bugfix: fix nil pointer in vtgate on topo connection error

### DIFF
--- a/go/vt/topo/topoproto/srvkeyspace.go
+++ b/go/vt/topo/topoproto/srvkeyspace.go
@@ -46,6 +46,9 @@ func (sra ShardReferenceArray) Sort() { sort.Sort(sra) }
 // SrvKeyspaceGetPartition returns a Partition for the given tablet type,
 // or nil if it's not there.
 func SrvKeyspaceGetPartition(sk *topodatapb.SrvKeyspace, tabletType topodatapb.TabletType) *topodatapb.SrvKeyspace_KeyspacePartition {
+	if sk == nil {
+		return nil
+	}
 	for _, p := range sk.Partitions {
 		if p.ServedType == tabletType {
 			return p


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
We see vtgate container restarts whenever there's a problem connecting to zk:

```
2023-01-18T22:12:28.921215833Z E0118 22:12:28.921183       6 keyspace_events.go:352] error while watching keyspace "SyncStore": zk: could not connect to a server
2023-01-18T22:12:28.921252801Z E0118 22:12:28.921232       6 keyspace_events.go:352] error while watching keyspace "SyncStore": zk: could not connect to a server
2023-01-18T22:12:28.923405294Z panic: runtime error: invalid memory address or nil pointer dereference
2023-01-18T22:12:28.923409629Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xe4d153]
2023-01-18T22:12:28.923411603Z 
2023-01-18T22:12:28.923413422Z goroutine 113 [running]:
2023-01-18T22:12:28.923415237Z vitess.io/vitess/go/vt/topo/topoproto.SrvKeyspaceGetPartition(...)
2023-01-18T22:12:28.923417145Z 	vitess.io/vitess/go/vt/topo/topoproto/srvkeyspace.go:54
2023-01-18T22:12:28.923419039Z vitess.io/vitess/go/vt/discovery.(*keyspaceState).ensureConsistentLocked(0x1b9a040?)
2023-01-18T22:12:28.923421892Z 	vitess.io/vitess/go/vt/discovery/keyspace_events.go:222 +0x33
2023-01-18T22:12:28.923423694Z vitess.io/vitess/go/vt/discovery.(*keyspaceState).onHealthCheck(0xc029529d10, 0xc0295bbdb0)
2023-01-18T22:12:28.923437929Z 	vitess.io/vitess/go/vt/discovery/keyspace_events.go:328 +0x1ba
2023-01-18T22:12:28.923443219Z vitess.io/vitess/go/vt/discovery.(*KeyspaceEventWatcher).processHealthCheck(0xc0006b5fa8?, 0xc0295bbdb0)
2023-01-18T22:12:28.923445196Z 	vitess.io/vitess/go/vt/discovery/keyspace_events.go:403 +0x3c
2023-01-18T22:12:28.923450507Z vitess.io/vitess/go/vt/discovery.(*KeyspaceEventWatcher).run.func1()
2023-01-18T22:12:28.92345682Z 	vitess.io/vitess/go/vt/discovery/keyspace_events.go:194 +0x7b
2023-01-18T22:12:28.923459099Z created by vitess.io/vitess/go/vt/discovery.(*KeyspaceEventWatcher).run
2023-01-18T22:12:28.923460969Z 	vitess.io/vitess/go/vt/discovery/keyspace_events.go:183 +0xf8
```

This is not desirable, there should be an error, but it should not kill the whole vtgate process.

This is called from [this healthcheck code](https://github.com/vitessio/vitess/blob/c5dced7f4527a064c066a123c5b897be7f1ce3ec/go/vt/discovery/keyspace_events.go#L223), which does a [nil check](https://github.com/vitessio/vitess/blob/c5dced7f4527a064c066a123c5b897be7f1ce3ec/go/vt/discovery/keyspace_events.go#L371) above, but then proceeds to this method without another nil check. If the return value of the method I have modified is nil, the healthcheck assumes the kss is in some sort of transient state and returns out, so this is safe to return nil from

The error we see above the nil pointer comes from this [same file](https://github.com/vitessio/vitess/blob/c5dced7f4527a064c066a123c5b897be7f1ce3ec/go/vt/discovery/keyspace_events.go#L353)

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
