### PR TITLE
evalengine: Implement LEFT, RIGHT, LPAD & RPAD

### DIFF
--- a/go/mysql/collations/charset/helpers.go
+++ b/go/mysql/collations/charset/helpers.go
@@ -21,14 +21,18 @@ func Slice(charset Charset, input []byte, from, to int) []byte {
 		return charset.Slice(input, from, to)
 	}
 	iter := input
+	start := 0
 	for i := 0; i < to; i++ {
 		r, size := charset.DecodeRune(iter)
 		if r == RuneError && size < 2 {
 			break
 		}
+		if i < from {
+			start += size
+		}
 		iter = iter[size:]
 	}
-	return input[:len(input)-len(iter)]
+	return input[start : len(input)-len(iter)]
 }
 
 func Validate(charset Charset, input []byte) bool {

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -825,6 +825,18 @@ func (cached *builtinJSONUnquote) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinLeftRight) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinLength) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -982,6 +994,18 @@ func (cached *builtinMultiComparison) CachedSize(alloc bool) int64 {
 	return size
 }
 func (cached *builtinNow) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
+func (cached *builtinPad) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
 	}

--- a/go/vt/vtgate/evalengine/expr_call.go
+++ b/go/vt/vtgate/evalengine/expr_call.go
@@ -56,3 +56,16 @@ func (c *CallExpr) arg2(env *ExpressionEnv) (left eval, right eval, err error) {
 	right, err = c.Arguments[1].eval(env)
 	return
 }
+
+func (c *CallExpr) arg3(env *ExpressionEnv) (arg1 eval, arg2 eval, arg3 eval, err error) {
+	arg1, err = c.Arguments[0].eval(env)
+	if err != nil {
+		return
+	}
+	arg2, err = c.Arguments[1].eval(env)
+	if err != nil {
+		return
+	}
+	arg3, err = c.Arguments[2].eval(env)
+	return
+}

--- a/go/vt/vtgate/evalengine/fn_base64.go
+++ b/go/vt/vtgate/evalengine/fn_base64.go
@@ -115,12 +115,7 @@ func (call *builtinToBase64) compile(c *compiler) (ctype, error) {
 		c.asm.Convert_xb(1, t, 0, false)
 	}
 
-	col := collations.TypedCollation{
-		Collation:    c.cfg.Collation,
-		Coercibility: collations.CoerceCoercible,
-		Repertoire:   collations.RepertoireASCII,
-	}
-
+	col := defaultCoercionCollation(c.cfg.Collation)
 	c.asm.Fn_TO_BASE64(t, col)
 	c.asm.jumpDestination(skip)
 

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -66,6 +66,10 @@ var Cases = []TestCase{
 	{Run: FnBitLength},
 	{Run: FnAscii},
 	{Run: FnRepeat},
+	{Run: FnLeft},
+	{Run: FnLpad},
+	{Run: FnRight},
+	{Run: FnRpad},
 	{Run: FnHex},
 	{Run: FnCeil},
 	{Run: FnFloor},
@@ -1213,7 +1217,47 @@ func FnRepeat(yield Query) {
 	counts := []string{"-1", "1.9", "3", "1073741825", "'1.9'"}
 	for _, str := range inputStrings {
 		for _, cnt := range counts {
-			yield(fmt.Sprintf("repeat(%s, %s)", str, cnt), nil)
+			yield(fmt.Sprintf("REPEAT(%s, %s)", str, cnt), nil)
+		}
+	}
+}
+
+func FnLeft(yield Query) {
+	counts := []string{"-1", "1.9", "3", "10", "'1.9'"}
+	for _, str := range inputStrings {
+		for _, cnt := range counts {
+			yield(fmt.Sprintf("LEFT(%s, %s)", str, cnt), nil)
+		}
+	}
+}
+
+func FnLpad(yield Query) {
+	counts := []string{"-1", "1.9", "3", "10", "'1.9'"}
+	for _, str := range inputStrings {
+		for _, cnt := range counts {
+			for _, pad := range inputStrings {
+				yield(fmt.Sprintf("LPAD(%s, %s, %s)", str, cnt, pad), nil)
+			}
+		}
+	}
+}
+
+func FnRight(yield Query) {
+	counts := []string{"-1", "1.9", "3", "10", "'1.9'"}
+	for _, str := range inputStrings {
+		for _, cnt := range counts {
+			yield(fmt.Sprintf("RIGHT(%s, %s)", str, cnt), nil)
+		}
+	}
+}
+
+func FnRpad(yield Query) {
+	counts := []string{"-1", "1.9", "3", "10", "'1.9'"}
+	for _, str := range inputStrings {
+		for _, cnt := range counts {
+			for _, pad := range inputStrings {
+				yield(fmt.Sprintf("RPAD(%s, %s, %s)", str, cnt, pad), nil)
+			}
 		}
 	}
 }

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -248,6 +248,16 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (Expr, error) 
 			return nil, argError(method)
 		}
 		return &builtinConv{CallExpr: call, collate: ast.cfg.Collation}, nil
+	case "left", "right":
+		if len(args) != 2 {
+			return nil, argError(method)
+		}
+		return &builtinLeftRight{CallExpr: call, collate: ast.cfg.Collation, left: method == "left"}, nil
+	case "lpad", "rpad":
+		if len(args) != 3 {
+			return nil, argError(method)
+		}
+		return &builtinPad{CallExpr: call, collate: ast.cfg.Collation, left: method == "lpad"}, nil
 	case "lower", "lcase":
 		if len(args) != 1 {
 			return nil, argError(method)


### PR DESCRIPTION
This implements a bunch of additional string functions, namely `LEFT()`, `RIGHT()`, `LPAD()` and `RPAD()`.

As is a tradition by now, new functions also uncover other issues. This time it turns out it's the charset slice helper which doesn't actually honor the `from` parameter.

Nothing else was using anything but `0` for `from` so there was no externally observable bug anywhere yet, but with these functions we also use it with a non `0` `from`.

## Related Issue(s)

Part of #9647

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
