### PR TITLE
Cleanup rate limiters

### DIFF
--- a/go/timer/rate_limiter_test.go
+++ b/go/timer/rate_limiter_test.go
@@ -27,6 +27,7 @@ import (
 func TestRateLimiterLong(t *testing.T) {
 	r := NewRateLimiter(time.Hour)
 	require.NotNil(t, r)
+	defer r.Stop()
 	val := 0
 	incr := func() error { val++; return nil }
 	for i := 0; i < 10; i++ {
@@ -39,6 +40,7 @@ func TestRateLimiterLong(t *testing.T) {
 func TestRateLimiterShort(t *testing.T) {
 	r := NewRateLimiter(time.Millisecond * 250)
 	require.NotNil(t, r)
+	defer r.Stop()
 	val := 0
 	incr := func() error { val++; return nil }
 	for i := 0; i < 10; i++ {
@@ -54,6 +56,7 @@ func TestRateLimiterShort(t *testing.T) {
 func TestRateLimiterStop(t *testing.T) {
 	r := NewRateLimiter(time.Millisecond * 10)
 	require.NotNil(t, r)
+	defer r.Stop()
 	val := 0
 	incr := func() error { val++; return nil }
 	for i := 0; i < 5; i++ {

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -158,8 +158,6 @@ func newVReplicator(id int32, source *binlogdatapb.BinlogSource, sourceVStreamer
 		stats:           stats,
 		dbClient:        newVDBClient(dbClient, stats),
 		mysqld:          mysqld,
-
-		throttleUpdatesRateLimiter: timer.NewRateLimiter(time.Second),
 	}
 }
 
@@ -185,6 +183,9 @@ func newVReplicator(id int32, source *binlogdatapb.BinlogSource, sourceVStreamer
 // However, there are some subtle differences, explained in the plan builder
 // code.
 func (vr *vreplicator) Replicate(ctx context.Context) error {
+	vr.throttleUpdatesRateLimiter = timer.NewRateLimiter(time.Second)
+	defer vr.throttleUpdatesRateLimiter.Stop()
+
 	err := vr.replicate(ctx)
 	if err != nil {
 		if err := vr.setMessage(err.Error()); err != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -183,9 +183,6 @@ func newVReplicator(id int32, source *binlogdatapb.BinlogSource, sourceVStreamer
 // However, there are some subtle differences, explained in the plan builder
 // code.
 func (vr *vreplicator) Replicate(ctx context.Context) error {
-	vr.throttleUpdatesRateLimiter = timer.NewRateLimiter(time.Second)
-	defer vr.throttleUpdatesRateLimiter.Stop()
-
 	err := vr.replicate(ctx)
 	if err != nil {
 		if err := vr.setMessage(err.Error()); err != nil {
@@ -250,6 +247,9 @@ func (vr *vreplicator) replicate(ctx context.Context) error {
 	}
 	//defensive guard, should be a no-op since it should happen after copy is done
 	defer vr.resetFKCheckAfterCopy(vr.dbClient)
+
+	vr.throttleUpdatesRateLimiter = timer.NewRateLimiter(time.Second)
+	defer vr.throttleUpdatesRateLimiter.Stop()
 
 	for {
 		select {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -299,6 +299,7 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 
 	throttleEvents := func(throttledEvents chan mysql.BinlogEvent) {
 		throttledHeartbeatsRateLimiter := timer.NewRateLimiter(HeartbeatTime)
+		defer throttledHeartbeatsRateLimiter.Stop()
 		for {
 			// check throttler.
 			if !vs.vse.throttlerClient.ThrottleCheckOKOrWait(ctx) {


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/13012 reported by @arthurschreiber

This PR ensures to `defer r.Stop()` for all overlooked cases of  `RateLimiter`. Where possible, the rate limiter's scope was reduced to strictly necessary functions, as opposed to being creates in struct scope.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/13012

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
