### PR TITLE
fix misleading primary not serving message

### DIFF
--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -303,7 +303,7 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 				}
 				primary, serving := kev.PrimaryIsNotServing(target)
 				if serving {
-					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, "primary is not serving, there is a reparent operation in progress")
+					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, "primary is not serving, there may be a reparent operation in progress")
 					continue
 				}
 				// if primary is serving, but we initially found no tablet, we're in an inconsistent state


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

If a primary is downed, you get the error `primary is not serving, there is a reparent operation in progress`, which in our case led to some debugging in a completely wrong direction because we thought there was a faulty reparent happening. While it's possible the primary isn't serving because of a reparent, it's not guaranteed to be because of a reparent, so this modifies the error wording to be a bit more clear

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes https://github.com/vitessio/vitess/issues/12605

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
