### PR TITLE
evalengine: Implement TRIM, RTRIM and LTRIM

### DIFF
--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -1461,15 +1461,20 @@ func (node *RegexpSubstrExpr) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (node *TrimFuncExpr) Format(buf *TrackedBuffer) {
 	buf.astPrintf(node, "%s(", node.TrimFuncType.ToString())
-	if node.Type.ToString() != "" {
-		buf.astPrintf(node, "%s ", node.Type.ToString())
-	}
-	if node.TrimArg != nil {
-		buf.astPrintf(node, "%v ", node.TrimArg)
-	}
+	if node.TrimFuncType == NormalTrimType {
+		var from bool
+		if node.Type != NoTrimType {
+			buf.astPrintf(node, "%s ", node.Type.ToString())
+			from = true
+		}
+		if node.TrimArg != nil {
+			buf.astPrintf(node, "%v ", node.TrimArg)
+			from = true
+		}
 
-	if (node.Type.ToString() != "") || (node.TrimArg != nil) {
-		buf.literal("from ")
+		if from {
+			buf.literal("from ")
+		}
 	}
 	buf.astPrintf(node, "%v", node.StringArg)
 	buf.WriteByte(')')

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1927,17 +1927,22 @@ func (node *RegexpSubstrExpr) formatFast(buf *TrackedBuffer) {
 func (node *TrimFuncExpr) formatFast(buf *TrackedBuffer) {
 	buf.WriteString(node.TrimFuncType.ToString())
 	buf.WriteByte('(')
-	if node.Type.ToString() != "" {
-		buf.WriteString(node.Type.ToString())
-		buf.WriteByte(' ')
-	}
-	if node.TrimArg != nil {
-		buf.printExpr(node, node.TrimArg, true)
-		buf.WriteByte(' ')
-	}
+	if node.TrimFuncType == NormalTrimType {
+		var from bool
+		if node.Type != NoTrimType {
+			buf.WriteString(node.Type.ToString())
+			buf.WriteByte(' ')
+			from = true
+		}
+		if node.TrimArg != nil {
+			buf.printExpr(node, node.TrimArg, true)
+			buf.WriteByte(' ')
+			from = true
+		}
 
-	if (node.Type.ToString() != "") || (node.TrimArg != nil) {
-		buf.WriteString("from ")
+		if from {
+			buf.WriteString("from ")
+		}
 	}
 	buf.printExpr(node, node.StringArg, true)
 	buf.WriteByte(')')

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -18140,7 +18140,7 @@ yydefault:
 		var yyLOCAL Expr
 //line sql.y:6025
 		{
-			yyLOCAL = &TrimFuncExpr{TrimFuncType: LTrimType, StringArg: yyDollar[3].exprUnion()}
+			yyLOCAL = &TrimFuncExpr{TrimFuncType: LTrimType, Type: LeadingTrimType, StringArg: yyDollar[3].exprUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 1173:
@@ -18148,7 +18148,7 @@ yydefault:
 		var yyLOCAL Expr
 //line sql.y:6029
 		{
-			yyLOCAL = &TrimFuncExpr{TrimFuncType: RTrimType, StringArg: yyDollar[3].exprUnion()}
+			yyLOCAL = &TrimFuncExpr{TrimFuncType: RTrimType, Type: TrailingTrimType, StringArg: yyDollar[3].exprUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 1174:

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -6023,11 +6023,11 @@ UTC_DATE func_paren_opt
   }
 | LTRIM openb expression closeb
   {
-    $$ = &TrimFuncExpr{TrimFuncType:LTrimType, StringArg: $3}
+    $$ = &TrimFuncExpr{TrimFuncType:LTrimType, Type: LeadingTrimType, StringArg: $3}
   }
 | RTRIM openb expression closeb
   {
-    $$ = &TrimFuncExpr{TrimFuncType:RTrimType, StringArg: $3}
+    $$ = &TrimFuncExpr{TrimFuncType:RTrimType, Type: TrailingTrimType, StringArg: $3}
   }
 | TRIM openb trim_type expression_opt FROM expression closeb
   {

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1221,6 +1221,18 @@ func (cached *builtinToBase64) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinTrim) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinTruncate) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -70,6 +70,9 @@ var Cases = []TestCase{
 	{Run: FnLpad},
 	{Run: FnRight},
 	{Run: FnRpad},
+	{Run: FnLTrim},
+	{Run: FnRTrim},
+	{Run: FnTrim},
 	{Run: FnHex},
 	{Run: FnCeil},
 	{Run: FnFloor},
@@ -1257,6 +1260,40 @@ func FnRpad(yield Query) {
 		for _, cnt := range counts {
 			for _, pad := range inputStrings {
 				yield(fmt.Sprintf("RPAD(%s, %s, %s)", str, cnt, pad), nil)
+			}
+		}
+	}
+}
+
+func FnLTrim(yield Query) {
+	for _, str := range inputTrimStrings {
+		yield(fmt.Sprintf("LTRIM(%s)", str), nil)
+	}
+}
+
+func FnRTrim(yield Query) {
+	for _, str := range inputTrimStrings {
+		yield(fmt.Sprintf("RTRIM(%s)", str), nil)
+	}
+}
+
+func FnTrim(yield Query) {
+	for _, str := range inputTrimStrings {
+		yield(fmt.Sprintf("TRIM(%s)", str), nil)
+	}
+
+	modes := []string{"LEADING", "TRAILING", "BOTH"}
+	for _, str := range inputTrimStrings {
+		for _, mode := range modes {
+			yield(fmt.Sprintf("TRIM(%s FROM %s)", mode, str), nil)
+		}
+	}
+
+	for _, str := range inputTrimStrings {
+		for _, pat := range inputTrimStrings {
+			yield(fmt.Sprintf("TRIM(%s FROM %s)", pat, str), nil)
+			for _, mode := range modes {
+				yield(fmt.Sprintf("TRIM(%s %s FROM %s)", mode, pat, str), nil)
 			}
 		}
 	}

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -155,7 +155,6 @@ var inputStrings = []string{
 	"-9223372036854775808",
 	"999999999999999999999999",
 	"-999999999999999999999999",
-	"_latin1 X'ÂÄÌå'",
 	"_binary 'Müller' ",
 	"_utf8mb4 'abcABCÅå'",
 	// TODO: support other multibyte encodings
@@ -212,4 +211,34 @@ var dateFormats = []struct {
 	{'Y', "YEAR(d)"},
 	{'y', "RIGHT(YEAR(d),2)"},
 	{'%', ""},
+}
+
+var inputTrimStrings = []string{
+	"\" Å å\" ",
+	"NULL",
+	"\"\"",
+	"\"a\"",
+	"\"abc\"",
+	"'abca'",
+	"1",
+	"-1",
+	"0123",
+	"0xAACC",
+	"3.1415926",
+	"\" 中文测试\"",
+	"\"日本語テスト \"",
+	"\"한국어 시험\"",
+	"\" 😊😂🤢\r\t \"",
+	"'123'",
+	"9223372036854775807",
+	"-9223372036854775808",
+	"999999999999999999999999",
+	"-999999999999999999999999",
+	"_binary 'Müller\r\n' ",
+	"_utf8mb4 '\nabcABCÅå '",
+	// utf8mb4 version of the non-breaking space
+	"_utf8mb4 0xC2A078C2A0",
+	// TODO: support other multibyte encodings
+	// latin1 version of the non-breaking space
+	///"_latin1 0xA078A0",
 }

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -631,6 +631,28 @@ func (ast *astCompiler) translateCallable(call sqlparser.Callable) (Expr, error)
 			prec:     uint8(call.Fsp),
 		}, nil
 
+	case *sqlparser.TrimFuncExpr:
+		var args []Expr
+		str, err := ast.translateExpr(call.StringArg)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, str)
+		if call.TrimArg != nil {
+			trim, err := ast.translateExpr(call.TrimArg)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, trim)
+		}
+
+		var cexpr = CallExpr{Arguments: args, Method: call.TrimFuncType.ToString()}
+		return &builtinTrim{
+			CallExpr: cexpr,
+			collate:  ast.cfg.Collation,
+			trim:     call.Type,
+		}, nil
+
 	default:
 		return nil, translateExprNotSupported(call)
 	}


### PR DESCRIPTION
Implements the `TRIM`, `RTRIM` and `LTRIM` functions in the evalengine.

Uncovers a small improvement to the parser where we should set the direction also if we see either `RTRIM` or `LTRIM` so we're consistent later with using it.

## Related Issue(s)

Part of #9647 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required