### PR TITLE
gen4 planner bugfix: issue when merging subqueries

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/merging.go
+++ b/go/vt/vtgate/planbuilder/operators/merging.go
@@ -194,7 +194,7 @@ func (jm *joinMerger) mergeTables(r1, r2 *ShardedRouting, op1, op2 *Route) (*Rou
 		VindexPreds:    append(r1.VindexPreds, r2.VindexPreds...),
 		keyspace:       r1.keyspace,
 		RouteOpCode:    r1.RouteOpCode,
-		SeenPredicates: r1.SeenPredicates,
+		SeenPredicates: append(r1.SeenPredicates, r2.SeenPredicates...),
 	}
 	if r1.SelectedVindex() == r2.SelectedVindex() {
 		tr.Selected = r1.Selected

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -7943,5 +7943,43 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "merge subquery using MAX and join into single route",
+    "query": "select 1 from user join music_extra on user.id = music_extra.user_id where music_extra.music_id = (select max(music_id) from music_extra where user_id = user.id)",
+    "v3-plan": {
+      "QueryType": "SELECT",
+      "Original": "select 1 from user join music_extra on user.id = music_extra.user_id where music_extra.music_id = (select max(music_id) from music_extra where user_id = user.id)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 1 from `user` join music_extra on `user`.id = music_extra.user_id where 1 != 1",
+        "Query": "select 1 from `user` join music_extra on `user`.id = music_extra.user_id where music_extra.music_id = (select max(music_id) from music_extra where user_id = `user`.id)",
+        "Table": "`user`, music_extra"
+      }
+    },
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select 1 from user join music_extra on user.id = music_extra.user_id where music_extra.music_id = (select max(music_id) from music_extra where user_id = user.id)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 1 from `user`, music_extra where 1 != 1",
+        "Query": "select 1 from `user`, music_extra where music_extra.music_id = (select max(music_id) from music_extra where user_id = `user`.id) and `user`.id = music_extra.user_id",
+        "Table": "`user`, music_extra"
+      },
+      "TablesUsed": [
+        "user.music_extra",
+        "user.user"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description
In PR #12197, a refactoring error resulted in a bug causing the generation of invalid query plans under specific conditions.

While merging a subquery with the outer query, predicates from the subquery were not copied properly. This led to a partial merge where certain expressions were treated as unmergeable, creating an inconsistency. Consequently, invalid query plans were produced, resulting in the following error:

```query arguments missing for __sq1```

This PR resolves the issue and includes a test to prevent similar problems from occurring in the future.

## Related Issue(s)

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
