### PR TITLE
evalengine: Implement UNHEX

### DIFF
--- a/go/vt/vtgate/evalengine/arena.go
+++ b/go/vt/vtgate/evalengine/arena.go
@@ -127,6 +127,14 @@ func (a *Arena) newEvalText(raw []byte, tc collations.TypedCollation) *evalBytes
 	return b
 }
 
+func (a *Arena) newEvalRaw(raw []byte, tt sqltypes.Type, tc collations.TypedCollation) *evalBytes {
+	b := a.newEvalBytesEmpty()
+	b.tt = int16(tt)
+	b.col = tc
+	b.bytes = raw
+	return b
+}
+
 func (a *Arena) newEvalTime(time datetime.Time, l int) *evalTemporal {
 	// TODO: reuse evalTemporal
 	return &evalTemporal{t: sqltypes.Time, dt: datetime.DateTime{Time: time.Round(l)}, prec: uint8(l)}

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1245,6 +1245,18 @@ func (cached *builtinTruncate) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinUnhex) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinUnixTimestamp) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -364,6 +364,10 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `timestamp '2000-01-01 10:34:58.978654' DIV '\t1 foo\t'`,
 			result:     `INT64(20000101103458)`,
 		},
+		{
+			expression: `UNHEX('f')`,
+			result:     `VARBINARY("\x0f")`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -18,6 +18,7 @@ package testcases
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"strconv"
@@ -74,6 +75,7 @@ var Cases = []TestCase{
 	{Run: FnRTrim},
 	{Run: FnTrim},
 	{Run: FnHex},
+	{Run: FnUnhex},
 	{Run: FnCeil},
 	{Run: FnFloor},
 	{Run: FnAbs},
@@ -1310,6 +1312,26 @@ func FnHex(yield Query) {
 
 	for _, str := range inputBitwise {
 		yield(fmt.Sprintf("hex(%s)", str), nil)
+	}
+}
+
+func FnUnhex(yield Query) {
+	var inputs = []string{
+		`'f'`,
+		`'fe'`,
+		`'fea'`,
+		`'666F6F626172'`,
+		// MySQL trims whitespace
+		`'  \t\r\n  4f  \n \t '`,
+	}
+
+	inputs = append(inputs, inputConversions...)
+	for _, input := range inputConversions {
+		inputs = append(inputs, "'"+hex.EncodeToString([]byte(input))+"'")
+	}
+
+	for _, lhs := range inputs {
+		yield(fmt.Sprintf("UNHEX(%s)", lhs), nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -97,6 +97,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (Expr, error) 
 			return nil, argError(method)
 		}
 		return &builtinHex{CallExpr: call, collate: ast.cfg.Collation}, nil
+	case "unhex":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		return &builtinUnhex{CallExpr: call}, nil
 	case "ceil", "ceiling":
 		if len(args) != 1 {
 			return nil, argError(method)


### PR DESCRIPTION
We already had `HEX`, but not `UNHEX`. This fixes the assymmetry.

## Related Issue(s)

Part of #9647

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required