### PR TITLE
planner: allow reference tables to specify global sources

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -7,7 +7,7 @@
       "Original": "select * from ambiguous_ref_with_source",
       "Instructions": {
         "OperatorType": "Route",
-        "Variant": "Reference",
+        "Variant": "Unsharded",
         "Keyspace": {
           "Name": "main",
           "Sharded": false
@@ -61,7 +61,7 @@
           },
           {
             "OperatorType": "Route",
-            "Variant": "Reference",
+            "Variant": "Unsharded",
             "Keyspace": {
               "Name": "main",
               "Sharded": false
@@ -101,7 +101,7 @@
       "Original": "select r1.col from ambiguous_ref_with_source r1 join ambiguous_ref_with_source",
       "Instructions": {
         "OperatorType": "Route",
-        "Variant": "Reference",
+        "Variant": "Unsharded",
         "Keyspace": {
           "Name": "main",
           "Sharded": false
@@ -121,8 +121,8 @@
           "Name": "main",
           "Sharded": false
         },
-        "FieldQuery": "select r1.col from ambiguous_ref_with_source as r1, ambiguous_ref_with_source where 1 != 1",
-        "Query": "select r1.col from ambiguous_ref_with_source as r1, ambiguous_ref_with_source",
+        "FieldQuery": "select r1.col from ambiguous_ref_with_source as r1 join ambiguous_ref_with_source where 1 != 1",
+        "Query": "select r1.col from ambiguous_ref_with_source as r1 join ambiguous_ref_with_source",
         "Table": "ambiguous_ref_with_source"
       },
       "TablesUsed": [
@@ -144,7 +144,7 @@
         "Inputs": [
           {
             "OperatorType": "Route",
-            "Variant": "Reference",
+            "Variant": "Unsharded",
             "Keyspace": {
               "Name": "main",
               "Sharded": false
@@ -201,7 +201,7 @@
         "Inputs": [
           {
             "OperatorType": "Route",
-            "Variant": "Reference",
+            "Variant": "Unsharded",
             "Keyspace": {
               "Name": "main",
               "Sharded": false
@@ -277,7 +277,7 @@
           },
           {
             "OperatorType": "Route",
-            "Variant": "Reference",
+            "Variant": "Unsharded",
             "Keyspace": {
               "Name": "main",
               "Sharded": false
@@ -508,15 +508,15 @@
   },
   {
     "comment": "join with unqualified reference optimize routes when source & reference have different names",
-    "query": "select user.col from user join ref_in_source",
+    "query": "select user.col from user join source_of_ref",
     "v3-plan": {
       "QueryType": "SELECT",
-      "Original": "select user.col from user join ref_in_source",
+      "Original": "select user.col from user join source_of_ref",
       "Instructions": {
         "OperatorType": "Join",
         "Variant": "Join",
         "JoinColumnIndexes": "L:0",
-        "TableName": "`user`_ref_in_source",
+        "TableName": "`user`_source_of_ref",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -531,21 +531,21 @@
           },
           {
             "OperatorType": "Route",
-            "Variant": "Reference",
+            "Variant": "Unsharded",
             "Keyspace": {
               "Name": "main",
               "Sharded": false
             },
-            "FieldQuery": "select 1 from ref_in_source where 1 != 1",
-            "Query": "select 1 from ref_in_source",
-            "Table": "ref_in_source"
+            "FieldQuery": "select 1 from source_of_ref where 1 != 1",
+            "Query": "select 1 from source_of_ref",
+            "Table": "source_of_ref"
           }
         ]
       }
     },
     "gen4-plan": {
       "QueryType": "SELECT",
-      "Original": "select user.col from user join ref_in_source",
+      "Original": "select user.col from user join source_of_ref",
       "Instructions": {
         "OperatorType": "Route",
         "Variant": "Scatter",
@@ -553,8 +553,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select `user`.col from `user`, ref_with_source as ref_in_source where 1 != 1",
-        "Query": "select `user`.col from `user`, ref_with_source as ref_in_source",
+        "FieldQuery": "select `user`.col from `user`, ref_with_source as source_of_ref where 1 != 1",
+        "Query": "select `user`.col from `user`, ref_with_source as source_of_ref",
         "Table": "`user`, ref_with_source"
       },
       "TablesUsed": [
@@ -588,7 +588,7 @@
           },
           {
             "OperatorType": "Route",
-            "Variant": "Reference",
+            "Variant": "Unsharded",
             "Keyspace": {
               "Name": "main",
               "Sharded": false

--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -310,7 +310,7 @@
     }
   },
   {
-    "comment": "insert into ambiguous qualified reference table routes to source",
+    "comment": "insert into ambiguous unqualified reference table routes to source",
     "query": "insert into ambiguous_ref_with_source(col) values(1)",
     "plan": {
       "QueryType": "INSERT",
@@ -617,6 +617,105 @@
       "TablesUsed": [
         "user.ref",
         "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "join with reference to unqualified source routes to optimal keyspace",
+    "query": "select user.col from user join global_ref",
+    "v3-plan": {
+      "QueryType": "SELECT",
+      "Original": "select user.col from user join global_ref",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0",
+        "TableName": "`user`_global_ref",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select `user`.col from `user` where 1 != 1",
+            "Query": "select `user`.col from `user`",
+            "Table": "`user`"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select 1 from global_ref where 1 != 1",
+            "Query": "select 1 from global_ref",
+            "Table": "global_ref"
+          }
+        ]
+      }
+    },
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select user.col from user join global_ref",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.col from `user`, global_ref where 1 != 1",
+        "Query": "select `user`.col from `user`, global_ref",
+        "Table": "`user`, global_ref"
+      },
+      "TablesUsed": [
+        "user.global_ref",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "insert into qualified reference with unqualified source routes v3 to requested keyspace gen4 to source",
+    "query": "insert into user.global_ref(col) values(1)",
+    "v3-plan": {
+      "QueryType": "INSERT",
+      "Original": "insert into user.global_ref(col) values(1)",
+      "Instructions": {
+        "OperatorType": "Insert",
+        "Variant": "Sharded",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "TargetTabletType": "PRIMARY",
+        "MultiShardAutocommit": false,
+        "Query": "insert into global_ref(col) values (1)",
+        "TableName": "global_ref"
+      },
+      "TablesUsed": [
+        "user.global_ref"
+      ]
+    },
+    "gen4-plan": {
+      "QueryType": "INSERT",
+      "Original": "insert into user.global_ref(col) values(1)",
+      "Instructions": {
+        "OperatorType": "Insert",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "TargetTabletType": "PRIMARY",
+        "MultiShardAutocommit": false,
+        "Query": "insert into global_ref(col) values (1)",
+        "TableName": "global_ref"
+      },
+      "TablesUsed": [
+        "main.global_ref"
       ]
     }
   }

--- a/go/vt/vtgate/planbuilder/testdata/show_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/show_cases.json
@@ -716,7 +716,7 @@
         "Fields": {
           "Tables": "VARCHAR"
         },
-        "RowCount": 10
+        "RowCount": 11
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
@@ -315,11 +315,15 @@
         },
         "ref_with_source": {
           "type": "reference",
-          "source": "main.ref_in_source"
+          "source": "main.source_of_ref"
         },
         "rerouted_ref": {
           "type": "reference",
           "source": "main.rerouted_ref"
+        },
+        "global_ref": {
+          "type": "reference",
+          "source": "global_ref"
         },
         "pin_test": {
           "pinned": "80"
@@ -476,18 +480,11 @@
         "seq": {
           "type": "sequence"
         },
-        "unsharded_ref": {
-          "type": "reference"
-        },
-        "ambiguous_ref_with_source": {
-          "type": "reference"
-        },
-        "ref_in_source": {
-          "type": "reference"
-        },
-        "rerouted_ref": {
-          "type": "reference"
-        }
+        "ambiguous_ref_with_source": {},
+        "global_ref": {},
+        "rerouted_ref": {},
+        "source_of_ref": {},
+        "unsharded_ref": {}
       }
     },
     "main_2": {

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -194,17 +194,17 @@ type ksJSON struct {
 func (ks *KeyspaceSchema) findTable(
 	tablename string,
 	constructUnshardedIfNotFound bool,
-) (*Table, error) {
+) *Table {
 	table := ks.Tables[tablename]
 	if table != nil {
-		return table, nil
+		return table
 	}
 
 	if constructUnshardedIfNotFound && !ks.Keyspace.Sharded {
-		return &Table{Name: sqlparser.NewIdentifierCS(tablename), Keyspace: ks.Keyspace}, nil
+		return &Table{Name: sqlparser.NewIdentifierCS(tablename), Keyspace: ks.Keyspace}
 	}
 
-	return nil, nil
+	return nil
 }
 
 // MarshalJSON returns a JSON representation of KeyspaceSchema.
@@ -916,7 +916,8 @@ func (vschema *VSchema) findGlobalTable(
 ) (*Table, error) {
 	if len(vschema.Keyspaces) == 1 {
 		for _, ks := range vschema.Keyspaces {
-			return ks.findTable(tablename, constructUnshardedIfNotFound)
+			table := ks.findTable(tablename, constructUnshardedIfNotFound)
+			return table, nil
 		}
 	}
 
@@ -964,7 +965,8 @@ func (vschema *VSchema) findTable(
 	if !ok {
 		return nil, vterrors.VT05003(keyspace)
 	}
-	return ks.findTable(tablename, constructUnshardedIfNotFound)
+	table := ks.findTable(tablename, constructUnshardedIfNotFound)
+	return table, nil
 }
 
 func (vschema *VSchema) FirstKeyspace() *Keyspace {


### PR DESCRIPTION
## Description

Allow reference tables to specify unqualified (a.k.a. global tables) as their source.

With the changes in this PR, this is now valid:

```json
{
  "ks1": {
    "tables": {
      "t1": {}
    }
  },
  "ks2": {
    "tables": {
      "t1": {
        "type": "reference",
        "source": "t1"
      }
    }
  },
}
```

Existing restrictions still apply:

  * Referenced table must be resolvable, if the global table is ambiguous, the reference table is invalid.
  * Referenced table must actually exist in the VSchema.
  * May not be a self-reference.
  
## Related Issue(s)

 * #11864

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added: https://github.com/vitessio/website/pull/1457

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
