### PR TITLE
Fix vreplication_log usage in VReplicationExec

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/controller_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_plan_test.go
@@ -218,6 +218,12 @@ func TestControllerPlan(t *testing.T) {
 			query:  "select * from _vt.copy_state",
 		},
 	}, {
+		in: "select * from _vt.vreplication_log",
+		plan: &testControllerPlan{
+			opcode: selectQuery,
+			query:  "select * from _vt.vreplication_log",
+		},
+	}, {
 		in:  "select * from _vt.a",
 		err: "invalid table name: a",
 	}, {


### PR DESCRIPTION
## Description

Interfacing with the `vreplication_log` table has not been working via the TabletManager's `VReplicationExec` RPC since the custom sidecar database work was added in: https://github.com/vitessio/vitess/pull/12240

If you tried to use the RPC you would get an error like this:
```
"rpc error: code = Unknown desc = TabletManager.VReplicationExec on zone1-0000000200 error: invalid table name: vreplication_log: invalid table name: vreplication_log"
```

This is because the database identifier is now stripped from the incoming table name and was then being compared to the const defined for the `vreplication_log` table name that still had the default database identifier in it. 

This PR corrects the issue and adds a unit test case for it.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13039
  - Seen while working on: https://github.com/vitessio/vitess/pull/13015

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required