### PR TITLE
CI: add a check on NeedsIssue label

### DIFF
--- a/.github/workflows/check_label.yml
+++ b/.github/workflows/check_label.yml
@@ -44,7 +44,7 @@ jobs:
             exit 1
           fi
 
-      - name: Check NeedsWebsiteDocsUpdate and NeedsDescriptionUpdate are off
+      - name: Check all Needs labels are off
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
@@ -62,6 +62,10 @@ jobs:
           fi
           if cat ${LABELS_JSON} | jq -r '.[].name ' | grep -q 'NeedsWebsiteDocsUpdate' ; then
             echo "Expecting PR to not have the NeedsWebsiteDocsUpdate label, please update the documentation and remove the label."
+            exit 1
+          fi
+          if cat ${LABELS_JSON} | jq -r '.[].name ' | grep -q 'NeedsIssue' ; then
+            echo "Expecting PR to not have the NeedsIssue label; please create a linked issue and remove the label."
             exit 1
           fi
           


### PR DESCRIPTION
## Description
We require a GitHub issue for all bug fixes, new features and enhancements. I have created a new label called `NeedsIssue` that reviewers can use to tag PRs without an issue.
This PR adds a check on that label to the `Check Pull Request labels` workflow to fail it if the `NeedsIssue` label is present.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
