### PR TITLE
OnlineDDL endtoend/CI: timestamp deviation toleration

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -637,6 +637,19 @@ func TestDiffSchemas(t *testing.T) {
 			},
 			tableRename: TableRenameHeuristicStatement,
 		},
+		{
+			name: "tables with irregular names",
+			from: "create table `t.2`(id int primary key); create table t3(`i.d` int primary key)",
+			to:   "create table `t.2` (id bigint primary key); create table t3(`i.d` int unsigned primary key)",
+			diffs: []string{
+				"alter table `t.2` modify column id bigint",
+				"alter table t3 modify column `i.d` int unsigned",
+			},
+			cdiffs: []string{
+				"ALTER TABLE `t.2` MODIFY COLUMN `id` bigint",
+				"ALTER TABLE `t3` MODIFY COLUMN `i.d` int unsigned",
+			},
+		},
 		// Foreign keys
 		{
 			name: "create tables with foreign keys, expect specific order",


### PR DESCRIPTION

## Description

Fixes https://github.com/vitessio/vitess/issues/12336

There's an irregularity in timestamp comparison, and we're seeing what should have been a future timestamp, come before a past timestamp.

https://github.com/vitessio/vitess/pull/12826 was an attempt to fix the irregularity by ensuring all timestamp evaluations are done in `golang` space. But it did not solve the problem.

The irregularity is not very important to the `endtoend` test. It does not affect the throttler, or imply a throttler issue. It's a shame to fail the entire `endtoend` on that timestamp comparison.

In this PR we agree to tolerate a `1sec` deviation. It's not ideal, but we've been chasing this around for months now and it's not worth spending so much efforts, as, again, the particular timestamp comparison is an insignificant part of the grand test.

While we're here we're also adding a `schemadiff` test that was in the pipeline.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/12336

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
