### PR TITLE
ApplySchema vttablet RPC: allow special characters in table and column names

### DIFF
--- a/go/test/endtoend/vreplication/config_test.go
+++ b/go/test/endtoend/vreplication/config_test.go
@@ -57,7 +57,7 @@ create table vdiff_order (order_id varchar(50) collate utf8mb4_unicode_ci not nu
 create table datze (id int, dt1 datetime not null default current_timestamp, dt2 datetime not null, ts1 timestamp default current_timestamp, primary key (id), key (dt1));
 create table json_tbl (id int, j1 json, j2 json, primary key(id));
 create table geom_tbl (id int, g geometry, p point, ls linestring, pg polygon, mp multipoint, mls multilinestring, mpg multipolygon, gc geometrycollection, primary key(id));
-create table blob_tbl (id int, val1 varchar(20), blb1 blob, val2 varbinary(20), blb2 longblob, txt1 text, blb3 tinyblob, txt2 longtext, blb4 mediumblob, primary key(id));
+create table  ` + "`blüb_tbl`" + ` (id int, val1 varchar(20), ` + "`blöb1`" + ` blob, val2 varbinary(20), ` + "`bl@b2`" + ` longblob, txt1 text, blb3 tinyblob, txt2 longtext, blb4 mediumblob, primary key(id));
 `
 	// These should always be ignored in vreplication
 	internalSchema = `
@@ -185,7 +185,7 @@ create table blob_tbl (id int, val1 varchar(20), blb1 blob, val2 varbinary(20), 
         }
       ]
     },
-    "blob_tbl": {
+    "blüb_tbl": {
       "column_vindexes": [
         {
           "column": "id",
@@ -332,7 +332,7 @@ create table blob_tbl (id int, val1 varchar(20), blb1 blob, val2 varbinary(20), 
         }
       ]
     },
-    "blob_tbl": {
+    "blüb_tbl": {
       "column_vindexes": [
         {
           "column": "id",

--- a/go/test/endtoend/vreplication/initial_data_test.go
+++ b/go/test/endtoend/vreplication/initial_data_test.go
@@ -95,15 +95,15 @@ func insertMoreProductsForTargetThrottler(t *testing.T) {
 }
 
 var blobTableQueries = []string{
-	"insert into blob_tbl(id, val1, txt1) values (1, 'Jøhn \"❤️\" Paül','Jøhn \"❤️\" Paül keyböard ⌨️ jo˙n')",
-	"insert into blob_tbl(id, val1, blb1, blb2) values (2, 'val1_aaa', 'blb1_aaa', 'blb2_AAAA')",
-	"update blob_tbl set val1 = 'val1_bbb', blb2 = 'blb2_bbb' where id = 1",
-	"insert into blob_tbl(id, val2, txt1, txt2, blb4) values (3, 'val2_ccc', 'txt1_ccc', 'txt2_ccc', 'blb4_CCC')",
-	"update blob_tbl set txt1 = 'txt1_ddd'",
-	"update blob_tbl set blb3 = 'blb3_eee'",
-	"delete from blob_tbl where id = 2",
-	"insert into blob_tbl(id, val2, txt1, txt2, blb4) values (4, 'val2_fff', 'txt1_fff', 'txt2_fff', 'blb4_FFF')",
-	"update blob_tbl set txt1 = 'txt1_eee', blb3 = 'blb3_eee' where id = 4",
+	"insert into `blüb_tbl`(id, val1, txt1) values (1, 'Jøhn \"❤️\" Paül','Jøhn \"❤️\" Paül keyböard ⌨️ jo˙n')",
+	"insert into `blüb_tbl`(id, val1, `blöb1`, `bl@b2`) values (2, 'val1_aaa', 'blb1_aaa', 'blb2_AAAA')",
+	"update `blüb_tbl` set val1 = 'val1_bbb', `bl@b2` = 'blb2_bbb' where id = 1",
+	"insert into `blüb_tbl`(id, val2, txt1, txt2, blb4) values (3, 'val2_ccc', 'txt1_ccc', 'txt2_ccc', 'blb4_CCC')",
+	"update `blüb_tbl` set txt1 = 'txt1_ddd'",
+	"update `blüb_tbl` set blb3 = 'blb3_eee'",
+	"delete from `blüb_tbl` where id = 2",
+	"insert into `blüb_tbl`(id, val2, txt1, txt2, blb4) values (4, 'val2_fff', 'txt1_fff', 'txt2_fff', 'blb4_FFF')",
+	"update `blüb_tbl` set txt1 = 'txt1_eee', blb3 = 'blb3_eee' where id = 4",
 }
 
 func insertIntoBlobTable(t *testing.T) {

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -682,7 +682,7 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 		defaultCell := cells[0]
 		custKs := vc.Cells[defaultCell.Name].Keyspaces["customer"]
 
-		tables := "customer,Lead,Lead-1,db_order_test,geom_tbl,json_tbl,blob_tbl,vdiff_order"
+		tables := "customer,Lead,Lead-1,db_order_test,geom_tbl,json_tbl,blüb_tbl,vdiff_order"
 		moveTablesAction(t, "Create", sourceCellOrAlias, workflow, sourceKs, targetKs, tables)
 
 		customerTab1 := custKs.Shards["-80"].Tablets["zone1-200"].Vttablet

--- a/go/test/endtoend/vreplication/vreplication_test_env.go
+++ b/go/test/endtoend/vreplication/vreplication_test_env.go
@@ -19,14 +19,14 @@ package vreplication
 var dryRunResultsSwitchWritesCustomerShard = []string{
 	"Lock keyspace product",
 	"Lock keyspace customer",
-	"Stop writes on keyspace product, tables [Lead,Lead-1,blob_tbl,customer,db_order_test,geom_tbl,json_tbl,vdiff_order]:",
+	"Stop writes on keyspace product, tables [Lead,Lead-1,blüb_tbl,customer,db_order_test,geom_tbl,json_tbl,vdiff_order]:",
 	"/       Keyspace product, Shard 0 at Position",
 	"Wait for VReplication on stopped streams to catchup for up to 30s",
 	"Create reverse replication workflow p2c_reverse",
 	"Create journal entries on source databases",
-	"Enable writes on keyspace customer tables [Lead,Lead-1,blob_tbl,customer,db_order_test,geom_tbl,json_tbl,vdiff_order]",
+	"Enable writes on keyspace customer tables [Lead,Lead-1,blüb_tbl,customer,db_order_test,geom_tbl,json_tbl,vdiff_order]",
 	"Switch routing from keyspace product to keyspace customer",
-	"Routing rules for tables [Lead,Lead-1,blob_tbl,customer,db_order_test,geom_tbl,json_tbl,vdiff_order] will be updated",
+	"Routing rules for tables [Lead,Lead-1,blüb_tbl,customer,db_order_test,geom_tbl,json_tbl,vdiff_order] will be updated",
 	"Switch writes completed, freeze and delete vreplication streams on:",
 	"       tablet 200 ",
 	"       tablet 300 ",
@@ -41,8 +41,8 @@ var dryRunResultsSwitchWritesCustomerShard = []string{
 
 var dryRunResultsReadCustomerShard = []string{
 	"Lock keyspace product",
-	"Switch reads for tables [Lead,Lead-1,blob_tbl,customer,db_order_test,geom_tbl,json_tbl,vdiff_order] to keyspace customer for tablet types [RDONLY,REPLICA]",
-	"Routing rules for tables [Lead,Lead-1,blob_tbl,customer,db_order_test,geom_tbl,json_tbl,vdiff_order] will be updated",
+	"Switch reads for tables [Lead,Lead-1,blüb_tbl,customer,db_order_test,geom_tbl,json_tbl,vdiff_order] to keyspace customer for tablet types [RDONLY,REPLICA]",
+	"Routing rules for tables [Lead,Lead-1,blüb_tbl,customer,db_order_test,geom_tbl,json_tbl,vdiff_order] will be updated",
 	"Unlock keyspace product",
 }
 

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1070,6 +1070,7 @@ func (mysqld *Mysqld) executeMysqlScript(connParams *mysql.ConnParams, sql io.Re
 	args := []string{
 		"--defaults-extra-file=" + cnf,
 		"--batch",
+		"--default-character-set=utf8mb4",
 	}
 	env, err := buildLdPaths()
 	if err != nil {


### PR DESCRIPTION
## Description

VReplication  MoveTables workflows which contain a table name or a column which has special characters (like `ö` or `ü`) are currently failing. While tracking down the issue it turned out that the target table/column names are being generated with incorrect character mappings. 

### Root Cause
VReplication uses the `tabletmanager`s `ApplySchema` RPC to copy over the schemas from the source to the target. 

It turns out that `ApplySchema` executes the actual ddl  using the mysql CLI in the `mysqlctl` package!!  It is not clear why we are following this approach instead of directly creating it in the tablet like how `OnlineDDL` does it, for example: this code was added way back ~2016. It is possible this is legacy and can be refactored out.

This PR sets the default character set in the extra config that is passed on to the CLI ( `--default-character-set=utf8mb4`) command line argument. An existing e2e test has been updated to use special characters in both table and column names. It was failing before this change and passes with the change.

## Related Issue(s)
  - Fixes: https://github.com/vitessio/vitess/issues/13069

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

