### PR TITLE
Purge old schema versions from memory in historian

### DIFF
--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -261,6 +261,7 @@ Usage of vttablet:
       --s3_backup_storage_root string                                    root prefix for all backup-related object names.
       --s3_backup_tls_skip_verify_cert                                   skip the 'certificate is valid' check for SSL connections.
       --sanitize_log_messages                                            Remove potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.
+      --schema-version-max-age-seconds int                               max age of schema version records to kept in memory by the vreplication historian
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service_map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
       --serving_state_grace_period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -119,7 +119,7 @@ func NewEngine(env tabletenv.Env) *Engine {
 
 		schemazHandler(se.GetSchema(), w, r)
 	})
-	se.historian = newHistorian(env.Config().TrackSchemaVersions, se.conns)
+	se.historian = newHistorian(env.Config().TrackSchemaVersions, env.Config().SchemaVersionMaxAgeSeconds, se.conns)
 	return se
 }
 
@@ -709,7 +709,7 @@ func NewEngineForTests() *Engine {
 	se := &Engine{
 		isOpen:    true,
 		tables:    make(map[string]*Table),
-		historian: newHistorian(false, nil),
+		historian: newHistorian(false, 0, nil),
 	}
 	return se
 }

--- a/go/vt/vttablet/tabletserver/schema/historian.go
+++ b/go/vt/vttablet/tabletserver/schema/historian.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"time"
+
+	"vitess.io/vitess/go/vt/sidecardb"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
-	"vitess.io/vitess/go/vt/sidecardb"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -33,36 +35,40 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-const getSchemaVersions = "select id, pos, ddl, time_updated, schemax from %s.schema_version where id > %d order by id asc"
+const getInitialSchemaVersions = "select id, pos, ddl, time_updated, schemax from %s.schema_version where from_unixtime(time_updated) > %d order by id asc"
+const getNextSchemaVersions = "select id, pos, ddl, time_updated, schemax from %s.schema_version where id > %d order by id asc"
 
 // vl defines the glog verbosity level for the package
 const vl = 10
 
 // trackedSchema has the snapshot of the table at a given pos (reached by ddl)
 type trackedSchema struct {
-	schema map[string]*binlogdatapb.MinimalTable
-	pos    mysql.Position
-	ddl    string
+	schema      map[string]*binlogdatapb.MinimalTable
+	pos         mysql.Position
+	ddl         string
+	timeUpdated int64
 }
 
 // historian implements the Historian interface by calling schema.Engine for the underlying schema
 // and supplying a schema for a specific version by loading the cached values from the schema_version table
 // The schema version table is populated by the Tracker
 type historian struct {
-	conns   *connpool.Pool
-	lastID  int64
-	schemas []*trackedSchema
-	mu      sync.Mutex
-	enabled bool
-	isOpen  bool
+	conns               *connpool.Pool
+	lastID              int64
+	schemas             []*trackedSchema
+	mu                  sync.Mutex
+	enabled             bool
+	isOpen              bool
+	schemaMaxAgeSeconds int64
 }
 
 // newHistorian creates a new historian. It expects a schema.Engine instance
-func newHistorian(enabled bool, conns *connpool.Pool) *historian {
+func newHistorian(enabled bool, schemaMaxAgeSeconds int64, conns *connpool.Pool) *historian {
 	sh := historian{
-		conns:   conns,
-		lastID:  0,
-		enabled: enabled,
+		conns:               conns,
+		lastID:              0,
+		enabled:             enabled,
+		schemaMaxAgeSeconds: schemaMaxAgeSeconds,
 	}
 	return &sh
 }
@@ -163,8 +169,17 @@ func (h *historian) loadFromDB(ctx context.Context) error {
 		return err
 	}
 	defer conn.Recycle()
-	tableData, err := conn.Exec(ctx, sqlparser.BuildParsedQuery(getSchemaVersions, sidecardb.GetIdentifier(),
-		h.lastID).Query, 10000, true)
+
+	var tableData *sqltypes.Result
+	if h.lastID == 0 && h.schemaMaxAgeSeconds > 0 { // only at vttablet start
+		schemaMaxAge := time.Now().UTC().Add(time.Duration(-h.schemaMaxAgeSeconds) * time.Second)
+		tableData, err = conn.Exec(ctx, sqlparser.BuildParsedQuery(getInitialSchemaVersions, sidecardb.GetIdentifier(),
+			schemaMaxAge.Unix()).Query, 10000, true)
+	} else {
+		tableData, err = conn.Exec(ctx, sqlparser.BuildParsedQuery(getNextSchemaVersions, sidecardb.GetIdentifier(),
+			h.lastID).Query, 10000, true)
+	}
+
 	if err != nil {
 		log.Infof("Error reading schema_tracking table %v, will operate with the latest available schema", err)
 		return nil
@@ -177,6 +192,14 @@ func (h *historian) loadFromDB(ctx context.Context) error {
 		h.schemas = append(h.schemas, trackedSchema)
 		h.lastID = id
 	}
+
+	if h.lastID != 0 && h.schemaMaxAgeSeconds > 0 {
+		// To avoid keeping old schemas in memory which can lead to an eventual memory leak
+		// we purge any older than h.schemaMaxAgeSeconds. Only needs to be done when adding
+		// new schema rows.
+		h.purgeOldSchemas()
+	}
+
 	h.sortSchemas()
 	return nil
 }
@@ -217,11 +240,23 @@ func (h *historian) readRow(row []sqltypes.Value) (*trackedSchema, int64, error)
 		tables[t.Name] = t
 	}
 	tSchema := &trackedSchema{
-		schema: tables,
-		pos:    pos,
-		ddl:    ddl,
+		schema:      tables,
+		pos:         pos,
+		ddl:         ddl,
+		timeUpdated: timeUpdated,
 	}
 	return tSchema, id, nil
+}
+
+func (h *historian) purgeOldSchemas() {
+	filtered := make([]*trackedSchema, 0)
+	maxAgeDuration := time.Duration(h.schemaMaxAgeSeconds) * time.Second
+	for _, s := range h.schemas {
+		if time.Since(time.Unix(s.timeUpdated, 0)) < maxAgeDuration {
+			filtered = append(filtered, s)
+		}
+	}
+	h.schemas = filtered
 }
 
 // sortSchemas sorts entries in ascending order of gtid, ex: 40,44,48

--- a/go/vt/vttablet/tabletserver/schema/historian.go
+++ b/go/vt/vttablet/tabletserver/schema/historian.go
@@ -34,7 +34,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-const getInitialSchemaVersions = "select id, pos, ddl, time_updated, schemax from %s.schema_version where from_unixtime(time_updated) > %d order by id asc"
+const getInitialSchemaVersions = "select id, pos, ddl, time_updated, schemax from %s.schema_version where time_updated > %d order by id asc"
 const getNextSchemaVersions = "select id, pos, ddl, time_updated, schemax from %s.schema_version where id > %d order by id asc"
 
 // vl defines the glog verbosity level for the package

--- a/go/vt/vttablet/tabletserver/schema/historian.go
+++ b/go/vt/vttablet/tabletserver/schema/historian.go
@@ -22,12 +22,11 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/vt/sidecardb"
-
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	"vitess.io/vitess/go/vt/sidecardb"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"

--- a/go/vt/vttablet/tabletserver/schema/historian_test.go
+++ b/go/vt/vttablet/tabletserver/schema/historian_test.go
@@ -212,7 +212,7 @@ func TestHistorianPurgeOldSchemas(t *testing.T) {
 	tables := make(map[string]*binlogdatapb.MinimalTable)
 	tables["t1"] = table
 	blob1 = getDbSchemaBlob(t, tables)
-	db.AddQueryPattern("select id, pos, ddl, time_updated, schemax from _vt\\.schema_version where from_unixtime\\(time_updated\\) \\>.*", &sqltypes.Result{
+	db.AddQueryPattern("select id, pos, ddl, time_updated, schemax from _vt\\.schema_version where time_updated \\>.*", &sqltypes.Result{
 		Fields: fields,
 		Rows: [][]sqltypes.Value{
 			{sqltypes.NewInt32(1), sqltypes.NewVarBinary(gtid1), sqltypes.NewVarBinary(ddl1), sqltypes.NewInt32(int32(ts1.Unix())), sqltypes.NewVarBinary(blob1)},

--- a/go/vt/vttablet/tabletserver/schema/historian_test.go
+++ b/go/vt/vttablet/tabletserver/schema/historian_test.go
@@ -19,6 +19,7 @@ package schema
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -70,7 +71,7 @@ func getDbSchemaBlob(t *testing.T, tables map[string]*binlogdatapb.MinimalTable)
 }
 
 func TestHistorian(t *testing.T) {
-	se, db, cancel := getTestSchemaEngine(t)
+	se, db, cancel := getTestSchemaEngine(t, 0)
 	defer cancel()
 
 	se.EnableHistorian(false)
@@ -172,4 +173,78 @@ func TestHistorian(t *testing.T) {
 	tab, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid3)
 	require.NoError(t, err)
 	require.Equal(t, exp3, fmt.Sprintf("%v", tab))
+}
+
+func TestHistorianPurgeOldSchemas(t *testing.T) {
+	schemaVersionMaxAgeSeconds := 3600 // 1 hour
+	se, db, cancel := getTestSchemaEngine(t, int64(schemaVersionMaxAgeSeconds))
+	defer cancel()
+
+	gtidPrefix := "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:"
+	gtid1 := gtidPrefix + "1-10"
+	ddl1 := "create table tracker_test (id int)"
+	// create the first record 1 day ago so it gets purged from memory
+	ts1 := time.Now().Add(time.Duration(-24) * time.Hour)
+	_, _, _ = ddl1, ts1, db
+	se.EnableHistorian(true)
+	_, err := se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid1)
+	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
+	var blob1 string
+
+	fields := []*querypb.Field{{
+		Name: "id",
+		Type: sqltypes.Int32,
+	}, {
+		Name: "pos",
+		Type: sqltypes.VarBinary,
+	}, {
+		Name: "ddl",
+		Type: sqltypes.VarBinary,
+	}, {
+		Name: "time_updated",
+		Type: sqltypes.Int32,
+	}, {
+		Name: "schemax",
+		Type: sqltypes.Blob,
+	}}
+
+	table := getTable("t1", []string{"id1", "id2"}, []querypb.Type{querypb.Type_INT32, querypb.Type_INT32}, []int64{0})
+	tables := make(map[string]*binlogdatapb.MinimalTable)
+	tables["t1"] = table
+	blob1 = getDbSchemaBlob(t, tables)
+	db.AddQueryPattern("select id, pos, ddl, time_updated, schemax from _vt\\.schema_version where from_unixtime\\(time_updated\\).*", &sqltypes.Result{
+		Fields: fields,
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewInt32(1), sqltypes.NewVarBinary(gtid1), sqltypes.NewVarBinary(ddl1), sqltypes.NewInt32(int32(ts1.Unix())), sqltypes.NewVarBinary(blob1)},
+		},
+	})
+	require.Nil(t, se.RegisterVersionEvent())
+	_, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid1)
+	// validate the old schema was been purged
+	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
+	require.Equal(t, 0, len(se.historian.schemas))
+
+	// add a second schema record row with a time_updated that won't be purged
+	gtid2 := gtidPrefix + "1-20"
+	_, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid2)
+	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
+
+	table = getTable("t1", []string{"id1", "id2"}, []querypb.Type{querypb.Type_INT32, querypb.Type_VARBINARY}, []int64{0})
+	tables["t1"] = table
+	blob2 := getDbSchemaBlob(t, tables)
+	ddl2 := "alter table t1 modify column id2 varbinary"
+	// set time_updated younger than the cutoff from historian.schemaMaxAgeSeconds
+	ts2 := time.Now().Add(time.Duration(-60) * time.Second)
+	db.AddQuery("select id, pos, ddl, time_updated, schemax from _vt.schema_version where id > 1 order by id asc", &sqltypes.Result{
+		Fields: fields,
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewInt32(2), sqltypes.NewVarBinary(gtid2), sqltypes.NewVarBinary(ddl2), sqltypes.NewInt32(int32(ts2.Unix())), sqltypes.NewVarBinary(blob2)},
+		},
+	})
+	require.Nil(t, se.RegisterVersionEvent())
+	exp2 := `name:"t1" fields:{name:"id1" type:INT32 table:"t1"} fields:{name:"id2" type:VARBINARY table:"t1"} p_k_columns:0`
+	tab, err := se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid2)
+	require.NoError(t, err)
+	require.Equal(t, exp2, fmt.Sprintf("%v", tab))
+	require.Equal(t, 1, len(se.historian.schemas))
 }

--- a/go/vt/vttablet/tabletserver/schema/historian_test.go
+++ b/go/vt/vttablet/tabletserver/schema/historian_test.go
@@ -212,7 +212,7 @@ func TestHistorianPurgeOldSchemas(t *testing.T) {
 	tables := make(map[string]*binlogdatapb.MinimalTable)
 	tables["t1"] = table
 	blob1 = getDbSchemaBlob(t, tables)
-	db.AddQueryPattern("select id, pos, ddl, time_updated, schemax from _vt\\.schema_version where from_unixtime\\(time_updated\\).*", &sqltypes.Result{
+	db.AddQueryPattern("select id, pos, ddl, time_updated, schemax from _vt\\.schema_version where from_unixtime\\(time_updated\\) \\>.*", &sqltypes.Result{
 		Fields: fields,
 		Rows: [][]sqltypes.Value{
 			{sqltypes.NewInt32(1), sqltypes.NewVarBinary(gtid1), sqltypes.NewVarBinary(ddl1), sqltypes.NewInt32(int32(ts1.Unix())), sqltypes.NewVarBinary(blob1)},
@@ -220,7 +220,7 @@ func TestHistorianPurgeOldSchemas(t *testing.T) {
 	})
 	require.Nil(t, se.RegisterVersionEvent())
 	_, err = se.GetTableForPos(sqlparser.NewIdentifierCS("t1"), gtid1)
-	// validate the old schema was been purged
+	// validate the old schema has been purged
 	require.Equal(t, "table t1 not found in vttablet schema", err.Error())
 	require.Equal(t, 0, len(se.historian.schemas))
 

--- a/go/vt/vttablet/tabletserver/schema/main_test.go
+++ b/go/vt/vttablet/tabletserver/schema/main_test.go
@@ -27,7 +27,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 )
 
-func getTestSchemaEngine(t *testing.T) (*Engine, *fakesqldb.DB, func()) {
+func getTestSchemaEngine(t *testing.T, schemaMaxAgeSeconds int64) (*Engine, *fakesqldb.DB, func()) {
 	db := fakesqldb.New(t)
 	db.AddQuery("select unix_timestamp()", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"t",
@@ -37,7 +37,7 @@ func getTestSchemaEngine(t *testing.T) (*Engine, *fakesqldb.DB, func()) {
 	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{})
 	db.AddQuery(mysql.BaseShowPrimary, &sqltypes.Result{})
 	AddFakeInnoDBReadRowsResult(db, 1)
-	se := newEngine(10, 10*time.Second, 10*time.Second, db)
+	se := newEngine(10, 10*time.Second, 10*time.Second, schemaMaxAgeSeconds, db)
 	require.NoError(t, se.Open())
 	cancel := func() {
 		defer db.Close()

--- a/go/vt/vttablet/tabletserver/schema/tracker_test.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestTracker(t *testing.T) {
 	initialSchemaInserted := false
-	se, db, cancel := getTestSchemaEngine(t)
+	se, db, cancel := getTestSchemaEngine(t, 0)
 	defer cancel()
 	gtid1 := "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10"
 	ddl1 := "create table tracker_test (id int)"
@@ -91,7 +91,7 @@ func TestTracker(t *testing.T) {
 
 func TestTrackerShouldNotInsertInitialSchema(t *testing.T) {
 	initialSchemaInserted := false
-	se, db, cancel := getTestSchemaEngine(t)
+	se, db, cancel := getTestSchemaEngine(t, 0)
 	gtid1 := "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10"
 
 	defer cancel()

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -148,6 +148,7 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&currentConfig.AnnotateQueries, "queryserver-config-annotate-queries", defaultConfig.AnnotateQueries, "prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type")
 	fs.BoolVar(&currentConfig.WatchReplication, "watch_replication_stream", false, "When enabled, vttablet will stream the MySQL replication stream from the local server, and use it to update schema when it sees a DDL.")
 	fs.BoolVar(&currentConfig.TrackSchemaVersions, "track_schema_versions", false, "When enabled, vttablet will store versions of schemas at each position that a DDL is applied and allow retrieval of the schema corresponding to a position")
+	fs.Int64Var(&currentConfig.SchemaVersionMaxAgeSeconds, "schema-version-max-age-seconds", 0, "max age of schema version records to kept in memory by the vreplication historian")
 	fs.BoolVar(&currentConfig.TwoPCEnable, "twopc_enable", defaultConfig.TwoPCEnable, "if the flag is on, 2pc is enabled. Other 2pc flags must be supplied.")
 	fs.StringVar(&currentConfig.TwoPCCoordinatorAddress, "twopc_coordinator_address", defaultConfig.TwoPCCoordinatorAddress, "address of the (VTGate) process(es) that will be used to notify of abandoned transactions.")
 	SecondsVar(fs, &currentConfig.TwoPCAbandonAge, "twopc_abandon_age", defaultConfig.TwoPCAbandonAge, "time in seconds. Any unresolved transaction older than this time will be sent to the coordinator to be resolved.")
@@ -316,6 +317,7 @@ type TabletConfig struct {
 	SignalSchemaChangeReloadIntervalSeconds flagutil.DeprecatedFloat64Seconds `json:"signalSchemaChangeReloadIntervalSeconds,omitempty"`
 	WatchReplication                        bool                              `json:"watchReplication,omitempty"`
 	TrackSchemaVersions                     bool                              `json:"trackSchemaVersions,omitempty"`
+	SchemaVersionMaxAgeSeconds              int64                             `json:"schemaVersionMaxAgeSeconds,omitempty"`
 	TerseErrors                             bool                              `json:"terseErrors,omitempty"`
 	AnnotateQueries                         bool                              `json:"annotateQueries,omitempty"`
 	MessagePostponeParallelism              int                               `json:"messagePostponeParallelism,omitempty"`


### PR DESCRIPTION
## Description

This PR adds the ability for the vttablet to configure purging schema versions _in memory_ used in vreplication schema tracking older than a certain time. The motivation for this change was that for tablets with very large schemas and very frequent DDLs the tablet process would eventually OOM because of storing all of the old schema versions in memory.

> NOTE: This does **_not_** delete the schema version rows from the `_vt.schema_version` table in mysql, but only purges them from the vttablet process memory.

I added a `schema-version-max-age-seconds` vttablet flag that defaults to `0` (no purging) and can be set to purge schema versions older than the set number of seconds. There was an [attempt in the past](https://github.com/vitessio/vitess/pull/8617) to limit the max number of schemas to keep in memory, but was not merged. It didn't account for if you have binlog events with a GTID which could use a schema older than the max number held in memory. Since this approach uses a time based approach the `schema-version-max-age-seconds` can be set to a value greater than your [mysql binlog retention seconds](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds) ensuring you don't have any binlogs with a GTID for a schema not in memory.

This work should eventually be replaced by https://github.com/vitessio/vitess/issues/11638.

TODO: 
- [x] write unit tests
- [x] update docs with new vttablet flag

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/8585
- https://github.com/vitessio/vitess/pull/8617

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
