### PR TITLE
evalengine: Add support for `STRCMP`

### DIFF
--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -1185,6 +1185,18 @@ func (cached *builtinSqrt) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinStrcmp) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinSysdate) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -368,6 +368,10 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `UNHEX('f')`,
 			result:     `VARBINARY("\x0f")`,
 		},
+		{
+			expression: `STRCMP(1234, '12_4')`,
+			result:     `INT64(-1)`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/go/vt/vtgate/evalengine/expr_collate.go
+++ b/go/vt/vtgate/evalengine/expr_collate.go
@@ -51,7 +51,7 @@ var collationJSON = collations.TypedCollation{
 var collationUtf8mb3 = collations.TypedCollation{
 	Collation:    collations.CollationUtf8ID,
 	Coercibility: collations.CoerceCoercible,
-	Repertoire:   collations.RepertoireASCII,
+	Repertoire:   collations.RepertoireUnicode,
 }
 
 type (
@@ -117,7 +117,7 @@ func evalCollation(e eval) collations.TypedCollation {
 	switch e := e.(type) {
 	case nil:
 		return collationNull
-	case evalNumeric:
+	case evalNumeric, *evalTemporal:
 		return collationNumeric
 	case *evalJSON:
 		return collationJSON

--- a/go/vt/vtgate/evalengine/expr_compare.go
+++ b/go/vt/vtgate/evalengine/expr_compare.go
@@ -650,5 +650,5 @@ func (expr *LikeExpr) compile(c *compiler) (ctype, error) {
 	}
 
 	c.asm.jumpDestination(skip)
-	return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean}, nil
+	return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean | flagNullable}, nil
 }

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -53,6 +53,7 @@ var Cases = []TestCase{
 	{Run: NegateArithmetic},
 	{Run: CollationOperations},
 	{Run: LikeComparison},
+	{Run: StrcmpComparison},
 	{Run: MultiComparisons},
 	{Run: IsStatement},
 	{Run: NotStatement},
@@ -1005,6 +1006,39 @@ func LikeComparison(yield Query) {
 	for _, lhs := range left {
 		for _, rhs := range right {
 			yield(fmt.Sprintf("%s LIKE %s", lhs, rhs), nil)
+		}
+	}
+}
+
+func StrcmpComparison(yield Query) {
+	inputs := append([]string{
+		`'foobar'`, `'FOOBAR'`,
+		`'1234'`, `1234`,
+		`_utf8mb4 'foobar' COLLATE utf8mb4_0900_as_cs`,
+		`_utf8mb4 'FOOBAR' COLLATE utf8mb4_0900_as_cs`,
+		`_utf8mb4 'foobar' COLLATE utf8mb4_0900_as_ci`,
+		`_utf8mb4 'FOOBAR' COLLATE utf8mb4_0900_as_ci`,
+		`'foo%'`, `'FOO%'`, `'foo_ar'`, `'FOO_AR'`,
+		`'12%'`, `'12_4'`, `'12x4'`, `'12$4'`,
+		`_utf8mb4 '12_4' COLLATE utf8mb4_0900_as_cs`,
+		`_utf8mb4 '12_4' COLLATE utf8mb4_0900_ai_ci`,
+		`_utf8mb4 '12x4' COLLATE utf8mb4_0900_as_cs`,
+		`_utf8mb4 '12x4' COLLATE utf8mb4_0900_ai_ci`,
+		`_utf8mb4 '12$4' COLLATE utf8mb4_0900_as_cs`,
+		`_utf8mb4 '12$4' COLLATE utf8mb4_0900_ai_ci`,
+		`_utf8mb4 'foo%' COLLATE utf8mb4_0900_as_cs`,
+		`_utf8mb4 'FOO%' COLLATE utf8mb4_0900_as_cs`,
+		`_utf8mb4 'foo_ar' COLLATE utf8mb4_0900_as_cs`,
+		`_utf8mb4 'FOO_AR' COLLATE utf8mb4_0900_as_cs`,
+		`_utf8mb4 'foo%' COLLATE utf8mb4_0900_as_ci`,
+		`_utf8mb4 'FOO%' COLLATE utf8mb4_0900_as_ci`,
+		`_utf8mb4 'foo_ar' COLLATE utf8mb4_0900_as_ci`,
+		`_utf8mb4 'FOO_AR' COLLATE utf8mb4_0900_as_ci`,
+	}, inputConversions...)
+
+	for _, lhs := range inputs {
+		for _, rhs := range inputs {
+			yield(fmt.Sprintf("STRCMP(%s, %s)", lhs, rhs), nil)
 		}
 	}
 }

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -493,6 +493,11 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (Expr, error) 
 			return nil, argError(method)
 		}
 		return &builtinConvertTz{CallExpr: call}, nil
+	case "strcmp":
+		if len(args) != 2 {
+			return nil, argError(method)
+		}
+		return &builtinStrcmp{CallExpr: call, collate: ast.cfg.Collation}, nil
 	default:
 		return nil, translateExprNotSupported(fn)
 	}


### PR DESCRIPTION
This adds support for the `STRCMP` function to the evalengine. MySQL seems to handle numerics as a somewhat special case for how collation merging works, so this tries to mirror that based on the test results.

## Related Issue(s)

Part of #9647 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required