### PR TITLE
evalengine: Add support for handling `IF`

### DIFF
--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -36,6 +36,7 @@ var Cases = []TestCase{
 	{Run: CharsetConversionOperators},
 	{Run: CaseExprWithPredicate},
 	{Run: CaseExprWithValue},
+	{Run: If},
 	{Run: Base64},
 	{Run: Conversion},
 	{Run: LargeDecimals},
@@ -705,6 +706,20 @@ func CaseExprWithValue(yield Query) {
 				continue
 			}
 			yield(fmt.Sprintf("case %s when %s then 1 else 0 end", cmpbase, val1), nil)
+		}
+	}
+}
+
+func If(yield Query) {
+	var elements []string
+	elements = append(elements, inputBitwise...)
+	elements = append(elements, inputComparisonElement...)
+
+	for _, cmpbase := range elements {
+		for _, val1 := range elements {
+			for _, val2 := range elements {
+				yield(fmt.Sprintf("if(%s, %s, %s)", cmpbase, val1, val2), nil)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Similar to how we handle `IFNULL` and `NULLIF`, we can also handle `IF` using a `CASE` internally in the evalengine.

This implements `IF` accordingly.

## Related Issue(s)

Part of #9647

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required