### PR TITLE
evalengine: `INTERVAL` support

### DIFF
--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -233,6 +233,18 @@ func (cached *InExpr) CachedSize(alloc bool) int64 {
 	size += cached.BinaryExpr.CachedSize(false)
 	return size
 }
+func (cached *IntervalExpr) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *IsExpr) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -372,6 +372,78 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `STRCMP(1234, '12_4')`,
 			result:     `INT64(-1)`,
 		},
+		{
+			expression: `INTERVAL(0, 0, 0, 0)`,
+			result:     `INT64(3)`,
+		},
+		{
+			expression: `INTERVAL(0, 0, 1, 0)`,
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `INTERVAL(0, 1, 0, 0)`,
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `INTERVAL(0, -1, 0, 0)`,
+			result:     `INT64(3)`,
+		},
+		{
+			expression: `INTERVAL(0, 1, 1, 1)`,
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `INTERVAL(0, -1, -1, -1)`,
+			result:     `INT64(3)`,
+		},
+		{
+			expression: `INTERVAL(0, 0, 0, 1)`,
+			result:     `INT64(2)`,
+		},
+		{
+			expression: `INTERVAL(0, 0, 0, -1)`,
+			result:     `INT64(3)`,
+		},
+		{
+			expression: `INTERVAL(0, NULL, 0, 0)`,
+			result:     `INT64(3)`,
+		},
+		{
+			expression: `INTERVAL(NULL, 0, 0, 0)`,
+			result:     `INT64(-1)`,
+		},
+		{
+			expression: `INTERVAL(0, 0, 0, NULL)`,
+			result:     `INT64(3)`,
+		},
+		{
+			expression: `INTERVAL(0, 0, 0, NULL, 1, 1)`,
+			result:     `INT64(3)`,
+		},
+		{
+			expression: `INTERVAL(0, 0, 2, NULL, 1, 1)`,
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `INTERVAL(0, 2, -1, NULL, -1, 1)`,
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `INTERVAL(0, 2, NULL, NULL, -1, 1)`,
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `INTERVAL(0, NULL, NULL, NULL, -1, 1)`,
+			result:     `INT64(4)`,
+		},
+		{
+			expression: `INTERVAL(0, 0, 0, -1, NULL, 1)`,
+			result:     `INT64(4)`,
+		},
+		{
+			expression: `INTERVAL(0, 0, 0, -1, NULL, NULL, 1)`,
+			result:     `INT64(5)`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -394,10 +466,6 @@ func TestCompilerSingle(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if cfg.CompilerErr != nil {
-				t.Fatalf("bad compilation: %v", cfg.CompilerErr)
-			}
-
 			env := evalengine.EmptyExpressionEnv()
 			env.Row = tc.values
 
@@ -407,6 +475,10 @@ func TestCompilerSingle(t *testing.T) {
 			}
 			if expected.String() != tc.result {
 				t.Fatalf("bad evaluation from eval engine: got %s, want %s", expected.String(), tc.result)
+			}
+
+			if cfg.CompilerErr != nil {
+				t.Fatalf("bad compilation: %v", cfg.CompilerErr)
 			}
 
 			// re-run the same evaluation multiple times to ensure results are always consistent

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -56,6 +56,7 @@ var Cases = []TestCase{
 	{Run: LikeComparison},
 	{Run: StrcmpComparison},
 	{Run: MultiComparisons},
+	{Run: IntervalStatement},
 	{Run: IsStatement},
 	{Run: NotStatement},
 	{Run: LogicalStatement},
@@ -1099,6 +1100,28 @@ func MultiComparisons(yield Query) {
 			yield(fmt.Sprintf("%s(%s, %s, %s)", method, arg[0], arg[1], arg[2]), nil)
 			yield(fmt.Sprintf("%s(%s, %s, %s)", method, arg[2], arg[1], arg[0]), nil)
 		})
+	}
+}
+
+func IntervalStatement(yield Query) {
+	inputs := []string{
+		"-1", "0", "1", "2", "3", "0xFF", "1.1", "1.9", "1.1e0", "1.9e0",
+		strconv.FormatUint(math.MaxUint64, 10),
+		strconv.FormatUint(math.MaxInt64, 10),
+		strconv.FormatUint(math.MaxInt64+1, 10),
+		strconv.FormatInt(math.MinInt64, 10),
+		"18446744073709551616",
+		"-9223372036854775809",
+		`"foobar"`, "NULL", "cast('invalid' as json)",
+	}
+	for _, base := range inputs {
+		for _, arg1 := range inputs {
+			for _, arg2 := range inputs {
+				for _, arg3 := range inputs {
+					yield(fmt.Sprintf("INTERVAL(%s, %s, %s, %s)", base, arg1, arg2, arg3), nil)
+				}
+			}
+		}
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -121,6 +121,31 @@ func (ast *astCompiler) translateLogicalExpr(opname string, left, right sqlparse
 	}, nil
 }
 
+func (ast *astCompiler) translateIntervalExpr(needle sqlparser.Expr, haystack []sqlparser.Expr) (Expr, error) {
+	exprs := make([]Expr, 0, len(haystack)+1)
+
+	expr, err := ast.translateExpr(needle)
+	if err != nil {
+		return nil, err
+	}
+
+	exprs = append(exprs, expr)
+	for _, e := range haystack {
+		expr, err := ast.translateExpr(e)
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, expr)
+	}
+
+	return &IntervalExpr{
+		CallExpr{
+			Arguments: exprs,
+			Method:    "INTERVAL",
+		},
+	}, nil
+}
+
 func (ast *astCompiler) translateIsExpr(left sqlparser.Expr, op sqlparser.IsExprOperator) (Expr, error) {
 	expr, err := ast.translateExpr(left)
 	if err != nil {
@@ -499,6 +524,8 @@ func (ast *astCompiler) translateExpr(e sqlparser.Expr) (Expr, error) {
 		return ast.translateCollateExpr(node)
 	case *sqlparser.IntroducerExpr:
 		return ast.translateIntroducerExpr(node)
+	case *sqlparser.IntervalFuncExpr:
+		return ast.translateIntervalExpr(node.Expr, node.Exprs)
 	case *sqlparser.IsExpr:
 		return ast.translateIsExpr(node.Left, node.Right)
 	case sqlparser.Callable:


### PR DESCRIPTION
This adds support for the `INTERVAL` function. Even though the official documentation describes that only a list of incrementing integers is supported, as a binary search is used, you can of course feed it many other values.

The changes here do support passing in unordered lists and behaves the same as MySQL here through reverse engineering with the tests. The implementation here does also use a binary search to match the MySQL behavior as well.

## Related Issue(s)

Part of #9647 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required