### PR TITLE
add constructor for vtctlclient in order to pass in ssl parameters

### DIFF
--- a/go/vt/vtctl/fakevtctlclient/fakevtctlclient.go
+++ b/go/vt/vtctl/fakevtctlclient/fakevtctlclient.go
@@ -39,7 +39,7 @@ func NewFakeVtctlClient() *FakeVtctlClient {
 }
 
 // FakeVtctlClientFactory always returns the current instance.
-func (f *FakeVtctlClient) FakeVtctlClientFactory(addr string) (vtctlclient.VtctlClient, error) {
+func (f *FakeVtctlClient) FakeVtctlClientFactory(addr, certLocation, keyLocation, caLocation, serverName string) (vtctlclient.VtctlClient, error) {
 	return f, nil
 }
 

--- a/go/vt/vtctl/grpcclientcommon/dial_option.go
+++ b/go/vt/vtctl/grpcclientcommon/dial_option.go
@@ -49,3 +49,22 @@ func RegisterFlags(fs *pflag.FlagSet) {
 func SecureDialOption() (grpc.DialOption, error) {
 	return grpcclient.SecureDialOption(cert, key, ca, crl, name)
 }
+
+// SecureDialOptionWithSslParams returns a grpc.DialOption configured to use TLS (or
+// insecure if no flags were set) based on the vtctld_grpc_* flags declared by
+// this package. It defaults to the values passed in by flags if the arguments are empty strings
+func SecureDialOptionWithSslParams(certLocation, keyLocation, caLocation, serverName string) (grpc.DialOption, error) {
+	if certLocation == "" {
+		certLocation = cert
+	}
+	if keyLocation == "" {
+		keyLocation = key
+	}
+	if caLocation == "" {
+		caLocation = ca
+	}
+	if serverName == "" {
+		serverName = name
+	}
+	return grpcclient.SecureDialOption(certLocation, keyLocation, caLocation, crl, serverName)
+}

--- a/go/vt/vtctl/grpcvtctlclient/client.go
+++ b/go/vt/vtctl/grpcvtctlclient/client.go
@@ -39,8 +39,8 @@ type gRPCVtctlClient struct {
 	c  vtctlservicepb.VtctlClient
 }
 
-func gRPCVtctlClientFactory(addr string) (vtctlclient.VtctlClient, error) {
-	opt, err := grpcclientcommon.SecureDialOption()
+func gRPCVtctlClientFactory(addr, certLocation, keyLocation, caLocation, serverName string) (vtctlclient.VtctlClient, error) {
+	opt, err := grpcclientcommon.SecureDialOptionWithSslParams(certLocation, keyLocation, caLocation, serverName)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/grpcvtctlclient/client_test.go
+++ b/go/vt/vtctl/grpcvtctlclient/client_test.go
@@ -53,7 +53,7 @@ func TestVtctlServer(t *testing.T) {
 	go server.Serve(listener)
 
 	// Create a VtctlClient gRPC client to talk to the fake server
-	client, err := gRPCVtctlClientFactory(fmt.Sprintf("localhost:%v", port))
+	client, err := gRPCVtctlClientFactory(fmt.Sprintf("localhost:%v", port), "", "", "", "")
 	if err != nil {
 		t.Fatalf("Cannot create client: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestVtctlAuthClient(t *testing.T) {
 	require.NoError(t, err, "failed to set `--grpc_auth_static_client_creds=%s`", f.Name())
 
 	// Create a VtctlClient gRPC client to talk to the fake server
-	client, err := gRPCVtctlClientFactory(fmt.Sprintf("localhost:%v", port))
+	client, err := gRPCVtctlClientFactory(fmt.Sprintf("localhost:%v", port), "", "", "", "")
 	if err != nil {
 		t.Fatalf("Cannot create client: %v", err)
 	}

--- a/go/vt/vtctl/vtctlclient/interface.go
+++ b/go/vt/vtctl/vtctlclient/interface.go
@@ -85,6 +85,8 @@ func New(addr string) (VtctlClient, error) {
 }
 
 // NewWithSslParams allows a user of the client library to get its implementation while specifying SSL parameters
+// certLocation is the cert used to connect, keyLocation is the key used to connect, caLocation is the server ca
+// used to validate servers when connecting, and serverName is the server name used to validated the server cert
 func NewWithSslParams(addr, certLocation, keyLocation, caLocation, serverName string) (VtctlClient, error) {
 	factory, ok := factories[vtctlClientProtocol]
 	if !ok {

--- a/go/vt/vtctl/vtctlclient/interface.go
+++ b/go/vt/vtctl/vtctlclient/interface.go
@@ -56,7 +56,7 @@ type VtctlClient interface {
 }
 
 // Factory functions are registered by client implementations
-type Factory func(addr string) (VtctlClient, error)
+type Factory func(addr, certLocation, keyLocation, caLocation, serverName string) (VtctlClient, error)
 
 var factories = make(map[string]Factory)
 
@@ -81,9 +81,14 @@ func UnregisterFactoryForTest(name string) {
 
 // New allows a user of the client library to get its implementation.
 func New(addr string) (VtctlClient, error) {
+	return NewWithSslParams(addr, "", "", "", "")
+}
+
+// NewWithSslParams allows a user of the client library to get its implementation while specifying SSL parameters
+func NewWithSslParams(addr, certLocation, keyLocation, caLocation, serverName string) (VtctlClient, error) {
 	factory, ok := factories[vtctlClientProtocol]
 	if !ok {
 		return nil, fmt.Errorf("unknown vtctl client protocol: %v", vtctlClientProtocol)
 	}
-	return factory(addr)
+	return factory(addr, certLocation, keyLocation, caLocation, serverName)
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This adds the option to programmatically create a new vtctl client and specify SSL parameters, so that the client will be able to use SSL. This adds `NewWithSslParams` in order to pass SSL parameters, and the existing `New` method remains the same.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Addresses this feature request: https://github.com/vitessio/vitess/issues/13084

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported

Requires no backporting

-   [x] Tests were added or are not required

Slightly modifies a few existing unit tests but I don't think it's necessary to add any new ones

-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
N/A
