### PR TITLE
Fix the resilientQuery to give correct results during initialization

### DIFF
--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -318,6 +318,7 @@ func TimeoutAction(t *testing.T, timeout time.Duration, errMsg string, action fu
 		select {
 		case <-deadline:
 			t.Error(errMsg)
+			return
 		case <-time.After(1 * time.Second):
 			ok = action()
 		}

--- a/go/vt/srvtopo/query_test.go
+++ b/go/vt/srvtopo/query_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package srvtopo
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"vitess.io/vitess/go/stats"
+)
+
+// TestResilientQueryGetCurrentValueInitialization tests that the resilient query returns the correct results when it has been
+// initialized.
+func TestResilientQueryGetCurrentValueInitialization(t *testing.T) {
+	// Create a basic query, which doesn't do anything other than return the same cell it got as an input.
+	// The query however needs to simulate being slow, so we have a sleep in there.
+	query := func(ctx context.Context, entry *queryEntry) (any, error) {
+		time.Sleep(1 * time.Second)
+		cell := entry.key.(cellName)
+		return cell, nil
+	}
+	counts := stats.NewCountersWithSingleLabel("TestResilientQueryGetCurrentValue", "Test for resilient query", "type")
+
+	// Create the resilient query
+	rq := &resilientQuery{
+		query:                query,
+		counts:               counts,
+		cacheRefreshInterval: 5 * time.Second,
+		cacheTTL:             5 * time.Second,
+		entries:              make(map[string]*queryEntry),
+	}
+
+	// Create a context and a cell.
+	ctx := context.Background()
+	cell := cellName("cell-1")
+
+	// Hammer the resilient query with multiple get requests just as it is created.
+	// We expect all of them to work.
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		// To test with both stale and not-stale, we use the modulo of our index.
+		stale := i%2 == 0
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, err := rq.getCurrentValue(ctx, cell, stale)
+			// Assert that we don't have any error and the value matches what we want.
+			assert.NoError(t, err)
+			assert.EqualValues(t, cell, res)
+		}()
+	}
+	// Wait for the wait group to be empty, otherwise the test is marked a success before any of the go routines finish completion!
+	wg.Wait()
+}


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the bug described in https://github.com/vitessio/vitess/issues/13079. Earlier, in `resilientQuery`, if we saw that we don't need to refresh the local cache information, we would immediately return the cached value or an error. But, if the cache gets hammered with multiple queries when it starts up, the first query tries to refresh the cache, but the subsequent end up returning the cached result, which doesn't exist! (cache is starting up).

The fix implemented is to first verify that the cache is actually valid or not. If it isn't, then we wait for the previous refresh's output as well.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/13079
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
