### PR TITLE
Fix benchmarks in `plan_test.go`

### DIFF
--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -408,7 +408,7 @@ func BenchmarkTPCH(b *testing.B) {
 
 func benchmarkWorkload(b *testing.B, name string) {
 	vschemaWrapper := &vschemaWrapper{
-		v:             loadSchema(b, name+"vschemas/_schema.json", true),
+		v:             loadSchema(b, "vschemas/"+name+"_schema.json", true),
 		sysVarEnabled: true,
 	}
 


### PR DESCRIPTION
## Description

The `BenchmarkOLTP`, `BenchmarkTPCC`, `BenchmarkTPCH` benchmark tests were failing because the vschema path was incorrect, this PR fixes it.
