### PR TITLE
evalengine: Add UUID functions

### DIFF
--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -429,6 +429,18 @@ func (cached *builtinAtan2) CachedSize(alloc bool) int64 {
 	size += cached.CallExpr.CachedSize(false)
 	return size
 }
+func (cached *builtinBinToUUID) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
 func (cached *builtinBitCount) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -850,6 +862,18 @@ func (cached *builtinIsIPV4Mapped) CachedSize(alloc bool) int64 {
 	return size
 }
 func (cached *builtinIsIPV6) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
+func (cached *builtinIsUUID) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
 	}
@@ -1390,6 +1414,30 @@ func (cached *builtinTrim) CachedSize(alloc bool) int64 {
 	return size
 }
 func (cached *builtinTruncate) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
+func (cached *builtinUUID) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field CallExpr vitess.io/vitess/go/vt/vtgate/evalengine.CallExpr
+	size += cached.CallExpr.CachedSize(false)
+	return size
+}
+func (cached *builtinUUIDToBin) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
 	}

--- a/go/vt/vtgate/evalengine/eval_temporal.go
+++ b/go/vt/vtgate/evalengine/eval_temporal.go
@@ -2,7 +2,6 @@ package evalengine
 
 import (
 	"time"
-	"unicode/utf8"
 
 	"vitess.io/vitess/go/hack"
 	"vitess.io/vitess/go/mysql/datetime"
@@ -154,35 +153,6 @@ func newEvalDate(d datetime.Date) *evalTemporal {
 
 func newEvalTime(time datetime.Time, l int) *evalTemporal {
 	return &evalTemporal{t: sqltypes.Time, dt: datetime.DateTime{Time: time.Round(l)}, prec: uint8(l)}
-}
-
-func sanitizeErrorValue(s []byte) []byte {
-	b := make([]byte, 0, len(s)+1)
-	invalid := false // previous byte was from an invalid UTF-8 sequence
-	for i := 0; i < len(s); {
-		c := s[i]
-		if c < utf8.RuneSelf {
-			i++
-			invalid = false
-			if c != 0 {
-				b = append(b, c)
-			}
-			continue
-		}
-		_, wid := utf8.DecodeRune(s[i:])
-		if wid == 1 {
-			i++
-			if !invalid {
-				invalid = true
-				b = append(b, '?')
-			}
-			continue
-		}
-		invalid = false
-		b = append(b, s[i:i+wid]...)
-		i += wid
-	}
-	return b
 }
 
 func errIncorrectTemporal(date string, in []byte) error {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -146,6 +146,10 @@ var Cases = []TestCase{
 	{Run: FnIsIPv4Compat},
 	{Run: FnIsIPv4Mapped},
 	{Run: FnIsIPv6},
+	{Run: FnBinToUUID},
+	{Run: FnIsUUID},
+	{Run: FnUUID},
+	{Run: FnUUIDToBin},
 }
 
 func JSONPathOperations(yield Query) {
@@ -1780,5 +1784,66 @@ func FnIsIPv4Mapped(yield Query) {
 func FnIsIPv6(yield Query) {
 	for _, d := range ipInputs {
 		yield(fmt.Sprintf("IS_IPV6(%s)", d), nil)
+	}
+}
+
+func FnBinToUUID(yield Query) {
+	args := []string{
+		"NULL",
+		"-1",
+		"0",
+		"1",
+		"2",
+		"''",
+		"'-1'",
+		"'0'",
+		"'1'",
+		"'2'",
+	}
+	for _, d := range uuidInputs {
+		yield(fmt.Sprintf("BIN_TO_UUID(%s)", d), nil)
+	}
+
+	for _, d := range uuidInputs {
+		for _, a := range args {
+			yield(fmt.Sprintf("BIN_TO_UUID(%s, %s)", d, a), nil)
+		}
+	}
+}
+
+func FnIsUUID(yield Query) {
+	for _, d := range uuidInputs {
+		yield(fmt.Sprintf("IS_UUID(%s)", d), nil)
+	}
+}
+
+func FnUUID(yield Query) {
+	yield("LENGTH(UUID())", nil)
+	yield("COLLATION(UUID())", nil)
+	yield("IS_UUID(UUID())", nil)
+	yield("LENGTH(UUID_TO_BIN(UUID())", nil)
+}
+
+func FnUUIDToBin(yield Query) {
+	args := []string{
+		"NULL",
+		"-1",
+		"0",
+		"1",
+		"2",
+		"''",
+		"'-1'",
+		"'0'",
+		"'1'",
+		"'2'",
+	}
+	for _, d := range uuidInputs {
+		yield(fmt.Sprintf("UUID_TO_BIN(%s)", d), nil)
+	}
+
+	for _, d := range uuidInputs {
+		for _, a := range args {
+			yield(fmt.Sprintf("UUID_TO_BIN(%s, %s)", d, a), nil)
+		}
 	}
 }

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -273,3 +273,15 @@ var ipInputs = []string{
 	strconv.FormatUint(math.MaxUint32+1, 10),
 	"0x0000000000000000000000000A000509",
 }
+
+var uuidInputs = []string{
+	"NULL",
+	"'foobar'",
+	"''",
+	"'09db81f6-f266-11ed-a6f9-20fc8fd6830e'",
+	"'09db81f6f26611eda6f920fc8fd6830e'",
+	"'{09db81f6-f266-11ed-a6f9-20fc8fd6830e}'",
+	"0x0000000000000000000000000A000509",
+	"0x09DB81F6F26611EDA6F920FC8FD6830E",
+	"0x11EDF26609DB81F6A6F920FC8FD6830E",
+}

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -505,6 +505,30 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (Expr, error) 
 			return nil, argError(method)
 		}
 		return &builtinIsIPV6{CallExpr: call}, nil
+	case "bin_to_uuid":
+		switch len(args) {
+		case 1, 2:
+			return &builtinBinToUUID{CallExpr: call, collate: ast.cfg.Collation}, nil
+		default:
+			return nil, argError(method)
+		}
+	case "is_uuid":
+		if len(args) != 1 {
+			return nil, argError(method)
+		}
+		return &builtinIsUUID{CallExpr: call}, nil
+	case "uuid":
+		if len(args) != 0 {
+			return nil, argError(method)
+		}
+		return &builtinUUID{CallExpr: call}, nil
+	case "uuid_to_bin":
+		switch len(args) {
+		case 1, 2:
+			return &builtinUUIDToBin{CallExpr: call}, nil
+		default:
+			return nil, argError(method)
+		}
 	case "user", "current_user", "session_user", "system_user":
 		if len(args) != 0 {
 			return nil, argError(method)


### PR DESCRIPTION
This adds `BIN_TO_UUID`, `IS_UUID`, `UUID` & `UUID_TO_BIN`. This doesn't implement `UUID_SHORT` though since that has specific requirements to use the `server_id` which is not something that conceptually makes sense for `vtgate` since it works across different backend MySQL servers.

So we avoid adding that here since there's no clear path for how to implement that.

## Related Issue(s)

Part of #9647

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required