### PR TITLE
Flaky vplayer tests: temporarily disable noblob variant

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -171,26 +171,29 @@ func TestMain(m *testing.M) {
 		}
 		defer utils.SetBinlogRowImageMode("", tempDir)
 		cancel, ret := setup()
-		if ret > 0 {
-			return ret
-		}
-		ret = m.Run()
-		if ret > 0 {
-			return ret
-		}
-
-		cancel()
-		runNoBlobTest = true
-		if err := utils.SetBinlogRowImageMode("noblob", tempDir); err != nil {
-			panic(err)
-		}
-		defer utils.SetBinlogRowImageMode("", tempDir)
-		cancel, ret = setup()
-		if ret > 0 {
-			return ret
-		}
 		defer cancel()
+		if ret > 0 {
+			return ret
+		}
 		ret = m.Run()
+		/*
+			// Temporarily disable running all tests again with `noblob` until we fix the raciness caused by global variables
+			// being reinitialized in the framework.
+			if ret > 0 {
+				return ret
+			}
+			runNoBlobTest = true
+			if err := utils.SetBinlogRowImageMode("noblob", tempDir); err != nil {
+				panic(err)
+			}
+			defer utils.SetBinlogRowImageMode("", tempDir)
+			cancel, ret = setup()
+			if ret > 0 {
+				return ret
+			}
+			defer cancel()
+			ret = m.Run()
+		*/
 		return ret
 
 	}()


### PR DESCRIPTION
## Description

The `noblob` PR https://github.com/vitessio/vitess/pull/12905 has introduced a race during the unit race test. This is caused by the re-initialization of `globalDBQueries`, which we do because we run all tests twice: once for the full image and once for noblob. It turns out that the post-copy vcopier task, in `TestCancelledDeferSecondaryKeys` which runs in a goroutine, gets invoked when we cancel the context before the second set of tests. Since we immediately reinit the query queue, there is a race because the post-copy task is writing to the same query queue.

We will need to do a non-trivial refactor of the test framework before re-enabling the `noblob` variant. This PR temporarily disables them since the flakiness is blocking other PRs

## Related Issue(s)

https://github.com/vitessio/vitess/issues/13093

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
