### PR TITLE
Flakes: enforce no concurrency/parallelism in vreplication unit test framework

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -59,9 +60,12 @@ import (
 )
 
 var (
-	playerEngine          *Engine
-	streamerEngine        *vstreamer.Engine
-	env                   *testenv.Env
+	playerEngine   *Engine
+	streamerEngine *vstreamer.Engine
+
+	envMu sync.Mutex
+	env   *testenv.Env
+
 	globalFBC             = &fakeBinlogClient{}
 	vrepldb               = "vrepl"
 	globalDBQueries       = make(chan string, 1000)
@@ -118,17 +122,19 @@ func cleanup() {
 	playerEngine.Close()
 	streamerEngine.Close()
 	env.Close()
+	envMu.Unlock()
 }
 
 func setup() (func(), int) {
-	globalDBQueries = make(chan string, 1000)
-	resetBinlogClient()
 	var err error
 	env, err = testenv.Init()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v", err)
 		return nil, 1
 	}
+	envMu.Lock()
+	globalDBQueries = make(chan string, 1000)
+	resetBinlogClient()
 
 	vttablet.VReplicationExperimentalFlags = 0
 
@@ -178,8 +184,8 @@ func TestMain(m *testing.M) {
 		if ret > 0 {
 			return ret
 		}
-
 		cancel()
+
 		runNoBlobTest = true
 		if err := utils.SetBinlogRowImageMode("noblob", tempDir); err != nil {
 			panic(err)
@@ -190,9 +196,7 @@ func TestMain(m *testing.M) {
 			return ret
 		}
 		defer cancel()
-		ret = m.Run()
-		return ret
-
+		return m.Run()
 	}()
 	os.Exit(exitCode)
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -837,7 +837,7 @@ func TestPlayerFilters(t *testing.T) {
 		),
 		table: "dst5",
 		data:  [][]string{{"1", "abc"}, {"4", "abc"}},
-	}, {
+	}, /*{
 		// test collation + filter
 		input: "insert into srcCharset values (1,'木元')",
 		output: qh.Expect(
@@ -848,7 +848,7 @@ func TestPlayerFilters(t *testing.T) {
 		),
 		table: "dstCharset",
 		data:  [][]string{{"1", "木abcxyz", "木abcxyz"}},
-	}}
+	}*/}
 
 	for _, tcase := range testcases {
 		t.Run(tcase.input, func(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -837,7 +837,7 @@ func TestPlayerFilters(t *testing.T) {
 		),
 		table: "dst5",
 		data:  [][]string{{"1", "abc"}, {"4", "abc"}},
-	}, /*{
+	}, {
 		// test collation + filter
 		input: "insert into srcCharset values (1,'木元')",
 		output: qh.Expect(
@@ -848,7 +848,7 @@ func TestPlayerFilters(t *testing.T) {
 		),
 		table: "dstCharset",
 		data:  [][]string{{"1", "木abcxyz", "木abcxyz"}},
-	}*/}
+	}}
 
 	for _, tcase := range testcases {
 		t.Run(tcase.input, func(t *testing.T) {


### PR DESCRIPTION
## Description

The tabletmanager's vreplication unit test framework relies heavily on globals for the test environment. I'm assuming this was done because the test environment is relatively heavy and costly to setup with actual mysqld's etc. The "right" way to do this would be to eliminate the usage of globals so that we could support parallelism and avoid data races — I explored that ([you can see the WiP patch here](https://gist.github.com/mattlord/fdb29007527461a49dcedf3b3051e718)) — but unfortunately it made each unit test take several orders of magnitude longer as now each one had to do a test env setup and teardown. I don't think that's workable given our current CI setup and resources, so I instead opted to a simpler approach that enforces one usage of the framework at a time with a mutex.

>**Note** I also attempted to fix the flaky `TestHandlePanicAndSendLogStatsMessageTruncation` test that was just added today. That was failing maybe 75% of the time locally for me with `-race`.

You can see the `unit race` workflow runs with these changes here (failed runs were NOT caused by related tests): https://github.com/vitessio/vitess/actions/runs/5006086462/jobs/8970892397?pr=13104

## Related Issue(s)
  - Fixes: https://github.com/vitessio/vitess/issues/13093

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were updated
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation is not required