### PR TITLE
Fix flakiness in `TestGatewayBufferingWhileReparenting`

### DIFF
--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -301,8 +301,8 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, "current keyspace is being resharded")
 					continue
 				}
-				primary, serving := kev.PrimaryIsNotServing(target)
-				if serving {
+				primary, notServing := kev.PrimaryIsNotServing(target)
+				if notServing {
 					err = vterrors.Errorf(vtrpcpb.Code_CLUSTER_EVENT, "primary is not serving, there may be a reparent operation in progress")
 					continue
 				}


### PR DESCRIPTION
## Description

This PR fixes `TestGatewayBufferingWhileReparenting`, after we elect the replica as primary, we were directly checking if the new elected primary is serving. This led to flakiness, we now have a timeout of 1 minute to periodically check the state of the new elected primary.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
