### PR TITLE
Fix vtcombo DBDDL plugin race condition

### DIFF
--- a/go/cmd/vtcombo/plugin_dbddl.go
+++ b/go/cmd/vtcombo/plugin_dbddl.go
@@ -31,7 +31,7 @@ var globalDropDb func(ctx context.Context, ksName string) error
 
 // DBDDL doesn't need to store any state - we use the global variables above instead
 type DBDDL struct {
-	createDbLock *sync.Mutex
+	mu sync.Mutex
 }
 
 // CreateDatabase implements the engine.DBDDLPlugin interface
@@ -42,8 +42,8 @@ func (plugin *DBDDL) CreateDatabase(ctx context.Context, name string) error {
 			Name: "0",
 		}},
 	}
-	plugin.createDbLock.Lock()
-	defer plugin.createDbLock.Unlock()
+	plugin.mu.Lock()
+	defer plugin.mu.Unlock()
 	return globalCreateDb(ctx, ks)
 }
 
@@ -54,6 +54,6 @@ func (plugin *DBDDL) DropDatabase(ctx context.Context, name string) error {
 
 func init() {
 	servenv.OnRun(func() {
-		engine.DBDDLRegister("vttest", &DBDDL{createDbLock: &sync.Mutex{}})
+		engine.DBDDLRegister("vttest", &DBDDL{})
 	})
 }

--- a/go/cmd/vtcombo/plugin_dbddl.go
+++ b/go/cmd/vtcombo/plugin_dbddl.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"sync"
 
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtgate/engine"
@@ -29,7 +30,9 @@ var globalCreateDb func(ctx context.Context, ks *vttestpb.Keyspace) error
 var globalDropDb func(ctx context.Context, ksName string) error
 
 // DBDDL doesn't need to store any state - we use the global variables above instead
-type DBDDL struct{}
+type DBDDL struct {
+	createDbLock *sync.Mutex
+}
 
 // CreateDatabase implements the engine.DBDDLPlugin interface
 func (plugin *DBDDL) CreateDatabase(ctx context.Context, name string) error {
@@ -39,6 +42,8 @@ func (plugin *DBDDL) CreateDatabase(ctx context.Context, name string) error {
 			Name: "0",
 		}},
 	}
+	plugin.createDbLock.Lock()
+	defer plugin.createDbLock.Unlock()
 	return globalCreateDb(ctx, ks)
 }
 
@@ -49,6 +54,6 @@ func (plugin *DBDDL) DropDatabase(ctx context.Context, name string) error {
 
 func init() {
 	servenv.OnRun(func() {
-		engine.DBDDLRegister("vttest", &DBDDL{})
+		engine.DBDDLRegister("vttest", &DBDDL{createDbLock: &sync.Mutex{}})
 	})
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Meant to fix the race condition reported in https://github.com/vitessio/vitess/issues/13116

As mentioned in the bug report above, mitigating the race condition as follows:

> I've tested (and will subsequently propose via PR) a solution which simply modifies vtcombo's DBDDL plugin implementation to use a mutex which locks before executing globalCreateDb and releases the lock after that completes which effectively guarantees that access and incrementing of the uid variable is atomic in turn preventing the issue. This seems to have fixed the issue for me.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes https://github.com/vitessio/vitess/issues/13116

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
