### PR TITLE
mysqlctl: Remove custom callbacks

### DIFF
--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -149,13 +149,6 @@ type flavor interface {
 	// returns NULL if GTIDs are not enabled.
 	waitUntilPositionCommand(ctx context.Context, pos Position) (string, error)
 
-	// enableBinlogPlaybackCommand and disableBinlogPlaybackCommand return an
-	// optional command to run to enable or disable binlog
-	// playback. This is used internally in Google, as the
-	// timestamp cannot be set by regular clients.
-	enableBinlogPlaybackCommand() string
-	disableBinlogPlaybackCommand() string
-
 	baseShowTables() string
 	baseShowTablesWithSizes() string
 
@@ -559,18 +552,6 @@ func (c *Conn) WaitUntilPositionCommand(ctx context.Context, pos Position) (stri
 func (c *Conn) WaitUntilFilePositionCommand(ctx context.Context, pos Position) (string, error) {
 	filePosFlavor := filePosFlavor{}
 	return filePosFlavor.waitUntilPositionCommand(ctx, pos)
-}
-
-// EnableBinlogPlaybackCommand returns a command to run to enable
-// binlog playback.
-func (c *Conn) EnableBinlogPlaybackCommand() string {
-	return c.flavor.enableBinlogPlaybackCommand()
-}
-
-// DisableBinlogPlaybackCommand returns a command to run to disable
-// binlog playback.
-func (c *Conn) DisableBinlogPlaybackCommand() string {
-	return c.flavor.disableBinlogPlaybackCommand()
 }
 
 // BaseShowTables returns a query that shows tables

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -316,16 +316,6 @@ func (*filePosFlavor) startSQLThreadUntilAfter(pos Position) string {
 	return "unsupported"
 }
 
-// enableBinlogPlaybackCommand is part of the Flavor interface.
-func (*filePosFlavor) enableBinlogPlaybackCommand() string {
-	return ""
-}
-
-// disableBinlogPlaybackCommand is part of the Flavor interface.
-func (*filePosFlavor) disableBinlogPlaybackCommand() string {
-	return ""
-}
-
 // baseShowTables is part of the Flavor interface.
 func (*filePosFlavor) baseShowTables() string {
 	return mysqlFlavor{}.baseShowTables()

--- a/go/mysql/flavor_mariadb_binlog_playback.go
+++ b/go/mysql/flavor_mariadb_binlog_playback.go
@@ -17,19 +17,6 @@ limitations under the License.
 
 package mysql
 
-// These two methods are isolated here so they can be easily changed
-// in other trees.
-
-// enableBinlogPlaybackCommand is part of the Flavor interface.
-func (mariadbFlavor) enableBinlogPlaybackCommand() string {
-	return ""
-}
-
-// disableBinlogPlaybackCommand is part of the Flavor interface.
-func (mariadbFlavor) disableBinlogPlaybackCommand() string {
-	return ""
-}
-
 // baseShowTables is part of the Flavor interface.
 func (mariadbFlavor) baseShowTables() string {
 	return mysqlFlavor{}.baseShowTables()

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -17,11 +17,10 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -296,16 +295,6 @@ func (mysqlFlavor) readBinlogEvent(c *Conn) (BinlogEvent, error) {
 	}
 	ev := NewMysql56BinlogEventWithSemiSyncInfo(buf, semiSyncAckRequested)
 	return ev, nil
-}
-
-// enableBinlogPlaybackCommand is part of the Flavor interface.
-func (mysqlFlavor) enableBinlogPlaybackCommand() string {
-	return ""
-}
-
-// disableBinlogPlaybackCommand is part of the Flavor interface.
-func (mysqlFlavor) disableBinlogPlaybackCommand() string {
-	return ""
 }
 
 // baseShowTables is part of the Flavor interface.

--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -158,9 +158,6 @@ type FakeMysqlDaemon struct {
 	// FetchSuperQueryResults is used by FetchSuperQuery
 	FetchSuperQueryMap map[string]*sqltypes.Result
 
-	// BinlogPlayerEnabled is used by {Enable,Disable}BinlogPlayer
-	BinlogPlayerEnabled atomic.Bool
-
 	// SemiSyncPrimaryEnabled represents the state of rpl_semi_sync_master_enabled.
 	SemiSyncPrimaryEnabled bool
 	// SemiSyncReplicaEnabled represents the state of rpl_semi_sync_slave_enabled.
@@ -537,18 +534,6 @@ func (fmd *FakeMysqlDaemon) FetchSuperQuery(ctx context.Context, query string) (
 		return nil, fmt.Errorf("unexpected query: %v", query)
 	}
 	return qr, nil
-}
-
-// EnableBinlogPlayback is part of the MysqlDaemon interface
-func (fmd *FakeMysqlDaemon) EnableBinlogPlayback() error {
-	fmd.BinlogPlayerEnabled.Store(true)
-	return nil
-}
-
-// DisableBinlogPlayback disable playback of binlog events
-func (fmd *FakeMysqlDaemon) DisableBinlogPlayback() error {
-	fmd.BinlogPlayerEnabled.Store(false)
-	return nil
 }
 
 // Close is part of the MysqlDaemon interface

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -113,12 +113,6 @@ type MysqlDaemon interface {
 	// FetchSuperQuery executes one query, returns the result
 	FetchSuperQuery(ctx context.Context, query string) (*sqltypes.Result, error)
 
-	// EnableBinlogPlayback enables playback of binlog events
-	EnableBinlogPlayback() error
-
-	// DisableBinlogPlayback disable playback of binlog events
-	DisableBinlogPlayback() error
-
 	// Close will close this instance of Mysqld. It will wait for all dba
 	// queries to be finished.
 	Close()

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -457,7 +457,7 @@ func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, host string, por
 	}
 	defer conn.Recycle()
 
-	cmds := []string{}
+	var cmds []string
 	if stopReplicationBefore {
 		cmds = append(cmds, conn.StopReplicationCommand())
 	}
@@ -554,54 +554,6 @@ func FindReplicas(mysqld MysqlDaemon) ([]string, error) {
 	}
 
 	return addrs, nil
-}
-
-// EnableBinlogPlayback prepares the server to play back events from a binlog stream.
-// Whatever it does for a given flavor, it must be idempotent.
-func (mysqld *Mysqld) EnableBinlogPlayback() error {
-	// Get a connection.
-	conn, err := getPoolReconnect(context.TODO(), mysqld.dbaPool)
-	if err != nil {
-		return err
-	}
-	defer conn.Recycle()
-
-	// See if we have a command to run, and run it.
-	cmd := conn.EnableBinlogPlaybackCommand()
-	if cmd == "" {
-		return nil
-	}
-	if err := mysqld.ExecuteSuperQuery(context.TODO(), cmd); err != nil {
-		log.Errorf("EnableBinlogPlayback: cannot run query '%v': %v", cmd, err)
-		return fmt.Errorf("EnableBinlogPlayback: cannot run query '%v': %v", cmd, err)
-	}
-
-	log.Info("EnableBinlogPlayback: successfully ran %v", cmd)
-	return nil
-}
-
-// DisableBinlogPlayback returns the server to the normal state after streaming.
-// Whatever it does for a given flavor, it must be idempotent.
-func (mysqld *Mysqld) DisableBinlogPlayback() error {
-	// Get a connection.
-	conn, err := getPoolReconnect(context.TODO(), mysqld.dbaPool)
-	if err != nil {
-		return err
-	}
-	defer conn.Recycle()
-
-	// See if we have a command to run, and run it.
-	cmd := conn.DisableBinlogPlaybackCommand()
-	if cmd == "" {
-		return nil
-	}
-	if err := mysqld.ExecuteSuperQuery(context.TODO(), cmd); err != nil {
-		log.Errorf("DisableBinlogPlayback: cannot run query '%v': %v", cmd, err)
-		return fmt.Errorf("DisableBinlogPlayback: cannot run query '%v': %v", cmd, err)
-	}
-
-	log.Info("DisableBinlogPlayback: successfully ran '%v'", cmd)
-	return nil
 }
 
 // GetBinlogInformation gets the binlog format, whether binlog is enabled and if updates on replica logging is enabled.
@@ -712,8 +664,8 @@ func (mysqld *Mysqld) SemiSyncEnabled() (primary, replica bool) {
 	if err != nil {
 		return false, false
 	}
-	primary = (vars["rpl_semi_sync_master_enabled"] == "ON")
-	replica = (vars["rpl_semi_sync_slave_enabled"] == "ON")
+	primary = vars["rpl_semi_sync_master_enabled"] == "ON"
+	replica = vars["rpl_semi_sync_slave_enabled"] == "ON"
 	return primary, replica
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -193,12 +193,6 @@ func (ct *controller) runBlp(ctx context.Context) (err error) {
 	default:
 	}
 
-	// Call this for youtube-specific customization.
-	// This should be done every time, in case mysql was restarted.
-	if err := ct.mysqld.EnableBinlogPlayback(); err != nil {
-		return err
-	}
-
 	dbClient := ct.dbClientFactory()
 	if err := dbClient.Connect(); err != nil {
 		return vterrors.Wrap(err, "can't connect to database")

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -319,7 +319,6 @@ func (vre *Engine) Close() {
 	// Wait for long-running functions to exit.
 	vre.wg.Wait()
 
-	vre.mysqld.DisableBinlogPlayback()
 	vre.isOpen = false
 
 	vre.updateStats()


### PR DESCRIPTION
These haven't been used for a while so afaik we can clean these up now to reduce the size of both the `mysqldaemon` and `flavor` interfaces, reducing coupling.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required