### PR TITLE
Test lookup_unicodeloosemd5_hash

### DIFF
--- a/go/test/endtoend/vtgate/lookup_test.go
+++ b/go/test/endtoend/vtgate/lookup_test.go
@@ -589,5 +589,9 @@ func TestLooseMD5Hash(t *testing.T) {
 	utils.Exec(t, conn, "insert into transfers(customer_id, external_id) values(43, 'p1')")
 	utils.Exec(t, conn, "insert into transfers(customer_id, external_id) values(44, 'p1')")
 
-	utils.AssertMatches(t, conn, "SELECT customer_id from transfers where external_id = 'p1'", `[[INT64(43)], [INT64(44)]]`)
+	exec := utils.Exec(t, conn, "SELECT customer_id from transfers where external_id = 'p1'")
+	fmt.Println(exec)
+
+	utils.AssertIsEmpty(t, conn, "SELECT customer_id from transfers where external_id = 'p1'")
+	//utils.AssertMatches(t, conn, "SELECT customer_id from transfers where external_id = 'p1'", `[[INT64(43)], [INT64(44)]]`)
 }

--- a/go/test/endtoend/vtgate/lookup_test.go
+++ b/go/test/endtoend/vtgate/lookup_test.go
@@ -581,3 +581,13 @@ func TestUnicodeLooseMD5CaseInsensitive(t *testing.T) {
 
 	utils.AssertMatches(t, conn, "SELECT id1, id2 from t4 where id2 = 'Test'", `[[INT64(1) VARCHAR("test")]]`)
 }
+
+func TestLooseMD5Hash(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	utils.Exec(t, conn, "insert into transfers(customer_id, external_id) values(43, 'p1')")
+	utils.Exec(t, conn, "insert into transfers(customer_id, external_id) values(44, 'p1')")
+
+	utils.AssertMatches(t, conn, "SELECT customer_id from transfers where external_id = 'p1'", `[[INT64(43)], [INT64(44)]]`)
+}

--- a/go/test/endtoend/vtgate/schema.sql
+++ b/go/test/endtoend/vtgate/schema.sql
@@ -152,3 +152,17 @@ create table t10_id_to_keyspace_id_idx
     keyspace_id varbinary(10),
     primary key (id)
 ) Engine = InnoDB;
+
+CREATE TABLE `transfers`
+(
+    `id`            bigint(20) NOT NULL AUTO_INCREMENT,
+    `customer_id` bigint(20) NOT NULL,
+    `external_id`   varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL
+)
+
+create table transfers_external_id_lookup
+(
+    `external_id` bigint(20) unsigned NOT NULL,
+    `customer_id` bigint(20) NOT NULL,
+    PRIMARY KEY (`external_id`, `customer_id`)
+)

--- a/go/test/endtoend/vtgate/schema.sql
+++ b/go/test/endtoend/vtgate/schema.sql
@@ -157,12 +157,13 @@ CREATE TABLE `transfers`
 (
     `id`            bigint(20) NOT NULL AUTO_INCREMENT,
     `customer_id` bigint(20) NOT NULL,
-    `external_id`   varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL
-)
+    `external_id`   varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+    PRIMARY KEY (id)
+) Engine = InnoDB;
 
 create table transfers_external_id_lookup
 (
     `external_id` bigint(20) unsigned NOT NULL,
     `customer_id` bigint(20) NOT NULL,
     PRIMARY KEY (`external_id`, `customer_id`)
-)
+) Engine = InnoDB;

--- a/go/test/endtoend/vtgate/vschema.json
+++ b/go/test/endtoend/vtgate/vschema.json
@@ -1,11 +1,10 @@
-
 {
   "sharded": true,
   "vindexes": {
-    "unicode_loose_xxhash" : {
+    "unicode_loose_xxhash": {
       "type": "unicode_loose_xxhash"
     },
-    "unicode_loose_md5" : {
+    "unicode_loose_md5": {
       "type": "unicode_loose_md5"
     },
     "hash": {
@@ -159,7 +158,10 @@
           "name": "hash"
         },
         {
-          "columns": ["id2", "id1"],
+          "columns": [
+            "id2",
+            "id1"
+          ],
           "name": "t4_id2_vdx"
         }
       ]
@@ -179,7 +181,10 @@
           "name": "hash"
         },
         {
-          "columns": ["id2", "id1"],
+          "columns": [
+            "id2",
+            "id1"
+          ],
           "name": "t6_id2_vdx"
         }
       ]
@@ -302,5 +307,27 @@
         }
       ]
     }
+  },
+  "transfers_external_id_lookup": {
+    "type": "lookup_unicodeloosemd5_hash",
+    "params": {
+      "table": "transfers_external_id_lookup",
+      "from": "external_id",
+      "to": "customer_id",
+      "ignore_nulls": "true",
+      "autocommit": "true"
+    },
+    "owner": "transfers"
+  },
+  "transfers": {
+    "columnVindexes": [
+      {
+        "column": "customer_id",
+        "name": "hash"
+      },
+      {
+        "column": "external_id",
+        "name": "transfers_external_id_lookup"
+      }
+    ]
   }
-}

--- a/go/test/endtoend/vtgate/vschema.json
+++ b/go/test/endtoend/vtgate/vschema.json
@@ -88,6 +88,17 @@
         "to": "keyspace_id"
       },
       "owner": "t10"
+    },
+    "transfers_external_id_lookup_vdx": {
+      "type": "lookup_unicodeloosemd5_hash",
+      "params": {
+        "table": "transfers_external_id_lookup",
+        "from": "external_id",
+        "to": "customer_id",
+        "ignore_nulls": "true",
+        "autocommit": "true"
+      },
+      "owner": "transfers"
     }
   },
   "tables": {
@@ -306,28 +317,26 @@
           "name": "hash"
         }
       ]
-    }
-  },
-  "transfers_external_id_lookup": {
-    "type": "lookup_unicodeloosemd5_hash",
-    "params": {
-      "table": "transfers_external_id_lookup",
-      "from": "external_id",
-      "to": "customer_id",
-      "ignore_nulls": "true",
-      "autocommit": "true"
     },
-    "owner": "transfers"
-  },
-  "transfers": {
-    "columnVindexes": [
-      {
-        "column": "customer_id",
-        "name": "hash"
-      },
-      {
-        "column": "external_id",
-        "name": "transfers_external_id_lookup"
-      }
-    ]
+    "transfers": {
+      "columnVindexes": [
+        {
+          "column": "customer_id",
+          "name": "hash"
+        },
+        {
+          "column": "external_id",
+          "name": "transfers_external_id_lookup_vdx"
+        }
+      ]
+    },
+    "transfers_external_id_lookup": {
+      "columnVindexes": [
+        {
+          "column": "external_id",
+          "name": "hash"
+        }
+      ]
+    }
   }
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR replicates a bug that I'm seeing when migrating our app from v14 to v16. It's part of this issue https://github.com/vitessio/vitess/issues/13140.
Specifically, it looks like some of our read queries fail to return rows if they use a lookup.
Here are the details on my app side (see repro logs after mysql code block): I'm expecting `select payment_id from movements where external_id = 'p1'`, which uses a lookup to return two rows.
```

mysql> select * from movements_external_id_lookup_hashed;
+----------------------+-------------+
| external_id          | customer_id |
+----------------------+-------------+
| 14003777312042024246 |          43 |
| 14003777312042024246 |          44 |
+----------------------+-------------+
2 rows in set (0.03 sec)

mysql> select external_id from movements;
+-------------+
| external_id |
+-------------+
| p1          |
| p1          |
+-------------+
2 rows in set (0.03 sec)

mysql> select payment_id from movements where external_id = 'p1';
Empty set (0.04 sec)

mysql> select payment_id from movements where external_id like 'p1';
+------------+
| payment_id |
+------------+
|  268435457 |
|  268435457 |
+------------+
2 rows in set (0.01 sec)
```

This PR reproduces the above error in vitess with minimal setup. Running the new test introduced in this PR, these are the logs I see from the gate.
In summary, it looks like loose MD5 hashed lookups return no rows in Gen4, while they return rows in V3.
```
~/Development/go/src/valerio/vitess/vtdataroot/vtroot_9301/tmp_9303 valerio.lookup-md5-hashed-test less vtgate-stderr.txt 

          "::external_id"
        ],
        "Vindex": "hash"
      },
      {
        "OperatorType": "Route",
        "Variant": "ByDestination",
        "Keyspace": {
          "Name": "ks",
          "Sharded": true
        },
        "FieldQuery": "select customer_id from transfers where 1 != 1",
        "Query": "select customer_id from transfers where external_id = :external_id /* VARCHAR */",
        "Table": "transfers"
      }
    ]
  }
}
E0523 11:52:43.508447   40416 compare_utils.go:43] V3's plan:
{
  "QueryType": "SELECT",
  "Instructions": {
    "OperatorType": "Route",
    "Variant": "Equal",
    "Keyspace": {
      "Name": "ks",
      "Sharded": true
    },
    "FieldQuery": "select customer_id from transfers where 1 != 1",
    "Query": "select customer_id from transfers where external_id = :external_id /* VARCHAR */",
    "Table": "transfers",
    "Values": [
      ":external_id"
    ],
    "Vindex": "transfers_external_id_lookup_vdx"
  }
}
E0523 11:52:43.508459   40416 compare_utils.go:45] Gen4's results:
E0523 11:52:43.508467   40416 compare_utils.go:46]      [rows affected: 0]
E0523 11:52:43.508474   40416 compare_utils.go:50] V3's results:
E0523 11:52:43.508480   40416 compare_utils.go:51]      [rows affected: 0]
E0523 11:52:43.508487   40416 compare_utils.go:53]      [INT64(44)]
E0523 11:52:43.508494   40416 compare_utils.go:53]      [INT64(43)]
E0523 11:52:43.508503   40416 compare_utils.go:55] End of diff.
E0523 11:52:43.508584   40416 vtgate.go:636] Execute: Code: INTERNAL
results did not match, see VTGate's logs for more information
, request: map[BindVariables:map[external_id:type:VARCHAR value:"p1"] Session:autocommit:true target_string:"ks" options:{included_fields:ALL workload:OLTP planner_version:Gen4CompareV3} last_insert_id:1 row_count:-1 DDLStrategy:"direct" SessionUUID:"dabf72f6-f981-11ed-b5f7-7a6a5d84a275" enable_system_settings:true Sql:SELECT customer_id from transfers where external_id = 'p1']
W0523 11:52:43.578289   40416 tablet_health_check.go:334] tablet alias:{cell:"test" uid:3979} hostname:"localhost" port_map:{key:"grpc" value:9311} port_map:{key:"vt" value:9310} keyspace:"ks" shard:"80-" key_range:{start:"\x80"} type:PRIMARY mysql_hostname:"localhost" mysql_port:9312 primary_term_start_time:{seconds:1684857130 nanoseconds:433011000} default_conn_collation:255 healthcheck stream error: Code: CANCELED
vttablet: rpc error: code = Canceled desc = context canceled
W0523 11:52:43.578269   40416 tablet_health_check.go:334] tablet alias:{cell:"test" uid:3978} hostname:"localhost" port_map:{key:"grpc" value:9308} port_map:{key:"vt" value:9307} keyspace:"ks" shard:"-80" key_range:{end:"\x80"} type:PRIMARY mysql_hostname:"localhost" mysql_port:9309 primary_term_start_time:{seconds:1684857125 nanoseconds:319693000} default_conn_collation:255 healthcheck stream error: Code: CANCELED
vttablet: rpc error: code = Canceled desc = context canceled
```



<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
