### PR TITLE
Upgrade mysqld memory limits to 1024Mi

### DIFF
--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -103,7 +103,7 @@ spec:
             mysqld:
               resources:
                 limits:
-                  memory: 512Mi
+                  memory: 1024Mi
                 requests:
                   cpu: 100m
                   memory: 512Mi

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -99,7 +99,7 @@ spec:
             mysqld:
               resources:
                 limits:
-                  memory: 512Mi
+                  memory: 1024Mi
                 requests:
                   cpu: 100m
                   memory: 512Mi
@@ -134,7 +134,7 @@ spec:
             mysqld:
               resources:
                 limits:
-                  memory: 512Mi
+                  memory: 1024Mi
                 requests:
                   cpu: 100m
                   memory: 512Mi

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -99,7 +99,7 @@ spec:
             mysqld:
               resources:
                 limits:
-                  memory: 512Mi
+                  memory: 1024Mi
                 requests:
                   cpu: 100m
                   memory: 512Mi
@@ -134,7 +134,7 @@ spec:
             mysqld:
               resources:
                 limits:
-                  memory: 512Mi
+                  memory: 1024Mi
                 requests:
                   cpu: 100m
                   memory: 512Mi
@@ -165,7 +165,7 @@ spec:
             mysqld:
               resources:
                 limits:
-                  memory: 512Mi
+                  memory: 1024Mi
                 requests:
                   cpu: 100m
                   memory: 512Mi

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -99,7 +99,7 @@ spec:
             mysqld:
               resources:
                 limits:
-                  memory: 512Mi
+                  memory: 1024Mi
                 requests:
                   cpu: 100m
                   memory: 512Mi
@@ -134,7 +134,7 @@ spec:
             mysqld:
               resources:
                 limits:
-                  memory: 512Mi
+                  memory: 1024Mi
                 requests:
                   cpu: 100m
                   memory: 512Mi


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Current k8s resources for the operator example aren't enough in the current version. See more details here: https://github.com/vitessio/vitess/issues/13118

This PR is related: https://github.com/vitessio/website/pull/1477

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

N/A
