### PR TITLE
mysqlctl: Remove usage of MYSQL_FLAVOR

### DIFF
--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -284,6 +284,7 @@ vttablet_v_replication_stream_state{counts="1",state="Running",workflow="commerc
 * Auto-population of DDL revert actions and tables at execution-time has been removed. This is now handled entirely at enqueue-time.
 * Backwards-compatibility for failed migrations without a `completed_timestamp` has been removed (see https://github.com/vitessio/vitess/issues/8499).
 * The deprecated `Key`, `Name`, `Up`, and `TabletExternallyReparentedTimestamp` fields were removed from the JSON representation of `TabletHealth` structures.
+* The `MYSQL_FLAVOR` environment variable is no longer used.
 
 ### <a id="deprecated-flags"/>Deprecated Command Line Flags
 

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -150,10 +150,6 @@ func TestRestart(t *testing.T) {
 func TestAutoDetect(t *testing.T) {
 	defer cluster.PanicHandler(t)
 
-	// Start up tablets with an empty MYSQL_FLAVOR, which means auto-detect
-	sqlFlavor := os.Getenv("MYSQL_FLAVOR")
-	os.Setenv("MYSQL_FLAVOR", "")
-
 	err := clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].VttabletProcess.Setup()
 	require.Nil(t, err, "error should be nil")
 	err = clusterInstance.Keyspaces[0].Shards[0].Vttablets[1].VttabletProcess.Setup()
@@ -162,8 +158,4 @@ func TestAutoDetect(t *testing.T) {
 	// Reparent tablets, which requires flavor detection
 	err = clusterInstance.VtctlclientProcess.InitializeShard(keyspaceName, shardName, cell, primaryTablet.TabletUID)
 	require.Nil(t, err, "error should be nil")
-
-	//Reset flavor
-	os.Setenv("MYSQL_FLAVOR", sqlFlavor)
-
 }

--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -147,10 +147,6 @@ func TestRestart(t *testing.T) {
 func TestAutoDetect(t *testing.T) {
 	defer cluster.PanicHandler(t)
 
-	// Start up tablets with an empty MYSQL_FLAVOR, which means auto-detect
-	sqlFlavor := os.Getenv("MYSQL_FLAVOR")
-	os.Setenv("MYSQL_FLAVOR", "")
-
 	err := clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].VttabletProcess.Setup()
 	require.Nil(t, err, "error should be nil")
 	err = clusterInstance.Keyspaces[0].Shards[0].Vttablets[1].VttabletProcess.Setup()
@@ -159,8 +155,4 @@ func TestAutoDetect(t *testing.T) {
 	// Reparent tablets, which requires flavor detection
 	err = clusterInstance.VtctlclientProcess.InitializeShard(keyspaceName, shardName, cell, primaryTablet.TabletUID)
 	require.Nil(t, err, "error should be nil")
-
-	//Reset flavor
-	os.Setenv("MYSQL_FLAVOR", sqlFlavor)
-
 }

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -178,35 +178,8 @@ func setVtMySQLRoot(mysqlRoot string) error {
 	return nil
 }
 
-// setDBFlavor sets the MYSQL_FLAVOR OS env var.
-// You should call this after calling setVtMySQLRoot() to ensure that the
-// correct flavor is used by mysqlctl based on the current mysqld version
-// in the path. If you don't do this then mysqlctl will use the incorrect
-// config/mycnf/<flavor>.cnf file and mysqld may fail to start.
-func setDBFlavor() error {
-	versionStr, err := mysqlctl.GetVersionString()
-	if err != nil {
-		return err
-	}
-	f, v, err := mysqlctl.ParseVersionString(versionStr)
-	if err != nil {
-		return err
-	}
-	flavor := fmt.Sprintf("%s%d%d", f, v.Major, v.Minor)
-	err = os.Setenv("MYSQL_FLAVOR", string(flavor))
-	if err != nil {
-		return err
-	}
-	fmt.Printf("MYSQL_FLAVOR is %s\n", string(flavor))
-	return nil
-}
-
 func unsetVtMySQLRoot() {
 	_ = os.Unsetenv("VT_MYSQL_ROOT")
-}
-
-func unsetDBFlavor() {
-	_ = os.Unsetenv("MYSQL_FLAVOR")
 }
 
 // getDBTypeVersionInUse checks the major DB version of the mysqld binary
@@ -781,12 +754,7 @@ func setupDBTypeVersion(t *testing.T, value string) func() {
 	if err := downloadDBTypeVersion(dbType, majorVersion, path); err != nil {
 		t.Fatalf("Could not download %s, error: %v", majorVersion, err)
 	}
-	// Set the MYSQL_FLAVOR OS ENV var for mysqlctl to use the correct config file
-	if err := setDBFlavor(); err != nil {
-		t.Fatalf("Could not set MYSQL_FLAVOR: %v", err)
-	}
 	return func() {
-		unsetDBFlavor()
 		unsetVtMySQLRoot()
 	}
 }

--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mysqlctl
 
 import (
-	"os"
 	"testing"
 )
 
@@ -102,39 +101,6 @@ func TestParseVersionString(t *testing.T) {
 		f, v, err := ParseVersionString(testcase.versionString)
 		if v != testcase.version || f != testcase.flavor || err != nil {
 			t.Errorf("ParseVersionString failed for: %#v, Got: %#v, %#v Expected: %#v, %#v", testcase.versionString, v, f, testcase.version, testcase.flavor)
-		}
-	}
-
-}
-
-func TestAssumeVersionString(t *testing.T) {
-
-	// In these cases, the versionstring is nonsensical or unspecified.
-	// MYSQL_FLAVOR is used instead.
-
-	var testcases = []testcase{
-		{
-			versionString: "MySQL80",
-			version:       ServerVersion{8, 0, 11},
-			flavor:        FlavorMySQL,
-		},
-		{
-			versionString: "MySQL56",
-			version:       ServerVersion{5, 7, 10}, // Yes, this has to lie!
-			flavor:        FlavorMySQL,             // There was no MySQL57 option
-		},
-		{
-			versionString: "MariaDB",
-			version:       ServerVersion{10, 6, 11},
-			flavor:        FlavorMariaDB,
-		},
-	}
-
-	for _, testcase := range testcases {
-		os.Setenv("MYSQL_FLAVOR", testcase.versionString)
-		f, v, err := GetVersionFromEnv()
-		if v != testcase.version || f != testcase.flavor || err != nil {
-			t.Errorf("GetVersionFromEnv() failed for: %#v, Got: %#v, %#v Expected: %#v, %#v", testcase.versionString, v, f, testcase.version, testcase.flavor)
 		}
 	}
 

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -103,21 +103,16 @@ type LocalTestEnv struct {
 	Env          []string
 }
 
-// DefaultMySQLFlavor is the MySQL flavor used by vttest when MYSQL_FLAVOR is not
-// set in the environment
+// DefaultMySQLFlavor is the MySQL flavor used by vttest when no explicit
+// flavor is given.
 const DefaultMySQLFlavor = "MySQL56"
 
 // GetMySQLOptions returns the default option set for the given MySQL
-// flavor. If flavor is not set, the value from the `MYSQL_FLAVOR` env
-// variable is used, and if this is not set, DefaultMySQLFlavor will
+// flavor. If flavor is not set, DefaultMySQLFlavor will
 // be used.
 // Returns the name of the MySQL flavor being used, the set of MySQL CNF
 // files specific to this flavor, and any errors.
 func GetMySQLOptions(flavor string) (string, []string, error) {
-	if flavor == "" {
-		flavor = os.Getenv("MYSQL_FLAVOR")
-	}
-
 	if flavor == "" {
 		flavor = DefaultMySQLFlavor
 	}
@@ -237,8 +232,7 @@ func randomPort() int {
 // up when closing the Environment.
 // - LogDirectory() is the `logs` subdir inside Directory()
 // - The MySQL flavor is set to `flavor`. If the argument is not set, it will
-// default to the value of MYSQL_FLAVOR, and if this variable is not set, to
-// DefaultMySQLFlavor
+// default DefaultMySQLFlavor
 // - PortForProtocol() will return ports based off the given basePort. If basePort
 // is zero, a random port between 10000 and 20000 will be chosen.
 // - DefaultProtocol() is always "grpc"


### PR DESCRIPTION
After the changes in https://github.com/vitessio/vitess/pull/13123, I realized that there's no cases left where we actually use or depend on `MYSQL_FLAVOR`.

This means we can actually remove usages of `MYSQL_FLAVOR`. It doesn't yet remove it from the artifacts we build, because we shouldn't clean that up until v18 then because users might mix versions during the upgrade and we don't want to have old code that still depends on this fail then.

## Related Issue(s)

Follow up to https://github.com/vitessio/vitess/pull/13123

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required