### PR TITLE
Remove enable-query-plan-field-caching flag that was deprecated in v15

### DIFF
--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -311,6 +311,7 @@ vttablet_v_replication_stream_state{counts="1",state="Running",workflow="commerc
 * Backwards-compatibility for failed migrations without a `completed_timestamp` has been removed (see https://github.com/vitessio/vitess/issues/8499).
 * The deprecated `Key`, `Name`, `Up`, and `TabletExternallyReparentedTimestamp` fields were removed from the JSON representation of `TabletHealth` structures.
 * The `MYSQL_FLAVOR` environment variable is no longer used.
+* The `--enable-query-plan-field-caching`/`--enable_query_plan_field_caching` vttablet flag was deprecated in v15 and has now been removed.
 
 ### <a id="deprecated-flags"/>Deprecated Command Line Flags
 

--- a/config/tablet/default.yaml
+++ b/config/tablet/default.yaml
@@ -108,7 +108,6 @@ watchReplication: false                  # watch_replication_stream
 terseErrors: false                       # queryserver-config-terse-errors
 truncateErrorLen: 0                      # queryserver-config-truncate-error-len
 messagePostponeParallelism: 4            # queryserver-config-message-postpone-cap
-cacheResultFields: true                  # enable-query-plan-field-caching
 
 
 # The following flags are currently not supported.

--- a/doc/design-docs/TabletServerParamsAsYAML.md
+++ b/doc/design-docs/TabletServerParamsAsYAML.md
@@ -134,7 +134,6 @@ schemaReloadIntervalSeconds: 1800        # queryserver-config-schema-reload-time
 watchReplication: false                  # watch_replication_stream
 terseErrors: false                       # queryserver-config-terse-errors
 messagePostponeParallelism: 4            # queryserver-config-message-postpone-cap
-cacheResultFields: true                  # enable-query-plan-field-caching
 sanitizeLogMessages: false               # sanitize_log_messages
 
 

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -325,7 +325,6 @@ type TabletConfig struct {
 	TruncateErrorLen                        int                               `json:"truncateErrorLen,omitempty"`
 	AnnotateQueries                         bool                              `json:"annotateQueries,omitempty"`
 	MessagePostponeParallelism              int                               `json:"messagePostponeParallelism,omitempty"`
-	DeprecatedCacheResultFields             bool                              `json:"cacheResultFields,omitempty"`
 	SignalWhenSchemaChange                  bool                              `json:"signalWhenSchemaChange,omitempty"`
 
 	ExternalConnections map[string]*dbconfigs.DBConfigs `json:"externalConnections,omitempty"`
@@ -786,7 +785,6 @@ var defaultConfig = TabletConfig{
 	SchemaReloadIntervalSeconds:             flagutil.NewDeprecatedFloat64Seconds("queryserver-config-schema-reload-time", 30*time.Minute),
 	SignalSchemaChangeReloadIntervalSeconds: flagutil.NewDeprecatedFloat64Seconds("queryserver-config-schema-change-signal-interval", 5*time.Second),
 	MessagePostponeParallelism:              4,
-	DeprecatedCacheResultFields:             true,
 	SignalWhenSchemaChange:                  true,
 
 	EnableTxThrottler:           false,

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -188,9 +188,6 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 	flagutil.DualFormatBoolVar(fs, &enableConsolidatorReplicas, "enable_consolidator_replicas", false, "This option enables the query consolidator only on replicas.")
 	fs.Int64Var(&currentConfig.ConsolidatorStreamQuerySize, "consolidator-stream-query-size", defaultConfig.ConsolidatorStreamQuerySize, "Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator.")
 	fs.Int64Var(&currentConfig.ConsolidatorStreamTotalSize, "consolidator-stream-total-size", defaultConfig.ConsolidatorStreamTotalSize, "Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator.")
-	flagutil.DualFormatBoolVar(fs, &currentConfig.DeprecatedCacheResultFields, "enable_query_plan_field_caching", defaultConfig.DeprecatedCacheResultFields, "This option fetches & caches fields (columns) when storing query plans")
-	_ = fs.MarkDeprecated("enable_query_plan_field_caching", "it will be removed in a future release.")
-	_ = fs.MarkDeprecated("enable-query-plan-field-caching", "it will be removed in a future release.")
 
 	currentConfig.Healthcheck.IntervalSeconds = flagutil.NewDeprecatedFloat64Seconds(defaultConfig.Healthcheck.IntervalSeconds.Name(), defaultConfig.Healthcheck.IntervalSeconds.Get())
 	currentConfig.Healthcheck.DegradedThresholdSeconds = flagutil.NewDeprecatedFloat64Seconds(defaultConfig.Healthcheck.DegradedThresholdSeconds.Name(), defaultConfig.Healthcheck.DegradedThresholdSeconds.Get())

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -125,8 +125,7 @@ oltpReadPool:
 func TestDefaultConfig(t *testing.T) {
 	gotBytes, err := yaml2.Marshal(NewDefaultConfig())
 	require.NoError(t, err)
-	want := `cacheResultFields: true
-consolidator: enable
+	want := `consolidator: enable
 consolidatorStreamQuerySize: 2097152
 consolidatorStreamTotalSize: 134217728
 gracePeriods: {}

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -219,7 +219,6 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 		"--mycnf_server_id", "1",
 		"--mycnf_socket_file", socket,
 		"--normalize_queries",
-		"--enable_query_plan_field_caching=false",
 		"--dbddl_plugin", "vttest",
 		"--foreign_key_mode", args.ForeignKeyMode,
 		"--planner-version", args.PlannerVersion,


### PR DESCRIPTION
## Description

The `enable-query-plan-field-caching` flag was deprecated in v15 in https://github.com/vitessio/vitess/commit/fb9e17864a0fc72976356456057f2a9ae20689e1. This was [noted in the release notes, along with our intention to remove it in v16](https://github.com/vitessio/vitess/blob/main/changelog/15.0/15.0.0/release_notes.md#vttablet-startup-flag-deprecations). We missed deleting it in v16, so doing it for v17.

## Related Issue(s)

  - Follow-up to: https://github.com/vitessio/vitess/pull/11501
  - https://github.com/vitessio/vitess/pull/10489

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required (I could not find any mention of the flag in the v17 docs)