### PR TITLE
VINDEX DDL enhancement for better user experience (#13133)

### DIFF
--- a/go/vt/vtgate/schema_check.go
+++ b/go/vt/vtgate/schema_check.go
@@ -1,0 +1,399 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"context"
+	"strings"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/log"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+func CheckVindexType(col string, colType string, vindexType string) error {
+	Values := strings.Split(colType, " ") //eg:tinyint unsigned
+	count := len(Values)
+
+	typeStr := Values[0]
+	UnsignedFlag := false
+	if count == 2 {
+		UnsignedFlag = true
+	}
+	sqlType := sqlparser.SQLTypeToQueryType(typeStr, UnsignedFlag)
+
+	//64 bit or smaller numeric or equivalent type
+	if vindexType == "hash" || vindexType == "numeric" ||
+		vindexType == "numeric_static_map" || vindexType == "reverse_bits" {
+		switch sqlType {
+		case sqltypes.Int8, sqltypes.Int16, sqltypes.Int24, sqltypes.Int32, sqltypes.Int64,
+			sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint24, sqltypes.Uint32, sqltypes.Uint64,
+			sqltypes.Float32, sqltypes.Float64, sqltypes.Decimal, sqltypes.Bit:
+			return nil
+
+		default:
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "column %v should not be %v for vindex type %v", col, colType, vindexType)
+		}
+	}
+
+	//String and numeric type
+	if vindexType == "region_experimental" || vindexType == "region_json" {
+		switch sqlType {
+		case sqltypes.Int8, sqltypes.Int16, sqltypes.Int24, sqltypes.Int32, sqltypes.Int64,
+			sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint24, sqltypes.Uint32, sqltypes.Uint64,
+			sqltypes.Float32, sqltypes.Float64, sqltypes.Decimal, sqltypes.Bit,
+			sqltypes.Text, sqltypes.VarChar, sqltypes.Char,
+			sqltypes.Set, sqltypes.Enum:
+			return nil
+
+		default:
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "column %v should not be %v for vindex type %v", col, colType, vindexType)
+		}
+	}
+
+	//String or binary types
+	if vindexType == "unicode_loose_md5" || vindexType == "unicode_loose_xxhash" {
+		switch sqlType {
+		case sqltypes.Text, sqltypes.VarChar, sqltypes.Char,
+			sqltypes.Set, sqltypes.Enum,
+			sqltypes.VarBinary, sqltypes.Binary, sqltypes.Blob:
+			break
+
+		default:
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "column %v should not be %v for vindex type %v", col, colType, vindexType)
+		}
+	}
+
+	return nil
+}
+
+func SchemaCheck(vc *vcursorImpl, ctx context.Context, ksName string, vschemaDDL *sqlparser.AlterVschema) error {
+	switch vschemaDDL.Action {
+	case sqlparser.AddColVindexDDLAction:
+		// refer to https://vitess.io/docs/16.0/reference/features/vindexes/
+
+		var vindexCols = vschemaDDL.VindexCols
+		var tableName = vschemaDDL.Table.Name.String()
+		var Qualifier = vschemaDDL.Table.Qualifier.String()
+		var Type = vschemaDDL.VindexSpec.Type
+		//var params = vschemaDDL.VindexSpec.Params
+
+		var executor = vc.executor.(*Executor)
+		var sql = "describe " + tableName
+		if Qualifier == "" {
+			Qualifier = ksName
+		}
+
+		ftRes, err := executor.fetchSchemaFromTablet(ctx, &sqlparser.ShowFilter{Like: ksName}, sql)
+
+		if err != nil {
+			return err
+		}
+		mapList := make(map[string]string)
+		for _, row := range ftRes.Rows {
+			field := row[0].ToString()
+			fieldType := row[1].ToString()
+			idx := strings.Index(fieldType, "(")
+			if idx != -1 {
+				fieldType = fieldType[:idx]
+			}
+			fieldType = strings.ToLower(fieldType)
+			mapList[field] = fieldType
+		}
+
+		for _, col := range vindexCols {
+			colName := col.String()
+			colType, ok := mapList[colName]
+			if !ok {
+				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "colmun %v does not existes", colName)
+			}
+			val := Type.String()
+			err = CheckVindexType(colName, colType, val)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case sqlparser.AddAutoIncDDLAction:
+		var executor = vc.executor.(*Executor)
+		var seqTableName = vschemaDDL.AutoIncSpec.Sequence.Name.String()
+		var seqQualifier = vschemaDDL.AutoIncSpec.Sequence.Qualifier.String()
+		if seqQualifier == "" {
+			seqQualifier = ksName
+		}
+
+		// check add vscheam add sequence
+		var srvVschema = vc.vm.GetCurrentSrvVschema()
+		ks := srvVschema.Keyspaces[seqQualifier]
+		_, ok := ks.Tables[seqTableName]
+		if !ok {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "sequence %v is not added in keyspace %v", seqTableName, seqQualifier)
+		}
+		// check shema for sequence
+		// eg:ALTER VSCHEMA on test2 ADD AUTO_INCREMENT customer_id using commerce.test_seq2;
+		autoTable := vschemaDDL.Table.Name.String()
+		autoColumn := vschemaDDL.AutoIncSpec.Column.String()
+		var sql = "describe " + autoTable
+		ftRes, err := executor.fetchSchemaFromTablet(ctx, &sqlparser.ShowFilter{Like: ksName}, sql)
+		if err != nil {
+			return err
+		}
+		for _, row := range ftRes.Rows {
+			field := row[0].ToString()
+			if field == autoColumn {
+				return nil
+			}
+		}
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "auto column %v does not exist in table %v", autoColumn, autoTable)
+
+	case sqlparser.AddSequenceDDLAction:
+		//  ALTER VSCHEMA ADD SEQUENCE commerce.test_seq;
+		var tableName = vschemaDDL.Table.Name.String()
+		var qualifier = vschemaDDL.Table.Qualifier.String()
+		if qualifier == "" {
+			qualifier = ksName
+		}
+
+		var executor = vc.executor.(*Executor)
+		var sql = "describe " + tableName
+		ftRes, err := executor.fetchSchemaFromTablet(ctx, &sqlparser.ShowFilter{Like: ksName}, sql)
+
+		if err != nil {
+			return err
+		}
+
+		if len(ftRes.Rows) == 0 {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "table %v does not exist in keyspace %v", tableName, qualifier)
+		}
+
+		// check1: id/next_id/cache, type is bigint
+		// check2: id is primary key
+		// +---------+--------+------+-----+---------+-------+
+		// | Field   | Type   | Null | Key | Default | Extra |
+		// +---------+--------+------+-----+---------+-------+
+		// | id      | bigint | NO   | PRI | NULL    |       |
+		// | next_id | bigint | YES  |     | NULL    |       |
+		// | cache   | bigint | YES  |     | NULL    |       |
+		// +---------+--------+------+-----+---------+-------+
+
+		mapList := make(map[string]int)
+		mapList["id"] = 1
+		mapList["next_id"] = 1
+		mapList["cache"] = 1
+		for _, row := range ftRes.Rows {
+			field := row[0].ToString()
+			fieldType := row[1].ToString()
+			keyCol := row[3].ToString()
+			idx := strings.Index(fieldType, "(")
+			if idx != -1 {
+				fieldType = fieldType[:idx]
+			}
+
+			fieldType = strings.ToLower(fieldType)
+			if fieldType != "bigint" {
+				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "column type should be bigint")
+			}
+			if field == "id" {
+				if keyCol != "PRI" {
+					return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "column id should be primary key")
+				}
+				mapList["id"] = 0
+			} else if field == "next_id" || field == "cache" {
+				mapList[field] = 0
+			} else {
+				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "column name should be id/next_id/cache")
+			}
+		}
+
+		for col, num := range mapList {
+			if num != 0 {
+				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "column %v does not exist", col)
+			}
+		}
+
+		// check 3: comments is 'vitess_sequence'
+		// SELECT table_name, table_comment FROM information_schema.TABLES WHERE table_schema='vt_commerce' and table_name = 'test_seq2';
+		// +------------+-----------------+
+		// | TABLE_NAME | TABLE_COMMENT   |
+		// +------------+-----------------+
+		// | test_seq2  | vitess_sequence |
+		// +------------+-----------------+
+
+		var sqlCheckTableComment = "SELECT table_name, table_comment FROM information_schema.TABLES WHERE table_schema='vt_" + qualifier + "' and table_name = '" + tableName + "'"
+		ftRes, err = executor.fetchSchemaFromTablet(ctx, &sqlparser.ShowFilter{Like: qualifier}, sqlCheckTableComment)
+
+		if err != nil {
+			return err
+		}
+
+		if len(ftRes.Rows) != 1 {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "can not get table_comment from table %v in keyspace %v", tableName, qualifier)
+		}
+
+		commentCol := ftRes.Rows[0][1].ToString()
+		if commentCol != "vitess_sequence" {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "table %v comment should be 'vitess_sequence'", tableName)
+		}
+
+		return nil
+
+	case sqlparser.CreateVindexDDLAction:
+		// create vindex
+		owner, params := vschemaDDL.VindexSpec.ParseParams()
+		lookup_table := params["table"]
+		from_col := params["from"]
+		to_col := params["to"]
+
+		// not lookup vindex, ie: create vindex hash using hash
+		if owner == "" && len(params) == 0 {
+			return nil
+		}
+
+		// check syntax
+		if owner == "" {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Syntax error: please specify the value for the keyword `owner`")
+		}
+		if lookup_table == "" {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Syntax error: please specify the value for the keyword `table`")
+		}
+		if from_col == "" {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Syntax error: please specify the value for the keyword `from`")
+		}
+		if to_col == "" {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Syntax error: please specify the value for the keyword `to`")
+		}
+
+		// get vschema
+		srvVschema := vc.vm.GetCurrentSrvVschema()
+		if srvVschema == nil {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vschema not loaded")
+		}
+
+		// check whether owner table exists
+		var ownerTable sqlparser.TableName
+		if strings.Contains(owner, ".") {
+			ownerTable = sqlparser.TableName{
+				Name:      sqlparser.NewIdentifierCS(strings.Split(owner, ".")[1]),
+				Qualifier: sqlparser.NewIdentifierCS(strings.Split(owner, ".")[0]),
+			}
+
+		} else {
+			ownerTable = sqlparser.TableName{
+				Name:      sqlparser.NewIdentifierCS(owner),
+				Qualifier: sqlparser.NewIdentifierCS(""),
+			}
+		}
+		var ownerksName string
+		if ownerTable.Qualifier.String() != "" {
+			ownerksName = ownerTable.Qualifier.String()
+		} else {
+			ownerksName = ksName
+		}
+		// check whether vschema contains owner table
+		ownerks := srvVschema.Keyspaces[ownerksName]
+		if _, ownervschemaok := ownerks.Tables[ownerTable.Name.String()]; !ownervschemaok {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vschema does not contain owner table '%s' in keyspace %s",
+				ownerTable.Name.String(), ownerksName)
+		}
+		// check whether owner table exists in the keyspace
+		ownerKsTableSchema, ownerKserr := vc.FindTableSchema(ctx, ownerksName)
+
+		if ownerKserr != nil {
+			return ownerKserr
+		}
+
+		if _, ownerschemaok := ownerKsTableSchema[ownerTable.Name.String()]; !ownerschemaok {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "owner table '%s' does not exist in keyspace %s",
+				ownerTable.Name.String(), ownerksName)
+		}
+
+		// check whether owner table have a primary vindex
+		// The first columnvindexes is used as primary vindex
+		if len(ownerks.Tables[ownerTable.Name.String()].ColumnVindexes) == 0 {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "The owner table '%s' does not have a primary vindex",
+				ownerTable.Name.String())
+		}
+
+		// check whether lookup table exists
+		var lookupTable sqlparser.TableName
+
+		if strings.Contains(lookup_table, ".") {
+			lookupTable = sqlparser.TableName{
+				Name:      sqlparser.NewIdentifierCS(strings.Split(lookup_table, ".")[1]),
+				Qualifier: sqlparser.NewIdentifierCS(strings.Split(lookup_table, ".")[0]),
+			}
+
+		} else {
+			lookupTable = sqlparser.TableName{
+				Name:      sqlparser.NewIdentifierCS(lookup_table),
+				Qualifier: sqlparser.NewIdentifierCS(""),
+			}
+		}
+		var lookupksName string
+		if lookupTable.Qualifier.String() != "" {
+			lookupksName = lookupTable.Qualifier.String()
+		} else {
+			lookupksName = ksName
+		}
+
+		// check whether vschema contains lookup table
+		lookupks := srvVschema.Keyspaces[lookupksName]
+		if _, lookupvschemaok := lookupks.Tables[lookupTable.Name.String()]; !lookupvschemaok {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vschema does not contain lookup table '%s' in keyspace %s",
+				lookupTable.Name.String(), lookupksName)
+		}
+		// check whether lookup table exists in the keyspace
+		lookupKsTableSchema := ownerKsTableSchema // read_only map
+		lookupKserr := ownerKserr
+		if !strings.EqualFold(lookupksName, ownerksName) {
+			lookupKsTableSchema, lookupKserr = vc.FindTableSchema(ctx, lookupksName)
+		}
+		if lookupKserr != nil {
+			return lookupKserr
+		}
+
+		if _, lookupschemaok := lookupKsTableSchema[lookupTable.Name.String()]; !lookupschemaok {
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "lookup table '%s' does not exist in keyspace %s",
+				lookupTable.Name.String(), lookupksName)
+		}
+
+		// check whether from col exists in table schema
+		for _, fromcol := range strings.Split(from_col, ",") {
+			fromcol_exists := false
+			for _, columnschema := range ownerKsTableSchema[ownerTable.Name.String()].Columns {
+				if columnschema.Name.EqualString(strings.TrimSpace(fromcol)) {
+					fromcol_exists = true
+					break
+				}
+			}
+			if !fromcol_exists {
+				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "from column '%s' does not exist in ownertable %s",
+					fromcol, ownerTable.Name.String())
+			}
+		}
+
+		if to_col != "" {
+			log.Infof("TODO:")
+		}
+		return nil
+	}
+
+	return nil
+}

--- a/go/vt/vtgate/schema_check_test.go
+++ b/go/vt/vtgate/schema_check_test.go
@@ -1,0 +1,921 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    `http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/sqltypes"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+func TestSchemaCheckWithAddColVindexDDL(t *testing.T) {
+	type testCase struct {
+		vindexSpec    *sqlparser.VindexSpec
+		sandboxRes    *sqltypes.Result
+		expectedError string
+	}
+
+	vindexParams := []sqlparser.VindexParam{{
+		Key: sqlparser.NewIdentifierCI("ksa"),
+		Val: "10",
+	}, {
+		Key: sqlparser.NewIdentifierCI("ks2"),
+		Val: "shard-0000",
+	}}
+
+	tests := []testCase{
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myhash"),
+				Type:   sqlparser.NewIdentifierCI("hash"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|tinyint|NO|PRI|NULL|",
+			),
+			expectedError: "",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myhash"),
+				Type:   sqlparser.NewIdentifierCI("hash"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|mediumint unsigned|NO|PRI|NULL|",
+			),
+			expectedError: "",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myhash"),
+				Type:   sqlparser.NewIdentifierCI("hash"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|varchar|NO|PRI|NULL|",
+			),
+			expectedError: "column id should not be varchar for vindex type hash",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myhash"),
+				Type:   sqlparser.NewIdentifierCI("hash"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|blob|NO|PRI|NULL|",
+			),
+			expectedError: "column id should not be blob for vindex type hash",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myhash"),
+				Type:   sqlparser.NewIdentifierCI("hash"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|year|NO|PRI|NULL|",
+			),
+			expectedError: "column id should not be year for vindex type hash",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myregion_json"),
+				Type:   sqlparser.NewIdentifierCI("region_json"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|tinyint|NO|PRI|NULL|",
+			),
+			expectedError: "",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myregion_json"),
+				Type:   sqlparser.NewIdentifierCI("region_json"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|mediumint unsigned|NO|PRI|NULL|",
+			),
+			expectedError: "",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myregion_json"),
+				Type:   sqlparser.NewIdentifierCI("region_json"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|varchar|NO|PRI|NULL|",
+			),
+			expectedError: "",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myregion_json"),
+				Type:   sqlparser.NewIdentifierCI("region_json"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|blob|NO|PRI|NULL|",
+			),
+			expectedError: "column id should not be blob for vindex type region_json",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myregion_json"),
+				Type:   sqlparser.NewIdentifierCI("region_json"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|year|NO|PRI|NULL|",
+			),
+			expectedError: "column id should not be year for vindex type region_json",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myunicode_loose_md5"),
+				Type:   sqlparser.NewIdentifierCI("unicode_loose_md5"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|tinyint|NO|PRI|NULL|",
+			),
+			expectedError: "column id should not be tinyint for vindex type unicode_loose_md5",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myunicode_loose_md5"),
+				Type:   sqlparser.NewIdentifierCI("unicode_loose_md5"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|mediumint unsigned|NO|PRI|NULL|",
+			),
+			expectedError: "column id should not be mediumint unsigned for vindex type unicode_loose_md5",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myunicode_loose_md5"),
+				Type:   sqlparser.NewIdentifierCI("unicode_loose_md5"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|varchar|NO|PRI|NULL|",
+			),
+			expectedError: "",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myunicode_loose_md5"),
+				Type:   sqlparser.NewIdentifierCI("unicode_loose_md5"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|blob|NO|PRI|NULL|",
+			),
+			expectedError: "",
+		},
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("myunicode_loose_md5"),
+				Type:   sqlparser.NewIdentifierCI("unicode_loose_md5"),
+				Params: vindexParams,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|year|NO|PRI|NULL|",
+			),
+			expectedError: "column id should not be year for vindex type unicode_loose_md5",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			r, sb, _, _ := createExecutorEnv()
+			sb.SetResults([]*sqltypes.Result{tc.sandboxRes})
+
+			vc, _ := newVCursorImpl(NewSafeSession(&vtgatepb.Session{TargetString: "@unknown"}), makeComments(""), r, nil, r.vm, r.VSchema(), r.resolver.resolver, nil, false, pv)
+			var ksName = "TestExecutor"
+
+			alterVschema := &sqlparser.AlterVschema{
+				Action: sqlparser.AddColVindexDDLAction,
+				Table: sqlparser.TableName{
+					Qualifier: sqlparser.NewIdentifierCS("TestExecutor"),
+					Name:      sqlparser.NewIdentifierCS("t2"),
+				},
+				VindexSpec: tc.vindexSpec,
+				AutoIncSpec: &sqlparser.AutoIncSpec{
+					Column: sqlparser.NewIdentifierCI("id"),
+					Sequence: sqlparser.TableName{
+						Qualifier: sqlparser.NewIdentifierCS("TestExecutor"),
+						Name:      sqlparser.NewIdentifierCS("t2"),
+					},
+				},
+				VindexCols: []sqlparser.IdentifierCI{sqlparser.NewIdentifierCI("id")},
+			}
+
+			err := SchemaCheck(vc, ctx, ksName, alterVschema)
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestSchemaCheckWithAddAutoIncDDL(t *testing.T) {
+	type testCase struct {
+		vschema       *sqlparser.AlterVschema
+		sandboxRes    *sqltypes.Result
+		expectedError string
+	}
+	vindexParams := []sqlparser.VindexParam{{
+		Key: sqlparser.NewIdentifierCI("ksa"),
+		Val: "10",
+	}, {
+		Key: sqlparser.NewIdentifierCI("ks2"),
+		Val: "shard-0000",
+	}}
+
+	alterVschema1 := &sqlparser.AlterVschema{
+		Action: sqlparser.AddAutoIncDDLAction,
+		Table: sqlparser.TableName{
+			Qualifier: sqlparser.NewIdentifierCS("TestExecutor"),
+			Name:      sqlparser.NewIdentifierCS("t1"),
+		},
+		VindexSpec: &sqlparser.VindexSpec{
+			Name:   sqlparser.NewIdentifierCI("hash"),
+			Type:   sqlparser.NewIdentifierCI("hash"),
+			Params: vindexParams,
+		},
+		AutoIncSpec: &sqlparser.AutoIncSpec{
+			Column: sqlparser.NewIdentifierCI("col_tinyint"),
+			Sequence: sqlparser.TableName{
+				Qualifier: sqlparser.NewIdentifierCS("TestExecutor"),
+				Name:      sqlparser.NewIdentifierCS("t1"),
+			},
+		},
+		VindexCols: []sqlparser.IdentifierCI{sqlparser.NewIdentifierCI("col_tinyint")},
+	}
+
+	tests := []testCase{
+		{
+			vschema: alterVschema1,
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"col_tinyint|tinyint|NO|PRI|NULL|",
+			),
+			expectedError: "",
+		},
+		{
+			vschema: alterVschema1,
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"col_xxx|tinyint|NO|PRI|NULL|",
+			),
+			expectedError: "auto column col_tinyint does not exist in table t1",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			r, sb, _, _ := createExecutorEnv()
+			sb.SetResults([]*sqltypes.Result{tc.sandboxRes})
+
+			vc, _ := newVCursorImpl(NewSafeSession(&vtgatepb.Session{TargetString: "@unknown"}), makeComments(""), r, nil, r.vm, r.VSchema(), r.resolver.resolver, nil, false, pv)
+			var ksName = "TestExecutor"
+			err := SchemaCheck(vc, ctx, ksName, tc.vschema)
+
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestSchemaCheckWithAddSequenceDDL(t *testing.T) {
+	type testCase struct {
+		vschema       *sqlparser.AlterVschema
+		sandboxRes    *sqltypes.Result
+		sandboxRes1   *sqltypes.Result
+		expectedError string
+	}
+
+	vindexParams := []sqlparser.VindexParam{{
+		Key: sqlparser.NewIdentifierCI("ksa"),
+		Val: "10",
+	}, {
+		Key: sqlparser.NewIdentifierCI("ks2"),
+		Val: "shard-0000",
+	}}
+
+	alterVschema1 := &sqlparser.AlterVschema{
+		Action: sqlparser.AddSequenceDDLAction,
+		Table: sqlparser.TableName{
+			Qualifier: sqlparser.NewIdentifierCS("TestExecutor"),
+			Name:      sqlparser.NewIdentifierCS("t2"),
+		},
+		VindexSpec: &sqlparser.VindexSpec{
+			Name:   sqlparser.NewIdentifierCI("hash"),
+			Type:   sqlparser.NewIdentifierCI("hash"),
+			Params: vindexParams,
+		},
+		AutoIncSpec: &sqlparser.AutoIncSpec{
+			Column: sqlparser.NewIdentifierCI("id"),
+			Sequence: sqlparser.TableName{
+				Qualifier: sqlparser.NewIdentifierCS("TestExecutor"),
+				Name:      sqlparser.NewIdentifierCS("t2"),
+			},
+		},
+		VindexCols: []sqlparser.IdentifierCI{sqlparser.NewIdentifierCI("col_tinyint")},
+	}
+
+	tests := []testCase{
+		{
+			vschema: alterVschema1,
+			sandboxRes: sqltypes.MakeTestResult(sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|bigint|NO|PRI|NULL|", "next_id|bigint|YES||NULL|", "cache|bigint|YES||NULL|"),
+			sandboxRes1: sqltypes.MakeTestResult(sqltypes.MakeTestFields("TABLE_NAME|TABLE_COMMENT", "varchar|varchar"),
+				"test_seq2|vitess_sequence"),
+			expectedError: "",
+		},
+		{
+			vschema: alterVschema1,
+			sandboxRes: sqltypes.MakeTestResult(sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|bigint|NO|PRI|NULL|", "next_id|bigint|YES||NULL|", "cache|bigint|YES||NULL|"),
+			sandboxRes1:   sqltypes.MakeTestResult(nil),
+			expectedError: "can not get table_comment from table t2 in keyspace TestExecutor",
+		},
+		{
+			vschema:       alterVschema1,
+			sandboxRes:    sqltypes.MakeTestResult(nil),
+			sandboxRes1:   sqltypes.MakeTestResult(nil),
+			expectedError: "table t2 does not exist in keyspace TestExecutor",
+		},
+		{
+			vschema: alterVschema1,
+			sandboxRes: sqltypes.MakeTestResult(sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|bigint|NO||NULL|", "next_id|bigint|YES||NULL|", "cache|bigint|YES||NULL|"),
+			sandboxRes1: sqltypes.MakeTestResult(sqltypes.MakeTestFields("TABLE_NAME|TABLE_COMMENT", "varchar|varchar"),
+				"test_seq2|vitess_sequence"),
+			expectedError: "column id should be primary key",
+		},
+		{
+			vschema: alterVschema1,
+			sandboxRes: sqltypes.MakeTestResult(sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id1|bigint|NO|PRI|NULL|", "next_id|bigint|YES||NULL|", "cache|bigint|YES||NULL|"),
+			sandboxRes1: sqltypes.MakeTestResult(sqltypes.MakeTestFields("TABLE_NAME|TABLE_COMMENT", "varchar|varchar"),
+				"test_seq2|vitess_sequence"),
+			expectedError: "column name should be id/next_id/cache",
+		},
+		{
+			vschema: alterVschema1,
+			sandboxRes: sqltypes.MakeTestResult(sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|bigint|NO|PRI|NULL|", "next_id|bigint|YES||NULL|"),
+			sandboxRes1: sqltypes.MakeTestResult(sqltypes.MakeTestFields("TABLE_NAME|TABLE_COMMENT", "varchar|varchar"),
+				"test_seq2|vitess_sequence"),
+			expectedError: "column cache does not exist",
+		},
+		{
+			vschema: alterVschema1,
+			sandboxRes: sqltypes.MakeTestResult(sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id1|int|NO|PRI|NULL|", "next_id|bigint|YES||NULL|", "cache|bigint|YES||NULL|"),
+			sandboxRes1: sqltypes.MakeTestResult(sqltypes.MakeTestFields("TABLE_NAME|TABLE_COMMENT", "varchar|varchar"),
+				"test_seq2|vitess_sequence"),
+			expectedError: "column type should be bigint",
+		},
+		{
+			vschema: alterVschema1,
+			sandboxRes: sqltypes.MakeTestResult(sqltypes.MakeTestFields("Field|Type|Null|Key|Default|Extra", "varchar|varchar|varchar|varchar|varchar|varchar"),
+				"id|bigint|NO|PRI|NULL|", "next_id|bigint|YES||NULL|", "cache|bigint|YES||NULL|"),
+			sandboxRes1: sqltypes.MakeTestResult(sqltypes.MakeTestFields("TABLE_NAME|TABLE_COMMENT", "varchar|varchar"),
+				"test_seq2|vitess_sequencexxxxxxx"),
+			expectedError: "table t2 comment should be 'vitess_sequence'",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			r, sb, _, _ := createExecutorEnv()
+			sb.SetResults([]*sqltypes.Result{tc.sandboxRes, tc.sandboxRes1})
+
+			vc, _ := newVCursorImpl(NewSafeSession(&vtgatepb.Session{TargetString: "@unknown"}), makeComments(""), r, nil, r.vm, r.VSchema(), r.resolver.resolver, nil, false, pv)
+			var ksName = "TestExecutor"
+			err := SchemaCheck(vc, ctx, ksName, tc.vschema)
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
+
+}
+
+func TestSchemaCheckWithCreateVindexDDL(t *testing.T) {
+	type testCase struct {
+		vindexSpec    *sqlparser.VindexSpec
+		sandboxRes    *sqltypes.Result
+		sandboxRes2   *sqltypes.Result
+		expectedError string
+	}
+
+	normal := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("owner"),
+			Val: "t2_lookup",
+		}, {
+			Key: sqlparser.NewIdentifierCI("table"),
+			Val: "TestUnsharded.wo_lu_idx",
+		}, {
+			Key: sqlparser.NewIdentifierCI("from"),
+			Val: "wo_lu_col",
+		}, {
+			Key: sqlparser.NewIdentifierCI("to"),
+			Val: "keyspace_id",
+		},
+	}
+	normal_owner := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("owner"),
+			Val: "TestExecutor.t2_lookup",
+		}, {
+			Key: sqlparser.NewIdentifierCI("table"),
+			Val: "TestUnsharded.wo_lu_idx",
+		}, {
+			Key: sqlparser.NewIdentifierCI("from"),
+			Val: "wo_lu_col",
+		}, {
+			Key: sqlparser.NewIdentifierCI("to"),
+			Val: "keyspace_id",
+		},
+	}
+
+	normal_lookup := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("owner"),
+			Val: "t2_lookup",
+		}, {
+			Key: sqlparser.NewIdentifierCI("table"),
+			Val: "t1",
+		}, {
+			Key: sqlparser.NewIdentifierCI("from"),
+			Val: "id",
+		}, {
+			Key: sqlparser.NewIdentifierCI("to"),
+			Val: "keyspace_id",
+		},
+	}
+
+	owner_not_exists := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("owner"),
+			Val: "ttt",
+		}, {
+			Key: sqlparser.NewIdentifierCI("table"),
+			Val: "TestUnsharded.wo_lu_idx",
+		}, {
+			Key: sqlparser.NewIdentifierCI("from"),
+			Val: "wo_lu_col",
+		}, {
+			Key: sqlparser.NewIdentifierCI("to"),
+			Val: "keyspace_id",
+		},
+	}
+
+	lookup_not_exists := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("owner"),
+			Val: "t2_lookup",
+		}, {
+			Key: sqlparser.NewIdentifierCI("table"),
+			Val: "TestUnsharded.sss",
+		}, {
+			Key: sqlparser.NewIdentifierCI("from"),
+			Val: "wo_lu_col",
+		}, {
+			Key: sqlparser.NewIdentifierCI("to"),
+			Val: "keyspace_id",
+		},
+	}
+
+	from_not_exists := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("owner"),
+			Val: "t2_lookup",
+		}, {
+			Key: sqlparser.NewIdentifierCI("table"),
+			Val: "TestUnsharded.wo_lu_idx",
+		}, {
+			Key: sqlparser.NewIdentifierCI("from"),
+			Val: "ddd",
+		}, {
+			Key: sqlparser.NewIdentifierCI("to"),
+			Val: "keyspace_id",
+		},
+	}
+
+	// to_not_exists := []sqlparser.VindexParam{
+	// 	{
+	// 		Key: sqlparser.NewIdentifierCI("owner"),
+	// 		Val: "corder",
+	// 	}, {
+	// 		Key: sqlparser.NewIdentifierCI("table"),
+	// 		Val: "order_lookup_table",
+	// 	}, {
+	// 		Key: sqlparser.NewIdentifierCI("from"),
+	// 		Val: "corder_id",
+	// 	}, {
+	// 		Key: sqlparser.NewIdentifierCI("to"),
+	// 		Val: "xxx",
+	// 	},
+	// }
+
+	all_not_exists := []sqlparser.VindexParam{}
+
+	not_owner_keyword := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("table"),
+			Val: "TestUnsharded.wo_lu_idx",
+		}, {
+			Key: sqlparser.NewIdentifierCI("from"),
+			Val: "wo_lu_col",
+		}, {
+			Key: sqlparser.NewIdentifierCI("to"),
+			Val: "keyspace_id",
+		},
+	}
+	not_table_keyword := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("owner"),
+			Val: "t2_lookup",
+		}, {
+			Key: sqlparser.NewIdentifierCI("from"),
+			Val: "wo_lu_col",
+		}, {
+			Key: sqlparser.NewIdentifierCI("to"),
+			Val: "keyspace_id",
+		},
+	}
+
+	not_from_keyword := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("owner"),
+			Val: "t2_lookup",
+		}, {
+			Key: sqlparser.NewIdentifierCI("table"),
+			Val: "TestUnsharded.wo_lu_idx",
+		}, {
+			Key: sqlparser.NewIdentifierCI("to"),
+			Val: "keyspace_id",
+		},
+	}
+
+	not_to_keyword := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("owner"),
+			Val: "t2_lookup",
+		}, {
+			Key: sqlparser.NewIdentifierCI("table"),
+			Val: "TestUnsharded.wo_lu_idx",
+		}, {
+			Key: sqlparser.NewIdentifierCI("from"),
+			Val: "wo_lu_col",
+		},
+	}
+
+	primary_exists := []sqlparser.VindexParam{
+		{
+			Key: sqlparser.NewIdentifierCI("owner"),
+			Val: "TestUnsharded.wo_lu_idx",
+		}, {
+			Key: sqlparser.NewIdentifierCI("table"),
+			Val: "TestUnsharded.wo_lu_idx",
+		}, {
+			Key: sqlparser.NewIdentifierCI("from"),
+			Val: "wo_lu_col",
+		}, {
+			Key: sqlparser.NewIdentifierCI("to"),
+			Val: "keyspace_id",
+		},
+	}
+
+	tests := []testCase{
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: normal,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: "",
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: normal_owner,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: "",
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: normal_lookup,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL",
+				"t1|id|bigint|PRI|1|NULL",
+				"t1|unq_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2:   nil,
+			expectedError: "",
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: not_owner_keyword,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Syntax error: please specify the value for the keyword `owner`").Error(),
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: not_table_keyword,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Syntax error: please specify the value for the keyword `table`").Error(),
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: not_from_keyword,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Syntax error: please specify the value for the keyword `from`").Error(),
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: not_to_keyword,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Syntax error: please specify the value for the keyword `to`").Error(),
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("test_hash"),
+				Type:   sqlparser.NewIdentifierCI("hash"),
+				Params: all_not_exists,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: "",
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: owner_not_exists,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vschema does not contain owner table '%s' in keyspace %s", "ttt", "TestExecutor").Error(),
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: lookup_not_exists,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vschema does not contain lookup table '%s' in keyspace %s", "sss", "TestUnsharded").Error(),
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: from_not_exists,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: vterrors.Errorf(vtrpcpb.Code_INTERNAL, "from column '%s' does not exist in ownertable %s", "ddd", "t2_lookup").Error(),
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: normal,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx_test|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx_test|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: vterrors.Errorf(vtrpcpb.Code_INTERNAL, "lookup table '%s' does not exist in keyspace %s", "wo_lu_idx", "TestUnsharded").Error(),
+		}, {
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: normal,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup_test|id|bigint|PRI|1|NULL",
+				"t2_lookup_test|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: vterrors.Errorf(vtrpcpb.Code_INTERNAL, "owner table '%s' does not exist in keyspace %s", "t2_lookup", "TestExecutor").Error(),
+		},
+		// {
+		// 	vindexSpec: &sqlparser.VindexSpec{
+		// 		Name:   sqlparser.NewIdentifierCI("order_lookup_idx"),
+		// 		Type:   sqlparser.NewIdentifierCI("consistent_lookup_unique"),
+		// 		Params: not_to_keyword,
+		// 	},
+		// 	sandboxRes: sqltypes.MakeTestResult(
+		// 		sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+		// 			"varchar|varchar|varchar|varchar|bool|varchar"),
+		// 		"t2_lookup|id|bigint|PRI|1|NULL",
+		// 		"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+		// 	sandboxRes2: sqltypes.MakeTestResult(
+		// 		sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+		// 			"varchar|varchar|varchar|varchar|bool|varchar"),
+		// 		"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+		// 		"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+		// 	expectedError: "",
+		// },
+		{
+			vindexSpec: &sqlparser.VindexSpec{
+				Name:   sqlparser.NewIdentifierCI("t2_wo_lu_vdx_test"),
+				Type:   sqlparser.NewIdentifierCI("lookup_unique"),
+				Params: primary_exists,
+			},
+			sandboxRes: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"t2_lookup|id|bigint|PRI|1|NULL",
+				"t2_lookup|wo_lu_col|bigint|UNI|NULL|NULL"),
+			sandboxRes2: sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("table_name|column_name|data_type|column_key|auto_increment|collation_name",
+					"varchar|varchar|varchar|varchar|bool|varchar"),
+				"wo_lu_idx|wo_lu_col|bigint|PRI|1|NULL",
+				"wo_lu_idx|keyspace_id|varchar(25)|NULL|NULL|NULL"),
+			expectedError: vterrors.Errorf(vtrpcpb.Code_INTERNAL, "The owner table '%s' does not have a primary vindex", "wo_lu_idx").Error(),
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			r, sbc1, _, sbclookup := createExecutorEnv()
+			sbc1.SetResults([]*sqltypes.Result{tt.sandboxRes})
+			sbclookup.SetResults([]*sqltypes.Result{tt.sandboxRes2})
+			vc, _ := newVCursorImpl(NewSafeSession(&vtgatepb.Session{TargetString: "@unknown"}), makeComments(""), r, nil, r.vm, r.VSchema(), r.resolver.resolver, nil, false, pv)
+			alterVschema := &sqlparser.AlterVschema{
+				Action:     sqlparser.CreateVindexDDLAction,
+				VindexSpec: tt.vindexSpec,
+			}
+
+			err := SchemaCheck(vc, ctx, "TestExecutor", alterVschema)
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
The feature of vindex DDL is not always convenient to use in some scenarios. It would be better for users if error messages could be provided in the following situations. 

1、Create the lookup vindex statement:
```
mysql> use customer;
mysql> ALTER VSCHEMA CREATE VINDEX lookup_unique_vdx USING lookup_unique WITH owner=user, table=name_user_idx, from=name, to=user_id;
Query OK, 0 rows affected (0.01 sec)
```

When executing vschema DDL,
The uniqueness of the field corresponding to "from" in the owner table should be checked.
The field corresponding to "from" in the lookup table should be the primary key column.
The field corresponding to "to" should be of the varbinary type.

2、Create a lookup vindex statement:

```
mysql> use customer;
mysql> ALTER VSCHEMA CREATE VINDEX lookup_vdx USING lookup WITH owner=user, table=name_user_idx, from=name, to=user_id;
Query OK, 0 rows affected (0.01 sec)
```
When executing the vschema DDL, the owner and table do not exist, but no error is reported.

3、The sequence has not yet been created, but it can be created successfully. Do we need to check it?
```
mysql> ALTER VSCHEMA ADD SEQUENCE test_seq;
Query OK, 0 rows affected (0.02 sec)
```
Optimization suggested to add checks for existing main table and sequence.


4、ON ... ADD AUTO_INCREMENT，The sequence has not been created, but adding auto-increment property is successful.
```
mysql> ALTER VSCHEMA on test2 ADD AUTO_INCREMENT customer_id using test_seq2;
Query OK, 0 rows affected (0.02 sec)
```
Optimization suggested to check the existence of customer_id in test1 table.
ERROR 1105 (HY000): syntax error at position 28 near 'SEQUENCE'

5、Adding feature to validate algorithms and data types.（column email is varchar）
```
mysql> alter vschema on customer.customer add vindex hash(email) using hash;
mysql> insert into user3 (user_id, name) values(8,'alice'),(7,'dan');
ERROR 1105 (HY000): could not map [VARCHAR("alice")] to a keyspace id
```
suggests taking measures to prevent such errors.
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#13133
## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
