### PR TITLE
VReplication: Do not delete sharded target vschema table entries on Cancel

### DIFF
--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1687,9 +1687,11 @@ func (ts *trafficSwitcher) dropParticipatingTablesFromKeyspace(ctx context.Conte
 	if err != nil {
 		return err
 	}
-	// VReplication does NOT create the vschema entries for sharded keyspaces and we should not delete them
-	// either as the user must create them and they contain information about the vindex definitions, etc.
-	if vschema.Sharded {
+	// VReplication does NOT create the vschema entries in SHARDED
+	// TARGET keyspaces and we should not delete them either as
+	// the user must create them and they contain information about
+	// the vindex definitions, etc.
+	if vschema.Sharded && keyspace == ts.TargetKeyspaceName() {
 		return nil
 	}
 	for _, tableName := range ts.Tables() {

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1688,9 +1688,10 @@ func (ts *trafficSwitcher) dropParticipatingTablesFromKeyspace(ctx context.Conte
 		return err
 	}
 	// VReplication does NOT create the vschema entries in SHARDED
-	// TARGET keyspaces and we should not delete them either as
-	// the user must create them and they contain information about
-	// the vindex definitions, etc.
+	// TARGET keyspaces -- as we cannot know the proper vindex
+	// definitions to use -- and we should not delete them either
+	// (on workflow Cancel) as the user must create them separately
+	// and they contain information about the vindex definitions, etc.
 	if vschema.Sharded && keyspace == ts.TargetKeyspaceName() {
 		return nil
 	}

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1687,6 +1687,11 @@ func (ts *trafficSwitcher) dropParticipatingTablesFromKeyspace(ctx context.Conte
 	if err != nil {
 		return err
 	}
+	// VReplication does NOT create the vschema entries for sharded keyspaces and we should not delete them
+	// either as the user must create them and they contain information about the vindex definitions, etc.
+	if vschema.Sharded {
+		return nil
+	}
 	for _, tableName := range ts.Tables() {
 		delete(vschema.Tables, tableName)
 	}
@@ -1774,7 +1779,6 @@ func (ts *trafficSwitcher) removeTargetTables(ctx context.Context) error {
 	}
 
 	return ts.dropParticipatingTablesFromKeyspace(ctx, ts.TargetKeyspaceName())
-
 }
 
 func (ts *trafficSwitcher) dropTargetShards(ctx context.Context) error {

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -456,7 +456,7 @@ func TestMoveTablesV2Cancel(t *testing.T) {
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks1", "t1"))
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks1", "t2"))
 
-	// Should target vschema entries should be deleted upon Cancel. For unsharded
+	// Should target vschema table entries be deleted upon Cancel. For unsharded
 	// keyspaces they should be as they are empty table entries that we also
 	// create when the workflow is Created.
 	targetVSchemaEntriesRemain := false

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -455,8 +455,20 @@ func TestMoveTablesV2Cancel(t *testing.T) {
 
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks1", "t1"))
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks1", "t2"))
-	require.False(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks2", "t1"))
-	require.False(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks2", "t2"))
+
+	// Should target vschema entries should be deleted upon Cancel. For unsharded
+	// keyspaces they should be as they are empty table entries that we also
+	// create when the workflow is Created.
+	targetVSchemaEntriesRemain := false
+	if len(tme.targetShards) > 1 {
+		// If the target keyspace is sharded -- which it is today in the test -- the
+		// vschema must be created by the user before the workflow is started. Thus
+		// we should also not delete the vschema table entries upon Cancel as the
+		// management of the sharded vschema is up to the user.
+		targetVSchemaEntriesRemain = true
+	}
+	require.Equal(t, targetVSchemaEntriesRemain, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks2", "t1"))
+	require.Equal(t, targetVSchemaEntriesRemain, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks2", "t2"))
 }
 
 func TestReshardV2(t *testing.T) {

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -340,6 +340,18 @@ func TestMoveTablesV2Complete(t *testing.T) {
 	require.NoError(t, testSwitchForward(t, wf))
 	require.Equal(t, WorkflowStateAllSwitched, wf.CurrentState())
 
+	// Should source vschema table entries be deleted upon Complete. For unsharded
+	// keyspaces they should be as they are empty table entries that we also
+	// create when the reverse workflow is Created.
+	sourceVSchemaEntriesRemain := false
+	if len(tme.sourceShards) > 1 {
+		// If the source keyspace is sharded -- which it is today in the test -- the
+		// vschema must be created by the user before the workflow is started. Thus
+		// we should also not delete the vschema table entries upon Complete as the
+		// management of the sharded vschema is up to the user.
+		sourceVSchemaEntriesRemain = true
+	}
+
 	//16 rules, 8 per table t1,t2 eg: t1,t1@replica,t1@rdonly,ks1.t1,ks1.t1@replica,ks1.t1@rdonly,ks2.t1@replica,ks2.t1@rdonly
 	validateRoutingRuleCount(ctx, t, wf.wr.ts, 16)
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks1", "t1"))
@@ -347,8 +359,8 @@ func TestMoveTablesV2Complete(t *testing.T) {
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks2", "t1"))
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks2", "t2"))
 	require.NoError(t, testComplete(t, wf))
-	require.False(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks1", "t1"))
-	require.False(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks1", "t2"))
+	require.Equal(t, sourceVSchemaEntriesRemain, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks1", "t1"))
+	require.Equal(t, sourceVSchemaEntriesRemain, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks1", "t2"))
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks2", "t1"))
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks2", "t2"))
 


### PR DESCRIPTION
## Description

When the _target keyspace is unsharded_ VReplication creates empty vschema table entries in the target keyspace for tables that it's moving from one keyspace to another (`MoveTables` or `Migrate`). It makes sense to also delete those entries it created if the workflow is subsequently [`Cancel`](https://vitess.io/docs/17.0/reference/vreplication/movetables/#cancel)ed.

However, for _sharded target keyspaces_ the vschema must be created by the user before the workflow is created — as VReplication cannot know the proper vindex definitions to use — so the vschema is managed by the user outside of the workflow. So for sharded target keyspaces we should also _NOT_ be deleting the those vschema table entries when the workflow is [`Cancel`](https://vitess.io/docs/17.0/reference/vreplication/movetables/#cancel)ed. Before this PR, we were deleting them and users then needed to re-create them again before creating a new replacement workflow.

Please see the issue for additional details: https://github.com/vitessio/vitess/issues/13144

>**Note** This only impacts `MoveTables` and `Migrate` as e.g. `Reshard Cancel` instead deletes the target shards and tablets from the Topo.

You can see a manual test case here:
```
git checkout main && make build
cd examples/local

./101_initial_cluster.sh; mysql < ../common/insert_commerce_data.sql; ./201_customer_tablets.sh; ./202_move_tables.sh; sleep 5; ./203_switch_reads.sh; ./204_switch_writes.sh; ./205_clean_commerce.sh; ./301_customer_sharded.sh; ./302_new_shards.sh; ./303_reshard.sh; sleep 5; ./304_switch_reads.sh; ./305_switch_writes.sh; vtctlclient Reshard Complete customer.cust2cust

# Add the product table to the vschema
vtctlclient ApplyVSchema -- --vschema='{"sharded":true,"vindexes":{"hash":{"type":"hash"}},"tables":{"corder":{"columnVindexes":[{"column":"customer_id","name":"hash"}],"autoIncrement":{"column":"order_id","sequence":"order_seq"}},"customer":{"columnVindexes":[{"column":"customer_id","name":"hash"}],"autoIncrement":{"column":"customer_id","sequence":"customer_seq"}},"product":{"columnVindexes":[{"column":"sku","name":"hash"}]}}}'  customer

vtctlclient GetVSchema customer

# Move the product table
vtctlclient MoveTables -- --source commerce --tables 'product' Create customer.commerce_product2customer

# Cancel it
vtctlclient MoveTables -- --source commerce --tables 'product' Cancel customer.commerce_product2customer

# Our product table entry is gone
vtctlclient GetVSchema customer
```

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13144
 
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were updated
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required (we do not mention the vschema at all today in the docs: https://vitess.io/docs/17.0/reference/vreplication/movetables/#cancel)