### PR TITLE
[16.0] evalengine: TypeOf for Columns should only use value type when we have a value

### DIFF
--- a/go/vt/vtgate/evalengine/expr_column_test.go
+++ b/go/vt/vtgate/evalengine/expr_column_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evalengine
+
+import (
+	"testing"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+func TestTypeOf(t *testing.T) {
+	env := &ExpressionEnv{
+		BindVars: make(map[string]*querypb.BindVariable),
+	}
+
+	field1 := &querypb.Field{
+		Name:  "field1",
+		Type:  querypb.Type_INT64,
+		Flags: uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
+	}
+	field2 := &querypb.Field{
+		Name:  "field2",
+		Type:  querypb.Type_VARCHAR,
+		Flags: 0,
+	}
+	fields := []*querypb.Field{field1, field2}
+
+	c := &Column{}
+	env.Row = sqltypes.Row{sqltypes.NewInt64(10)}
+	env.Fields = fields
+
+	t.Run("Check when row value is not null", func(t *testing.T) {
+		typ, f := c.typeof(env)
+		if typ != sqltypes.Int64 || f != flag(0) {
+			t.Errorf("typeof() failed, expected sqltypes.Int64 and typeFlag 0, got %v and %v", typ, f)
+		}
+	})
+
+	t.Run("Check when row value is null", func(t *testing.T) {
+		env.Row = sqltypes.Row{
+			sqltypes.NULL,
+		}
+		typ, flag := c.typeof(env)
+		if typ != querypb.Type_INT64 || flag != flagNullable {
+			t.Errorf("typeof() failed, expected querypb.Type_INT64 and flagNullable, got %v and %v", typ, flag)
+		}
+	})
+}

--- a/go/vt/vtgate/evalengine/expressions.go
+++ b/go/vt/vtgate/evalengine/expressions.go
@@ -578,10 +578,9 @@ func (c *Column) typeof(env *ExpressionEnv) (sqltypes.Type, flag) {
 	// we'll try to do the best possible with the information we have
 	if c.Offset < len(env.Row) {
 		value := env.Row[c.Offset]
-		if value.IsNull() {
-			return sqltypes.Null, flagNull | flagNullable
+		if !value.IsNull() {
+			return value.Type(), flag(0)
 		}
-		return value.Type(), flag(0)
 	}
 
 	if c.Offset < len(env.Fields) {


### PR DESCRIPTION
## Description
While working on other parts of Vitess, we noticed this issue. Difficult to show the bug using end to end tests, but the unit test should show the behaviour we want.

## Related Issue(s)
Issue: #13149
Backport of: #13148

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
