### PR TITLE
VReplication: Pass on --keep_routing_rules flag value for Cancel action

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2274,6 +2274,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *pfl
 		vrwp.MaxAllowedTransactionLagSeconds = int64(math.Ceil(maxReplicationLagAllowed.Seconds()))
 	case vReplicationWorkflowActionCancel:
 		vrwp.KeepData = *keepData
+		vrwp.KeepRoutingRules = *keepRoutingRules
 	case vReplicationWorkflowActionComplete:
 		switch workflowType {
 		case wrangler.MoveTablesWorkflow:


### PR DESCRIPTION
## Description

VReplication vtctl client workflow commands such as [`MoveTables`](https://vitess.io/docs/reference/vreplication/movetables/) and [`Reshard`](https://vitess.io/docs/reference/vreplication/reshard/) take a [`--keep_routing_rules`](https://vitess.io/docs/reference/vreplication/movetables/#--keep_routing_rules) flag. This flag's value, however, was NOT passed on to the command execution for the [`Cancel`](https://vitess.io/docs/reference/vreplication/movetables/#cancel) action. This PR corrects that and adds endtoend testing for it in the existing `TestVReplicationDDLHandling` test since that does a lot of `Cancel`s.

Manual test:
```sh
git checkout main && make build
cd examples/local

./101_initial_cluster.sh; mysql < ../common/insert_commerce_data.sql; ./201_customer_tablets.sh

vtctlclient MoveTables -- --source commerce --tables 'customer,corder' Create customer.commerce2customer
vtctldclient GetRoutingRules

vtctlclient MoveTables -- --source commerce --keep_routing_rules Cancel customer.commerce2customer
vtctldclient GetRoutingRules

./401_teardown.sh
```

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13170

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
