### PR TITLE
Flakes: Skip flaky viperutil test TestPersistConfig for now to unblock CI

### DIFF
--- a/go/viperutil/internal/sync/sync_test.go
+++ b/go/viperutil/internal/sync/sync_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 func TestPersistConfig(t *testing.T) {
+	t.Skip("temporarily skipping this to unblock PRs since it's flaky")
 	type config struct {
 		Foo int `json:"foo"`
 	}


### PR DESCRIPTION
## Description

`TestPersistConfig` is very flaky at the moment. Skipping temporarily to unblock CI.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
