### PR TITLE
Improve VTOrc failure detection to be able to better handle dead primary failures

### DIFF
--- a/go/test/endtoend/vtorc/api/api_test.go
+++ b/go/test/endtoend/vtorc/api/api_test.go
@@ -92,7 +92,7 @@ func TestAPIEndpoints(t *testing.T) {
 
 	// Before we disable recoveries, let us wait until VTOrc has fixed all the issues (if any).
 	_, _ = utils.MakeAPICallRetry(t, vtorc, "/api/replication-analysis", func(_ int, response string) bool {
-		return response != "[]"
+		return response != "null"
 	})
 
 	t.Run("Disable Recoveries API", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestAPIEndpoints(t *testing.T) {
 		// Wait until VTOrc picks up on this issue and verify
 		// that we see a not null result on the api/replication-analysis page
 		status, resp := utils.MakeAPICallRetry(t, vtorc, "/api/replication-analysis", func(_ int, response string) bool {
-			return response == "[]"
+			return response == "null"
 		})
 		assert.Equal(t, 200, status, resp)
 		assert.Contains(t, resp, fmt.Sprintf(`"AnalyzedInstanceAlias": "%s"`, replica.Alias))
@@ -134,7 +134,7 @@ func TestAPIEndpoints(t *testing.T) {
 		status, resp, err = utils.MakeAPICall(t, vtorc, "/api/replication-analysis?keyspace=ks&shard=80-")
 		require.NoError(t, err)
 		assert.Equal(t, 200, status, resp)
-		assert.Equal(t, "[]", resp)
+		assert.Equal(t, "null", resp)
 
 		// Check that filtering using just the shard fails
 		status, resp, err = utils.MakeAPICall(t, vtorc, "/api/replication-analysis?shard=0")

--- a/go/test/endtoend/vtorc/general/vtorc_test.go
+++ b/go/test/endtoend/vtorc/general/vtorc_test.go
@@ -421,7 +421,7 @@ func TestDurabilityPolicySetLater(t *testing.T) {
 	time.Sleep(30 * time.Second)
 
 	// Now set the correct durability policy
-	out, err := newCluster.VtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspace.Name, "--durability-policy=semi_sync")
+	out, err := newCluster.ClusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspace.Name, "--durability-policy=semi_sync")
 	require.NoError(t, err, out)
 
 	// VTOrc should promote a new primary after seeing the durability policy change

--- a/go/test/endtoend/vtorc/primaryfailure/main_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/main_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 	var cellInfos []*utils.CellInfo
 	cellInfos = append(cellInfos, &utils.CellInfo{
 		CellName:    utils.Cell1,
-		NumReplicas: 12,
+		NumReplicas: 13,
 		NumRdonly:   3,
 		UIDBase:     100,
 	})

--- a/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
@@ -127,7 +127,7 @@ func TestDownPrimaryBeforeVTOrc(t *testing.T) {
 	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{rdonly, replica}, 10*time.Second)
 
 	// Make the current primary vttablet unavailable.
-	_ = curPrimary.VttabletProcess.Kill()
+	_ = curPrimary.VttabletProcess.TearDown()
 	err = curPrimary.MysqlctlProcess.Stop()
 	require.NoError(t, err)
 

--- a/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
@@ -97,6 +97,61 @@ func TestDownPrimary(t *testing.T) {
 	utils.WaitForSuccessfulRecoveryCount(t, vtOrcProcess, logic.RecoverDeadPrimaryRecoveryName, 1)
 }
 
+// bring down primary before VTOrc has started, let vtorc repair.
+func TestDownPrimaryBeforeVTOrc(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{}, 0, "none")
+	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
+	shard0 := &keyspace.Shards[0]
+	curPrimary := shard0.Vttablets[0]
+
+	// Promote the first tablet as the primary
+	err := clusterInfo.ClusterInstance.VtctlclientProcess.InitializeShard(keyspace.Name, shard0.Name, clusterInfo.ClusterInstance.Cell, curPrimary.TabletUID)
+	require.NoError(t, err)
+
+	// find the replica and rdonly tablets
+	var replica, rdonly *cluster.Vttablet
+	for _, tablet := range shard0.Vttablets {
+		// we know we have only two replcia tablets, so the one not the primary must be the other replica
+		if tablet.Alias != curPrimary.Alias && tablet.Type == "replica" {
+			replica = tablet
+		}
+		if tablet.Type == "rdonly" {
+			rdonly = tablet
+		}
+	}
+	assert.NotNil(t, replica, "could not find replica tablet")
+	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+
+	// check that the replication is setup correctly before we failover
+	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{rdonly, replica}, 10*time.Second)
+
+	// Make the current primary vttablet unavailable.
+	err = curPrimary.VttabletProcess.TearDown()
+	require.NoError(t, err)
+	err = curPrimary.MysqlctlProcess.Stop()
+	require.NoError(t, err)
+
+	// Start a VTOrc instance
+	utils.StartVTOrcs(t, clusterInfo, []string{"--remote_operation_timeout=10s"}, cluster.VTOrcConfiguration{
+		PreventCrossDataCenterPrimaryFailover: true,
+	}, 1)
+
+	vtOrcProcess := clusterInfo.ClusterInstance.VTOrcProcesses[0]
+
+	defer func() {
+		// we remove the tablet from our global list
+		utils.PermanentlyRemoveVttablet(clusterInfo, curPrimary)
+	}()
+
+	// check that the replica gets promoted
+	utils.CheckPrimaryTablet(t, clusterInfo, replica, true)
+
+	// also check that the replication is working correctly after failover
+	utils.VerifyWritesSucceed(t, clusterInfo, replica, []*cluster.Vttablet{rdonly}, 10*time.Second)
+	utils.WaitForSuccessfulRecoveryCount(t, vtOrcProcess, logic.RecoverDeadPrimaryRecoveryName, 1)
+}
+
 // TestDeadPrimaryRecoversImmediately test Vtorc ability to recover immediately if primary is dead.
 // Reason is, unlike other recoveries, in DeadPrimary we don't call DiscoverInstance since we know
 // that primary is unreachable. This help us save few seconds depending on value of `RemoteOperationTimeout` flag.

--- a/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
@@ -127,8 +127,7 @@ func TestDownPrimaryBeforeVTOrc(t *testing.T) {
 	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{rdonly, replica}, 10*time.Second)
 
 	// Make the current primary vttablet unavailable.
-	err = curPrimary.VttabletProcess.TearDown()
-	require.NoError(t, err)
+	_ = curPrimary.VttabletProcess.Kill()
 	err = curPrimary.MysqlctlProcess.Stop()
 	require.NoError(t, err)
 

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -67,11 +67,10 @@ type CellInfo struct {
 
 // VTOrcClusterInfo stores the information for a cluster. This is supposed to be used only for VTOrc tests.
 type VTOrcClusterInfo struct {
-	ClusterInstance     *cluster.LocalProcessCluster
-	Ts                  *topo.Server
-	CellInfos           []*CellInfo
-	VtctldClientProcess *cluster.VtctldClientProcess
-	lastUsedValue       int
+	ClusterInstance *cluster.LocalProcessCluster
+	Ts              *topo.Server
+	CellInfos       []*CellInfo
+	lastUsedValue   int
 }
 
 // CreateClusterAndStartTopo starts the cluster and topology service
@@ -100,17 +99,13 @@ func CreateClusterAndStartTopo(cellInfos []*CellInfo) (*VTOrcClusterInfo, error)
 		return nil, err
 	}
 
-	// store the vtctldclient process
-	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
-
 	// create topo server connection
 	ts, err := topo.OpenServer(*clusterInstance.TopoFlavorString(), clusterInstance.VtctlProcess.TopoGlobalAddress, clusterInstance.VtctlProcess.TopoGlobalRoot)
 	return &VTOrcClusterInfo{
-		ClusterInstance:     clusterInstance,
-		Ts:                  ts,
-		CellInfos:           cellInfos,
-		lastUsedValue:       100,
-		VtctldClientProcess: vtctldClientProcess,
+		ClusterInstance: clusterInstance,
+		Ts:              ts,
+		CellInfos:       cellInfos,
+		lastUsedValue:   100,
 	}, err
 }
 
@@ -307,7 +302,7 @@ func SetupVttabletsAndVTOrcs(t *testing.T, clusterInfo *VTOrcClusterInfo, numRep
 	if durability == "" {
 		durability = "none"
 	}
-	out, err := clusterInfo.VtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, fmt.Sprintf("--durability-policy=%s", durability))
+	out, err := clusterInfo.ClusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, fmt.Sprintf("--durability-policy=%s", durability))
 	require.NoError(t, err, out)
 
 	// start vtorc
@@ -829,20 +824,17 @@ func SetupNewClusterSemiSync(t *testing.T) *VTOrcClusterInfo {
 		require.NoError(t, err)
 	}
 
-	vtctldClientProcess := cluster.VtctldClientProcessInstance("localhost", clusterInstance.VtctldProcess.GrpcPort, clusterInstance.TmpDirectory)
-
-	out, err := vtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
+	out, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
 	require.NoError(t, err, out)
 
 	// create topo server connection
 	ts, err := topo.OpenServer(*clusterInstance.TopoFlavorString(), clusterInstance.VtctlProcess.TopoGlobalAddress, clusterInstance.VtctlProcess.TopoGlobalRoot)
 	require.NoError(t, err)
 	clusterInfo := &VTOrcClusterInfo{
-		ClusterInstance:     clusterInstance,
-		Ts:                  ts,
-		CellInfos:           nil,
-		lastUsedValue:       100,
-		VtctldClientProcess: vtctldClientProcess,
+		ClusterInstance: clusterInstance,
+		Ts:              ts,
+		CellInfos:       nil,
+		lastUsedValue:   100,
 	}
 	return clusterInfo
 }

--- a/go/vt/vtorc/inst/analysis.go
+++ b/go/vt/vtorc/inst/analysis.go
@@ -31,6 +31,7 @@ type StructureAnalysisCode string
 const (
 	NoProblem                              AnalysisCode = "NoProblem"
 	ClusterHasNoPrimary                    AnalysisCode = "ClusterHasNoPrimary"
+	InvalidPrimary                         AnalysisCode = "InvalidPrimary"
 	DeadPrimaryWithoutReplicas             AnalysisCode = "DeadPrimaryWithoutReplicas"
 	DeadPrimary                            AnalysisCode = "DeadPrimary"
 	DeadPrimaryAndReplicas                 AnalysisCode = "DeadPrimaryAndReplicas"

--- a/go/vt/vtorc/inst/analysis.go
+++ b/go/vt/vtorc/inst/analysis.go
@@ -32,6 +32,7 @@ const (
 	NoProblem                              AnalysisCode = "NoProblem"
 	ClusterHasNoPrimary                    AnalysisCode = "ClusterHasNoPrimary"
 	InvalidPrimary                         AnalysisCode = "InvalidPrimary"
+	InvalidReplica                         AnalysisCode = "InvalidReplica"
 	DeadPrimaryWithoutReplicas             AnalysisCode = "DeadPrimaryWithoutReplicas"
 	DeadPrimary                            AnalysisCode = "DeadPrimary"
 	DeadPrimaryAndReplicas                 AnalysisCode = "DeadPrimaryAndReplicas"

--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -415,7 +415,7 @@ func GetReplicationAnalysis(keyspace string, shard string, hints *ReplicationAna
 		}
 		// ca has clusterwide info
 		ca := clusters[keyspaceShard]
-		// Increment the total amount of tablets.
+		// Increment the total number of tablets.
 		ca.totalTablets += 1
 		if ca.hasClusterwideAction {
 			// We can only take one cluster level action at a time.
@@ -616,7 +616,7 @@ func postProcessAnalyses(result []*ReplicationAnalysis, clusters map[string]*clu
 		// Store whether we have changed the result of replication analysis or not.
 		resultChanged := false
 
-		// Go over all the analysis.
+		// Go over all the analyses.
 		for _, analysis := range result {
 			// If one of them is an InvalidPrimary, then we see if all the other tablets in this keyspace shard are
 			// unable to replicate or not.

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -565,7 +565,7 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 			}},
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
-			codeWanted:     NoProblem,
+			codeWanted:     InvalidReplica,
 		}, {
 			name: "DeadPrimary when VTOrc is starting up",
 			info: []*test.InfoForRecoveryAnalysis{{
@@ -708,7 +708,9 @@ func TestGetReplicationAnalysis(t *testing.T) {
 			// We should wait for the MySQL information to be refreshed once.
 			// This situation only happens when we haven't been able to read the MySQL information even once for this tablet.
 			// So it is likely a new tablet.
-			codeWanted: NoProblem,
+			codeWanted:     InvalidReplica,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
 		},
 	}
 
@@ -815,7 +817,7 @@ func TestPostProcessAnalyses(t *testing.T) {
 	ks0 := ClusterInfo{
 		Keyspace:       "ks",
 		Shard:          "0",
-		CountInstances: 3,
+		CountInstances: 4,
 	}
 	ks80 := ClusterInfo{
 		Keyspace:       "ks",
@@ -842,13 +844,16 @@ func TestPostProcessAnalyses(t *testing.T) {
 				{
 					Analysis:       ReplicationStopped,
 					TabletType:     topodatapb.TabletType_REPLICA,
+					LastCheckValid: true,
 					ClusterDetails: ks0,
 				}, {
 					Analysis:       ReplicaSemiSyncMustBeSet,
+					LastCheckValid: true,
 					TabletType:     topodatapb.TabletType_REPLICA,
 					ClusterDetails: ks0,
 				}, {
 					Analysis:       PrimaryHasPrimary,
+					LastCheckValid: true,
 					TabletType:     topodatapb.TabletType_REPLICA,
 					ClusterDetails: ks0,
 				},
@@ -863,24 +868,34 @@ func TestPostProcessAnalyses(t *testing.T) {
 					ClusterDetails:        ks0,
 				}, {
 					Analysis:              NoProblem,
+					LastCheckValid:        true,
 					AnalyzedInstanceAlias: "zone1-202",
 					TabletType:            topodatapb.TabletType_RDONLY,
 					ClusterDetails:        ks80,
 				}, {
 					Analysis:              ConnectedToWrongPrimary,
+					LastCheckValid:        true,
 					AnalyzedInstanceAlias: "zone1-101",
 					TabletType:            topodatapb.TabletType_REPLICA,
 					ReplicationStopped:    true,
 					ClusterDetails:        ks0,
 				}, {
 					Analysis:              ReplicationStopped,
+					LastCheckValid:        true,
 					AnalyzedInstanceAlias: "zone1-102",
 					TabletType:            topodatapb.TabletType_RDONLY,
 					ReplicationStopped:    true,
 					ClusterDetails:        ks0,
 				}, {
+					Analysis:              InvalidReplica,
+					AnalyzedInstanceAlias: "zone1-108",
+					TabletType:            topodatapb.TabletType_REPLICA,
+					LastCheckValid:        false,
+					ClusterDetails:        ks0,
+				}, {
 					Analysis:              NoProblem,
 					AnalyzedInstanceAlias: "zone1-302",
+					LastCheckValid:        true,
 					TabletType:            topodatapb.TabletType_REPLICA,
 					ClusterDetails:        ks80,
 				},
@@ -893,11 +908,13 @@ func TestPostProcessAnalyses(t *testing.T) {
 					ClusterDetails:        ks0,
 				}, {
 					Analysis:              NoProblem,
+					LastCheckValid:        true,
 					AnalyzedInstanceAlias: "zone1-202",
 					TabletType:            topodatapb.TabletType_RDONLY,
 					ClusterDetails:        ks80,
 				}, {
 					Analysis:              NoProblem,
+					LastCheckValid:        true,
 					AnalyzedInstanceAlias: "zone1-302",
 					TabletType:            topodatapb.TabletType_REPLICA,
 					ClusterDetails:        ks80,
@@ -915,21 +932,25 @@ func TestPostProcessAnalyses(t *testing.T) {
 				}, {
 					Analysis:              NoProblem,
 					AnalyzedInstanceAlias: "zone1-202",
+					LastCheckValid:        true,
 					TabletType:            topodatapb.TabletType_RDONLY,
 					ClusterDetails:        ks80,
 				}, {
 					Analysis:              NoProblem,
+					LastCheckValid:        true,
 					AnalyzedInstanceAlias: "zone1-101",
 					TabletType:            topodatapb.TabletType_REPLICA,
 					ClusterDetails:        ks0,
 				}, {
 					Analysis:              ReplicationStopped,
+					LastCheckValid:        true,
 					AnalyzedInstanceAlias: "zone1-102",
 					TabletType:            topodatapb.TabletType_RDONLY,
 					ReplicationStopped:    true,
 					ClusterDetails:        ks0,
 				}, {
 					Analysis:              NoProblem,
+					LastCheckValid:        true,
 					AnalyzedInstanceAlias: "zone1-302",
 					TabletType:            topodatapb.TabletType_REPLICA,
 					ClusterDetails:        ks80,

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -695,9 +695,10 @@ func TestGetReplicationAnalysis(t *testing.T) {
 			},
 			// As long as we have the vitess record stating that this tablet is the primary
 			// It would be incorrect to run a PRS.
-			// This situation only happens when we haven't been able to read the MySQL information even once for this tablet.
-			// So it is likely a new tablet.
-			codeWanted: NoProblem,
+			// We should still flag this tablet as Invalid.
+			codeWanted:     InvalidPrimary,
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
 		}, {
 			name: "Removing Replica Tablet's MySQL record",
 			sql: []string{

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -567,6 +567,66 @@ func TestGetReplicationAnalysisDecision(t *testing.T) {
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
 			codeWanted:     NoProblem,
+		}, {
+			name: "DeadPrimary when VTOrc is starting up",
+			info: []*test.InfoForRecoveryAnalysis{{
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_PRIMARY,
+					MysqlHostname: "localhost",
+					MysqlPort:     6708,
+				},
+				DurabilityPolicy: "none",
+				IsInvalid:        1,
+			}, {
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_REPLICA,
+					MysqlHostname: "localhost",
+					MysqlPort:     6709,
+				},
+				LastCheckValid:     1,
+				ReplicationStopped: 1,
+			}, {
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 103},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_REPLICA,
+					MysqlHostname: "localhost",
+					MysqlPort:     6710,
+				},
+				LastCheckValid:     1,
+				ReplicationStopped: 1,
+			}},
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     DeadPrimary,
+		}, {
+			name: "Invalid Primary",
+			info: []*test.InfoForRecoveryAnalysis{{
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_PRIMARY,
+					MysqlHostname: "localhost",
+					MysqlPort:     6708,
+				},
+				DurabilityPolicy: "none",
+				IsInvalid:        1,
+			}},
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     InvalidPrimary,
 		},
 	}
 	for _, tt := range tests {

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -195,8 +195,6 @@ func refreshTabletsInKeyspaceShard(ctx context.Context, keyspace, shard string, 
 
 func refreshTablets(tablets map[string]*topo.TabletInfo, query string, args []any, loader func(tabletAlias string), forceRefresh bool, tabletsToIgnore []string) {
 	// Discover new tablets.
-	// TODO(sougou): enhance this to work with multi-schema,
-	// where each instanceKey can have multiple tablets.
 	latestInstances := make(map[string]bool)
 	var wg sync.WaitGroup
 	for _, tabletInfo := range tablets {
@@ -206,9 +204,6 @@ func refreshTablets(tablets map[string]*topo.TabletInfo, query string, args []an
 		}
 		tabletAliasString := topoproto.TabletAliasString(tablet.Alias)
 		latestInstances[tabletAliasString] = true
-		if tablet.MysqlHostname == "" {
-			continue
-		}
 		old, err := inst.ReadTablet(tabletAliasString)
 		if err != nil && err != inst.ErrTabletAliasNil {
 			log.Error(err)

--- a/go/vt/vtorc/logic/tablet_discovery_test.go
+++ b/go/vt/vtorc/logic/tablet_discovery_test.go
@@ -142,22 +142,28 @@ func TestRefreshTabletsInKeyspaceShard(t *testing.T) {
 	})
 
 	t.Run("tablet shutdown removes mysql hostname and port. We shouldn't forget the tablet", func(t *testing.T) {
+		startPort := tab100.MysqlPort
+		startHostname := tab100.MysqlHostname
 		defer func() {
+			tab100.MysqlPort = startPort
+			tab100.MysqlHostname = startHostname
 			_, err = ts.UpdateTabletFields(context.Background(), tab100.Alias, func(tablet *topodatapb.Tablet) error {
-				tablet.MysqlHostname = hostname
-				tablet.MysqlPort = 100
+				tablet.MysqlHostname = startHostname
+				tablet.MysqlPort = startPort
 				return nil
 			})
 		}()
-		// Let's assume tab100 shutdown. This would clear its tablet hostname and port
+		// Let's assume tab100 shutdown. This would clear its tablet hostname and port.
+		tab100.MysqlPort = 0
+		tab100.MysqlHostname = ""
 		_, err = ts.UpdateTabletFields(context.Background(), tab100.Alias, func(tablet *topodatapb.Tablet) error {
 			tablet.MysqlHostname = ""
 			tablet.MysqlPort = 0
 			return nil
 		})
 		require.NoError(t, err)
-		// We expect no tablets to be refreshed. Also, tab100 shouldn't be forgotten
-		verifyRefreshTabletsInKeyspaceShard(t, false, 0, tablets, nil)
+		// tab100 shouldn't be forgotten
+		verifyRefreshTabletsInKeyspaceShard(t, false, 1, tablets, nil)
 	})
 
 	t.Run("change a tablet and call refreshTabletsInKeyspaceShard again", func(t *testing.T) {

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -87,7 +87,7 @@ func TestAnalysisEntriesHaveSameRecovery(t *testing.T) {
 	t.Parallel()
 	for _, tt := range tests {
 		t.Run(string(tt.prevAnalysisCode)+","+string(tt.newAnalysisCode), func(t *testing.T) {
-			res := analysisEntriesHaveSameRecovery(inst.ReplicationAnalysis{Analysis: tt.prevAnalysisCode}, inst.ReplicationAnalysis{Analysis: tt.newAnalysisCode})
+			res := analysisEntriesHaveSameRecovery(&inst.ReplicationAnalysis{Analysis: tt.prevAnalysisCode}, &inst.ReplicationAnalysis{Analysis: tt.newAnalysisCode})
 			require.Equal(t, tt.shouldBeEqual, res)
 		})
 	}
@@ -117,7 +117,7 @@ func TestElectNewPrimaryPanic(t *testing.T) {
 	}
 	err = inst.SaveTablet(tablet)
 	require.NoError(t, err)
-	analysisEntry := inst.ReplicationAnalysis{
+	analysisEntry := &inst.ReplicationAnalysis{
 		AnalyzedInstanceAlias: topoproto.TabletAliasString(tablet.Alias),
 	}
 	ts = memorytopo.NewServer("zone1")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR reworks the VTOrc failure detection logic to include a post-process phase after the initial analysis has run. This is needed because sometimes we need to look at information from analyses of multiple tablets and not just from one. One such case (implemented in this PR), is that of having a primary which is already broken when VTOrc comes up. In this case, VTOrc won't be able to reach the instance and previously it would infer a `ClusterHasNoPrimary` recovery, but that isn't correct. Instead we create a new failure mode called `InvalidPrimary` signifying that VTOrc hasn't been able to reach the given primary tablet.

If VTOrc detects the `InvalidPrimary` failure, it checks whether all the other tablets in the given keyspace shard have their replication broken or not. If the replication for all of them are broken, then we assume that the primary is actually dead and change the `InvalidPrimary` recovery to `DeadPrimary`. When we do this, we also remove all the other issues like `ReplicationStopped`, since an ERS will fix them all up.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #13189 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
