### PR TITLE
[16.0] Fix: TabletServer ReserveBeginExecute to return transaction ID on error

### DIFF
--- a/go/vt/vttablet/grpcqueryservice/server.go
+++ b/go/vt/vttablet/grpcqueryservice/server.go
@@ -422,8 +422,8 @@ func (q *query) ReserveBeginExecute(ctx context.Context, request *querypb.Reserv
 	)
 	state, result, err := q.server.ReserveBeginExecute(ctx, request.Target, request.PreQueries, request.PostBeginQueries, request.Query.Sql, request.Query.BindVariables, request.Options)
 	if err != nil {
-		// if we have a valid reservedID, return the error in-band
-		if state.ReservedID != 0 {
+		// if we have a valid reservedID or transactionID, return the error in-band
+		if state.TransactionID != 0 || state.ReservedID != 0 {
 			return &querypb.ReserveBeginExecuteResponse{
 				Error:               vterrors.ToVTRPC(err),
 				TransactionId:       state.TransactionID,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the issue with `ReserveBeginExecute` to return transaction ID on error. 
Without this fix, the transaction was lost and was only cleared by the transaction killer.

There is a separate PR for main: https://github.com/vitessio/vitess/pull/13127


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Fixes https://github.com/vitessio/vitess/issues/13192

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported 15.0
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
