### PR TITLE
Temporarily disable panic in mysqld when socket files are directly used

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1276,7 +1276,10 @@ func (mysqld *Mysqld) ApplyBinlogFile(ctx context.Context, binlogFile string, re
 // remote through mysqlctl.
 func noSocketFile() {
 	if socketFile != "" {
-		panic("Running remotely through mysqlctl, socketFile must not be set")
+		// We log an error for now until we fix the issue with ApplySchema,
+		// see https://github.com/vitessio/vitess/pull/13178
+		//panic("Running remotely through mysqlctl, socketFile must not be set")
+		log.Error("Running remotely through mysqlctl, socketFile must not be set")
 	}
 }
 

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1276,8 +1276,8 @@ func (mysqld *Mysqld) ApplyBinlogFile(ctx context.Context, binlogFile string, re
 // remote through mysqlctl.
 func noSocketFile() {
 	if socketFile != "" {
-		// We log an error for now until we fix the issue with ApplySchema,
-		// see https://github.com/vitessio/vitess/pull/13178
+		// We log an error for now until we fix the issue with ApplySchema surfacing in MoveTables.
+		// See https://github.com/vitessio/vitess/issues/13203 and https://github.com/vitessio/vitess/pull/13178
 		//panic("Running remotely through mysqlctl, socketFile must not be set")
 		log.Error("Running remotely through mysqlctl, socketFile must not be set")
 	}

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1279,7 +1279,7 @@ func noSocketFile() {
 		// We log an error for now until we fix the issue with ApplySchema surfacing in MoveTables.
 		// See https://github.com/vitessio/vitess/issues/13203 and https://github.com/vitessio/vitess/pull/13178
 		//panic("Running remotely through mysqlctl, socketFile must not be set")
-		log.Error("Running remotely through mysqlctl, socketFile must not be set")
+		log.Warning("Running remotely through mysqlctl and thus socketFile should not be set")
 	}
 }
 


### PR DESCRIPTION
## Description

The change in #13123 will cause `MoveTables` workflows to panic in certain cases because they use the mysql CLI directly to create the schema of new tables on the target.

The real fix is at https://github.com/vitessio/vitess/pull/13178. However that has exposed a race where vttablets don't always find the newly created tables. To move forward with the v17 RC1 release we comment out the panic until we find a proper solution for this.

## Related Issue(s)

Temporary fix for https://github.com/vitessio/vitess/issues/13203

Also:
#13123 
#13178

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

