### PR TITLE
vindexes: make lookup_unicodeloosemd5_hash non-planable

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -524,12 +524,12 @@
         },
         "TargetTabletType": "PRIMARY",
         "ChangedVindexValues": [
-          "email_user_map:3"
+          "email_user_map:4"
         ],
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "MultiShardAutocommit": false,
-        "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io' from user_metadata where user_id = 1 for update",
+        "OwnedVindexQuery": "select user_id, email, address, non_planable, email = 'juan@vitess.io' from user_metadata where user_id = 1 for update",
         "Query": "update user_metadata set email = 'juan@vitess.io' where user_id = 1",
         "Table": "user_metadata",
         "Values": [
@@ -553,12 +553,12 @@
         },
         "TargetTabletType": "PRIMARY",
         "ChangedVindexValues": [
-          "email_user_map:3"
+          "email_user_map:4"
         ],
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "MultiShardAutocommit": false,
-        "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io' from user_metadata where user_id = 1 for update",
+        "OwnedVindexQuery": "select user_id, email, address, non_planable, email = 'juan@vitess.io' from user_metadata where user_id = 1 for update",
         "Query": "update user_metadata set email = 'juan@vitess.io' where user_id = 1",
         "Table": "user_metadata",
         "Values": [
@@ -591,13 +591,13 @@
         },
         "TargetTabletType": "PRIMARY",
         "ChangedVindexValues": [
-          "address_user_map:4",
-          "email_user_map:3"
+          "address_user_map:5",
+          "email_user_map:4"
         ],
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "MultiShardAutocommit": false,
-        "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io', address = '155 5th street' from user_metadata where user_id = 1 for update",
+        "OwnedVindexQuery": "select user_id, email, address, non_planable, email = 'juan@vitess.io', address = '155 5th street' from user_metadata where user_id = 1 for update",
         "Query": "update user_metadata set email = 'juan@vitess.io', address = '155 5th street' where user_id = 1",
         "Table": "user_metadata",
         "Values": [
@@ -621,13 +621,13 @@
         },
         "TargetTabletType": "PRIMARY",
         "ChangedVindexValues": [
-          "address_user_map:4",
-          "email_user_map:3"
+          "address_user_map:5",
+          "email_user_map:4"
         ],
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "MultiShardAutocommit": false,
-        "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io', address = '155 5th street' from user_metadata where user_id = 1 for update",
+        "OwnedVindexQuery": "select user_id, email, address, non_planable, email = 'juan@vitess.io', address = '155 5th street' from user_metadata where user_id = 1 for update",
         "Query": "update user_metadata set email = 'juan@vitess.io', address = '155 5th street' where user_id = 1",
         "Table": "user_metadata",
         "Values": [
@@ -655,12 +655,12 @@
         },
         "TargetTabletType": "PRIMARY",
         "ChangedVindexValues": [
-          "email_user_map:3"
+          "email_user_map:4"
         ],
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "MultiShardAutocommit": false,
-        "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io' from user_metadata where user_id = 1 order by user_id asc limit 10 for update",
+        "OwnedVindexQuery": "select user_id, email, address, non_planable, email = 'juan@vitess.io' from user_metadata where user_id = 1 order by user_id asc limit 10 for update",
         "Query": "update user_metadata set email = 'juan@vitess.io' where user_id = 1 order by user_id asc limit 10",
         "Table": "user_metadata",
         "Values": [
@@ -684,12 +684,12 @@
         },
         "TargetTabletType": "PRIMARY",
         "ChangedVindexValues": [
-          "email_user_map:3"
+          "email_user_map:4"
         ],
         "KsidLength": 1,
         "KsidVindex": "user_index",
         "MultiShardAutocommit": false,
-        "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io' from user_metadata where user_id = 1 order by user_id asc limit 10 for update",
+        "OwnedVindexQuery": "select user_id, email, address, non_planable, email = 'juan@vitess.io' from user_metadata where user_id = 1 order by user_id asc limit 10 for update",
         "Query": "update user_metadata set email = 'juan@vitess.io' where user_id = 1 order by user_id asc limit 10",
         "Table": "user_metadata",
         "Values": [

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -8018,5 +8018,50 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "Query with non-plannable lookup vindex",
+    "query": "SELECT * FROM user_metadata WHERE user_metadata.non_planable = 'foo'",
+    "v3-plan": {
+      "QueryType": "SELECT",
+      "Original": "SELECT * FROM user_metadata WHERE user_metadata.non_planable = 'foo'",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Equal",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select * from user_metadata where 1 != 1",
+        "Query": "select * from user_metadata where user_metadata.non_planable = 'foo'",
+        "Table": "user_metadata",
+        "Values": [
+          "VARCHAR(\"foo\")"
+        ],
+        "Vindex": "non_planable_user_map"
+      }
+    },
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "SELECT * FROM user_metadata WHERE user_metadata.non_planable = 'foo'",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Equal",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select * from user_metadata where 1 != 1",
+        "Query": "select * from user_metadata where user_metadata.non_planable = 'foo'",
+        "Table": "user_metadata",
+        "Values": [
+          "VARCHAR(\"foo\")"
+        ],
+        "Vindex": "non_planable_user_map"
+      },
+      "TablesUsed": [
+        "user.user_metadata"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
@@ -124,6 +124,15 @@
         "name_muticoltbl_map": {
           "type": "name_lkp_test",
           "owner": "multicol_tbl"
+        },
+        "non_planable_user_map": {
+          "type": "lookup_unicodeloosemd5_hash",
+          "params": {
+            "table": "non_planable_user_vdx",
+            "from": "non_planable",
+            "to": "keyspace_id"
+          },
+          "owner": "user_metadata"
         }
       },
       "tables": {
@@ -188,6 +197,10 @@
             {
               "column": "md5",
               "name": "user_md5_index"
+            },
+            {
+              "column": "non_planable",
+              "name": "non_planable_user_map"
             }
           ]
         },
@@ -377,6 +390,14 @@
           "column_vindexes": [
             {
               "column": "name",
+              "name": "user_index"
+            }
+          ]
+        },
+        "non_planable_user_vdx": {
+          "column_vindexes": [
+            {
+              "column": "non_planable",
               "name": "user_index"
             }
           ]


### PR DESCRIPTION
## Description

https://github.com/vitessio/vitess/pull/10490 externalized a lot of the logic of lookup vindexes, so that Gen4 planner can ask lookup vindexes "how should I perform the lookup query?", and then runs the query. This works for other lookup vindexes, but doesn't appear to take into account the internal hashing logic of the `lookup_unicodeloosemd5_hash`  vindexes. 

https://github.com/vitessio/vitess/blob/090ca9597e0cf88646af1fc47865120ac1f491e1/go/vt/vtgate/vindexes/lookup_unicodeloosemd5_hash.go#L127-L131

I think what would need to happen for those vindexes to properly implement `LookupPlannable` is to expose a method like `ConvertIDs` which the planner could use to convert IDs before binding them to the result of `Query()`.

That might be more effort than it is worth. Since these vindexes are deprecated ([according to docs](https://vitess.io/docs/16.0/reference/features/vindexes/#predefined-vindexes) anyway), this PR offers having these Vindexes un-implement `LookupPlanable` as a low-effort, short-term solution to make them work with the Gen4 planner.

## Related Issue(s)

* https://github.com/vitessio/vitess/issues/13140

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported 15.0 and 16.0
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
