### PR TITLE
`FullStatus` RPC: return `error` from heartbeat writer

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -63,7 +63,7 @@ func (tm *TabletManager) ReplicationStatus(ctx context.Context) (*replicationdat
 // FullStatus returns the full status of MySQL including the replication information, semi-sync information, GTID information among others
 func (tm *TabletManager) FullStatus(ctx context.Context) (*replicationdatapb.FullStatus, error) {
 	// Return error if heartbeat writer has an error. This indicates a
-	// problem with the PRIMARY.
+	// problem with INSERT'ing to the PRIMARY.
 	heartbeatWriter := tm.QueryServiceControl.HeartbeatWriter()
 	if err := heartbeatWriter.LastError(); err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -62,6 +62,13 @@ func (tm *TabletManager) ReplicationStatus(ctx context.Context) (*replicationdat
 
 // FullStatus returns the full status of MySQL including the replication information, semi-sync information, GTID information among others
 func (tm *TabletManager) FullStatus(ctx context.Context) (*replicationdatapb.FullStatus, error) {
+	// Return error if heartbeat writer has an error. This indicates a
+	// problem with the PRIMARY.
+	heartbeatWriter := tm.QueryServiceControl.HeartbeatWriter()
+	if err := heartbeatWriter.LastError(); err != nil {
+		return nil, err
+	}
+
 	// Server ID - "select @@global.server_id"
 	serverID, err := tm.MysqlDaemon.GetServerID(ctx)
 	if err != nil {

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -62,8 +62,9 @@ func (tm *TabletManager) ReplicationStatus(ctx context.Context) (*replicationdat
 
 // FullStatus returns the full status of MySQL including the replication information, semi-sync information, GTID information among others
 func (tm *TabletManager) FullStatus(ctx context.Context) (*replicationdatapb.FullStatus, error) {
-	// Return error if heartbeat writer has an error. This indicates a
-	// problem with INSERT'ing to the PRIMARY.
+	// Raise errors from the heartbeat writer. This indicates a problem
+	// with INSERT'ing to the PRIMARY. Non-PRIMARY tablets return nil
+	// because they don't write heartbeats
 	heartbeatWriter := tm.QueryServiceControl.HeartbeatWriter()
 	if err := heartbeatWriter.LastError(); err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletserver/controller.go
+++ b/go/vt/vttablet/tabletserver/controller.go
@@ -23,6 +23,7 @@ import (
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/heartbeat"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/rules"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -89,6 +90,9 @@ type Controller interface {
 
 	// TopoServer returns the topo server.
 	TopoServer() *topo.Server
+
+	// HeartbeatWriter returns the heartbeat writer.
+	HeartbeatWriter() heartbeat.HeartbeatWriter
 }
 
 // Ensure TabletServer satisfies Controller interface.

--- a/go/vt/vttablet/tabletserver/heartbeat/heartbeat_writer.go
+++ b/go/vt/vttablet/tabletserver/heartbeat/heartbeat_writer.go
@@ -19,4 +19,5 @@ package heartbeat
 //revive:disable because that's the name I want to use
 type HeartbeatWriter interface {
 	RequestHeartbeats()
+	LastError() error
 }

--- a/go/vt/vttablet/tabletserver/repltracker/writer.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer.go
@@ -145,6 +145,7 @@ func (w *heartbeatWriter) Open() {
 		go w.RequestHeartbeats()
 	}
 
+	w.errorChan = make(chan error, 2)
 	w.isOpen = true
 }
 
@@ -163,6 +164,7 @@ func (w *heartbeatWriter) Close() {
 	w.appPool.Close()
 	w.allPrivsPool.Close()
 	w.isOpen = false
+	close(w.errorChan)
 	log.Info("Hearbeat Writer: closed")
 }
 

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -57,6 +57,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/onlineddl"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/gc"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/heartbeat"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/messager"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/repltracker"
@@ -453,6 +454,11 @@ func (tsv *TabletServer) ClearQueryPlanCache() {
 	// but query plan cache clearing is safe to call even if the
 	// tabletserver is down.
 	tsv.qe.ClearQueryPlanCache()
+}
+
+// HeartbeatWriter returns the heartbeat writer part of TabletServer.
+func (tsv *TabletServer) HeartbeatWriter() heartbeat.HeartbeatWriter {
+	return tsv.rt.HeartbeatWriter()
 }
 
 // QueryService returns the QueryService part of TabletServer.

--- a/go/vt/vttablet/tabletservermock/controller.go
+++ b/go/vt/vttablet/tabletservermock/controller.go
@@ -108,7 +108,7 @@ func NewController() *Controller {
 		StateChanges:        make(chan *StateChange, 10),
 		queryRulesMap:       make(map[string]*rules.Rules),
 		replTracker: repltracker.NewReplTracker(
-			tabletenv.NewEnv("tabletservermock", tabletenv.NewDefaultConfig()),
+			tabletenv.NewEnv(tabletenv.NewDefaultConfig(), "tabletservermock"),
 			nil,
 		),
 	}

--- a/go/vt/vttablet/tabletservermock/controller.go
+++ b/go/vt/vttablet/tabletservermock/controller.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/heartbeat"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/rules"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -216,6 +217,11 @@ func (tqsc *Controller) BroadcastHealth() {
 // TopoServer is part of the tabletserver.Controller interface.
 func (tqsc *Controller) TopoServer() *topo.Server {
 	return tqsc.TS
+}
+
+// HeartbeatWriter returns the heartbeat writer.
+func (tqsc *Controller) HeartbeatWriter() heartbeat.HeartbeatWriter {
+	return tqsc.TS.HeartbeatWriter()
 }
 
 // EnterLameduck implements tabletserver.Controller.

--- a/go/vt/vttablet/tabletservermock/controller.go
+++ b/go/vt/vttablet/tabletservermock/controller.go
@@ -93,7 +93,7 @@ type Controller struct {
 	isInLameduck bool
 
 	// queryRulesMap has the latest query rules.
-	queryRulesMap map[string]*rules.Rule
+	queryRulesMap map[string]*rules.Rules
 
 	// replTracker has the replication tracker.
 	replTracker *repltracker.ReplTracker
@@ -108,7 +108,7 @@ func NewController() *Controller {
 		StateChanges:        make(chan *StateChange, 10),
 		queryRulesMap:       make(map[string]*rules.Rules),
 		replTracker: repltracker.NewReplTracker(
-			tabletenv.New("tabletservermock", tabletenv.NewDefaultConfig()),
+			tabletenv.NewEnv("tabletservermock", tabletenv.NewDefaultConfig()),
 			nil,
 		),
 	}


### PR DESCRIPTION
## Description

This PR causes the `FullStatus` RPC to return errors from the heartbeat writer, if any

Errors from writing heartbeats is used to indicate a problem with `PRIMARY` tablets, which should be the only tablet actively running `.writeHeartbeat()`. An example problem-scenario this would detect is a `PRIMARY` in a stalled-but-alive state

The driver for this new `error`-response is for `vtorc` to remediate this scenario

As an example, our production encounters a unsolved scenario where:
1. `PRIMARY` is alive/reachable but stalled. Write operations are blocked waiting
    - This can be simulated with `fscheck --freeze /path/to/mysql/datadir`
    - `REPLICA` com-dump connections remain open and healthy to the stalled `mysqld`
    - `/proc/sys/kernel/hung_task_warnings` counters increase due to stalled tasks
1. `REPLICA`s believe the `PRIMARY` is healthy
    - IO thread: `Yes`
        - Because the com-dump connection isn't impacted
    - SQL thread: `Yes`
    - From the `REPLICA`'s perspective we are healthy but there are no new writes
1. `FullStatus` RPCs continue to respond to `vtorc`

We assume this issue is triggered by failures in our storage hardware as `vttablet` and `mysqld` remain alive, but we are yet to confirm this

## Related Issue(s)

https://vitess.slack.com/archives/C02GSRZ8XAN/p1685456224040299

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
