### PR TITLE
schemadiff: validating case-sensitive view names

### DIFF
--- a/go/vt/schemadiff/diff_test.go
+++ b/go/vt/schemadiff/diff_test.go
@@ -777,6 +777,22 @@ func TestDiffSchemas(t *testing.T) {
 				"CREATE TABLE `t4` (\n\t`id` int,\n\tPRIMARY KEY (`id`)\n)",
 			},
 		},
+		{
+			// Making sure schemadiff distinguishes between VIEWs with different casing
+			name: "case insensitive views",
+			from: "create view v1 as select * from t; create table t(id int primary key); create view V1 as select * from t",
+			to:   "",
+			diffs: []string{
+				"drop view v1",
+				"drop view V1",
+				"drop table t",
+			},
+			cdiffs: []string{
+				"DROP VIEW `v1`",
+				"DROP VIEW `V1`",
+				"DROP TABLE `t`",
+			},
+		},
 	}
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {


### PR DESCRIPTION

## Description

This PR complements https://github.com/vitessio/vitess/pull/13107 and adds a `schemadiff` validation for capitonym views.


## Related Issue(s)

- https://github.com/vitessio/vitess/issues/13105
- https://github.com/vitessio/vitess/issues/13107

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
