### PR TITLE
gentler warning message on config-not-found

### DIFF
--- a/go/viperutil/config.go
+++ b/go/viperutil/config.go
@@ -165,7 +165,7 @@ func LoadConfig() (context.CancelFunc, error) {
 			msg := "Failed to read in config %s: %s"
 			switch configFileNotFoundHandling.Get() {
 			case WarnOnConfigFileNotFound:
-				msg += ". This is optional, and can be ignored if you are not using config files. For further reading, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files."
+				msg += ". This is optional, and can be ignored if you are not using config files. For a detailed explanation, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files."
 				log.WARN(msg, registry.Static.ConfigFileUsed(), nferr.Error())
 				fallthrough // after warning, ignore the error
 			case IgnoreConfigFileNotFound:

--- a/go/viperutil/config.go
+++ b/go/viperutil/config.go
@@ -165,6 +165,7 @@ func LoadConfig() (context.CancelFunc, error) {
 			msg := "Failed to read in config %s: %s"
 			switch configFileNotFoundHandling.Get() {
 			case WarnOnConfigFileNotFound:
+				msg += ". This is optional, and can be ignored if you are not using config files. For further reading, see https://github.com/vitessio/vitess/blob/main/doc/viper/viper.md#config-files."
 				log.WARN(msg, registry.Static.ConfigFileUsed(), nferr.Error())
 				fallthrough // after warning, ignore the error
 			case IgnoreConfigFileNotFound:


### PR DESCRIPTION

## Description

Makes the error message (for `WARN` _only_ ) indicate optionality and provide additional resources.

## Related Issue(s)

#11456 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
