### PR TITLE
fix: GetField to use existing session for query

### DIFF
--- a/go/test/endtoend/vtgate/transaction/single/main_test.go
+++ b/go/test/endtoend/vtgate/transaction/single/main_test.go
@@ -20,15 +20,16 @@ import (
 	"context"
 	_ "embed"
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/test/endtoend/utils"
-
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder"
 )
 
 var (
@@ -70,6 +71,7 @@ func TestMain(m *testing.M) {
 		}
 
 		// Start vtgate
+		clusterInstance.VtGatePlannerVersion = planbuilder.Gen4
 		clusterInstance.VtGateExtraArgs = []string{"--transaction_mode", "SINGLE"}
 		err = clusterInstance.StartVtgate()
 		if err != nil {
@@ -168,12 +170,8 @@ func TestLookupDangleRowLaterMultiDB(t *testing.T) {
 }
 
 func TestLookupDangleRowRecordInSameShard(t *testing.T) {
-	conn, err := mysql.Connect(context.Background(), &vtParams)
-	require.NoError(t, err)
-	defer conn.Close()
-	defer func() {
-		utils.Exec(t, conn, `delete from txn_unique_constraints where txn_id = 'txn1'`)
-	}()
+	conn, cleanup := setup(t)
+	defer cleanup()
 
 	// insert a dangling row in lookup table
 	utils.Exec(t, conn, `INSERT INTO uniqueConstraint_vdx(unique_constraint, keyspace_id) VALUES ('foo', 'J\xda\xf0p\x0e\xcc(\x8fਁ\xa7P\x86\xa5=')`)
@@ -190,12 +188,8 @@ func TestLookupDangleRowRecordInSameShard(t *testing.T) {
 }
 
 func TestMultiDbSecondRecordLookupDangle(t *testing.T) {
-	conn, err := mysql.Connect(context.Background(), &vtParams)
-	require.NoError(t, err)
-	defer conn.Close()
-	defer func() {
-		utils.Exec(t, conn, `delete from uniqueConstraint_vdx where unique_constraint = 'bar'`)
-	}()
+	conn, cleanup := setup(t)
+	defer cleanup()
 
 	// insert a dangling row in lookup table
 	utils.Exec(t, conn, `INSERT INTO uniqueConstraint_vdx(unique_constraint, keyspace_id) VALUES ('bar', '\x86\xc8\xc5\x1ac\xfb\x8c+6\xe4\x1f\x03\xd8ϝB')`)
@@ -219,4 +213,36 @@ func TestMultiDbSecondRecordLookupDangle(t *testing.T) {
 
 	// no row should exist.
 	utils.AssertMatches(t, conn, `select txn_id from txn_unique_constraints`, `[]`)
+}
+
+func TestLookupSelectNotFail(t *testing.T) {
+	conn, cleanup := setup(t)
+	defer cleanup()
+
+	utils.AssertMatches(t, conn, `select @@transaction_mode`, `[[VARCHAR("SINGLE")]]`)
+	utils.Exec(t, conn, `begin`)
+	utils.Exec(t, conn, `INSERT INTO t1(id, txn_id) VALUES (1, "t1")`)
+	utils.Exec(t, conn, `SELECT * FROM t2 WHERE id = 1`)
+	utils.Exec(t, conn, `commit`)
+
+}
+
+func setup(t *testing.T) (*mysql.Conn, func()) {
+	t.Helper()
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+
+	tables := []string{
+		"txn_unique_constraints", "uniqueConstraint_vdx",
+		"t1", "t1_id_vdx", "t2", "t2_id_vdx",
+	}
+	cleanup := func() {
+		utils.Exec(t, conn, "set transaction_mode=multi")
+		for _, table := range tables {
+			utils.Exec(t, conn, fmt.Sprintf("delete from %s /* cleanup */", table))
+		}
+		utils.Exec(t, conn, "set transaction_mode=single")
+	}
+	cleanup()
+	return conn, cleanup
 }

--- a/go/test/endtoend/vtgate/transaction/single/schema.sql
+++ b/go/test/endtoend/vtgate/transaction/single/schema.sql
@@ -12,3 +12,27 @@ CREATE TABLE uniqueConstraint_vdx(
     `keyspace_id`       VARBINARY(50) NOT NULL,
     PRIMARY KEY(unique_constraint)
 ) ENGINE=InnoDB;
+
+CREATE TABLE `t1` (
+    `id` bigint(20) NOT NULL,
+    `txn_id` varchar(50) DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `t1_id_vdx` (
+    `id` bigint(20) NOT NULL,
+    `keyspace_id` varbinary(50) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `t2` (
+    `id` bigint(20) NOT NULL,
+    `txn_id` varchar(50) DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `t2_id_vdx` (
+    `id` bigint(20) NOT NULL,
+    `keyspace_id` varbinary(50) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/go/test/endtoend/vtgate/transaction/single/vschema.json
+++ b/go/test/endtoend/vtgate/transaction/single/vschema.json
@@ -13,6 +13,29 @@
         "autocommit": "true"
       },
       "owner": "txn_unique_constraints"
+    },
+    "hash_vdx": {
+      "type": "hash"
+    },
+    "t1_id_vdx": {
+      "type": "consistent_lookup_unique",
+      "params": {
+        "autocommit": "true",
+        "from": "id",
+        "table": "t1_id_vdx",
+        "to": "keyspace_id"
+      },
+      "owner": "t1"
+    },
+    "t2_id_vdx": {
+      "type": "consistent_lookup_unique",
+      "params": {
+        "autocommit": "true",
+        "from": "id",
+        "table": "t2_id_vdx",
+        "to": "keyspace_id"
+      },
+      "owner": "t2"
     }
   },
   "tables": {
@@ -33,6 +56,46 @@
         {
           "column": "unique_constraint",
           "name": "unicode_loose_md5_vdx"
+        }
+      ]
+    },
+    "t1": {
+      "columnVindexes": [
+        {
+          "column": "txn_id",
+          "name": "unicode_loose_md5_vdx"
+        },
+        {
+          "column": "id",
+          "name": "t1_id_vdx"
+        }
+      ]
+    },
+    "t2": {
+      "columnVindexes": [
+        {
+          "column": "txn_id",
+          "name": "unicode_loose_md5_vdx"
+        },
+        {
+          "column": "id",
+          "name": "t2_id_vdx"
+        }
+      ]
+    },
+    "t1_id_vdx": {
+      "columnVindexes": [
+        {
+          "column": "id",
+          "name": "hash_vdx"
+        }
+      ]
+    },
+    "t2_id_vdx": {
+      "columnVindexes": [
+        {
+          "column": "id",
+          "name": "hash_vdx"
         }
       ]
     }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes an issue with `GetField` primitive function to retrieve the Field Information using the available/existing shard session.

When VTGate has `transaction_mode = single` then if VTGate opens `two or more` shard sessions it believes that the transaction has gone `multi-shard` and VTGate implicitly rolls back the transaction.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Fixes https://github.com/vitessio/vitess/issues/13214

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported 17.0
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
