### PR TITLE
VReplication: More intelligently manage vschema table entries on unsharded targets

### DIFF
--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -71,30 +71,37 @@ const (
 	createDDLAsCopyDropForeignKeys = "copy:drop_foreign_keys"
 )
 
-// addTablesToVSchema adds tables to an (unsharded) vschema. Depending on copyAttributes It will also add any sequence info
-// that is associated with a table by copying it from the vschema of the source keyspace.
-// For a migrate workflow we do not copy attributes since the source keyspace is just a proxy to import data into Vitess
-// Todo: For now we only copy sequence but later we may also want to copy other attributes like authoritative column flag and list of columns
-func (wr *Wrangler) addTablesToVSchema(ctx context.Context, sourceKeyspace string, targetVSchema *vschemapb.Keyspace, tables []string, copyAttributes bool) error {
+// addTablesToVSchema adds tables to an (unsharded) vschema if they are not already defined.
+// If copyVschema is true then we copy over the vschema table definitions from the source,
+// otherwise we create empty ones.
+// For a migrate workflow we do not copy the vschema since the source keyspace is just a
+// proxy to import data into Vitess.
+func (wr *Wrangler) addTablesToVSchema(ctx context.Context, sourceKeyspace string, targetVSchema *vschemapb.Keyspace, tables []string, copyVSchema bool) error {
 	if targetVSchema.Tables == nil {
 		targetVSchema.Tables = make(map[string]*vschemapb.Table)
 	}
-	for _, table := range tables {
-		targetVSchema.Tables[table] = &vschemapb.Table{}
-	}
-
-	if copyAttributes { // if source keyspace is provided, copy over the sequence info.
+	if copyVSchema { // If source keyspace is provided, copy over the vschema table definitions.
 		srcVSchema, err := wr.ts.GetVSchema(ctx, sourceKeyspace)
 		if err != nil {
 			return err
 		}
 		for _, table := range tables {
-			srcTable, ok := srcVSchema.Tables[table]
-			if ok {
-				targetVSchema.Tables[table].AutoIncrement = srcTable.AutoIncrement
+			srcTable, sok := srcVSchema.Tables[table]
+			if _, tok := targetVSchema.Tables[table]; sok && !tok {
+				targetVSchema.Tables[table] = srcTable
+				// If going from sharded to unsharded, then we need to remove the
+				// column vindexes as they are not valid for unsharded tables.
+				if srcVSchema.Sharded {
+					targetVSchema.Tables[table].ColumnVindexes = nil
+				}
 			}
 		}
-
+	} else { // Create empty table definitions.
+		for _, table := range tables {
+			if _, tok := targetVSchema.Tables[table]; !tok {
+				targetVSchema.Tables[table] = &vschemapb.Table{}
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

When moving or resharding tables to an _unsharded keyspace_, we currently blindly create empty vschema table entires in the target keyspace. For most cases that's fine, but there are certain kinds of tables that contain additional attributes -- e.g. `type` for sequence or reference tables. Currently you lose that important information and have to manually recreate it yourself.

In this PR we change the behavior so that for _unsharded targets_ we copy the source vschema table entry over _if there's not already one defined_ on the target. In the case of Migrate, where we don't have direct access to the source vschema, we continue to create an empty vschema table entry but _only if the target does not already have one defined_.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13217
  - Fixes: https://github.com/vitessio/vitess/issues/13216

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation is not required