### PR TITLE
add flag to make all queries go use the old horizon planner

### DIFF
--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -44,6 +44,7 @@ var (
 	normalize          bool
 	dbName             string
 	plannerVersionStr  string
+	oldHorizonPlanner  bool
 
 	numShards       = 2
 	replicationMode = "ROW"
@@ -62,6 +63,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&ksShardMapFileFlag, "ks-shard-map-file", ksShardMapFileFlag, "File containing json blob of keyspace name -> shard name -> ShardReference object")
 	fs.StringVar(&replicationMode, "replication-mode", replicationMode, "The replication mode to simulate -- must be set to either ROW or STATEMENT")
 	fs.BoolVar(&normalize, "normalize", normalize, "Whether to enable vtgate normalization")
+	fs.BoolVar(&oldHorizonPlanner, "old-horizon-planner", false, "Falls back to using the V16 horizon planner")
 	fs.StringVar(&dbName, "dbname", dbName, "Optional database target to override normal routing")
 	fs.StringVar(&plannerVersionStr, "planner-version", plannerVersionStr, "Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4. An empty value will use VTGate's default planner")
 	fs.IntVar(&numShards, "shards", numShards, "Number of shards per keyspace. Passing --ks-shard-map/--ks-shard-map-file causes this flag to be ignored.")
@@ -138,12 +140,13 @@ func parseAndRun() error {
 	}
 
 	opts := &vtexplain.Options{
-		ExecutionMode:   executionMode,
-		PlannerVersion:  plannerVersion,
-		ReplicationMode: replicationMode,
-		NumShards:       numShards,
-		Normalize:       normalize,
-		Target:          dbName,
+		ExecutionMode:     executionMode,
+		PlannerVersion:    plannerVersion,
+		ReplicationMode:   replicationMode,
+		NumShards:         numShards,
+		Normalize:         normalize,
+		Target:            dbName,
+		OldHorizonPlanner: oldHorizonPlanner,
 	}
 
 	vte, err := vtexplain.Init(vschema, schema, ksShardMap, opts)

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -91,6 +91,9 @@ type (
 		// Target is used to override the "database" target in the
 		// vtgate session to simulate `USE <target>`
 		Target string
+
+		// OldHorizonPlanner can be used to fall back to the V16 horizon planner
+		OldHorizonPlanner bool
 	}
 
 	// TabletQuery defines a query that was sent to a given tablet and how it was

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -73,7 +73,20 @@ func (vte *VTExplain) initVtgateExecutor(vSchemaStr, ksShardMapStr string, opts 
 
 	streamSize := 10
 	var schemaTracker vtgate.SchemaInfo // no schema tracker for these tests
-	vte.vtgateExecutor = vtgate.NewExecutor(context.Background(), vte.explainTopo, vtexplainCell, resolver, opts.Normalize, false, streamSize, cache.DefaultConfig, schemaTracker, false, opts.PlannerVersion)
+	vte.vtgateExecutor = vtgate.NewExecutor(
+		context.Background(),
+		vte.explainTopo,
+		vtexplainCell,
+		resolver,
+		opts.Normalize,
+		false,
+		streamSize,
+		cache.DefaultConfig,
+		schemaTracker,
+		false,
+		opts.PlannerVersion,
+		opts.OldHorizonPlanner,
+	)
 
 	queryLogBufferSize := 10
 	vtgate.SetQueryLogger(streamlog.New[*logstats.LogStats]("VTGate", queryLogBufferSize))

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -174,7 +174,7 @@ func createExecutorEnv() (executor *Executor, sbc1, sbc2, sbclookup *sandboxconn
 	bad.VSchema = badVSchema
 
 	getSandbox(KsTestUnsharded).VSchema = unshardedVSchema
-	executor = NewExecutor(context.Background(), serv, cell, resolver, false, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3)
+	executor = NewExecutor(context.Background(), serv, cell, resolver, false, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3, false)
 
 	key.AnyShardPicker = DestinationAnyShardPickerFirstShard{}
 	// create a new session each time so that ShardSessions don't get re-used across tests
@@ -198,7 +198,7 @@ func createCustomExecutor(vschema string) (executor *Executor, sbc1, sbc2, sbclo
 	sbclookup = hc.AddTestTablet(cell, "0", 1, KsTestUnsharded, "0", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	getSandbox(KsTestUnsharded).VSchema = unshardedVSchema
 
-	executor = NewExecutor(context.Background(), serv, cell, resolver, false, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3)
+	executor = NewExecutor(context.Background(), serv, cell, resolver, false, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3, false)
 	// create a new session each time so that ShardSessions don't get re-used across tests
 	primarySession = &vtgatepb.Session{
 		TargetString: "@primary",
@@ -227,7 +227,7 @@ func createCustomExecutorSetValues(vschema string, values []*sqltypes.Result) (e
 	sbclookup = hc.AddTestTablet(cell, "0", 1, KsTestUnsharded, "0", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	getSandbox(KsTestUnsharded).VSchema = unshardedVSchema
 
-	executor = NewExecutor(context.Background(), serv, cell, resolver, false, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3)
+	executor = NewExecutor(context.Background(), serv, cell, resolver, false, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3, false)
 	// create a new session each time so that ShardSessions don't get re-used across tests
 	primarySession = &vtgatepb.Session{
 		TargetString: "@primary",

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -1498,7 +1498,7 @@ func TestStreamSelectIN(t *testing.T) {
 }
 
 func createExecutor(serv *sandboxTopo, cell string, resolver *Resolver) *Executor {
-	return NewExecutor(context.Background(), serv, cell, resolver, false, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3)
+	return NewExecutor(context.Background(), serv, cell, resolver, false, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3, false)
 }
 
 func TestSelectScatter(t *testing.T) {
@@ -3025,7 +3025,7 @@ func TestStreamOrderByLimitWithMultipleResults(t *testing.T) {
 		count++
 	}
 
-	executor := NewExecutor(context.Background(), serv, cell, resolver, true, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3)
+	executor := NewExecutor(context.Background(), serv, cell, resolver, true, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3, false)
 	before := runtime.NumGoroutine()
 
 	query := "select id, col from user order by id limit 2"

--- a/go/vt/vtgate/executor_stream_test.go
+++ b/go/vt/vtgate/executor_stream_test.go
@@ -61,7 +61,7 @@ func TestStreamSQLSharded(t *testing.T) {
 	for _, shard := range shards {
 		_ = hc.AddTestTablet(cell, shard, 1, "TestExecutor", shard, topodatapb.TabletType_PRIMARY, true, 1, nil)
 	}
-	executor := NewExecutor(context.Background(), serv, cell, resolver, false, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3)
+	executor := NewExecutor(context.Background(), serv, cell, resolver, false, false, testBufferSize, cache.DefaultConfig, nil, false, querypb.ExecuteOptions_V3, false)
 
 	sql := "stream * from sharded_user_msgs"
 	result, err := executorStreamMessages(executor, sql)

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -205,7 +205,7 @@ func buildAlterView(ctx context.Context, vschema plancontext.VSchema, ddl *sqlpa
 		return nil, nil, err
 	}
 
-	selectPlan, err := createInstructionFor(ctx, sqlparser.String(ddl.Select), ddl.Select, reservedVars, vschema, enableOnlineDDL, enableDirectDDL)
+	selectPlan, err := createInstructionFor(ctx, sqlparser.String(ddl.Select), ddl.Select, reservedVars, vschema, enableOnlineDDL, enableDirectDDL, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -247,7 +247,7 @@ func buildCreateView(ctx context.Context, vschema plancontext.VSchema, ddl *sqlp
 	}
 	ddl.ViewName.Qualifier = sqlparser.NewIdentifierCS("")
 
-	selectPlan, err := createInstructionFor(ctx, sqlparser.String(ddl.Select), ddl.Select, reservedVars, vschema, enableOnlineDDL, enableDirectDDL)
+	selectPlan, err := createInstructionFor(ctx, sqlparser.String(ddl.Select), ddl.Select, reservedVars, vschema, enableOnlineDDL, enableDirectDDL, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/vt/vtgate/planbuilder/gen4_compare_v3_planner.go
+++ b/go/vt/vtgate/planbuilder/gen4_compare_v3_planner.go
@@ -114,7 +114,7 @@ func preliminaryChecks(statement sqlparser.Statement) (bool, bool, error) {
 func planWithPlannerVersion(statement sqlparser.Statement, vars *sqlparser.ReservedVars, ctxVSchema plancontext.VSchema, query string, version plancontext.PlannerVersion) (*planResult, error) {
 	ctxVSchema.SetPlannerVersion(version)
 	stmt := sqlparser.CloneStatement(statement)
-	return createInstructionFor(context.Background(), query, stmt, vars, ctxVSchema, false, false)
+	return createInstructionFor(context.Background(), query, stmt, vars, ctxVSchema, false, false, false)
 }
 
 // hasLockPrimitive recursively walks through the given primitive and its children

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -273,10 +273,10 @@ func getStatementAndPlanner(
 ) (selectStmt sqlparser.SelectStatement, configuredPlanner stmtPlanner, err error) {
 	switch stmt := ins.Rows.(type) {
 	case *sqlparser.Select:
-		configuredPlanner, err = getConfiguredPlanner(vschema, buildSelectPlan, stmt, "")
+		configuredPlanner, err = getConfiguredPlanner(vschema, buildSelectPlan, stmt, "", false)
 		selectStmt = stmt
 	case *sqlparser.Union:
-		configuredPlanner, err = getConfiguredPlanner(vschema, buildUnionPlan, stmt, "")
+		configuredPlanner, err = getConfiguredPlanner(vschema, buildUnionPlan, stmt, "", false)
 		selectStmt = stmt
 	default:
 		err = vterrors.VT12001(fmt.Sprintf("INSERT plan with %T", ins.Rows))

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -51,6 +51,11 @@ func errHorizonNotPlanned() error {
 var _errHorizonNotPlanned = vterrors.VT12001("query cannot be fully operator planned")
 
 func tryHorizonPlanning(ctx *plancontext.PlanningContext, root ops.Operator) (output ops.Operator, err error) {
+	if ctx.UseOldHorizonPlanner {
+		err := planOffsetsOnJoins(ctx, root)
+		return root, err
+	}
+
 	backup := Clone(root)
 	defer func() {
 		// If we encounter the _errHorizonNotPlanned error, we'll revert to using the old horizon planning strategy.

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -39,17 +39,26 @@ type PlanningContext struct {
 	// If we during planning have turned this expression into an argument name,
 	// we can continue using the same argument name
 	ReservedArguments map[sqlparser.Expr]string
+
+	UseOldHorizonPlanner bool
 }
 
-func NewPlanningContext(reservedVars *sqlparser.ReservedVars, semTable *semantics.SemTable, vschema VSchema, version querypb.ExecuteOptions_PlannerVersion) *PlanningContext {
+func NewPlanningContext(
+	reservedVars *sqlparser.ReservedVars,
+	semTable *semantics.SemTable,
+	vschema VSchema,
+	version querypb.ExecuteOptions_PlannerVersion,
+	useOldHorizonPlanner bool,
+) *PlanningContext {
 	ctx := &PlanningContext{
-		ReservedVars:      reservedVars,
-		SemTable:          semTable,
-		VSchema:           vschema,
-		JoinPredicates:    map[sqlparser.Expr][]sqlparser.Expr{},
-		SkipPredicates:    map[sqlparser.Expr]any{},
-		PlannerVersion:    version,
-		ReservedArguments: map[sqlparser.Expr]string{},
+		ReservedVars:         reservedVars,
+		SemTable:             semTable,
+		VSchema:              vschema,
+		JoinPredicates:       map[sqlparser.Expr][]sqlparser.Expr{},
+		SkipPredicates:       map[sqlparser.Expr]any{},
+		PlannerVersion:       version,
+		ReservedArguments:    map[sqlparser.Expr]string{},
+		UseOldHorizonPlanner: useOldHorizonPlanner,
 	}
 	return ctx
 }

--- a/go/vt/vtgate/planbuilder/routeGen4.go
+++ b/go/vt/vtgate/planbuilder/routeGen4.go
@@ -90,7 +90,7 @@ func (rb *routeGen4) WireupGen4(ctx *plancontext.PlanningContext) error {
 	}
 	reservedVars := sqlparser.NewReservedVars("vtg", reserved)
 
-	lookupPrimitive, err := gen4SelectStmtPlanner(query, querypb.ExecuteOptions_Gen4, stmt.(sqlparser.SelectStatement), reservedVars, ctx.VSchema)
+	lookupPrimitive, err := gen4SelectStmtPlanner(query, querypb.ExecuteOptions_Gen4, stmt.(sqlparser.SelectStatement), reservedVars, ctx.VSchema, false)
 	if err != nil {
 		return vterrors.Wrapf(err, "failed to plan the lookup query: [%s]", query)
 	}

--- a/go/vt/vtgate/planbuilder/simplifier_test.go
+++ b/go/vt/vtgate/planbuilder/simplifier_test.go
@@ -132,12 +132,12 @@ func keepSameError(query string, reservedVars *sqlparser.ReservedVars, vschema *
 	}
 	rewritten, _ := sqlparser.RewriteAST(stmt, vschema.currentDb(), sqlparser.SQLSelectLimitUnset, "", nil, nil)
 	ast := rewritten.AST
-	_, expected := BuildFromStmt(context.Background(), query, ast, reservedVars, vschema, rewritten.BindVarNeeds, true, true)
+	_, expected := BuildFromStmt(context.Background(), query, ast, reservedVars, vschema, rewritten.BindVarNeeds, true, true, false)
 	if expected == nil {
 		panic("query does not fail to plan")
 	}
 	return func(statement sqlparser.SelectStatement) bool {
-		_, myErr := BuildFromStmt(context.Background(), query, statement, reservedVars, vschema, needs, true, true)
+		_, myErr := BuildFromStmt(context.Background(), query, statement, reservedVars, vschema, needs, true, true, false)
 		if myErr == nil {
 			return false
 		}
@@ -159,7 +159,7 @@ func keepPanicking(query string, reservedVars *sqlparser.ReservedVars, vschema *
 			}
 		}()
 		log.Errorf("trying %s", sqlparser.String(statement))
-		_, _ = BuildFromStmt(context.Background(), query, statement, reservedVars, vschema, needs, true, true)
+		_, _ = BuildFromStmt(context.Background(), query, statement, reservedVars, vschema, needs, true, true, false)
 		log.Errorf("did not panic")
 
 		return false

--- a/go/vt/vtgate/planbuilder/vexplain.go
+++ b/go/vt/vtgate/planbuilder/vexplain.go
@@ -90,7 +90,7 @@ func explainTabPlan(explain *sqlparser.ExplainTab, vschema plancontext.VSchema) 
 }
 
 func buildVExplainVtgatePlan(ctx context.Context, explainStatement sqlparser.Statement, reservedVars *sqlparser.ReservedVars, vschema plancontext.VSchema, enableOnlineDDL, enableDirectDDL bool) (*planResult, error) {
-	innerInstruction, err := createInstructionFor(ctx, sqlparser.String(explainStatement), explainStatement, reservedVars, vschema, enableOnlineDDL, enableDirectDDL)
+	innerInstruction, err := createInstructionFor(ctx, sqlparser.String(explainStatement), explainStatement, reservedVars, vschema, enableOnlineDDL, enableDirectDDL, false)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func buildVExplainVtgatePlan(ctx context.Context, explainStatement sqlparser.Sta
 }
 
 func buildVExplainLoggingPlan(ctx context.Context, explain *sqlparser.VExplainStmt, reservedVars *sqlparser.ReservedVars, vschema plancontext.VSchema, enableOnlineDDL, enableDirectDDL bool) (*planResult, error) {
-	input, err := createInstructionFor(ctx, sqlparser.String(explain.Statement), explain.Statement, reservedVars, vschema, enableOnlineDDL, enableDirectDDL)
+	input, err := createInstructionFor(ctx, sqlparser.String(explain.Statement), explain.Statement, reservedVars, vschema, enableOnlineDDL, enableDirectDDL, false)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -106,6 +106,9 @@ var (
 	// vtgate views flags
 	enableViews bool
 
+	// oldHorizonPlanner uses the v16 horizon planner
+	oldHorizonPlanner bool
+
 	// queryLogToFile controls whether query logs are sent to a file
 	queryLogToFile string
 	// queryLogBufferSize controls how many query logs will be buffered before dropping them if logging is not fast enough
@@ -147,6 +150,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&queryLogBufferSize, "querylog-buffer-size", queryLogBufferSize, "Maximum number of buffered query logs before throttling log output")
 	fs.DurationVar(&messageStreamGracePeriod, "message_stream_grace_period", messageStreamGracePeriod, "the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent.")
 	fs.BoolVar(&enableViews, "enable-views", enableViews, "Enable views support in vtgate.")
+	fs.BoolVar(&oldHorizonPlanner, "old-horizon-planner", false, "Falls back to using the V16 horizon planner")
 }
 func init() {
 	servenv.OnParseFor("vtgate", registerFlags)
@@ -306,6 +310,7 @@ func Init(
 		si,
 		noScatter,
 		pv,
+		oldHorizonPlanner,
 	)
 
 	// connect the schema tracker with the vschema manager


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
