### PR TITLE
Fix and Make aggregation planner handle aggregation functions better

### DIFF
--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -705,7 +705,7 @@ func (cluster *LocalProcessCluster) NewVtgateInstance() *VtgateProcess {
 		cluster.Cell,
 		cluster.Cell,
 		cluster.Hostname,
-		"PRIMARY,REPLICA",
+		"PRIMARY",
 		cluster.TopoProcess.Port,
 		cluster.TmpDirectory,
 		cluster.VtGateExtraArgs,

--- a/go/test/endtoend/utils/utils.go
+++ b/go/test/endtoend/utils/utils.go
@@ -220,7 +220,7 @@ func AssertMatchesWithTimeout(t *testing.T, conn *mysql.Conn, query, expected st
 }
 
 // WaitForAuthoritative waits for a table to become authoritative
-func WaitForAuthoritative(t *testing.T, vtgateProcess cluster.VtgateProcess, ks, tbl string) error {
+func WaitForAuthoritative(t *testing.T, ks, tbl string, readVSchema func() (*interface{}, error)) error {
 	timeout := time.After(10 * time.Second)
 	for {
 		select {
@@ -228,7 +228,7 @@ func WaitForAuthoritative(t *testing.T, vtgateProcess cluster.VtgateProcess, ks,
 			return fmt.Errorf("schema tracking didn't mark table t2 as authoritative until timeout")
 		default:
 			time.Sleep(1 * time.Second)
-			res, err := vtgateProcess.ReadVSchema()
+			res, err := readVSchema()
 			require.NoError(t, err, res)
 			t2Map := getTableT2Map(res, ks, tbl)
 			authoritative, fieldPresent := t2Map["column_list_authoritative"]

--- a/go/test/endtoend/vtgate/gen4/gen4_test.go
+++ b/go/test/endtoend/vtgate/gen4/gen4_test.go
@@ -430,9 +430,9 @@ func TestOuterJoin(t *testing.T) {
 }
 
 func TestUsingJoin(t *testing.T) {
-	require.NoError(t, utils.WaitForAuthoritative(t, clusterInstance.VtgateProcess, shardedKs, "t1"))
-	require.NoError(t, utils.WaitForAuthoritative(t, clusterInstance.VtgateProcess, shardedKs, "t2"))
-	require.NoError(t, utils.WaitForAuthoritative(t, clusterInstance.VtgateProcess, shardedKs, "t3"))
+	require.NoError(t, utils.WaitForAuthoritative(t, shardedKs, "t1", clusterInstance.VtgateProcess.ReadVSchema))
+	require.NoError(t, utils.WaitForAuthoritative(t, shardedKs, "t2", clusterInstance.VtgateProcess.ReadVSchema))
+	require.NoError(t, utils.WaitForAuthoritative(t, shardedKs, "t3", clusterInstance.VtgateProcess.ReadVSchema))
 
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -424,3 +424,15 @@ func TestAggregationRandomOnAnAggregatedValue(t *testing.T) {
 	mcmp.AssertMatchesNoOrder("select /*vt+ PLANNER=gen4 */ A.a, A.b, (A.a / A.b) as d from (select sum(a) as a, sum(b) as b from t10 where a = 100) A;",
 		`[[DECIMAL(100) DECIMAL(10) DECIMAL(10.0000)]]`)
 }
+
+func TestBuggyQueries(t *testing.T) {
+	// These queries have been found to be producing the wrong results by the query fuzzer
+	// Adding them as end2end tests to make sure we never get them wrong again
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec("insert into t10(k, a, b) values (0, 100, 10), (10, 200, 20), (20, null, null)")
+
+	mcmp.AssertMatches("select /*vt+ PLANNER=Gen4 */ sum(t1.a) from t10 as t1, t10 as t2",
+		`[[DECIMAL(900)]]`)
+}

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -33,7 +33,7 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	deleteAll := func() {
 		_, _ = utils.ExecAllowError(t, mcmp.VtConn, "set workload = oltp")
 
-		tables := []string{"t9", "aggr_test", "t3", "t7_xxhash", "aggr_test_dates", "t7_xxhash_idx", "t1", "t2"}
+		tables := []string{"t9", "aggr_test", "t3", "t7_xxhash", "aggr_test_dates", "t7_xxhash_idx", "t1", "t2", "t10"}
 		for _, table := range tables {
 			_, _ = mcmp.ExecAndIgnore("delete from " + table)
 		}

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -435,4 +435,9 @@ func TestBuggyQueries(t *testing.T) {
 
 	mcmp.AssertMatches("select /*vt+ PLANNER=Gen4 */ sum(t1.a) from t10 as t1, t10 as t2",
 		`[[DECIMAL(900)]]`)
+
+	mcmp.AssertMatches("select /*vt+ PLANNER=gen4 */t1.a, sum(t1.a), count(*), t1.a, sum(t1.a), count(*) from t10 as t1, t10 as t2 group by t1.a",
+		"[[NULL NULL INT64(3) NULL NULL INT64(3)] "+
+			"[INT32(100) DECIMAL(300) INT64(3) INT32(100) DECIMAL(300) INT64(3)] "+
+			"[INT32(200) DECIMAL(600) INT64(3) INT32(200) DECIMAL(600) INT64(3)]]")
 }

--- a/go/test/endtoend/vtgate/queries/aggregation/distinct_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/distinct_test.go
@@ -49,5 +49,6 @@ func TestDistinctIt(t *testing.T) {
 		mcmp.AssertMatches("select /*vt+ PLANNER=Gen4 */ distinct val1 from aggr_test order by val1 desc", `[[VARCHAR("e")] [VARCHAR("d")] [VARCHAR("c")] [VARCHAR("b")] [VARCHAR("a")]]`)
 		mcmp.AssertMatchesNoOrder("select /*vt+ PLANNER=Gen4 */ distinct val1, count(*) from aggr_test group by val1", `[[VARCHAR("a") INT64(2)] [VARCHAR("b") INT64(1)] [VARCHAR("c") INT64(2)] [VARCHAR("d") INT64(1)] [VARCHAR("e") INT64(2)]]`)
 		mcmp.AssertMatchesNoOrder("select /*vt+ PLANNER=Gen4 */ distinct val1+val2 from aggr_test", `[[NULL] [FLOAT64(1)] [FLOAT64(3)] [FLOAT64(4)]]`)
+		mcmp.AssertMatchesNoOrder("select /*vt+ PLANNER=Gen4 */ distinct count(*) from aggr_test group by val1", `[[INT64(2)] [INT64(1)]]`)
 	}
 }

--- a/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go
+++ b/go/test/endtoend/vtgate/queries/foundrows/found_rows_test.go
@@ -44,7 +44,7 @@ func TestFoundRows(t *testing.T) {
 	// Wait for schema tracking to run and mark t2 as authoritative before we try out the queries.
 	// Some of the queries depend on schema tracking to run successfully to be able to replace the StarExpr
 	// in the select clause with the definitive column list.
-	err = utils.WaitForAuthoritative(t, clusterInstance.VtgateProcess, keyspaceName, "t2")
+	err = utils.WaitForAuthoritative(t, keyspaceName, "t2", clusterInstance.VtgateProcess.ReadVSchema)
 	require.NoError(t, err)
 	runTests := func(workload string) {
 		mcmp.AssertFoundRowsValue("select * from t2", workload, 5)

--- a/go/vt/vtgate/endtoend/last_insert_id_test.go
+++ b/go/vt/vtgate/endtoend/last_insert_id_test.go
@@ -21,15 +21,18 @@ import (
 	"fmt"
 	"testing"
 
-	"vitess.io/vitess/go/vt/vtgate/evalengine"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/utils"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
 func TestLastInsertId(t *testing.T) {
+	require.NoError(t,
+		utils.WaitForAuthoritative(t, "ks", "t1_last_insert_id", cluster.VTProcess().ReadVSchema))
+
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)
@@ -53,6 +56,9 @@ func TestLastInsertId(t *testing.T) {
 }
 
 func TestLastInsertIdWithRollback(t *testing.T) {
+	require.NoError(t,
+		utils.WaitForAuthoritative(t, "ks", "t1_last_insert_id", cluster.VTProcess().ReadVSchema))
+
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
 	require.NoError(t, err)

--- a/go/vt/vtgate/endtoend/main_test.go
+++ b/go/vt/vtgate/endtoend/main_test.go
@@ -18,6 +18,7 @@ package endtoend
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"os"
 	"testing"
@@ -25,10 +26,9 @@ import (
 	_flag "vitess.io/vitess/go/internal/flag"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/vttest"
-
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	vttestpb "vitess.io/vitess/go/vt/proto/vttest"
+	"vitess.io/vitess/go/vt/vttest"
 )
 
 var (
@@ -37,82 +37,8 @@ var (
 	mysqlParams mysql.ConnParams
 	grpcAddress string
 
-	schema = `
-create table t1(
-	id1 bigint,
-	id2 bigint,
-	primary key(id1)
-) Engine=InnoDB;
-
-create table t1_copy_basic(
-	id1 bigint,
-	id2 bigint,
-	primary key(id1)
-) Engine=InnoDB;
-
-create table t1_copy_all(
-	id1 bigint,
-	id2 bigint,
-	primary key(id1)
-) Engine=InnoDB;
-
-create table t1_copy_resume(
-	id1 bigint,
-	id2 bigint,
-	primary key(id1)
-) Engine=InnoDB;
-
-create table t1_id2_idx(
-	id2 bigint,
-	keyspace_id varbinary(10),
-	primary key(id2)
-) Engine=InnoDB;
-
-create table vstream_test(
-	id bigint,
-	val bigint,
-	primary key(id)
-) Engine=InnoDB;
-
-create table aggr_test(
-	id bigint,
-	val1 varchar(16),
-	val2 bigint,
-	primary key(id)
-) Engine=InnoDB;
-
-create table t2(
-	id3 bigint,
-	id4 bigint,
-	primary key(id3)
-) Engine=InnoDB;
-
-create table t2_id4_idx(
-	id bigint not null auto_increment,
-	id4 bigint,
-	id3 bigint,
-	primary key(id),
-	key idx_id4(id4)
-) Engine=InnoDB;
-
-create table t1_last_insert_id(
-	id bigint not null auto_increment,
-	id1 bigint,
-	primary key(id)
-) Engine=InnoDB;
-
-create table t1_row_count(
-	id bigint not null,
-	id1 bigint,
-	primary key(id)
-) Engine=InnoDB;
-
-create table t1_sharded(
-	id1 bigint,
-	id2 bigint,
-	primary key(id1)
-) Engine=InnoDB;
-`
+	//go:embed schema.sql
+	Schema string
 
 	vschema = &vschemapb.Keyspace{
 		Sharded: true,
@@ -281,7 +207,7 @@ func TestMain(m *testing.M) {
 				},
 			},
 		}
-		if err := cfg.InitSchemas("ks", schema, vschema); err != nil {
+		if err := cfg.InitSchemas("ks", Schema, vschema); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.RemoveAll(cfg.SchemaDir)
 			return 1

--- a/go/vt/vtgate/endtoend/schema.sql
+++ b/go/vt/vtgate/endtoend/schema.sql
@@ -1,0 +1,74 @@
+create table t1(
+                   id1 bigint,
+                   id2 bigint,
+                   primary key(id1)
+) Engine=InnoDB;
+
+create table t1_copy_basic(
+                              id1 bigint,
+                              id2 bigint,
+                              primary key(id1)
+) Engine=InnoDB;
+
+create table t1_copy_all(
+                            id1 bigint,
+                            id2 bigint,
+                            primary key(id1)
+) Engine=InnoDB;
+
+create table t1_copy_resume(
+                               id1 bigint,
+                               id2 bigint,
+                               primary key(id1)
+) Engine=InnoDB;
+
+create table t1_id2_idx(
+                           id2 bigint,
+                           keyspace_id varbinary(10),
+                           primary key(id2)
+) Engine=InnoDB;
+
+create table vstream_test(
+                             id bigint,
+                             val bigint,
+                             primary key(id)
+) Engine=InnoDB;
+
+create table aggr_test(
+                          id bigint,
+                          val1 varchar(16),
+                          val2 bigint,
+                          primary key(id)
+) Engine=InnoDB;
+
+create table t2(
+                   id3 bigint,
+                   id4 bigint,
+                   primary key(id3)
+) Engine=InnoDB;
+
+create table t2_id4_idx(
+                           id bigint not null auto_increment,
+                           id4 bigint,
+                           id3 bigint,
+                           primary key(id),
+                           key idx_id4(id4)
+) Engine=InnoDB;
+
+create table t1_last_insert_id(
+                                  id bigint not null auto_increment,
+                                  id1 bigint,
+                                  primary key(id)
+) Engine=InnoDB;
+
+create table t1_row_count(
+                             id bigint not null,
+                             id1 bigint,
+                             primary key(id)
+) Engine=InnoDB;
+
+create table t1_sharded(
+                           id1 bigint,
+                           id2 bigint,
+                           primary key(id1)
+) Engine=InnoDB;

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -588,8 +588,6 @@ func (cached *OnlineDDL) CachedSize(alloc bool) int64 {
 	}
 	return size
 }
-
-//go:nocheckptr
 func (cached *OrderedAggregate) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -610,17 +608,6 @@ func (cached *OrderedAggregate) CachedSize(alloc bool) int64 {
 		size += hack.RuntimeAllocSize(int64(cap(cached.GroupByKeys)) * int64(8))
 		for _, elem := range cached.GroupByKeys {
 			size += elem.CachedSize(true)
-		}
-	}
-	// field Collations map[int]vitess.io/vitess/go/mysql/collations.ID
-	if cached.Collations != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.Collations)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 96))
-		if len(cached.Collations) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 96))
 		}
 	}
 	// field Input vitess.io/vitess/go/vt/vtgate/engine.Primitive
@@ -898,8 +885,6 @@ func (cached *SQLCalcFoundRows) CachedSize(alloc bool) int64 {
 	}
 	return size
 }
-
-//go:nocheckptr
 func (cached *ScalarAggregate) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -913,17 +898,6 @@ func (cached *ScalarAggregate) CachedSize(alloc bool) int64 {
 		size += hack.RuntimeAllocSize(int64(cap(cached.Aggregates)) * int64(8))
 		for _, elem := range cached.Aggregates {
 			size += elem.CachedSize(true)
-		}
-	}
-	// field Collations map[int]vitess.io/vitess/go/mysql/collations.ID
-	if cached.Collations != nil {
-		size += int64(48)
-		hmap := reflect.ValueOf(cached.Collations)
-		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
-		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
-		size += hack.RuntimeAllocSize(int64(numOldBuckets * 96))
-		if len(cached.Collations) > 0 || numBuckets > 1 {
-			size += hack.RuntimeAllocSize(int64(numBuckets * 96))
 		}
 	}
 	// field Input vitess.io/vitess/go/vt/vtgate/engine.Primitive

--- a/go/vt/vtgate/engine/distinct.go
+++ b/go/vt/vtgate/engine/distinct.go
@@ -35,7 +35,7 @@ type (
 	Distinct struct {
 		Source    Primitive
 		CheckCols []CheckCol
-		Truncate  bool
+		Truncate  int
 	}
 	CheckCol struct {
 		Col       int
@@ -189,8 +189,8 @@ func (d *Distinct) TryExecute(ctx context.Context, vcursor VCursor, bindVars map
 			result.Rows = append(result.Rows, row)
 		}
 	}
-	if d.Truncate {
-		return result.Truncate(len(d.CheckCols)), nil
+	if d.Truncate > 0 {
+		return result.Truncate(d.Truncate), nil
 	}
 	return result, err
 }
@@ -260,8 +260,8 @@ func (d *Distinct) description() PrimitiveDescription {
 		other["Collations"] = colls
 	}
 
-	if d.Truncate {
-		other["ResultColumns"] = len(d.CheckCols)
+	if d.Truncate > 0 {
+		other["ResultColumns"] = d.Truncate
 	}
 	return PrimitiveDescription{
 		Other:        other,

--- a/go/vt/vtgate/engine/distinct_test.go
+++ b/go/vt/vtgate/engine/distinct_test.go
@@ -96,7 +96,6 @@ func TestDistinct(t *testing.T) {
 			distinct := &Distinct{
 				Source:    &fakePrimitive{results: []*sqltypes.Result{tc.inputs}},
 				CheckCols: checkCols,
-				Truncate:  false,
 			}
 
 			qr, err := distinct.TryExecute(context.Background(), &noopVCursor{}, nil, true)
@@ -145,7 +144,7 @@ func TestWeightStringFallBack(t *testing.T) {
 	distinct := &Distinct{
 		Source:    &fakePrimitive{results: []*sqltypes.Result{input}},
 		CheckCols: checkCols,
-		Truncate:  true,
+		Truncate:  1,
 	}
 
 	qr, err := distinct.TryExecute(context.Background(), &noopVCursor{}, nil, true)

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -668,13 +668,13 @@ func TestMerge(t *testing.T) {
 		"1|3|2.8|2|bc",
 	)
 
-	merged, _, err := merge(fields, r.Rows[0], r.Rows[1], nil, nil, oa.Aggregates)
+	merged, _, err := merge(fields, r.Rows[0], r.Rows[1], nil, oa.Aggregates)
 	assert.NoError(err)
 	want := sqltypes.MakeTestResult(fields, "1|5|6.0|2|bc").Rows[0]
 	assert.Equal(want, merged)
 
 	// swap and retry
-	merged, _, err = merge(fields, r.Rows[1], r.Rows[0], nil, nil, oa.Aggregates)
+	merged, _, err = merge(fields, r.Rows[1], r.Rows[0], nil, oa.Aggregates)
 	assert.NoError(err)
 	assert.Equal(want, merged)
 }
@@ -1018,7 +1018,6 @@ func TestOrderedAggregateCollate(t *testing.T) {
 		}},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
 		Input:       fp,
-		Collations:  map[int]collations.ID{0: collationID},
 	}
 
 	result, err := oa.TryExecute(context.Background(), &noopVCursor{}, nil, false)
@@ -1060,7 +1059,6 @@ func TestOrderedAggregateCollateAS(t *testing.T) {
 			Col:    1,
 		}},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
-		Collations:  map[int]collations.ID{0: collationID},
 		Input:       fp,
 	}
 
@@ -1105,7 +1103,6 @@ func TestOrderedAggregateCollateKS(t *testing.T) {
 			Col:    1,
 		}},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
-		Collations:  map[int]collations.ID{0: collationID},
 		Input:       fp,
 	}
 

--- a/go/vt/vtgate/planbuilder/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/aggregation_pushing.go
@@ -226,14 +226,9 @@ func addAggregationToSelect(ctx *plancontext.PlanningContext, sel *sqlparser.Sel
 	return newOffset(len(sel.SelectExprs) - 1)
 }
 
-func countStarAggr() *operators.Aggr {
+func countStarAggr() operators.Aggr {
 	f := &sqlparser.CountStar{}
-
-	return &operators.Aggr{
-		Original: &sqlparser.AliasedExpr{Expr: f},
-		OpCode:   popcode.AggregateCountStar,
-		Alias:    "count(*)",
-	}
+	return operators.NewAggr(popcode.AggregateCountStar, f, &sqlparser.AliasedExpr{Expr: f}, "count(*)")
 }
 
 /*
@@ -446,7 +441,7 @@ func splitAggregationsToLeftAndRight(
 			rhsAggrs = append(rhsAggrs, &newAggr)
 		} else {
 			deps := ctx.SemTable.RecursiveDeps(aggr.Original.Expr)
-			var other *operators.Aggr
+			var other operators.Aggr
 			// if we are sending down min/max/random, we don't have to multiply the results with anything
 			if !isMinOrMax(aggr.OpCode) && !isRandom(aggr.OpCode) {
 				other = countStarAggr()
@@ -454,10 +449,10 @@ func splitAggregationsToLeftAndRight(
 			switch {
 			case deps.IsSolvedBy(join.Left.ContainsTables()):
 				lhsAggrs = append(lhsAggrs, &newAggr)
-				rhsAggrs = append(rhsAggrs, other)
+				rhsAggrs = append(rhsAggrs, &other)
 			case deps.IsSolvedBy(join.Right.ContainsTables()):
 				rhsAggrs = append(rhsAggrs, &newAggr)
-				lhsAggrs = append(lhsAggrs, other)
+				lhsAggrs = append(lhsAggrs, &other)
 			default:
 				return nil, nil, vterrors.VT12001("aggregation on columns from different sources")
 			}

--- a/go/vt/vtgate/planbuilder/distinct.go
+++ b/go/vt/vtgate/planbuilder/distinct.go
@@ -27,10 +27,21 @@ var _ logicalPlan = (*distinct)(nil)
 type distinct struct {
 	logicalPlanCommon
 	checkCols      []engine.CheckCol
+	truncateColumn int
+
+	// needToTruncate is the old way to check weight_string column and set truncation.
 	needToTruncate bool
 }
 
-func newDistinct(source logicalPlan, checkCols []engine.CheckCol, needToTruncate bool) logicalPlan {
+func newDistinct(source logicalPlan, checkCols []engine.CheckCol, truncateColumn int) logicalPlan {
+	return &distinct{
+		logicalPlanCommon: newBuilderCommon(source),
+		checkCols:         checkCols,
+		truncateColumn:    truncateColumn,
+	}
+}
+
+func newDistinctGen4Legacy(source logicalPlan, checkCols []engine.CheckCol, needToTruncate bool) logicalPlan {
 	return &distinct{
 		logicalPlanCommon: newBuilderCommon(source),
 		checkCols:         checkCols,
@@ -47,13 +58,18 @@ func (d *distinct) Primitive() engine.Primitive {
 		// If we are missing the checkCols information, we are on the V3 planner and should produce a V3 Distinct
 		return &engine.DistinctV3{Source: d.input.Primitive()}
 	}
-	truncate := false
+
+	truncate := d.truncateColumn
 	if d.needToTruncate {
+		wsColFound := false
 		for _, col := range d.checkCols {
 			if col.WsCol != nil {
-				truncate = true
+				wsColFound = true
 				break
 			}
+		}
+		if wsColFound {
+			truncate = len(d.checkCols)
 		}
 	}
 	return &engine.Distinct{

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -119,7 +119,7 @@ func transformDistinct(ctx *plancontext.PlanningContext, op *operators.Distinct)
 	if err != nil {
 		return nil, err
 	}
-	return newDistinct(src, op.Columns /*needToTruncate*/, false), nil
+	return newDistinct(src, op.Columns, op.Truncate), nil
 }
 
 func transformOrdering(ctx *plancontext.PlanningContext, op *operators.Ordering) (logicalPlan, error) {
@@ -683,7 +683,7 @@ func transformUnionPlan(ctx *plancontext.PlanningContext, op *operators.Union, i
 		if err != nil {
 			return nil, err
 		}
-		return newDistinct(result, checkCols, isRoot), nil
+		return newDistinctGen4Legacy(result, checkCols, isRoot), nil
 	}
 	return result, nil
 

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -90,12 +90,14 @@ func transformAggregator(ctx *plancontext.PlanningContext, op *operators.Aggrega
 			return nil, vterrors.VT12001(fmt.Sprintf("in scatter query: aggregation function '%s'", sqlparser.String(aggr.Original)))
 		}
 		oa.aggregates = append(oa.aggregates, &engine.AggregateParams{
-			Opcode:     aggr.OpCode,
-			Col:        aggr.ColOffset,
-			Alias:      aggr.Alias,
-			Expr:       aggr.Func,
-			Original:   aggr.Original,
-			OrigOpcode: aggr.OriginalOpCode,
+			Opcode:      aggr.OpCode,
+			Col:         aggr.ColOffset,
+			Alias:       aggr.Alias,
+			Expr:        aggr.Func,
+			Original:    aggr.Original,
+			OrigOpcode:  aggr.OriginalOpCode,
+			WCol:        aggr.WSOffset,
+			CollationID: aggr.GetCollation(ctx),
 		})
 	}
 	for _, groupBy := range op.Grouping {

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -41,10 +41,6 @@ func tryPushingDownAggregator(ctx *plancontext.PlanningContext, aggregator *Aggr
 	case *Filter:
 		output, applyResult, err = pushDownAggregationThroughFilter(ctx, aggregator, src)
 	default:
-		if aggregator.Original {
-			err = vterrors.VT12001(fmt.Sprintf("using aggregation on top of a %T plan", src))
-			return
-		}
 		return aggregator, rewrite.SameTree, nil
 	}
 
@@ -608,6 +604,9 @@ func (p *joinPusher) addGrouping(ctx *plancontext.PlanningContext, gb GroupBy) s
 	if copyGB.ColOffset != -1 {
 		offset := p.useColumn(copyGB.ColOffset)
 		copyGB.ColOffset = offset
+	} else {
+		copyGB.ColOffset = len(p.pushed.Columns)
+		p.pushed.Columns = append(p.pushed.Columns, aeWrap(copyGB.Inner))
 	}
 	p.pushed.Grouping = append(p.pushed.Grouping, copyGB)
 	return expr

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -349,13 +349,12 @@ func splitAggrColumnsToLeftAndRight(
 outer:
 	// we prefer adding the aggregations in the same order as the columns are declared
 	for colIdx, col := range aggregator.Columns {
-		for aggrIdx, aggr := range aggregator.Aggregations {
+		for _, aggr := range aggregator.Aggregations {
 			if aggr.ColOffset == colIdx {
-				aggrToKeep, err := builder.handleAggr(ctx, aggr)
+				err := builder.handleAggr(ctx, aggr)
 				if err != nil {
 					return nil, nil, err
 				}
-				aggregator.Aggregations[aggrIdx] = aggrToKeep
 				continue outer
 			}
 		}
@@ -426,19 +425,19 @@ func (p *joinPusher) countStar(ctx *plancontext.PlanningContext) (*sqlparser.Ali
 	return p.csAE, true
 }
 
-func (ab *aggBuilder) handleAggr(ctx *plancontext.PlanningContext, aggr Aggr) (Aggr, error) {
+func (ab *aggBuilder) handleAggr(ctx *plancontext.PlanningContext, aggr Aggr) error {
 	switch aggr.OpCode {
 	case opcode.AggregateCountStar:
-		return ab.handleCountStar(ctx, aggr)
+		ab.handleCountStar(ctx, aggr)
+		return nil
 	case opcode.AggregateMax, opcode.AggregateMin, opcode.AggregateRandom:
 		return ab.handlePushThroughAggregation(ctx, aggr)
 	case opcode.AggregateCount, opcode.AggregateSum:
 		return ab.handleAggrWithCountStarMultiplier(ctx, aggr)
-
 	case opcode.AggregateUnassigned:
-		return Aggr{}, vterrors.VT12001(fmt.Sprintf("in scatter query: aggregation function '%s'", sqlparser.String(aggr.Original)))
+		return vterrors.VT12001(fmt.Sprintf("in scatter query: aggregation function '%s'", sqlparser.String(aggr.Original)))
 	default:
-		return Aggr{}, errHorizonNotPlanned()
+		return errHorizonNotPlanned()
 	}
 }
 
@@ -460,23 +459,22 @@ func (ab *aggBuilder) pushThroughRight(aggr Aggr) {
 	})
 }
 
-func (ab *aggBuilder) handlePushThroughAggregation(ctx *plancontext.PlanningContext, aggr Aggr) (Aggr, error) {
+func (ab *aggBuilder) handlePushThroughAggregation(ctx *plancontext.PlanningContext, aggr Aggr) error {
 	ab.proj.addUnexploredExpr(aggr.Original, aggr.Original.Expr)
 
 	deps := ctx.SemTable.RecursiveDeps(aggr.Original.Expr)
 	switch {
 	case deps.IsSolvedBy(ab.lhs.tableID):
 		ab.pushThroughLeft(aggr)
-		return aggr, nil
 	case deps.IsSolvedBy(ab.rhs.tableID):
 		ab.pushThroughRight(aggr)
-		return aggr, nil
 	default:
-		return Aggr{}, vterrors.VT12001("aggregation on columns from different sources: " + sqlparser.String(aggr.Original.Expr))
+		return vterrors.VT12001("aggregation on columns from different sources: " + sqlparser.String(aggr.Original.Expr))
 	}
+	return nil
 }
 
-func (ab *aggBuilder) handleCountStar(ctx *plancontext.PlanningContext, aggr Aggr) (Aggr, error) {
+func (ab *aggBuilder) handleCountStar(ctx *plancontext.PlanningContext, aggr Aggr) {
 	// Projection is necessary since we are going to need to do arithmetics to summarize the aggregates
 	ab.projectionRequired = true
 
@@ -484,6 +482,35 @@ func (ab *aggBuilder) handleCountStar(ctx *plancontext.PlanningContext, aggr Agg
 	lhsAE := ab.leftCountStar(ctx)
 	rhsAE := ab.rightCountStar(ctx)
 
+	ab.buildProjectionForAggr(lhsAE, rhsAE, aggr)
+}
+
+func (ab *aggBuilder) handleAggrWithCountStarMultiplier(ctx *plancontext.PlanningContext, aggr Aggr) error {
+	ab.projectionRequired = true
+
+	deps := ctx.SemTable.RecursiveDeps(aggr.Original.Expr)
+
+	var lhsAE, rhsAE *sqlparser.AliasedExpr
+	switch {
+	case deps.IsSolvedBy(ab.lhs.tableID):
+		ab.pushThroughLeft(aggr)
+		lhsAE = aggr.Original
+		rhsAE = ab.rightCountStar(ctx)
+
+	case deps.IsSolvedBy(ab.rhs.tableID):
+		ab.pushThroughRight(aggr)
+		lhsAE = ab.leftCountStar(ctx)
+		rhsAE = aggr.Original
+
+	default:
+		return errHorizonNotPlanned()
+	}
+
+	ab.buildProjectionForAggr(lhsAE, rhsAE, aggr)
+	return nil
+}
+
+func (ab *aggBuilder) buildProjectionForAggr(lhsAE *sqlparser.AliasedExpr, rhsAE *sqlparser.AliasedExpr, aggr Aggr) {
 	// We expect the expressions to be different on each side of the join, otherwise it's an error.
 	if lhsAE.Expr == rhsAE.Expr {
 		panic(fmt.Sprintf("Need the two produced expressions to be different. %T %T", lhsAE, rhsAE))
@@ -513,45 +540,6 @@ func (ab *aggBuilder) handleCountStar(ctx *plancontext.PlanningContext, aggr Agg
 	}
 
 	ab.proj.addUnexploredExpr(projAE, projExpr)
-	return aggr, nil
-}
-
-func (ab *aggBuilder) handleAggrWithCountStarMultiplier(ctx *plancontext.PlanningContext, aggr Aggr) (Aggr, error) {
-	ab.projectionRequired = true
-
-	expr := aggr.Original.Expr
-	deps := ctx.SemTable.RecursiveDeps(expr)
-	var otherSide sqlparser.Expr
-
-	switch {
-	case deps.IsSolvedBy(ab.lhs.tableID):
-		ab.pushThroughLeft(aggr)
-		ae := ab.rightCountStar(ctx)
-		otherSide = ae.Expr
-
-	case deps.IsSolvedBy(ab.rhs.tableID):
-		ab.pushThroughRight(aggr)
-		ae := ab.leftCountStar(ctx)
-		otherSide = ae.Expr
-
-	default:
-		return Aggr{}, errHorizonNotPlanned()
-	}
-
-	if ab.outerJoin {
-		otherSide = coalesceFunc(otherSide)
-	}
-
-	projAE := &sqlparser.AliasedExpr{
-		Expr: aggr.Original.Expr,
-		As:   sqlparser.NewIdentifierCI(aggr.Original.ColumnName()),
-	}
-	ab.proj.addUnexploredExpr(projAE, &sqlparser.BinaryExpr{
-		Operator: sqlparser.MultOp,
-		Left:     expr,
-		Right:    otherSide,
-	})
-	return aggr, nil
 }
 
 func coalesceFunc(e sqlparser.Expr) sqlparser.Expr {
@@ -584,8 +572,10 @@ func (p *joinPusher) addAggr(ctx *plancontext.PlanningContext, aggr Aggr) sqlpar
 // pushThroughAggr pushes through an aggregation without changing dependencies.
 // Can be used for aggregations we can push in one piece
 func (p *joinPusher) pushThroughAggr(aggr Aggr) {
-	p.pushed.Columns = append(p.pushed.Columns, aggr.Original)
-	p.pushed.Aggregations = append(p.pushed.Aggregations, aggr)
+	newAggr := NewAggr(aggr.OpCode, aggr.Func, aggr.Original, aggr.Alias)
+	newAggr.ColOffset = len(p.pushed.Columns)
+	p.pushed.Columns = append(p.pushed.Columns, newAggr.Original)
+	p.pushed.Aggregations = append(p.pushed.Aggregations, newAggr)
 }
 
 // addGrouping creates a copy of the given GroupBy, updates its column offset to point to the correct location in the new Aggregator,

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -420,11 +420,7 @@ func (p *joinPusher) countStar(ctx *plancontext.PlanningContext) (*sqlparser.Ali
 	}
 	cs := &sqlparser.CountStar{}
 	ae := aeWrap(cs)
-	csAggr := Aggr{
-		Original: ae,
-		Func:     cs,
-		OpCode:   opcode.AggregateCountStar,
-	}
+	csAggr := NewAggr(opcode.AggregateCountStar, cs, ae, "")
 	expr := p.addAggr(ctx, csAggr)
 	p.csAE = aeWrap(expr)
 	return p.csAE, true

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -436,8 +436,8 @@ func (ab *aggBuilder) handleAggr(ctx *plancontext.PlanningContext, aggr Aggr) (A
 		return ab.handleCountStar(ctx, aggr)
 	case opcode.AggregateMax, opcode.AggregateMin, opcode.AggregateRandom:
 		return ab.handlePushThroughAggregation(ctx, aggr)
-	case opcode.AggregateCount:
-		return ab.handleCount(ctx, aggr)
+	case opcode.AggregateCount, opcode.AggregateSum:
+		return ab.handleAggrWithCountStarMultiplier(ctx, aggr)
 
 	case opcode.AggregateUnassigned:
 		return Aggr{}, vterrors.VT12001(fmt.Sprintf("in scatter query: aggregation function '%s'", sqlparser.String(aggr.Original)))
@@ -520,7 +520,7 @@ func (ab *aggBuilder) handleCountStar(ctx *plancontext.PlanningContext, aggr Agg
 	return aggr, nil
 }
 
-func (ab *aggBuilder) handleCount(ctx *plancontext.PlanningContext, aggr Aggr) (Aggr, error) {
+func (ab *aggBuilder) handleAggrWithCountStarMultiplier(ctx *plancontext.PlanningContext, aggr Aggr) (Aggr, error) {
 	ab.projectionRequired = true
 
 	expr := aggr.Original.Expr

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -236,11 +236,7 @@ func (a *Aggregator) planOffsets(ctx *plancontext.PlanningContext) error {
 	}
 
 	for idx, aggr := range a.Aggregations {
-		needsWS, err := aggr.NeedWeightString(ctx)
-		if err != nil {
-			return err
-		}
-		if !needsWS {
+		if !aggr.NeedWeightString(ctx) {
 			continue
 		}
 		offset, err := addColumn(aeWrap(weightStringFor(aggr.Func.GetArg())), true)

--- a/go/vt/vtgate/planbuilder/operators/distinct.go
+++ b/go/vt/vtgate/planbuilder/operators/distinct.go
@@ -33,6 +33,8 @@ type (
 
 		// When offset planning, we'll fill in this field
 		Columns []engine.CheckCol
+
+		Truncate int
 	}
 )
 
@@ -72,10 +74,11 @@ func (d *Distinct) planOffsets(ctx *plancontext.PlanningContext) error {
 
 func (d *Distinct) Clone(inputs []ops.Operator) ops.Operator {
 	return &Distinct{
-		Source:  inputs[0],
-		Columns: slices.Clone(d.Columns),
-		QP:      d.QP,
-		Pushed:  d.Pushed,
+		Source:   inputs[0],
+		Columns:  slices.Clone(d.Columns),
+		QP:       d.QP,
+		Pushed:   d.Pushed,
+		Truncate: d.Truncate,
 	}
 }
 
@@ -121,4 +124,8 @@ func (d *Distinct) ShortDescription() string {
 
 func (d *Distinct) GetOrdering() ([]ops.OrderBy, error) {
 	return d.Source.GetOrdering()
+}
+
+func (d *Distinct) setTruncateColumnCount(offset int) {
+	d.Truncate = offset
 }

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -221,12 +221,14 @@ func addOrderBysAndGroupBysForAggregations(ctx *plancontext.PlanningContext, roo
 	visitor := func(in ops.Operator, _ semantics.TableSet, isRoot bool) (ops.Operator, *rewrite.ApplyResult, error) {
 		switch in := in.(type) {
 		case *Aggregator:
-			// first we update the incoming columns, so we know about any new columns that have been added
-			columns, err := in.Source.GetColumns()
-			if err != nil {
-				return nil, nil, err
+			if in.Pushed {
+				// first we update the incoming columns, so we know about any new columns that have been added
+				columns, err := in.Source.GetColumns()
+				if err != nil {
+					return nil, nil, err
+				}
+				in.Columns = columns
 			}
-			in.Columns = columns
 
 			requireOrdering, err := needsOrdering(in, ctx)
 			if err != nil {

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -193,6 +193,8 @@ func tryPushingDownDistinct(in *Distinct) (ops.Operator, *rewrite.ApplyResult, e
 		}
 	case *Distinct:
 		return src, rewrite.NewTree("removed double distinct", src), nil
+	case *Aggregator:
+		return in, rewrite.SameTree, nil
 	}
 
 	cols, err := in.Source.GetColumns()

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -801,20 +801,20 @@ outer:
 			return nil, err
 		}
 		for idx, groupBy := range a.Grouping {
-			if ae == groupBy.aliasedExpr {
+			if ctx.SemTable.EqualsExprWithDeps(groupBy.SimplifiedExpr, ae.Expr) {
 				a.Columns = append(a.Columns, ae)
 				a.Grouping[idx].ColOffset = colIdx
 				continue outer
 			}
 		}
 		for idx, aggr := range a.Aggregations {
-			if ae == aggr.Original {
+			if ctx.SemTable.EqualsExprWithDeps(aggr.Original.Expr, ae.Expr) {
 				a.Columns = append(a.Columns, ae)
 				a.Aggregations[idx].ColOffset = colIdx
 				continue outer
 			}
 		}
-		return nil, vterrors.VT13001(fmt.Sprintf("Could not find the %v in aggregation in the original query", expr))
+		return nil, vterrors.VT13001(fmt.Sprintf("Could not find the %s in aggregation in the original query", sqlparser.String(ae)))
 	}
 
 	return a, nil

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -96,8 +96,7 @@ func tryHorizonPlanning(ctx *plancontext.PlanningContext, root ops.Operator) (ou
 // If we can't, we will instead expand the Horizon into
 // smaller operators and try to push these down as far as possible
 func planHorizons(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Operator, error) {
-	var err error
-	root, err = optimizeHorizonPlanning(ctx, root)
+	root, err := optimizeHorizonPlanning(ctx, root)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -24,6 +24,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
@@ -94,7 +95,9 @@ type (
 		Index    *int
 		Distinct bool
 
-		ColOffset int // points to the column on the same aggregator
+		// the offsets point to columns on the same aggregator
+		ColOffset int
+		WSOffset  int
 	}
 
 	AggrRewriter struct {
@@ -104,6 +107,29 @@ type (
 	}
 )
 
+func (aggr Aggr) NeedWeightString(ctx *plancontext.PlanningContext) (bool, error) {
+	switch aggr.OpCode {
+	case opcode.AggregateCountDistinct, opcode.AggregateSumDistinct:
+		return ctx.SemTable.NeedsWeightString(aggr.Func.GetArg()), nil
+	case opcode.AggregateMin, opcode.AggregateMax:
+		if ctx.SemTable.NeedsWeightString(aggr.Func.GetArg()) {
+			return true, vterrors.VT12001(fmt.Sprintf("column collation not known for the function: %s", sqlparser.String(aggr.Func)))
+		}
+	}
+	return false, nil
+}
+
+func (aggr Aggr) GetCollation(ctx *plancontext.PlanningContext) collations.ID {
+	if aggr.Func == nil {
+		return collations.Unknown
+	}
+	switch aggr.OpCode {
+	case opcode.AggregateMin, opcode.AggregateMax, opcode.AggregateSumDistinct, opcode.AggregateCountDistinct:
+		return ctx.SemTable.CollationForExpr(aggr.Func.GetArg())
+	}
+	return collations.Unknown
+}
+
 // NewGroupBy creates a new group by from the given fields.
 func NewGroupBy(inner, simplified sqlparser.Expr, aliasedExpr *sqlparser.AliasedExpr) GroupBy {
 	return GroupBy{
@@ -112,6 +138,17 @@ func NewGroupBy(inner, simplified sqlparser.Expr, aliasedExpr *sqlparser.Aliased
 		aliasedExpr:    aliasedExpr,
 		ColOffset:      -1,
 		WSOffset:       -1,
+	}
+}
+
+func NewAggr(opCode opcode.AggregateOpcode, f sqlparser.AggrFunc, original *sqlparser.AliasedExpr, alias string) Aggr {
+	return Aggr{
+		Original:  original,
+		Func:      f,
+		OpCode:    opCode,
+		Alias:     alias,
+		ColOffset: -1,
+		WSOffset:  -1,
 	}
 }
 
@@ -617,12 +654,9 @@ orderBy:
 
 		if !sqlparser.ContainsAggregation(expr.Col) {
 			if !qp.isExprInGroupByExprs(ctx, expr) {
-				out = append(out, Aggr{
-					Original: aliasedExpr,
-					OpCode:   opcode.AggregateRandom,
-					Alias:    aliasedExpr.ColumnName(),
-					Index:    &idxCopy,
-				})
+				aggr := NewAggr(opcode.AggregateRandom, nil, aliasedExpr, aliasedExpr.ColumnName())
+				aggr.Index = &idxCopy
+				out = append(out, aggr)
 			}
 			continue
 		}
@@ -639,9 +673,9 @@ orderBy:
 			}
 		}
 
-		aggr, _ := aliasedExpr.Expr.(sqlparser.AggrFunc)
+		aggrF, _ := aliasedExpr.Expr.(sqlparser.AggrFunc)
 
-		if aggr.IsDistinct() {
+		if aggrF.IsDistinct() {
 			switch code {
 			case opcode.AggregateCount:
 				code = opcode.AggregateCountDistinct
@@ -650,14 +684,10 @@ orderBy:
 			}
 		}
 
-		out = append(out, Aggr{
-			Original: aliasedExpr,
-			Func:     aggr,
-			OpCode:   code,
-			Alias:    aliasedExpr.ColumnName(),
-			Index:    &idxCopy,
-			Distinct: aggr.IsDistinct(),
-		})
+		aggr := NewAggr(code, aggrF, aliasedExpr, aliasedExpr.ColumnName())
+		aggr.Index = &idxCopy
+		aggr.Distinct = aggrF.IsDistinct()
+		out = append(out, aggr)
 	}
 	return
 }

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -107,16 +107,16 @@ type (
 	}
 )
 
-func (aggr Aggr) NeedWeightString(ctx *plancontext.PlanningContext) (bool, error) {
+func (aggr Aggr) NeedWeightString(ctx *plancontext.PlanningContext) bool {
 	switch aggr.OpCode {
 	case opcode.AggregateCountDistinct, opcode.AggregateSumDistinct:
-		return ctx.SemTable.NeedsWeightString(aggr.Func.GetArg()), nil
+		return ctx.SemTable.NeedsWeightString(aggr.Func.GetArg())
 	case opcode.AggregateMin, opcode.AggregateMax:
-		if ctx.SemTable.NeedsWeightString(aggr.Func.GetArg()) {
-			return true, vterrors.VT12001(fmt.Sprintf("column collation not known for the function: %s", sqlparser.String(aggr.Func)))
-		}
+		// currently this returns false, as aggregation engine primitive does not support the usage of weight_string
+		// for comparison. If Min/Max column is non-comparable then it will fail at runtime.
+		return false
 	}
-	return false, nil
+	return false
 }
 
 func (aggr Aggr) GetCollation(ctx *plancontext.PlanningContext) collations.ID {

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -226,18 +225,6 @@ func findAlias(colname *sqlparser.ColName, selects sqlparser.SelectExprs) sqlpar
 
 // Primitive implements the logicalPlan interface
 func (oa *orderedAggregate) Primitive() engine.Primitive {
-	colls := map[int]collations.ID{}
-	for _, key := range oa.aggregates {
-		if key.CollationID != collations.Unknown {
-			colls[key.KeyCol] = key.CollationID
-		}
-	}
-	for _, key := range oa.groupByKeys {
-		if key.CollationID != collations.Unknown {
-			colls[key.KeyCol] = key.CollationID
-		}
-	}
-
 	input := oa.input.Primitive()
 	if len(oa.groupByKeys) == 0 {
 		return &engine.ScalarAggregate{
@@ -245,7 +232,6 @@ func (oa *orderedAggregate) Primitive() engine.Primitive {
 			AggrOnEngine:        oa.aggrOnEngine,
 			Aggregates:          oa.aggregates,
 			TruncateColumnCount: oa.truncateColumnCount,
-			Collations:          colls,
 			Input:               input,
 		}
 	}
@@ -256,7 +242,6 @@ func (oa *orderedAggregate) Primitive() engine.Primitive {
 		Aggregates:          oa.aggregates,
 		GroupByKeys:         oa.groupByKeys,
 		TruncateColumnCount: oa.truncateColumnCount,
-		Collations:          colls,
 		Input:               input,
 	}
 }

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -5631,9 +5631,9 @@
               {
                 "OperatorType": "Join",
                 "Variant": "LeftJoin",
-                "JoinColumnIndexes": "L:0,R:0,L:2",
+                "JoinColumnIndexes": "L:0,R:0,L:1",
                 "JoinVars": {
-                  "user_foo": 1
+                  "user_foo": 2
                 },
                 "TableName": "`user`_music",
                 "Inputs": [
@@ -5644,9 +5644,9 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select count(*), `user`.foo, `user`.col from `user` where 1 != 1 group by `user`.col, `user`.foo",
-                    "OrderBy": "2 ASC",
-                    "Query": "select count(*), `user`.foo, `user`.col from `user` group by `user`.col, `user`.foo order by `user`.col asc",
+                    "FieldQuery": "select count(*), `user`.col, `user`.foo from `user` where 1 != 1 group by `user`.col, `user`.foo",
+                    "OrderBy": "1 ASC",
+                    "Query": "select count(*), `user`.col, `user`.foo from `user` group by `user`.col, `user`.foo order by `user`.col asc",
                     "Table": "`user`"
                   },
                   {
@@ -5766,9 +5766,9 @@
               {
                 "OperatorType": "Join",
                 "Variant": "LeftJoin",
-                "JoinColumnIndexes": "L:0,R:0,L:2",
+                "JoinColumnIndexes": "L:0,R:0,L:1",
                 "JoinVars": {
-                  "user_foo": 1
+                  "user_foo": 2
                 },
                 "TableName": "`user`_music",
                 "Inputs": [
@@ -5779,9 +5779,9 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select count(*), `user`.foo, `user`.col from `user` where 1 != 1 group by `user`.col, `user`.foo",
-                    "OrderBy": "2 ASC",
-                    "Query": "select count(*), `user`.foo, `user`.col from `user` group by `user`.col, `user`.foo order by `user`.col asc",
+                    "FieldQuery": "select count(*), `user`.col, `user`.foo from `user` where 1 != 1 group by `user`.col, `user`.foo",
+                    "OrderBy": "1 ASC",
+                    "Query": "select count(*), `user`.col, `user`.foo from `user` group by `user`.col, `user`.foo order by `user`.col asc",
                     "Table": "`user`"
                   },
                   {
@@ -6160,67 +6160,69 @@
         "user.user"
       ]
     }
-  },  {
-  "comment": "scatter aggregate with ambiguous aliases",
-  "query": "select distinct a, b as a from user",
-  "v3-plan": "generating ORDER BY clause: VT03021: ambiguous column reference: a",
-  "gen4-plan": {
-    "QueryType": "SELECT",
-    "Original": "select distinct a, b as a from user",
-    "Instructions": {
-      "OperatorType": "Aggregate",
-      "Variant": "Ordered",
-      "GroupBy": "(0|2), (1|3)",
-      "ResultColumns": 2,
-      "Inputs": [
-        {
-          "OperatorType": "Route",
-          "Variant": "Scatter",
-          "Keyspace": {
-            "Name": "user",
-            "Sharded": true
-          },
-          "FieldQuery": "select a, b as a, weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, b, weight_string(a), weight_string(b)",
-          "OrderBy": "(0|2) ASC, (1|3) ASC",
-          "Query": "select a, b as a, weight_string(a), weight_string(b) from `user` group by a, b, weight_string(a), weight_string(b) order by a asc, b asc",
-          "Table": "`user`"
-        }
+  },
+  {
+    "comment": "scatter aggregate with ambiguous aliases",
+    "query": "select distinct a, b as a from user",
+    "v3-plan": "generating ORDER BY clause: VT03021: ambiguous column reference: a",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select distinct a, b as a from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "GroupBy": "(0|2), (1|3)",
+        "ResultColumns": 2,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select a, b as a, weight_string(a), weight_string(b) from `user` where 1 != 1 group by a, b, weight_string(a), weight_string(b)",
+            "OrderBy": "(0|2) ASC, (1|3) ASC",
+            "Query": "select a, b as a, weight_string(a), weight_string(b) from `user` group by a, b, weight_string(a), weight_string(b) order by a asc, b asc",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
       ]
-    },
-    "TablesUsed": [
-      "user.user"
-    ]
-  }
-},  {
-  "comment": "scatter aggregate with complex select list (can't build order by)",
-  "query": "select distinct a+1 from user",
-  "v3-plan": "generating ORDER BY clause: VT12001: unsupported: reference a complex expression",
-  "gen4-plan": {
-    "QueryType": "SELECT",
-    "Original": "select distinct a+1 from user",
-    "Instructions": {
-      "OperatorType": "Aggregate",
-      "Variant": "Ordered",
-      "GroupBy": "(0|1)",
-      "ResultColumns": 1,
-      "Inputs": [
-        {
-          "OperatorType": "Route",
-          "Variant": "Scatter",
-          "Keyspace": {
-            "Name": "user",
-            "Sharded": true
-          },
-          "FieldQuery": "select a + 1, weight_string(a + 1) from `user` where 1 != 1 group by a + 1, weight_string(a + 1)",
-          "OrderBy": "(0|1) ASC",
-          "Query": "select a + 1, weight_string(a + 1) from `user` group by a + 1, weight_string(a + 1) order by a + 1 asc",
-          "Table": "`user`"
-        }
+    }
+  },
+  {
+    "comment": "scatter aggregate with complex select list (can't build order by)",
+    "query": "select distinct a+1 from user",
+    "v3-plan": "generating ORDER BY clause: VT12001: unsupported: reference a complex expression",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select distinct a+1 from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "GroupBy": "(0|1)",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select a + 1, weight_string(a + 1) from `user` where 1 != 1 group by a + 1, weight_string(a + 1)",
+            "OrderBy": "(0|1) ASC",
+            "Query": "select a + 1, weight_string(a + 1) from `user` group by a + 1, weight_string(a + 1) order by a + 1 asc",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
       ]
-    },
-    "TablesUsed": [
-      "user.user"
-    ]
+    }
   }
-}
 ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -75,15 +75,15 @@
           {
             "OperatorType": "Projection",
             "Expressions": [
-              "[COLUMN 0] * COALESCE([COLUMN 1], INT64(1)) as sum(`user`.col)"
+              "[COLUMN 0] * [COLUMN 1] as sum(`user`.col)"
             ],
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "L:1,R:1",
+                "JoinColumnIndexes": "L:0,R:0",
                 "JoinVars": {
-                  "user_foo": 0
+                  "user_foo": 1
                 },
                 "TableName": "`user`_user_extra",
                 "Inputs": [
@@ -94,8 +94,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select `user`.foo, sum(`user`.col), weight_string(`user`.foo) from `user` where 1 != 1 group by `user`.foo, weight_string(`user`.foo)",
-                    "Query": "select `user`.foo, sum(`user`.col), weight_string(`user`.foo) from `user` group by `user`.foo, weight_string(`user`.foo)",
+                    "FieldQuery": "select sum(`user`.col), `user`.foo from `user` where 1 != 1 group by `user`.foo",
+                    "Query": "select sum(`user`.col), `user`.foo from `user` group by `user`.foo",
                     "Table": "`user`"
                   },
                   {
@@ -105,8 +105,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select 1, count(*) from user_extra where 1 != 1 group by 1",
-                    "Query": "select 1, count(*) from user_extra where user_extra.bar = :user_foo group by 1",
+                    "FieldQuery": "select count(*) from user_extra where 1 != 1 group by .0",
+                    "Query": "select count(*) from user_extra where user_extra.bar = :user_foo group by .0",
                     "Table": "user_extra"
                   }
                 ]
@@ -3919,62 +3919,6 @@
     }
   },
   {
-    "comment": "interleaving grouping, aggregation and join",
-    "query": "select user.col, min(user_extra.foo), user.bar, max(user_extra.bar) from user join user_extra on user.col = user_extra.bar group by user.col, user.bar",
-    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
-    "gen4-plan": {
-      "QueryType": "SELECT",
-      "Original": "select user.col, min(user_extra.foo), user.bar, max(user_extra.bar) from user join user_extra on user.col = user_extra.bar group by user.col, user.bar",
-      "Instructions": {
-        "OperatorType": "Aggregate",
-        "Variant": "Ordered",
-        "Aggregates": "min(1) AS min(user_extra.foo), max(3) AS max(user_extra.bar)",
-        "GroupBy": "0, (2|4)",
-        "ResultColumns": 4,
-        "Inputs": [
-          {
-            "OperatorType": "Join",
-            "Variant": "Join",
-            "JoinColumnIndexes": "R:0,R:1,L:0,L:1,L:2",
-            "JoinVars": {
-              "user_col": 0
-            },
-            "TableName": "`user`_user_extra",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select `user`.col, `user`.bar, weight_string(`user`.bar) from `user` where 1 != 1 group by `user`.col, `user`.bar, weight_string(`user`.bar)",
-                "OrderBy": "0 ASC, (1|2) ASC",
-                "Query": "select `user`.col, `user`.bar, weight_string(`user`.bar) from `user` group by `user`.col, `user`.bar, weight_string(`user`.bar) order by `user`.col asc, `user`.bar asc",
-                "Table": "`user`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select min(user_extra.foo), max(user_extra.bar) from user_extra where 1 != 1 group by .0",
-                "Query": "select min(user_extra.foo), max(user_extra.bar) from user_extra where user_extra.bar = :user_col group by .0",
-                "Table": "user_extra"
-              }
-            ]
-          }
-        ]
-      },
-      "TablesUsed": [
-        "user.user",
-        "user.user_extra"
-      ]
-    }
-  },
-  {
     "comment": "group_concat on single shards",
     "query": "select group_concat(user_id order by name), id from user group by id",
     "v3-plan": {
@@ -6260,5 +6204,68 @@
     "TablesUsed": [
       "user.user"
     ]
+  },
+  {
+    "comment": "scalar aggregates with min, max, sum distinct and count distinct using collations",
+    "query": "select min(textcol1), max(textcol2), sum(distinct textcol1), count(distinct textcol1) from user",
+    "v3-plan": "VT12001: unsupported: only one DISTINCT aggregation allowed in a SELECT: count(distinct textcol1)",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select min(textcol1), max(textcol2), sum(distinct textcol1), count(distinct textcol1) from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "min(0) AS min(textcol1), max(1) AS max(textcol2), sum_distinct(2 COLLATE latin1_swedish_ci) AS sum(distinct textcol1), count_distinct(3 COLLATE latin1_swedish_ci) AS count(distinct textcol1)",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select min(textcol1), max(textcol2), textcol1, textcol1 from `user` where 1 != 1 group by textcol1",
+            "OrderBy": "2 ASC COLLATE latin1_swedish_ci",
+            "Query": "select min(textcol1), max(textcol2), textcol1, textcol1 from `user` group by textcol1 order by textcol1 asc",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "grouping aggregates with mi, max, sum distinct and count distinct using collations",
+    "query": "select col, min(textcol1), max(textcol2), sum(distinct textcol1), count(distinct textcol1) from user group by col",
+    "v3-plan": "VT12001: unsupported: only one DISTINCT aggregation allowed in a SELECT: count(distinct textcol1)",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select col, min(textcol1), max(textcol2), sum(distinct textcol1), count(distinct textcol1) from user group by col",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "Aggregates": "min(1) AS min(textcol1), max(2) AS max(textcol2), sum_distinct(3 COLLATE latin1_swedish_ci) AS sum(distinct textcol1), count_distinct(4 COLLATE latin1_swedish_ci) AS count(distinct textcol1)",
+        "GroupBy": "0",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select col, min(textcol1), max(textcol2), textcol1, textcol1 from `user` where 1 != 1 group by col, textcol1",
+            "OrderBy": "0 ASC, 3 ASC COLLATE latin1_swedish_ci",
+            "Query": "select col, min(textcol1), max(textcol2), textcol1, textcol1 from `user` group by col, textcol1 order by col asc, textcol1 asc",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6387,5 +6387,61 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "interleaving grouping, aggregation and join with min, max columns",
+    "query": "select user.col, min(user_extra.foo), user.bar, max(user_extra.bar) from user join user_extra on user.col = user_extra.bar group by user.col, user.bar",
+    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select user.col, min(user_extra.foo), user.bar, max(user_extra.bar) from user join user_extra on user.col = user_extra.bar group by user.col, user.bar",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "Aggregates": "min(1) AS min(user_extra.foo), max(3) AS max(user_extra.bar)",
+        "GroupBy": "0, (2|4)",
+        "ResultColumns": 4,
+        "Inputs": [
+          {
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "L:0,R:0,L:1,R:1,L:2",
+            "JoinVars": {
+              "user_col": 0
+            },
+            "TableName": "`user`_user_extra",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select `user`.col, `user`.bar, weight_string(`user`.bar) from `user` where 1 != 1 group by `user`.col, `user`.bar, weight_string(`user`.bar)",
+                "OrderBy": "0 ASC, (1|2) ASC",
+                "Query": "select `user`.col, `user`.bar, weight_string(`user`.bar) from `user` group by `user`.col, `user`.bar, weight_string(`user`.bar) order by `user`.col asc, `user`.bar asc",
+                "Table": "`user`"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select min(user_extra.foo), max(user_extra.bar) from user_extra where 1 != 1 group by .0",
+                "Query": "select min(user_extra.foo), max(user_extra.bar) from user_extra where user_extra.bar = :user_col group by .0",
+                "Table": "user_extra"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6279,7 +6279,7 @@
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "sum_count_star(2) AS count(*)",
-        "GroupBy": "1",
+        "GroupBy": "0",
         "Inputs": [
           {
             "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6267,5 +6267,37 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "using a grouping column multiple times should be OK",
+    "query": "select col, col, count(*) from user group by col",
+    "v3-plan": "generating ORDER BY clause: VT03021: ambiguous column reference: col",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select col, col, count(*) from user group by col",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "Aggregates": "sum_count_star(2) AS count(*)",
+        "GroupBy": "1",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select col, col, count(*) from `user` where 1 != 1 group by col",
+            "OrderBy": "0 ASC",
+            "Query": "select col, col, count(*) from `user` group by col order by col asc",
+            "Table": "`user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -3374,7 +3374,7 @@
             "OperatorType": "Projection",
             "Expressions": [
               "[COLUMN 2] as a",
-              "[COLUMN 0] * [COLUMN 1] as count(user_extra.a)",
+              "[COLUMN 1] * [COLUMN 0] as count(user_extra.a)",
               "[COLUMN 3] as weight_string(`user`.a)"
             ],
             "Inputs": [
@@ -3437,7 +3437,7 @@
             "OperatorType": "Projection",
             "Expressions": [
               "[COLUMN 0] * [COLUMN 1] as count(u.textcol1)",
-              "[COLUMN 2] * [COLUMN 3] as count(ue.foo)",
+              "[COLUMN 3] * [COLUMN 2] as count(ue.foo)",
               "[COLUMN 4] as bar",
               "[COLUMN 5] as weight_string(us.bar)"
             ],
@@ -6297,6 +6297,94 @@
       },
       "TablesUsed": [
         "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "multiple count star and a count with 3 table join",
+    "query": "select count(*), count(*), count(u.col) from user u, user u2, user_extra ue",
+    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select count(*), count(*), count(u.col) from user u, user u2, user_extra ue",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "sum_count_star(0) AS count(*), sum_count_star(1) AS count(*), sum_count(2) AS count(u.col)",
+        "Inputs": [
+          {
+            "OperatorType": "Projection",
+            "Expressions": [
+              "[COLUMN 0] * [COLUMN 1] as count(*)",
+              "[COLUMN 0] * [COLUMN 1] as count(*)",
+              "[COLUMN 0] * [COLUMN 2] as count(u.col)"
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "L:0,R:0,R:1",
+                "TableName": "user_extra_`user`_`user`",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select count(*) from user_extra as ue where 1 != 1",
+                    "Query": "select count(*) from user_extra as ue",
+                    "Table": "user_extra"
+                  },
+                  {
+                    "OperatorType": "Projection",
+                    "Expressions": [
+                      "[COLUMN 0] * [COLUMN 1] as count(*)",
+                      "[COLUMN 2] * [COLUMN 1] as count(u.col)"
+                    ],
+                    "Inputs": [
+                      {
+                        "OperatorType": "Join",
+                        "Variant": "Join",
+                        "JoinColumnIndexes": "L:0,R:0,L:1",
+                        "TableName": "`user`_`user`",
+                        "Inputs": [
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select count(*), count(u.col) from `user` as u where 1 != 1 group by .0",
+                            "Query": "select count(*), count(u.col) from `user` as u group by .0",
+                            "Table": "`user`"
+                          },
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select count(*) from `user` as u2 where 1 != 1 group by .0",
+                            "Query": "select count(*) from `user` as u2 group by .0",
+                            "Table": "`user`"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
       ]
     }
   }

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6224,5 +6224,41 @@
         "user.user"
       ]
     }
+  },
+  {
+    "QueryType": "SELECT",
+    "Original": "select distinct count(*) from user group by col",
+    "Instructions": {
+      "OperatorType": "Distinct",
+      "Collations": [
+        "0"
+      ],
+      "ResultColumns": 1,
+      "Inputs": [
+        {
+          "OperatorType": "Aggregate",
+          "Variant": "Ordered",
+          "Aggregates": "sum_count_star(0) AS count(*)",
+          "GroupBy": "1",
+          "Inputs": [
+            {
+              "OperatorType": "Route",
+              "Variant": "Scatter",
+              "Keyspace": {
+                "Name": "user",
+                "Sharded": true
+              },
+              "FieldQuery": "select count(*), col from `user` where 1 != 1 group by col",
+              "OrderBy": "1 ASC",
+              "Query": "select count(*), col from `user` group by col order by col asc",
+              "Table": "`user`"
+            }
+          ]
+        }
+      ]
+    },
+    "TablesUsed": [
+      "user.user"
+    ]
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -3282,5 +3282,84 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "having filter with %",
+    "query": "select a.tcol1 from user a join music b where a.tcol1 = b.tcol2 group by a.tcol1 having repeat(a.tcol1,min(a.id)) like \"A\\%B\" order by a.tcol1",
+    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select a.tcol1 from user a join music b where a.tcol1 = b.tcol2 group by a.tcol1 having repeat(a.tcol1,min(a.id)) like \"A\\%B\" order by a.tcol1",
+      "Instructions": {
+        "OperatorType": "SimpleProjection",
+        "Columns": [
+          0
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Filter",
+            "Predicate": "repeat(a.tcol1, :1) like 'A\\%B'",
+            "Inputs": [
+              {
+                "OperatorType": "Aggregate",
+                "Variant": "Ordered",
+                "Aggregates": "min(1) AS min(a.id)",
+                "GroupBy": "(0|2)",
+                "Inputs": [
+                  {
+                    "OperatorType": "Projection",
+                    "Expressions": [
+                      "[COLUMN 0] as tcol1",
+                      "[COLUMN 2] as min(a.id)",
+                      "[COLUMN 1]"
+                    ],
+                    "Inputs": [
+                      {
+                        "OperatorType": "Join",
+                        "Variant": "Join",
+                        "JoinColumnIndexes": "L:0,L:2,L:1",
+                        "JoinVars": {
+                          "a_tcol1": 0
+                        },
+                        "TableName": "`user`_music",
+                        "Inputs": [
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select a.tcol1, min(a.id), weight_string(a.tcol1) from `user` as a where 1 != 1 group by a.tcol1, weight_string(a.tcol1)",
+                            "OrderBy": "(0|2) ASC",
+                            "Query": "select a.tcol1, min(a.id), weight_string(a.tcol1) from `user` as a group by a.tcol1, weight_string(a.tcol1) order by a.tcol1 asc",
+                            "Table": "`user`"
+                          },
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select 1 from music as b where 1 != 1 group by 1",
+                            "Query": "select 1 from music as b where b.tcol2 = :a_tcol1 group by 1",
+                            "Table": "music"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -25,38 +25,38 @@
           {
             "OperatorType": "Sort",
             "Variant": "Memory",
-            "OrderBy": "1 DESC, (2|5) ASC",
+            "OrderBy": "1 DESC, (2|4) ASC",
             "ResultColumns": 4,
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum(1) AS revenue",
-                "GroupBy": "(0|6), (2|5), (3|4)",
+                "GroupBy": "(0|5), (2|4), (3|6)",
                 "Inputs": [
                   {
                     "OperatorType": "Projection",
                     "Expressions": [
-                      "[COLUMN 0] as l_orderkey",
-                      "([COLUMN 6] * COALESCE([COLUMN 7], INT64(1))) * COALESCE([COLUMN 8], INT64(1)) as revenue",
-                      "[COLUMN 1] as o_orderdate",
-                      "[COLUMN 2] as o_shippriority",
-                      "[COLUMN 5]",
-                      "[COLUMN 4]",
-                      "[COLUMN 3]"
+                      "[COLUMN 2] as l_orderkey",
+                      "[COLUMN 0] * [COLUMN 1] as revenue",
+                      "[COLUMN 3] as o_orderdate",
+                      "[COLUMN 4] as o_shippriority",
+                      "[COLUMN 5] as weight_string(o_orderdate)",
+                      "[COLUMN 6] as weight_string(l_orderkey)",
+                      "[COLUMN 7] as weight_string(o_shippriority)"
                     ],
                     "Inputs": [
                       {
                         "OperatorType": "Sort",
                         "Variant": "Memory",
-                        "OrderBy": "(0|3) ASC, (1|4) ASC, (2|5) ASC",
+                        "OrderBy": "(2|6) ASC, (3|5) ASC, (4|7) ASC",
                         "Inputs": [
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "L:0,R:0,R:1,L:2,R:2,R:3,L:1,R:4,R:5",
+                            "JoinColumnIndexes": "L:0,R:0,L:1,R:1,R:2,R:3,L:2,R:4",
                             "JoinVars": {
-                              "l_orderkey": 0
+                              "l_orderkey": 1
                             },
                             "TableName": "lineitem_orders_customer",
                             "Inputs": [
@@ -67,48 +67,60 @@
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_orderkey) from lineitem where 1 != 1 group by l_orderkey, weight_string(l_orderkey)",
-                                "Query": "select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_orderkey) from lineitem where l_shipdate > date('1995-03-15') group by l_orderkey, weight_string(l_orderkey)",
+                                "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_orderkey, weight_string(l_orderkey) from lineitem where 1 != 1 group by l_orderkey, weight_string(l_orderkey)",
+                                "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_orderkey, weight_string(l_orderkey) from lineitem where l_shipdate > date('1995-03-15') group by l_orderkey, weight_string(l_orderkey)",
                                 "Table": "lineitem"
                               },
                               {
-                                "OperatorType": "Join",
-                                "Variant": "Join",
-                                "JoinColumnIndexes": "L:3,L:5,L:4,L:6,L:1,R:1",
-                                "JoinVars": {
-                                  "o_custkey": 0
-                                },
-                                "TableName": "orders_customer",
+                                "OperatorType": "Projection",
+                                "Expressions": [
+                                  "[COLUMN 0] * [COLUMN 1] as count(*)",
+                                  "[COLUMN 2] as o_orderdate",
+                                  "[COLUMN 3] as o_shippriority",
+                                  "[COLUMN 4] as weight_string(o_orderdate)",
+                                  "[COLUMN 5] as weight_string(o_shippriority)"
+                                ],
                                 "Inputs": [
                                   {
-                                    "OperatorType": "Route",
-                                    "Variant": "EqualUnique",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
+                                    "OperatorType": "Join",
+                                    "Variant": "Join",
+                                    "JoinColumnIndexes": "L:0,R:0,L:1,L:2,L:4,L:5",
+                                    "JoinVars": {
+                                      "o_custkey": 3
                                     },
-                                    "FieldQuery": "select o_custkey, count(*), weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority) from orders where 1 != 1 group by o_custkey, weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority)",
-                                    "Query": "select o_custkey, count(*), weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority) from orders where o_orderdate < date('1995-03-15') and o_orderkey = :l_orderkey group by o_custkey, weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority)",
-                                    "Table": "orders",
-                                    "Values": [
-                                      ":l_orderkey"
-                                    ],
-                                    "Vindex": "hash"
-                                  },
-                                  {
-                                    "OperatorType": "Route",
-                                    "Variant": "EqualUnique",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
-                                    },
-                                    "FieldQuery": "select 1, count(*) from customer where 1 != 1 group by 1",
-                                    "Query": "select 1, count(*) from customer where c_mktsegment = 'BUILDING' and c_custkey = :o_custkey group by 1",
-                                    "Table": "customer",
-                                    "Values": [
-                                      ":o_custkey"
-                                    ],
-                                    "Vindex": "hash"
+                                    "TableName": "orders_customer",
+                                    "Inputs": [
+                                      {
+                                        "OperatorType": "Route",
+                                        "Variant": "EqualUnique",
+                                        "Keyspace": {
+                                          "Name": "main",
+                                          "Sharded": true
+                                        },
+                                        "FieldQuery": "select count(*), o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority) from orders where 1 != 1 group by o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority)",
+                                        "Query": "select count(*), o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority) from orders where o_orderdate < date('1995-03-15') and o_orderkey = :l_orderkey group by o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority)",
+                                        "Table": "orders",
+                                        "Values": [
+                                          ":l_orderkey"
+                                        ],
+                                        "Vindex": "hash"
+                                      },
+                                      {
+                                        "OperatorType": "Route",
+                                        "Variant": "EqualUnique",
+                                        "Keyspace": {
+                                          "Name": "main",
+                                          "Sharded": true
+                                        },
+                                        "FieldQuery": "select count(*) from customer where 1 != 1 group by .0",
+                                        "Query": "select count(*) from customer where c_mktsegment = 'BUILDING' and c_custkey = :o_custkey group by .0",
+                                        "Table": "customer",
+                                        "Values": [
+                                          ":o_custkey"
+                                        ],
+                                        "Vindex": "hash"
+                                      }
+                                    ]
                                   }
                                 ]
                               }
@@ -246,178 +258,218 @@
               {
                 "OperatorType": "Projection",
                 "Expressions": [
-                  "[COLUMN 0] as n_name",
-                  "(((([COLUMN 2] * COALESCE([COLUMN 3], INT64(1))) * COALESCE([COLUMN 4], INT64(1))) * COALESCE([COLUMN 5], INT64(1))) * COALESCE([COLUMN 6], INT64(1))) * COALESCE([COLUMN 7], INT64(1)) as revenue",
-                  "[COLUMN 1]"
+                  "[COLUMN 2] as n_name",
+                  "[COLUMN 0] * [COLUMN 1] as revenue",
+                  "[COLUMN 3] as weight_string(n_name)"
                 ],
                 "Inputs": [
                   {
                     "OperatorType": "Sort",
                     "Variant": "Memory",
-                    "OrderBy": "(0|1) ASC",
+                    "OrderBy": "(2|3) ASC",
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "R:0,R:1,L:3,L:4,L:5,L:6,R:2,R:3",
+                        "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
                         "JoinVars": {
-                          "s_nationkey": 0
+                          "s_nationkey": 2
                         },
                         "TableName": "orders_customer_lineitem_supplier_nation_region",
                         "Inputs": [
                           {
-                            "OperatorType": "Join",
-                            "Variant": "Join",
-                            "JoinColumnIndexes": "R:0,R:1,R:2,L:6,L:7,R:3,R:4",
-                            "JoinVars": {
-                              "c_nationkey": 1,
-                              "o_orderkey": 0
-                            },
-                            "TableName": "orders_customer_lineitem_supplier",
+                            "OperatorType": "Projection",
+                            "Expressions": [
+                              "[COLUMN 0] as revenue",
+                              "[COLUMN 0] * [COLUMN 1] as revenue",
+                              "[COLUMN 2] as s_nationkey"
+                            ],
                             "Inputs": [
                               {
                                 "OperatorType": "Join",
                                 "Variant": "Join",
-                                "JoinColumnIndexes": "L:0,R:0,L:0,R:0,L:4,R:2,L:2,R:1",
+                                "JoinColumnIndexes": "R:0,L:0,R:2",
                                 "JoinVars": {
-                                  "o_custkey": 1
+                                  "c_nationkey": 2,
+                                  "o_orderkey": 1
                                 },
-                                "TableName": "orders_customer",
+                                "TableName": "orders_customer_lineitem_supplier",
                                 "Inputs": [
                                   {
-                                    "OperatorType": "Route",
-                                    "Variant": "Scatter",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
-                                    },
-                                    "FieldQuery": "select o_orderkey, o_custkey, count(*), weight_string(o_custkey), weight_string(o_orderkey) from orders where 1 != 1 group by o_custkey, weight_string(o_custkey), o_orderkey, weight_string(o_orderkey)",
-                                    "Query": "select o_orderkey, o_custkey, count(*), weight_string(o_custkey), weight_string(o_orderkey) from orders where o_orderdate >= date('1994-01-01') and o_orderdate < date('1994-01-01') + interval '1' year group by o_custkey, weight_string(o_custkey), o_orderkey, weight_string(o_orderkey)",
-                                    "Table": "orders"
-                                  },
-                                  {
-                                    "OperatorType": "Route",
-                                    "Variant": "EqualUnique",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
-                                    },
-                                    "FieldQuery": "select c_nationkey, count(*), weight_string(c_nationkey) from customer where 1 != 1 group by c_nationkey, weight_string(c_nationkey)",
-                                    "Query": "select c_nationkey, count(*), weight_string(c_nationkey) from customer where c_custkey = :o_custkey group by c_nationkey, weight_string(c_nationkey)",
-                                    "Table": "customer",
-                                    "Values": [
-                                      ":o_custkey"
+                                    "OperatorType": "Projection",
+                                    "Expressions": [
+                                      "[COLUMN 0] * [COLUMN 1] as count(*)",
+                                      "[COLUMN 2] as o_orderkey",
+                                      "[COLUMN 3] as c_nationkey"
                                     ],
-                                    "Vindex": "hash"
-                                  }
-                                ]
-                              },
-                              {
-                                "OperatorType": "Join",
-                                "Variant": "Join",
-                                "JoinColumnIndexes": "R:0,R:0,R:2,L:1,R:1",
-                                "JoinVars": {
-                                  "l_suppkey": 0
-                                },
-                                "TableName": "lineitem_supplier",
-                                "Inputs": [
-                                  {
-                                    "OperatorType": "VindexLookup",
-                                    "Variant": "EqualUnique",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
-                                    },
-                                    "Values": [
-                                      ":o_orderkey"
-                                    ],
-                                    "Vindex": "lineitem_map",
                                     "Inputs": [
                                       {
-                                        "OperatorType": "Route",
-                                        "Variant": "IN",
-                                        "Keyspace": {
-                                          "Name": "main",
-                                          "Sharded": true
+                                        "OperatorType": "Join",
+                                        "Variant": "Join",
+                                        "JoinColumnIndexes": "L:0,R:0,L:1,R:1",
+                                        "JoinVars": {
+                                          "o_custkey": 2
                                         },
-                                        "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
-                                        "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                                        "Table": "lineitem_map",
-                                        "Values": [
-                                          "::l_orderkey"
-                                        ],
-                                        "Vindex": "md5"
-                                      },
-                                      {
-                                        "OperatorType": "Route",
-                                        "Variant": "ByDestination",
-                                        "Keyspace": {
-                                          "Name": "main",
-                                          "Sharded": true
-                                        },
-                                        "FieldQuery": "select l_suppkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_suppkey) from lineitem where 1 != 1 group by l_suppkey, weight_string(l_suppkey)",
-                                        "Query": "select l_suppkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_suppkey) from lineitem where l_orderkey = :o_orderkey group by l_suppkey, weight_string(l_suppkey)",
-                                        "Table": "lineitem"
+                                        "TableName": "orders_customer",
+                                        "Inputs": [
+                                          {
+                                            "OperatorType": "Route",
+                                            "Variant": "Scatter",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "FieldQuery": "select count(*), o_orderkey, o_custkey from orders where 1 != 1 group by o_orderkey, o_custkey",
+                                            "Query": "select count(*), o_orderkey, o_custkey from orders where o_orderdate >= date('1994-01-01') and o_orderdate < date('1994-01-01') + interval '1' year group by o_orderkey, o_custkey",
+                                            "Table": "orders"
+                                          },
+                                          {
+                                            "OperatorType": "Route",
+                                            "Variant": "EqualUnique",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "FieldQuery": "select count(*), c_nationkey from customer where 1 != 1 group by c_nationkey",
+                                            "Query": "select count(*), c_nationkey from customer where c_custkey = :o_custkey group by c_nationkey",
+                                            "Table": "customer",
+                                            "Values": [
+                                              ":o_custkey"
+                                            ],
+                                            "Vindex": "hash"
+                                          }
+                                        ]
                                       }
                                     ]
                                   },
                                   {
-                                    "OperatorType": "Route",
-                                    "Variant": "EqualUnique",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
-                                    },
-                                    "FieldQuery": "select s_nationkey, count(*), weight_string(s_nationkey) from supplier where 1 != 1 group by s_nationkey, weight_string(s_nationkey)",
-                                    "Query": "select s_nationkey, count(*), weight_string(s_nationkey) from supplier where s_nationkey = :c_nationkey and s_suppkey = :l_suppkey group by s_nationkey, weight_string(s_nationkey)",
-                                    "Table": "supplier",
-                                    "Values": [
-                                      ":l_suppkey"
+                                    "OperatorType": "Projection",
+                                    "Expressions": [
+                                      "[COLUMN 0] as revenue",
+                                      "[COLUMN 0] * [COLUMN 1] as revenue",
+                                      "[COLUMN 2] as s_nationkey"
                                     ],
-                                    "Vindex": "hash"
+                                    "Inputs": [
+                                      {
+                                        "OperatorType": "Join",
+                                        "Variant": "Join",
+                                        "JoinColumnIndexes": "L:0,R:0,R:1",
+                                        "JoinVars": {
+                                          "l_suppkey": 1
+                                        },
+                                        "TableName": "lineitem_supplier",
+                                        "Inputs": [
+                                          {
+                                            "OperatorType": "VindexLookup",
+                                            "Variant": "EqualUnique",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "Values": [
+                                              ":o_orderkey"
+                                            ],
+                                            "Vindex": "lineitem_map",
+                                            "Inputs": [
+                                              {
+                                                "OperatorType": "Route",
+                                                "Variant": "IN",
+                                                "Keyspace": {
+                                                  "Name": "main",
+                                                  "Sharded": true
+                                                },
+                                                "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
+                                                "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
+                                                "Table": "lineitem_map",
+                                                "Values": [
+                                                  "::l_orderkey"
+                                                ],
+                                                "Vindex": "md5"
+                                              },
+                                              {
+                                                "OperatorType": "Route",
+                                                "Variant": "ByDestination",
+                                                "Keyspace": {
+                                                  "Name": "main",
+                                                  "Sharded": true
+                                                },
+                                                "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_suppkey from lineitem where 1 != 1 group by l_suppkey",
+                                                "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_suppkey from lineitem where l_orderkey = :o_orderkey group by l_suppkey",
+                                                "Table": "lineitem"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "OperatorType": "Route",
+                                            "Variant": "EqualUnique",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "FieldQuery": "select count(*), s_nationkey from supplier where 1 != 1 group by s_nationkey",
+                                            "Query": "select count(*), s_nationkey from supplier where s_nationkey = :c_nationkey and s_suppkey = :l_suppkey group by s_nationkey",
+                                            "Table": "supplier",
+                                            "Values": [
+                                              ":l_suppkey"
+                                            ],
+                                            "Vindex": "hash"
+                                          }
+                                        ]
+                                      }
+                                    ]
                                   }
                                 ]
                               }
                             ]
                           },
                           {
-                            "OperatorType": "Join",
-                            "Variant": "Join",
-                            "JoinColumnIndexes": "L:3,L:4,L:1,R:1",
-                            "JoinVars": {
-                              "n_regionkey": 0
-                            },
-                            "TableName": "nation_region",
+                            "OperatorType": "Projection",
+                            "Expressions": [
+                              "[COLUMN 0] * [COLUMN 1] as count(*)",
+                              "[COLUMN 2] as n_name",
+                              "[COLUMN 3] as weight_string(n_name)"
+                            ],
                             "Inputs": [
                               {
-                                "OperatorType": "Route",
-                                "Variant": "EqualUnique",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": true
+                                "OperatorType": "Join",
+                                "Variant": "Join",
+                                "JoinColumnIndexes": "L:0,R:0,L:1,L:3",
+                                "JoinVars": {
+                                  "n_regionkey": 2
                                 },
-                                "FieldQuery": "select n_regionkey, count(*), weight_string(n_regionkey), n_name, weight_string(n_name) from nation where 1 != 1 group by n_regionkey, weight_string(n_regionkey), n_name, weight_string(n_name)",
-                                "Query": "select n_regionkey, count(*), weight_string(n_regionkey), n_name, weight_string(n_name) from nation where n_nationkey = :s_nationkey group by n_regionkey, weight_string(n_regionkey), n_name, weight_string(n_name)",
-                                "Table": "nation",
-                                "Values": [
-                                  ":s_nationkey"
-                                ],
-                                "Vindex": "hash"
-                              },
-                              {
-                                "OperatorType": "Route",
-                                "Variant": "EqualUnique",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select 1, count(*) from region where 1 != 1 group by 1",
-                                "Query": "select 1, count(*) from region where r_name = 'ASIA' and r_regionkey = :n_regionkey group by 1",
-                                "Table": "region",
-                                "Values": [
-                                  ":n_regionkey"
-                                ],
-                                "Vindex": "hash"
+                                "TableName": "nation_region",
+                                "Inputs": [
+                                  {
+                                    "OperatorType": "Route",
+                                    "Variant": "EqualUnique",
+                                    "Keyspace": {
+                                      "Name": "main",
+                                      "Sharded": true
+                                    },
+                                    "FieldQuery": "select count(*), n_name, n_regionkey, weight_string(n_name) from nation where 1 != 1 group by n_name, n_regionkey, weight_string(n_name)",
+                                    "Query": "select count(*), n_name, n_regionkey, weight_string(n_name) from nation where n_nationkey = :s_nationkey group by n_name, n_regionkey, weight_string(n_name)",
+                                    "Table": "nation",
+                                    "Values": [
+                                      ":s_nationkey"
+                                    ],
+                                    "Vindex": "hash"
+                                  },
+                                  {
+                                    "OperatorType": "Route",
+                                    "Variant": "EqualUnique",
+                                    "Keyspace": {
+                                      "Name": "main",
+                                      "Sharded": true
+                                    },
+                                    "FieldQuery": "select count(*) from region where 1 != 1 group by .0",
+                                    "Query": "select count(*) from region where r_name = 'ASIA' and r_regionkey = :n_regionkey group by .0",
+                                    "Table": "region",
+                                    "Values": [
+                                      ":n_regionkey"
+                                    ],
+                                    "Vindex": "hash"
+                                  }
+                                ]
                               }
                             ]
                           }
@@ -713,37 +765,37 @@
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum(2) AS revenue",
-                "GroupBy": "(0|14), (1|13), (3|12), (6|11), (4|10), (5|9), (7|8)",
+                "GroupBy": "(0|8), (1|9), (3|10), (6|11), (4|12), (5|13), (7|14)",
                 "Inputs": [
                   {
                     "OperatorType": "Projection",
                     "Expressions": [
-                      "[COLUMN 0] as c_custkey",
-                      "[COLUMN 1] as c_name",
-                      "(([COLUMN 14] * COALESCE([COLUMN 15], INT64(1))) * COALESCE([COLUMN 16], INT64(1))) * COALESCE([COLUMN 17], INT64(1)) as revenue",
-                      "[COLUMN 2] as c_acctbal",
-                      "[COLUMN 4] as n_name",
-                      "[COLUMN 5] as c_address",
-                      "[COLUMN 3] as c_phone",
-                      "[COLUMN 6] as c_comment",
-                      "[COLUMN 13]",
-                      "[COLUMN 12]",
-                      "[COLUMN 11]",
-                      "[COLUMN 10]",
-                      "[COLUMN 9]",
-                      "[COLUMN 8]",
-                      "[COLUMN 7]"
+                      "[COLUMN 2] as c_custkey",
+                      "[COLUMN 3] as c_name",
+                      "[COLUMN 0] * [COLUMN 1] as revenue",
+                      "[COLUMN 4] as c_acctbal",
+                      "[COLUMN 6] as n_name",
+                      "[COLUMN 7] as c_address",
+                      "[COLUMN 5] as c_phone",
+                      "[COLUMN 8] as c_comment",
+                      "[COLUMN 9] as weight_string(c_custkey)",
+                      "[COLUMN 10] as weight_string(c_name)",
+                      "[COLUMN 11] as weight_string(c_acctbal)",
+                      "[COLUMN 12] as weight_string(c_phone)",
+                      "[COLUMN 13] as weight_string(n_name)",
+                      "[COLUMN 14] as weight_string(c_address)",
+                      "[COLUMN 15] as weight_string(c_comment)"
                     ],
                     "Inputs": [
                       {
                         "OperatorType": "Sort",
                         "Variant": "Memory",
-                        "OrderBy": "(0|7) ASC, (1|8) ASC, (2|9) ASC, (3|10) ASC, (4|11) ASC, (5|12) ASC, (6|13) ASC",
+                        "OrderBy": "(2|9) ASC, (3|10) ASC, (4|11) ASC, (5|12) ASC, (6|13) ASC, (7|14) ASC, (8|15) ASC",
                         "Inputs": [
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "R:0,R:1,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13,L:3,L:4,R:14,R:15",
+                            "JoinColumnIndexes": "L:1,R:0,R:1,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13,R:14",
                             "JoinVars": {
                               "o_custkey": 0
                             },
@@ -752,7 +804,7 @@
                               {
                                 "OperatorType": "Join",
                                 "Variant": "Join",
-                                "JoinColumnIndexes": "L:0,L:0,L:4,L:2,R:1",
+                                "JoinColumnIndexes": "L:0,R:0",
                                 "JoinVars": {
                                   "o_orderkey": 1
                                 },
@@ -765,8 +817,8 @@
                                       "Name": "main",
                                       "Sharded": true
                                     },
-                                    "FieldQuery": "select o_custkey, o_orderkey, count(*), weight_string(o_orderkey), weight_string(o_custkey) from orders where 1 != 1 group by o_orderkey, weight_string(o_orderkey), o_custkey, weight_string(o_custkey)",
-                                    "Query": "select o_custkey, o_orderkey, count(*), weight_string(o_orderkey), weight_string(o_custkey) from orders where o_orderdate >= date('1993-10-01') and o_orderdate < date('1993-10-01') + interval '3' month group by o_orderkey, weight_string(o_orderkey), o_custkey, weight_string(o_custkey)",
+                                    "FieldQuery": "select o_custkey, o_orderkey from orders where 1 != 1 group by o_custkey, o_orderkey",
+                                    "Query": "select o_custkey, o_orderkey from orders where o_orderdate >= date('1993-10-01') and o_orderdate < date('1993-10-01') + interval '3' month group by o_custkey, o_orderkey",
                                     "Table": "orders"
                                   },
                                   {
@@ -803,8 +855,8 @@
                                           "Name": "main",
                                           "Sharded": true
                                         },
-                                        "FieldQuery": "select 1, sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where 1 != 1 group by 1",
-                                        "Query": "select 1, sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey group by 1",
+                                        "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) from lineitem where 1 != 1 group by .0",
+                                        "Query": "select sum(l_extendedprice * (1 - l_discount)) from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey group by .0",
                                         "Table": "lineitem"
                                       }
                                     ]
@@ -812,43 +864,65 @@
                                 ]
                               },
                               {
-                                "OperatorType": "Join",
-                                "Variant": "Join",
-                                "JoinColumnIndexes": "L:3,L:5,L:7,L:9,R:1,L:11,L:13,L:4,L:6,L:8,L:10,R:2,L:12,L:14,L:1,R:0",
-                                "JoinVars": {
-                                  "c_nationkey": 0
-                                },
-                                "TableName": "customer_nation",
+                                "OperatorType": "Projection",
+                                "Expressions": [
+                                  "[COLUMN 0] * [COLUMN 1] as count(*)",
+                                  "[COLUMN 2] as c_custkey",
+                                  "[COLUMN 3] as c_name",
+                                  "[COLUMN 4] as c_acctbal",
+                                  "[COLUMN 5] as c_phone",
+                                  "[COLUMN 6] as n_name",
+                                  "[COLUMN 7] as c_address",
+                                  "[COLUMN 8] as c_comment",
+                                  "[COLUMN 9] as weight_string(c_custkey)",
+                                  "[COLUMN 10] as weight_string(c_name)",
+                                  "[COLUMN 11] as weight_string(c_acctbal)",
+                                  "[COLUMN 12] as weight_string(c_phone)",
+                                  "[COLUMN 13] as weight_string(n_name)",
+                                  "[COLUMN 14] as weight_string(c_address)",
+                                  "[COLUMN 15] as weight_string(c_comment)"
+                                ],
                                 "Inputs": [
                                   {
-                                    "OperatorType": "Route",
-                                    "Variant": "EqualUnique",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
+                                    "OperatorType": "Join",
+                                    "Variant": "Join",
+                                    "JoinColumnIndexes": "L:0,R:0,L:1,L:2,L:3,L:4,R:1,L:5,L:6,L:8,L:9,L:10,L:11,R:2,L:12,L:13",
+                                    "JoinVars": {
+                                      "c_nationkey": 7
                                     },
-                                    "FieldQuery": "select c_nationkey, count(*), weight_string(c_nationkey), c_custkey, weight_string(c_custkey), c_name, weight_string(c_name), c_acctbal, weight_string(c_acctbal), c_phone, weight_string(c_phone), c_address, weight_string(c_address), c_comment, weight_string(c_comment) from customer where 1 != 1 group by c_nationkey, weight_string(c_nationkey), c_custkey, weight_string(c_custkey), c_name, weight_string(c_name), c_acctbal, weight_string(c_acctbal), c_phone, weight_string(c_phone), c_address, weight_string(c_address), c_comment, weight_string(c_comment)",
-                                    "Query": "select c_nationkey, count(*), weight_string(c_nationkey), c_custkey, weight_string(c_custkey), c_name, weight_string(c_name), c_acctbal, weight_string(c_acctbal), c_phone, weight_string(c_phone), c_address, weight_string(c_address), c_comment, weight_string(c_comment) from customer where c_custkey = :o_custkey group by c_nationkey, weight_string(c_nationkey), c_custkey, weight_string(c_custkey), c_name, weight_string(c_name), c_acctbal, weight_string(c_acctbal), c_phone, weight_string(c_phone), c_address, weight_string(c_address), c_comment, weight_string(c_comment)",
-                                    "Table": "customer",
-                                    "Values": [
-                                      ":o_custkey"
-                                    ],
-                                    "Vindex": "hash"
-                                  },
-                                  {
-                                    "OperatorType": "Route",
-                                    "Variant": "EqualUnique",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
-                                    },
-                                    "FieldQuery": "select count(*), n_name, weight_string(n_name) from nation where 1 != 1 group by n_name, weight_string(n_name)",
-                                    "Query": "select count(*), n_name, weight_string(n_name) from nation where n_nationkey = :c_nationkey group by n_name, weight_string(n_name)",
-                                    "Table": "nation",
-                                    "Values": [
-                                      ":c_nationkey"
-                                    ],
-                                    "Vindex": "hash"
+                                    "TableName": "customer_nation",
+                                    "Inputs": [
+                                      {
+                                        "OperatorType": "Route",
+                                        "Variant": "EqualUnique",
+                                        "Keyspace": {
+                                          "Name": "main",
+                                          "Sharded": true
+                                        },
+                                        "FieldQuery": "select count(*), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment) from customer where 1 != 1 group by c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment)",
+                                        "Query": "select count(*), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment) from customer where c_custkey = :o_custkey group by c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment)",
+                                        "Table": "customer",
+                                        "Values": [
+                                          ":o_custkey"
+                                        ],
+                                        "Vindex": "hash"
+                                      },
+                                      {
+                                        "OperatorType": "Route",
+                                        "Variant": "EqualUnique",
+                                        "Keyspace": {
+                                          "Name": "main",
+                                          "Sharded": true
+                                        },
+                                        "FieldQuery": "select count(*), n_name, weight_string(n_name) from nation where 1 != 1 group by n_name, weight_string(n_name)",
+                                        "Query": "select count(*), n_name, weight_string(n_name) from nation where n_nationkey = :c_nationkey group by n_name, weight_string(n_name)",
+                                        "Table": "nation",
+                                        "Values": [
+                                          ":c_nationkey"
+                                        ],
+                                        "Vindex": "hash"
+                                      }
+                                    ]
                                   }
                                 ]
                               }
@@ -895,23 +969,23 @@
           {
             "OperatorType": "Projection",
             "Expressions": [
-              "[COLUMN 0] as l_shipmode",
-              "[COLUMN 2] * COALESCE([COLUMN 3], INT64(1)) as high_line_count",
-              "[COLUMN 4] * COALESCE([COLUMN 5], INT64(1)) as low_line_count",
-              "[COLUMN 1]"
+              "[COLUMN 3] as l_shipmode",
+              "[COLUMN 0] * [COLUMN 1] as high_line_count",
+              "[COLUMN 2] * [COLUMN 1] as low_line_count",
+              "[COLUMN 4] as weight_string(l_shipmode)"
             ],
             "Inputs": [
               {
                 "OperatorType": "Sort",
                 "Variant": "Memory",
-                "OrderBy": "(0|1) ASC",
+                "OrderBy": "(3|4) ASC",
                 "Inputs": [
                   {
                     "OperatorType": "Join",
                     "Variant": "Join",
-                    "JoinColumnIndexes": "R:1,R:2,L:1,R:0,L:2,R:0",
+                    "JoinColumnIndexes": "L:0,R:0,L:1,R:1,R:2",
                     "JoinVars": {
-                      "o_orderkey": 0
+                      "o_orderkey": 2
                     },
                     "TableName": "orders_lineitem",
                     "Inputs": [
@@ -922,8 +996,8 @@
                           "Name": "main",
                           "Sharded": true
                         },
-                        "FieldQuery": "select o_orderkey, sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, weight_string(o_orderkey) from orders where 1 != 1 group by o_orderkey, weight_string(o_orderkey)",
-                        "Query": "select o_orderkey, sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, weight_string(o_orderkey) from orders group by o_orderkey, weight_string(o_orderkey)",
+                        "FieldQuery": "select sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, o_orderkey from orders where 1 != 1 group by o_orderkey",
+                        "Query": "select sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, o_orderkey from orders group by o_orderkey",
                         "Table": "orders"
                       },
                       {
@@ -1288,18 +1362,18 @@
           {
             "OperatorType": "Projection",
             "Expressions": [
-              "[COLUMN 0] * COALESCE([COLUMN 1], INT64(1)) as revenue"
+              "[COLUMN 0] * [COLUMN 1] as revenue"
             ],
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "L:4,R:1",
+                "JoinColumnIndexes": "L:0,R:0",
                 "JoinVars": {
-                  "l_partkey": 0,
-                  "l_quantity": 1,
-                  "l_shipinstruct": 3,
-                  "l_shipmode": 2
+                  "l_partkey": 1,
+                  "l_quantity": 2,
+                  "l_shipinstruct": 4,
+                  "l_shipmode": 3
                 },
                 "TableName": "lineitem_part",
                 "Inputs": [
@@ -1310,8 +1384,8 @@
                       "Name": "main",
                       "Sharded": true
                     },
-                    "FieldQuery": "select l_partkey, l_quantity, l_shipmode, l_shipinstruct, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_partkey), weight_string(l_quantity), weight_string(l_shipmode), weight_string(l_shipinstruct) from lineitem where 1 != 1 group by l_partkey, weight_string(l_partkey), l_quantity, weight_string(l_quantity), l_shipmode, weight_string(l_shipmode), l_shipinstruct, weight_string(l_shipinstruct)",
-                    "Query": "select l_partkey, l_quantity, l_shipmode, l_shipinstruct, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_partkey), weight_string(l_quantity), weight_string(l_shipmode), weight_string(l_shipinstruct) from lineitem group by l_partkey, weight_string(l_partkey), l_quantity, weight_string(l_quantity), l_shipmode, weight_string(l_shipmode), l_shipinstruct, weight_string(l_shipinstruct)",
+                    "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_partkey, l_quantity, l_shipmode, l_shipinstruct from lineitem where 1 != 1 group by l_partkey, l_quantity, l_shipmode, l_shipinstruct",
+                    "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_partkey, l_quantity, l_shipmode, l_shipinstruct from lineitem group by l_partkey, l_quantity, l_shipmode, l_shipinstruct",
                     "Table": "lineitem"
                   },
                   {
@@ -1321,8 +1395,8 @@
                       "Name": "main",
                       "Sharded": true
                     },
-                    "FieldQuery": "select 1, count(*) from part where 1 != 1 group by 1",
-                    "Query": "select 1, count(*) from part where p_partkey = :l_partkey and p_brand = 'Brand#12' and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and :l_quantity >= 1 and :l_quantity <= 1 + 10 and p_size between 1 and 5 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' or p_partkey = :l_partkey and p_brand = 'Brand#23' and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') and :l_quantity >= 10 and :l_quantity <= 10 + 10 and p_size between 1 and 10 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' or p_partkey = :l_partkey and p_brand = 'Brand#34' and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') and :l_quantity >= 20 and :l_quantity <= 20 + 10 and p_size between 1 and 15 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' group by 1",
+                    "FieldQuery": "select count(*) from part where 1 != 1 group by .0",
+                    "Query": "select count(*) from part where p_partkey = :l_partkey and p_brand = 'Brand#12' and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and :l_quantity >= 1 and :l_quantity <= 1 + 10 and p_size between 1 and 5 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' or p_partkey = :l_partkey and p_brand = 'Brand#23' and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') and :l_quantity >= 10 and :l_quantity <= 10 + 10 and p_size between 1 and 10 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' or p_partkey = :l_partkey and p_brand = 'Brand#34' and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') and :l_quantity >= 20 and :l_quantity <= 20 + 10 and p_size between 1 and 15 and :l_shipmode in ('AIR', 'AIR REG') and :l_shipinstruct = 'DELIVER IN PERSON' group by .0",
                     "Table": "part"
                   }
                 ]

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -273,22 +273,21 @@
                         "Variant": "Join",
                         "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
                         "JoinVars": {
-                          "s_nationkey": 2
+                          "s_nationkey": 1
                         },
                         "TableName": "orders_customer_lineitem_supplier_nation_region",
                         "Inputs": [
                           {
                             "OperatorType": "Projection",
                             "Expressions": [
-                              "[COLUMN 0] as revenue",
-                              "[COLUMN 0] * [COLUMN 1] as revenue",
+                              "[COLUMN 1] * [COLUMN 0] as revenue",
                               "[COLUMN 2] as s_nationkey"
                             ],
                             "Inputs": [
                               {
                                 "OperatorType": "Join",
                                 "Variant": "Join",
-                                "JoinColumnIndexes": "R:0,L:0,R:2",
+                                "JoinColumnIndexes": "R:0,L:0,R:1",
                                 "JoinVars": {
                                   "c_nationkey": 2,
                                   "o_orderkey": 1
@@ -345,7 +344,6 @@
                                   {
                                     "OperatorType": "Projection",
                                     "Expressions": [
-                                      "[COLUMN 0] as revenue",
                                       "[COLUMN 0] * [COLUMN 1] as revenue",
                                       "[COLUMN 2] as s_nationkey"
                                     ],
@@ -795,69 +793,78 @@
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "L:1,R:0,R:1,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13,R:14",
+                            "JoinColumnIndexes": "L:0,R:0,R:1,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13,R:14",
                             "JoinVars": {
-                              "o_custkey": 0
+                              "o_custkey": 1
                             },
                             "TableName": "orders_lineitem_customer_nation",
                             "Inputs": [
                               {
-                                "OperatorType": "Join",
-                                "Variant": "Join",
-                                "JoinColumnIndexes": "L:0,R:0",
-                                "JoinVars": {
-                                  "o_orderkey": 1
-                                },
-                                "TableName": "orders_lineitem",
+                                "OperatorType": "Projection",
+                                "Expressions": [
+                                  "[COLUMN 1] * [COLUMN 0] as revenue",
+                                  "[COLUMN 2] as o_custkey"
+                                ],
                                 "Inputs": [
                                   {
-                                    "OperatorType": "Route",
-                                    "Variant": "Scatter",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
+                                    "OperatorType": "Join",
+                                    "Variant": "Join",
+                                    "JoinColumnIndexes": "R:0,L:0,L:1",
+                                    "JoinVars": {
+                                      "o_orderkey": 2
                                     },
-                                    "FieldQuery": "select o_custkey, o_orderkey from orders where 1 != 1 group by o_custkey, o_orderkey",
-                                    "Query": "select o_custkey, o_orderkey from orders where o_orderdate >= date('1993-10-01') and o_orderdate < date('1993-10-01') + interval '3' month group by o_custkey, o_orderkey",
-                                    "Table": "orders"
-                                  },
-                                  {
-                                    "OperatorType": "VindexLookup",
-                                    "Variant": "EqualUnique",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
-                                    },
-                                    "Values": [
-                                      ":o_orderkey"
-                                    ],
-                                    "Vindex": "lineitem_map",
+                                    "TableName": "orders_lineitem",
                                     "Inputs": [
                                       {
                                         "OperatorType": "Route",
-                                        "Variant": "IN",
+                                        "Variant": "Scatter",
                                         "Keyspace": {
                                           "Name": "main",
                                           "Sharded": true
                                         },
-                                        "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
-                                        "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                                        "Table": "lineitem_map",
-                                        "Values": [
-                                          "::l_orderkey"
-                                        ],
-                                        "Vindex": "md5"
+                                        "FieldQuery": "select count(*), o_custkey, o_orderkey from orders where 1 != 1 group by o_custkey, o_orderkey",
+                                        "Query": "select count(*), o_custkey, o_orderkey from orders where o_orderdate >= date('1993-10-01') and o_orderdate < date('1993-10-01') + interval '3' month group by o_custkey, o_orderkey",
+                                        "Table": "orders"
                                       },
                                       {
-                                        "OperatorType": "Route",
-                                        "Variant": "ByDestination",
+                                        "OperatorType": "VindexLookup",
+                                        "Variant": "EqualUnique",
                                         "Keyspace": {
                                           "Name": "main",
                                           "Sharded": true
                                         },
-                                        "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) from lineitem where 1 != 1 group by .0",
-                                        "Query": "select sum(l_extendedprice * (1 - l_discount)) from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey group by .0",
-                                        "Table": "lineitem"
+                                        "Values": [
+                                          ":o_orderkey"
+                                        ],
+                                        "Vindex": "lineitem_map",
+                                        "Inputs": [
+                                          {
+                                            "OperatorType": "Route",
+                                            "Variant": "IN",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
+                                            "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
+                                            "Table": "lineitem_map",
+                                            "Values": [
+                                              "::l_orderkey"
+                                            ],
+                                            "Vindex": "md5"
+                                          },
+                                          {
+                                            "OperatorType": "Route",
+                                            "Variant": "ByDestination",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where 1 != 1 group by .0",
+                                            "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey group by .0",
+                                            "Table": "lineitem"
+                                          }
+                                        ]
                                       }
                                     ]
                                   }

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -494,5 +494,11 @@
     "comment": "extremum on input from both sides",
     "query": "insert into music(user_id, id) select foo, bar from music on duplicate key update id = id+1",
     "plan": "VT12001: unsupported: DML cannot update vindex column"
+  },
+  {
+    "comment": "interleaving grouping, aggregation and join with min, max columns",
+    "query": "select user.col, min(user_extra.foo), user.bar, max(user_extra.bar) from user join user_extra on user.col = user_extra.bar group by user.col, user.bar",
+    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
+    "gen4-plan": "VT12001: unsupported: column collation not known for the function: min(user_extra.foo)"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -494,11 +494,5 @@
     "comment": "extremum on input from both sides",
     "query": "insert into music(user_id, id) select foo, bar from music on duplicate key update id = id+1",
     "plan": "VT12001: unsupported: DML cannot update vindex column"
-  },
-  {
-    "comment": "interleaving grouping, aggregation and join with min, max columns",
-    "query": "select user.col, min(user_extra.foo), user.bar, max(user_extra.bar) from user join user_extra on user.col = user_extra.bar group by user.col, user.bar",
-    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
-    "gen4-plan": "VT12001: unsupported: column collation not known for the function: min(user_extra.foo)"
   }
 ]

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path"
@@ -759,4 +761,29 @@ func LoadSQLFile(filename, sourceroot string) ([]string, error) {
 	}
 
 	return sql, nil
+}
+
+func (db *LocalCluster) VTProcess() *VtProcess {
+	return db.vt
+}
+
+// ReadVSchema reads the vschema from the vtgate endpoint for it and returns
+// a pointer to the interface. To read this vschema, the caller must convert it to a map
+func (vt *VtProcess) ReadVSchema() (*interface{}, error) {
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	resp, err := httpClient.Get(fmt.Sprintf("http://%s:%d/debug/vschema", "127.0.0.1", vt.Port))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	res, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var results interface{}
+	err = json.Unmarshal(res, &results)
+	if err != nil {
+		return nil, err
+	}
+	return &results, nil
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR makes multiple aggregation planning improvements and fixes some subtle bugs.

1. When we can't push down aggregation, instead we'll now push down the arguments to the aggregation function and then do all of the grouping and aggregating on the vtgate. Before this change, the planner would just fail instead.
2. The DISTINCT operator was only stripping out `weight_string`, and could sometimes return too many columns.
4. Handle SUM with the new operator horizon planning 
5. Refactored how collation information is shared between the planner and runtime 
6. Fix the issue with mixed aggregation and columns in the select expression list.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/issues/11626

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
