### PR TITLE
Use $hostname in vtadmin script as all other scripts do

### DIFF
--- a/examples/common/scripts/vtadmin-up.sh
+++ b/examples/common/scripts/vtadmin-up.sh
@@ -11,8 +11,8 @@ vtadmin_api_port=14200
 vtadmin_web_port=14201
 
 vtadmin \
-  --addr ":${vtadmin_api_port}" \
-  --http-origin "http://localhost:${vtadmin_web_port}" \
+  --addr "${hostname}:${vtadmin_api_port}" \
+  --http-origin "http://${hostname}:${vtadmin_web_port}" \
   --http-tablet-url-tmpl "http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
   --tracer "opentracing-jaeger" \
   --grpc-tracing \
@@ -29,7 +29,7 @@ echo ${vtadmin_api_pid} > "${log_dir}/vtadmin-api.pid"
 
 echo "\
 vtadmin-api is running!
-  - API: http://localhost:${vtadmin_api_port}
+  - API: http://${hostname}:${vtadmin_api_port}
   - Logs: ${log_dir}/vtadmin-api.out
   - PID: ${vtadmin_api_pid}
 "
@@ -37,7 +37,7 @@ vtadmin-api is running!
 # Wait for vtadmin to successfully discover the cluster
 expected_cluster_result="{\"result\":{\"clusters\":[{\"id\":\"${cluster_name}\",\"name\":\"${cluster_name}\"}]},\"ok\":true}"
 for _ in {0..300}; do
-  result=$(curl -s "http://localhost:${vtadmin_api_port}/api/clusters")
+  result=$(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters")
   if [[ ${result} == "${expected_cluster_result}" ]]; then
     break
   fi
@@ -45,7 +45,7 @@ for _ in {0..300}; do
 done
 
 # Check one last time
-[[ $(curl -s "http://localhost:${vtadmin_api_port}/api/clusters") == "${expected_cluster_result}" ]] || fail "vtadmin failed to discover the running example Vitess cluster."
+[[ $(curl -s "http://${hostname}:${vtadmin_api_port}/api/clusters") == "${expected_cluster_result}" ]] || fail "vtadmin failed to discover the running example Vitess cluster."
 
 # Download nvm and node
 if [[ -z ${NVM_DIR} ]]; then
@@ -74,7 +74,7 @@ nvm install "$NODE_VERSION" || fail "Could not install and use nvm $NODE_VERSION
 # other Vitess components.)
 npm --prefix "$web_dir" --silent install
 
-VITE_VTADMIN_API_ADDRESS="http://localhost:${vtadmin_api_port}" \
+VITE_VTADMIN_API_ADDRESS="http://${hostname}:${vtadmin_api_port}" \
   VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS="true" \
   npm run --prefix "$web_dir" build
 
@@ -86,7 +86,7 @@ echo ${vtadmin_web_pid} > "${log_dir}/vtadmin-web.pid"
 
 echo "\
 vtadmin-web is running!
-  - Browser: http://localhost:${vtadmin_web_port}
+  - Browser: http://${hostname}:${vtadmin_web_port}
   - Logs: ${log_dir}/vtadmin-web.out
   - PID: ${vtadmin_web_pid}
 "


### PR DESCRIPTION
## Description

All of the example scripts use the [`$hostname` variable defined in `env.sh` as the output of `hostname -f`](https://github.com/vitessio/vitess/blob/main/examples/common/env.sh#L19) when defining host:port values. An exception to that, however, was the [`vtadmin-up.sh`](https://github.com/vitessio/vitess/blob/6061d95381de77f2c249830f53fc66c350b09e74/examples/common/scripts/vtadmin-up.sh) script which used a combination of [no host](https://github.com/vitessio/vitess/blob/6061d95381de77f2c249830f53fc66c350b09e74/examples/common/scripts/vtadmin-up.sh#L14), and [localhost](https://github.com/vitessio/vitess/blob/6061d95381de77f2c249830f53fc66c350b09e74/examples/common/scripts/vtadmin-up.sh#L77). The no host case could end up using IPV6 on some hosts, and localhost could resolve to anything (typically IPV4 127.0.0.1).

This meant that the behavior was undefined, as well as being non-uniform. An example of problems this could lead to [was discussed in the Vitess slack where the web app is using IPV4 and the API server IPV6 and the two cannot talk](https://vitess.slack.com/archives/C02JQQ88Z1C/p1685643345872059).

## Related Issue(s)

  - Fixes: 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required