### PR TITLE
Backport #13130: Tablet throttler: throttler-config-via-topo defaults 'true', deprecation message for old flags

### DIFF
--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -14,6 +14,7 @@
   - **[New command line flags and behavior](#new-flag)**
     - [Builtin backup: read buffering flags](#builtin-backup-read-buffering-flags)
     - [Manifest backup external decompressor command](#manifest-backup-external-decompressor-command)
+    - [Throttler config via topo enabled by default](#throttler-config-via-topo)
   - **[New stats](#new-stats)**
     - [Detailed backup and restore stats](#detailed-backup-and-restore-stats)
     - [VTtablet Error count with code](#vttablet-error-count-with-code)
@@ -163,6 +164,12 @@ This feature enables the following flow:
             --manifest-external-decompressor="zstd -d"
     ```
  2. Restore that backup with a mere `Restore` command, without having to specify `--external-decompressor`.
+
+#### <a id="throttler-config-via-topo" />vttablet --throttler-config-via-topo
+
+This flag was introduced in v16 and defaulted to `false`. In v17 it defaults to `true`, and there is no need to supply it.
+
+Note that this flag overrides `--enable-lag-throttler` and `--throttle-threshold`, which now give warnings, and will be removed in v18.
 
 ### <a id="new-stats"/>New stats
 

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -316,7 +316,7 @@ Usage of vttablet:
       --throttle_metrics_threshold float                                 Override default throttle threshold, respective to --throttle_metrics_query (default 1.7976931348623157e+308)
       --throttle_tablet_types string                                     Comma separated VTTablet types to be considered by the throttler. default: 'replica'. example: 'replica,rdonly'. 'replica' aways implicitly included (default "replica")
       --throttle_threshold duration                                      Replication lag threshold for default lag throttling (default 1s)
-      --throttler-config-via-topo                                        When 'true', read config from topo service and ignore throttle_threshold, throttle_metrics_threshold, throttle_metrics_query, throttle_check_as_check_self
+      --throttler-config-via-topo                                        When 'true', read config from topo service and ignore throttle_threshold, throttle_metrics_threshold, throttle_metrics_query, throttle_check_as_check_self (default true)
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
       --topo_consul_lock_session_checks string                           List of checks for consul session. (default "serfHealth")
       --topo_consul_lock_session_ttl string                              TTL for consul session.

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -35,6 +35,7 @@ import (
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/onlineddl"
+	"vitess.io/vitess/go/test/endtoend/throttler"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -150,9 +151,6 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtTabletExtraArgs = []string{
-			"--enable-lag-throttler",
-			"--throttle_threshold", "1s",
-			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
 			"--migration_check_interval", "5s",
@@ -204,6 +202,8 @@ func TestSchemaChange(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	shards = clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
+
+	throttler.EnableLagThrottlerAndWaitForStatus(t, clusterInstance, time.Second)
 
 	t.Run("revertible", testRevertible)
 	t.Run("revert", testRevert)

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -38,6 +38,7 @@ import (
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/onlineddl"
+	"vitess.io/vitess/go/test/endtoend/throttler"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -187,9 +188,6 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtTabletExtraArgs = []string{
-			"--enable-lag-throttler",
-			"--throttle_threshold", "1s",
-			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
 			"--watch_replication_stream",
@@ -234,6 +232,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestSchemaChange(t *testing.T) {
+
+	throttler.EnableLagThrottlerAndWaitForStatus(t, clusterInstance, time.Second)
+
 	t.Run("scheduler", testScheduler)
 	t.Run("singleton", testSingleton)
 	t.Run("declarative", testDeclarative)

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -171,8 +171,6 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtTabletExtraArgs = []string{
-			"--throttler-config-via-topo",
-			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
 			"--migration_check_interval", "5s",
@@ -259,7 +257,7 @@ func TestSchemaChange(t *testing.T) {
 	err := clusterInstance.WaitForTabletsToHealthyInVtgate()
 	require.NoError(t, err)
 
-	_, err = throttler.UpdateThrottlerTopoConfig(clusterInstance, true, false, 0, "", false)
+	_, err = throttler.UpdateThrottlerTopoConfig(clusterInstance, true, false, 0, "")
 	require.NoError(t, err)
 
 	for _, ks := range clusterInstance.Keyspaces {

--- a/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
@@ -35,6 +35,7 @@ import (
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/onlineddl"
+	"vitess.io/vitess/go/test/endtoend/throttler"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -177,9 +178,6 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtTabletExtraArgs = []string{
-			"--enable-lag-throttler",
-			"--throttle_threshold", "1s",
-			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
 			"--migration_check_interval", "5s",
@@ -231,6 +229,8 @@ func TestSchemaChange(t *testing.T) {
 
 	shards = clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
+
+	throttler.EnableLagThrottlerAndWaitForStatus(t, clusterInstance, time.Second)
 
 	t.Run("create schema", func(t *testing.T) {
 		assert.Equal(t, 1, len(clusterInstance.Keyspaces[0].Shards))

--- a/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
@@ -47,6 +47,7 @@ import (
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/onlineddl"
+	"vitess.io/vitess/go/test/endtoend/throttler"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -429,9 +430,6 @@ func TestMain(m *testing.M) {
 		// thereby examining lastPK on vcopier side. We will be iterating tables using non-PK order throughout
 		// this test suite, and so the low setting ensures we hit the more interesting code paths.
 		clusterInstance.VtTabletExtraArgs = []string{
-			"--enable-lag-throttler",
-			"--throttle_threshold", "1s",
-			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
 			"--migration_check_interval", "5s",
@@ -484,6 +482,8 @@ func TestSchemaChange(t *testing.T) {
 
 	shards = clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
+
+	throttler.EnableLagThrottlerAndWaitForStatus(t, clusterInstance, time.Second)
 
 	for _, testcase := range testCases {
 		require.NotEmpty(t, testcase.name)

--- a/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
@@ -34,6 +34,7 @@ import (
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/onlineddl"
+	"vitess.io/vitess/go/test/endtoend/throttler"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,9 +83,6 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtTabletExtraArgs = []string{
-			"--enable-lag-throttler",
-			"--throttle_threshold", "1s",
-			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
 			"--migration_check_interval", "5s",
@@ -133,6 +131,8 @@ func TestSchemaChange(t *testing.T) {
 
 	shards := clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
+
+	throttler.EnableLagThrottlerAndWaitForStatus(t, clusterInstance, time.Second)
 
 	files, err := os.ReadDir(testDataPath)
 	require.NoError(t, err)

--- a/go/test/endtoend/schemadiff/vrepl/schemadiff_vrepl_suite_test.go
+++ b/go/test/endtoend/schemadiff/vrepl/schemadiff_vrepl_suite_test.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +34,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/onlineddl"
+	"vitess.io/vitess/go/test/endtoend/throttler"
 	"vitess.io/vitess/go/vt/schemadiff"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
@@ -87,9 +89,6 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtTabletExtraArgs = []string{
-			"--enable-lag-throttler",
-			"--throttle_threshold", "1s",
-			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
 			"--migration_check_interval", "5s",
@@ -138,6 +137,8 @@ func TestSchemaChange(t *testing.T) {
 
 	shards := clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
+
+	throttler.EnableLagThrottlerAndWaitForStatus(t, clusterInstance, time.Second)
 
 	files, err := os.ReadDir(testDataPath)
 	require.NoError(t, err)

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -97,7 +97,6 @@ func TestMain(m *testing.M) {
 			"--lock_tables_timeout", "5s",
 			"--watch_replication_stream",
 			"--enable_replication_reporter",
-			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--gc_check_interval", gcCheckInterval.String(),
 			"--gc_purge_check_interval", gcPurgeCheckInterval.String(),

--- a/go/test/endtoend/tabletmanager/throttler/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler/throttler_test.go
@@ -96,12 +96,12 @@ func TestMain(m *testing.M) {
 
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
+			"--throttler-config-via-topo=false",
 			"--lock_tables_timeout", "5s",
 			"--watch_replication_stream",
 			"--enable_replication_reporter",
 			"--enable-lag-throttler",
 			"--throttle_threshold", throttlerThreshold.String(),
-			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", onDemandHeartbeatDuration.String(),
 			"--disable_active_reparents",

--- a/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
@@ -98,6 +98,7 @@ func TestMain(m *testing.M) {
 
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
+			"--throttler-config-via-topo=false",
 			"--lock_tables_timeout", "5s",
 			"--watch_replication_stream",
 			"--enable_replication_reporter",
@@ -105,7 +106,6 @@ func TestMain(m *testing.M) {
 			"--throttle_metrics_query", "show global status like 'threads_running'",
 			"--throttle_metrics_threshold", fmt.Sprintf("%d", testThreshold),
 			"--throttle_check_as_check_self",
-			"--heartbeat_enable",
 			"--heartbeat_interval", "250ms",
 		}
 

--- a/go/test/endtoend/throttler/util.go
+++ b/go/test/endtoend/throttler/util.go
@@ -21,13 +21,15 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/buger/jsonparser"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -51,13 +53,8 @@ var DefaultConfig = &Config{
 // This retries the command until it succeeds or times out as the
 // SrvKeyspace record may not yet exist for a newly created
 // Keyspace that is still initializing before it becomes serving.
-func UpdateThrottlerTopoConfig(clusterInstance *cluster.LocalProcessCluster, enable bool, disable bool, threshold float64, metricsQuery string, viaVtctldClient bool) (result string, err error) {
+func UpdateThrottlerTopoConfigRaw(vtctldProcess *cluster.VtctldClientProcess, keyspaceName string, enable bool, disable bool, threshold float64, metricsQuery string) (result string, err error) {
 	args := []string{}
-	clientfunc := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput
-	if !viaVtctldClient {
-		args = append(args, "--")
-		clientfunc = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput
-	}
 	args = append(args, "UpdateThrottlerConfig")
 	if enable {
 		args = append(args, "--enable")
@@ -74,7 +71,7 @@ func UpdateThrottlerTopoConfig(clusterInstance *cluster.LocalProcessCluster, ena
 	} else {
 		args = append(args, "--check-as-check-shard")
 	}
-	args = append(args, clusterInstance.Keyspaces[0].Name)
+	args = append(args, keyspaceName)
 
 	ctx, cancel := context.WithTimeout(context.Background(), ConfigTimeout)
 	defer cancel()
@@ -83,7 +80,7 @@ func UpdateThrottlerTopoConfig(clusterInstance *cluster.LocalProcessCluster, ena
 	defer ticker.Stop()
 
 	for {
-		result, err = clientfunc(args...)
+		result, err = vtctldProcess.ExecuteCommandWithOutput(args...)
 		if err == nil {
 			return result, nil
 		}
@@ -95,40 +92,87 @@ func UpdateThrottlerTopoConfig(clusterInstance *cluster.LocalProcessCluster, ena
 	}
 }
 
+// UpdateThrottlerTopoConfig runs vtctlclient UpdateThrottlerConfig.
+// This retries the command until it succeeds or times out as the
+// SrvKeyspace record may not yet exist for a newly created
+// Keyspace that is still initializing before it becomes serving.
+func UpdateThrottlerTopoConfig(clusterInstance *cluster.LocalProcessCluster, enable bool, disable bool, threshold float64, metricsQuery string) (string, error) {
+	rec := concurrency.AllErrorRecorder{}
+	var (
+		err error
+		res strings.Builder
+	)
+	for _, ks := range clusterInstance.Keyspaces {
+		ires, err := UpdateThrottlerTopoConfigRaw(&clusterInstance.VtctldClientProcess, ks.Name, enable, disable, threshold, metricsQuery)
+		if err != nil {
+			rec.RecordError(err)
+		}
+		res.WriteString(ires)
+	}
+	if rec.HasErrors() {
+		err = rec.Error()
+	}
+	return res.String(), err
+}
+
 // WaitForThrottlerStatusEnabled waits for a tablet to report its throttler status as
 // enabled/disabled and have the provided config (if any) until the specified timeout.
 func WaitForThrottlerStatusEnabled(t *testing.T, tablet *cluster.Vttablet, enabled bool, config *Config, timeout time.Duration) {
 	enabledJSONPath := "IsEnabled"
 	queryJSONPath := "Query"
 	thresholdJSONPath := "Threshold"
-	url := fmt.Sprintf("http://localhost:%d/throttler/status", tablet.HTTPPort)
+	throttlerURL := fmt.Sprintf("http://localhost:%d/throttler/status", tablet.HTTPPort)
+	tabletURL := fmt.Sprintf("http://localhost:%d/debug/status_details", tablet.HTTPPort)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
 	for {
-		body := getHTTPBody(url)
-		isEnabled, err := jsonparser.GetBoolean([]byte(body), enabledJSONPath)
-		require.NoError(t, err)
+		throttlerBody := getHTTPBody(throttlerURL)
+		isEnabled := gjson.Get(throttlerBody, enabledJSONPath).Bool()
 		if isEnabled == enabled {
 			if config == nil {
 				return
 			}
-			query, err := jsonparser.GetString([]byte(body), queryJSONPath)
-			require.NoError(t, err)
-			threshold, err := jsonparser.GetFloat([]byte(body), thresholdJSONPath)
-			require.NoError(t, err)
+			query := gjson.Get(throttlerBody, queryJSONPath).String()
+			threshold := gjson.Get(throttlerBody, thresholdJSONPath).Float()
 			if query == config.Query && threshold == config.Threshold {
 				return
 			}
 		}
+		// If the tablet is Not Serving due to e.g. being involved in a
+		// Reshard where its QueryService is explicitly disabled, then
+		// we should not fail the test as the throttler will not be Open.
+		tabletBody := getHTTPBody(tabletURL)
+		class := strings.ToLower(gjson.Get(tabletBody, "0.Class").String())
+		value := strings.ToLower(gjson.Get(tabletBody, "0.Value").String())
+		if class == "unhappy" && strings.Contains(value, "not serving") {
+			log.Infof("tablet %s is Not Serving, so ignoring throttler status as the throttler will not be Opened", tablet.Alias)
+			return
+		}
 		select {
 		case <-ctx.Done():
 			t.Errorf("timed out waiting for the %s tablet's throttler status enabled to be %t with the correct config after %v; last seen value: %s",
-				tablet.Alias, enabled, timeout, body)
+				tablet.Alias, enabled, timeout, throttlerBody)
 			return
 		case <-ticker.C:
+		}
+	}
+}
+
+// EnableLagThrottlerAndWaitForStatus is a utility function to enable the throttler at the beginning of an endtoend test.
+// The throttler is configued to use the standard replication lag metric. The function waits until the throttler is confirmed
+// to be running on all tablets.
+func EnableLagThrottlerAndWaitForStatus(t *testing.T, clusterInstance *cluster.LocalProcessCluster, lag time.Duration) {
+	_, err := UpdateThrottlerTopoConfig(clusterInstance, true, false, lag.Seconds(), "")
+	require.NoError(t, err)
+
+	for _, ks := range clusterInstance.Keyspaces {
+		for _, shard := range ks.Shards {
+			for _, tablet := range shard.Vttablets {
+				WaitForThrottlerStatusEnabled(t, tablet, true, nil, time.Minute)
+			}
 		}
 	}
 }
@@ -147,32 +191,6 @@ func getHTTPBody(url string) string {
 	respByte, _ := io.ReadAll(resp.Body)
 	body := string(respByte)
 	return body
-}
-
-// WaitForQueryResult waits for a tablet to return the given result for the given
-// query until the specified timeout.
-// This is for simple queries that return 1 column in 1 row. It compares the result
-// for that column as a string with the provided result.
-func WaitForQueryResult(t *testing.T, tablet *cluster.Vttablet, query, result string, timeout time.Duration) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		res, err := tablet.VttabletProcess.QueryTablet(query, "", false)
-		require.NoError(t, err)
-		if res != nil && len(res.Rows) == 1 && res.Rows[0][0].ToString() == result {
-			return
-		}
-		select {
-		case <-ctx.Done():
-			t.Errorf("timed out waiting for the %q query to produce a result of %q on tablet %s after %v; last seen value: %s",
-				query, result, tablet.Alias, timeout, res.Rows[0][0].ToString())
-			return
-		case <-ticker.C:
-		}
-	}
 }
 
 // WaitForValidData waits for a tablet's checks to return a non 500 http response

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -125,6 +125,7 @@ func tstWorkflowExec(t *testing.T, cells, workflow, sourceKs, targetKs, tables, 
 	if tabletTypes != "" {
 		args = append(args, "--tablet_types", tabletTypes)
 	}
+	args = append(args, "--timeout", time.Minute.String())
 	ksWorkflow := fmt.Sprintf("%s.%s", targetKs, workflow)
 	args = append(args, action, ksWorkflow)
 	output, err := vc.VtctlClient.ExecuteCommandWithOutput(args...)

--- a/go/vt/srvtopo/watch.go
+++ b/go/vt/srvtopo/watch.go
@@ -195,7 +195,7 @@ func (entry *watchEntry) onErrorLocked(err error, init bool) {
 		// This watcher will able to continue to return the last value till it is not able to connect to the topo server even if the cache TTL is reached.
 		// TTL cache is only checked if the error is a known error i.e topo.Error.
 		_, isTopoErr := err.(topo.Error)
-		if isTopoErr && time.Since(entry.lastValueTime) > entry.rw.cacheTTL {
+		if entry.value != nil && isTopoErr && time.Since(entry.lastValueTime) > entry.rw.cacheTTL {
 			log.Errorf("WatchSrvKeyspace clearing cached entry for %v", entry.key)
 			entry.value = nil
 		}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -968,7 +968,7 @@ func (qre *QueryExecutor) execShowMigrationLogs() (*sqltypes.Result, error) {
 }
 
 func (qre *QueryExecutor) execShowThrottledApps() (*sqltypes.Result, error) {
-	if err := qre.tsv.lagThrottler.CheckIsReady(); err != nil {
+	if err := qre.tsv.lagThrottler.CheckIsOpen(); err != nil {
 		return nil, err
 	}
 	if _, ok := qre.plan.FullStmt.(*sqlparser.ShowThrottledApps); !ok {
@@ -1007,7 +1007,7 @@ func (qre *QueryExecutor) execShowThrottlerStatus() (*sqltypes.Result, error) {
 		return nil, vterrors.New(vtrpcpb.Code_INTERNAL, "Expecting SHOW VITESS_THROTTLER STATUS plan")
 	}
 	var enabled int32
-	if err := qre.tsv.lagThrottler.CheckIsReady(); err == nil {
+	if qre.tsv.lagThrottler.IsEnabled() {
 		enabled = 1
 	}
 	result := &sqltypes.Result{


### PR DESCRIPTION
Backport of https://github.com/vitessio/vitess/pull/13130

---

## Description

- `v16` introduced a new `vttablet` flag: `--throttler-config-via-topo`, see the docs: https://vitess.io/docs/16.0/reference/features/tablet-throttler/
- In `v16` this flag defaults `false`, and the old per-tablet `--enable-lag-throttler` configuration is still supported.
- For `v17`, **the target of this PR**, this PR sets the default for `--throttler-config-via-topo` to `true`. The old configuration is still supported but if used there's a deprecation warning.
- In `v18`, the old configuration & logic will be compeletely removed and it will be assumed that `--throttler-config-via-topo` is always `true` whether specified or not. The flag will issue a deprecation message.
- In `v19` we will remove the flag `--throttler-config-via-topo`.

We remove all references to `--enable-lag-throttler` in Vitess's own `endtoend` tests, and use the dynamic throttler config everywhere.


## Related Issue(s)

Follow up to:

- https://github.com/vitessio/vitess/pull/11604
- https://github.com/vitessio/vitess/pull/12520

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation: https://github.com/vitessio/website/pull/1489