### PR TITLE
Fix vtcompose command incorrect regex

### DIFF
--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -317,10 +317,10 @@ func getTableName(sqlFile string) string {
 		log.Fatalf("reading sqlFile file %s: %s", sqlFile, err)
 	}
 
-	r, _ := regexp.Compile("CREATE TABLE ([a-z_-]*) \\(")
+	r, _ := regexp.Compile("CREATE TABLE (IF NOT EXISTS)? ?([a-z_-]*) \\(")
 	rs := r.FindStringSubmatch(string(sqlFileData))
 	// replace all ` from table name if exists
-	return strings.ReplaceAll(rs[1], "`", "")
+	return strings.ReplaceAll(rs[len(rs)-1], "`", "")
 }
 
 func getPrimaryKey(sqlFile string) string {

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -317,7 +317,7 @@ func getTableName(sqlFile string) string {
 		log.Fatalf("reading sqlFile file %s: %s", sqlFile, err)
 	}
 
-	r, _ := regexp.Compile("CREATE TABLE (IF NOT EXISTS)? ?([a-z_-]*) \\(")
+	r, _ := regexp.Compile("(?i)CREATE[[:space:]]*TABLE[[:space:]]*(IF NOT EXISTS)?[[:space:]]*([a-z_-]*)[[:space:]]*\\(")
 	rs := r.FindStringSubmatch(string(sqlFileData))
 	// replace all ` from table name if exists
 	return strings.ReplaceAll(rs[len(rs)-1], "`", "")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
The vtcompose utility in `examples/compose/` had an incorrect regex which would make it panic on the provided example schema files.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are **not required**
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

