### PR TITLE
Fix new vtctl upgrade downgrade test on `release-16.0`

### DIFF
--- a/go/test/endtoend/cluster/cluster_util.go
+++ b/go/test/endtoend/cluster/cluster_util.go
@@ -179,12 +179,22 @@ func getTablet(tabletGrpcPort int, hostname string) *topodatapb.Tablet {
 func filterResultForWarning(input string) string {
 	lines := strings.Split(input, "\n")
 	var result string
-	for _, line := range lines {
+	for i, line := range lines {
 		if strings.Contains(line, "WARNING: vtctl should only be used for VDiff v1 workflows. Please use VDiff v2 and consider using vtctldclient for all other commands.") {
 			continue
 		}
-		result = result + line + "\n"
+
+		if strings.Contains(line, "Failed to read in config") && strings.Contains(line, `Config File "vtconfig" Not Found in`) {
+			continue
+		}
+
+		result += line
+
+		if i < len(lines)-1 {
+			result += "\n"
+		}
 	}
+
 	return result
 }
 

--- a/go/test/endtoend/cluster/vtctlclient_process.go
+++ b/go/test/endtoend/cluster/vtctlclient_process.go
@@ -219,7 +219,7 @@ func (vtctlclient *VtctlClientProcess) ExecuteCommandWithOutput(args ...string) 
 		}
 		time.Sleep(retryDelay)
 	}
-	return filterResultWhenRunsForCoverage(resultStr), err
+	return filterResultForWarning(filterResultWhenRunsForCoverage(resultStr)), err
 }
 
 // VtctlClientProcessInstance returns a VtctlProcess handle for vtctlclient process

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -63,7 +63,7 @@ var (
 	replicationWaitTimeout = time.Duration(15 * time.Second)
 )
 
-//region cluster setup/teardown
+// region cluster setup/teardown
 
 // SetupReparentCluster is used to setup the reparent cluster
 func SetupReparentCluster(t *testing.T, durability string) *cluster.LocalProcessCluster {
@@ -133,7 +133,7 @@ func setupCluster(ctx context.Context, t *testing.T, shardName string, cells []s
 	err = clusterInstance.SetupCluster(keyspace, []cluster.Shard{*shard})
 	require.NoError(t, err, "Cannot launch cluster")
 
-	//Start MySql
+	// Start MySql
 	var mysqlCtlProcessList []*exec.Cmd
 	for _, shard := range clusterInstance.Keyspaces[0].Shards {
 		for _, tablet := range shard.Vttablets {
@@ -234,7 +234,7 @@ func StartNewVTTablet(t *testing.T, clusterInstance *cluster.LocalProcessCluster
 	return tablet
 }
 
-//endregion
+// endregion
 
 // region database queries
 func getMysqlConnParam(tablet *cluster.Vttablet) mysql.ConnParams {
@@ -262,7 +262,7 @@ func execute(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {
 	return qr
 }
 
-//endregion
+// endregion
 
 // region ers, prs
 
@@ -350,8 +350,13 @@ func ValidateTopology(t *testing.T, clusterInstance *cluster.LocalProcessCluster
 		args = append(args, "--", "--ping-tablets=true")
 	}
 	out, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(args...)
-	require.Empty(t, out)
 	require.NoError(t, err)
+
+	ver, err := cluster.GetMajorVersion("vtctlclient")
+	require.NoError(t, err)
+	if ver <= 16 {
+		require.Empty(t, out)
+	}
 }
 
 // ConfirmReplication confirms that the replication is working properly

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -350,13 +350,8 @@ func ValidateTopology(t *testing.T, clusterInstance *cluster.LocalProcessCluster
 		args = append(args, "--", "--ping-tablets=true")
 	}
 	out, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(args...)
+	require.Empty(t, out)
 	require.NoError(t, err)
-
-	ver, err := cluster.GetMajorVersion("vtctlclient")
-	require.NoError(t, err)
-	if ver <= 16 {
-		require.Empty(t, out)
-	}
 }
 
 // ConfirmReplication confirms that the replication is working properly


### PR DESCRIPTION
## Description

This PR implements proper filtering of the warning for `vtctlclient`. We will now remove the error produced by a missing or incorrect `vtconfig` on `release-17.0` and above. This is useful to make the upgrade downgrade test pass.
