### PR TITLE
Remove `out.txt` and add `release-17.0` to go upgrade automation

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [ main, release-16.0, release-15.0, release-14.0 ]
+        branch: [ main, release-17.0, release-16.0, release-15.0, release-14.0 ]
     name: Update Golang Version
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -55,8 +55,10 @@ jobs:
           # Check if the PR already exists, if it does then do not create new PR.
           gh pr list -S "is:open [${{ matrix.branch }}] Upgrade the Golang version to go${go_version}" > out.txt 2>&1 | true
           if [ -s out.txt ]; then
+            rm -f out.txt
             exit 0
           fi
+          rm -f out.txt
           echo "create-pr=true" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request


### PR DESCRIPTION
## Description

This PR removes the file `out.txt` and makes sure it will no longer be created.

This PR also adds the `release-17.0` branch to the golang upgrade automation tool.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
