### PR TITLE
Set the number of threads for release notes generation with a flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -460,8 +460,5 @@ generate_ci_workflows:
 generate-flag-testdata:
 	./tools/generate_flag_testdata.sh
 
-release-notes:
-	go run ./go/tools/release-notes --from "$(FROM)" --to "$(TO)" --version "$(VERSION)" --summary "$(SUMMARY)"
-
 install_kubectl_kind:
 	./tools/get_kubectl_kind.sh

--- a/doc/internal/ReleaseInstructions.md
+++ b/doc/internal/ReleaseInstructions.md
@@ -271,12 +271,16 @@ We need to verify that _arewefastyet_ has finished the benchmark too.
     2. Run the following command to generate the release notes:
         1. Release Candidate:
             ```shell
-            make VERSION="v15.0.0-rc1" FROM="v14.0.3" TO="HEAD" SUMMARY="./changelog/15.0/15.0.0/summary.md" release-notes  
+            go run ./go/tools/release-notes --from "v14.0.3" --to "HEAD" --version "v15.0.0-rc1" --summary "./changelog/15.0/15.0.0/summary.md" [--threads=[0-9.]]
             ```
         2. General Availability:
             ```shell
-            make VERSION="v15.0.0-rc1" FROM="v14.0.3" TO="HEAD" SUMMARY="./changelog/15.0/15.0.0/summary.md" release-notes  
+            go run ./go/tools/release-notes --from "v14.0.3" --to "HEAD" --version "v15.0.0" --summary "./changelog/15.0/15.0.0/summary.md" [--threads=[0-9.]]
             ```
+    
+        > Important note: The release note generation fetches a lot of data from the GitHub API. You might reach the API request limit.
+        In which case you should use the `--threads=` flag and set an integer value lower than 10 (the default).
+
        This command will generate the release notes by looking at all the commits between the tag `v14.0.3` and the reference `HEAD`.
        It will also use the file located in `./changelog/15.0/15.0.0/summary.md` to prefix the release notes with a text that the maintainers wrote before the release.
        Please verify the generated release notes to make sure it is well-formatted and all the bookmarks are generated properly.

--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -82,6 +82,7 @@ type (
 
 var (
 	releaseNotesPath = `changelog/`
+	numberOfThreads  = 10
 )
 
 const (
@@ -134,7 +135,6 @@ The entire changelog for this release can be found [here]({{ .PathToChangeLogFil
 
 	prefixType        = "Type: "
 	prefixComponent   = "Component: "
-	numberOfThreads   = 10
 	lengthOfSingleSHA = 40
 )
 
@@ -499,6 +499,7 @@ func main() {
 	pflag.StringVarP(&to, "to", "t", to, "to sha/tag/branch")
 	pflag.StringVarP(&versionName, "version", "v", "", "name of the version (has to be the following format: v11.0.0)")
 	pflag.StringVarP(&summaryFile, "summary", "s", "", "readme file on which there is a summary of the release")
+	pflag.IntVar(&numberOfThreads, "threads", numberOfThreads, "Define the number of threads used to fetch data from GitHub's API. Lower this number if you hit request limit errors.")
 	pflag.Parse()
 
 	// The -version flag must be of a valid format.

--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -502,6 +502,8 @@ func main() {
 	pflag.IntVar(&numberOfThreads, "threads", numberOfThreads, "Define the number of threads used to fetch data from GitHub's API. Lower this number if you hit request limit errors.")
 	pflag.Parse()
 
+	log.Println(numberOfThreads)
+	os.Exit(1)
 	// The -version flag must be of a valid format.
 	rx := regexp.MustCompile(`v([0-9]+)\.([0-9]+)\.([0-9]+)`)
 	// There should be 4 sub-matches, input: "v14.0.0", output: ["v14.0.0", "14", "0", "0"].


### PR DESCRIPTION
## Description

In the previous RC1 release, @mattlord encountered an issue where the release note generation was hitting a request limit error from the GitHub's API. This was due to the high number of concurrency. From now on, we can directly modify the concurrency level using a flag, without having to modify the codebase.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
