### PR TITLE
Skip `--config-file-not-found-handling` in upgrade downgrade tests when `vttablet < 17.x.x`

### DIFF
--- a/examples/common/env.sh
+++ b/examples/common/env.sh
@@ -32,8 +32,7 @@ done;
 
 # vtctlclient has a separate alias setup below
 for binary in vttablet vtgate vtctld mysqlctl vtorc vtctl; do
-  out=$($binary --version)
-  majorVersion=$(echo $out | awk -F'[:.]' '{print $2}' | awk '{gsub(" ", ""); print}' | tr -d '[:space:]')
+  majorVersion=$("${binary}" --version | sed -rn 's/^Version:[[:space:]]*([[:digit:]]+)\.[[:digit:]]+\.[[:digit:]]+.*/\1/p')
   if [[ $majorVersion -gt "16" ]]; then
     alias $binary="$binary --config-file-not-found-handling=ignore"
   fi

--- a/examples/common/env.sh
+++ b/examples/common/env.sh
@@ -32,7 +32,11 @@ done;
 
 # vtctlclient has a separate alias setup below
 for binary in vttablet vtgate vtctld mysqlctl vtorc vtctl; do
-  alias $binary="$binary --config-file-not-found-handling=ignore"
+  out=$($binary --version)
+  majorVersion=$(echo $out | awk -F'[:.]' '{print $2}' | awk '{gsub(" ", ""); print}' | tr -d '[:space:]')
+  if [[ $majorVersion -gt "16" ]]; then
+    alias $binary="$binary --config-file-not-found-handling=ignore"
+  fi
 done;
 
 if [ "${TOPO}" = "zk2" ]; then


### PR DESCRIPTION
## Description

Saw in https://github.com/vitessio/vitess/pull/13268 that the `[Upgrade Downgrade Test - Backups - Manual](https://github.com/vitessio/vitess/actions/runs/5204734892/jobs/9402321444?pr=13268#logs)` test was failing due to an invalid flag when running with `vttablet:16.0.2` from the `release-17.0` branch. The incorrect flag is: `--config-file-not-found-handling`.

This PR ensures we do not add the flag if the version of `vttablet` is not greater or equal to 17.

Log fragment from previous CI run:
```
unknown flag: --config-file-not-found-handling
```

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
