### PR TITLE
Add metric for showing the errant GTIDs in VTOrc

### DIFF
--- a/go/test/endtoend/vtorc/api/api_test.go
+++ b/go/test/endtoend/vtorc/api/api_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package api
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -197,5 +199,15 @@ func TestAPIEndpoints(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 400, status, resp)
 		assert.Equal(t, "Filtering by shard without keyspace isn't supported\n", resp)
+
+		// Also verify that the metric for errant GTIDs is reporting the correct information.
+		_, resp, err = utils.MakeAPICall(t, vtorc, "/debug/vars")
+		require.NoError(t, err)
+		resultMap := make(map[string]any)
+		err = json.Unmarshal([]byte(resp), &resultMap)
+		require.NoError(t, err)
+		errantGtidTablets := reflect.ValueOf(resultMap["ErrantGtidMap"]).MapKeys()
+		require.Len(t, errantGtidTablets, 1)
+		require.EqualValues(t, replica.Alias, errantGtidTablets[0].String())
 	})
 }

--- a/go/test/endtoend/vtorc/api/api_test.go
+++ b/go/test/endtoend/vtorc/api/api_test.go
@@ -206,8 +206,16 @@ func TestAPIEndpoints(t *testing.T) {
 		resultMap := make(map[string]any)
 		err = json.Unmarshal([]byte(resp), &resultMap)
 		require.NoError(t, err)
-		errantGtidTablets := reflect.ValueOf(resultMap["ErrantGtidMap"]).MapKeys()
-		require.Len(t, errantGtidTablets, 1)
-		require.EqualValues(t, replica.Alias, errantGtidTablets[0].String())
+		errantGTIDMap := reflect.ValueOf(resultMap["ErrantGtidMap"])
+		errantGtidTablets := errantGTIDMap.MapKeys()
+		require.Len(t, errantGtidTablets, 3)
+
+		errantGTIDinReplica := ""
+		for _, tabletKey := range errantGtidTablets {
+			if tabletKey.String() == replica.Alias {
+				errantGTIDinReplica = errantGTIDMap.MapIndex(tabletKey).Interface().(string)
+			}
+		}
+		require.NotEmpty(t, errantGTIDinReplica)
 	})
 }

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -435,12 +435,10 @@ Cleanup:
 				redactedPrimaryExecutedGtidSet.RemoveUUID(instance.SourceUUID)
 
 				instance.GtidErrant, err = vitessmysql.Subtract(redactedExecutedGtidSet.String(), redactedPrimaryExecutedGtidSet.String())
-				// update the errant gtid map
-				if err == nil {
-					errantGtidMap[topoproto.TabletAliasString(tablet.Alias)] = instance.GtidErrant
-				}
 			}
 		}
+		// update the errant gtid map
+		errantGtidMap[topoproto.TabletAliasString(tablet.Alias)] = instance.GtidErrant
 	}
 
 	latency.Stop("instance")

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -442,9 +442,11 @@ Cleanup:
 			}
 		}
 		// update the errant gtid map
-		errantGtidMapMu.Lock()
-		defer errantGtidMapMu.Unlock()
-		errantGtidMap[topoproto.TabletAliasString(tablet.Alias)] = instance.GtidErrant
+		go func() {
+			errantGtidMapMu.Lock()
+			defer errantGtidMapMu.Unlock()
+			errantGtidMap[topoproto.TabletAliasString(tablet.Alias)] = instance.GtidErrant
+		}()
 	}
 
 	latency.Stop("instance")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds a new metric to VTOrc that shows the errant GTIDs detected by VTOrc. The metric looks like the following - 
```
"ErrantGtidMap": {"zone1-0000000100": "b06fd52a-09b4-11ee-8d3b-5677533821fe:1", "zone1-0000000101": "", "zone1-0000000102": ""},
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #13307 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
