### PR TITLE
increase length of reparent_journal columns

### DIFF
--- a/go/vt/sidecardb/schema/misc/reparent_journal.sql
+++ b/go/vt/sidecardb/schema/misc/reparent_journal.sql
@@ -17,8 +17,8 @@ limitations under the License.
 CREATE TABLE IF NOT EXISTS reparent_journal
 (
     `time_created_ns`      bigint(20) unsigned NOT NULL,
-    `action_name`          varbinary(250)      NOT NULL,
-    `primary_alias`        varbinary(32)       NOT NULL,
+    `action_name`          varbinary(255)      NOT NULL,
+    `primary_alias`        varbinary(255)       NOT NULL,
     `replication_position` varbinary(64000) DEFAULT NULL,
 
     PRIMARY KEY (`time_created_ns`)


### PR DESCRIPTION
## Description
`primary_alias` column is now of length 255, increased from previous length of 32.
I also changed `action_name` to 255, just for consistency. 
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes #13286
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
