### PR TITLE
vtgate planner: HAVING in the new operator horizon planner

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -44,7 +44,6 @@ func tryPushingDownAggregator(ctx *plancontext.PlanningContext, aggregator *Aggr
 			output, applyResult, err = pushDownAggregationThroughFilter(ctx, aggregator, src)
 		}
 	default:
-		aggregator.Pushed = true
 		return aggregator, rewrite.SameTree, nil
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -207,6 +207,13 @@ func (a *Aggregator) GetOrdering() ([]ops.OrderBy, error) {
 }
 
 func (a *Aggregator) planOffsets(ctx *plancontext.PlanningContext) error {
+	if !a.Pushed {
+		err := a.planOffsetsNotPushed(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
 	addColumn := func(aliasedExpr *sqlparser.AliasedExpr, addToGroupBy bool) (int, error) {
 		newSrc, offset, err := a.Source.AddColumn(ctx, aliasedExpr, true, addToGroupBy)
 		if err != nil {
@@ -218,13 +225,6 @@ func (a *Aggregator) planOffsets(ctx *plancontext.PlanningContext) error {
 			a.Columns = append(a.Columns, aliasedExpr)
 		}
 		return offset, nil
-	}
-
-	if !a.Pushed {
-		err := a.planOffsetsNotPushed(ctx)
-		if err != nil {
-			return err
-		}
 	}
 
 	for idx, gb := range a.Grouping {

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -167,6 +167,8 @@ func (a *Aggregator) AddColumn(ctx *plancontext.PlanningContext, expr *sqlparser
 
 func (a *Aggregator) GetColumns() ([]*sqlparser.AliasedExpr, error) {
 	// we update the incoming columns, so we know about any new columns that have been added
+	// in the optimization phase, other operators could be pushed down resulting in additional columns for aggregator.
+	// Aggregator should be made aware of these to truncate them in final result.
 	columns, err := a.Source.GetColumns()
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -210,10 +210,7 @@ func (a *Aggregator) GetOrdering() ([]ops.OrderBy, error) {
 
 func (a *Aggregator) planOffsets(ctx *plancontext.PlanningContext) error {
 	if !a.Pushed {
-		err := a.planOffsetsNotPushed(ctx)
-		if err != nil {
-			return err
-		}
+		return a.planOffsetsNotPushed(ctx)
 	}
 
 	addColumn := func(aliasedExpr *sqlparser.AliasedExpr, addToGroupBy bool) (int, error) {

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -19,6 +19,8 @@ package operators
 import (
 	"strings"
 
+	"golang.org/x/exp/slices"
+
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -46,11 +48,9 @@ func newFilter(op ops.Operator, expr sqlparser.Expr) ops.Operator {
 
 // Clone implements the Operator interface
 func (f *Filter) Clone(inputs []ops.Operator) ops.Operator {
-	predicatesClone := make([]sqlparser.Expr, len(f.Predicates))
-	copy(predicatesClone, f.Predicates)
 	return &Filter{
 		Source:         inputs[0],
-		Predicates:     predicatesClone,
+		Predicates:     slices.Clone(f.Predicates),
 		FinalPredicate: f.FinalPredicate,
 	}
 }

--- a/go/vt/vtgate/planbuilder/operators/filter.go
+++ b/go/vt/vtgate/planbuilder/operators/filter.go
@@ -49,8 +49,9 @@ func (f *Filter) Clone(inputs []ops.Operator) ops.Operator {
 	predicatesClone := make([]sqlparser.Expr, len(f.Predicates))
 	copy(predicatesClone, f.Predicates)
 	return &Filter{
-		Source:     inputs[0],
-		Predicates: predicatesClone,
+		Source:         inputs[0],
+		Predicates:     predicatesClone,
+		FinalPredicate: f.FinalPredicate,
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
@@ -50,10 +50,9 @@ func expandHorizon(ctx *plancontext.PlanningContext, horizon horizonLike) (ops.O
 	}
 
 	if sel.Having != nil {
-		expr := sel.Having.Expr
 		op = &Filter{
 			Source:         op,
-			Predicates:     sqlparser.SplitAndExpression(nil, expr),
+			Predicates:     sqlparser.SplitAndExpression(nil, sel.Having.Expr),
 			FinalPredicate: nil,
 		}
 	}

--- a/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
@@ -29,10 +29,6 @@ func expandHorizon(ctx *plancontext.PlanningContext, horizon horizonLike) (ops.O
 		return nil, nil, errHorizonNotPlanned()
 	}
 
-	if sel.Having != nil {
-		return nil, nil, errHorizonNotPlanned()
-	}
-
 	op, err := createProjectionFromSelect(ctx, horizon)
 	if err != nil {
 		return nil, nil, err
@@ -47,6 +43,15 @@ func expandHorizon(ctx *plancontext.PlanningContext, horizon horizonLike) (ops.O
 		op = &Distinct{
 			Source: op,
 			QP:     qp,
+		}
+	}
+
+	if sel.Having != nil {
+		expr := sel.Having.Expr
+		op = &Filter{
+			Source:         op,
+			Predicates:     sqlparser.SplitAndExpression(nil, expr),
+			FinalPredicate: nil,
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2023 The Vitess Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/go/vt/vtgate/planbuilder/operators/horizon_phases.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_phases.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"golang.org/x/exp/slices"
+
+	"vitess.io/vitess/go/slices2"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/rewrite"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/semantics"
+)
+
+// Phase defines the different planning phases to go through to produce an optimized plan for the input query.
+type Phase struct {
+	Name string
+	// preOptimizeAction is the action to be taken before calling plan optimization operation.
+	preOptimizeAction func(ctx *plancontext.PlanningContext, op ops.Operator) (ops.Operator, error)
+	// preOptimizeAction is the action to be taken before calling plan optimization operation.
+	postOptimizeAction func(op ops.Operator) (ops.Operator, error)
+}
+
+// getPhases returns the phases the planner will go through.
+// It's used to control so rewriters collaborate correctly
+func getPhases() []Phase {
+	return []Phase{{
+		// Initial optimization
+		Name: "initial horizon planning optimization phase",
+	}, {
+		Name: "add columns if needed by filter",
+		preOptimizeAction: func(ctx *plancontext.PlanningContext, op ops.Operator) (ops.Operator, error) {
+			return addColumnsToFilter(ctx, op)
+		},
+	}, {
+		// Adding Ordering Op - Any aggregation that is performed in the VTGate needs the input to be ordered
+		Name: "add ORDER BY to aggregations above the route and add GROUP BY to aggregations on the RHS of join",
+		preOptimizeAction: func(ctx *plancontext.PlanningContext, op ops.Operator) (ops.Operator, error) {
+			ctx.Phases.PushAggregation = true
+			return addOrderBysForAggregations(ctx, op)
+		},
+		// Adding Group by - This is needed if the grouping is performed on a join with a join condition then
+		//                   aggregation happening at route needs a group by to ensure only matching rows returns
+		//                   the aggregations otherwise returns no result.
+		postOptimizeAction: addGroupByOnRHSOfJoin,
+	}}
+}
+
+func addColumnsToFilter(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Operator, error) {
+	visitor := func(in ops.Operator, _ semantics.TableSet, isRoot bool) (ops.Operator, *rewrite.ApplyResult, error) {
+		filter, ok := in.(*Filter)
+		if !ok {
+			return in, rewrite.SameTree, nil
+		}
+
+		columns, err := filter.GetColumns()
+		if err != nil {
+			return nil, nil, vterrors.Wrap(err, "while planning filter")
+		}
+		proj, areOnTopOfProj := filter.Source.(selectExpressions)
+		if !areOnTopOfProj {
+			// not much we can do here
+			return in, rewrite.SameTree, nil
+		}
+		addedColumns := false
+		for _, expr := range filter.Predicates {
+			sqlparser.Rewrite(expr, func(cursor *sqlparser.Cursor) bool {
+				e, ok := cursor.Node().(sqlparser.Expr)
+				if !ok {
+					return true
+				}
+				offset := slices.IndexFunc(columns, func(expr *sqlparser.AliasedExpr) bool {
+					return ctx.SemTable.EqualsExprWithDeps(expr.Expr, e)
+				})
+
+				if offset >= 0 {
+					// this expression can be fetched from the input - we can stop here
+					return false
+				}
+
+				if fetchByOffset(e) {
+					// this expression has to be fetched from the input, but we didn't find it in the input. let's add it
+					_, addToGroupBy := e.(*sqlparser.ColName)
+					proj.addColumnWithoutPushing(aeWrap(e), addToGroupBy)
+					addedColumns = true
+					columns, err = proj.GetColumns()
+					if err != nil {
+						panic("this should not happen")
+					}
+					return false
+				}
+				return true
+			}, nil)
+		}
+		if addedColumns {
+			return in, rewrite.NewTree("added columns because filter needs it", in), nil
+		}
+
+		return in, rewrite.SameTree, nil
+	}
+
+	return rewrite.TopDown(root, TableID, visitor, stopAtRoute)
+}
+
+// addOrderBysForAggregations runs after we have run horizonPlanning until the op tree stops changing
+// this means that we have pushed aggregations and other ops as far down as they'll go
+// addOrderBysForAggregations will find Aggregators that have not been pushed under routes and
+// add the necessary Ordering operators for them
+func addOrderBysForAggregations(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Operator, error) {
+	visitor := func(in ops.Operator, _ semantics.TableSet, isRoot bool) (ops.Operator, *rewrite.ApplyResult, error) {
+		aggrOp, ok := in.(*Aggregator)
+		if !ok {
+			return in, rewrite.SameTree, nil
+		}
+
+		requireOrdering, err := needsOrdering(aggrOp, ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !requireOrdering {
+			return in, rewrite.SameTree, nil
+		}
+		aggrOp.Source = &Ordering{
+			Source: aggrOp.Source,
+			Order: slices2.Map(aggrOp.Grouping, func(from GroupBy) ops.OrderBy {
+				return from.AsOrderBy()
+			}),
+		}
+		return in, rewrite.NewTree("added ordering before aggregation", in), nil
+	}
+
+	return rewrite.TopDown(root, TableID, visitor, stopAtRoute)
+}
+
+func needsOrdering(in *Aggregator, ctx *plancontext.PlanningContext) (bool, error) {
+	if len(in.Grouping) == 0 {
+		return false, nil
+	}
+	srcOrdering, err := in.Source.GetOrdering()
+	if err != nil {
+		return false, err
+	}
+	if len(srcOrdering) < len(in.Grouping) {
+		return true, nil
+	}
+	for idx, gb := range in.Grouping {
+		if !ctx.SemTable.EqualsExprWithDeps(srcOrdering[idx].SimplifiedExpr, gb.SimplifiedExpr) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func addGroupByOnRHSOfJoin(root ops.Operator) (ops.Operator, error) {
+	visitor := func(in ops.Operator, _ semantics.TableSet, isRoot bool) (ops.Operator, *rewrite.ApplyResult, error) {
+		join, ok := in.(*ApplyJoin)
+		if !ok {
+			return in, rewrite.SameTree, nil
+		}
+
+		return addLiteralGroupingToRHS(join)
+	}
+
+	return rewrite.TopDown(root, TableID, visitor, stopAtRoute)
+}
+
+func addLiteralGroupingToRHS(in *ApplyJoin) (ops.Operator, *rewrite.ApplyResult, error) {
+	_ = rewrite.Visit(in.RHS, func(op ops.Operator) error {
+		aggr, isAggr := op.(*Aggregator)
+		if !isAggr {
+			return nil
+		}
+		if len(aggr.Grouping) == 0 {
+			gb := sqlparser.NewIntLiteral(".0")
+			aggr.Grouping = append(aggr.Grouping, NewGroupBy(gb, gb, aeWrap(gb)))
+		}
+		return nil
+	})
+	return in, rewrite.SameTree, nil
+}

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -19,9 +19,6 @@ package operators
 import (
 	"io"
 
-	"golang.org/x/exp/slices"
-
-	"vitess.io/vitess/go/slices2"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
@@ -92,33 +89,6 @@ func tryHorizonPlanning(ctx *plancontext.PlanningContext, root ops.Operator) (ou
 	return
 }
 
-// Phase defines the different planning phases to go through to produce an optimized plan for the input query.
-type Phase struct {
-	Name string
-	// preOptimizeAction is the action to be taken before calling plan optimization operation.
-	preOptimizeAction func(ctx *plancontext.PlanningContext, op ops.Operator) (ops.Operator, error)
-}
-
-// getPhases returns the phases the planner will go through.
-// It's used to control so rewriters collaborate correctly
-func getPhases() []Phase {
-	return []Phase{{
-		// Initial optimization
-		Name:              "initial horizon planning optimization phase",
-		preOptimizeAction: addColumnsToFilter,
-	}, {
-		// Initial optimization
-		Name: "add columns if needed by filter",
-	}, {
-		// Adding Ordering Op - Any aggregation that is performed in the VTGate needs the input to be ordered
-		// Adding Group by - This is needed if the grouping is performed on a join with a join condition then
-		//                   aggregation happening at route needs a group by to ensure only matching rows returns
-		//                   the aggregations otherwise returns no result.
-		Name:              "add ORDER BY to aggregations above the route and add GROUP BY to aggregations on the RHS of join",
-		preOptimizeAction: addOrderBysAndGroupBysForAggregations,
-	}}
-}
-
 // planHorizons is the process of figuring out how to perform the operations in the Horizon
 // If we can push it under a route - done.
 // If we can't, we will instead expand the Horizon into
@@ -138,8 +108,14 @@ func planHorizons(ctx *plancontext.PlanningContext, root ops.Operator) (op ops.O
 		if err != nil {
 			return nil, err
 		}
-	}
+		if phase.postOptimizeAction != nil {
+			op, err = phase.postOptimizeAction(op)
+			if err != nil {
+				return nil, err
+			}
+		}
 
+	}
 	return op, nil
 }
 
@@ -177,307 +153,35 @@ func optimizeHorizonPlanning(ctx *plancontext.PlanningContext, root ops.Operator
 	return newOp, nil
 }
 
-func tryPushingDownFilter(ctx *plancontext.PlanningContext, in *Filter) (ops.Operator, *rewrite.ApplyResult, error) {
-	switch src := in.Source.(type) {
-	case *Projection:
-		return pushFilterUnderProjection(ctx, in, src)
-	case *Route:
-		return rewrite.Swap(in, src, "push filter into Route")
-	}
-
-	return in, rewrite.SameTree, nil
-}
-
-func pushFilterUnderProjection(ctx *plancontext.PlanningContext, filter *Filter, projection *Projection) (ops.Operator, *rewrite.ApplyResult, error) {
-	for _, p := range filter.Predicates {
-		cantPushDown := false
-		_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-			if !fetchByOffset(node) {
-				return true, nil
-			}
-
-			if projection.needsEvaluation(ctx, node.(sqlparser.Expr)) {
-				cantPushDown = true
-				return false, io.EOF
-			}
-
-			return true, nil
-		}, p)
-
-		if cantPushDown {
-			return filter, rewrite.SameTree, nil
+func pushOrExpandHorizon(ctx *plancontext.PlanningContext, in horizonLike) (ops.Operator, *rewrite.ApplyResult, error) {
+	if derived, ok := in.(*Derived); ok {
+		if len(derived.ColumnAliases) > 0 {
+			return nil, nil, errHorizonNotPlanned()
 		}
 	}
-	return rewrite.Swap(filter, projection, "push filter under projection")
-
-}
-func tryPushingDownDistinct(in *Distinct) (ops.Operator, *rewrite.ApplyResult, error) {
-	if in.Pushed {
-		return in, rewrite.SameTree, nil
-	}
-	switch src := in.Source.(type) {
-	case *Route:
-		if src.IsSingleShard() {
-			return rewrite.Swap(in, src, "push distinct under route")
-		}
-	case *Distinct:
-		return src, rewrite.NewTree("removed double distinct", src), nil
-	case *Aggregator:
-		return in, rewrite.SameTree, nil
+	rb, isRoute := in.src().(*Route)
+	if isRoute && rb.IsSingleShard() {
+		return rewrite.Swap(in, rb, "push horizon into route")
 	}
 
-	cols, err := in.Source.GetColumns()
+	sel, isSel := in.selectStatement().(*sqlparser.Select)
+	if !isSel {
+		return nil, nil, errHorizonNotPlanned()
+	}
+
+	qp, err := in.getQP(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	aggr := &Aggregator{
-		Source:   in.Source,
-		QP:       in.QP,
-		Original: true,
+	needsOrdering := len(qp.OrderExprs) > 0
+	canPushDown := isRoute && sel.Having == nil && !needsOrdering && !qp.NeedsAggregation() && !sel.Distinct && sel.Limit == nil
+
+	if canPushDown {
+		return rewrite.Swap(in, rb, "push horizon into route")
 	}
 
-	for _, col := range cols {
-		aggr.addColumnWithoutPushing(col, true)
-	}
-
-	return aggr, rewrite.NewTree("replace distinct with aggregator", in), nil
-}
-
-func addColumnsToFilter(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Operator, error) {
-	visitor := func(in ops.Operator, _ semantics.TableSet, isRoot bool) (ops.Operator, *rewrite.ApplyResult, error) {
-		filter, ok := in.(*Filter)
-		if !ok {
-			return in, rewrite.SameTree, nil
-		}
-
-		columns, err := filter.GetColumns()
-		if err != nil {
-			return nil, nil, vterrors.Wrap(err, "while planning filter")
-		}
-		proj, areOnTopOfProj := filter.Source.(selectExpressions)
-		if !areOnTopOfProj {
-			// not much we can do here
-			return in, rewrite.SameTree, nil
-		}
-		addedColumns := false
-		for _, expr := range filter.Predicates {
-			sqlparser.Rewrite(expr, func(cursor *sqlparser.Cursor) bool {
-				e, ok := cursor.Node().(sqlparser.Expr)
-				if !ok {
-					return true
-				}
-				offset := slices.IndexFunc(columns, func(expr *sqlparser.AliasedExpr) bool {
-					return ctx.SemTable.EqualsExprWithDeps(expr.Expr, e)
-				})
-
-				if offset >= 0 {
-					// this expression can be fetched from the input - we can stop here
-					return false
-				}
-
-				if fetchByOffset(e) {
-					// this expression has to be fetched from the input, but we didn't find it in the input. let's add it
-					_, addToGroupBy := e.(*sqlparser.ColName)
-					proj.addColumnWithoutPushing(aeWrap(e), addToGroupBy)
-					addedColumns = true
-					columns, err = proj.GetColumns()
-					if err != nil {
-						panic("this should not happen")
-					}
-					return false
-				}
-				return true
-			}, nil)
-		}
-		if addedColumns {
-			return in, rewrite.NewTree("added columns because filter needs it", in), nil
-		}
-
-		return in, rewrite.SameTree, nil
-	}
-
-	return rewrite.TopDown(root, TableID, visitor, stopAtRoute)
-}
-
-// addOrderBysForAggregations runs after we have run horizonPlanning until the op tree stops changing
-// this means that we have pushed aggregations and other ops as far down as they'll go
-// addOrderBysForAggregations will find Aggregators that have not been pushed under routes and
-// add the necessary Ordering operators for them
-func addOrderBysAndGroupBysForAggregations(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Operator, error) {
-	visitor := func(in ops.Operator, _ semantics.TableSet, isRoot bool) (ops.Operator, *rewrite.ApplyResult, error) {
-		switch op := in.(type) {
-		case *ApplyJoin:
-			return addLiteralGroupingToRHS(op)
-		case *Aggregator:
-			return addOrderingForAggregation(ctx, op)
-		default:
-			return in, rewrite.SameTree, nil
-		}
-	}
-
-	return rewrite.TopDown(root, TableID, visitor, stopAtRoute)
-}
-
-func addLiteralGroupingToRHS(in *ApplyJoin) (ops.Operator, *rewrite.ApplyResult, error) {
-	_ = rewrite.Visit(in.RHS, func(op ops.Operator) error {
-		aggr, isAggr := op.(*Aggregator)
-		if !isAggr {
-			return nil
-		}
-		if len(aggr.Grouping) == 0 {
-			gb := sqlparser.NewIntLiteral(".0")
-			aggr.Grouping = append(aggr.Grouping, NewGroupBy(gb, gb, aeWrap(gb)))
-		}
-		return nil
-	})
-	return in, rewrite.NewTree("added grouping to the RHS", in), nil
-}
-
-func addOrderingForAggregation(ctx *plancontext.PlanningContext, in *Aggregator) (ops.Operator, *rewrite.ApplyResult, error) {
-	requireOrdering, err := needsOrdering(in, ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	if !requireOrdering {
-		return in, rewrite.SameTree, nil
-	}
-	in.Source = &Ordering{
-		Source: in.Source,
-		Order: slices2.Map(in.Grouping, func(from GroupBy) ops.OrderBy {
-			return from.AsOrderBy()
-		}),
-	}
-	return in, rewrite.NewTree("added ordering before aggregation", in), nil
-}
-
-func needsOrdering(in *Aggregator, ctx *plancontext.PlanningContext) (bool, error) {
-	if len(in.Grouping) == 0 {
-		return false, nil
-	}
-	srcOrdering, err := in.Source.GetOrdering()
-	if err != nil {
-		return false, err
-	}
-	if len(srcOrdering) < len(in.Grouping) {
-		return true, nil
-	}
-	for idx, gb := range in.Grouping {
-		if !ctx.SemTable.EqualsExprWithDeps(srcOrdering[idx].SimplifiedExpr, gb.SimplifiedExpr) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func tryPushingDownOrdering(ctx *plancontext.PlanningContext, in *Ordering) (ops.Operator, *rewrite.ApplyResult, error) {
-	switch src := in.Source.(type) {
-	case *Route:
-		return rewrite.Swap(in, src, "push ordering under route")
-	case *ApplyJoin:
-		if canPushLeft(ctx, src, in.Order) {
-			// ApplyJoin is stable in regard to the columns coming from the LHS,
-			// so if all the ordering columns come from the LHS, we can push down the Ordering there
-			src.LHS, in.Source = in, src.LHS
-			return src, rewrite.NewTree("push down ordering on the LHS of a join", in), nil
-		}
-	case *Ordering:
-		// we'll just remove the order underneath. The top order replaces whatever was incoming
-		in.Source = src.Source
-		return in, rewrite.NewTree("remove double ordering", src), nil
-	case *Projection:
-		// we can move ordering under a projection if it's not introducing a column we're sorting by
-		for _, by := range in.Order {
-			if !fetchByOffset(by.SimplifiedExpr) {
-				return in, rewrite.SameTree, nil
-			}
-		}
-		return rewrite.Swap(in, src, "push ordering under projection")
-	case *Aggregator:
-		if !(src.QP.AlignGroupByAndOrderBy(ctx) || overlaps(ctx, in.Order, src.Grouping)) {
-			return in, rewrite.SameTree, nil
-		}
-
-		return pushOrderingUnderAggr(ctx, in, src)
-
-	}
-	return in, rewrite.SameTree, nil
-}
-
-func overlaps(ctx *plancontext.PlanningContext, order []ops.OrderBy, grouping []GroupBy) bool {
-ordering:
-	for _, orderBy := range order {
-		for _, groupBy := range grouping {
-			if ctx.SemTable.EqualsExprWithDeps(orderBy.SimplifiedExpr, groupBy.SimplifiedExpr) {
-				continue ordering
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func pushOrderingUnderAggr(ctx *plancontext.PlanningContext, order *Ordering, aggregator *Aggregator) (ops.Operator, *rewrite.ApplyResult, error) {
-	// Step 1: Align the GROUP BY and ORDER BY.
-	//         Reorder the GROUP BY columns to match the ORDER BY columns.
-	//         Since the GB clause is a set, we can reorder these columns freely.
-	var newGrouping []GroupBy
-	used := make([]bool, len(aggregator.Grouping))
-	for _, orderExpr := range order.Order {
-		for grpIdx, by := range aggregator.Grouping {
-			if !used[grpIdx] && ctx.SemTable.EqualsExprWithDeps(by.SimplifiedExpr, orderExpr.SimplifiedExpr) {
-				newGrouping = append(newGrouping, by)
-				used[grpIdx] = true
-			}
-		}
-	}
-
-	// Step 2: Add any missing columns from the ORDER BY.
-	//         The ORDER BY column is not a set, but we can add more elements
-	//         to the end without changing the semantics of the query.
-	if len(newGrouping) != len(aggregator.Grouping) {
-		// we are missing some groupings. We need to add them both to the new groupings list, but also to the ORDER BY
-		for i, added := range used {
-			if !added {
-				groupBy := aggregator.Grouping[i]
-				newGrouping = append(newGrouping, groupBy)
-				order.Order = append(order.Order, groupBy.AsOrderBy())
-			}
-		}
-	}
-
-	aggregator.Grouping = newGrouping
-	aggrSource, isOrdering := aggregator.Source.(*Ordering)
-	if isOrdering {
-		// Transform the query plan tree:
-		// From:   Ordering(1)      To: Aggregation
-		//               |                 |
-		//         Aggregation          Ordering(1)
-		//               |                 |
-		//         Ordering(2)          <Inputs>
-		//               |
-		//           <Inputs>
-		//
-		// Remove Ordering(2) from the plan tree, as it's redundant
-		// after pushing down the higher ordering.
-		order.Source = aggrSource.Source
-		aggrSource.Source = nil // removing from plan tree
-		aggregator.Source = order
-		return aggregator, rewrite.NewTree("push ordering under aggregation, removing extra ordering", aggregator), nil
-	}
-	return rewrite.Swap(order, aggregator, "push ordering under aggregation")
-}
-
-func canPushLeft(ctx *plancontext.PlanningContext, aj *ApplyJoin, order []ops.OrderBy) bool {
-	lhs := TableID(aj.LHS)
-	for _, order := range order {
-		deps := ctx.SemTable.DirectDeps(order.Inner.Expr)
-		if !deps.IsSolvedBy(lhs) {
-			return false
-		}
-	}
-	return true
+	return expandHorizon(ctx, in)
 }
 
 func tryPushingDownProjection(
@@ -685,11 +389,6 @@ func createProjectionWithTheseColumns(
 	return proj, nil
 }
 
-func stopAtRoute(operator ops.Operator) rewrite.VisitRule {
-	_, isRoute := operator.(*Route)
-	return rewrite.VisitRule(!isRoute)
-}
-
 func tryPushingDownLimit(in *Limit) (ops.Operator, *rewrite.ApplyResult, error) {
 	switch src := in.Source.(type) {
 	case *Route:
@@ -701,6 +400,14 @@ func tryPushingDownLimit(in *Limit) (ops.Operator, *rewrite.ApplyResult, error) 
 	default:
 		return setUpperLimit(in)
 	}
+}
+
+func tryPushingDownLimitInRoute(in *Limit, src *Route) (ops.Operator, *rewrite.ApplyResult, error) {
+	if src.IsSingleShard() {
+		return rewrite.Swap(in, src, "limit pushed into single sharded route")
+	}
+
+	return setUpperLimit(in)
 }
 
 func setUpperLimit(in *Limit) (ops.Operator, *rewrite.ApplyResult, error) {
@@ -736,47 +443,182 @@ func setUpperLimit(in *Limit) (ops.Operator, *rewrite.ApplyResult, error) {
 	return in, rewrite.SameTree, nil
 }
 
-func tryPushingDownLimitInRoute(in *Limit, src *Route) (ops.Operator, *rewrite.ApplyResult, error) {
-	if src.IsSingleShard() {
-		return rewrite.Swap(in, src, "limit pushed into single sharded route")
-	}
+func tryPushingDownOrdering(ctx *plancontext.PlanningContext, in *Ordering) (ops.Operator, *rewrite.ApplyResult, error) {
+	switch src := in.Source.(type) {
+	case *Route:
+		return rewrite.Swap(in, src, "push ordering under route")
+	case *ApplyJoin:
+		if canPushLeft(ctx, src, in.Order) {
+			// ApplyJoin is stable in regard to the columns coming from the LHS,
+			// so if all the ordering columns come from the LHS, we can push down the Ordering there
+			src.LHS, in.Source = in, src.LHS
+			return src, rewrite.NewTree("push down ordering on the LHS of a join", in), nil
+		}
+	case *Ordering:
+		// we'll just remove the order underneath. The top order replaces whatever was incoming
+		in.Source = src.Source
+		return in, rewrite.NewTree("remove double ordering", src), nil
+	case *Projection:
+		// we can move ordering under a projection if it's not introducing a column we're sorting by
+		for _, by := range in.Order {
+			if !fetchByOffset(by.SimplifiedExpr) {
+				return in, rewrite.SameTree, nil
+			}
+		}
+		return rewrite.Swap(in, src, "push ordering under projection")
+	case *Aggregator:
+		if !(src.QP.AlignGroupByAndOrderBy(ctx) || overlaps(ctx, in.Order, src.Grouping)) {
+			return in, rewrite.SameTree, nil
+		}
 
-	return setUpperLimit(in)
+		return pushOrderingUnderAggr(ctx, in, src)
+
+	}
+	return in, rewrite.SameTree, nil
 }
 
-func pushOrExpandHorizon(ctx *plancontext.PlanningContext, in horizonLike) (ops.Operator, *rewrite.ApplyResult, error) {
-	if derived, ok := in.(*Derived); ok {
-		if len(derived.ColumnAliases) > 0 {
-			return nil, nil, errHorizonNotPlanned()
+func overlaps(ctx *plancontext.PlanningContext, order []ops.OrderBy, grouping []GroupBy) bool {
+ordering:
+	for _, orderBy := range order {
+		for _, groupBy := range grouping {
+			if ctx.SemTable.EqualsExprWithDeps(orderBy.SimplifiedExpr, groupBy.SimplifiedExpr) {
+				continue ordering
+			}
+		}
+		return false
+	}
+
+	return true
+}
+
+func pushOrderingUnderAggr(ctx *plancontext.PlanningContext, order *Ordering, aggregator *Aggregator) (ops.Operator, *rewrite.ApplyResult, error) {
+	// Step 1: Align the GROUP BY and ORDER BY.
+	//         Reorder the GROUP BY columns to match the ORDER BY columns.
+	//         Since the GB clause is a set, we can reorder these columns freely.
+	var newGrouping []GroupBy
+	used := make([]bool, len(aggregator.Grouping))
+	for _, orderExpr := range order.Order {
+		for grpIdx, by := range aggregator.Grouping {
+			if !used[grpIdx] && ctx.SemTable.EqualsExprWithDeps(by.SimplifiedExpr, orderExpr.SimplifiedExpr) {
+				newGrouping = append(newGrouping, by)
+				used[grpIdx] = true
+			}
 		}
 	}
-	rb, isRoute := in.src().(*Route)
-	if isRoute && rb.IsSingleShard() {
-		return rewrite.Swap(in, rb, "push horizon into route")
+
+	// Step 2: Add any missing columns from the ORDER BY.
+	//         The ORDER BY column is not a set, but we can add more elements
+	//         to the end without changing the semantics of the query.
+	if len(newGrouping) != len(aggregator.Grouping) {
+		// we are missing some groupings. We need to add them both to the new groupings list, but also to the ORDER BY
+		for i, added := range used {
+			if !added {
+				groupBy := aggregator.Grouping[i]
+				newGrouping = append(newGrouping, groupBy)
+				order.Order = append(order.Order, groupBy.AsOrderBy())
+			}
+		}
 	}
 
-	sel, isSel := in.selectStatement().(*sqlparser.Select)
-	if !isSel {
-		return nil, nil, errHorizonNotPlanned()
+	aggregator.Grouping = newGrouping
+	aggrSource, isOrdering := aggregator.Source.(*Ordering)
+	if isOrdering {
+		// Transform the query plan tree:
+		// From:   Ordering(1)      To: Aggregation
+		//               |                 |
+		//         Aggregation          Ordering(1)
+		//               |                 |
+		//         Ordering(2)          <Inputs>
+		//               |
+		//           <Inputs>
+		//
+		// Remove Ordering(2) from the plan tree, as it's redundant
+		// after pushing down the higher ordering.
+		order.Source = aggrSource.Source
+		aggrSource.Source = nil // removing from plan tree
+		aggregator.Source = order
+		return aggregator, rewrite.NewTree("push ordering under aggregation, removing extra ordering", aggregator), nil
+	}
+	return rewrite.Swap(order, aggregator, "push ordering under aggregation")
+}
+
+func canPushLeft(ctx *plancontext.PlanningContext, aj *ApplyJoin, order []ops.OrderBy) bool {
+	lhs := TableID(aj.LHS)
+	for _, order := range order {
+		deps := ctx.SemTable.DirectDeps(order.Inner.Expr)
+		if !deps.IsSolvedBy(lhs) {
+			return false
+		}
+	}
+	return true
+}
+
+func tryPushingDownFilter(ctx *plancontext.PlanningContext, in *Filter) (ops.Operator, *rewrite.ApplyResult, error) {
+	switch src := in.Source.(type) {
+	case *Projection:
+		return pushFilterUnderProjection(ctx, in, src)
+	case *Route:
+		return rewrite.Swap(in, src, "push filter into Route")
 	}
 
-	qp, err := in.getQP(ctx)
+	return in, rewrite.SameTree, nil
+}
+
+func pushFilterUnderProjection(ctx *plancontext.PlanningContext, filter *Filter, projection *Projection) (ops.Operator, *rewrite.ApplyResult, error) {
+	for _, p := range filter.Predicates {
+		cantPushDown := false
+		_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+			if !fetchByOffset(node) {
+				return true, nil
+			}
+
+			if projection.needsEvaluation(ctx, node.(sqlparser.Expr)) {
+				cantPushDown = true
+				return false, io.EOF
+			}
+
+			return true, nil
+		}, p)
+
+		if cantPushDown {
+			return filter, rewrite.SameTree, nil
+		}
+	}
+	return rewrite.Swap(filter, projection, "push filter under projection")
+
+}
+
+func tryPushingDownDistinct(in *Distinct) (ops.Operator, *rewrite.ApplyResult, error) {
+	if in.Pushed {
+		return in, rewrite.SameTree, nil
+	}
+	switch src := in.Source.(type) {
+	case *Route:
+		if src.IsSingleShard() {
+			return rewrite.Swap(in, src, "push distinct under route")
+		}
+	case *Distinct:
+		return src, rewrite.NewTree("removed double distinct", src), nil
+	case *Aggregator:
+		return in, rewrite.SameTree, nil
+	}
+
+	cols, err := in.Source.GetColumns()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	needsOrdering := len(qp.OrderExprs) > 0
-	canPushDown := isRoute && sel.Having == nil && !needsOrdering && !qp.NeedsAggregation() && !sel.Distinct && sel.Limit == nil
-
-	if canPushDown {
-		return rewrite.Swap(in, rb, "push horizon into route")
+	aggr := &Aggregator{
+		Source:   in.Source,
+		QP:       in.QP,
+		Original: true,
 	}
 
-	return expandHorizon(ctx, in)
-}
+	for _, col := range cols {
+		aggr.addColumnWithoutPushing(col, true)
+	}
 
-func aeWrap(e sqlparser.Expr) *sqlparser.AliasedExpr {
-	return &sqlparser.AliasedExpr{Expr: e}
+	return aggr, rewrite.NewTree("replace distinct with aggregator", in), nil
 }
 
 // makeSureOutputIsCorrect uses the original Horizon to make sure that the output columns line up with what the user asked for
@@ -807,4 +649,13 @@ func makeSureOutputIsCorrect(ctx *plancontext.PlanningContext, oldHorizon ops.Op
 		return nil, err
 	}
 	return proj, nil
+}
+
+func stopAtRoute(operator ops.Operator) rewrite.VisitRule {
+	_, isRoute := operator.(*Route)
+	return rewrite.VisitRule(!isRoute)
+}
+
+func aeWrap(e sqlparser.Expr) *sqlparser.AliasedExpr {
+	return &sqlparser.AliasedExpr{Expr: e}
 }

--- a/go/vt/vtgate/planbuilder/operators/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_planning.go
@@ -465,7 +465,7 @@ func tryPushingDownOrdering(ctx *plancontext.PlanningContext, in *Ordering) (ops
 		}
 		return rewrite.Swap(in, src, "push ordering under projection")
 	case *Aggregator:
-		if !(src.QP.AlignGroupByAndOrderBy(ctx) || overlaps(ctx, in.Order, src.Grouping)) {
+		if !src.QP.AlignGroupByAndOrderBy(ctx) && !overlaps(ctx, in.Order, src.Grouping) {
 			return in, rewrite.SameTree, nil
 		}
 

--- a/go/vt/vtgate/planbuilder/operators/offset_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/offset_planning.go
@@ -19,6 +19,8 @@ package operators
 import (
 	"fmt"
 
+	"golang.org/x/exp/slices"
+
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators/ops"
@@ -77,4 +79,132 @@ func planOffsetsOnJoins(ctx *plancontext.PlanningContext, op ops.Operator) error
 		return join.planOffsets(ctx)
 	})
 	return err
+}
+
+// useOffsets rewrites an expression to use values from the input
+func useOffsets(ctx *plancontext.PlanningContext, expr sqlparser.Expr, op ops.Operator) (sqlparser.Expr, error) {
+	in := op.Inputs()[0]
+	columns, err := in.GetColumns()
+	if err != nil {
+		return nil, err
+	}
+
+	var exprOffset *sqlparser.Offset
+
+	found := func(e sqlparser.Expr, offset int) { exprOffset = sqlparser.NewOffset(offset, e) }
+
+	notFound := func(e sqlparser.Expr) error {
+		_, addToGroupBy := e.(*sqlparser.ColName)
+		var offset int
+		in, offset, err = in.AddColumn(ctx, aeWrap(e), true, addToGroupBy)
+		if err != nil {
+			return err
+		}
+		op.SetInputs([]ops.Operator{in})
+		columns, err = in.GetColumns()
+		if err != nil {
+			return err
+		}
+		exprOffset = sqlparser.NewOffset(offset, e)
+		return nil
+	}
+
+	getColumns := func() []*sqlparser.AliasedExpr { return columns }
+	visitor := getVisitor(ctx, getColumns, found, notFound)
+
+	// The cursor replace is not available while walking `down`, so `up` is used to do the replacement.
+	up := func(cursor *sqlparser.CopyOnWriteCursor) {
+		if exprOffset != nil {
+			cursor.Replace(exprOffset)
+			exprOffset = nil
+		}
+	}
+
+	rewritten := sqlparser.CopyOnRewrite(expr, visitor, up, ctx.SemTable.CopyDependenciesOnSQLNodes)
+	if err != nil {
+		return nil, err
+	}
+
+	return rewritten.(sqlparser.Expr), nil
+}
+
+// addColumnsToInput adds columns needed by an operator to its input.
+// This happens only when the filter expression can be retrieved as an offset from the underlying mysql.
+func addColumnsToInput(ctx *plancontext.PlanningContext, root ops.Operator) (ops.Operator, error) {
+	visitor := func(in ops.Operator, _ semantics.TableSet, isRoot bool) (ops.Operator, *rewrite.ApplyResult, error) {
+		filter, ok := in.(*Filter)
+		if !ok {
+			return in, rewrite.SameTree, nil
+		}
+
+		columns, err := filter.GetColumns()
+		if err != nil {
+			return nil, nil, err
+		}
+		proj, areOnTopOfProj := filter.Source.(selectExpressions)
+		if !areOnTopOfProj {
+			// not much we can do here
+			return in, rewrite.SameTree, nil
+		}
+		addedColumns := false
+		found := func(expr sqlparser.Expr, i int) {}
+		notFound := func(e sqlparser.Expr) error {
+			_, addToGroupBy := e.(*sqlparser.ColName)
+			proj.addColumnWithoutPushing(aeWrap(e), addToGroupBy)
+			addedColumns = true
+			columns, err = proj.GetColumns()
+			return nil
+		}
+		getColumns := func() []*sqlparser.AliasedExpr {
+			return columns
+		}
+		visitor := getVisitor(ctx, getColumns, found, notFound)
+
+		for _, expr := range filter.Predicates {
+			sqlparser.CopyOnRewrite(expr, visitor, nil, ctx.SemTable.CopyDependenciesOnSQLNodes)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		if addedColumns {
+			return in, rewrite.NewTree("added columns because filter needs it", in), nil
+		}
+
+		return in, rewrite.SameTree, nil
+	}
+
+	return rewrite.TopDown(root, TableID, visitor, stopAtRoute)
+}
+
+func getVisitor(
+	ctx *plancontext.PlanningContext,
+	getColumns func() []*sqlparser.AliasedExpr,
+	found func(sqlparser.Expr, int),
+	notFound func(sqlparser.Expr) error,
+) func(node, parent sqlparser.SQLNode) bool {
+	var err error
+	return func(node, parent sqlparser.SQLNode) bool {
+		if err != nil {
+			return false
+		}
+		e, ok := node.(sqlparser.Expr)
+		if !ok {
+			return true
+		}
+		offset := slices.IndexFunc(getColumns(), func(expr *sqlparser.AliasedExpr) bool {
+			return ctx.SemTable.EqualsExprWithDeps(expr.Expr, e)
+		})
+
+		if offset >= 0 {
+			found(e, offset)
+			return false
+		}
+
+		if fetchByOffset(e) {
+			err = notFound(e)
+			return false
+		}
+
+		return true
+	}
 }

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -39,6 +39,12 @@ type PlanningContext struct {
 	// If we during planning have turned this expression into an argument name,
 	// we can continue using the same argument name
 	ReservedArguments map[sqlparser.Expr]string
+
+	Phases *PlanningPhases
+}
+
+type PlanningPhases struct {
+	PushAggregation bool
 }
 
 func NewPlanningContext(reservedVars *sqlparser.ReservedVars, semTable *semantics.SemTable, vschema VSchema, version querypb.ExecuteOptions_PlannerVersion) *PlanningContext {
@@ -50,6 +56,7 @@ func NewPlanningContext(reservedVars *sqlparser.ReservedVars, semTable *semantic
 		SkipPredicates:    map[sqlparser.Expr]any{},
 		PlannerVersion:    version,
 		ReservedArguments: map[sqlparser.Expr]string{},
+		Phases:            &PlanningPhases{},
 	}
 	return ctx
 }

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -40,11 +40,9 @@ type PlanningContext struct {
 	// we can continue using the same argument name
 	ReservedArguments map[sqlparser.Expr]string
 
-	Phases *PlanningPhases
-}
-
-type PlanningPhases struct {
-	PushAggregation bool
+	// DelegateAggregation tells us when we are allowed to split an aggregation across vtgate and mysql
+	// We aggregate within a shard, and then at the vtgate level we aggregate the incoming shard aggregates
+	DelegateAggregation bool
 }
 
 func NewPlanningContext(reservedVars *sqlparser.ReservedVars, semTable *semantics.SemTable, vschema VSchema, version querypb.ExecuteOptions_PlannerVersion) *PlanningContext {
@@ -56,7 +54,6 @@ func NewPlanningContext(reservedVars *sqlparser.ReservedVars, semTable *semantic
 		SkipPredicates:    map[sqlparser.Expr]any{},
 		PlannerVersion:    version,
 		ReservedArguments: map[sqlparser.Expr]string{},
-		Phases:            &PlanningPhases{},
 	}
 	return ctx
 }

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6524,7 +6524,7 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "count_star(0) AS count(*)",
+        "Aggregates": "sum_count_star(0) AS count(*)",
         "GroupBy": "(1|2)",
         "ResultColumns": 1,
         "Inputs": [
@@ -6534,35 +6534,45 @@
             "OrderBy": "(1|2) ASC",
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:0,R:0,R:1",
-                "JoinVars": {
-                  "user_id": 1
-                },
-                "TableName": "`user`_user_extra",
+                "OperatorType": "Projection",
+                "Expressions": [
+                  "[COLUMN 0] * [COLUMN 1] as count(*)",
+                  "[COLUMN 2] as `user`.id + user_extra.id",
+                  "[COLUMN 3] as weight_string(`user`.id + user_extra.id)"
+                ],
                 "Inputs": [
                   {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
+                    "OperatorType": "Join",
+                    "Variant": "Join",
+                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
+                    "JoinVars": {
+                      "user_id": 1
                     },
-                    "FieldQuery": "select 1, `user`.id from `user` where 1 != 1",
-                    "Query": "select 1, `user`.id from `user`",
-                    "Table": "`user`"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select :user_id + user_extra.id, weight_string(:user_id + user_extra.id) from user_extra where 1 != 1",
-                    "Query": "select :user_id + user_extra.id, weight_string(:user_id + user_extra.id) from user_extra",
-                    "Table": "user_extra"
+                    "TableName": "`user`_user_extra",
+                    "Inputs": [
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select count(*), `user`.id from `user` where 1 != 1 group by `user`.id",
+                        "Query": "select count(*), `user`.id from `user` group by `user`.id",
+                        "Table": "`user`"
+                      },
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select count(*), :user_id + user_extra.id, weight_string(:user_id + user_extra.id) from user_extra where 1 != 1 group by :user_id + user_extra.id",
+                        "Query": "select count(*), :user_id + user_extra.id, weight_string(:user_id + user_extra.id) from user_extra group by :user_id + user_extra.id",
+                        "Table": "user_extra"
+                      }
+                    ]
                   }
                 ]
               }

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6170,6 +6170,47 @@
     }
   },
   {
+    "comment": "distinct on top of aggregation",
+    "query": "select distinct count(*) from user group by col",
+    "v3-plan": "VT12001: unsupported: in scatter query: GROUP BY column must reference column in SELECT list",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select distinct count(*) from user group by col",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Ordered",
+            "Aggregates": "sum_count_star(0) AS count(*)",
+            "GroupBy": "1",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select count(*), col from `user` where 1 != 1 group by col",
+                "OrderBy": "1 ASC",
+                "Query": "select count(*), col from `user` group by col order by col asc",
+                "Table": "`user`"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "scalar aggregates with min, max, sum distinct and count distinct using collations",
     "query": "select min(textcol1), max(textcol2), sum(distinct textcol1), count(distinct textcol1) from user",
     "v3-plan": "VT12001: unsupported: only one DISTINCT aggregation allowed in a SELECT: count(distinct textcol1)",
@@ -6462,7 +6503,7 @@
     }
   },
   {
-    "comment": "aggregate on input from both sides",
+    "comment": "aggregate on input from both sides - TODO optimize more",
     "query": "select sum(user.foo+user_extra.bar) from user, user_extra",
     "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
     "gen4-plan": {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -1441,9 +1441,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` where 1 != 1 group by a, b, c, d, weight_string(d), weight_string(b), weight_string(a), weight_string(c)",
+            "FieldQuery": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` where 1 != 1 group by d, b, a, c, weight_string(d), weight_string(b), weight_string(a), weight_string(c)",
             "OrderBy": "(3|5) ASC, (1|6) ASC, (0|7) ASC, (2|8) ASC",
-            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by a, b, c, d, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by d asc, b asc, a asc, c asc",
+            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by d, b, a, c, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by d asc, b asc, a asc, c asc",
             "Table": "`user`"
           }
         ]
@@ -1498,9 +1498,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` where 1 != 1 group by c, b, a, d, weight_string(d), weight_string(b), weight_string(a), weight_string(c)",
+            "FieldQuery": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` where 1 != 1 group by d, b, a, c, weight_string(d), weight_string(b), weight_string(a), weight_string(c)",
             "OrderBy": "(3|5) ASC, (1|6) ASC, (0|7) ASC, (2|8) ASC",
-            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by c, b, a, d, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by d asc, b asc, a asc, c asc",
+            "Query": "select a, b, c, d, count(*), weight_string(d), weight_string(b), weight_string(a), weight_string(c) from `user` group by d, b, a, c, weight_string(d), weight_string(b), weight_string(a), weight_string(c) order by d asc, b asc, a asc, c asc",
             "Table": "`user`"
           }
         ]
@@ -1555,9 +1555,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select a, b, c, count(*), weight_string(a), weight_string(c), weight_string(b) from `user` where 1 != 1 group by c, b, a, weight_string(a), weight_string(c), weight_string(b)",
+            "FieldQuery": "select a, b, c, count(*), weight_string(a), weight_string(c), weight_string(b) from `user` where 1 != 1 group by a, c, b, weight_string(a), weight_string(c), weight_string(b)",
             "OrderBy": "(0|4) DESC, (2|5) DESC, (1|6) ASC",
-            "Query": "select a, b, c, count(*), weight_string(a), weight_string(c), weight_string(b) from `user` group by c, b, a, weight_string(a), weight_string(c), weight_string(b) order by a desc, c desc, b asc",
+            "Query": "select a, b, c, count(*), weight_string(a), weight_string(c), weight_string(b) from `user` group by a, c, b, weight_string(a), weight_string(c), weight_string(b) order by a desc, c desc, b asc",
             "Table": "`user`"
           }
         ]
@@ -2666,7 +2666,7 @@
       "Original": "select count(*) a from user having a = 10",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": ":0 = 10",
+        "Predicate": "count(*) = 10",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -2702,7 +2702,7 @@
       "Original": "select count(*) a from user having a = '1'",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": ":0 = '1'",
+        "Predicate": "count(*) = '1'",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -2738,7 +2738,7 @@
       "Original": "select count(*) a from user having a != 10",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": ":0 != 10",
+        "Predicate": "count(*) != 10",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -2774,7 +2774,7 @@
       "Original": "select count(*) a from user having a != '1'",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": ":0 != '1'",
+        "Predicate": "count(*) != '1'",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -2810,7 +2810,7 @@
       "Original": "select count(*) a from user having a > 10",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": ":0 > 10",
+        "Predicate": "count(*) > 10",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -2846,7 +2846,7 @@
       "Original": "select count(*) a from user having a >= 10",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": ":0 >= 10",
+        "Predicate": "count(*) >= 10",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -2882,7 +2882,7 @@
       "Original": "select count(*) a from user having a < 10",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": ":0 < 10",
+        "Predicate": "count(*) < 10",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -2918,7 +2918,7 @@
       "Original": "select count(*) a from user having a <= 10",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": ":0 <= 10",
+        "Predicate": "count(*) <= 10",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -2954,7 +2954,7 @@
       "Original": "select col, count(*) a from user group by col having a <= 10",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": ":1 <= 10",
+        "Predicate": "count(*) <= 10",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -2999,7 +2999,7 @@
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": ":0 = 1.00",
+            "Predicate": "count(*) = 1.00",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -3119,7 +3119,7 @@
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": ":1 = 10",
+            "Predicate": "count(id) = 10",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -3264,7 +3264,7 @@
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": ":1 = 10",
+            "Predicate": "count(id) = 10",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -3429,32 +3429,42 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum_count(0) AS count(u.textcol1), sum_count(1) AS count(ue.foo)",
-        "GroupBy": "(2|3)",
-        "ResultColumns": 3,
+        "Aggregates": "count(0) AS count(u.textcol1), count(1) AS count(ue.foo)",
+        "GroupBy": "(2|0)",
         "Inputs": [
           {
-            "OperatorType": "Projection",
-            "Expressions": [
-              "[COLUMN 0] * [COLUMN 1] as count(u.textcol1)",
-              "[COLUMN 3] * [COLUMN 2] as count(ue.foo)",
-              "[COLUMN 4] as bar",
-              "[COLUMN 5] as weight_string(us.bar)"
-            ],
+            "OperatorType": "Sort",
+            "Variant": "Memory",
+            "OrderBy": "(1|0) ASC",
             "Inputs": [
               {
-                "OperatorType": "Sort",
-                "Variant": "Memory",
-                "OrderBy": "(4|5) ASC",
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "R:0,R:1",
+                "JoinVars": {
+                  "u_foo": 0
+                },
+                "TableName": "`user`_user_extra_unsharded",
                 "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select u.foo from `user` as u where 1 != 1",
+                    "Query": "select u.foo from `user` as u",
+                    "Table": "`user`"
+                  },
                   {
                     "OperatorType": "Join",
                     "Variant": "Join",
-                    "JoinColumnIndexes": "L:0,R:0,R:1,L:1,R:2,R:3",
+                    "JoinColumnIndexes": "R:0,R:1",
                     "JoinVars": {
-                      "u_foo": 2
+                      "ue_bar": 0
                     },
-                    "TableName": "`user`_user_extra_unsharded",
+                    "TableName": "user_extra_unsharded",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -3463,53 +3473,20 @@
                           "Name": "user",
                           "Sharded": true
                         },
-                        "FieldQuery": "select count(u.textcol1), count(*), u.foo from `user` as u where 1 != 1 group by u.foo",
-                        "Query": "select count(u.textcol1), count(*), u.foo from `user` as u group by u.foo",
-                        "Table": "`user`"
+                        "FieldQuery": "select ue.bar from user_extra as ue where 1 != 1",
+                        "Query": "select ue.bar from user_extra as ue where ue.bar = :u_foo",
+                        "Table": "user_extra"
                       },
                       {
-                        "OperatorType": "Projection",
-                        "Expressions": [
-                          "[COLUMN 0] * [COLUMN 1] as count(*)",
-                          "[COLUMN 2] * [COLUMN 1] as count(ue.foo)",
-                          "[COLUMN 3] as bar",
-                          "[COLUMN 4] as weight_string(us.bar)"
-                        ],
-                        "Inputs": [
-                          {
-                            "OperatorType": "Join",
-                            "Variant": "Join",
-                            "JoinColumnIndexes": "L:0,R:0,L:1,R:1,R:2",
-                            "JoinVars": {
-                              "ue_bar": 2
-                            },
-                            "TableName": "user_extra_unsharded",
-                            "Inputs": [
-                              {
-                                "OperatorType": "Route",
-                                "Variant": "Scatter",
-                                "Keyspace": {
-                                  "Name": "user",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select count(*), count(ue.foo), ue.bar from user_extra as ue where 1 != 1 group by ue.bar",
-                                "Query": "select count(*), count(ue.foo), ue.bar from user_extra as ue where ue.bar = :u_foo group by ue.bar",
-                                "Table": "user_extra"
-                              },
-                              {
-                                "OperatorType": "Route",
-                                "Variant": "Unsharded",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": false
-                                },
-                                "FieldQuery": "select count(*), us.bar, weight_string(us.bar) from unsharded as us where 1 != 1 group by us.bar, weight_string(us.bar)",
-                                "Query": "select count(*), us.bar, weight_string(us.bar) from unsharded as us where us.baz = :ue_bar group by us.bar, weight_string(us.bar)",
-                                "Table": "unsharded"
-                              }
-                            ]
-                          }
-                        ]
+                        "OperatorType": "Route",
+                        "Variant": "Unsharded",
+                        "Keyspace": {
+                          "Name": "main",
+                          "Sharded": false
+                        },
+                        "FieldQuery": "select weight_string(us.bar), us.bar from unsharded as us where 1 != 1",
+                        "Query": "select weight_string(us.bar), us.bar from unsharded as us where us.baz = :ue_bar",
+                        "Table": "unsharded"
                       }
                     ]
                   }
@@ -4072,7 +4049,7 @@
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": ":1 = 3",
+            "Predicate": "count(*) = 3",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -4120,7 +4097,7 @@
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": ":1 + :2 = 42",
+            "Predicate": "sum(foo) + sum(bar) = 42",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -4168,7 +4145,7 @@
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": ":1 + :2 = 42",
+            "Predicate": "sum(foo) + sum(bar) = 42",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -4214,7 +4191,7 @@
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": ":1 = 3",
+            "Predicate": "count(*) = 3",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -4260,63 +4237,53 @@
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": ":1 = 3",
+            "Predicate": "count(u.`name`) = 3",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
-                "Aggregates": "sum_count(1) AS count(u.`name`)",
-                "GroupBy": "(0|2)",
+                "Aggregates": "count(1) AS count(u.`name`)",
+                "GroupBy": "0",
                 "Inputs": [
                   {
-                    "OperatorType": "Projection",
-                    "Expressions": [
-                      "[COLUMN 0] as id",
-                      "[COLUMN 2] * COALESCE([COLUMN 3], INT64(1)) as count(u.`name`)",
-                      "[COLUMN 1]"
-                    ],
+                    "OperatorType": "Sort",
+                    "Variant": "Memory",
+                    "OrderBy": "(1|0) ASC",
                     "Inputs": [
                       {
-                        "OperatorType": "Sort",
-                        "Variant": "Memory",
-                        "OrderBy": "(0|1) ASC",
+                        "OperatorType": "Join",
+                        "Variant": "Join",
+                        "JoinColumnIndexes": "R:0,R:1",
+                        "JoinVars": {
+                          "ue_id": 0
+                        },
+                        "TableName": "user_extra_`user`",
                         "Inputs": [
                           {
-                            "OperatorType": "Join",
-                            "Variant": "Join",
-                            "JoinColumnIndexes": "R:1,R:2,L:1,R:0",
-                            "JoinVars": {
-                              "ue_id": 0
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
                             },
-                            "TableName": "user_extra_`user`",
-                            "Inputs": [
-                              {
-                                "OperatorType": "Route",
-                                "Variant": "Scatter",
-                                "Keyspace": {
-                                  "Name": "user",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select ue.id, count(*), weight_string(ue.id) from user_extra as ue where 1 != 1 group by ue.id, weight_string(ue.id)",
-                                "Query": "select ue.id, count(*), weight_string(ue.id) from user_extra as ue group by ue.id, weight_string(ue.id)",
-                                "Table": "user_extra"
-                              },
-                              {
-                                "OperatorType": "Route",
-                                "Variant": "EqualUnique",
-                                "Keyspace": {
-                                  "Name": "user",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select count(u.`name`), u.id, weight_string(u.id) from `user` as u where 1 != 1 group by u.id, weight_string(u.id)",
-                                "Query": "select count(u.`name`), u.id, weight_string(u.id) from `user` as u where u.id = :ue_id group by u.id, weight_string(u.id)",
-                                "Table": "`user`",
-                                "Values": [
-                                  ":ue_id"
-                                ],
-                                "Vindex": "user_index"
-                              }
-                            ]
+                            "FieldQuery": "select ue.id from user_extra as ue where 1 != 1",
+                            "Query": "select ue.id from user_extra as ue",
+                            "Table": "user_extra"
+                          },
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "EqualUnique",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select weight_string(u.id), u.id from `user` as u where 1 != 1",
+                            "Query": "select weight_string(u.id), u.id from `user` as u where u.id = :ue_id",
+                            "Table": "`user`",
+                            "Values": [
+                              ":ue_id"
+                            ],
+                            "Vindex": "user_index"
                           }
                         ]
                       }
@@ -4387,63 +4354,53 @@
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": ":1 < 3 and :1 > 5",
+            "Predicate": "count(*) < 3 and count(*) > 5",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
-                "Aggregates": "sum_count_star(1) AS count(*)",
-                "GroupBy": "(0|2)",
+                "Aggregates": "count_star(1) AS count(*)",
+                "GroupBy": "0",
                 "Inputs": [
                   {
-                    "OperatorType": "Projection",
-                    "Expressions": [
-                      "[COLUMN 0] as id",
-                      "[COLUMN 2] * COALESCE([COLUMN 3], INT64(1)) as count(*)",
-                      "[COLUMN 1]"
-                    ],
+                    "OperatorType": "Sort",
+                    "Variant": "Memory",
+                    "OrderBy": "(1|0) ASC",
                     "Inputs": [
                       {
-                        "OperatorType": "Sort",
-                        "Variant": "Memory",
-                        "OrderBy": "(0|1) ASC",
+                        "OperatorType": "Join",
+                        "Variant": "Join",
+                        "JoinColumnIndexes": "R:0,R:1",
+                        "JoinVars": {
+                          "ue_id": 0
+                        },
+                        "TableName": "user_extra_`user`",
                         "Inputs": [
                           {
-                            "OperatorType": "Join",
-                            "Variant": "Join",
-                            "JoinColumnIndexes": "R:1,R:2,L:1,R:0",
-                            "JoinVars": {
-                              "ue_id": 0
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
                             },
-                            "TableName": "user_extra_`user`",
-                            "Inputs": [
-                              {
-                                "OperatorType": "Route",
-                                "Variant": "Scatter",
-                                "Keyspace": {
-                                  "Name": "user",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select ue.id, count(*), weight_string(ue.id) from user_extra as ue where 1 != 1 group by ue.id, weight_string(ue.id)",
-                                "Query": "select ue.id, count(*), weight_string(ue.id) from user_extra as ue group by ue.id, weight_string(ue.id)",
-                                "Table": "user_extra"
-                              },
-                              {
-                                "OperatorType": "Route",
-                                "Variant": "EqualUnique",
-                                "Keyspace": {
-                                  "Name": "user",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select count(*), u.id, weight_string(u.id) from `user` as u where 1 != 1 group by u.id, weight_string(u.id)",
-                                "Query": "select count(*), u.id, weight_string(u.id) from `user` as u where u.id = :ue_id group by u.id, weight_string(u.id)",
-                                "Table": "`user`",
-                                "Values": [
-                                  ":ue_id"
-                                ],
-                                "Vindex": "user_index"
-                              }
-                            ]
+                            "FieldQuery": "select ue.id from user_extra as ue where 1 != 1",
+                            "Query": "select ue.id from user_extra as ue",
+                            "Table": "user_extra"
+                          },
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "EqualUnique",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select weight_string(u.id), u.id from `user` as u where 1 != 1",
+                            "Query": "select weight_string(u.id), u.id from `user` as u where u.id = :ue_id",
+                            "Table": "`user`",
+                            "Values": [
+                              ":ue_id"
+                            ],
+                            "Vindex": "user_index"
                           }
                         ]
                       }
@@ -5034,60 +4991,48 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "random(1) AS name, sum_count(2) AS count(m.predef1)",
-        "GroupBy": "(0|3)",
-        "ResultColumns": 3,
+        "Aggregates": "random(1) AS name, count(2) AS count(m.predef1)",
+        "GroupBy": "0",
         "Inputs": [
           {
-            "OperatorType": "Projection",
-            "Expressions": [
-              "[COLUMN 3] as id",
-              "[COLUMN 0] as name",
-              "[COLUMN 1] * [COLUMN 2] as count(m.predef1)",
-              "[COLUMN 4] as weight_string(u.id)"
-            ],
+            "OperatorType": "Sort",
+            "Variant": "Memory",
+            "OrderBy": "(1|0) ASC",
             "Inputs": [
               {
-                "OperatorType": "Sort",
-                "Variant": "Memory",
-                "OrderBy": "(3|4) ASC",
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "R:0,R:1",
+                "JoinVars": {
+                  "m_order": 0
+                },
+                "TableName": "user_extra_`user`",
                 "Inputs": [
                   {
-                    "OperatorType": "Join",
-                    "Variant": "Join",
-                    "JoinColumnIndexes": "R:0,L:0,R:1,R:2,R:3",
-                    "JoinVars": {
-                      "m_order": 1
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
                     },
-                    "TableName": "user_extra_`user`",
-                    "Inputs": [
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select count(m.predef1), m.`order` from user_extra as m where 1 != 1 group by m.`order`",
-                        "Query": "select count(m.predef1), m.`order` from user_extra as m group by m.`order`",
-                        "Table": "user_extra"
-                      },
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "EqualUnique",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select u.`name`, count(*), u.id, weight_string(u.id) from `user` as u where 1 != 1 group by u.id, weight_string(u.id)",
-                        "Query": "select u.`name`, count(*), u.id, weight_string(u.id) from `user` as u where u.id = :m_order group by u.id, weight_string(u.id)",
-                        "Table": "`user`",
-                        "Values": [
-                          ":m_order"
-                        ],
-                        "Vindex": "user_index"
-                      }
-                    ]
+                    "FieldQuery": "select m.`order` from user_extra as m where 1 != 1",
+                    "Query": "select m.`order` from user_extra as m",
+                    "Table": "user_extra"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select weight_string(u.id), u.id from `user` as u where 1 != 1",
+                    "Query": "select weight_string(u.id), u.id from `user` as u where u.id = :m_order",
+                    "Table": "`user`",
+                    "Values": [
+                      ":m_order"
+                    ],
+                    "Vindex": "user_index"
                   }
                 ]
               }
@@ -5625,55 +5570,45 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum_count_star(0) AS count(*)",
-        "GroupBy": "(1|2)",
+        "Aggregates": "count_star(0) AS count(*)",
+        "GroupBy": "(0|1)",
         "ResultColumns": 1,
         "Inputs": [
           {
-            "OperatorType": "Projection",
-            "Expressions": [
-              "[COLUMN 0] * COALESCE([COLUMN 1], INT64(1)) as count(*)",
-              "[COLUMN 2] as col",
-              "[COLUMN 3] as weight_string(music.col)"
-            ],
+            "OperatorType": "Sort",
+            "Variant": "Memory",
+            "OrderBy": "(0|1) ASC",
             "Inputs": [
               {
-                "OperatorType": "Sort",
-                "Variant": "Memory",
-                "OrderBy": "(2|3) ASC",
+                "OperatorType": "Join",
+                "Variant": "LeftJoin",
+                "JoinColumnIndexes": "R:0,R:1",
+                "JoinVars": {
+                  "user_foo": 0
+                },
+                "TableName": "`user`_music",
                 "Inputs": [
                   {
-                    "OperatorType": "Join",
-                    "Variant": "LeftJoin",
-                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
-                    "JoinVars": {
-                      "user_foo": 1
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
                     },
-                    "TableName": "`user`_music",
-                    "Inputs": [
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                        "Query": "select count(*), `user`.foo from `user` group by `user`.foo",
-                        "Table": "`user`"
-                      },
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select count(*), music.col, weight_string(music.col) from music where 1 != 1 group by music.col, weight_string(music.col)",
-                        "Query": "select count(*), music.col, weight_string(music.col) from music where music.bar = :user_foo group by music.col, weight_string(music.col)",
-                        "Table": "music"
-                      }
-                    ]
+                    "FieldQuery": "select `user`.foo from `user` where 1 != 1",
+                    "Query": "select `user`.foo from `user`",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select music.col, weight_string(music.col) from music where 1 != 1",
+                    "Query": "select music.col, weight_string(music.col) from music where music.bar = :user_foo",
+                    "Table": "music"
                   }
                 ]
               }
@@ -5760,55 +5695,45 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "sum_count_star(0) AS count(*)",
-        "GroupBy": "(1|2)",
+        "Aggregates": "count_star(0) AS count(*)",
+        "GroupBy": "(0|1)",
         "ResultColumns": 1,
         "Inputs": [
           {
-            "OperatorType": "Projection",
-            "Expressions": [
-              "[COLUMN 0] * COALESCE([COLUMN 1], INT64(1)) as count(*)",
-              "[COLUMN 2] as col",
-              "[COLUMN 3] as weight_string(music.col)"
-            ],
+            "OperatorType": "Sort",
+            "Variant": "Memory",
+            "OrderBy": "(0|1) ASC",
             "Inputs": [
               {
-                "OperatorType": "Sort",
-                "Variant": "Memory",
-                "OrderBy": "(2|3) ASC",
+                "OperatorType": "Join",
+                "Variant": "LeftJoin",
+                "JoinColumnIndexes": "R:0,R:1",
+                "JoinVars": {
+                  "user_foo": 0
+                },
+                "TableName": "`user`_music",
                 "Inputs": [
                   {
-                    "OperatorType": "Join",
-                    "Variant": "LeftJoin",
-                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
-                    "JoinVars": {
-                      "user_foo": 1
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
                     },
-                    "TableName": "`user`_music",
-                    "Inputs": [
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
-                        "Query": "select count(*), `user`.foo from `user` group by `user`.foo",
-                        "Table": "`user`"
-                      },
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select count(*), music.col, weight_string(music.col) from music where 1 != 1 group by music.col, weight_string(music.col)",
-                        "Query": "select count(*), music.col, weight_string(music.col) from music where music.bar = :user_foo group by music.col, weight_string(music.col)",
-                        "Table": "music"
-                      }
-                    ]
+                    "FieldQuery": "select `user`.foo from `user` where 1 != 1",
+                    "Query": "select `user`.foo from `user`",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select music.col, weight_string(music.col) from music where 1 != 1",
+                    "Query": "select music.col, weight_string(music.col) from music where music.bar = :user_foo",
+                    "Table": "music"
                   }
                 ]
               }
@@ -6022,8 +5947,8 @@
           {
             "OperatorType": "Projection",
             "Expressions": [
-              "[COLUMN 2] as col",
-              "[COLUMN 3] as intcol",
+              "[COLUMN 3] as col",
+              "[COLUMN 2] as intcol",
               "[COLUMN 0] * [COLUMN 1] as count(*)"
             ],
             "Inputs": [
@@ -6040,9 +5965,9 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select count(*), u.col, u.intcol from `user` as u where 1 != 1 group by u.col, u.intcol",
-                    "OrderBy": "2 ASC, 1 ASC",
-                    "Query": "select count(*), u.col, u.intcol from `user` as u group by u.col, u.intcol order by u.intcol asc, u.col asc",
+                    "FieldQuery": "select count(*), u.intcol, u.col from `user` as u where 1 != 1 group by u.intcol, u.col",
+                    "OrderBy": "1 ASC, 2 ASC",
+                    "Query": "select count(*), u.intcol, u.col from `user` as u group by u.intcol, u.col order by u.intcol asc, u.col asc",
                     "Table": "`user`"
                   },
                   {
@@ -6168,42 +6093,6 @@
         "user.user"
       ]
     }
-  },
-  {
-    "QueryType": "SELECT",
-    "Original": "select distinct count(*) from user group by col",
-    "Instructions": {
-      "OperatorType": "Distinct",
-      "Collations": [
-        "0"
-      ],
-      "ResultColumns": 1,
-      "Inputs": [
-        {
-          "OperatorType": "Aggregate",
-          "Variant": "Ordered",
-          "Aggregates": "sum_count_star(0) AS count(*)",
-          "GroupBy": "1",
-          "Inputs": [
-            {
-              "OperatorType": "Route",
-              "Variant": "Scatter",
-              "Keyspace": {
-                "Name": "user",
-                "Sharded": true
-              },
-              "FieldQuery": "select count(*), col from `user` where 1 != 1 group by col",
-              "OrderBy": "1 ASC",
-              "Query": "select count(*), col from `user` group by col order by col asc",
-              "Table": "`user`"
-            }
-          ]
-        }
-      ]
-    },
-    "TablesUsed": [
-      "user.user"
-    ]
   },
   {
     "comment": "scalar aggregates with min, max, sum distinct and count distinct using collations",
@@ -6433,6 +6322,174 @@
                 "FieldQuery": "select min(user_extra.foo), max(user_extra.bar) from user_extra where 1 != 1 group by .0",
                 "Query": "select min(user_extra.foo), max(user_extra.bar) from user_extra where user_extra.bar = :user_col group by .0",
                 "Table": "user_extra"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "extremum on input from both sides",
+    "query": "select max(u.foo*ue.bar) from user u join user_extra ue",
+    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select max(u.foo*ue.bar) from user u join user_extra ue",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "max(0) AS max(u.foo * ue.bar)",
+        "Inputs": [
+          {
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "R:0",
+            "JoinVars": {
+              "u_foo": 0
+            },
+            "TableName": "`user`_user_extra",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select u.foo from `user` as u where 1 != 1",
+                "Query": "select u.foo from `user` as u",
+                "Table": "`user`"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select :u_foo * ue.bar from user_extra as ue where 1 != 1",
+                "Query": "select :u_foo * ue.bar from user_extra as ue",
+                "Table": "user_extra"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "aggregate on input from both sides",
+    "query": "select sum(user.foo+user_extra.bar) from user, user_extra",
+    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select sum(user.foo+user_extra.bar) from user, user_extra",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "sum(0) AS sum(`user`.foo + user_extra.bar)",
+        "Inputs": [
+          {
+            "OperatorType": "Join",
+            "Variant": "Join",
+            "JoinColumnIndexes": "R:0",
+            "JoinVars": {
+              "user_foo": 0
+            },
+            "TableName": "`user`_user_extra",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select `user`.foo from `user` where 1 != 1",
+                "Query": "select `user`.foo from `user`",
+                "Table": "`user`"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select :user_foo + user_extra.bar from user_extra where 1 != 1",
+                "Query": "select :user_foo + user_extra.bar from user_extra",
+                "Table": "user_extra"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "grouping column could be coming from multiple sides",
+    "query": "select count(*) from user, user_extra group by user.id+user_extra.id",
+    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
+    "gen4-plan": {
+      "QueryType": "SELECT",
+      "Original": "select count(*) from user, user_extra group by user.id+user_extra.id",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "Aggregates": "count_star(0) AS count(*)",
+        "GroupBy": "(0|1)",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Sort",
+            "Variant": "Memory",
+            "OrderBy": "(0|1) ASC",
+            "Inputs": [
+              {
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "R:0,R:1",
+                "JoinVars": {
+                  "user_id": 0
+                },
+                "TableName": "`user`_user_extra",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select `user`.id from `user` where 1 != 1",
+                    "Query": "select `user`.id from `user`",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select :user_id + user_extra.id, weight_string(:user_id + user_extra.id) from user_extra where 1 != 1",
+                    "Query": "select :user_id + user_extra.id, weight_string(:user_id + user_extra.id) from user_extra",
+                    "Table": "user_extra"
+                  }
+                ]
               }
             ]
           }

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -3430,19 +3430,20 @@
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "count(0) AS count(u.textcol1), count(1) AS count(ue.foo)",
-        "GroupBy": "(2|0)",
+        "GroupBy": "(2|3)",
+        "ResultColumns": 3,
         "Inputs": [
           {
             "OperatorType": "Sort",
             "Variant": "Memory",
-            "OrderBy": "(1|0) ASC",
+            "OrderBy": "(2|3) ASC",
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "R:0,R:1",
+                "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
                 "JoinVars": {
-                  "u_foo": 0
+                  "u_foo": 1
                 },
                 "TableName": "`user`_user_extra_unsharded",
                 "Inputs": [
@@ -3453,16 +3454,16 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select u.foo from `user` as u where 1 != 1",
-                    "Query": "select u.foo from `user` as u",
+                    "FieldQuery": "select u.textcol1, u.foo from `user` as u where 1 != 1",
+                    "Query": "select u.textcol1, u.foo from `user` as u",
                     "Table": "`user`"
                   },
                   {
                     "OperatorType": "Join",
                     "Variant": "Join",
-                    "JoinColumnIndexes": "R:0,R:1",
+                    "JoinColumnIndexes": "L:0,R:0,R:1",
                     "JoinVars": {
-                      "ue_bar": 0
+                      "ue_bar": 1
                     },
                     "TableName": "user_extra_unsharded",
                     "Inputs": [
@@ -3473,8 +3474,8 @@
                           "Name": "user",
                           "Sharded": true
                         },
-                        "FieldQuery": "select ue.bar from user_extra as ue where 1 != 1",
-                        "Query": "select ue.bar from user_extra as ue where ue.bar = :u_foo",
+                        "FieldQuery": "select ue.foo, ue.bar from user_extra as ue where 1 != 1",
+                        "Query": "select ue.foo, ue.bar from user_extra as ue where ue.bar = :u_foo",
                         "Table": "user_extra"
                       },
                       {
@@ -3484,8 +3485,8 @@
                           "Name": "main",
                           "Sharded": false
                         },
-                        "FieldQuery": "select weight_string(us.bar), us.bar from unsharded as us where 1 != 1",
-                        "Query": "select weight_string(us.bar), us.bar from unsharded as us where us.baz = :ue_bar",
+                        "FieldQuery": "select us.bar, weight_string(us.bar) from unsharded as us where 1 != 1",
+                        "Query": "select us.bar, weight_string(us.bar) from unsharded as us where us.baz = :ue_bar",
                         "Table": "unsharded"
                       }
                     ]
@@ -4243,17 +4244,17 @@
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "count(1) AS count(u.`name`)",
-                "GroupBy": "0",
+                "GroupBy": "(0|2)",
                 "Inputs": [
                   {
                     "OperatorType": "Sort",
                     "Variant": "Memory",
-                    "OrderBy": "(1|0) ASC",
+                    "OrderBy": "(0|2) ASC",
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "R:0,R:1",
+                        "JoinColumnIndexes": "R:0,R:1,R:2",
                         "JoinVars": {
                           "ue_id": 0
                         },
@@ -4277,8 +4278,8 @@
                               "Name": "user",
                               "Sharded": true
                             },
-                            "FieldQuery": "select weight_string(u.id), u.id from `user` as u where 1 != 1",
-                            "Query": "select weight_string(u.id), u.id from `user` as u where u.id = :ue_id",
+                            "FieldQuery": "select u.id, u.`name`, weight_string(u.id) from `user` as u where 1 != 1",
+                            "Query": "select u.id, u.`name`, weight_string(u.id) from `user` as u where u.id = :ue_id",
                             "Table": "`user`",
                             "Values": [
                               ":ue_id"
@@ -4360,19 +4361,19 @@
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "count_star(1) AS count(*)",
-                "GroupBy": "0",
+                "GroupBy": "(0|2)",
                 "Inputs": [
                   {
                     "OperatorType": "Sort",
                     "Variant": "Memory",
-                    "OrderBy": "(1|0) ASC",
+                    "OrderBy": "(0|2) ASC",
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "R:0,R:1",
+                        "JoinColumnIndexes": "R:0,L:0,R:1",
                         "JoinVars": {
-                          "ue_id": 0
+                          "ue_id": 1
                         },
                         "TableName": "user_extra_`user`",
                         "Inputs": [
@@ -4383,8 +4384,8 @@
                               "Name": "user",
                               "Sharded": true
                             },
-                            "FieldQuery": "select ue.id from user_extra as ue where 1 != 1",
-                            "Query": "select ue.id from user_extra as ue",
+                            "FieldQuery": "select 1, ue.id from user_extra as ue where 1 != 1",
+                            "Query": "select 1, ue.id from user_extra as ue",
                             "Table": "user_extra"
                           },
                           {
@@ -4394,8 +4395,8 @@
                               "Name": "user",
                               "Sharded": true
                             },
-                            "FieldQuery": "select weight_string(u.id), u.id from `user` as u where 1 != 1",
-                            "Query": "select weight_string(u.id), u.id from `user` as u where u.id = :ue_id",
+                            "FieldQuery": "select u.id, weight_string(u.id) from `user` as u where 1 != 1",
+                            "Query": "select u.id, weight_string(u.id) from `user` as u where u.id = :ue_id",
                             "Table": "`user`",
                             "Values": [
                               ":ue_id"
@@ -4992,19 +4993,20 @@
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "random(1) AS name, count(2) AS count(m.predef1)",
-        "GroupBy": "0",
+        "GroupBy": "(0|3)",
+        "ResultColumns": 3,
         "Inputs": [
           {
             "OperatorType": "Sort",
             "Variant": "Memory",
-            "OrderBy": "(1|0) ASC",
+            "OrderBy": "(0|3) ASC",
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "R:0,R:1",
+                "JoinColumnIndexes": "R:0,R:1,L:0,R:2",
                 "JoinVars": {
-                  "m_order": 0
+                  "m_order": 1
                 },
                 "TableName": "user_extra_`user`",
                 "Inputs": [
@@ -5015,8 +5017,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select m.`order` from user_extra as m where 1 != 1",
-                    "Query": "select m.`order` from user_extra as m",
+                    "FieldQuery": "select m.predef1, m.`order` from user_extra as m where 1 != 1",
+                    "Query": "select m.predef1, m.`order` from user_extra as m",
                     "Table": "user_extra"
                   },
                   {
@@ -5026,8 +5028,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select weight_string(u.id), u.id from `user` as u where 1 != 1",
-                    "Query": "select weight_string(u.id), u.id from `user` as u where u.id = :m_order",
+                    "FieldQuery": "select u.id, u.`name`, weight_string(u.id) from `user` as u where 1 != 1",
+                    "Query": "select u.id, u.`name`, weight_string(u.id) from `user` as u where u.id = :m_order",
                     "Table": "`user`",
                     "Values": [
                       ":m_order"
@@ -5571,20 +5573,20 @@
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "count_star(0) AS count(*)",
-        "GroupBy": "(0|1)",
+        "GroupBy": "(1|2)",
         "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Sort",
             "Variant": "Memory",
-            "OrderBy": "(0|1) ASC",
+            "OrderBy": "(1|2) ASC",
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "LeftJoin",
-                "JoinColumnIndexes": "R:0,R:1",
+                "JoinColumnIndexes": "L:0,R:0,R:1",
                 "JoinVars": {
-                  "user_foo": 0
+                  "user_foo": 1
                 },
                 "TableName": "`user`_music",
                 "Inputs": [
@@ -5595,8 +5597,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select `user`.foo from `user` where 1 != 1",
-                    "Query": "select `user`.foo from `user`",
+                    "FieldQuery": "select 1, `user`.foo from `user` where 1 != 1",
+                    "Query": "select 1, `user`.foo from `user`",
                     "Table": "`user`"
                   },
                   {
@@ -5696,20 +5698,20 @@
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "count_star(0) AS count(*)",
-        "GroupBy": "(0|1)",
+        "GroupBy": "(1|2)",
         "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Sort",
             "Variant": "Memory",
-            "OrderBy": "(0|1) ASC",
+            "OrderBy": "(1|2) ASC",
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "LeftJoin",
-                "JoinColumnIndexes": "R:0,R:1",
+                "JoinColumnIndexes": "L:0,R:0,R:1",
                 "JoinVars": {
-                  "user_foo": 0
+                  "user_foo": 1
                 },
                 "TableName": "`user`_music",
                 "Inputs": [
@@ -5720,8 +5722,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select `user`.foo from `user` where 1 != 1",
-                    "Query": "select `user`.foo from `user`",
+                    "FieldQuery": "select 1, `user`.foo from `user` where 1 != 1",
+                    "Query": "select 1, `user`.foo from `user`",
                     "Table": "`user`"
                   },
                   {
@@ -6450,20 +6452,20 @@
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "count_star(0) AS count(*)",
-        "GroupBy": "(0|1)",
+        "GroupBy": "(1|2)",
         "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Sort",
             "Variant": "Memory",
-            "OrderBy": "(0|1) ASC",
+            "OrderBy": "(1|2) ASC",
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "R:0,R:1",
+                "JoinColumnIndexes": "L:0,R:0,R:1",
                 "JoinVars": {
-                  "user_id": 0
+                  "user_id": 1
                 },
                 "TableName": "`user`_user_extra",
                 "Inputs": [
@@ -6474,8 +6476,8 @@
                       "Name": "user",
                       "Sharded": true
                     },
-                    "FieldQuery": "select `user`.id from `user` where 1 != 1",
-                    "Query": "select `user`.id from `user`",
+                    "FieldQuery": "select 1, `user`.id from `user` where 1 != 1",
+                    "Query": "select 1, `user`.id from `user`",
                     "Table": "`user`"
                   },
                   {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -3429,43 +3429,32 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "count(0) AS count(u.textcol1), count(1) AS count(ue.foo)",
+        "Aggregates": "sum_count(0) AS count(u.textcol1), sum_count(1) AS count(ue.foo)",
         "GroupBy": "(2|3)",
         "ResultColumns": 3,
         "Inputs": [
           {
-            "OperatorType": "Sort",
-            "Variant": "Memory",
-            "OrderBy": "(2|3) ASC",
+            "OperatorType": "Projection",
+            "Expressions": [
+              "[COLUMN 0] * [COLUMN 1] as count(u.textcol1)",
+              "[COLUMN 3] * [COLUMN 2] as count(ue.foo)",
+              "[COLUMN 4] as bar",
+              "[COLUMN 5] as weight_string(us.bar)"
+            ],
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
-                "JoinVars": {
-                  "u_foo": 1
-                },
-                "TableName": "`user`_user_extra_unsharded",
+                "OperatorType": "Sort",
+                "Variant": "Memory",
+                "OrderBy": "(4|5) ASC",
                 "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select u.textcol1, u.foo from `user` as u where 1 != 1",
-                    "Query": "select u.textcol1, u.foo from `user` as u",
-                    "Table": "`user`"
-                  },
                   {
                     "OperatorType": "Join",
                     "Variant": "Join",
-                    "JoinColumnIndexes": "L:0,R:0,R:1",
+                    "JoinColumnIndexes": "L:0,R:0,R:1,L:1,R:2,R:3",
                     "JoinVars": {
-                      "ue_bar": 1
+                      "u_foo": 2
                     },
-                    "TableName": "user_extra_unsharded",
+                    "TableName": "`user`_user_extra_unsharded",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -3474,20 +3463,53 @@
                           "Name": "user",
                           "Sharded": true
                         },
-                        "FieldQuery": "select ue.foo, ue.bar from user_extra as ue where 1 != 1",
-                        "Query": "select ue.foo, ue.bar from user_extra as ue where ue.bar = :u_foo",
-                        "Table": "user_extra"
+                        "FieldQuery": "select count(u.textcol1), count(*), u.foo from `user` as u where 1 != 1 group by u.foo",
+                        "Query": "select count(u.textcol1), count(*), u.foo from `user` as u group by u.foo",
+                        "Table": "`user`"
                       },
                       {
-                        "OperatorType": "Route",
-                        "Variant": "Unsharded",
-                        "Keyspace": {
-                          "Name": "main",
-                          "Sharded": false
-                        },
-                        "FieldQuery": "select us.bar, weight_string(us.bar) from unsharded as us where 1 != 1",
-                        "Query": "select us.bar, weight_string(us.bar) from unsharded as us where us.baz = :ue_bar",
-                        "Table": "unsharded"
+                        "OperatorType": "Projection",
+                        "Expressions": [
+                          "[COLUMN 0] * [COLUMN 1] as count(*)",
+                          "[COLUMN 2] * [COLUMN 1] as count(ue.foo)",
+                          "[COLUMN 3] as bar",
+                          "[COLUMN 4] as weight_string(us.bar)"
+                        ],
+                        "Inputs": [
+                          {
+                            "OperatorType": "Join",
+                            "Variant": "Join",
+                            "JoinColumnIndexes": "L:0,R:0,L:1,R:1,R:2",
+                            "JoinVars": {
+                              "ue_bar": 2
+                            },
+                            "TableName": "user_extra_unsharded",
+                            "Inputs": [
+                              {
+                                "OperatorType": "Route",
+                                "Variant": "Scatter",
+                                "Keyspace": {
+                                  "Name": "user",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select count(*), count(ue.foo), ue.bar from user_extra as ue where 1 != 1 group by ue.bar",
+                                "Query": "select count(*), count(ue.foo), ue.bar from user_extra as ue where ue.bar = :u_foo group by ue.bar",
+                                "Table": "user_extra"
+                              },
+                              {
+                                "OperatorType": "Route",
+                                "Variant": "Unsharded",
+                                "Keyspace": {
+                                  "Name": "main",
+                                  "Sharded": false
+                                },
+                                "FieldQuery": "select count(*), us.bar, weight_string(us.bar) from unsharded as us where 1 != 1 group by us.bar, weight_string(us.bar)",
+                                "Query": "select count(*), us.bar, weight_string(us.bar) from unsharded as us where us.baz = :ue_bar group by us.bar, weight_string(us.bar)",
+                                "Table": "unsharded"
+                              }
+                            ]
+                          }
+                        ]
                       }
                     ]
                   }
@@ -4243,48 +4265,58 @@
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
-                "Aggregates": "count(1) AS count(u.`name`)",
+                "Aggregates": "sum_count(1) AS count(u.`name`)",
                 "GroupBy": "(0|2)",
                 "Inputs": [
                   {
-                    "OperatorType": "Sort",
-                    "Variant": "Memory",
-                    "OrderBy": "(0|2) ASC",
+                    "OperatorType": "Projection",
+                    "Expressions": [
+                      "[COLUMN 2] as id",
+                      "[COLUMN 1] * [COLUMN 0] as count(u.`name`)",
+                      "[COLUMN 3] as weight_string(u.id)"
+                    ],
                     "Inputs": [
                       {
-                        "OperatorType": "Join",
-                        "Variant": "Join",
-                        "JoinColumnIndexes": "R:0,R:1,R:2",
-                        "JoinVars": {
-                          "ue_id": 0
-                        },
-                        "TableName": "user_extra_`user`",
+                        "OperatorType": "Sort",
+                        "Variant": "Memory",
+                        "OrderBy": "(2|3) ASC",
                         "Inputs": [
                           {
-                            "OperatorType": "Route",
-                            "Variant": "Scatter",
-                            "Keyspace": {
-                              "Name": "user",
-                              "Sharded": true
+                            "OperatorType": "Join",
+                            "Variant": "Join",
+                            "JoinColumnIndexes": "R:0,L:0,R:1,R:2",
+                            "JoinVars": {
+                              "ue_id": 1
                             },
-                            "FieldQuery": "select ue.id from user_extra as ue where 1 != 1",
-                            "Query": "select ue.id from user_extra as ue",
-                            "Table": "user_extra"
-                          },
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "EqualUnique",
-                            "Keyspace": {
-                              "Name": "user",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select u.id, u.`name`, weight_string(u.id) from `user` as u where 1 != 1",
-                            "Query": "select u.id, u.`name`, weight_string(u.id) from `user` as u where u.id = :ue_id",
-                            "Table": "`user`",
-                            "Values": [
-                              ":ue_id"
-                            ],
-                            "Vindex": "user_index"
+                            "TableName": "user_extra_`user`",
+                            "Inputs": [
+                              {
+                                "OperatorType": "Route",
+                                "Variant": "Scatter",
+                                "Keyspace": {
+                                  "Name": "user",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select count(*), ue.id from user_extra as ue where 1 != 1 group by ue.id",
+                                "Query": "select count(*), ue.id from user_extra as ue group by ue.id",
+                                "Table": "user_extra"
+                              },
+                              {
+                                "OperatorType": "Route",
+                                "Variant": "EqualUnique",
+                                "Keyspace": {
+                                  "Name": "user",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select count(u.`name`), u.id, weight_string(u.id) from `user` as u where 1 != 1 group by u.id, weight_string(u.id)",
+                                "Query": "select count(u.`name`), u.id, weight_string(u.id) from `user` as u where u.id = :ue_id group by u.id, weight_string(u.id)",
+                                "Table": "`user`",
+                                "Values": [
+                                  ":ue_id"
+                                ],
+                                "Vindex": "user_index"
+                              }
+                            ]
                           }
                         ]
                       }
@@ -4360,48 +4392,58 @@
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
-                "Aggregates": "count_star(1) AS count(*)",
+                "Aggregates": "sum_count_star(1) AS count(*)",
                 "GroupBy": "(0|2)",
                 "Inputs": [
                   {
-                    "OperatorType": "Sort",
-                    "Variant": "Memory",
-                    "OrderBy": "(0|2) ASC",
+                    "OperatorType": "Projection",
+                    "Expressions": [
+                      "[COLUMN 2] as id",
+                      "[COLUMN 0] * [COLUMN 1] as count(*)",
+                      "[COLUMN 3] as weight_string(u.id)"
+                    ],
                     "Inputs": [
                       {
-                        "OperatorType": "Join",
-                        "Variant": "Join",
-                        "JoinColumnIndexes": "R:0,L:0,R:1",
-                        "JoinVars": {
-                          "ue_id": 1
-                        },
-                        "TableName": "user_extra_`user`",
+                        "OperatorType": "Sort",
+                        "Variant": "Memory",
+                        "OrderBy": "(2|3) ASC",
                         "Inputs": [
                           {
-                            "OperatorType": "Route",
-                            "Variant": "Scatter",
-                            "Keyspace": {
-                              "Name": "user",
-                              "Sharded": true
+                            "OperatorType": "Join",
+                            "Variant": "Join",
+                            "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
+                            "JoinVars": {
+                              "ue_id": 1
                             },
-                            "FieldQuery": "select 1, ue.id from user_extra as ue where 1 != 1",
-                            "Query": "select 1, ue.id from user_extra as ue",
-                            "Table": "user_extra"
-                          },
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "EqualUnique",
-                            "Keyspace": {
-                              "Name": "user",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select u.id, weight_string(u.id) from `user` as u where 1 != 1",
-                            "Query": "select u.id, weight_string(u.id) from `user` as u where u.id = :ue_id",
-                            "Table": "`user`",
-                            "Values": [
-                              ":ue_id"
-                            ],
-                            "Vindex": "user_index"
+                            "TableName": "user_extra_`user`",
+                            "Inputs": [
+                              {
+                                "OperatorType": "Route",
+                                "Variant": "Scatter",
+                                "Keyspace": {
+                                  "Name": "user",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select count(*), ue.id from user_extra as ue where 1 != 1 group by ue.id",
+                                "Query": "select count(*), ue.id from user_extra as ue group by ue.id",
+                                "Table": "user_extra"
+                              },
+                              {
+                                "OperatorType": "Route",
+                                "Variant": "EqualUnique",
+                                "Keyspace": {
+                                  "Name": "user",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select count(*), u.id, weight_string(u.id) from `user` as u where 1 != 1 group by u.id, weight_string(u.id)",
+                                "Query": "select count(*), u.id, weight_string(u.id) from `user` as u where u.id = :ue_id group by u.id, weight_string(u.id)",
+                                "Table": "`user`",
+                                "Values": [
+                                  ":ue_id"
+                                ],
+                                "Vindex": "user_index"
+                              }
+                            ]
                           }
                         ]
                       }
@@ -4992,49 +5034,60 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "random(1) AS name, count(2) AS count(m.predef1)",
+        "Aggregates": "random(1) AS name, sum_count(2) AS count(m.predef1)",
         "GroupBy": "(0|3)",
         "ResultColumns": 3,
         "Inputs": [
           {
-            "OperatorType": "Sort",
-            "Variant": "Memory",
-            "OrderBy": "(0|3) ASC",
+            "OperatorType": "Projection",
+            "Expressions": [
+              "[COLUMN 3] as id",
+              "[COLUMN 0] as name",
+              "[COLUMN 1] * [COLUMN 2] as count(m.predef1)",
+              "[COLUMN 4] as weight_string(u.id)"
+            ],
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "Join",
-                "JoinColumnIndexes": "R:0,R:1,L:0,R:2",
-                "JoinVars": {
-                  "m_order": 1
-                },
-                "TableName": "user_extra_`user`",
+                "OperatorType": "Sort",
+                "Variant": "Memory",
+                "OrderBy": "(3|4) ASC",
                 "Inputs": [
                   {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
+                    "OperatorType": "Join",
+                    "Variant": "Join",
+                    "JoinColumnIndexes": "R:0,L:0,R:1,R:2,R:3",
+                    "JoinVars": {
+                      "m_order": 1
                     },
-                    "FieldQuery": "select m.predef1, m.`order` from user_extra as m where 1 != 1",
-                    "Query": "select m.predef1, m.`order` from user_extra as m",
-                    "Table": "user_extra"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "EqualUnique",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select u.id, u.`name`, weight_string(u.id) from `user` as u where 1 != 1",
-                    "Query": "select u.id, u.`name`, weight_string(u.id) from `user` as u where u.id = :m_order",
-                    "Table": "`user`",
-                    "Values": [
-                      ":m_order"
-                    ],
-                    "Vindex": "user_index"
+                    "TableName": "user_extra_`user`",
+                    "Inputs": [
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select count(m.predef1), m.`order` from user_extra as m where 1 != 1 group by m.`order`",
+                        "Query": "select count(m.predef1), m.`order` from user_extra as m group by m.`order`",
+                        "Table": "user_extra"
+                      },
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "EqualUnique",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select u.`name`, count(*), u.id, weight_string(u.id) from `user` as u where 1 != 1 group by u.id, weight_string(u.id)",
+                        "Query": "select u.`name`, count(*), u.id, weight_string(u.id) from `user` as u where u.id = :m_order group by u.id, weight_string(u.id)",
+                        "Table": "`user`",
+                        "Values": [
+                          ":m_order"
+                        ],
+                        "Vindex": "user_index"
+                      }
+                    ]
                   }
                 ]
               }
@@ -5572,45 +5625,55 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "count_star(0) AS count(*)",
+        "Aggregates": "sum_count_star(0) AS count(*)",
         "GroupBy": "(1|2)",
         "ResultColumns": 1,
         "Inputs": [
           {
-            "OperatorType": "Sort",
-            "Variant": "Memory",
-            "OrderBy": "(1|2) ASC",
+            "OperatorType": "Projection",
+            "Expressions": [
+              "[COLUMN 0] * COALESCE([COLUMN 1], INT64(1)) as count(*)",
+              "[COLUMN 2] as col",
+              "[COLUMN 3] as weight_string(music.col)"
+            ],
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "LeftJoin",
-                "JoinColumnIndexes": "L:0,R:0,R:1",
-                "JoinVars": {
-                  "user_foo": 1
-                },
-                "TableName": "`user`_music",
+                "OperatorType": "Sort",
+                "Variant": "Memory",
+                "OrderBy": "(2|3) ASC",
                 "Inputs": [
                   {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
+                    "OperatorType": "Join",
+                    "Variant": "LeftJoin",
+                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
+                    "JoinVars": {
+                      "user_foo": 1
                     },
-                    "FieldQuery": "select 1, `user`.foo from `user` where 1 != 1",
-                    "Query": "select 1, `user`.foo from `user`",
-                    "Table": "`user`"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select music.col, weight_string(music.col) from music where 1 != 1",
-                    "Query": "select music.col, weight_string(music.col) from music where music.bar = :user_foo",
-                    "Table": "music"
+                    "TableName": "`user`_music",
+                    "Inputs": [
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
+                        "Query": "select count(*), `user`.foo from `user` group by `user`.foo",
+                        "Table": "`user`"
+                      },
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select count(*), music.col, weight_string(music.col) from music where 1 != 1 group by music.col, weight_string(music.col)",
+                        "Query": "select count(*), music.col, weight_string(music.col) from music where music.bar = :user_foo group by music.col, weight_string(music.col)",
+                        "Table": "music"
+                      }
+                    ]
                   }
                 ]
               }
@@ -5697,45 +5760,55 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "count_star(0) AS count(*)",
+        "Aggregates": "sum_count_star(0) AS count(*)",
         "GroupBy": "(1|2)",
         "ResultColumns": 1,
         "Inputs": [
           {
-            "OperatorType": "Sort",
-            "Variant": "Memory",
-            "OrderBy": "(1|2) ASC",
+            "OperatorType": "Projection",
+            "Expressions": [
+              "[COLUMN 0] * COALESCE([COLUMN 1], INT64(1)) as count(*)",
+              "[COLUMN 2] as col",
+              "[COLUMN 3] as weight_string(music.col)"
+            ],
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "LeftJoin",
-                "JoinColumnIndexes": "L:0,R:0,R:1",
-                "JoinVars": {
-                  "user_foo": 1
-                },
-                "TableName": "`user`_music",
+                "OperatorType": "Sort",
+                "Variant": "Memory",
+                "OrderBy": "(2|3) ASC",
                 "Inputs": [
                   {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
+                    "OperatorType": "Join",
+                    "Variant": "LeftJoin",
+                    "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
+                    "JoinVars": {
+                      "user_foo": 1
                     },
-                    "FieldQuery": "select 1, `user`.foo from `user` where 1 != 1",
-                    "Query": "select 1, `user`.foo from `user`",
-                    "Table": "`user`"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "Scatter",
-                    "Keyspace": {
-                      "Name": "user",
-                      "Sharded": true
-                    },
-                    "FieldQuery": "select music.col, weight_string(music.col) from music where 1 != 1",
-                    "Query": "select music.col, weight_string(music.col) from music where music.bar = :user_foo",
-                    "Table": "music"
+                    "TableName": "`user`_music",
+                    "Inputs": [
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select count(*), `user`.foo from `user` where 1 != 1 group by `user`.foo",
+                        "Query": "select count(*), `user`.foo from `user` group by `user`.foo",
+                        "Table": "`user`"
+                      },
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select count(*), music.col, weight_string(music.col) from music where 1 != 1 group by music.col, weight_string(music.col)",
+                        "Query": "select count(*), music.col, weight_string(music.col) from music where music.bar = :user_foo group by music.col, weight_string(music.col)",
+                        "Table": "music"
+                      }
+                    ]
                   }
                 ]
               }

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -6598,7 +6598,7 @@
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": "repeat(a.textcol1, :1) like 'And%res'",
+            "Predicate": "repeat(a.textcol1, sum(a.id)) like 'And%res'",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -6609,16 +6609,16 @@
                   {
                     "OperatorType": "Projection",
                     "Expressions": [
-                      "[COLUMN 0] as textcol1",
-                      "[COLUMN 1] * COALESCE([COLUMN 2], INT64(1)) as sum(a.id)"
+                      "[COLUMN 2] as textcol1",
+                      "[COLUMN 0] * [COLUMN 1] as sum(a.id)"
                     ],
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "L:0,L:1,R:1",
+                        "JoinColumnIndexes": "L:0,R:0,L:1",
                         "JoinVars": {
-                          "a_textcol1": 0
+                          "a_textcol1": 1
                         },
                         "TableName": "`user`_`user`",
                         "Inputs": [
@@ -6629,9 +6629,9 @@
                               "Name": "user",
                               "Sharded": true
                             },
-                            "FieldQuery": "select a.textcol1, sum(a.id) from `user` as a where 1 != 1 group by a.textcol1",
-                            "OrderBy": "0 ASC COLLATE latin1_swedish_ci",
-                            "Query": "select a.textcol1, sum(a.id) from `user` as a group by a.textcol1 order by a.textcol1 asc",
+                            "FieldQuery": "select sum(a.id), a.textcol1 from `user` as a where 1 != 1 group by a.textcol1",
+                            "OrderBy": "1 ASC COLLATE latin1_swedish_ci",
+                            "Query": "select sum(a.id), a.textcol1 from `user` as a group by a.textcol1 order by a.textcol1 asc",
                             "Table": "`user`"
                           },
                           {
@@ -6641,8 +6641,8 @@
                               "Name": "user",
                               "Sharded": true
                             },
-                            "FieldQuery": "select 1, count(*) from `user` as b where 1 != 1 group by 1",
-                            "Query": "select 1, count(*) from `user` as b where b.textcol2 = :a_textcol1 group by 1",
+                            "FieldQuery": "select count(*) from `user` as b where 1 != 1 group by .0",
+                            "Query": "select count(*) from `user` as b where b.textcol2 = :a_textcol1 group by .0",
                             "Table": "`user`"
                           }
                         ]

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -3102,7 +3102,7 @@
       "Original": "select count(*) a from user having a = 0x01",
       "Instructions": {
         "OperatorType": "Filter",
-        "Predicate": ":0 = 0x01",
+        "Predicate": "count(*) = 0x01",
         "Inputs": [
           {
             "OperatorType": "Aggregate",
@@ -3291,14 +3291,14 @@
       "QueryType": "SELECT",
       "Original": "select a.tcol1 from user a join music b where a.tcol1 = b.tcol2 group by a.tcol1 having repeat(a.tcol1,min(a.id)) like \"A\\%B\" order by a.tcol1",
       "Instructions": {
-        "OperatorType": "SimpleProjection",
-        "Columns": [
-          0
-        ],
+        "OperatorType": "Sort",
+        "Variant": "Memory",
+        "OrderBy": "(0|2) ASC",
+        "ResultColumns": 1,
         "Inputs": [
           {
             "OperatorType": "Filter",
-            "Predicate": "repeat(a.tcol1, :1) like 'A\\%B'",
+            "Predicate": "repeat(a.tcol1, min(a.id)) like 'A\\%B'",
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
@@ -3307,46 +3307,36 @@
                 "GroupBy": "(0|2)",
                 "Inputs": [
                   {
-                    "OperatorType": "Projection",
-                    "Expressions": [
-                      "[COLUMN 0] as tcol1",
-                      "[COLUMN 2] as min(a.id)",
-                      "[COLUMN 1]"
-                    ],
+                    "OperatorType": "Join",
+                    "Variant": "Join",
+                    "JoinColumnIndexes": "L:1,L:0,L:2",
+                    "JoinVars": {
+                      "a_tcol1": 1
+                    },
+                    "TableName": "`user`_music",
                     "Inputs": [
                       {
-                        "OperatorType": "Join",
-                        "Variant": "Join",
-                        "JoinColumnIndexes": "L:0,L:2,L:1",
-                        "JoinVars": {
-                          "a_tcol1": 0
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
                         },
-                        "TableName": "`user`_music",
-                        "Inputs": [
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "Scatter",
-                            "Keyspace": {
-                              "Name": "user",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select a.tcol1, min(a.id), weight_string(a.tcol1) from `user` as a where 1 != 1 group by a.tcol1, weight_string(a.tcol1)",
-                            "OrderBy": "(0|2) ASC",
-                            "Query": "select a.tcol1, min(a.id), weight_string(a.tcol1) from `user` as a group by a.tcol1, weight_string(a.tcol1) order by a.tcol1 asc",
-                            "Table": "`user`"
-                          },
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "Scatter",
-                            "Keyspace": {
-                              "Name": "user",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select 1 from music as b where 1 != 1 group by 1",
-                            "Query": "select 1 from music as b where b.tcol2 = :a_tcol1 group by 1",
-                            "Table": "music"
-                          }
-                        ]
+                        "FieldQuery": "select min(a.id), a.tcol1, weight_string(a.tcol1) from `user` as a where 1 != 1 group by a.tcol1, weight_string(a.tcol1)",
+                        "OrderBy": "(1|2) ASC",
+                        "Query": "select min(a.id), a.tcol1, weight_string(a.tcol1) from `user` as a group by a.tcol1, weight_string(a.tcol1) order by a.tcol1 asc",
+                        "Table": "`user`"
+                      },
+                      {
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select 1 from music as b where 1 != 1 group by .0",
+                        "Query": "select 1 from music as b where b.tcol2 = :a_tcol1 group by .0",
+                        "Table": "music"
                       }
                     ]
                   }

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -970,7 +970,7 @@
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "sum(1) AS high_line_count, sum(2) AS low_line_count",
-        "GroupBy": "(0|3)",
+        "GroupBy": "0",
         "ResultColumns": 3,
         "Inputs": [
           {

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -25,38 +25,38 @@
           {
             "OperatorType": "Sort",
             "Variant": "Memory",
-            "OrderBy": "1 DESC, (2|4) ASC",
+            "OrderBy": "1 DESC, (2|5) ASC",
             "ResultColumns": 4,
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum(1) AS revenue",
-                "GroupBy": "(0|5), (2|4), (3|6)",
+                "GroupBy": "(0|6), (2|5), (3|4)",
                 "Inputs": [
                   {
                     "OperatorType": "Projection",
                     "Expressions": [
-                      "[COLUMN 2] as l_orderkey",
-                      "[COLUMN 0] * [COLUMN 1] as revenue",
-                      "[COLUMN 3] as o_orderdate",
-                      "[COLUMN 4] as o_shippriority",
-                      "[COLUMN 5] as weight_string(o_orderdate)",
-                      "[COLUMN 6] as weight_string(l_orderkey)",
-                      "[COLUMN 7] as weight_string(o_shippriority)"
+                      "[COLUMN 0] as l_orderkey",
+                      "([COLUMN 6] * COALESCE([COLUMN 7], INT64(1))) * COALESCE([COLUMN 8], INT64(1)) as revenue",
+                      "[COLUMN 1] as o_orderdate",
+                      "[COLUMN 2] as o_shippriority",
+                      "[COLUMN 5]",
+                      "[COLUMN 4]",
+                      "[COLUMN 3]"
                     ],
                     "Inputs": [
                       {
                         "OperatorType": "Sort",
                         "Variant": "Memory",
-                        "OrderBy": "(2|6) ASC, (3|5) ASC, (4|7) ASC",
+                        "OrderBy": "(0|3) ASC, (1|4) ASC, (2|5) ASC",
                         "Inputs": [
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "L:0,R:0,L:1,R:1,R:2,R:3,L:2,R:4",
+                            "JoinColumnIndexes": "L:0,R:0,R:1,L:2,R:2,R:3,L:1,R:4,R:5",
                             "JoinVars": {
-                              "l_orderkey": 1
+                              "l_orderkey": 0
                             },
                             "TableName": "lineitem_orders_customer",
                             "Inputs": [
@@ -67,60 +67,48 @@
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_orderkey, weight_string(l_orderkey) from lineitem where 1 != 1 group by l_orderkey, weight_string(l_orderkey)",
-                                "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_orderkey, weight_string(l_orderkey) from lineitem where l_shipdate > date('1995-03-15') group by l_orderkey, weight_string(l_orderkey)",
+                                "FieldQuery": "select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_orderkey) from lineitem where 1 != 1 group by l_orderkey, weight_string(l_orderkey)",
+                                "Query": "select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_orderkey) from lineitem where l_shipdate > date('1995-03-15') group by l_orderkey, weight_string(l_orderkey)",
                                 "Table": "lineitem"
                               },
                               {
-                                "OperatorType": "Projection",
-                                "Expressions": [
-                                  "[COLUMN 0] * [COLUMN 1] as count(*)",
-                                  "[COLUMN 2] as o_orderdate",
-                                  "[COLUMN 3] as o_shippriority",
-                                  "[COLUMN 4] as weight_string(o_orderdate)",
-                                  "[COLUMN 5] as weight_string(o_shippriority)"
-                                ],
+                                "OperatorType": "Join",
+                                "Variant": "Join",
+                                "JoinColumnIndexes": "L:3,L:5,L:4,L:6,L:1,R:1",
+                                "JoinVars": {
+                                  "o_custkey": 0
+                                },
+                                "TableName": "orders_customer",
                                 "Inputs": [
                                   {
-                                    "OperatorType": "Join",
-                                    "Variant": "Join",
-                                    "JoinColumnIndexes": "L:0,R:0,L:1,L:2,L:4,L:5",
-                                    "JoinVars": {
-                                      "o_custkey": 3
+                                    "OperatorType": "Route",
+                                    "Variant": "EqualUnique",
+                                    "Keyspace": {
+                                      "Name": "main",
+                                      "Sharded": true
                                     },
-                                    "TableName": "orders_customer",
-                                    "Inputs": [
-                                      {
-                                        "OperatorType": "Route",
-                                        "Variant": "EqualUnique",
-                                        "Keyspace": {
-                                          "Name": "main",
-                                          "Sharded": true
-                                        },
-                                        "FieldQuery": "select count(*), o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority) from orders where 1 != 1 group by o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority)",
-                                        "Query": "select count(*), o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority) from orders where o_orderdate < date('1995-03-15') and o_orderkey = :l_orderkey group by o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority)",
-                                        "Table": "orders",
-                                        "Values": [
-                                          ":l_orderkey"
-                                        ],
-                                        "Vindex": "hash"
-                                      },
-                                      {
-                                        "OperatorType": "Route",
-                                        "Variant": "EqualUnique",
-                                        "Keyspace": {
-                                          "Name": "main",
-                                          "Sharded": true
-                                        },
-                                        "FieldQuery": "select count(*) from customer where 1 != 1 group by .0",
-                                        "Query": "select count(*) from customer where c_mktsegment = 'BUILDING' and c_custkey = :o_custkey group by .0",
-                                        "Table": "customer",
-                                        "Values": [
-                                          ":o_custkey"
-                                        ],
-                                        "Vindex": "hash"
-                                      }
-                                    ]
+                                    "FieldQuery": "select o_custkey, count(*), weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority) from orders where 1 != 1 group by o_custkey, weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority)",
+                                    "Query": "select o_custkey, count(*), weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority) from orders where o_orderdate < date('1995-03-15') and o_orderkey = :l_orderkey group by o_custkey, weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority)",
+                                    "Table": "orders",
+                                    "Values": [
+                                      ":l_orderkey"
+                                    ],
+                                    "Vindex": "hash"
+                                  },
+                                  {
+                                    "OperatorType": "Route",
+                                    "Variant": "EqualUnique",
+                                    "Keyspace": {
+                                      "Name": "main",
+                                      "Sharded": true
+                                    },
+                                    "FieldQuery": "select 1, count(*) from customer where 1 != 1 group by 1",
+                                    "Query": "select 1, count(*) from customer where c_mktsegment = 'BUILDING' and c_custkey = :o_custkey group by 1",
+                                    "Table": "customer",
+                                    "Values": [
+                                      ":o_custkey"
+                                    ],
+                                    "Vindex": "hash"
                                   }
                                 ]
                               }
@@ -247,229 +235,180 @@
         "OperatorType": "Sort",
         "Variant": "Memory",
         "OrderBy": "1 DESC",
-        "ResultColumns": 2,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum(1) AS revenue",
-            "GroupBy": "(0|2)",
+            "GroupBy": "0",
             "Inputs": [
               {
-                "OperatorType": "Projection",
-                "Expressions": [
-                  "[COLUMN 2] as n_name",
-                  "[COLUMN 0] * [COLUMN 1] as revenue",
-                  "[COLUMN 3] as weight_string(n_name)"
-                ],
+                "OperatorType": "Sort",
+                "Variant": "Memory",
+                "OrderBy": "(1|0) ASC",
                 "Inputs": [
                   {
-                    "OperatorType": "Sort",
-                    "Variant": "Memory",
-                    "OrderBy": "(2|3) ASC",
+                    "OperatorType": "Join",
+                    "Variant": "Join",
+                    "JoinColumnIndexes": "R:0,R:1",
+                    "JoinVars": {
+                      "s_nationkey": 0
+                    },
+                    "TableName": "orders_customer_lineitem_supplier_nation_region",
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
+                        "JoinColumnIndexes": "R:0",
                         "JoinVars": {
-                          "s_nationkey": 1
+                          "c_nationkey": 1,
+                          "o_orderkey": 0
                         },
-                        "TableName": "orders_customer_lineitem_supplier_nation_region",
+                        "TableName": "orders_customer_lineitem_supplier",
                         "Inputs": [
                           {
-                            "OperatorType": "Projection",
-                            "Expressions": [
-                              "[COLUMN 1] * [COLUMN 0] as revenue",
-                              "[COLUMN 2] as s_nationkey"
-                            ],
+                            "OperatorType": "Join",
+                            "Variant": "Join",
+                            "JoinColumnIndexes": "L:0,R:0",
+                            "JoinVars": {
+                              "o_custkey": 1
+                            },
+                            "TableName": "orders_customer",
                             "Inputs": [
                               {
-                                "OperatorType": "Join",
-                                "Variant": "Join",
-                                "JoinColumnIndexes": "R:0,L:0,R:1",
-                                "JoinVars": {
-                                  "c_nationkey": 2,
-                                  "o_orderkey": 1
+                                "OperatorType": "Route",
+                                "Variant": "Scatter",
+                                "Keyspace": {
+                                  "Name": "main",
+                                  "Sharded": true
                                 },
-                                "TableName": "orders_customer_lineitem_supplier",
-                                "Inputs": [
-                                  {
-                                    "OperatorType": "Projection",
-                                    "Expressions": [
-                                      "[COLUMN 0] * [COLUMN 1] as count(*)",
-                                      "[COLUMN 2] as o_orderkey",
-                                      "[COLUMN 3] as c_nationkey"
-                                    ],
-                                    "Inputs": [
-                                      {
-                                        "OperatorType": "Join",
-                                        "Variant": "Join",
-                                        "JoinColumnIndexes": "L:0,R:0,L:1,R:1",
-                                        "JoinVars": {
-                                          "o_custkey": 2
-                                        },
-                                        "TableName": "orders_customer",
-                                        "Inputs": [
-                                          {
-                                            "OperatorType": "Route",
-                                            "Variant": "Scatter",
-                                            "Keyspace": {
-                                              "Name": "main",
-                                              "Sharded": true
-                                            },
-                                            "FieldQuery": "select count(*), o_orderkey, o_custkey from orders where 1 != 1 group by o_orderkey, o_custkey",
-                                            "Query": "select count(*), o_orderkey, o_custkey from orders where o_orderdate >= date('1994-01-01') and o_orderdate < date('1994-01-01') + interval '1' year group by o_orderkey, o_custkey",
-                                            "Table": "orders"
-                                          },
-                                          {
-                                            "OperatorType": "Route",
-                                            "Variant": "EqualUnique",
-                                            "Keyspace": {
-                                              "Name": "main",
-                                              "Sharded": true
-                                            },
-                                            "FieldQuery": "select count(*), c_nationkey from customer where 1 != 1 group by c_nationkey",
-                                            "Query": "select count(*), c_nationkey from customer where c_custkey = :o_custkey group by c_nationkey",
-                                            "Table": "customer",
-                                            "Values": [
-                                              ":o_custkey"
-                                            ],
-                                            "Vindex": "hash"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "OperatorType": "Projection",
-                                    "Expressions": [
-                                      "[COLUMN 0] * [COLUMN 1] as revenue",
-                                      "[COLUMN 2] as s_nationkey"
-                                    ],
-                                    "Inputs": [
-                                      {
-                                        "OperatorType": "Join",
-                                        "Variant": "Join",
-                                        "JoinColumnIndexes": "L:0,R:0,R:1",
-                                        "JoinVars": {
-                                          "l_suppkey": 1
-                                        },
-                                        "TableName": "lineitem_supplier",
-                                        "Inputs": [
-                                          {
-                                            "OperatorType": "VindexLookup",
-                                            "Variant": "EqualUnique",
-                                            "Keyspace": {
-                                              "Name": "main",
-                                              "Sharded": true
-                                            },
-                                            "Values": [
-                                              ":o_orderkey"
-                                            ],
-                                            "Vindex": "lineitem_map",
-                                            "Inputs": [
-                                              {
-                                                "OperatorType": "Route",
-                                                "Variant": "IN",
-                                                "Keyspace": {
-                                                  "Name": "main",
-                                                  "Sharded": true
-                                                },
-                                                "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
-                                                "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                                                "Table": "lineitem_map",
-                                                "Values": [
-                                                  "::l_orderkey"
-                                                ],
-                                                "Vindex": "md5"
-                                              },
-                                              {
-                                                "OperatorType": "Route",
-                                                "Variant": "ByDestination",
-                                                "Keyspace": {
-                                                  "Name": "main",
-                                                  "Sharded": true
-                                                },
-                                                "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_suppkey from lineitem where 1 != 1 group by l_suppkey",
-                                                "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_suppkey from lineitem where l_orderkey = :o_orderkey group by l_suppkey",
-                                                "Table": "lineitem"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "OperatorType": "Route",
-                                            "Variant": "EqualUnique",
-                                            "Keyspace": {
-                                              "Name": "main",
-                                              "Sharded": true
-                                            },
-                                            "FieldQuery": "select count(*), s_nationkey from supplier where 1 != 1 group by s_nationkey",
-                                            "Query": "select count(*), s_nationkey from supplier where s_nationkey = :c_nationkey and s_suppkey = :l_suppkey group by s_nationkey",
-                                            "Table": "supplier",
-                                            "Values": [
-                                              ":l_suppkey"
-                                            ],
-                                            "Vindex": "hash"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
+                                "FieldQuery": "select o_orderkey, o_custkey from orders where 1 != 1",
+                                "Query": "select o_orderkey, o_custkey from orders where o_orderdate >= date('1994-01-01') and o_orderdate < date('1994-01-01') + interval '1' year",
+                                "Table": "orders"
+                              },
+                              {
+                                "OperatorType": "Route",
+                                "Variant": "EqualUnique",
+                                "Keyspace": {
+                                  "Name": "main",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select c_nationkey from customer where 1 != 1",
+                                "Query": "select c_nationkey from customer where c_custkey = :o_custkey",
+                                "Table": "customer",
+                                "Values": [
+                                  ":o_custkey"
+                                ],
+                                "Vindex": "hash"
                               }
                             ]
                           },
                           {
-                            "OperatorType": "Projection",
-                            "Expressions": [
-                              "[COLUMN 0] * [COLUMN 1] as count(*)",
-                              "[COLUMN 2] as n_name",
-                              "[COLUMN 3] as weight_string(n_name)"
-                            ],
+                            "OperatorType": "Join",
+                            "Variant": "Join",
+                            "JoinColumnIndexes": "R:0",
+                            "JoinVars": {
+                              "l_suppkey": 0
+                            },
+                            "TableName": "lineitem_supplier",
                             "Inputs": [
                               {
-                                "OperatorType": "Join",
-                                "Variant": "Join",
-                                "JoinColumnIndexes": "L:0,R:0,L:1,L:3",
-                                "JoinVars": {
-                                  "n_regionkey": 2
+                                "OperatorType": "VindexLookup",
+                                "Variant": "EqualUnique",
+                                "Keyspace": {
+                                  "Name": "main",
+                                  "Sharded": true
                                 },
-                                "TableName": "nation_region",
+                                "Values": [
+                                  ":o_orderkey"
+                                ],
+                                "Vindex": "lineitem_map",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Route",
-                                    "Variant": "EqualUnique",
+                                    "Variant": "IN",
                                     "Keyspace": {
                                       "Name": "main",
                                       "Sharded": true
                                     },
-                                    "FieldQuery": "select count(*), n_name, n_regionkey, weight_string(n_name) from nation where 1 != 1 group by n_name, n_regionkey, weight_string(n_name)",
-                                    "Query": "select count(*), n_name, n_regionkey, weight_string(n_name) from nation where n_nationkey = :s_nationkey group by n_name, n_regionkey, weight_string(n_name)",
-                                    "Table": "nation",
+                                    "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
+                                    "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
+                                    "Table": "lineitem_map",
                                     "Values": [
-                                      ":s_nationkey"
+                                      "::l_orderkey"
                                     ],
-                                    "Vindex": "hash"
+                                    "Vindex": "md5"
                                   },
                                   {
                                     "OperatorType": "Route",
-                                    "Variant": "EqualUnique",
+                                    "Variant": "ByDestination",
                                     "Keyspace": {
                                       "Name": "main",
                                       "Sharded": true
                                     },
-                                    "FieldQuery": "select count(*) from region where 1 != 1 group by .0",
-                                    "Query": "select count(*) from region where r_name = 'ASIA' and r_regionkey = :n_regionkey group by .0",
-                                    "Table": "region",
-                                    "Values": [
-                                      ":n_regionkey"
-                                    ],
-                                    "Vindex": "hash"
+                                    "FieldQuery": "select l_suppkey from lineitem where 1 != 1",
+                                    "Query": "select l_suppkey from lineitem where l_orderkey = :o_orderkey",
+                                    "Table": "lineitem"
                                   }
                                 ]
+                              },
+                              {
+                                "OperatorType": "Route",
+                                "Variant": "EqualUnique",
+                                "Keyspace": {
+                                  "Name": "main",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select s_nationkey from supplier where 1 != 1",
+                                "Query": "select s_nationkey from supplier where s_nationkey = :c_nationkey and s_suppkey = :l_suppkey",
+                                "Table": "supplier",
+                                "Values": [
+                                  ":l_suppkey"
+                                ],
+                                "Vindex": "hash"
                               }
                             ]
+                          }
+                        ]
+                      },
+                      {
+                        "OperatorType": "Join",
+                        "Variant": "Join",
+                        "JoinColumnIndexes": "L:0,L:1",
+                        "JoinVars": {
+                          "n_regionkey": 2
+                        },
+                        "TableName": "nation_region",
+                        "Inputs": [
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "EqualUnique",
+                            "Keyspace": {
+                              "Name": "main",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select weight_string(n_name), n_name, n_regionkey from nation where 1 != 1",
+                            "Query": "select weight_string(n_name), n_name, n_regionkey from nation where n_nationkey = :s_nationkey",
+                            "Table": "nation",
+                            "Values": [
+                              ":s_nationkey"
+                            ],
+                            "Vindex": "hash"
+                          },
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "EqualUnique",
+                            "Keyspace": {
+                              "Name": "main",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select 1 from region where 1 != 1",
+                            "Query": "select 1 from region where r_name = 'ASIA' and r_regionkey = :n_regionkey",
+                            "Table": "region",
+                            "Values": [
+                              ":n_regionkey"
+                            ],
+                            "Vindex": "hash"
                           }
                         ]
                       }
@@ -763,175 +702,122 @@
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum(2) AS revenue",
-                "GroupBy": "(0|8), (1|9), (3|10), (6|11), (4|12), (5|13), (7|14)",
+                "GroupBy": "0, 1, (3|2), (6|3), 4, 5, (7|6)",
                 "Inputs": [
                   {
-                    "OperatorType": "Projection",
-                    "Expressions": [
-                      "[COLUMN 2] as c_custkey",
-                      "[COLUMN 3] as c_name",
-                      "[COLUMN 0] * [COLUMN 1] as revenue",
-                      "[COLUMN 4] as c_acctbal",
-                      "[COLUMN 6] as n_name",
-                      "[COLUMN 7] as c_address",
-                      "[COLUMN 5] as c_phone",
-                      "[COLUMN 8] as c_comment",
-                      "[COLUMN 9] as weight_string(c_custkey)",
-                      "[COLUMN 10] as weight_string(c_name)",
-                      "[COLUMN 11] as weight_string(c_acctbal)",
-                      "[COLUMN 12] as weight_string(c_phone)",
-                      "[COLUMN 13] as weight_string(n_name)",
-                      "[COLUMN 14] as weight_string(c_address)",
-                      "[COLUMN 15] as weight_string(c_comment)"
-                    ],
+                    "OperatorType": "Sort",
+                    "Variant": "Memory",
+                    "OrderBy": "(7|0) ASC, (8|1) ASC, (9|2) ASC, (10|3) ASC, (11|4) ASC, (12|5) ASC, (13|6) ASC",
                     "Inputs": [
                       {
-                        "OperatorType": "Sort",
-                        "Variant": "Memory",
-                        "OrderBy": "(2|9) ASC, (3|10) ASC, (4|11) ASC, (5|12) ASC, (6|13) ASC, (7|14) ASC, (8|15) ASC",
+                        "OperatorType": "Join",
+                        "Variant": "Join",
+                        "JoinColumnIndexes": "R:0,R:1,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13",
+                        "JoinVars": {
+                          "o_custkey": 0
+                        },
+                        "TableName": "orders_lineitem_customer_nation",
                         "Inputs": [
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "L:0,R:0,R:1,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13,R:14",
+                            "JoinColumnIndexes": "L:0",
                             "JoinVars": {
-                              "o_custkey": 1
+                              "o_orderkey": 1
                             },
-                            "TableName": "orders_lineitem_customer_nation",
+                            "TableName": "orders_lineitem",
                             "Inputs": [
                               {
-                                "OperatorType": "Projection",
-                                "Expressions": [
-                                  "[COLUMN 1] * [COLUMN 0] as revenue",
-                                  "[COLUMN 2] as o_custkey"
-                                ],
-                                "Inputs": [
-                                  {
-                                    "OperatorType": "Join",
-                                    "Variant": "Join",
-                                    "JoinColumnIndexes": "R:0,L:0,L:1",
-                                    "JoinVars": {
-                                      "o_orderkey": 2
-                                    },
-                                    "TableName": "orders_lineitem",
-                                    "Inputs": [
-                                      {
-                                        "OperatorType": "Route",
-                                        "Variant": "Scatter",
-                                        "Keyspace": {
-                                          "Name": "main",
-                                          "Sharded": true
-                                        },
-                                        "FieldQuery": "select count(*), o_custkey, o_orderkey from orders where 1 != 1 group by o_custkey, o_orderkey",
-                                        "Query": "select count(*), o_custkey, o_orderkey from orders where o_orderdate >= date('1993-10-01') and o_orderdate < date('1993-10-01') + interval '3' month group by o_custkey, o_orderkey",
-                                        "Table": "orders"
-                                      },
-                                      {
-                                        "OperatorType": "VindexLookup",
-                                        "Variant": "EqualUnique",
-                                        "Keyspace": {
-                                          "Name": "main",
-                                          "Sharded": true
-                                        },
-                                        "Values": [
-                                          ":o_orderkey"
-                                        ],
-                                        "Vindex": "lineitem_map",
-                                        "Inputs": [
-                                          {
-                                            "OperatorType": "Route",
-                                            "Variant": "IN",
-                                            "Keyspace": {
-                                              "Name": "main",
-                                              "Sharded": true
-                                            },
-                                            "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
-                                            "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                                            "Table": "lineitem_map",
-                                            "Values": [
-                                              "::l_orderkey"
-                                            ],
-                                            "Vindex": "md5"
-                                          },
-                                          {
-                                            "OperatorType": "Route",
-                                            "Variant": "ByDestination",
-                                            "Keyspace": {
-                                              "Name": "main",
-                                              "Sharded": true
-                                            },
-                                            "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where 1 != 1 group by .0",
-                                            "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey group by .0",
-                                            "Table": "lineitem"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
+                                "OperatorType": "Route",
+                                "Variant": "Scatter",
+                                "Keyspace": {
+                                  "Name": "main",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select o_custkey, o_orderkey from orders where 1 != 1",
+                                "Query": "select o_custkey, o_orderkey from orders where o_orderdate >= date('1993-10-01') and o_orderdate < date('1993-10-01') + interval '3' month",
+                                "Table": "orders"
                               },
                               {
-                                "OperatorType": "Projection",
-                                "Expressions": [
-                                  "[COLUMN 0] * [COLUMN 1] as count(*)",
-                                  "[COLUMN 2] as c_custkey",
-                                  "[COLUMN 3] as c_name",
-                                  "[COLUMN 4] as c_acctbal",
-                                  "[COLUMN 5] as c_phone",
-                                  "[COLUMN 6] as n_name",
-                                  "[COLUMN 7] as c_address",
-                                  "[COLUMN 8] as c_comment",
-                                  "[COLUMN 9] as weight_string(c_custkey)",
-                                  "[COLUMN 10] as weight_string(c_name)",
-                                  "[COLUMN 11] as weight_string(c_acctbal)",
-                                  "[COLUMN 12] as weight_string(c_phone)",
-                                  "[COLUMN 13] as weight_string(n_name)",
-                                  "[COLUMN 14] as weight_string(c_address)",
-                                  "[COLUMN 15] as weight_string(c_comment)"
+                                "OperatorType": "VindexLookup",
+                                "Variant": "EqualUnique",
+                                "Keyspace": {
+                                  "Name": "main",
+                                  "Sharded": true
+                                },
+                                "Values": [
+                                  ":o_orderkey"
                                 ],
+                                "Vindex": "lineitem_map",
                                 "Inputs": [
                                   {
-                                    "OperatorType": "Join",
-                                    "Variant": "Join",
-                                    "JoinColumnIndexes": "L:0,R:0,L:1,L:2,L:3,L:4,R:1,L:5,L:6,L:8,L:9,L:10,L:11,R:2,L:12,L:13",
-                                    "JoinVars": {
-                                      "c_nationkey": 7
+                                    "OperatorType": "Route",
+                                    "Variant": "IN",
+                                    "Keyspace": {
+                                      "Name": "main",
+                                      "Sharded": true
                                     },
-                                    "TableName": "customer_nation",
-                                    "Inputs": [
-                                      {
-                                        "OperatorType": "Route",
-                                        "Variant": "EqualUnique",
-                                        "Keyspace": {
-                                          "Name": "main",
-                                          "Sharded": true
-                                        },
-                                        "FieldQuery": "select count(*), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment) from customer where 1 != 1 group by c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment)",
-                                        "Query": "select count(*), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment) from customer where c_custkey = :o_custkey group by c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment)",
-                                        "Table": "customer",
-                                        "Values": [
-                                          ":o_custkey"
-                                        ],
-                                        "Vindex": "hash"
-                                      },
-                                      {
-                                        "OperatorType": "Route",
-                                        "Variant": "EqualUnique",
-                                        "Keyspace": {
-                                          "Name": "main",
-                                          "Sharded": true
-                                        },
-                                        "FieldQuery": "select count(*), n_name, weight_string(n_name) from nation where 1 != 1 group by n_name, weight_string(n_name)",
-                                        "Query": "select count(*), n_name, weight_string(n_name) from nation where n_nationkey = :c_nationkey group by n_name, weight_string(n_name)",
-                                        "Table": "nation",
-                                        "Values": [
-                                          ":c_nationkey"
-                                        ],
-                                        "Vindex": "hash"
-                                      }
-                                    ]
+                                    "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
+                                    "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
+                                    "Table": "lineitem_map",
+                                    "Values": [
+                                      "::l_orderkey"
+                                    ],
+                                    "Vindex": "md5"
+                                  },
+                                  {
+                                    "OperatorType": "Route",
+                                    "Variant": "ByDestination",
+                                    "Keyspace": {
+                                      "Name": "main",
+                                      "Sharded": true
+                                    },
+                                    "FieldQuery": "select 1 from lineitem where 1 != 1",
+                                    "Query": "select 1 from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey",
+                                    "Table": "lineitem"
                                   }
                                 ]
+                              }
+                            ]
+                          },
+                          {
+                            "OperatorType": "Join",
+                            "Variant": "Join",
+                            "JoinColumnIndexes": "L:0,L:1,L:2,L:3,R:0,L:4,L:5,L:6,L:7,L:8,L:9,R:1,L:10,L:11",
+                            "JoinVars": {
+                              "c_nationkey": 12
+                            },
+                            "TableName": "customer_nation",
+                            "Inputs": [
+                              {
+                                "OperatorType": "Route",
+                                "Variant": "EqualUnique",
+                                "Keyspace": {
+                                  "Name": "main",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey from customer where 1 != 1",
+                                "Query": "select weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey from customer where c_custkey = :o_custkey",
+                                "Table": "customer",
+                                "Values": [
+                                  ":o_custkey"
+                                ],
+                                "Vindex": "hash"
+                              },
+                              {
+                                "OperatorType": "Route",
+                                "Variant": "EqualUnique",
+                                "Keyspace": {
+                                  "Name": "main",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select weight_string(n_name), n_name from nation where 1 != 1",
+                                "Query": "select weight_string(n_name), n_name from nation where n_nationkey = :c_nationkey",
+                                "Table": "nation",
+                                "Values": [
+                                  ":c_nationkey"
+                                ],
+                                "Vindex": "hash"
                               }
                             ]
                           }
@@ -970,82 +856,70 @@
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "sum(1) AS high_line_count, sum(2) AS low_line_count",
-        "GroupBy": "(0|3)",
-        "ResultColumns": 3,
+        "GroupBy": "0",
         "Inputs": [
           {
-            "OperatorType": "Projection",
-            "Expressions": [
-              "[COLUMN 3] as l_shipmode",
-              "[COLUMN 0] * [COLUMN 1] as high_line_count",
-              "[COLUMN 2] * [COLUMN 1] as low_line_count",
-              "[COLUMN 4] as weight_string(l_shipmode)"
-            ],
+            "OperatorType": "Sort",
+            "Variant": "Memory",
+            "OrderBy": "(1|0) ASC",
             "Inputs": [
               {
-                "OperatorType": "Sort",
-                "Variant": "Memory",
-                "OrderBy": "(3|4) ASC",
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "R:0,R:1",
+                "JoinVars": {
+                  "o_orderkey": 0
+                },
+                "TableName": "orders_lineitem",
                 "Inputs": [
                   {
-                    "OperatorType": "Join",
-                    "Variant": "Join",
-                    "JoinColumnIndexes": "L:0,R:0,L:1,R:1,R:2",
-                    "JoinVars": {
-                      "o_orderkey": 2
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
                     },
-                    "TableName": "orders_lineitem",
+                    "FieldQuery": "select o_orderkey from orders where 1 != 1",
+                    "Query": "select o_orderkey from orders",
+                    "Table": "orders"
+                  },
+                  {
+                    "OperatorType": "VindexLookup",
+                    "Variant": "EqualUnique",
+                    "Keyspace": {
+                      "Name": "main",
+                      "Sharded": true
+                    },
+                    "Values": [
+                      ":o_orderkey"
+                    ],
+                    "Vindex": "lineitem_map",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
-                        "Variant": "Scatter",
+                        "Variant": "IN",
                         "Keyspace": {
                           "Name": "main",
                           "Sharded": true
                         },
-                        "FieldQuery": "select sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, o_orderkey from orders where 1 != 1 group by o_orderkey",
-                        "Query": "select sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end) as low_line_count, o_orderkey from orders group by o_orderkey",
-                        "Table": "orders"
+                        "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
+                        "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
+                        "Table": "lineitem_map",
+                        "Values": [
+                          "::l_orderkey"
+                        ],
+                        "Vindex": "md5"
                       },
                       {
-                        "OperatorType": "VindexLookup",
-                        "Variant": "EqualUnique",
+                        "OperatorType": "Route",
+                        "Variant": "ByDestination",
                         "Keyspace": {
                           "Name": "main",
                           "Sharded": true
                         },
-                        "Values": [
-                          ":o_orderkey"
-                        ],
-                        "Vindex": "lineitem_map",
-                        "Inputs": [
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "IN",
-                            "Keyspace": {
-                              "Name": "main",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
-                            "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                            "Table": "lineitem_map",
-                            "Values": [
-                              "::l_orderkey"
-                            ],
-                            "Vindex": "md5"
-                          },
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "ByDestination",
-                            "Keyspace": {
-                              "Name": "main",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select count(*), l_shipmode, weight_string(l_shipmode) from lineitem where 1 != 1 group by l_shipmode, weight_string(l_shipmode)",
-                            "Query": "select count(*), l_shipmode, weight_string(l_shipmode) from lineitem where l_shipmode in ('MAIL', 'SHIP') and l_commitdate < l_receiptdate and l_shipdate < l_commitdate and l_receiptdate >= date('1994-01-01') and l_receiptdate < date('1994-01-01') + interval '1' year and l_orderkey = :o_orderkey group by l_shipmode, weight_string(l_shipmode)",
-                            "Table": "lineitem"
-                          }
-                        ]
+                        "FieldQuery": "select weight_string(l_shipmode), l_shipmode from lineitem where 1 != 1",
+                        "Query": "select weight_string(l_shipmode), l_shipmode from lineitem where l_shipmode in ('MAIL', 'SHIP') and l_commitdate < l_receiptdate and l_shipdate < l_commitdate and l_receiptdate >= date('1994-01-01') and l_receiptdate < date('1994-01-01') + interval '1' year and l_orderkey = :o_orderkey",
+                        "Table": "lineitem"
                       }
                     ]
                   }

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -235,31 +235,32 @@
         "OperatorType": "Sort",
         "Variant": "Memory",
         "OrderBy": "1 DESC",
+        "ResultColumns": 2,
         "Inputs": [
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
             "Aggregates": "sum(1) AS revenue",
-            "GroupBy": "0",
+            "GroupBy": "(0|2)",
             "Inputs": [
               {
                 "OperatorType": "Sort",
                 "Variant": "Memory",
-                "OrderBy": "(1|0) ASC",
+                "OrderBy": "(0|2) ASC",
                 "Inputs": [
                   {
                     "OperatorType": "Join",
                     "Variant": "Join",
-                    "JoinColumnIndexes": "R:0,R:1",
+                    "JoinColumnIndexes": "R:0,L:0,R:1",
                     "JoinVars": {
-                      "s_nationkey": 0
+                      "s_nationkey": 1
                     },
                     "TableName": "orders_customer_lineitem_supplier_nation_region",
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "R:0",
+                        "JoinColumnIndexes": "R:0,R:1",
                         "JoinVars": {
                           "c_nationkey": 1,
                           "o_orderkey": 0
@@ -306,9 +307,9 @@
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "R:0",
+                            "JoinColumnIndexes": "L:0,R:0",
                             "JoinVars": {
-                              "l_suppkey": 0
+                              "l_suppkey": 1
                             },
                             "TableName": "lineitem_supplier",
                             "Inputs": [
@@ -346,8 +347,8 @@
                                       "Name": "main",
                                       "Sharded": true
                                     },
-                                    "FieldQuery": "select l_suppkey from lineitem where 1 != 1",
-                                    "Query": "select l_suppkey from lineitem where l_orderkey = :o_orderkey",
+                                    "FieldQuery": "select l_extendedprice * (1 - l_discount), l_suppkey from lineitem where 1 != 1",
+                                    "Query": "select l_extendedprice * (1 - l_discount), l_suppkey from lineitem where l_orderkey = :o_orderkey",
                                     "Table": "lineitem"
                                   }
                                 ]
@@ -387,8 +388,8 @@
                               "Name": "main",
                               "Sharded": true
                             },
-                            "FieldQuery": "select weight_string(n_name), n_name, n_regionkey from nation where 1 != 1",
-                            "Query": "select weight_string(n_name), n_name, n_regionkey from nation where n_nationkey = :s_nationkey",
+                            "FieldQuery": "select n_name, weight_string(n_name), n_regionkey from nation where 1 != 1",
+                            "Query": "select n_name, weight_string(n_name), n_regionkey from nation where n_nationkey = :s_nationkey",
                             "Table": "nation",
                             "Values": [
                               ":s_nationkey"
@@ -702,26 +703,26 @@
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum(2) AS revenue",
-                "GroupBy": "0, 1, (3|2), (6|3), 4, 5, (7|6)",
+                "GroupBy": "(0|8), (1|9), (3|10), (6|11), (4|12), (5|13), (7|14)",
                 "Inputs": [
                   {
                     "OperatorType": "Sort",
                     "Variant": "Memory",
-                    "OrderBy": "(7|0) ASC, (8|1) ASC, (9|2) ASC, (10|3) ASC, (11|4) ASC, (12|5) ASC, (13|6) ASC",
+                    "OrderBy": "(0|8) ASC, (1|9) ASC, (3|10) ASC, (6|11) ASC, (4|12) ASC, (5|13) ASC, (7|14) ASC",
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "R:0,R:1,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13",
+                        "JoinColumnIndexes": "R:0,R:1,L:0,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13",
                         "JoinVars": {
-                          "o_custkey": 0
+                          "o_custkey": 1
                         },
                         "TableName": "orders_lineitem_customer_nation",
                         "Inputs": [
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "L:0",
+                            "JoinColumnIndexes": "R:0,L:0",
                             "JoinVars": {
                               "o_orderkey": 1
                             },
@@ -772,8 +773,8 @@
                                       "Name": "main",
                                       "Sharded": true
                                     },
-                                    "FieldQuery": "select 1 from lineitem where 1 != 1",
-                                    "Query": "select 1 from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey",
+                                    "FieldQuery": "select l_extendedprice * (1 - l_discount) from lineitem where 1 != 1",
+                                    "Query": "select l_extendedprice * (1 - l_discount) from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey",
                                     "Table": "lineitem"
                                   }
                                 ]
@@ -783,7 +784,7 @@
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "L:0,L:1,L:2,L:3,R:0,L:4,L:5,L:6,L:7,L:8,L:9,R:1,L:10,L:11",
+                            "JoinColumnIndexes": "L:0,L:1,L:2,R:0,L:3,L:4,L:5,L:6,L:7,L:8,L:9,R:1,L:10,L:11",
                             "JoinVars": {
                               "c_nationkey": 12
                             },
@@ -796,8 +797,8 @@
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey from customer where 1 != 1",
-                                "Query": "select weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey from customer where c_custkey = :o_custkey",
+                                "FieldQuery": "select c_custkey, c_name, c_acctbal, c_address, c_phone, c_comment, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment), c_nationkey from customer where 1 != 1",
+                                "Query": "select c_custkey, c_name, c_acctbal, c_address, c_phone, c_comment, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment), c_nationkey from customer where c_custkey = :o_custkey",
                                 "Table": "customer",
                                 "Values": [
                                   ":o_custkey"
@@ -811,8 +812,8 @@
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select weight_string(n_name), n_name from nation where 1 != 1",
-                                "Query": "select weight_string(n_name), n_name from nation where n_nationkey = :c_nationkey",
+                                "FieldQuery": "select n_name, weight_string(n_name) from nation where 1 != 1",
+                                "Query": "select n_name, weight_string(n_name) from nation where n_nationkey = :c_nationkey",
                                 "Table": "nation",
                                 "Values": [
                                   ":c_nationkey"
@@ -856,19 +857,20 @@
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
         "Aggregates": "sum(1) AS high_line_count, sum(2) AS low_line_count",
-        "GroupBy": "0",
+        "GroupBy": "(0|3)",
+        "ResultColumns": 3,
         "Inputs": [
           {
             "OperatorType": "Sort",
             "Variant": "Memory",
-            "OrderBy": "(1|0) ASC",
+            "OrderBy": "(0|3) ASC",
             "Inputs": [
               {
                 "OperatorType": "Join",
                 "Variant": "Join",
-                "JoinColumnIndexes": "R:0,R:1",
+                "JoinColumnIndexes": "R:0,L:0,L:1,R:1",
                 "JoinVars": {
-                  "o_orderkey": 0
+                  "o_orderkey": 2
                 },
                 "TableName": "orders_lineitem",
                 "Inputs": [
@@ -879,8 +881,8 @@
                       "Name": "main",
                       "Sharded": true
                     },
-                    "FieldQuery": "select o_orderkey from orders where 1 != 1",
-                    "Query": "select o_orderkey from orders",
+                    "FieldQuery": "select case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end, case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end, o_orderkey from orders where 1 != 1",
+                    "Query": "select case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end, case when o_orderpriority != '1-URGENT' and o_orderpriority != '2-HIGH' then 1 else 0 end, o_orderkey from orders",
                     "Table": "orders"
                   },
                   {
@@ -917,8 +919,8 @@
                           "Name": "main",
                           "Sharded": true
                         },
-                        "FieldQuery": "select weight_string(l_shipmode), l_shipmode from lineitem where 1 != 1",
-                        "Query": "select weight_string(l_shipmode), l_shipmode from lineitem where l_shipmode in ('MAIL', 'SHIP') and l_commitdate < l_receiptdate and l_shipdate < l_commitdate and l_receiptdate >= date('1994-01-01') and l_receiptdate < date('1994-01-01') + interval '1' year and l_orderkey = :o_orderkey",
+                        "FieldQuery": "select l_shipmode, weight_string(l_shipmode) from lineitem where 1 != 1",
+                        "Query": "select l_shipmode, weight_string(l_shipmode) from lineitem where l_shipmode in ('MAIL', 'SHIP') and l_commitdate < l_receiptdate and l_shipdate < l_commitdate and l_receiptdate >= date('1994-01-01') and l_receiptdate < date('1994-01-01') + interval '1' year and l_orderkey = :o_orderkey",
                         "Table": "lineitem"
                       }
                     ]

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -25,38 +25,38 @@
           {
             "OperatorType": "Sort",
             "Variant": "Memory",
-            "OrderBy": "1 DESC, (2|5) ASC",
+            "OrderBy": "1 DESC, (2|4) ASC",
             "ResultColumns": 4,
             "Inputs": [
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Ordered",
                 "Aggregates": "sum(1) AS revenue",
-                "GroupBy": "(0|6), (2|5), (3|4)",
+                "GroupBy": "(0|5), (2|4), (3|6)",
                 "Inputs": [
                   {
                     "OperatorType": "Projection",
                     "Expressions": [
-                      "[COLUMN 0] as l_orderkey",
-                      "([COLUMN 6] * COALESCE([COLUMN 7], INT64(1))) * COALESCE([COLUMN 8], INT64(1)) as revenue",
-                      "[COLUMN 1] as o_orderdate",
-                      "[COLUMN 2] as o_shippriority",
-                      "[COLUMN 5]",
-                      "[COLUMN 4]",
-                      "[COLUMN 3]"
+                      "[COLUMN 2] as l_orderkey",
+                      "[COLUMN 0] * [COLUMN 1] as revenue",
+                      "[COLUMN 3] as o_orderdate",
+                      "[COLUMN 4] as o_shippriority",
+                      "[COLUMN 5] as weight_string(o_orderdate)",
+                      "[COLUMN 6] as weight_string(l_orderkey)",
+                      "[COLUMN 7] as weight_string(o_shippriority)"
                     ],
                     "Inputs": [
                       {
                         "OperatorType": "Sort",
                         "Variant": "Memory",
-                        "OrderBy": "(0|3) ASC, (1|4) ASC, (2|5) ASC",
+                        "OrderBy": "(2|6) ASC, (3|5) ASC, (4|7) ASC",
                         "Inputs": [
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "L:0,R:0,R:1,L:2,R:2,R:3,L:1,R:4,R:5",
+                            "JoinColumnIndexes": "L:0,R:0,L:1,R:1,R:2,R:3,L:2,R:4",
                             "JoinVars": {
-                              "l_orderkey": 0
+                              "l_orderkey": 1
                             },
                             "TableName": "lineitem_orders_customer",
                             "Inputs": [
@@ -67,48 +67,60 @@
                                   "Name": "main",
                                   "Sharded": true
                                 },
-                                "FieldQuery": "select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_orderkey) from lineitem where 1 != 1 group by l_orderkey, weight_string(l_orderkey)",
-                                "Query": "select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, weight_string(l_orderkey) from lineitem where l_shipdate > date('1995-03-15') group by l_orderkey, weight_string(l_orderkey)",
+                                "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_orderkey, weight_string(l_orderkey) from lineitem where 1 != 1 group by l_orderkey, weight_string(l_orderkey)",
+                                "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_orderkey, weight_string(l_orderkey) from lineitem where l_shipdate > date('1995-03-15') group by l_orderkey, weight_string(l_orderkey)",
                                 "Table": "lineitem"
                               },
                               {
-                                "OperatorType": "Join",
-                                "Variant": "Join",
-                                "JoinColumnIndexes": "L:3,L:5,L:4,L:6,L:1,R:1",
-                                "JoinVars": {
-                                  "o_custkey": 0
-                                },
-                                "TableName": "orders_customer",
+                                "OperatorType": "Projection",
+                                "Expressions": [
+                                  "[COLUMN 0] * [COLUMN 1] as count(*)",
+                                  "[COLUMN 2] as o_orderdate",
+                                  "[COLUMN 3] as o_shippriority",
+                                  "[COLUMN 4] as weight_string(o_orderdate)",
+                                  "[COLUMN 5] as weight_string(o_shippriority)"
+                                ],
                                 "Inputs": [
                                   {
-                                    "OperatorType": "Route",
-                                    "Variant": "EqualUnique",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
+                                    "OperatorType": "Join",
+                                    "Variant": "Join",
+                                    "JoinColumnIndexes": "L:0,R:0,L:1,L:2,L:4,L:5",
+                                    "JoinVars": {
+                                      "o_custkey": 3
                                     },
-                                    "FieldQuery": "select o_custkey, count(*), weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority) from orders where 1 != 1 group by o_custkey, weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority)",
-                                    "Query": "select o_custkey, count(*), weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority) from orders where o_orderdate < date('1995-03-15') and o_orderkey = :l_orderkey group by o_custkey, weight_string(o_custkey), o_orderdate, weight_string(o_orderdate), o_shippriority, weight_string(o_shippriority)",
-                                    "Table": "orders",
-                                    "Values": [
-                                      ":l_orderkey"
-                                    ],
-                                    "Vindex": "hash"
-                                  },
-                                  {
-                                    "OperatorType": "Route",
-                                    "Variant": "EqualUnique",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
-                                    },
-                                    "FieldQuery": "select 1, count(*) from customer where 1 != 1 group by 1",
-                                    "Query": "select 1, count(*) from customer where c_mktsegment = 'BUILDING' and c_custkey = :o_custkey group by 1",
-                                    "Table": "customer",
-                                    "Values": [
-                                      ":o_custkey"
-                                    ],
-                                    "Vindex": "hash"
+                                    "TableName": "orders_customer",
+                                    "Inputs": [
+                                      {
+                                        "OperatorType": "Route",
+                                        "Variant": "EqualUnique",
+                                        "Keyspace": {
+                                          "Name": "main",
+                                          "Sharded": true
+                                        },
+                                        "FieldQuery": "select count(*), o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority) from orders where 1 != 1 group by o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority)",
+                                        "Query": "select count(*), o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority) from orders where o_orderdate < date('1995-03-15') and o_orderkey = :l_orderkey group by o_orderdate, o_shippriority, o_custkey, weight_string(o_orderdate), weight_string(o_shippriority)",
+                                        "Table": "orders",
+                                        "Values": [
+                                          ":l_orderkey"
+                                        ],
+                                        "Vindex": "hash"
+                                      },
+                                      {
+                                        "OperatorType": "Route",
+                                        "Variant": "EqualUnique",
+                                        "Keyspace": {
+                                          "Name": "main",
+                                          "Sharded": true
+                                        },
+                                        "FieldQuery": "select count(*) from customer where 1 != 1 group by .0",
+                                        "Query": "select count(*) from customer where c_mktsegment = 'BUILDING' and c_custkey = :o_custkey group by .0",
+                                        "Table": "customer",
+                                        "Values": [
+                                          ":o_custkey"
+                                        ],
+                                        "Vindex": "hash"
+                                      }
+                                    ]
                                   }
                                 ]
                               }
@@ -244,172 +256,220 @@
             "GroupBy": "(0|2)",
             "Inputs": [
               {
-                "OperatorType": "Sort",
-                "Variant": "Memory",
-                "OrderBy": "(0|2) ASC",
+                "OperatorType": "Projection",
+                "Expressions": [
+                  "[COLUMN 2] as n_name",
+                  "[COLUMN 0] * [COLUMN 1] as revenue",
+                  "[COLUMN 3] as weight_string(n_name)"
+                ],
                 "Inputs": [
                   {
-                    "OperatorType": "Join",
-                    "Variant": "Join",
-                    "JoinColumnIndexes": "R:0,L:0,R:1",
-                    "JoinVars": {
-                      "s_nationkey": 1
-                    },
-                    "TableName": "orders_customer_lineitem_supplier_nation_region",
+                    "OperatorType": "Sort",
+                    "Variant": "Memory",
+                    "OrderBy": "(2|3) ASC",
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "R:0,R:1",
+                        "JoinColumnIndexes": "L:0,R:0,R:1,R:2",
                         "JoinVars": {
-                          "c_nationkey": 1,
-                          "o_orderkey": 0
+                          "s_nationkey": 1
                         },
-                        "TableName": "orders_customer_lineitem_supplier",
+                        "TableName": "orders_customer_lineitem_supplier_nation_region",
                         "Inputs": [
                           {
-                            "OperatorType": "Join",
-                            "Variant": "Join",
-                            "JoinColumnIndexes": "L:0,R:0",
-                            "JoinVars": {
-                              "o_custkey": 1
-                            },
-                            "TableName": "orders_customer",
+                            "OperatorType": "Projection",
+                            "Expressions": [
+                              "[COLUMN 1] * [COLUMN 0] as revenue",
+                              "[COLUMN 2] as s_nationkey"
+                            ],
                             "Inputs": [
                               {
-                                "OperatorType": "Route",
-                                "Variant": "Scatter",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": true
+                                "OperatorType": "Join",
+                                "Variant": "Join",
+                                "JoinColumnIndexes": "R:0,L:0,R:1",
+                                "JoinVars": {
+                                  "c_nationkey": 2,
+                                  "o_orderkey": 1
                                 },
-                                "FieldQuery": "select o_orderkey, o_custkey from orders where 1 != 1",
-                                "Query": "select o_orderkey, o_custkey from orders where o_orderdate >= date('1994-01-01') and o_orderdate < date('1994-01-01') + interval '1' year",
-                                "Table": "orders"
-                              },
-                              {
-                                "OperatorType": "Route",
-                                "Variant": "EqualUnique",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select c_nationkey from customer where 1 != 1",
-                                "Query": "select c_nationkey from customer where c_custkey = :o_custkey",
-                                "Table": "customer",
-                                "Values": [
-                                  ":o_custkey"
-                                ],
-                                "Vindex": "hash"
+                                "TableName": "orders_customer_lineitem_supplier",
+                                "Inputs": [
+                                  {
+                                    "OperatorType": "Projection",
+                                    "Expressions": [
+                                      "[COLUMN 0] * [COLUMN 1] as count(*)",
+                                      "[COLUMN 2] as o_orderkey",
+                                      "[COLUMN 3] as c_nationkey"
+                                    ],
+                                    "Inputs": [
+                                      {
+                                        "OperatorType": "Join",
+                                        "Variant": "Join",
+                                        "JoinColumnIndexes": "L:0,R:0,L:1,R:1",
+                                        "JoinVars": {
+                                          "o_custkey": 2
+                                        },
+                                        "TableName": "orders_customer",
+                                        "Inputs": [
+                                          {
+                                            "OperatorType": "Route",
+                                            "Variant": "Scatter",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "FieldQuery": "select count(*), o_orderkey, o_custkey from orders where 1 != 1 group by o_orderkey, o_custkey",
+                                            "Query": "select count(*), o_orderkey, o_custkey from orders where o_orderdate >= date('1994-01-01') and o_orderdate < date('1994-01-01') + interval '1' year group by o_orderkey, o_custkey",
+                                            "Table": "orders"
+                                          },
+                                          {
+                                            "OperatorType": "Route",
+                                            "Variant": "EqualUnique",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "FieldQuery": "select count(*), c_nationkey from customer where 1 != 1 group by c_nationkey",
+                                            "Query": "select count(*), c_nationkey from customer where c_custkey = :o_custkey group by c_nationkey",
+                                            "Table": "customer",
+                                            "Values": [
+                                              ":o_custkey"
+                                            ],
+                                            "Vindex": "hash"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "OperatorType": "Projection",
+                                    "Expressions": [
+                                      "[COLUMN 0] * [COLUMN 1] as revenue",
+                                      "[COLUMN 2] as s_nationkey"
+                                    ],
+                                    "Inputs": [
+                                      {
+                                        "OperatorType": "Join",
+                                        "Variant": "Join",
+                                        "JoinColumnIndexes": "L:0,R:0,R:1",
+                                        "JoinVars": {
+                                          "l_suppkey": 1
+                                        },
+                                        "TableName": "lineitem_supplier",
+                                        "Inputs": [
+                                          {
+                                            "OperatorType": "VindexLookup",
+                                            "Variant": "EqualUnique",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "Values": [
+                                              ":o_orderkey"
+                                            ],
+                                            "Vindex": "lineitem_map",
+                                            "Inputs": [
+                                              {
+                                                "OperatorType": "Route",
+                                                "Variant": "IN",
+                                                "Keyspace": {
+                                                  "Name": "main",
+                                                  "Sharded": true
+                                                },
+                                                "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
+                                                "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
+                                                "Table": "lineitem_map",
+                                                "Values": [
+                                                  "::l_orderkey"
+                                                ],
+                                                "Vindex": "md5"
+                                              },
+                                              {
+                                                "OperatorType": "Route",
+                                                "Variant": "ByDestination",
+                                                "Keyspace": {
+                                                  "Name": "main",
+                                                  "Sharded": true
+                                                },
+                                                "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_suppkey from lineitem where 1 != 1 group by l_suppkey",
+                                                "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue, l_suppkey from lineitem where l_orderkey = :o_orderkey group by l_suppkey",
+                                                "Table": "lineitem"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "OperatorType": "Route",
+                                            "Variant": "EqualUnique",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "FieldQuery": "select count(*), s_nationkey from supplier where 1 != 1 group by s_nationkey",
+                                            "Query": "select count(*), s_nationkey from supplier where s_nationkey = :c_nationkey and s_suppkey = :l_suppkey group by s_nationkey",
+                                            "Table": "supplier",
+                                            "Values": [
+                                              ":l_suppkey"
+                                            ],
+                                            "Vindex": "hash"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
                               }
                             ]
                           },
                           {
-                            "OperatorType": "Join",
-                            "Variant": "Join",
-                            "JoinColumnIndexes": "L:0,R:0",
-                            "JoinVars": {
-                              "l_suppkey": 1
-                            },
-                            "TableName": "lineitem_supplier",
+                            "OperatorType": "Projection",
+                            "Expressions": [
+                              "[COLUMN 0] * [COLUMN 1] as count(*)",
+                              "[COLUMN 2] as n_name",
+                              "[COLUMN 3] as weight_string(n_name)"
+                            ],
                             "Inputs": [
                               {
-                                "OperatorType": "VindexLookup",
-                                "Variant": "EqualUnique",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": true
+                                "OperatorType": "Join",
+                                "Variant": "Join",
+                                "JoinColumnIndexes": "L:0,R:0,L:1,L:3",
+                                "JoinVars": {
+                                  "n_regionkey": 2
                                 },
-                                "Values": [
-                                  ":o_orderkey"
-                                ],
-                                "Vindex": "lineitem_map",
+                                "TableName": "nation_region",
                                 "Inputs": [
                                   {
                                     "OperatorType": "Route",
-                                    "Variant": "IN",
+                                    "Variant": "EqualUnique",
                                     "Keyspace": {
                                       "Name": "main",
                                       "Sharded": true
                                     },
-                                    "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
-                                    "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                                    "Table": "lineitem_map",
+                                    "FieldQuery": "select count(*), n_name, n_regionkey, weight_string(n_name) from nation where 1 != 1 group by n_name, n_regionkey, weight_string(n_name)",
+                                    "Query": "select count(*), n_name, n_regionkey, weight_string(n_name) from nation where n_nationkey = :s_nationkey group by n_name, n_regionkey, weight_string(n_name)",
+                                    "Table": "nation",
                                     "Values": [
-                                      "::l_orderkey"
+                                      ":s_nationkey"
                                     ],
-                                    "Vindex": "md5"
+                                    "Vindex": "hash"
                                   },
                                   {
                                     "OperatorType": "Route",
-                                    "Variant": "ByDestination",
+                                    "Variant": "EqualUnique",
                                     "Keyspace": {
                                       "Name": "main",
                                       "Sharded": true
                                     },
-                                    "FieldQuery": "select l_extendedprice * (1 - l_discount), l_suppkey from lineitem where 1 != 1",
-                                    "Query": "select l_extendedprice * (1 - l_discount), l_suppkey from lineitem where l_orderkey = :o_orderkey",
-                                    "Table": "lineitem"
+                                    "FieldQuery": "select count(*) from region where 1 != 1 group by .0",
+                                    "Query": "select count(*) from region where r_name = 'ASIA' and r_regionkey = :n_regionkey group by .0",
+                                    "Table": "region",
+                                    "Values": [
+                                      ":n_regionkey"
+                                    ],
+                                    "Vindex": "hash"
                                   }
                                 ]
-                              },
-                              {
-                                "OperatorType": "Route",
-                                "Variant": "EqualUnique",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select s_nationkey from supplier where 1 != 1",
-                                "Query": "select s_nationkey from supplier where s_nationkey = :c_nationkey and s_suppkey = :l_suppkey",
-                                "Table": "supplier",
-                                "Values": [
-                                  ":l_suppkey"
-                                ],
-                                "Vindex": "hash"
                               }
                             ]
-                          }
-                        ]
-                      },
-                      {
-                        "OperatorType": "Join",
-                        "Variant": "Join",
-                        "JoinColumnIndexes": "L:0,L:1",
-                        "JoinVars": {
-                          "n_regionkey": 2
-                        },
-                        "TableName": "nation_region",
-                        "Inputs": [
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "EqualUnique",
-                            "Keyspace": {
-                              "Name": "main",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select n_name, weight_string(n_name), n_regionkey from nation where 1 != 1",
-                            "Query": "select n_name, weight_string(n_name), n_regionkey from nation where n_nationkey = :s_nationkey",
-                            "Table": "nation",
-                            "Values": [
-                              ":s_nationkey"
-                            ],
-                            "Vindex": "hash"
-                          },
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "EqualUnique",
-                            "Keyspace": {
-                              "Name": "main",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select 1 from region where 1 != 1",
-                            "Query": "select 1 from region where r_name = 'ASIA' and r_regionkey = :n_regionkey",
-                            "Table": "region",
-                            "Values": [
-                              ":n_regionkey"
-                            ],
-                            "Vindex": "hash"
                           }
                         ]
                       }
@@ -706,119 +766,172 @@
                 "GroupBy": "(0|8), (1|9), (3|10), (6|11), (4|12), (5|13), (7|14)",
                 "Inputs": [
                   {
-                    "OperatorType": "Sort",
-                    "Variant": "Memory",
-                    "OrderBy": "(0|8) ASC, (1|9) ASC, (3|10) ASC, (6|11) ASC, (4|12) ASC, (5|13) ASC, (7|14) ASC",
+                    "OperatorType": "Projection",
+                    "Expressions": [
+                      "[COLUMN 2] as c_custkey",
+                      "[COLUMN 3] as c_name",
+                      "[COLUMN 0] * [COLUMN 1] as revenue",
+                      "[COLUMN 4] as c_acctbal",
+                      "[COLUMN 6] as n_name",
+                      "[COLUMN 7] as c_address",
+                      "[COLUMN 5] as c_phone",
+                      "[COLUMN 8] as c_comment",
+                      "[COLUMN 9] as weight_string(c_custkey)",
+                      "[COLUMN 10] as weight_string(c_name)",
+                      "[COLUMN 11] as weight_string(c_acctbal)",
+                      "[COLUMN 12] as weight_string(c_phone)",
+                      "[COLUMN 13] as weight_string(n_name)",
+                      "[COLUMN 14] as weight_string(c_address)",
+                      "[COLUMN 15] as weight_string(c_comment)"
+                    ],
                     "Inputs": [
                       {
-                        "OperatorType": "Join",
-                        "Variant": "Join",
-                        "JoinColumnIndexes": "R:0,R:1,L:0,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13",
-                        "JoinVars": {
-                          "o_custkey": 1
-                        },
-                        "TableName": "orders_lineitem_customer_nation",
+                        "OperatorType": "Sort",
+                        "Variant": "Memory",
+                        "OrderBy": "(2|9) ASC, (3|10) ASC, (4|11) ASC, (5|12) ASC, (6|13) ASC, (7|14) ASC, (8|15) ASC",
                         "Inputs": [
                           {
                             "OperatorType": "Join",
                             "Variant": "Join",
-                            "JoinColumnIndexes": "R:0,L:0",
+                            "JoinColumnIndexes": "L:0,R:0,R:1,R:2,R:3,R:4,R:5,R:6,R:7,R:8,R:9,R:10,R:11,R:12,R:13,R:14",
                             "JoinVars": {
-                              "o_orderkey": 1
+                              "o_custkey": 1
                             },
-                            "TableName": "orders_lineitem",
+                            "TableName": "orders_lineitem_customer_nation",
                             "Inputs": [
                               {
-                                "OperatorType": "Route",
-                                "Variant": "Scatter",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select o_custkey, o_orderkey from orders where 1 != 1",
-                                "Query": "select o_custkey, o_orderkey from orders where o_orderdate >= date('1993-10-01') and o_orderdate < date('1993-10-01') + interval '3' month",
-                                "Table": "orders"
-                              },
-                              {
-                                "OperatorType": "VindexLookup",
-                                "Variant": "EqualUnique",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": true
-                                },
-                                "Values": [
-                                  ":o_orderkey"
+                                "OperatorType": "Projection",
+                                "Expressions": [
+                                  "[COLUMN 1] * [COLUMN 0] as revenue",
+                                  "[COLUMN 2] as o_custkey"
                                 ],
-                                "Vindex": "lineitem_map",
                                 "Inputs": [
                                   {
-                                    "OperatorType": "Route",
-                                    "Variant": "IN",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
+                                    "OperatorType": "Join",
+                                    "Variant": "Join",
+                                    "JoinColumnIndexes": "R:0,L:0,L:1",
+                                    "JoinVars": {
+                                      "o_orderkey": 2
                                     },
-                                    "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
-                                    "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
-                                    "Table": "lineitem_map",
-                                    "Values": [
-                                      "::l_orderkey"
-                                    ],
-                                    "Vindex": "md5"
-                                  },
-                                  {
-                                    "OperatorType": "Route",
-                                    "Variant": "ByDestination",
-                                    "Keyspace": {
-                                      "Name": "main",
-                                      "Sharded": true
-                                    },
-                                    "FieldQuery": "select l_extendedprice * (1 - l_discount) from lineitem where 1 != 1",
-                                    "Query": "select l_extendedprice * (1 - l_discount) from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey",
-                                    "Table": "lineitem"
+                                    "TableName": "orders_lineitem",
+                                    "Inputs": [
+                                      {
+                                        "OperatorType": "Route",
+                                        "Variant": "Scatter",
+                                        "Keyspace": {
+                                          "Name": "main",
+                                          "Sharded": true
+                                        },
+                                        "FieldQuery": "select count(*), o_custkey, o_orderkey from orders where 1 != 1 group by o_custkey, o_orderkey",
+                                        "Query": "select count(*), o_custkey, o_orderkey from orders where o_orderdate >= date('1993-10-01') and o_orderdate < date('1993-10-01') + interval '3' month group by o_custkey, o_orderkey",
+                                        "Table": "orders"
+                                      },
+                                      {
+                                        "OperatorType": "VindexLookup",
+                                        "Variant": "EqualUnique",
+                                        "Keyspace": {
+                                          "Name": "main",
+                                          "Sharded": true
+                                        },
+                                        "Values": [
+                                          ":o_orderkey"
+                                        ],
+                                        "Vindex": "lineitem_map",
+                                        "Inputs": [
+                                          {
+                                            "OperatorType": "Route",
+                                            "Variant": "IN",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "FieldQuery": "select l_orderkey, l_linenumber from lineitem_map where 1 != 1",
+                                            "Query": "select l_orderkey, l_linenumber from lineitem_map where l_orderkey in ::__vals",
+                                            "Table": "lineitem_map",
+                                            "Values": [
+                                              "::l_orderkey"
+                                            ],
+                                            "Vindex": "md5"
+                                          },
+                                          {
+                                            "OperatorType": "Route",
+                                            "Variant": "ByDestination",
+                                            "Keyspace": {
+                                              "Name": "main",
+                                              "Sharded": true
+                                            },
+                                            "FieldQuery": "select sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where 1 != 1 group by .0",
+                                            "Query": "select sum(l_extendedprice * (1 - l_discount)) as revenue from lineitem where l_returnflag = 'R' and l_orderkey = :o_orderkey group by .0",
+                                            "Table": "lineitem"
+                                          }
+                                        ]
+                                      }
+                                    ]
                                   }
                                 ]
-                              }
-                            ]
-                          },
-                          {
-                            "OperatorType": "Join",
-                            "Variant": "Join",
-                            "JoinColumnIndexes": "L:0,L:1,L:2,R:0,L:3,L:4,L:5,L:6,L:7,L:8,L:9,R:1,L:10,L:11",
-                            "JoinVars": {
-                              "c_nationkey": 12
-                            },
-                            "TableName": "customer_nation",
-                            "Inputs": [
-                              {
-                                "OperatorType": "Route",
-                                "Variant": "EqualUnique",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select c_custkey, c_name, c_acctbal, c_address, c_phone, c_comment, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment), c_nationkey from customer where 1 != 1",
-                                "Query": "select c_custkey, c_name, c_acctbal, c_address, c_phone, c_comment, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment), c_nationkey from customer where c_custkey = :o_custkey",
-                                "Table": "customer",
-                                "Values": [
-                                  ":o_custkey"
-                                ],
-                                "Vindex": "hash"
                               },
                               {
-                                "OperatorType": "Route",
-                                "Variant": "EqualUnique",
-                                "Keyspace": {
-                                  "Name": "main",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select n_name, weight_string(n_name) from nation where 1 != 1",
-                                "Query": "select n_name, weight_string(n_name) from nation where n_nationkey = :c_nationkey",
-                                "Table": "nation",
-                                "Values": [
-                                  ":c_nationkey"
+                                "OperatorType": "Projection",
+                                "Expressions": [
+                                  "[COLUMN 0] * [COLUMN 1] as count(*)",
+                                  "[COLUMN 2] as c_custkey",
+                                  "[COLUMN 3] as c_name",
+                                  "[COLUMN 4] as c_acctbal",
+                                  "[COLUMN 5] as c_phone",
+                                  "[COLUMN 6] as n_name",
+                                  "[COLUMN 7] as c_address",
+                                  "[COLUMN 8] as c_comment",
+                                  "[COLUMN 9] as weight_string(c_custkey)",
+                                  "[COLUMN 10] as weight_string(c_name)",
+                                  "[COLUMN 11] as weight_string(c_acctbal)",
+                                  "[COLUMN 12] as weight_string(c_phone)",
+                                  "[COLUMN 13] as weight_string(n_name)",
+                                  "[COLUMN 14] as weight_string(c_address)",
+                                  "[COLUMN 15] as weight_string(c_comment)"
                                 ],
-                                "Vindex": "hash"
+                                "Inputs": [
+                                  {
+                                    "OperatorType": "Join",
+                                    "Variant": "Join",
+                                    "JoinColumnIndexes": "L:0,R:0,L:1,L:2,L:3,L:4,R:1,L:5,L:6,L:8,L:9,L:10,L:11,R:2,L:12,L:13",
+                                    "JoinVars": {
+                                      "c_nationkey": 7
+                                    },
+                                    "TableName": "customer_nation",
+                                    "Inputs": [
+                                      {
+                                        "OperatorType": "Route",
+                                        "Variant": "EqualUnique",
+                                        "Keyspace": {
+                                          "Name": "main",
+                                          "Sharded": true
+                                        },
+                                        "FieldQuery": "select count(*), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment) from customer where 1 != 1 group by c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment)",
+                                        "Query": "select count(*), c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment) from customer where c_custkey = :o_custkey group by c_custkey, c_name, c_acctbal, c_phone, c_address, c_comment, c_nationkey, weight_string(c_custkey), weight_string(c_name), weight_string(c_acctbal), weight_string(c_phone), weight_string(c_address), weight_string(c_comment)",
+                                        "Table": "customer",
+                                        "Values": [
+                                          ":o_custkey"
+                                        ],
+                                        "Vindex": "hash"
+                                      },
+                                      {
+                                        "OperatorType": "Route",
+                                        "Variant": "EqualUnique",
+                                        "Keyspace": {
+                                          "Name": "main",
+                                          "Sharded": true
+                                        },
+                                        "FieldQuery": "select count(*), n_name, weight_string(n_name) from nation where 1 != 1 group by n_name, weight_string(n_name)",
+                                        "Query": "select count(*), n_name, weight_string(n_name) from nation where n_nationkey = :c_nationkey group by n_name, weight_string(n_name)",
+                                        "Table": "nation",
+                                        "Values": [
+                                          ":c_nationkey"
+                                        ],
+                                        "Vindex": "hash"
+                                      }
+                                    ]
+                                  }
+                                ]
                               }
                             ]
                           }

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -467,28 +467,10 @@
     "plan": "VT12001: unsupported: Assignment expression"
   },
   {
-    "comment": "grouping column could be coming from multiple sides",
-    "query": "select count(*) from user, user_extra group by user.id+user_extra.id",
-    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
-    "gen4-plan": "VT12001: unsupported: grouping on columns from different sources"
-  },
-  {
-    "comment": "aggregate on input from both sides",
-    "query": "select sum(user.foo+user_extra.bar) from user, user_extra",
-    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
-    "gen4-plan": "VT12001: unsupported: aggregation on columns from different sources"
-  },
-  {
     "comment": "combine the output of two aggregations in the final result",
     "query": "select greatest(sum(user.foo), sum(user_extra.bar)) from user join user_extra on user.col = user_extra.col",
     "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
     "gen4-plan": "VT12001: unsupported: in scatter query: complex aggregate expression"
-  },
-  {
-    "comment": "extremum on input from both sides",
-    "query": "select max(u.foo*ue.bar) from user u join user_extra ue",
-    "v3-plan": "VT12001: unsupported: cross-shard query with aggregates",
-    "gen4-plan": "VT12001: unsupported: aggregation on columns from different sources: max(u.foo * ue.bar)"
   },
   {
     "comment": "extremum on input from both sides",


### PR DESCRIPTION
## Description
Adds support for HAVING planning

In order to support HAVING in a clean way, I had to introduce more phases in the planner.

The current phases are:
- Join ordering (route_planning)
- PushOrExpand horizons, and push down everything we can, except aggregations
- Add columns missing from Filter
- Add ordering before aggregations running on the vtgate
- Add group by on the RHS of join to get empty results correctly

## Related Issue(s)
Depends on https://github.com/vitessio/vitess/pull/13294
Tracking issue https://github.com/vitessio/vitess/issues/11626

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
