### PR TITLE
k8stopo: Include deprecation warning

### DIFF
--- a/changelog/17.0/17.0.0/release_notes.md
+++ b/changelog/17.0/17.0.0/release_notes.md
@@ -35,6 +35,7 @@
   - **[Deprecations and Deletions](#deprecations-and-deletions)**
     - [Deprecated Flags](#deprecated-flags)
     - [Deprecated Stats](#deprecated-stats)
+    - [`k8stopo` deprecated](#deprecated-k8stopo)
 
 
 ## <a id="major-changes"/>Major Changes
@@ -451,10 +452,13 @@ These stats are deprecated in v17.
 | `backup_duration_seconds` | `BackupDurationNanoseconds` |
 | `restore_duration_seconds` | `RestoreDurationNanoseconds` |
 
+#### <a id="deprecated-k8stopo"/>Deprecated `k8stopo`
+
+The `k8stopo` has been deprecated, also see https://github.com/vitessio/vitess/issues/13298. With Vitess 18 the `k8stopo` will be removed.
+
 ------------
 The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/17.0/17.0.0/changelog.md).
 
 The release includes 432 commits (excluding merges)
 
 Thanks to all our contributors: @Ayman161803, @GuptaManan100, @L3o-pold, @Phanatic, @WilliamLu99, @adsr, @ajm188, @andylim-duo, @arthurschreiber, @austenLacy, @cuishuang, @dasl-, @dbussink, @deepthi, @dependabot[bot], @ejortegau, @fatih, @frouioui, @github-actions[bot], @harshit-gangal, @hkdsun, @jeremycole, @jhump, @johanstenberg92, @jwangace, @kevinpurwito, @kovyrin, @lixin963, @mattlord, @maxbrunet, @maxenglander, @mdlayher, @moberghammer, @notfelineit, @olyazavr, @pbibra, @pnacht, @rohit-nayak-ps, @rsajwani, @shlomi-noach, @systay, @timvaillancourt, @twthorn, @vbalys, @vinimdocarmo, @vitess-bot[bot], @vmg, @yoheimuta
-

--- a/changelog/17.0/17.0.0/summary.md
+++ b/changelog/17.0/17.0.0/summary.md
@@ -34,6 +34,7 @@
   - **[Deprecations and Deletions](#deprecations-and-deletions)**
     - [Deprecated Flags](#deprecated-flags)
     - [Deprecated Stats](#deprecated-stats)
+    - [Deprecated `k8stopo`](#deprecated-k8stopo)
 
 
 ## <a id="major-changes"/>Major Changes
@@ -449,3 +450,7 @@ These stats are deprecated in v17.
 |-|-|
 | `backup_duration_seconds` | `BackupDurationNanoseconds` |
 | `restore_duration_seconds` | `RestoreDurationNanoseconds` |
+
+#### <a id="deprecated-k8stopo"/>Deprecated `k8stopo`
+
+The `k8stopo` has been deprecated, also see https://github.com/vitessio/vitess/issues/13298. With Vitess 18 the `k8stopo` will be removed.

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -240,6 +240,9 @@ func OpenServer(implementation, serverAddress, root string) (*Server, error) {
 // Open returns a Server using the command line parameter flags
 // for implementation, address and root. It log.Exits out if an error occurs.
 func Open() *Server {
+	if topoImplementation == "k8s" {
+		log.Warningf("The `k8stopo` is deprecated. We recommend using the `etcd2topo` instead. The `k8stopo` will be removed in Vitess 18.")
+	}
 	if topoGlobalServerAddress == "" && topoImplementation != "k8s" {
 		log.Exitf("topo_global_server_address must be configured")
 	}


### PR DESCRIPTION
## Description

Include a deprecation warning for Vitess 17.

## Related Issue(s)

Part of #13298 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required