### PR TITLE
Deprecate VTGR

### DIFF
--- a/changelog/17.0/17.0.0/release_notes.md
+++ b/changelog/17.0/17.0.0/release_notes.md
@@ -35,6 +35,7 @@
   - **[Deprecations and Deletions](#deprecations-and-deletions)**
     - [Deprecated Flags](#deprecated-flags)
     - [Deprecated Stats](#deprecated-stats)
+    - [`vtgr` Deprecated](#deprecated-vtgr)
 
 
 ## <a id="major-changes"/>Major Changes
@@ -450,6 +451,10 @@ These stats are deprecated in v17.
 |-|-|
 | `backup_duration_seconds` | `BackupDurationNanoseconds` |
 | `restore_duration_seconds` | `RestoreDurationNanoseconds` |
+
+### <a id="deprecated-vtgr"/>Deprecated `vtgr`
+
+The `vtgr` component has been deprecated, also see https://github.com/vitessio/vitess/issues/13300. In Vitess 18 `vtgr` will be removed.
 
 ------------
 The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/17.0/17.0.0/changelog.md).

--- a/go/cmd/vtgr/main.go
+++ b/go/cmd/vtgr/main.go
@@ -15,15 +15,21 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtgr"
 )
 
+const deprecationMsg = "vtgr is deprecated and will be removed in Vitess 18. We recommend using VTOrc with semi-sync replication instead."
+
 func main() {
+	fmt.Println(deprecationMsg)
+
 	var clustersToWatch []string
 	servenv.OnParseFor("vtgr", func(fs *pflag.FlagSet) {
 		fs.StringSliceVar(&clustersToWatch, "clusters_to_watch", nil, `Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"`)
@@ -31,6 +37,8 @@ func main() {
 		acl.RegisterFlags(fs)
 	})
 	servenv.ParseFlags("vtgr")
+
+	log.Warning(deprecationMsg)
 
 	// openTabletDiscovery will open up a connection to topo server
 	// and populate the tablets in memory


### PR DESCRIPTION
## Description

This officially deprecates the `vtgr` component in v17 and slates it for removal in v18. Please [see the issue](https://github.com/vitessio/vitess/issues/13300) for more details.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13300

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation: ???