### PR TITLE
Add median and 99th query timings metrics to vtgate and vttablet

### DIFF
--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -87,7 +87,7 @@ func (be PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 		newHistogramCollector(st, be.buildPromName(name))
 	case *stats.StringMapFuncWithMultiLabels:
 		newStringMapFuncWithMultiLabelsCollector(st, be.buildPromName(name))
-	case *stats.String, stats.StringFunc, stats.StringMapFunc, *stats.Rates, *stats.RatesFunc:
+	case *stats.String, stats.StringFunc, stats.StringMapFunc, *stats.Rates, *stats.RatesFunc, stats.JSONFunc:
 		// Silently ignore these types since they don't make sense to
 		// export to Prometheus' data model.
 	default:

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -216,6 +216,7 @@ func (e *Executor) Execute(ctx context.Context, method string, safeSession *Safe
 
 	logStats.SaveEndTime()
 	QueryLogger.Send(logStats)
+	TimingStatistics.RecordStats(logStats)
 	err = vterrors.TruncateError(err, truncateErrorLen)
 	return result, err
 }

--- a/go/vt/vtgate/timingstats.go
+++ b/go/vt/vtgate/timingstats.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"encoding/json"
+	"flag"
+	"sync"
+	"time"
+
+	"vitess.io/vitess/go/vt/vtgate/logstats"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"vitess.io/vitess/go/stats"
+)
+
+type TimingStats struct {
+	totalQueryTime prometheus.Summary
+}
+
+type TimingMeasurement struct {
+	Median      float64
+	NinetyNinth float64
+}
+
+type TimingMeasurements struct {
+	TotalQueryTime TimingMeasurement
+}
+
+var (
+	TimingStatistics = &TimingStats{totalQueryTime: prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name:       "total_query_time",
+			Help:       "Distributions of total time for vttablet queries.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001},
+			MaxAge:     time.Minute})}
+	timingStatsEnabled = flag.Bool("enable-aggregate-vttablet-timings", false, "This enables median and 99th timings for all queries.")
+
+	publishOnce sync.Once
+)
+
+func (timingStats *TimingStats) RecordStats(logStats *logstats.LogStats) {
+	if *timingStatsEnabled {
+		timingStats.registerIfNeeded()
+		timingStats.totalQueryTime.Observe(float64(logStats.TotalTime().Nanoseconds()))
+	}
+}
+
+func (timingStats *TimingStats) GetMeasurementsJson() string {
+	b, err := json.MarshalIndent(TimingStatistics.GetMeasurements(), "", " ")
+	if err != nil {
+		return "{}"
+	} else {
+		return string(b)
+	}
+}
+
+func (timingStats *TimingStats) GetMeasurements() TimingMeasurements {
+	return TimingMeasurements{TotalQueryTime: getMeasurement(timingStats.totalQueryTime)}
+}
+
+func (timingStats *TimingStats) registerIfNeeded() {
+	publishOnce.Do(func() {
+		stats.PublishJSONFunc("AggregateQueryTimings", func() string {
+			return TimingStatistics.GetMeasurementsJson()
+		})
+	})
+}
+
+func getMeasurement(summary prometheus.Summary) TimingMeasurement {
+	dtoMetric := &dto.Metric{}
+	err := summary.Write(dtoMetric)
+	if err != nil {
+		return TimingMeasurement{}
+	}
+	return TimingMeasurement{Median: dtoMetric.Summary.GetQuantile()[0].GetValue(),
+		NinetyNinth: dtoMetric.Summary.GetQuantile()[1].GetValue()}
+}

--- a/go/vt/vtgate/timingstats_test.go
+++ b/go/vt/vtgate/timingstats_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimingStats_GetMeasurementsJson(t *testing.T) {
+	type fields struct {
+		totalQueryTime            prometheus.Summary
+		mysqlQueryTime            prometheus.Summary
+		connectionAcquisitionTime prometheus.Summary
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "stat1",
+			fields: fields{
+				totalQueryTime: TimingStatistics.totalQueryTime,
+			},
+			want: "{\n \"TotalQueryTime\": {\n  \"Median\": 2000,\n  \"NinetyNinth\": 50000000\n }\n}",
+		},
+	}
+
+	tests[0].fields.totalQueryTime.Observe(50000000)
+	tests[0].fields.totalQueryTime.Observe(1000)
+	tests[0].fields.totalQueryTime.Observe(2000)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timingStats := &TimingStats{
+				totalQueryTime: tt.fields.totalQueryTime,
+			}
+			assert.Equalf(t, tt.want, timingStats.GetMeasurementsJson(), "GetMeasurementsJson()")
+		})
+	}
+}

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -211,6 +211,8 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&currentConfig.EnableViews, "queryserver-enable-views", false, "Enable views support in vttablet.")
 
 	fs.BoolVar(&currentConfig.EnablePerWorkloadTableMetrics, "enable-per-workload-table-metrics", defaultConfig.EnablePerWorkloadTableMetrics, "If true, query counts and query error metrics include a label that identifies the workload")
+
+	fs.BoolVar(&currentConfig.EnableAggregateQueryTimings, "enable-aggregate-query-timings", defaultConfig.EnableAggregateQueryTimings, "This enables median and 99th timings for all queries.")
 }
 
 var (
@@ -360,6 +362,7 @@ type TabletConfig struct {
 	EnableViews bool `json:"-"`
 
 	EnablePerWorkloadTableMetrics bool `json:"-"`
+	EnableAggregateQueryTimings   bool
 }
 
 func (cfg *TabletConfig) MarshalJSON() ([]byte, error) {

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -78,6 +78,9 @@ func NewLogStats(ctx context.Context, methodName string) *LogStats {
 func (stats *LogStats) Send() {
 	stats.EndTime = time.Now()
 	StatsLogger.Send(stats)
+	if currentConfig.EnableAggregateQueryTimings {
+		TimingStatistics.recordStats(stats)
+	}
 }
 
 // ImmediateCaller returns the immediate caller stored in LogStats.Ctx

--- a/go/vt/vttablet/tabletserver/tabletenv/timingstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/timingstats.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletenv
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"vitess.io/vitess/go/stats"
+)
+
+type TimingStats struct {
+	totalQueryTime            prometheus.Summary
+	mysqlQueryTime            prometheus.Summary
+	connectionAcquisitionTime prometheus.Summary
+}
+
+type TimingMeasurement struct {
+	Median      float64
+	NinetyNinth float64
+}
+
+type TimingMeasurements struct {
+	TotalQueryTime            TimingMeasurement
+	MysqlQueryTime            TimingMeasurement
+	ConnectionAcquisitionTime TimingMeasurement
+}
+
+var (
+	TimingStatistics = &TimingStats{totalQueryTime: prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name:       "total_query_time",
+			Help:       "Distributions of total time for vttablet queries.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001},
+			MaxAge:     time.Minute}),
+		mysqlQueryTime: prometheus.NewSummary(
+			prometheus.SummaryOpts{
+				Name:       "mysql_query_time",
+				Help:       "Distributions of time querying msyql for vttablet queries.",
+				Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001},
+				MaxAge:     time.Minute}),
+		connectionAcquisitionTime: prometheus.NewSummary(
+			prometheus.SummaryOpts{
+				Name:       "connection_acquisition_time",
+				Help:       "Distributions of time spent acquiring msyql connections for vttablet queries.",
+				Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001},
+				MaxAge:     time.Minute})}
+	publishOnce sync.Once
+)
+
+func (timingStats *TimingStats) recordStats(logStats *LogStats) {
+	timingStats.registerIfNeeded()
+	timingStats.totalQueryTime.Observe(float64(logStats.TotalTime().Nanoseconds()))
+	timingStats.mysqlQueryTime.Observe(float64(logStats.MysqlResponseTime.Nanoseconds()))
+	timingStats.connectionAcquisitionTime.Observe(float64(logStats.WaitingForConnection.Nanoseconds()))
+}
+
+func (timingStats *TimingStats) GetMeasurementsJson() string {
+	b, err := json.MarshalIndent(TimingStatistics.GetMeasurements(), "", " ")
+	if err != nil {
+		return "{}"
+	} else {
+		return string(b)
+	}
+}
+
+func (timingStats *TimingStats) GetMeasurements() TimingMeasurements {
+	return TimingMeasurements{TotalQueryTime: getMeasurement(timingStats.totalQueryTime),
+		MysqlQueryTime:            getMeasurement(timingStats.mysqlQueryTime),
+		ConnectionAcquisitionTime: getMeasurement(timingStats.connectionAcquisitionTime)}
+}
+
+func (timingStats *TimingStats) registerIfNeeded() {
+	publishOnce.Do(func() {
+		stats.PublishJSONFunc("AggregateQueryTimings", func() string {
+			return TimingStatistics.GetMeasurementsJson()
+		})
+	})
+}
+
+func getMeasurement(summary prometheus.Summary) TimingMeasurement {
+	dtoMetric := &dto.Metric{}
+	err := summary.Write(dtoMetric)
+	if err != nil {
+		return TimingMeasurement{}
+	}
+	return TimingMeasurement{Median: dtoMetric.Summary.GetQuantile()[0].GetValue(),
+		NinetyNinth: dtoMetric.Summary.GetQuantile()[1].GetValue()}
+}

--- a/go/vt/vttablet/tabletserver/tabletenv/timingstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/timingstats_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletenv
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimingStats_GetMeasurementsJson(t *testing.T) {
+	type fields struct {
+		totalQueryTime            prometheus.Summary
+		mysqlQueryTime            prometheus.Summary
+		connectionAcquisitionTime prometheus.Summary
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "stat1",
+			fields: fields{
+				totalQueryTime:            TimingStatistics.totalQueryTime,
+				mysqlQueryTime:            TimingStatistics.mysqlQueryTime,
+				connectionAcquisitionTime: TimingStatistics.connectionAcquisitionTime,
+			},
+			want: "{\n \"TotalQueryTime\": {\n  \"Median\": 200,\n  \"NinetyNinth\": 400\n },\n \"MysqlQueryTime\": {\n  \"Median\": 200,\n  \"NinetyNinth\": 300\n },\n \"ConnectionAcquisitionTime\": {\n  \"Median\": 20,\n  \"NinetyNinth\": 30\n }\n}",
+		},
+	}
+
+	tests[0].fields.mysqlQueryTime.Observe(100)
+	tests[0].fields.mysqlQueryTime.Observe(200)
+	tests[0].fields.mysqlQueryTime.Observe(300)
+	tests[0].fields.totalQueryTime.Observe(100)
+	tests[0].fields.totalQueryTime.Observe(200)
+	tests[0].fields.totalQueryTime.Observe(300)
+	tests[0].fields.totalQueryTime.Observe(400)
+	tests[0].fields.connectionAcquisitionTime.Observe(10)
+	tests[0].fields.connectionAcquisitionTime.Observe(20)
+	tests[0].fields.connectionAcquisitionTime.Observe(30)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timingStats := &TimingStats{
+				totalQueryTime:            tt.fields.totalQueryTime,
+				mysqlQueryTime:            tt.fields.mysqlQueryTime,
+				connectionAcquisitionTime: tt.fields.connectionAcquisitionTime,
+			}
+			assert.Equalf(t, tt.want, timingStats.GetMeasurementsJson(), "GetMeasurementsJson()")
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds logic to grab the median and 99th query timings metrics to vtgate and vttablet. With this change we can know:
- Distribution of total times for vttablet queries
- Distributions of time querying msyql for vttablet queries
- Distributions of time spent acquiring msyql connections for vttablet queries

All of this is gated behind the flag `enable-aggregate-vttablet-timings` which enables median and 99th timings for _all_ queries

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes https://github.com/vitessio/vitess/issues/13317

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
