### PR TITLE
Bug fix: SQL queries erroring with message `unknown aggregation random`

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -371,6 +371,9 @@ func TestAggregateRandom(t *testing.T) {
 	mcmp.Exec("insert into t2(id, shardKey) values (1, 10), (2, 20)")
 
 	mcmp.AssertMatches("SELECT /*vt+ PLANNER=gen4 */ t1.shardKey, t1.name, count(t2.id) FROM t1 JOIN t2 ON t1.value != t2.shardKey GROUP BY t1.t1_id", `[[INT64(1) VARCHAR("name 1") INT64(2)] [INT64(2) VARCHAR("name 2") INT64(2)]]`)
+
+	mcmp.Exec("set sql_mode=''")
+	mcmp.AssertMatches("select /*vt+ PLANNER=Gen4 */ tbl0.comm, count(*) from emp as tbl0, emp as tbl1 where tbl0.empno = tbl1.deptno", `[[NULL INT64(0)]]`)
 }
 
 // TestAggregateLeftJoin tests that aggregates work with left joins and does not ignore the count when column value does not match the right side table.

--- a/go/test/endtoend/vtgate/queries/aggregation/schema.sql
+++ b/go/test/endtoend/vtgate/queries/aggregation/schema.sql
@@ -78,22 +78,22 @@ CREATE TABLE t10 (
 );
 
 CREATE TABLE emp (
-                     empno bigint NOT NULL,
-                     ename VARCHAR(10),
-                     job VARCHAR(9),
-                     mgr bigint,
-                     hiredate DATE,
-                     sal bigint,
-                     comm bigint,
-                     deptno bigint,
-                     PRIMARY KEY (empno)
+    empno bigint NOT NULL,
+    ename VARCHAR(10),
+    job VARCHAR(9),
+    mgr bigint,
+    hiredate DATE,
+    sal bigint,
+    comm bigint,
+    deptno bigint,
+    PRIMARY KEY (empno)
 ) Engine = InnoDB
   COLLATE = utf8mb4_general_ci;
 
 CREATE TABLE dept (
-                      deptno bigint,
-                      dname VARCHAR(14),
-                      loc VARCHAR(13),
-                      PRIMARY KEY (deptno)
+    deptno bigint,
+    dname VARCHAR(14),
+    loc VARCHAR(13),
+    PRIMARY KEY (deptno)
 ) Engine = InnoDB
   COLLATE = utf8mb4_general_ci;

--- a/go/test/endtoend/vtgate/queries/aggregation/schema.sql
+++ b/go/test/endtoend/vtgate/queries/aggregation/schema.sql
@@ -76,3 +76,24 @@ CREATE TABLE t10 (
    a INT,
    b INT
 );
+
+CREATE TABLE emp (
+                     empno bigint NOT NULL,
+                     ename VARCHAR(10),
+                     job VARCHAR(9),
+                     mgr bigint,
+                     hiredate DATE,
+                     sal bigint,
+                     comm bigint,
+                     deptno bigint,
+                     PRIMARY KEY (empno)
+) Engine = InnoDB
+  COLLATE = utf8mb4_general_ci;
+
+CREATE TABLE dept (
+                      deptno bigint,
+                      dname VARCHAR(14),
+                      loc VARCHAR(13),
+                      PRIMARY KEY (deptno)
+) Engine = InnoDB
+  COLLATE = utf8mb4_general_ci;

--- a/go/test/endtoend/vtgate/queries/aggregation/vschema.json
+++ b/go/test/endtoend/vtgate/queries/aggregation/vschema.json
@@ -131,6 +131,22 @@
           "name": "hash"
         }
       ]
+    },
+    "emp": {
+      "column_vindexes": [
+        {
+          "column": "deptno",
+          "name": "hash"
+        }
+      ]
+    },
+    "dept": {
+      "column_vindexes": [
+        {
+          "column": "deptno",
+          "name": "hash"
+        }
+      ]
     }
   }
 }

--- a/go/vt/vtgate/engine/scalar_aggregation.go
+++ b/go/vt/vtgate/engine/scalar_aggregation.go
@@ -209,7 +209,8 @@ func createEmptyValueFor(opcode AggregateOpcode) (sqltypes.Value, error) {
 		AggregateSumDistinct,
 		AggregateSum,
 		AggregateMin,
-		AggregateMax:
+		AggregateMax,
+		AggregateRandom:
 		return sqltypes.NULL, nil
 
 	}


### PR DESCRIPTION
## Description

This PR fixes a bug in certain SQL queries, for example:
`select /*vt+ PLANNER=Gen4 */ tbl0.comm, count(*) from emp as tbl0, emp as tbl1 where tbl0.empno = tbl1.deptno`

With `only_full_group_by` disabled and a non-grouping column selected, Vitess will sometimes error with the message `unknown aggregation random`.

## Related Issue(s)

This was found with automated query fuzzing (#13279)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes
