### PR TITLE
Handle inconsistent state error in query buffering

### DIFF
--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -309,6 +309,7 @@ func (gw *TabletGateway) withRetry(ctx context.Context, target *querypb.Target, 
 				// if primary is serving, but we initially found no tablet, we're in an inconsistent state
 				// we then retry the entire loop
 				if primary != nil {
+					err = vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "inconsistent state detected, primary is serving but initially found no available tablet")
 					continue
 				}
 			}


### PR DESCRIPTION
## Description

This PR fixes an unhandled error when reaching an inconsistent state in query buffering.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/13329

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
