### PR TITLE
mysqlctl: Move more to use built in MySQL client

### DIFF
--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -43,22 +43,11 @@ var autoIncr = regexp.MustCompile(` AUTO_INCREMENT=\d+`)
 
 // executeSchemaCommands executes some SQL commands. It uses the dba connection parameters, with credentials.
 func (mysqld *Mysqld) executeSchemaCommands(ctx context.Context, sql string) error {
-	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	params, err := mysqld.dbcfgs.DbaConnector().MysqlParams()
 	if err != nil {
 		return err
 	}
-	defer conn.Recycle()
-	_, more, err := conn.ExecuteFetchMulti(sql, 0, false)
-	if err != nil {
-		return err
-	}
-	for more {
-		_, more, _, err = conn.ReadQueryResult(0, false)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return mysqld.executeMysqlScript(ctx, params, sql)
 }
 
 func encodeEntityName(name string) string {


### PR DESCRIPTION
`executeMysqlScript` was still using a `mysql` client binary for initialization, but there's no reason it needs to do that. We can also move this to our built in MySQL client to be faster and have less dependencies here.

This essentially reverts back `executeSchemaCommands` to what it was before and pushes down the change to use the direction connection into `executeMysqlScript` instead, removing the dependency on the `mysql` CLI client entirely. 

## Related Issue(s)

Follow up to #13178 where we already moved things for just the schema commands.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required