### PR TITLE
Add RestorePosition and RestoredBackupTime as metrics to vttablet

### DIFF
--- a/changelog/16.0/16.0.0/release_notes.md
+++ b/changelog/16.0/16.0.0/release_notes.md
@@ -5,6 +5,7 @@
 
 - **[Known Issues](#known-issues)**
   - [MySQL & Xtrabackup known issue](#mysql-xtrabackup-ddl)
+  - [VTTablet Restore Metrics](#vttablet-restore-metrics)
 - **[Major Changes](#major-changes)**
   - **[Breaking Changes](#breaking-changes)**
     - [VTGate Advertised MySQL Version](#advertised-mysql-version)
@@ -99,6 +100,11 @@ or
 > SET @@ddl_strategy='vitess';
 > ALTER TABLE your_table ENGINE=InnoDB;
 ```
+
+#### <a id="vttablet-restore-metrics">VTTablet Restore Metrics
+
+As part of the VTTablet Sidecar Schema Maintenance Refactor in v16.0.0, we dropped the `local_metadata` table from the sidecar database schema. This table was storing a couple of metrics related to restores from backup, which have now been lost.
+They have been re-introduced in v17.0.0 as metrics that can be accessed from `/debug/vars`.
 
 ## <a id="major-changes"/>Major Changes
 

--- a/changelog/17.0/17.0.0/release_notes.md
+++ b/changelog/17.0/17.0.0/release_notes.md
@@ -12,6 +12,7 @@
     - [Shard name validation in TopoServer](#shard-name-validation)
     - [Compression CLI flags removed from vtctld and vtctldclient binaries](#remove-compression-flags-from-vtctld-binaries)
     - [VtctldClient command RestoreFromBackup will now use the correct context](#VtctldClient-RestoreFromBackup)
+    - [VTTablet Restore Metrics](#vttablet-restore-metrics)
   - **[New command line flags and behavior](#new-flag)**
     - [Builtin backup: read buffering flags](#builtin-backup-read-buffering-flags)
     - [Manifest backup external decompressor command](#manifest-backup-external-decompressor-command)
@@ -131,6 +132,11 @@ The VtctldClient command RestoreFromBackup initiates an asynchronous process on 
 Prior to v17, this asynchronous process could run indefinitely in the background since it was called using the background context. In v17 [PR#12830](https://github.com/vitessio/vitess/issues/12830),
 this behavior was changed to use a context with a timeout of `action_timeout`. If you are using VtctldClient to initiate a restore, make sure you provide an appropriate value for action_timeout to give enough
 time for the restore process to complete. Otherwise, the restore will throw an error if the context expires before it completes.
+
+#### <a id="vttablet-restore-metrics">VTTablet Restore Metrics
+
+As part of the VTTablet Sidecar Schema Maintenance Refactor in v16.0.0, we dropped the `local_metadata` table from the sidecar database schema. This table was storing a couple of metrics related to restores from backup.
+They have now been re-introduced as metrics that can be accessed from `/debug/vars`.
 
 ### <a id="Vttablet-TxThrottler">Vttablet's transaction throttler now also throttles DML outside of `BEGIN; ...; COMMIT;` blocks
 

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -1233,11 +1233,27 @@ func verifyTabletBackupStats(t *testing.T, vars map[string]any) {
 	if backupstorage.BackupStorageImplementation == "file" {
 		require.Contains(t, bd, "BackupStorage.File.File:Write")
 	}
+
+}
+
+func verifyRestorePositionAndTimeStats(t *testing.T, vars map[string]any) {
+	backupPosition := vars["RestorePosition"].(string)
+	backupTime := vars["RestoredBackupTime"].(string)
+	require.Contains(t, vars, "RestoredBackupTime")
+	require.Contains(t, vars, "RestorePosition")
+	require.NotEqual(t, "", backupPosition)
+	require.NotEqual(t, "", backupTime)
+	rp, err := mysql.DecodePosition(backupPosition)
+	require.NoError(t, err)
+	require.False(t, rp.IsZero())
 }
 
 func verifyTabletRestoreStats(t *testing.T, vars map[string]any) {
 	// Currently only the builtin backup engine instruments bytes-processed
 	// counts.
+
+	verifyRestorePositionAndTimeStats(t, vars)
+
 	if !useXtrabackup {
 		require.Contains(t, vars, "RestoreBytes")
 		bb := vars["RestoreBytes"].(map[string]any)


### PR DESCRIPTION
## Description

The  `RestoredBackupTime` and `RestorePosition` attributes of backups were stored in `local_metadata` before v16. They were lost in the refactor where we dropped that table. Adding these back as metrics in vttablet.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/13336

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required https://github.com/vitessio/website/pull/1508
