### PR TITLE
Flakes: Remove CI endtoend test for VReplication Copy Phase Throttling

### DIFF
--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -221,6 +221,13 @@ func TestVReplicationDDLHandling(t *testing.T) {
 	moveTablesAction(t, "Cancel", defaultCellName, workflow, sourceKs, targetKs, table)
 }
 
+// TestVreplicationCopyThrottling tests the logic that is used
+// by vstreamer when starting a copy phase cycle.
+// This logic today supports waiting for MySQL replication lag
+// and/or InnoDB MVCC history to be below a certain threshold
+// before starting the next copy phase. This test focuses on
+// the innodb history list length check.
+// NOTE: this is a manual test. It is not executed in the CI.
 func TestVreplicationCopyThrottling(t *testing.T) {
 	workflow := "copy-throttling"
 	cell := "zone1"

--- a/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
@@ -164,52 +164,14 @@ func expectUpdateCount(t *testing.T, wantCount int64) int64 {
 	panic("unreachable")
 }
 
+// TestVStreamerWaitForMySQL tests the wait for MySQL to catch-up
+// logic that is used by vstreamer when starting a copy phase cycle.
+// This logic today supports waiting for MySQL replication lag
+// and/or InnoDB MVCC history to be below a certain threshold before
+// starting the next copy phase.
 func TestVStreamerWaitForMySQL(t *testing.T) {
 	tableName := "test"
-	type fields struct {
-		vse                   *Engine
-		cp                    dbconfigs.Connector
-		se                    *schema.Engine
-		ReplicationLagSeconds int64
-		maxInnoDBTrxHistLen   int64
-		maxMySQLReplLagSecs   int64
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		wantErr bool
-	}{
-		{
-			name: "Small InnoDB MVCC impact limit",
-			fields: fields{
-				vse:                 engine,
-				se:                  engine.se,
-				maxInnoDBTrxHistLen: 100,
-				maxMySQLReplLagSecs: 5000,
-			},
-			wantErr: true,
-		},
-		{
-			name: "Small Repl Lag impact limit",
-			fields: fields{
-				vse:                 engine,
-				se:                  engine.se,
-				maxInnoDBTrxHistLen: 10000,
-				maxMySQLReplLagSecs: 5,
-			},
-			wantErr: true,
-		},
-		{
-			name: "Large impact limits",
-			fields: fields{
-				vse:                 engine,
-				se:                  engine.se,
-				maxInnoDBTrxHistLen: 10000,
-				maxMySQLReplLagSecs: 200,
-			},
-			wantErr: false,
-		},
-	}
+	expectedWaits := int64(0)
 	testDB := fakesqldb.New(t)
 	hostres := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"hostname|port",
@@ -226,9 +188,58 @@ func TestVStreamerWaitForMySQL(t *testing.T) {
 		"int64"),
 		"10",
 	)
+	type fields struct {
+		vse                   *Engine
+		cp                    dbconfigs.Connector
+		se                    *schema.Engine
+		ReplicationLagSeconds int64
+		maxInnoDBTrxHistLen   int64
+		maxMySQLReplLagSecs   int64
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		shouldWait bool
+		wantErr    bool
+	}{
+		{
+			name: "Small InnoDB MVCC impact limit",
+			fields: fields{
+				vse:                 engine,
+				se:                  engine.se,
+				maxInnoDBTrxHistLen: 100, // Should wait on this
+				maxMySQLReplLagSecs: 5000,
+			},
+			shouldWait: true,
+			wantErr:    true,
+		},
+		{
+			name: "Small Repl Lag impact limit",
+			fields: fields{
+				vse:                 engine,
+				se:                  engine.se,
+				maxInnoDBTrxHistLen: 10000,
+				maxMySQLReplLagSecs: 5, // Should wait on this
+			},
+			shouldWait: true,
+			wantErr:    true,
+		},
+		{
+			name: "Large impact limits",
+			fields: fields{
+				vse:                 engine,
+				se:                  engine.se,
+				maxInnoDBTrxHistLen: 10000,
+				maxMySQLReplLagSecs: 200,
+			},
+			wantErr: false,
+		},
+	}
+
 	testDB.AddQuery(hostQuery, hostres)
 	testDB.AddQuery(trxHistoryLenQuery, thlres)
 	testDB.AddQuery(replicaLagQuery, sbmres)
+
 	for _, tt := range tests {
 		tt.fields.cp = testDB.ConnParams()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -247,9 +258,12 @@ func TestVStreamerWaitForMySQL(t *testing.T) {
 			if err := uvs.vse.waitForMySQL(ctx, uvs.cp, tableName); (err != nil) != tt.wantErr {
 				t.Errorf("vstreamer.waitForMySQL() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			if tt.shouldWait {
+				expectedWaits++
+			}
 		})
 	}
 
-	require.Equal(t, engine.rowStreamerWaits.Counts()["VStreamerTest.waitForMySQL"], int64(2))
-	require.Equal(t, engine.vstreamerPhaseTimings.Counts()["VStreamerTest."+tableName+":waitForMySQL"], int64(2))
+	require.Equal(t, engine.rowStreamerWaits.Counts()["VStreamerTest.waitForMySQL"], expectedWaits)
+	require.Equal(t, engine.vstreamerPhaseTimings.Counts()["VStreamerTest."+tableName+":waitForMySQL"], expectedWaits)
 }

--- a/test/config.json
+++ b/test/config.json
@@ -1035,15 +1035,6 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
-		"vreplication_copy_throttling": {
-			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestVreplicationCopyThrottling"],
-			"Command": [],
-			"Manual": false,
-			"Shard": "vreplication_basic",
-			"RetryMax": 1,
-			"Tags": []
-		},
 		"vreplication_copy_parallel": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestVreplicationCopyParallel"],


### PR DESCRIPTION
## Description

The `TestVStreamerWaitForMySQL` e2e test [added in #PR9923](https://github.com/vitessio/vitess/pull/9923) has become flaky again recently. This PR addresses this by removing the endtoend test entirely as:

1. We have unit test coverage for it
2. It's a pretty simple feature and related behavior

I also made some minor improvements to the comments and unit test.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required