### PR TITLE
bug: don't always wrap aggregation in coalesce

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -386,8 +386,10 @@ func TestAggregateLeftJoin(t *testing.T) {
 
 	mcmp.AssertMatchesNoOrder("SELECT t1.shardkey FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[INT64(1)] [INT64(0)]]`)
 	mcmp.AssertMatches("SELECT count(t1.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[INT64(2)]]`)
+	mcmp.AssertMatches("SELECT count(t2.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[INT64(1)]]`)
 	mcmp.AssertMatches("SELECT count(*) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[INT64(2)]]`)
 	mcmp.AssertMatches("SELECT sum(t1.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[DECIMAL(1)]]`)
+	mcmp.AssertMatches("SELECT sum(t2.shardkey) FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id", `[[DECIMAL(1)]]`)
 	mcmp.AssertMatches("SELECT count(*) FROM t2 LEFT JOIN t1 ON t1.t1_id = t2.id WHERE IFNULL(t1.name, 'NOTSET') = 'r'", `[[INT64(1)]]`)
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -5102,7 +5102,7 @@
     }
   },
   {
-    "comment": "Aggregation in a left join query",
+    "comment": "Aggregation on column from inner side in a left join query",
     "query": "select count (u.id) from user u left join user_extra ue on u.col = ue.col",
     "plan": {
       "QueryType": "SELECT",
@@ -5147,6 +5147,66 @@
                     },
                     "FieldQuery": "select count(*) from user_extra as ue where 1 != 1 group by .0",
                     "Query": "select count(*) from user_extra as ue where ue.col = :u_col group by .0",
+                    "Table": "user_extra"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "Aggregation on outer side in a left join query",
+    "query": "select count(ue.id) from user u left join user_extra ue on u.col = ue.col",
+    "plan": {
+      "QueryType": "SELECT",
+      "Original": "select count(ue.id) from user u left join user_extra ue on u.col = ue.col",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "sum_count(0) AS count(ue.id)",
+        "Inputs": [
+          {
+            "OperatorType": "Projection",
+            "Expressions": [
+              "[COLUMN 1] * [COLUMN 0] as count(ue.id)"
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "Join",
+                "Variant": "LeftJoin",
+                "JoinColumnIndexes": "R:0,L:0",
+                "JoinVars": {
+                  "u_col": 1
+                },
+                "TableName": "`user`_user_extra",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select count(*), u.col from `user` as u where 1 != 1 group by u.col",
+                    "Query": "select count(*), u.col from `user` as u group by u.col",
+                    "Table": "`user`"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select count(ue.id) from user_extra as ue where 1 != 1 group by .0",
+                    "Query": "select count(ue.id) from user_extra as ue where ue.col = :u_col group by .0",
                     "Table": "user_extra"
                   }
                 ]


### PR DESCRIPTION
## Description
Some aggregations on the outer side of an outer join would fail, returning the wrong results.

Example query:

```sql
SELECT count(t2.shardkey) 
FROM t1 LEFT JOIN t2 ON t1.t1_id = t2.id
```

When pushing down aggregation to the outer side of a query, we should not always wrap the RHS expression in `COALESCE`.

## Related Issue(s)
Found with https://github.com/vitessio/vitess/pull/13260


## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
