### PR TITLE
Code freeze of release-17.0

### DIFF
--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - name: Fail if Code Freeze is enabled
       run: |
-        exit 0
+        exit 1


### PR DESCRIPTION
## Description

This enables code freeze for the release-17.0 branch in the run up to the GA release on Tuesday, June 27th.

## Related Issue(s)

  - Part of: https://github.com/vitessio/vitess/issues/13151

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required