### PR TITLE
Forward port of release notes changes from v17.0.0 GA

### DIFF
--- a/changelog/17.0/17.0.0/changelog.md
+++ b/changelog/17.0/17.0.0/changelog.md
@@ -1,4 +1,4 @@
-# Changelog of Vitess v17.0.0-rc2
+# Changelog of Vitess v17.0.0
 
 ### Announcement 
 #### Governance
@@ -10,18 +10,18 @@
  * do not demote a new primary after backup completion [#12856](https://github.com/vitessio/vitess/pull/12856)
  * go/vt/mysqlctl: fix dup open/close backup stats [#12947](https://github.com/vitessio/vitess/pull/12947)
  * Incremental backup: fix calculation of binlog files to use [#13066](https://github.com/vitessio/vitess/pull/13066)
- * restore: Run PITR through mysqlctl [#13123](https://github.com/vitessio/vitess/pull/13123)
+ * restore: Run PITR through mysqlctl [#13123](https://github.com/vitessio/vitess/pull/13123) 
 #### Build/CI
  * Prevent bootstrap of ZK from clearing previous dist binaries [#12236](https://github.com/vitessio/vitess/pull/12236)
  * Fix dubious ownership of git directory in `vitess/base` Docker build [#12530](https://github.com/vitessio/vitess/pull/12530)
  * Small fixes to the auto-upgrade golang tool [#12838](https://github.com/vitessio/vitess/pull/12838)
  * Add timeout to `golangci-lint` and bump its version [#12852](https://github.com/vitessio/vitess/pull/12852)
- * codegen: ensure goimports also simplifies [#12883](https://github.com/vitessio/vitess/pull/12883)
+ * codegen: ensure goimports also simplifies [#12883](https://github.com/vitessio/vitess/pull/12883) 
 #### CLI
  * Purge logs without panicking [#12187](https://github.com/vitessio/vitess/pull/12187)
  * Fix `vtctldclient`'s Root command to return an error on unknown command [#12481](https://github.com/vitessio/vitess/pull/12481)
  * vtctldclient: Format GetKeyspace output using cli.MarshalJSON [#12495](https://github.com/vitessio/vitess/pull/12495)
- * VReplication: Pass on --keep_routing_rules flag value for Cancel action [#13171](https://github.com/vitessio/vitess/pull/13171)
+ * VReplication: Pass on --keep_routing_rules flag value for Cancel action [#13171](https://github.com/vitessio/vitess/pull/13171) 
 #### Cluster management
  * Fix initialization code to also stop replication to prevent crash [#12534](https://github.com/vitessio/vitess/pull/12534)
  * Update topo {Get,Create}Keyspace to prevent invalid keyspace names [#12732](https://github.com/vitessio/vitess/pull/12732)
@@ -30,14 +30,14 @@
  * [topo] Disallow the slash character in shard names [#12843](https://github.com/vitessio/vitess/pull/12843)
  * TabletThrottler: `vtctlclient UpdateThrottlerConfig` use VtctldServer RPC [#12936](https://github.com/vitessio/vitess/pull/12936)
  * Keep retrying mysql port if it is 0 in Vttablets [#12986](https://github.com/vitessio/vitess/pull/12986)
- * Fix: convertBoolToSemiSyncAction method to account for all semi sync actions [#13075](https://github.com/vitessio/vitess/pull/13075)
+ * Fix: convertBoolToSemiSyncAction method to account for all semi sync actions [#13075](https://github.com/vitessio/vitess/pull/13075) 
 #### Evalengine
  * evalengine: fix bugs with decimal rounding [#12360](https://github.com/vitessio/vitess/pull/12360)
  * json: Fix JSON SQL serialization and ensure to run tests [#12861](https://github.com/vitessio/vitess/pull/12861)
  * evalengine: unset Type for NewColumnWithCollation [#12886](https://github.com/vitessio/vitess/pull/12886)
  * datetime: Fix weekday calculation for DST changes [#12931](https://github.com/vitessio/vitess/pull/12931)
  * evalengine: Fix wrong coercion into float [#12998](https://github.com/vitessio/vitess/pull/12998)
- * evalengine: TypeOf for Columns should only use value type when we have a value [#13148](https://github.com/vitessio/vitess/pull/13148)
+ * evalengine: TypeOf for Columns should only use value type when we have a value [#13148](https://github.com/vitessio/vitess/pull/13148) 
 #### Examples
  * Examples: Add lib functions to wait for shard states [#12239](https://github.com/vitessio/vitess/pull/12239)
  * Fixes for local docker environment [#12382](https://github.com/vitessio/vitess/pull/12382)
@@ -45,7 +45,7 @@
  * Fix Vtop example and release script [#12457](https://github.com/vitessio/vitess/pull/12457)
  * Open vtadmin-api port in docker-local example to enable vtadmin access [#12467](https://github.com/vitessio/vitess/pull/12467)
  * Use new init_db.sql file in all places and update v17.0.0 summary [#12716](https://github.com/vitessio/vitess/pull/12716)
- * Use $hostname in vtadmin script as all other scripts do (#13231) [#13236](https://github.com/vitessio/vitess/pull/13236)
+ * [release-17.0] Use $hostname in vtadmin script as all other scripts do (#13231) [#13236](https://github.com/vitessio/vitess/pull/13236) 
 #### General
  * Fix shorthand flag for recursive delete in zk tool [#12460](https://github.com/vitessio/vitess/pull/12460)
  * Forward port of #12436: Sidecar schema init: use COPY algorithm while altering sidecardb tables [#12464](https://github.com/vitessio/vitess/pull/12464)
@@ -53,9 +53,9 @@
  * Fix backup flaky tests [#12834](https://github.com/vitessio/vitess/pull/12834)
  * Fix auto-upgrade-golang tooling [#13048](https://github.com/vitessio/vitess/pull/13048)
  * Flakes: Skip flaky viperutil test TestPersistConfig for now to unblock CI [#13186](https://github.com/vitessio/vitess/pull/13186)
- * Temporarily disable panic in mysqld when socket files are directly used [#13198](https://github.com/vitessio/vitess/pull/13198)
+ * Temporarily disable panic in mysqld when socket files are directly used [#13198](https://github.com/vitessio/vitess/pull/13198) 
 #### Observability
- * Reset the current lag when closing the replication lag reader. [#12683](https://github.com/vitessio/vitess/pull/12683)
+ * Reset the current lag when closing the replication lag reader. [#12683](https://github.com/vitessio/vitess/pull/12683) 
 #### Online DDL
  * Allow zero (in) date when setting up internal _vt schema [#12262](https://github.com/vitessio/vitess/pull/12262)
  * Online DDL: improve retry of vreplication errors with `vitess` `ALTER TABLE` migrations [#12323](https://github.com/vitessio/vitess/pull/12323)
@@ -65,10 +65,10 @@
  * Online DDL: `ready_to_complete` race fix [#12612](https://github.com/vitessio/vitess/pull/12612)
  * Mysqld.GetSchema: tolerate tables being dropped while inspecting schema [#12641](https://github.com/vitessio/vitess/pull/12641)
  * Flaky test fix: OnlineDDL: convert time->unix->TIMESTAMP in golang space [#12826](https://github.com/vitessio/vitess/pull/12826)
- * OnlineDDL: reject partial key coverage in PRIMARY KEY for vitess migrations [#12921](https://github.com/vitessio/vitess/pull/12921)
+ * OnlineDDL: reject partial key coverage in PRIMARY KEY for vitess migrations [#12921](https://github.com/vitessio/vitess/pull/12921) 
 #### Operator
  * Use latest k8s for operator example to work [#13085](https://github.com/vitessio/vitess/pull/13085)
- * Upgrade mysqld memory limits to 1024Mi [#13122](https://github.com/vitessio/vitess/pull/13122)
+ * Upgrade mysqld memory limits to 1024Mi [#13122](https://github.com/vitessio/vitess/pull/13122) 
 #### Query Serving
  * fix dual table handling [#12204](https://github.com/vitessio/vitess/pull/12204)
  * grpcvtgateconn: add Dial and deprecate DialWithOpts [#12210](https://github.com/vitessio/vitess/pull/12210)
@@ -111,12 +111,16 @@
  * Remove the `200` indentation limit in the SQL parser [#13158](https://github.com/vitessio/vitess/pull/13158)
  * vindexes: make lookup_unicodeloosemd5_hash non-planable [#13200](https://github.com/vitessio/vitess/pull/13200)
  * fix: GetField to use existing session for query [#13219](https://github.com/vitessio/vitess/pull/13219)
- * Fix and Make aggregation planner handle aggregation functions better and handle Distinct in operator [#13277](https://github.com/vitessio/vitess/pull/13277)
+ * [17.0] Fix and Make aggregation planner handle aggregation functions better and handle Distinct in operator [#13277](https://github.com/vitessio/vitess/pull/13277)
+ * Bug fix: SQL queries erroring with message `unknown aggregation random` [#13330](https://github.com/vitessio/vitess/pull/13330)
+ * bugfixes: collection of fixes to bugs found while fuzzing [#13332](https://github.com/vitessio/vitess/pull/13332)
+ * bug: don't always wrap aggregation in coalesce [#13348](https://github.com/vitessio/vitess/pull/13348) 
 #### TabletManager
  * TableFilter: fix excluded RE listing [#12318](https://github.com/vitessio/vitess/pull/12318)
  * TableGC: fix PURGE race condition [#12505](https://github.com/vitessio/vitess/pull/12505)
  * Fix transaction throttler ignoring the initial rate [#12618](https://github.com/vitessio/vitess/pull/12618)
  * Skip recalculating the rate in MaxReplicationLagModule when it can't be done [#12620](https://github.com/vitessio/vitess/pull/12620)
+ * mysqlctl: Correctly encode database and table names [#13312](https://github.com/vitessio/vitess/pull/13312) 
 #### VReplication
  * VReplication Last Error: retry error if it happens after timeout [#12114](https://github.com/vitessio/vitess/pull/12114)
  * VReplication: workflows with multiple streams fail to start on multi-primary setups [#12228](https://github.com/vitessio/vitess/pull/12228)
@@ -130,11 +134,11 @@
  * Flaky vplayer tests: temporarily disable noblob variant [#13100](https://github.com/vitessio/vitess/pull/13100)
  * VReplication: Do not delete sharded target vschema table entries on Cancel [#13146](https://github.com/vitessio/vitess/pull/13146)
  * VReplication: Handle reference tables in sharded->sharded MoveTables [#13161](https://github.com/vitessio/vitess/pull/13161)
- * VReplication: Fix VDiff2 DeleteByUUID Query [#13255](https://github.com/vitessio/vitess/pull/13255)
+ * VReplication: Fix VDiff2 DeleteByUUID Query [#13255](https://github.com/vitessio/vitess/pull/13255) 
 #### VTAdmin
  * [vtadmin] racy vtexplain [#12635](https://github.com/vitessio/vitess/pull/12635)
  * fix: vtadmin vttablet url protocol [#12836](https://github.com/vitessio/vitess/pull/12836)
- * update vite base to respect absolute path [#13110](https://github.com/vitessio/vitess/pull/13110)
+ * update vite base to respect absolute path [#13110](https://github.com/vitessio/vitess/pull/13110) 
 #### VTorc
  * Fix Vtorc recovery time during `DeadPrimary` [#12870](https://github.com/vitessio/vitess/pull/12870)
  * Add new field to health status [#12942](https://github.com/vitessio/vitess/pull/12942)
@@ -151,59 +155,63 @@
  * Flakes: Wait for throttler to open in throttler custom config test [#12980](https://github.com/vitessio/vitess/pull/12980)
  * Add minimal token permissions (continued) [#12996](https://github.com/vitessio/vitess/pull/12996)
  * workflows: Update to latest actions/setup-go [#13023](https://github.com/vitessio/vitess/pull/13023)
- * CI: add a check on NeedsIssue label [#13044](https://github.com/vitessio/vitess/pull/13044)
+ * CI: add a check on NeedsIssue label [#13044](https://github.com/vitessio/vitess/pull/13044) 
 #### Examples
- * Examples, Flakes: Wait for Shard's VReplication Engine to Open [#12560](https://github.com/vitessio/vitess/pull/12560)
+ * Examples, Flakes: Wait for Shard's VReplication Engine to Open [#12560](https://github.com/vitessio/vitess/pull/12560) 
 #### General
  * Bump reported version of main to 17.0.0-SNAPSHOT [#12234](https://github.com/vitessio/vitess/pull/12234)
- * Upgrade the Golang version to `go1.20.2` [#12706](https://github.com/vitessio/vitess/pull/12706)
+ * [main] Upgrade the Golang version to `go1.20.2` [#12706](https://github.com/vitessio/vitess/pull/12706)
  * Do not fail build on incorrect Go version [#12809](https://github.com/vitessio/vitess/pull/12809)
- * Upgrade the Golang version to `go1.20.3` [#12833](https://github.com/vitessio/vitess/pull/12833)
+ * [main] Upgrade the Golang version to `go1.20.3` [#12833](https://github.com/vitessio/vitess/pull/12833)
  * Remove misleading message in `build.env` [#12841](https://github.com/vitessio/vitess/pull/12841)
- * Upgrade the Golang version to `go1.20.4` [#13052](https://github.com/vitessio/vitess/pull/13052)
+ * [main] Upgrade the Golang version to `go1.20.4` [#13052](https://github.com/vitessio/vitess/pull/13052)
  * Code owners update [#13070](https://github.com/vitessio/vitess/pull/13070)
- * Upgrade the Golang version to `go1.20.5` [#13266](https://github.com/vitessio/vitess/pull/13266)
+ * [release-17.0] Upgrade the Golang version to `go1.20.5` [#13266](https://github.com/vitessio/vitess/pull/13266) 
 #### Online DDL
  * Fixing `onlineddl_vrepl` flakiness, and adding more tests [#12325](https://github.com/vitessio/vitess/pull/12325)
  * CI: extend timeouts in onlineddl_vrepl due to slow CI runners [#12583](https://github.com/vitessio/vitess/pull/12583)
- * CI: increase overall test timeouts for all OnlineDDL tests [#12584](https://github.com/vitessio/vitess/pull/12584)
+ * CI: increase overall test timeouts for all OnlineDDL tests [#12584](https://github.com/vitessio/vitess/pull/12584) 
 #### Query Serving
  * Fix `SHOW VSCHEMA TABLES` tests using v17 vtgate that expected `dual` [#12381](https://github.com/vitessio/vitess/pull/12381)
- * go/vt/vttablet/tabletserver: temporarily skip flaky consolidation test [#12604](https://github.com/vitessio/vitess/pull/12604)
+ * go/vt/vttablet/tabletserver: temporarily skip flaky consolidation test [#12604](https://github.com/vitessio/vitess/pull/12604) 
+#### VReplication
+ * [release-17.0] Flakes: Remove CI endtoend test for VReplication Copy Phase Throttling (#13343) [#13345](https://github.com/vitessio/vitess/pull/13345) 
 #### VTAdmin
  * Remove `nvm use` from vtadmin-up.sh script [#12788](https://github.com/vitessio/vitess/pull/12788)
-### Dependabot
+### Dependabot 
 #### Build/CI
  * Bump golang.org/x/net from 0.5.0 to 0.7.0 [#12390](https://github.com/vitessio/vitess/pull/12390)
  * Update additional Go dependencies [#12401](https://github.com/vitessio/vitess/pull/12401)
  * Fix another mixin dep [#12403](https://github.com/vitessio/vitess/pull/12403) 
 #### Observability
  * Bump vitess.io/vitess from 0.15.2 to 0.16.1 in /vitess-mixin [#12875](https://github.com/vitessio/vitess/pull/12875)
- * build(deps): bump vitess.io/vitess from 0.16.1 to 0.16.2 in /vitess-mixin [#13076](https://github.com/vitessio/vitess/pull/13076)
+ * build(deps): bump vitess.io/vitess from 0.16.1 to 0.16.2 in /vitess-mixin [#13076](https://github.com/vitessio/vitess/pull/13076) 
 #### VTAdmin
  * Bump dns-packet from 5.3.1 to 5.4.0 in /web/vtadmin [#12545](https://github.com/vitessio/vitess/pull/12545)
  * Bump webpack from 5.65.0 to 5.76.1 in /web/vtadmin [#12632](https://github.com/vitessio/vitess/pull/12632)
-### Documentation
+ * [release-17.0] build(deps-dev): bump vite from 4.2.1 to 4.2.3 in /web/vtadmin (#13240) [#13254](https://github.com/vitessio/vitess/pull/13254)
+### Documentation 
 #### Cluster management
- * fix help text for backup_storage_number_blocks [#12258](https://github.com/vitessio/vitess/pull/12258)
+ * fix help text for backup_storage_number_blocks [#12258](https://github.com/vitessio/vitess/pull/12258) 
 #### Documentation
  * release notes and misc cleanup around tabletenv flags [#12953](https://github.com/vitessio/vitess/pull/12953)
  * Add Vinted to the list of adopters [#13134](https://github.com/vitessio/vitess/pull/13134)
+ * update link for reparenting guide [#13350](https://github.com/vitessio/vitess/pull/13350) 
 #### Query Serving
  * Copy remaining query serving design docs [#12170](https://github.com/vitessio/vitess/pull/12170)
  * Add release notes summary for views [#12422](https://github.com/vitessio/vitess/pull/12422)
  * SQLError: adding some code comments [#12613](https://github.com/vitessio/vitess/pull/12613)
  * update v16 release notes about VTGate Advertised MySQL Version [#12957](https://github.com/vitessio/vitess/pull/12957)
-### Enhancement
+### Enhancement 
 #### ACL
- * remove tablet server's ACL check on the /healthz HTTP api route [#12897](https://github.com/vitessio/vitess/pull/12897)
+ * remove tablet server's ACL check on the /healthz HTTP api route [#12897](https://github.com/vitessio/vitess/pull/12897) 
 #### Backup and Restore
  * vtbackup, mysqlctl: detailed backup and restore metrics [#11979](https://github.com/vitessio/vitess/pull/11979)
  * go/vt/mysqlctl: add configurable read buffer to builtin backups [#12073](https://github.com/vitessio/vitess/pull/12073)
  * go/{vt,flags}: register builtin backup flags with vtbackup [#12558](https://github.com/vitessio/vitess/pull/12558)
  * go/vt/mysqlctl: optionally store decompressor cmd in manifest [#12633](https://github.com/vitessio/vitess/pull/12633)
  * Fix restore from backup execution path to use context from caller [#12828](https://github.com/vitessio/vitess/pull/12828)
- * Incremental backup and point in time recovery for XtraBackup  [#13156](https://github.com/vitessio/vitess/pull/13156)
+ * Incremental backup and point in time recovery for XtraBackup  [#13156](https://github.com/vitessio/vitess/pull/13156) 
 #### Build/CI
  * Revert default MySQL 80 version to `8.0.30` [#12252](https://github.com/vitessio/vitess/pull/12252)
  * Block merge if the `Do Not Merge` label is set [#12489](https://github.com/vitessio/vitess/pull/12489)
@@ -211,8 +219,9 @@
  * Add read-only token permissions to GitHub Action workflows [#12718](https://github.com/vitessio/vitess/pull/12718)
  * Remove unnecessary code bits in workflows [#12756](https://github.com/vitessio/vitess/pull/12756)
  * tools/build_version_flags: allow configurable `build time` [#12876](https://github.com/vitessio/vitess/pull/12876)
+ * Set the number of threads for release notes generation with a flag [#13273](https://github.com/vitessio/vitess/pull/13273) 
 #### CLI
- * [flags] extract tabletenv seconds type [#12920](https://github.com/vitessio/vitess/pull/12920)
+ * [flags] extract tabletenv seconds type [#12920](https://github.com/vitessio/vitess/pull/12920) 
 #### Cluster management
  * Introducing new error counter in VTTablet  [#12266](https://github.com/vitessio/vitess/pull/12266)
  * Auto refresh tables on vtgate Status Page [#12335](https://github.com/vitessio/vitess/pull/12335)
@@ -220,7 +229,7 @@
  * Add tablet type filtering to vtctldclient GetTablets [#12915](https://github.com/vitessio/vitess/pull/12915)
  * topo: Move to allow list for invalid names [#12917](https://github.com/vitessio/vitess/pull/12917)
  * Add vstream metrics to vtgate [#13098](https://github.com/vitessio/vitess/pull/13098)
- * increase length of reparent_journal columns (#13287) [#13291](https://github.com/vitessio/vitess/pull/13291)
+ * [release-17.0] increase length of reparent_journal columns (#13287) [#13291](https://github.com/vitessio/vitess/pull/13291) 
 #### Evalengine
  * evalengine: virtual machine [#12369](https://github.com/vitessio/vitess/pull/12369)
  * Add 128 bit hashing for the evalengine [#12428](https://github.com/vitessio/vitess/pull/12428)
@@ -252,18 +261,19 @@
  * evalengine: `INTERVAL` support [#13073](https://github.com/vitessio/vitess/pull/13073)
  * evalengine: Implement IP related functions [#13082](https://github.com/vitessio/vitess/pull/13082)
  * evalengine: Implement `CONCAT` and `CONCAT_WS` [#13091](https://github.com/vitessio/vitess/pull/13091)
- * evalengine: Add UUID functions [#13097](https://github.com/vitessio/vitess/pull/13097)
+ * evalengine: Add UUID functions [#13097](https://github.com/vitessio/vitess/pull/13097) 
 #### Examples
- * examples schema: demi-idempotency via CREATE TABLE IF NOT EXISTS [#12453](https://github.com/vitessio/vitess/pull/12453)
+ * examples schema: demi-idempotency via CREATE TABLE IF NOT EXISTS [#12453](https://github.com/vitessio/vitess/pull/12453) 
 #### General
  * Upgrade to `go1.20.1` [#12399](https://github.com/vitessio/vitess/pull/12399)
  * adding log statment to vtbackup [#12569](https://github.com/vitessio/vitess/pull/12569)
  * Automatically add milestone to new Pull Request [#12759](https://github.com/vitessio/vitess/pull/12759)
- * Remove viper warnings from local examples [#13234](https://github.com/vitessio/vitess/pull/13234)
+ * Miscellaneous code modifications based on observations made while doing a code walkthrough [#12873](https://github.com/vitessio/vitess/pull/12873)
+ * Remove viper warnings from local examples [#13234](https://github.com/vitessio/vitess/pull/13234) 
 #### Observability
  * Add `Uptime` metric [#12712](https://github.com/vitessio/vitess/pull/12712)
  * go/{stats,vt}: publish VReplicationStreamState to prometheus backend [#12772](https://github.com/vitessio/vitess/pull/12772)
- * [vtadmin] log response errors [#12844](https://github.com/vitessio/vitess/pull/12844)
+ * [vtadmin] log response errors [#12844](https://github.com/vitessio/vitess/pull/12844) 
 #### Online DDL
  * schemadiff/OnlineDDL: ExtractConstraintOriginalName understands auto-generated names [#12275](https://github.com/vitessio/vitess/pull/12275)
  * schemadiff: diffing two schemas generates a rich SchemaDiff object [#12551](https://github.com/vitessio/vitess/pull/12551)
@@ -271,7 +281,7 @@
  * Online DDL: configurable cut-over threshold [#12594](https://github.com/vitessio/vitess/pull/12594)
  * gh-ost migrations: improved error log message [#12882](https://github.com/vitessio/vitess/pull/12882)
  * OnlineDDL/vitess: only KILL 'RENAME' statement if not known to be successful [#12989](https://github.com/vitessio/vitess/pull/12989)
- * Online DDL: better reporting of error message when RENAME fails [#13143](https://github.com/vitessio/vitess/pull/13143)
+ * Online DDL: better reporting of error message when RENAME fails [#13143](https://github.com/vitessio/vitess/pull/13143) 
 #### Query Serving
  * VSCopy: Enable to copy from all shards in either a specified keyspace or all keyspaces [#11909](https://github.com/vitessio/vitess/pull/11909)
  * vtgate: metrics for prepared stmts [#12141](https://github.com/vitessio/vitess/pull/12141)
@@ -280,7 +290,7 @@
  * evalengine: new evaluation framework [#12247](https://github.com/vitessio/vitess/pull/12247)
  * evalengine: it's time for JSON! [#12274](https://github.com/vitessio/vitess/pull/12274)
  * Add parsing support for linestring constructor [#12299](https://github.com/vitessio/vitess/pull/12299)
- * Add database name to _vt.views table (#12368) [#12374](https://github.com/vitessio/vitess/pull/12374)
+ * [main] add database name to _vt.views table (#12368) [#12374](https://github.com/vitessio/vitess/pull/12374)
  * Schema RPC to fetch table/view definition [#12375](https://github.com/vitessio/vitess/pull/12375)
  * sqlparser: add parsing support for polygon spatial datatype [#12377](https://github.com/vitessio/vitess/pull/12377)
  * Emit per workload labels for existing per table vttablet metrics [#12394](https://github.com/vitessio/vitess/pull/12394)
@@ -324,20 +334,20 @@
  * Add parsing support to geomCollection property functions and geohash/geojson functions [#13072](https://github.com/vitessio/vitess/pull/13072)
  * Schema Tracking Refactor: Merge schema-tracking in health-streamer into schema.Engine [#13121](https://github.com/vitessio/vitess/pull/13121)
  * enable settings pool by default [#13127](https://github.com/vitessio/vitess/pull/13127)
- * Augmenting the `GetSchema` RPC to also work for `Table` and `All` type of input [#13197](https://github.com/vitessio/vitess/pull/13197)
+ * Augmenting the `GetSchema` RPC to also work for `Table` and `All` type of input [#13197](https://github.com/vitessio/vitess/pull/13197) 
 #### TabletManager
  * ApplySchema: deprecate '--skip_preflight' flag [#10716](https://github.com/vitessio/vitess/pull/10716)
  * Update tabletpicker to support cell pref and tablet order options [#12282](https://github.com/vitessio/vitess/pull/12282)
  * SidecarDB Init: don't fail on schema init errors [#12328](https://github.com/vitessio/vitess/pull/12328)
  * Tablet throttler: adding log entries [#12966](https://github.com/vitessio/vitess/pull/12966)
  * Tablet throttler: throttler-config-via-topo defaults 'true', deprecation message for old flags [#13130](https://github.com/vitessio/vitess/pull/13130)
- * Tablet throttler: be explicit about client app name, exempt some apps from checks and heartbeat renewals [#13195](https://github.com/vitessio/vitess/pull/13195)
+ * Tablet throttler: be explicit about client app name, exempt some apps from checks and heartbeat renewals [#13195](https://github.com/vitessio/vitess/pull/13195) 
 #### VReplication
- * VReplication: Use MariaDB Compat JSON Functions (#12420) [#12434](https://github.com/vitessio/vitess/pull/12434)
+ * [main] VReplication: Use MariaDB Compat JSON Functions (#12420) [#12434](https://github.com/vitessio/vitess/pull/12434)
  * Add Workflow Update Client Command [#12622](https://github.com/vitessio/vitess/pull/12622)
  * VDiff: Add --update-table-stats flag to VDiff2 [#12868](https://github.com/vitessio/vitess/pull/12868)
  * VReplication: Support MySQL Binary Log Transaction Compression  [#12950](https://github.com/vitessio/vitess/pull/12950)
- * VReplication: More intelligently manage vschema table entries on unsharded targets [#13220](https://github.com/vitessio/vitess/pull/13220)
+ * VReplication: More intelligently manage vschema table entries on unsharded targets [#13220](https://github.com/vitessio/vitess/pull/13220) 
 #### VTorc
  * vtorc: have cooldown only apply to the same kind of analysis [#13103](https://github.com/vitessio/vitess/pull/13103) 
 #### web UI
@@ -347,30 +357,30 @@
 #### Cluster management
  * Initialize Tablet with super_read_only mode [#12206](https://github.com/vitessio/vitess/pull/12206) 
 #### Online DDL
- * SchemaDiff: normalize boolean columns to tinyint(1), and, add TableQualifier hint to force adding a db qualifier to the alter diff. [#12133](https://github.com/vitessio/vitess/pull/12133)
+ * SchemaDiff: normalize boolean columns to tinyint(1), and, add TableQualifier hint to force adding a db qualifier to the alter diff. [#12133](https://github.com/vitessio/vitess/pull/12133) 
 #### Query Serving
  * Support Custom SidecarDB Names on VTTablets [#12240](https://github.com/vitessio/vitess/pull/12240)
  * Create Views allowed for same keyspace [#12409](https://github.com/vitessio/vitess/pull/12409)
  * Add Prepare, Execute and Deallocate Statement Support related to prepared statement [#12752](https://github.com/vitessio/vitess/pull/12752)
  * feat: keep track of the full table name of expanded columns [#12976](https://github.com/vitessio/vitess/pull/12976)
- * gen4 planner: push aggregation under filtering [#13169](https://github.com/vitessio/vitess/pull/13169)
+ * gen4 planner: push aggregation under filtering [#13169](https://github.com/vitessio/vitess/pull/13169) 
 #### VReplication
  * Workflow Show: display rows copied  [#12231](https://github.com/vitessio/vitess/pull/12231)
- * VReplication Workflows: support noblob binlog_row_image format for MoveTables and Reshard [#12905](https://github.com/vitessio/vitess/pull/12905)
+ * VReplication Workflows: support noblob binlog_row_image format for MoveTables and Reshard [#12905](https://github.com/vitessio/vitess/pull/12905) 
 #### VTAdmin
  * [VTAdmin] Add GetSrvKeyspaces and GetSrvKeyspace [#12702](https://github.com/vitessio/vitess/pull/12702)
  * Add panic recovery handler to vtadmin http middleware [#12864](https://github.com/vitessio/vitess/pull/12864)
 ### Internal Cleanup 
 #### Build/CI
  * Stop launchable integration for unit tests [#12386](https://github.com/vitessio/vitess/pull/12386)
- * Run launchable only on PRs against `main`  [#12694](https://github.com/vitessio/vitess/pull/12694)
+ * Run launchable only on PRs against `main`  [#12694](https://github.com/vitessio/vitess/pull/12694) 
 #### CLI
  * Cleanup TODOs in vtorc flag parsing code from v15 [#12787](https://github.com/vitessio/vitess/pull/12787)
- * [vtctld] Delete legacy dual purpose duration/int flag parsing [#12860](https://github.com/vitessio/vitess/pull/12860)
+ * [vtctld] Delete legacy dual purpose duration/int flag parsing [#12860](https://github.com/vitessio/vitess/pull/12860) 
 #### Cluster management
  * delete deprecated vtctld healthcheck flags and associated realtime stats code [#12373](https://github.com/vitessio/vitess/pull/12373)
  * [misc] Delete `automation*` protos [#12449](https://github.com/vitessio/vitess/pull/12449)
- * Deprecate `durability_policy` flag in vtctld [#12930](https://github.com/vitessio/vitess/pull/12930)
+ * Deprecate `durability_policy` flag in vtctld [#12930](https://github.com/vitessio/vitess/pull/12930) 
 #### Evalengine
  * evalengine: use 128 bit hashing internally [#12452](https://github.com/vitessio/vitess/pull/12452)
  * evalengine: Refactorings & fixes [#12554](https://github.com/vitessio/vitess/pull/12554)
@@ -378,9 +388,9 @@
  * Move the JSON parser from evalengine [#12757](https://github.com/vitessio/vitess/pull/12757)
  * datetime: Unify parse and print APIs [#12815](https://github.com/vitessio/vitess/pull/12815)
  * evalengine/compiler: Unify compilation [#12913](https://github.com/vitessio/vitess/pull/12913)
- * mysql/evalengine: Unify float parsing [#12979](https://github.com/vitessio/vitess/pull/12979)
+ * mysql/evalengine: Unify float parsing [#12979](https://github.com/vitessio/vitess/pull/12979) 
 #### Examples
- * Remove `are-you-alive` example [#12432](https://github.com/vitessio/vitess/pull/12432)
+ * Remove `are-you-alive` example [#12432](https://github.com/vitessio/vitess/pull/12432) 
 #### General
  * Fix CodeQL identified issues [#12199](https://github.com/vitessio/vitess/pull/12199)
  * Fix typecasting issue for workflow types [#12217](https://github.com/vitessio/vitess/pull/12217)
@@ -394,7 +404,7 @@
  * Remove a bunch of debug logging [#12404](https://github.com/vitessio/vitess/pull/12404)
  * Update the pull request template to include a checkpoint for verifying modified/created tests aren't flaky [#12443](https://github.com/vitessio/vitess/pull/12443)
  * Add steps on how to merge during code-freeze [#12444](https://github.com/vitessio/vitess/pull/12444)
- * Add a known issue into the release notes for xtrabackup and DDLs (#12536) [#12537](https://github.com/vitessio/vitess/pull/12537)
+ * [main] Add a known issue into the release notes for xtrabackup and DDLs (#12536) [#12537](https://github.com/vitessio/vitess/pull/12537)
  * Remove unused JQuery includes [#12552](https://github.com/vitessio/vitess/pull/12552)
  * Minor Cleanup of SidecarDB Package [#12652](https://github.com/vitessio/vitess/pull/12652)
  * [misc] Cleanup/fix/delete TODO comments [#12758](https://github.com/vitessio/vitess/pull/12758)
@@ -408,15 +418,16 @@
  * coverage: Remove sonar coverage setup [#13000](https://github.com/vitessio/vitess/pull/13000)
  * Update GOVERNANCE.md [#13047](https://github.com/vitessio/vitess/pull/13047)
  * Deprecate VTGR [#13301](https://github.com/vitessio/vitess/pull/13301)
+ * Cherry-pick all pending PRs into `release-17.0` [#13364](https://github.com/vitessio/vitess/pull/13364) 
 #### Governance
- * Added [Twitter] & [Etsy] to ADOPTERS.md [#12508](https://github.com/vitessio/vitess/pull/12508)
+ * Added [Twitter] & [Etsy] to ADOPTERS.md [#12508](https://github.com/vitessio/vitess/pull/12508) 
 #### Observability
- * flags: deprecate vtctld_addr and delete related code [#12580](https://github.com/vitessio/vitess/pull/12580)
+ * flags: deprecate vtctld_addr and delete related code [#12580](https://github.com/vitessio/vitess/pull/12580) 
 #### Online DDL
  * Deprecating VExec, part 2 - *post v16* [#12074](https://github.com/vitessio/vitess/pull/12074)
  * Online DDL: remove legacy "stowaway table" logic [#12288](https://github.com/vitessio/vitess/pull/12288)
  * [onlineddl] Remove some old backwards-compatibilities in online ddl code [#12427](https://github.com/vitessio/vitess/pull/12427)
- * Query executor: preparing for `SHOW VITESS_MIGRATIONS` via `ShowBasic` [#12688](https://github.com/vitessio/vitess/pull/12688)
+ * Query executor: preparing for `SHOW VITESS_MIGRATIONS` via `ShowBasic` [#12688](https://github.com/vitessio/vitess/pull/12688) 
 #### Query Serving
  * [vtgate planner] Routing & Merging refactor [#12197](https://github.com/vitessio/vitess/pull/12197)
  * Use the correct uint32 type for the GTID file position [#12229](https://github.com/vitessio/vitess/pull/12229)
@@ -440,27 +451,27 @@
  * fix misleading primary not serving message [#13022](https://github.com/vitessio/vitess/pull/13022)
  * Remove enable-query-plan-field-caching flag that was deprecated in v15 [#13141](https://github.com/vitessio/vitess/pull/13141)
  * sqlparser: Improve interval parsing [#13165](https://github.com/vitessio/vitess/pull/13165)
- * refactor QueryProjection [#13174](https://github.com/vitessio/vitess/pull/13174)
+ * refactor QueryProjection [#13174](https://github.com/vitessio/vitess/pull/13174) 
 #### TabletManager
  * Table GC: remove spammy log entry [#12625](https://github.com/vitessio/vitess/pull/12625)
  * mysqlctl: Remove unused schema version [#12999](https://github.com/vitessio/vitess/pull/12999)
  * vttablet: Cleanup unused db version string [#13102](https://github.com/vitessio/vitess/pull/13102)
  * mysqlctl: Remove custom callbacks [#13119](https://github.com/vitessio/vitess/pull/13119)
  * mysqlctl: Remove usage of MYSQL_FLAVOR [#13135](https://github.com/vitessio/vitess/pull/13135)
- * k8stopo: Include deprecation warning (#13299) [#13302](https://github.com/vitessio/vitess/pull/13302)
+ * [release-17.0] k8stopo: Include deprecation warning (#13299) [#13302](https://github.com/vitessio/vitess/pull/13302) 
 #### VReplication
  * Use consistent type for vreplication id [#12218](https://github.com/vitessio/vitess/pull/12218)
- * Use consistent type port and replication state [#12248](https://github.com/vitessio/vitess/pull/12248)
+ * Use consistent type port and replication state [#12248](https://github.com/vitessio/vitess/pull/12248) 
 #### VTAdmin
- * [vtadmin-api] standardize cluster ids [#12803](https://github.com/vitessio/vitess/pull/12803)
+ * [vtadmin-api] standardize cluster ids [#12803](https://github.com/vitessio/vitess/pull/12803) 
 #### VTorc
  * Cleanup vtorc ssl package [#12423](https://github.com/vitessio/vitess/pull/12423)
- * vtgr: Remove unused code [#12975](https://github.com/vitessio/vitess/pull/12975)
+ * vtgr: Remove unused code [#12975](https://github.com/vitessio/vitess/pull/12975) 
 #### web UI
  * Add nvm and node to vtadmin-up.sh [#12439](https://github.com/vitessio/vitess/pull/12439)
 ### Performance 
 #### General
- * Use `MarshalVT`/`UnmarshalVT` instead of `proto.Marshal`/`proto.Unmarshal`. [#12525](https://github.com/vitessio/vitess/pull/12525)
+ * Use `MarshalVT`/`UnmarshalVT` instead of `proto.Marshal`/`proto.Unmarshal`. [#12525](https://github.com/vitessio/vitess/pull/12525) 
 #### Online DDL
  * OnlineDDL: optimizing --singleton-context conflict check [#12539](https://github.com/vitessio/vitess/pull/12539)
 ### RFC 
@@ -469,10 +480,13 @@
 ### Regression 
 #### ACL
  * vtgate : Disable Automatically setting immediateCallerID to user from static authentication context  [#12961](https://github.com/vitessio/vitess/pull/12961) 
+#### Backup and Restore
+ * Add RestorePosition and RestoredBackupTime as metrics to vttablet [#13339](https://github.com/vitessio/vitess/pull/13339) 
 #### Query Serving
  * gen4 planner bugfix: issue when merging subqueries [#13025](https://github.com/vitessio/vitess/pull/13025)
  * gen4 planner: allow last_insert_id with arguments [#13026](https://github.com/vitessio/vitess/pull/13026)
  * fix: ShardedRouting clone to clone slice of reference correctly [#13265](https://github.com/vitessio/vitess/pull/13265)
+ * [release-17.0] Handle inconsistent state error in query buffering (#13333) [#13353](https://github.com/vitessio/vitess/pull/13353)
 ### Release 
 #### Documentation
  * Update the release instructions after v16 code freeze [#12245](https://github.com/vitessio/vitess/pull/12245)
@@ -481,7 +495,8 @@
  * Update the release instructions for the local install guide [#12746](https://github.com/vitessio/vitess/pull/12746)
  * Fix incorrect path during release notes generation [#12769](https://github.com/vitessio/vitess/pull/12769)
  * Fix format error in the `v16.0.2` release notes [#13057](https://github.com/vitessio/vitess/pull/13057)
- * consolidate all deprecated flags under one header in release notes [#13163](https://github.com/vitessio/vitess/pull/13163) 
+ * consolidate all deprecated flags under one header in release notes [#13163](https://github.com/vitessio/vitess/pull/13163)
+ * Prepare and clean summary docs for `v17.0.0` [#13363](https://github.com/vitessio/vitess/pull/13363) 
 #### General
  * Fix release script for the version in the docker script [#12284](https://github.com/vitessio/vitess/pull/12284)
  * Improve release process post `v16.0.0 GA` code freeze [#12487](https://github.com/vitessio/vitess/pull/12487)
@@ -493,29 +508,33 @@
  * Release of v17.0.0-rc1 [#13211](https://github.com/vitessio/vitess/pull/13211)
  * Back to dev mode [#13249](https://github.com/vitessio/vitess/pull/13249)
  * Code freeze of release-17.0 for rc2 [#13296](https://github.com/vitessio/vitess/pull/13296)
+ * Release of v17.0.0-rc2 [#13305](https://github.com/vitessio/vitess/pull/13305)
+ * Back to dev mode after v17.0.0-rc2 [#13313](https://github.com/vitessio/vitess/pull/13313) 
 #### VTAdmin
  * Add the vtadmin `web` directory to the release packages [#12639](https://github.com/vitessio/vitess/pull/12639)
 ### Testing 
 #### Build/CI
  * testutils: use a rows parser for test comparisons [#12138](https://github.com/vitessio/vitess/pull/12138)
- * Don't keep data in upgrade-downgrade tests (#12462) [#12465](https://github.com/vitessio/vitess/pull/12465)
+ * [main] Don't keep data in upgrade-downgrade tests (#12462) [#12465](https://github.com/vitessio/vitess/pull/12465)
  * Flakes: Address Common Unit Test Races [#12546](https://github.com/vitessio/vitess/pull/12546)
  * Throttler: Expose Tablet's Config & Leverage to Deflake Tests [#12737](https://github.com/vitessio/vitess/pull/12737)
  * Remove TODO from e2e upgrade test [#12792](https://github.com/vitessio/vitess/pull/12792)
  * fakesqldb: Guard query log usage with lock [#12813](https://github.com/vitessio/vitess/pull/12813)
  * fakedbclient: Add locking to avoid races [#12814](https://github.com/vitessio/vitess/pull/12814)
  * test: fix cfc flaky test [#12941](https://github.com/vitessio/vitess/pull/12941)
- * [ci] add generator for templated flag testdata [#13150](https://github.com/vitessio/vitess/pull/13150)
+ * [ci] add generator for templated flag testdata [#13150](https://github.com/vitessio/vitess/pull/13150) 
+#### CLI
+ * Skip `--config-file-not-found-handling` in upgrade downgrade tests when `vttablet < 17.x.x` [#13275](https://github.com/vitessio/vitess/pull/13275) 
 #### Evalengine
  * evalengine: Try to reduce test flakyness around time [#12819](https://github.com/vitessio/vitess/pull/12819)
- * evalengine: Skip integration tests under race detector [#12948](https://github.com/vitessio/vitess/pull/12948)
+ * evalengine: Skip integration tests under race detector [#12948](https://github.com/vitessio/vitess/pull/12948) 
 #### Examples
- * Examples: Add ENV Var to Local Examples to Skip VTAdmin [#12547](https://github.com/vitessio/vitess/pull/12547)
+ * Examples: Add ENV Var to Local Examples to Skip VTAdmin [#12547](https://github.com/vitessio/vitess/pull/12547) 
 #### General
  * Fix fullstatus test for backward compat [#12685](https://github.com/vitessio/vitess/pull/12685)
- * VDiff: cleanup test log output [#12840](https://github.com/vitessio/vitess/pull/12840)
+ * VDiff: cleanup test log output [#12840](https://github.com/vitessio/vitess/pull/12840) 
 #### Online DDL
- * OnlineDDL endtoend/CI: timestamp deviation toleration [#13046](https://github.com/vitessio/vitess/pull/13046)
+ * OnlineDDL endtoend/CI: timestamp deviation toleration [#13046](https://github.com/vitessio/vitess/pull/13046) 
 #### Query Serving
  * Use atomic.Bool for fakesqldb behavior flags [#12603](https://github.com/vitessio/vitess/pull/12603)
  * go/{mysql,sync2,vt}: rework tabletserver consolidator test, modify consolidator result type [#12609](https://github.com/vitessio/vitess/pull/12609)
@@ -523,16 +542,16 @@
  * fix: deflake TestGetSchemaRPC test [#12977](https://github.com/vitessio/vitess/pull/12977)
  * Fix `TestStartFindMysqlPort` test flakiness [#13019](https://github.com/vitessio/vitess/pull/13019)
  * Fix benchmarks in `plan_test.go` [#13096](https://github.com/vitessio/vitess/pull/13096)
- * tests: stop tests not supported by older versions from running [#13183](https://github.com/vitessio/vitess/pull/13183)
+ * tests: stop tests not supported by older versions from running [#13183](https://github.com/vitessio/vitess/pull/13183) 
 #### VReplication
  * Flakes: Use new healthy shard check in vreplication e2e tests [#12502](https://github.com/vitessio/vitess/pull/12502)
  * Flakes: Handle Non-Determinstic Shard Ordering in VGTID [#12637](https://github.com/vitessio/vitess/pull/12637)
  * Flakes: Handle Non-Deterministic VStream Event Ordering [#12642](https://github.com/vitessio/vitess/pull/12642)
  * vreplication: Run all appropriate tests [#12862](https://github.com/vitessio/vitess/pull/12862)
  * Generated Invisible Primary Keys: add vreplication test cases  [#13004](https://github.com/vitessio/vitess/pull/13004)
- * Flakes: enforce no concurrency/parallelism in vreplication unit test framework [#13104](https://github.com/vitessio/vitess/pull/13104)
+ * Flakes: enforce no concurrency/parallelism in vreplication unit test framework [#13104](https://github.com/vitessio/vitess/pull/13104) 
 #### VTAdmin
- * [vtctldserver] Remove parallelization from tests that mutate shared state [#12257](https://github.com/vitessio/vitess/pull/12257)
+ * [vtctldserver] Remove parallelization from tests that mutate shared state [#12257](https://github.com/vitessio/vitess/pull/12257) 
 #### VTorc
  * Fix flakiness in `TestDeadPrimaryRecoversImmediately` [#13232](https://github.com/vitessio/vitess/pull/13232)
 

--- a/changelog/17.0/17.0.0/release_notes.md
+++ b/changelog/17.0/17.0.0/release_notes.md
@@ -12,6 +12,7 @@
     - [Shard name validation in TopoServer](#shard-name-validation)
     - [Compression CLI flags removed from vtctld and vtctldclient binaries](#remove-compression-flags-from-vtctld-binaries)
     - [VtctldClient command RestoreFromBackup will now use the correct context](#vtctldclient-command-restorefrombackup-will-now-use-the-correct-context)
+    - [VTTablet Restore Metrics](#vttablet-restore-metrics)
   - **[New command line flags and behavior](#new-flag)**
     - [Builtin backup: read buffering flags](#builtin-backup-read-buffering-flags)
     - [Manifest backup external decompressor command](#manifest-backup-external-decompressor-command)
@@ -133,6 +134,11 @@ The VtctldClient command `RestoreFromBackup` initiates an asynchronous process o
 Prior to v17, this asynchronous process could run indefinitely in the background since it was called using the background context. In v17 [PR#12830](https://github.com/vitessio/vitess/issues/12830),
 this behavior was changed to use a context with a timeout of `action_timeout`. If you are using VtctldClient to initiate a restore, make sure you provide an appropriate value for action_timeout to give enough
 time for the restore process to complete. Otherwise, the restore will throw an error if the context expires before it completes.
+
+#### <a id="vttablet-restore-metrics">VTTablet Restore Metrics
+
+As part of the VTTablet Sidecar Schema Maintenance Refactor in v16.0.0, we dropped the `local_metadata` table from the sidecar database schema. This table was storing a couple of metrics related to restores from backup.
+They have now been re-introduced as metrics that can be accessed from `/debug/vars`.
 
 ### <a id="Vttablet-TxThrottler">Vttablet's transaction throttler now also throttles DML outside of `BEGIN; ...; COMMIT;` blocks
 

--- a/changelog/17.0/17.0.0/release_notes.md
+++ b/changelog/17.0/17.0.0/release_notes.md
@@ -1,4 +1,4 @@
-# Release of Vitess v17.0.0-rc2
+# Release of Vitess v17.0.0
 ## Summary
 
 ### Table of Contents
@@ -11,8 +11,7 @@
     - [Keyspace name validation in TopoServer](#keyspace-name-validation)
     - [Shard name validation in TopoServer](#shard-name-validation)
     - [Compression CLI flags removed from vtctld and vtctldclient binaries](#remove-compression-flags-from-vtctld-binaries)
-    - [VtctldClient command RestoreFromBackup will now use the correct context](#VtctldClient-RestoreFromBackup)
-    - [VTTablet Restore Metrics](#vttablet-restore-metrics)
+    - [VtctldClient command RestoreFromBackup will now use the correct context](#vtctldclient-command-restorefrombackup-will-now-use-the-correct-context)
   - **[New command line flags and behavior](#new-flag)**
     - [Builtin backup: read buffering flags](#builtin-backup-read-buffering-flags)
     - [Manifest backup external decompressor command](#manifest-backup-external-decompressor-command)
@@ -61,8 +60,8 @@ func NewTabletPicker(
 Where ctx, localCell, option are all new parameters.
 
 `option` is of type `TabletPickerOptions` and includes two fields, `CellPreference` and `TabletOrder`.
-CellPreference`: "PreferLocalWithAlias" (default) gives preference to vtgate's local cell, or "OnlySpecified" which only picks from the cells explicitly passed in by the client
-`TabletOrder`: "Any" (default) for no ordering or random, or "InOrder" to use the order specified by the client
+- `CellPreference`: "PreferLocalWithAlias" (default) gives preference to vtgate's local cell, or "OnlySpecified" which only picks from the cells explicitly passed in by the client
+- `TabletOrder`: "Any" (default) for no ordering or random, or "InOrder" to use the order specified by the client
 
 See [PR 12282 Description](https://github.com/vitessio/vitess/pull/12282) for examples on how this changes cell picking behavior.
 
@@ -70,9 +69,11 @@ See [PR 12282 Description](https://github.com/vitessio/vitess/pull/12282) for ex
 
 When using TLS with `vtgr`, we now default to TLS 1.2 if no other explicit version is configured. Configuration flags are provided to explicitly configure the minimum TLS version to be used.
 
+`vtgr` is now deprecated as part of `v17.0.0`, please see [the deprecation notice](#deprecated-vtgr).
+
 #### <a id="dedicated-vtgate-prepare-stats">Dedicated stats for VTGate Prepare operations
 
-Prior to v17 Vitess incorrectly combined stats for VTGate Execute and Prepare operations under a single stats key (`Execute`). In v17 Execute and Prepare operations generate stats under independent stats keys.
+Prior to v17 Vitess incorrectly combined stats for VTGate `Execute` and `Prepare` operations under a single stats key (`Execute`). In v17 `Execute` and `Prepare` operations generate stats under independent stats keys.
 
 Here is a (condensed) example of stats output:
 
@@ -128,15 +129,10 @@ The CLI flags below were mistakenly added to `vtctld` and `vtctldclient` in v15.
 
 #### <a id="VtctldClient-RestoreFromBackup">VtctldClient command RestoreFromBackup will now use the correct context
 
-The VtctldClient command RestoreFromBackup initiates an asynchronous process on the specified tablet to restore data from either the latest backup or the closest one before the specified backup-timestamp.
+The VtctldClient command `RestoreFromBackup` initiates an asynchronous process on the specified tablet to restore data from either the latest backup or the closest one before the specified backup-timestamp.
 Prior to v17, this asynchronous process could run indefinitely in the background since it was called using the background context. In v17 [PR#12830](https://github.com/vitessio/vitess/issues/12830),
 this behavior was changed to use a context with a timeout of `action_timeout`. If you are using VtctldClient to initiate a restore, make sure you provide an appropriate value for action_timeout to give enough
 time for the restore process to complete. Otherwise, the restore will throw an error if the context expires before it completes.
-
-#### <a id="vttablet-restore-metrics">VTTablet Restore Metrics
-
-As part of the VTTablet Sidecar Schema Maintenance Refactor in v16.0.0, we dropped the `local_metadata` table from the sidecar database schema. This table was storing a couple of metrics related to restores from backup.
-They have now been re-introduced as metrics that can be accessed from `/debug/vars`.
 
 ### <a id="Vttablet-TxThrottler">Vttablet's transaction throttler now also throttles DML outside of `BEGIN; ...; COMMIT;` blocks
 
@@ -147,12 +143,12 @@ In v17 [PR#13040](https://github.com/vitessio/vitess/issues/13037), this behavio
 
 #### <a id="builtin-backup-read-buffering-flags"/>Backup --builtinbackup-file-read-buffer-size and --builtinbackup-file-write-buffer-size
 
-Prior to v17 the builtin Backup Engine does not use read buffering for restores, and for backups uses a hardcoded write buffer size of 2097152 bytes.
+Prior to v17 the builtin Backup Engine does not use read buffering for restores, and for backups uses a hardcoded write buffer size of `2097152 bytes`.
 
 In v17 these defaults may be tuned with, respectively `--builtinbackup-file-read-buffer-size` and `--builtinbackup-file-write-buffer-size`.
 
-- `--builtinbackup-file-read-buffer-size`:  read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
-- `--builtinbackup-file-write-buffer-size`: write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
+- `--builtinbackup-file-read-buffer-size`:  read files using an IO buffer of this many bytes. Golang defaults are used when set to `0`.
+- `--builtinbackup-file-write-buffer-size`: write files using an IO buffer of this many bytes. Golang defaults are used when set to `0`. (default `2097152`)
 
 These flags are applicable to the following programs:
 
@@ -189,7 +185,9 @@ Note that this flag overrides `--enable-lag-throttler` and `--throttle-threshold
 
 Metrics related to backup operations are available in both Vtbackup and VTTablet.
 
-**BackupBytes, BackupCount, BackupDurationNanoseconds**
+- `BackupBytes`
+- `BackupCount`
+- `BackupDurationNanosecond`
 
 Depending on the Backup Engine and Backup Storage in-use, a backup may be a complex pipeline of operations, including but not limited to:
 
@@ -201,9 +199,11 @@ These operations are counted and timed, and the number of bytes consumed or prod
 
 ##### Restore metrics
 
-Metrics related to restore operations are available in both Vtbackup and VTTablet.
+Metrics related to restore operations are available in both Vtbackup and VTTablet:
 
-**RestoreBytes, RestoreCount, RestoreDurationNanoseconds**
+- `RestoreBytes`
+- `RestoreCount`
+- `RestoreDurationNanoseconds`
 
 Depending on the Backup Engine and Backup Storage in-use, a restore may be a complex pipeline of operations, including but not limited to:
 
@@ -215,13 +215,13 @@ These operations are counted and timed, and the number of bytes consumed or prod
 
 ##### Vtbackup metrics
 
-Vtbackup exports some metrics which are not available elsewhere.
+Vtbackup exports some metrics which are not available elsewhere:
 
-**DurationByPhaseSeconds**
+- `DurationByPhaseSeconds`
 
 Vtbackup fetches the last backup, restores it to an empty mysql installation, replicates recent changes into that installation, and then takes a backup of that installation.
 
-_DurationByPhaseSeconds_ exports timings for these individual phases.
+`DurationByPhaseSeconds` exports timings for these individual phases.
 
 ##### Example
 
@@ -404,7 +404,7 @@ This could be a breaking change for grpc api users based on how they have implem
 Gen4 planner was made default in v14 for `SELECT` queries. In v15 `UPDATE` and `DELETE` queries were moved to Gen4 framework.
 With this release `INSERT` queries are moved to Gen4.
 
-Clients can move to old v3 planner for inserts by using `V3Insert` planner version with `--planner-version` vtgate flag or with comment directive `/*vt+ planner=<planner_version>` for individual query.
+Clients can move to old v3 planner for inserts by using `V3Insert` planner version with `--planner-version` vtgate flag or with comment directive /*vt+ planner=<planner_version>` for individual query.
 
 ### <a id="deprecations-and-deletions"/>Deprecations and Deletions
 
@@ -470,7 +470,7 @@ The `k8stopo` has been deprecated, also see https://github.com/vitessio/vitess/i
 ------------
 The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/17.0/17.0.0/changelog.md).
 
-The release includes 442 commits (excluding merges)
+The release includes 457 commits (excluding merges)
 
-Thanks to all our contributors: @Ayman161803, @GuptaManan100, @L3o-pold, @Phanatic, @WilliamLu99, @adsr, @ajm188, @andylim-duo, @arthurschreiber, @austenLacy, @cuishuang, @dasl-, @dbussink, @deepthi, @dependabot[bot], @ejortegau, @fatih, @frouioui, @github-actions[bot], @harshit-gangal, @hkdsun, @jeremycole, @jhump, @johanstenberg92, @jwangace, @kevinpurwito, @kovyrin, @lixin963, @mattlord, @maxbrunet, @maxenglander, @mdlayher, @moberghammer, @notfelineit, @olyazavr, @pbibra, @pnacht, @rohit-nayak-ps, @rsajwani, @shlomi-noach, @systay, @timvaillancourt, @twthorn, @vbalys, @vinimdocarmo, @vitess-bot[bot], @vmg, @yoheimuta
+Thanks to all our contributors: @Ayman161803, @GuptaManan100, @L3o-pold, @Phanatic, @WilliamLu99, @adsr, @ajm188, @andylim-duo, @arthurschreiber, @arvind-murty, @austenLacy, @cuishuang, @dasl-, @dbussink, @deepthi, @dependabot[bot], @ejortegau, @fatih, @frouioui, @github-actions[bot], @harshit-gangal, @hkdsun, @jeremycole, @jhump, @johanstenberg92, @jwangace, @kevinpurwito, @kovyrin, @lixin963, @mattlord, @maxbrunet, @maxenglander, @mdlayher, @moberghammer, @notfelineit, @olyazavr, @pbibra, @pnacht, @rohit-nayak-ps, @rsajwani, @shlomi-noach, @systay, @timvaillancourt, @twthorn, @vbalys, @vinimdocarmo, @vitess-bot[bot], @vmg, @yoheimuta
 


### PR DESCRIPTION
## Description

This is a forward port of the v17.0.0 GA release notes from: https://github.com/vitessio/vitess/pull/13369

## Related Issue(s)

  - Part of: https://github.com/vitessio/vitess/issues/13151

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required