### PR TITLE
v15 backport: vitess Online DDL atomic cut-over

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
@@ -140,6 +140,7 @@ const (
 	maxConcurrency                = 20
 	singleConnectionSleepInterval = 2 * time.Millisecond
 	countIterations               = 5
+	migrationWaitTimeout          = 60 * time.Second
 )
 
 func resetOpOrder() {
@@ -344,7 +345,7 @@ func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy str
 	assert.NoError(t, err)
 
 	if !strategySetting.Strategy.IsDirect() {
-		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, 30*time.Second, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, migrationWaitTimeout, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
 		fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 	}
 

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -81,6 +81,8 @@ const (
 	alterSchemaMigrationsComponentThrottled            = "ALTER TABLE _vt.schema_migrations add column component_throttled tinytext NOT NULL"
 	alterSchemaMigrationsCancelledTimestamp            = "ALTER TABLE _vt.schema_migrations add column cancelled_timestamp timestamp NULL DEFAULT NULL"
 	alterSchemaMigrationsTablePostponeLaunch           = "ALTER TABLE _vt.schema_migrations add column postpone_launch tinyint unsigned NOT NULL DEFAULT 0"
+	alterSchemaMigrationsStage                         = "ALTER TABLE _vt.schema_migrations add column stage text not null"
+	alterSchemaMigrationsCutoverAttempts               = "ALTER TABLE _vt.schema_migrations add column cutover_attempts int unsigned NOT NULL DEFAULT 0"
 
 	sqlInsertMigration = `INSERT IGNORE INTO _vt.schema_migrations (
 		migration_uuid,
@@ -202,6 +204,16 @@ const (
 		WHERE
 			migration_uuid=%a
 	`
+	sqlUpdateStage = `UPDATE _vt.schema_migrations
+			SET stage=%a
+		WHERE
+			migration_uuid=%a
+	`
+	sqlIncrementCutoverAttempts = `UPDATE _vt.schema_migrations
+			SET cutover_attempts=cutover_attempts+1
+		WHERE
+			migration_uuid=%a
+	`
 	sqlUpdateReadyForCleanup = `UPDATE _vt.schema_migrations
 			SET retain_artifacts_seconds=-1
 		WHERE
@@ -284,6 +296,8 @@ const (
 			retries=retries + 1,
 			tablet_failure=0,
 			message='',
+			stage='',
+			cutover_attempts=0,
 			ready_timestamp=NULL,
 			started_timestamp=NULL,
 			liveness_timestamp=NULL,
@@ -302,6 +316,8 @@ const (
 			retries=retries + 1,
 			tablet_failure=0,
 			message='',
+			stage='',
+			cutover_attempts=0,
 			ready_timestamp=NULL,
 			started_timestamp=NULL,
 			liveness_timestamp=NULL,
@@ -587,9 +603,12 @@ const (
 			_vt.copy_state
 		WHERE vrepl_id=%a
 		`
-	sqlSwapTables      = "RENAME TABLE `%a` TO `%a`, `%a` TO `%a`, `%a` TO `%a`"
-	sqlRenameTable     = "RENAME TABLE `%a` TO `%a`"
-	sqlRenameTwoTables = "RENAME TABLE `%a` TO `%a`, `%a` TO `%a`"
+	sqlSwapTables         = "RENAME TABLE `%a` TO `%a`, `%a` TO `%a`, `%a` TO `%a`"
+	sqlRenameTable        = "RENAME TABLE `%a` TO `%a`"
+	sqlLockTwoTablesWrite = "LOCK TABLES `%a` WRITE, `%a` WRITE"
+	sqlUnlockTables       = "UNLOCK TABLES"
+	sqlCreateSentryTable  = "CREATE TABLE IF NOT EXISTS `%a` (id INT PRIMARY KEY)"
+	sqlFindProcess        = "SELECT id, Info as info FROM information_schema.processlist WHERE id=%a AND Info LIKE %a"
 )
 
 const (
@@ -661,4 +680,6 @@ var ApplyDDL = []string{
 	alterSchemaMigrationsComponentThrottled,
 	alterSchemaMigrationsCancelledTimestamp,
 	alterSchemaMigrationsTablePostponeLaunch,
+	alterSchemaMigrationsStage,
+	alterSchemaMigrationsCutoverAttempts,
 }


### PR DESCRIPTION

## Description

This is a (manual) backport of https://github.com/vitessio/vitess/pull/11460, changing the vreplication cut-over algorithm to be atomic.

The change is deemed safe to backport per https://github.com/vitessio/vitess/issues/11226#issuecomment-1401480438 and after additional review of the changes. If the tests pass in CI, this should be good to go.

We were supposed to do this backport months ago, but it was lost.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/11226
- #6926

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
