### PR TITLE
use underscore for parameter

### DIFF
--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -93,7 +93,7 @@ func registerPluginFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&mysqlConnReadTimeout, "mysql_server_read_timeout", mysqlConnReadTimeout, "connection read timeout")
 	fs.DurationVar(&mysqlConnWriteTimeout, "mysql_server_write_timeout", mysqlConnWriteTimeout, "connection write timeout")
 	fs.DurationVar(&mysqlQueryTimeout, "mysql_server_query_timeout", mysqlQueryTimeout, "mysql query timeout")
-	fs.BoolVar(&mysqlConnBufferPooling, "mysql-server-pool-conn-read-buffers", mysqlConnBufferPooling, "If set, the server will pool incoming connection read buffers")
+	fs.BoolVar(&mysqlConnBufferPooling, "mysql_server_pool_conn_read_buffers", mysqlConnBufferPooling, "If set, the server will pool incoming connection read buffers")
 	fs.StringVar(&mysqlDefaultWorkloadName, "mysql_default_workload", mysqlDefaultWorkloadName, "Default session workload (OLTP, OLAP, DBA)")
 }
 


### PR DESCRIPTION
## Description
Use underscore for parameter name like the rest


## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
-   [X] Documentation was added or is not required

