### PR TITLE
[release-17.0] Upgrade-Downgrade Fix: Schema-initialization stuck on semi-sync ACKs while upgrading

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -273,14 +273,6 @@ jobs:
         source build.env ; cd examples/backups
         ./take_backups.sh
 
-    # Stopping the tablets so we can perform the upgrade.
-    - name: Stop tablets
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 10
-      run: |
-        source build.env ; cd examples/backups
-        ./stop_tablets.sh
-
     # We upgrade: we swap binaries and use the version N of the tablet.
     - name: Upgrade - Swap binaries, use VTTablet N
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
@@ -299,9 +291,7 @@ jobs:
       timeout-minutes: 10
       run: |
         source build.env ; cd examples/backups
-        ./restart_tablets.sh
-        # give enough time to the tablets to restore the backup
-        sleep 90
+        ./upgrade_cluster.sh
 
     # We count the number of rows in every table to check that the restore step was successful.
     - name: Assert the number of rows in every table

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -276,14 +276,6 @@ jobs:
         source build.env ; cd examples/backups
         ./take_backups.sh
 
-    # Stopping the tablets so we can perform the upgrade.
-    - name: Stop tablets
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 10
-      run: |
-        source build.env ; cd examples/backups
-        ./stop_tablets.sh
-
     # We upgrade: we swap binaries and use the version N of the tablet.
     - name: Upgrade - Swap binaries, use VTTablet N
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
@@ -302,9 +294,7 @@ jobs:
       timeout-minutes: 10
       run: |
         source build.env ; cd examples/backups
-        ./restart_tablets.sh
-        # give enough time to the tablets to restore the backup
-        sleep 90
+        ./upgrade_cluster.sh
 
     # We count the number of rows in every table to check that the restore step was successful.
     - name: Assert the number of rows in every table

--- a/examples/backups/restart_tablets.sh
+++ b/examples/backups/restart_tablets.sh
@@ -58,6 +58,6 @@ for i in 101 201 301; do
   exit 1
 done
 
-vtctldclient InitShardPrimary --force commerce/0 zone1-100
-vtctldclient InitShardPrimary --force customer/-80 zone1-200
-vtctldclient InitShardPrimary --force customer/80- zone1-300
+vtctldclient PlannedReparentShard commerce/0 --new-primary "zone1-100"
+vtctldclient PlannedReparentShard customer/-80 --new-primary "zone1-200"
+vtctldclient PlannedReparentShard customer/80- --new-primary "zone1-300"

--- a/examples/backups/start_cluster.sh
+++ b/examples/backups/start_cluster.sh
@@ -31,6 +31,8 @@ fi
 # start vtctld
 CELL=zone1 ../common/scripts/vtctld-up.sh
 
+# Create keyspace and set the semi_sync durability policy.
+vtctldclient CreateKeyspace --durability-policy=semi_sync commerce || fail "Failed to create and configure the commerce keyspace"
 
 # start vttablets for keyspace commerce
 for i in 100 101 102; do
@@ -39,12 +41,14 @@ for i in 100 101 102; do
 done
 
 # set one of the replicas to primary
-vtctldclient InitShardPrimary --force commerce/0 zone1-100
+vtctldclient PlannedReparentShard commerce/0 --new-primary "zone1-100"
 
 # create the schema for commerce
 vtctlclient ApplySchema -- --sql-file ./create_commerce_schema.sql commerce || fail "Could not apply schema for the commerce keyspace"
 vtctlclient ApplyVSchema -- --vschema_file ../local/vschema_commerce_seq.json commerce || fail "Could not apply vschema for the commerce keyspace"
 
+# Create keyspace and set the semi_sync durability policy.
+vtctldclient CreateKeyspace --durability-policy=semi_sync customer || fail "Failed to create and configure the customer keyspace"
 
 # start vttablets for keyspace customer
 for i in 200 201 202; do
@@ -57,8 +61,8 @@ for i in 300 301 302; do
 done
 
 # set one of the replicas to primary
-vtctldclient InitShardPrimary --force customer/-80 zone1-200
-vtctldclient InitShardPrimary --force customer/80- zone1-300
+vtctldclient PlannedReparentShard customer/-80 --new-primary "zone1-200"
+vtctldclient PlannedReparentShard customer/80- --new-primary "zone1-300"
 
 for shard in "-80" "80-"; do
 	wait_for_healthy_shard customer "${shard}" || exit 1

--- a/examples/backups/upgrade_cluster.sh
+++ b/examples/backups/upgrade_cluster.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Copyright 2023 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this script brings up new tablets for the two new shards that we will
+# be creating in the customer keyspace and copies the schema
+
+source ../common/env.sh
+
+# Restart the replica tablets so that they come up with new vttablet versions
+for i in 101 102; do
+  echo "Shutting down tablet zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/vttablet-down.sh
+  echo "Shutting down mysql zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
+  echo "Removing tablet directory zone1-$i"
+  vtctlclient DeleteTablet -- --allow_primary=true zone1-$i
+  rm -Rf $VTDATAROOT/vt_0000000$i
+  echo "Starting tablet zone1-$i again"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh
+  CELL=zone1 KEYSPACE=commerce TABLET_UID=$i ../common/scripts/vttablet-up.sh
+done
+
+for i in 201 202; do
+  echo "Shutting down tablet zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/vttablet-down.sh
+  echo "Shutting down mysql zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
+  echo "Removing tablet directory zone1-$i"
+  vtctlclient DeleteTablet -- --allow_primary=true zone1-$i
+  rm -Rf $VTDATAROOT/vt_0000000$i
+  echo "Starting tablet zone1-$i again"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh
+  SHARD=-80 CELL=zone1 KEYSPACE=customer TABLET_UID=$i ../common/scripts/vttablet-up.sh
+done
+
+for i in 301 302; do
+  echo "Shutting down tablet zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/vttablet-down.sh
+  echo "Shutting down mysql zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
+  echo "Removing tablet directory zone1-$i"
+  vtctlclient DeleteTablet -- --allow_primary=true zone1-$i
+  rm -Rf $VTDATAROOT/vt_0000000$i
+  echo "Starting tablet zone1-$i again"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh
+  SHARD=80- CELL=zone1 KEYSPACE=customer TABLET_UID=$i ../common/scripts/vttablet-up.sh
+done
+
+# Wait for all the replica tablets to be in the serving state before reparenting to them.
+totalTime=600
+for i in 101 201 301; do
+  while [ $totalTime -gt 0 ]; do
+    status=$(curl "http://$hostname:15$i/debug/status_details")
+    echo "$status" | grep "REPLICA: Serving" && break
+    totalTime=$((totalTime-1))
+    sleep 0.1
+  done
+done
+
+# Check that all the replica tablets have reached REPLICA: Serving state
+for i in 101 201 301; do
+  status=$(curl "http://$hostname:15$i/debug/status_details")
+  echo "$status" | grep "REPLICA: Serving" && continue
+  echo "tablet-$i did not reach REPLICA: Serving state. Exiting due to failure."
+  exit 1
+done
+
+# Promote the replica tablets to primary
+vtctldclient PlannedReparentShard commerce/0 --new-primary "zone1-101"
+vtctldclient PlannedReparentShard customer/-80 --new-primary "zone1-201"
+vtctldclient PlannedReparentShard customer/80- --new-primary "zone1-301"
+
+# Restart the old primary tablets so that they are on the latest version of vttablet too.
+echo "Restarting tablet zone1-100"
+CELL=zone1 TABLET_UID=100 ../common/scripts/vttablet-down.sh
+CELL=zone1 KEYSPACE=commerce TABLET_UID=100 ../common/scripts/vttablet-up.sh
+
+echo "Restarting tablet zone1-200"
+CELL=zone1 TABLET_UID=200 ../common/scripts/vttablet-down.sh
+SHARD=-80 CELL=zone1 KEYSPACE=customer TABLET_UID=200 ../common/scripts/vttablet-up.sh
+
+echo "Restarting tablet zone1-300"
+CELL=zone1 TABLET_UID=300 ../common/scripts/vttablet-down.sh
+SHARD=80- CELL=zone1 KEYSPACE=customer TABLET_UID=300 ../common/scripts/vttablet-up.sh

--- a/examples/common/scripts/vttablet-up.sh
+++ b/examples/common/scripts/vttablet-up.sh
@@ -54,7 +54,6 @@ vttablet \
  --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
  --pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
  --vtctld_addr http://$hostname:$vtctld_web_port/ \
- --disable_active_reparents \
  --throttler-config-via-topo --heartbeat_enable --heartbeat_interval=250ms --heartbeat_on_demand_duration=5s \
  > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 

--- a/go/vt/vtctl/reparentutil/planned_reparenter.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter.go
@@ -629,7 +629,7 @@ func (pr *PlannedReparenter) reparentTablets(
 	replCtx, replCancel := context.WithTimeout(ctx, opts.WaitReplicasTimeout)
 	defer replCancel()
 
-	// Go thorugh all the tablets.
+	// Go through all the tablets.
 	// - New primary: populate the reparent journal.
 	// - Everybody else: reparent to the new primary; wait for the reparent
 	//	 journal row.
@@ -644,7 +644,7 @@ func (pr *PlannedReparenter) reparentTablets(
 
 	// Point all replicas at the new primary and check that they receive the
 	// reparent journal entry, proving that they are replicating from the new
-	// primary. We do this concurrently with  adding the journal entry (after
+	// primary. We do this concurrently with adding the journal entry (after
 	// this loop), because if semi-sync is enabled, the update to the journal
 	// table will block until at least one replica is successfully attached to
 	// the new primary.
@@ -672,7 +672,7 @@ func (pr *PlannedReparenter) reparentTablets(
 		}(alias, tabletInfo.Tablet)
 	}
 
-	// If `PromoteReplica` call is requried, we should call it and use the position that it returns.
+	// If `PromoteReplica` call is required, we should call it and use the position that it returns.
 	if promoteReplicaRequired {
 		// Promote the candidate primary to type:PRIMARY.
 		primaryPosition, err := pr.tmc.PromoteReplica(replCtx, ev.NewPrimary, SemiSyncAckers(opts.durability, ev.NewPrimary) > 0)

--- a/go/vt/vtctl/reparentutil/planned_reparenter.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter.go
@@ -213,7 +213,7 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 	primaryElect *topodatapb.Tablet,
 	tabletMap map[string]*topo.TabletInfo,
 	opts PlannedReparentOptions,
-) (string, error) {
+) error {
 	primaryElectAliasStr := topoproto.TabletAliasString(primaryElect.Alias)
 	ev.OldPrimary = proto.Clone(currentPrimary.Tablet).(*topodatapb.Tablet)
 
@@ -231,7 +231,7 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 
 	snapshotPos, err := pr.tmc.PrimaryPosition(snapshotCtx, currentPrimary.Tablet)
 	if err != nil {
-		return "", vterrors.Wrapf(err, "cannot get replication position on current primary %v; current primary must be healthy to perform PlannedReparent", currentPrimary.AliasString())
+		return vterrors.Wrapf(err, "cannot get replication position on current primary %v; current primary must be healthy to perform PlannedReparent", currentPrimary.AliasString())
 	}
 
 	// Next, we wait for the primary-elect to catch up to that snapshot point.
@@ -246,12 +246,12 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 	defer setSourceCancel()
 
 	if err := pr.tmc.SetReplicationSource(setSourceCtx, primaryElect, currentPrimary.Alias, 0, snapshotPos, true, IsReplicaSemiSync(opts.durability, currentPrimary.Tablet, primaryElect)); err != nil {
-		return "", vterrors.Wrapf(err, "replication on primary-elect %v did not catch up in time; replication must be healthy to perform PlannedReparent", primaryElectAliasStr)
+		return vterrors.Wrapf(err, "replication on primary-elect %v did not catch up in time; replication must be healthy to perform PlannedReparent", primaryElectAliasStr)
 	}
 
 	// Verify we still have the topology lock before doing the demotion.
 	if err := topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
-		return "", vterrors.Wrap(err, "lost topology lock; aborting")
+		return vterrors.Wrap(err, "lost topology lock; aborting")
 	}
 
 	// Next up, demote the current primary and get its replication position.
@@ -265,7 +265,7 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 
 	primaryStatus, err := pr.tmc.DemotePrimary(demoteCtx, currentPrimary.Tablet)
 	if err != nil {
-		return "", vterrors.Wrapf(err, "failed to DemotePrimary on current primary %v: %v", currentPrimary.AliasString(), err)
+		return vterrors.Wrapf(err, "failed to DemotePrimary on current primary %v: %v", currentPrimary.AliasString(), err)
 	}
 
 	// Wait for the primary-elect to catch up to the position we demoted the
@@ -298,26 +298,10 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 			finalWaitErr = vterrors.Wrapf(finalWaitErr, "encountered error while performing UndoDemotePrimary(%v): %v", currentPrimary.AliasString(), undoErr)
 		}
 
-		return "", finalWaitErr
+		return finalWaitErr
 	}
 
-	// Primary-elect is caught up to the current primary. We can do the
-	// promotion now.
-	promoteCtx, promoteCancel := context.WithTimeout(ctx, opts.WaitReplicasTimeout)
-	defer promoteCancel()
-
-	rp, err := pr.tmc.PromoteReplica(promoteCtx, primaryElect, SemiSyncAckers(opts.durability, primaryElect) > 0)
-	if err != nil {
-		return "", vterrors.Wrapf(err, "primary-elect tablet %v failed to be promoted to primary; please try again", primaryElectAliasStr)
-	}
-
-	if ctx.Err() == context.DeadlineExceeded {
-		// PromoteReplica succeeded, but we ran out of time. PRS needs to be
-		// re-run to complete fully.
-		return "", vterrors.Errorf(vtrpc.Code_DEADLINE_EXCEEDED, "PLannedReparent timed out after successfully promoting primary-elect %v; please re-run to fix up the replicas", primaryElectAliasStr)
-	}
-
-	return rp, nil
+	return nil
 }
 
 func (pr *PlannedReparenter) performInitialPromotion(
@@ -383,7 +367,7 @@ func (pr *PlannedReparenter) performPotentialPromotion(
 	primaryElect *topodatapb.Tablet,
 	tabletMap map[string]*topo.TabletInfo,
 	opts PlannedReparentOptions,
-) (string, error) {
+) error {
 	primaryElectAliasStr := topoproto.TabletAliasString(primaryElect.Alias)
 
 	pr.logger.Infof("no clear winner found for current primary term; checking if it's safe to recover by electing %v", primaryElectAliasStr)
@@ -457,7 +441,7 @@ func (pr *PlannedReparenter) performPotentialPromotion(
 	close(positions)
 
 	if rec.HasErrors() {
-		return "", vterrors.Wrap(rec.Error(), "failed to demote all tablets")
+		return vterrors.Wrap(rec.Error(), "failed to demote all tablets")
 	}
 
 	// Construct a mapping of alias to tablet position.
@@ -478,7 +462,7 @@ func (pr *PlannedReparenter) performPotentialPromotion(
 	// if the candidate primary is behind that tablet.
 	tp, ok := tabletPosMap[primaryElectAliasStr]
 	if !ok {
-		return "", vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary-elect tablet %v not found in tablet map", primaryElectAliasStr)
+		return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary-elect tablet %v not found in tablet map", primaryElectAliasStr)
 	}
 
 	primaryElectPos := tp.pos
@@ -487,7 +471,7 @@ func (pr *PlannedReparenter) performPotentialPromotion(
 		// The primary-elect pos has to be at least as advanced as every tablet
 		// in the shard.
 		if !primaryElectPos.AtLeast(tp.pos) {
-			return "", vterrors.Errorf(
+			return vterrors.Errorf(
 				vtrpc.Code_FAILED_PRECONDITION,
 				"tablet %v (position: %v) contains transactions not found in primary-elect %v (position: %v)",
 				tp.alias, tp.pos, primaryElectAliasStr, primaryElectPos,
@@ -497,19 +481,9 @@ func (pr *PlannedReparenter) performPotentialPromotion(
 
 	// Check that we still have the topology lock.
 	if err := topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
-		return "", vterrors.Wrap(err, "lost topology lock; aborting")
+		return vterrors.Wrap(err, "lost topology lock; aborting")
 	}
-
-	// Promote the candidate primary to type:PRIMARY.
-	promoteCtx, promoteCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
-	defer promoteCancel()
-
-	rp, err := pr.tmc.PromoteReplica(promoteCtx, primaryElect, SemiSyncAckers(opts.durability, primaryElect) > 0)
-	if err != nil {
-		return "", vterrors.Wrapf(err, "failed to promote %v to primary", primaryElectAliasStr)
-	}
-
-	return rp, nil
+	return nil
 }
 
 func (pr *PlannedReparenter) reparentShardLocked(
@@ -553,6 +527,11 @@ func (pr *PlannedReparenter) reparentShardLocked(
 
 	currentPrimary := FindCurrentPrimary(tabletMap, pr.logger)
 	reparentJournalPos := ""
+	// promoteReplicaRequired is a boolean that is used to store whether we need to call
+	// `PromoteReplica` when we reparent the tablets. This is required to be done when we are doing
+	// a potential or a graceful promotion.
+	// InitialPromotion calls `InitPrimary` and for partial promotion, the tablet is already a primary.
+	promoteReplicaRequired := false
 	// needsRefresh is used to keep track of whether we need to refresh the state
 	// of the new primary tablet. The only case that we need to reload the state
 	// is when we are initializing the new primary. The reason is that the first
@@ -601,7 +580,9 @@ func (pr *PlannedReparenter) reparentShardLocked(
 	case currentPrimary == nil && ev.ShardInfo.PrimaryAlias != nil:
 		// Case (2): no clear current primary. Try to find a safe promotion
 		// candidate, and promote to it.
-		reparentJournalPos, err = pr.performPotentialPromotion(ctx, keyspace, shard, ev.NewPrimary, tabletMap, opts)
+		err = pr.performPotentialPromotion(ctx, keyspace, shard, ev.NewPrimary, tabletMap, opts)
+		// We need to call `PromoteReplica` when we reparent the tablets.
+		promoteReplicaRequired = true
 	case topoproto.TabletAliasEqual(currentPrimary.Alias, opts.NewPrimaryAlias):
 		// Case (3): desired new primary is the current primary. Attempt to fix
 		// up replicas to recover from a previous partial promotion.
@@ -609,7 +590,9 @@ func (pr *PlannedReparenter) reparentShardLocked(
 	default:
 		// Case (4): desired primary and current primary differ. Do a graceful
 		// demotion-then-promotion.
-		reparentJournalPos, err = pr.performGracefulPromotion(ctx, ev, keyspace, shard, currentPrimary, ev.NewPrimary, tabletMap, opts)
+		err = pr.performGracefulPromotion(ctx, ev, keyspace, shard, currentPrimary, ev.NewPrimary, tabletMap, opts)
+		// We need to call `PromoteReplica` when we reparent the tablets.
+		promoteReplicaRequired = true
 	}
 
 	if err != nil {
@@ -620,7 +603,7 @@ func (pr *PlannedReparenter) reparentShardLocked(
 		return vterrors.Wrap(err, "lost topology lock, aborting")
 	}
 
-	if err := pr.reparentTablets(ctx, ev, reparentJournalPos, tabletMap, opts); err != nil {
+	if err := pr.reparentTablets(ctx, ev, reparentJournalPos, promoteReplicaRequired, tabletMap, opts); err != nil {
 		return err
 	}
 
@@ -637,6 +620,7 @@ func (pr *PlannedReparenter) reparentTablets(
 	ctx context.Context,
 	ev *events.Reparent,
 	reparentJournalPosition string,
+	promoteReplicaRequired bool,
 	tabletMap map[string]*topo.TabletInfo,
 	opts PlannedReparentOptions,
 ) error {
@@ -686,6 +670,20 @@ func (pr *PlannedReparenter) reparentTablets(
 				rec.RecordError(vterrors.Wrapf(err, "tablet %v failed to SetReplicationSource(%v): %v", alias, primaryElectAliasStr, err))
 			}
 		}(alias, tabletInfo.Tablet)
+	}
+
+	// If `PromoteReplica` call is requried, we should call it and use the position that it returns.
+	if promoteReplicaRequired {
+		// Promote the candidate primary to type:PRIMARY.
+		primaryPosition, err := pr.tmc.PromoteReplica(replCtx, ev.NewPrimary, SemiSyncAckers(opts.durability, ev.NewPrimary) > 0)
+		if err != nil {
+			pr.logger.Warningf("primary %v failed to PromoteReplica; cancelling replica reparent attempts", primaryElectAliasStr)
+			replCancel()
+			replicasWg.Wait()
+
+			return vterrors.Wrapf(err, "failed PromoteReplica(primary=%v, ts=%v): %v", primaryElectAliasStr, reparentJournalTimestamp, err)
+		}
+		reparentJournalPosition = primaryPosition
 	}
 
 	// Add a reparent journal entry on the new primary. If semi-sync is enabled,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
When we introduced the schema-init-db code, we failed to realize that it would start doing writes as part of the code to change the tablet type. As part of the PRS process, we used to call `PromoteReplica` first, followed by calls to `SetReplicationSource`. 

When a user upgrades from v16 (/v15) to v17 (/v16), as part of `PromoteReplica` call, the schema-init realizes that there are schema diffs to apply and ends up writing to the database. The problem is that if semi-sync is enabled, all of these writes get blocked indefinitely. Eventually, `PromoteReplica` fails and this fails the entire `PRS` call.

In this PR we fix this issue, by altering the PRS flow slightly, where we call `SetReplicationSource` on all the replicas and `PromoteReplica` on the new primary in parallel. This allows `PromoteReplica` to be unblocked just as any semi-sync capable replica reparents to it.

As part of this PR, the upgrade-downgrade tests for manual backups has been augmented as well to start using semi-sync and to follow the correct steps to upgrade the cluser instead of just shutting down all the tablets and restarting all the tablets. Also, we call `PlannedReparentShard` now in the test instead of `InitShardPrimary` which has been long deprecated.

## Related Issue(s)
- Fixes #13426 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
