### PR TITLE
Examples: only terminate vtadmin if it was started

### DIFF
--- a/examples/common/lib/utils.sh
+++ b/examples/common/lib/utils.sh
@@ -139,6 +139,31 @@ function wait_for_healthy_shard() {
 	wait_for_shard_vreplication_engine "${keyspace}" "${shard}"
 }
 
+# Stop the specified vtadmin binary name using the provided PID file.
+# Example:
+#  stop_vtadmin_process "vtadmin-web" "$VTDATAROOT/tmp/vtadmin-web.pid"
+function stop_vtadmin_process() {
+  if [[ -z ${1} || -z ${2} ]]; then
+    fail "A binary name and PID file must be specified when attempting to shutdown vtadmin"
+  fi
+
+  local binary_name="${1}"
+  local pidfile="${2}"
+  local pid=""
+
+  if [[ -e "${pidfile}" ]]; then
+    pid=$(cat "${pidfile}")
+    echo "Stopping ${binary_name}..."
+    kill "${pid}"
+    # Wait for the process to terminate
+    while ps -p "${pid}" > /dev/null; do
+      sleep 1
+    done
+  else
+    echo "Skipping stopping ${binary_name} because the specified PID file (${pidfile}) does not exist."
+  fi
+}
+
 # Print error message and exit with error code.
 function fail() {
 	echo "ERROR: ${1}"

--- a/examples/common/lib/utils.sh
+++ b/examples/common/lib/utils.sh
@@ -139,29 +139,37 @@ function wait_for_healthy_shard() {
 	wait_for_shard_vreplication_engine "${keyspace}" "${shard}"
 }
 
-# Stop the specified vtadmin binary name using the provided PID file.
+# Stop the specified binary name using the provided PID file.
 # Example:
-#  stop_vtadmin_process "vtadmin-web" "$VTDATAROOT/tmp/vtadmin-web.pid"
-function stop_vtadmin_process() {
-  if [[ -z ${1} || -z ${2} ]]; then
-    fail "A binary name and PID file must be specified when attempting to shutdown vtadmin"
-  fi
+#  stop_process "vtadmin-web" "$VTDATAROOT/tmp/vtadmin-web.pid"
+function stop_process() {
+	if [[ -z ${1} || -z ${2} ]]; then
+		fail "A binary name and PID file must be specified when attempting to shutdown vtadmin"
+	fi
 
-  local binary_name="${1}"
-  local pidfile="${2}"
-  local pid=""
+	local binary_name="${1}"
+	local pidfile="${2}"
+	local pid=""
+	local wait_secs=90
 
-  if [[ -e "${pidfile}" ]]; then
-    pid=$(cat "${pidfile}")
-    echo "Stopping ${binary_name}..."
-    kill "${pid}"
-    # Wait for the process to terminate
-    while ps -p "${pid}" > /dev/null; do
-      sleep 1
-    done
-  else
-    echo "Skipping stopping ${binary_name} because the specified PID file (${pidfile}) does not exist."
-  fi
+	if [[ -e "${pidfile}" ]]; then
+		pid=$(cat "${pidfile}")
+		echo "Stopping ${binary_name}..."
+		kill "${pid}"
+		# Wait for the process to terminate
+		for _ in $(seq 1 ${wait_secs}); do
+			if ! ps -p "${pid}" > /dev/null; then
+      				break
+			fi
+			sleep 1
+		done
+	else
+		echo "Skipping stopping ${binary_name} because the specified PID file (${pidfile}) does not exist."
+	fi
+
+        if ps -p "${pid}" > /dev/null; then
+                fail "Timed out after ${wait_secs} seconds waiting for the ${binary_name} using PID file ${pidfile} to terminate"
+        fi
 }
 
 # Print error message and exit with error code.

--- a/examples/common/lib/utils.sh
+++ b/examples/common/lib/utils.sh
@@ -144,7 +144,7 @@ function wait_for_healthy_shard() {
 #  stop_process "vtadmin-web" "$VTDATAROOT/tmp/vtadmin-web.pid"
 function stop_process() {
 	if [[ -z ${1} || -z ${2} ]]; then
-		fail "A binary name and PID file must be specified when attempting to shutdown vtadmin"
+		fail "A binary name and PID file must be specified when attempting to shutdown a process"
 	fi
 
 	local binary_name="${1}"

--- a/examples/common/lib/utils.sh
+++ b/examples/common/lib/utils.sh
@@ -160,7 +160,7 @@ function stop_process() {
 		# Wait for the process to terminate
 		for _ in $(seq 1 ${wait_secs}); do
 			if ! ps -p "${pid}" > /dev/null; then
-      				break
+				break
 			fi
 			sleep 1
 		done

--- a/examples/common/lib/utils.sh
+++ b/examples/common/lib/utils.sh
@@ -156,6 +156,7 @@ function stop_process() {
 		pid=$(cat "${pidfile}")
 		echo "Stopping ${binary_name}..."
 		kill "${pid}"
+
 		# Wait for the process to terminate
 		for _ in $(seq 1 ${wait_secs}); do
 			if ! ps -p "${pid}" > /dev/null; then
@@ -163,13 +164,12 @@ function stop_process() {
 			fi
 			sleep 1
 		done
+		if ps -p "${pid}" > /dev/null; then
+			fail "Timed out after ${wait_secs} seconds waiting for the ${binary_name} using PID file ${pidfile} to terminate"
+		fi
 	else
 		echo "Skipping stopping ${binary_name} because the specified PID file (${pidfile}) does not exist."
 	fi
-
-        if ps -p "${pid}" > /dev/null; then
-                fail "Timed out after ${wait_secs} seconds waiting for the ${binary_name} using PID file ${pidfile} to terminate"
-        fi
 }
 
 # Print error message and exit with error code.

--- a/examples/common/scripts/consul-down.sh
+++ b/examples/common/scripts/consul-down.sh
@@ -18,5 +18,5 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-echo "Stopping consul..."
-kill -9 `cat $VTDATAROOT/tmp/consul.pid` 
+stop_process "consul" "$VTDATAROOT/tmp/consul.pid"
+

--- a/examples/common/scripts/etcd-down.sh
+++ b/examples/common/scripts/etcd-down.sh
@@ -18,5 +18,5 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-echo "Stopping etcd..."
-kill -9 `cat $VTDATAROOT/tmp/etcd.pid` 
+stop_process "vttablet" "$VTDATAROOT/tmp/etcd.pid"
+

--- a/examples/common/scripts/etcd-down.sh
+++ b/examples/common/scripts/etcd-down.sh
@@ -18,5 +18,5 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-stop_process "vttablet" "$VTDATAROOT/tmp/etcd.pid"
+stop_process "etcd" "$VTDATAROOT/tmp/etcd.pid"
 

--- a/examples/common/scripts/vtadmin-down.sh
+++ b/examples/common/scripts/vtadmin-down.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2023 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
 function stop_vtadmin() {

--- a/examples/common/scripts/vtadmin-down.sh
+++ b/examples/common/scripts/vtadmin-down.sh
@@ -16,5 +16,5 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-stop_vtadmin_process "vtadmin-web" "$VTDATAROOT/tmp/vtadmin-web.pid"
-stop_vtadmin_process "vtadmin-api" "$VTDATAROOT/tmp/vtadmin-api.pid"
+stop_process "vtadmin-web" "$VTDATAROOT/tmp/vtadmin-web.pid"
+stop_process "vtadmin-api" "$VTDATAROOT/tmp/vtadmin-api.pid"

--- a/examples/common/scripts/vtadmin-down.sh
+++ b/examples/common/scripts/vtadmin-down.sh
@@ -16,25 +16,5 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-function stop_vtadmin() {
-  local name="$1"
-  local file="$2"
-
-  if [[ -z ${1} || -z ${2} ]]; then
-    fail "A binary name and PID file must be specified when attempting to shutdown vtadmin"
-  fi
-  if [[ -e "$file" ]]; then
-    echo "Stopping $name..."
-    local pid=$(cat "$file")
-    kill $pid
-    # Wait for the process to terminate
-    while ps -p $pid > /dev/null; do
-      sleep 1
-    done
-  else
-    echo "Skipping stopping $name because no pid file."
-  fi
-}
-
-stop_vtadmin "vtadmin-web" "$VTDATAROOT/tmp/vtadmin-web.pid"
-stop_vtadmin "vtadmin-api" "$VTDATAROOT/tmp/vtadmin-api.pid"
+stop_vtadmin_process "vtadmin-web" "$VTDATAROOT/tmp/vtadmin-web.pid"
+stop_vtadmin_process "vtadmin-api" "$VTDATAROOT/tmp/vtadmin-api.pid"

--- a/examples/common/scripts/vtadmin-down.sh
+++ b/examples/common/scripts/vtadmin-down.sh
@@ -2,8 +2,16 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-echo "Stopping vtadmin-web..."
-kill -9 "$(cat "$VTDATAROOT/tmp/vtadmin-web.pid")"
+if test -e "$VTDATAROOT/tmp/vtadmin-web.pid"; then
+  echo "Stopping vtadmin-web..."
+  kill -9 "$(cat "$VTDATAROOT/tmp/vtadmin-web.pid")"
+else
+  echo "Skipping stopping vtadmin-web because no pid file."
+fi
 
-echo "Stopping vtadmin-api..."
-kill -9 "$(cat "$VTDATAROOT/tmp/vtadmin-api.pid")"
+if test -e "$VTDATAROOT/tmp/vtadmin-api.pid"; then
+  echo "Stopping vtadmin-api..."
+  kill -9 "$(cat "$VTDATAROOT/tmp/vtadmin-api.pid")"
+else
+  echo "Skipping stopping vtadmin-web because no pid file."
+fi

--- a/examples/common/scripts/vtadmin-down.sh
+++ b/examples/common/scripts/vtadmin-down.sh
@@ -8,7 +8,12 @@ function stop_vtadmin() {
 
   if [[ -e "$file" ]]; then
     echo "Stopping $name..."
-    kill -9 "$(cat "$file")"
+    local pid=$(cat "$file")
+    kill $pid
+    # Wait for the process to terminate
+    while ps -p $pid > /dev/null; do
+      sleep 1
+    done
   else
     echo "Skipping stopping $name because no pid file."
   fi

--- a/examples/common/scripts/vtadmin-down.sh
+++ b/examples/common/scripts/vtadmin-down.sh
@@ -6,7 +6,7 @@ function stop_vtadmin() {
   local name="$1"
   local file="$2"
 
-  if test -e "$file"; then
+  if [[ -e "$file" ]]; then
     echo "Stopping $name..."
     kill -9 "$(cat "$file")"
   else

--- a/examples/common/scripts/vtadmin-down.sh
+++ b/examples/common/scripts/vtadmin-down.sh
@@ -6,6 +6,9 @@ function stop_vtadmin() {
   local name="$1"
   local file="$2"
 
+  if [[ -z ${1} || -z ${2} ]]; then
+    fail "A binary name and PID file must be specified when attempting to shutdown vtadmin"
+  fi
   if [[ -e "$file" ]]; then
     echo "Stopping $name..."
     local pid=$(cat "$file")

--- a/examples/common/scripts/vtadmin-down.sh
+++ b/examples/common/scripts/vtadmin-down.sh
@@ -2,16 +2,17 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-if test -e "$VTDATAROOT/tmp/vtadmin-web.pid"; then
-  echo "Stopping vtadmin-web..."
-  kill -9 "$(cat "$VTDATAROOT/tmp/vtadmin-web.pid")"
-else
-  echo "Skipping stopping vtadmin-web because no pid file."
-fi
+function stop_vtadmin() {
+  local name="$1"
+  local file="$2"
 
-if test -e "$VTDATAROOT/tmp/vtadmin-api.pid"; then
-  echo "Stopping vtadmin-api..."
-  kill -9 "$(cat "$VTDATAROOT/tmp/vtadmin-api.pid")"
-else
-  echo "Skipping stopping vtadmin-web because no pid file."
-fi
+  if test -e "$file"; then
+    echo "Stopping $name..."
+    kill -9 "$(cat "$file")"
+  else
+    echo "Skipping stopping $name because no pid file."
+  fi
+}
+
+stop_vtadmin "vtadmin-web" "$VTDATAROOT/tmp/vtadmin-web.pid"
+stop_vtadmin "vtadmin-api" "$VTDATAROOT/tmp/vtadmin-api.pid"

--- a/examples/common/scripts/vtctld-down.sh
+++ b/examples/common/scripts/vtctld-down.sh
@@ -18,5 +18,5 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-echo "Stopping vtctld..."
-kill -9 `cat $VTDATAROOT/tmp/vtctld.pid`
+stop_process "vtctld" "$VTDATAROOT/tmp/vtctld.pid"
+

--- a/examples/common/scripts/vtgate-down.sh
+++ b/examples/common/scripts/vtgate-down.sh
@@ -18,6 +18,5 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-# Stop vtgate.
-echo "Stopping vtgate..."
-kill `cat $VTDATAROOT/tmp/vtgate.pid`
+stop_process "vtgate" "$VTDATAROOT/tmp/vtgate.pid"
+

--- a/examples/common/scripts/vtorc-down.sh
+++ b/examples/common/scripts/vtorc-down.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2023 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
 stop_process "vtorc" "$VTDATAROOT/tmp/vtorc.pid"

--- a/examples/common/scripts/vtorc-down.sh
+++ b/examples/common/scripts/vtorc-down.sh
@@ -2,6 +2,7 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-echo "Stopping vtorc."
-kill -9 "$(cat "$VTDATAROOT/tmp/vtorc.pid")"
+echo "Stopping vtorc..."
+
+stop_process "vttablet" "$VTDATAROOT/tmp/vtorc.pid"
 

--- a/examples/common/scripts/vtorc-down.sh
+++ b/examples/common/scripts/vtorc-down.sh
@@ -2,5 +2,5 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-stop_process "vttablet" "$VTDATAROOT/tmp/vtorc.pid"
+stop_process "vtorc" "$VTDATAROOT/tmp/vtorc.pid"
 

--- a/examples/common/scripts/vtorc-down.sh
+++ b/examples/common/scripts/vtorc-down.sh
@@ -2,7 +2,5 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-echo "Stopping vtorc..."
-
 stop_process "vttablet" "$VTDATAROOT/tmp/vtorc.pid"
 

--- a/examples/common/scripts/vttablet-down.sh
+++ b/examples/common/scripts/vttablet-down.sh
@@ -19,12 +19,7 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 
-printf -v tablet_dir 'vt_%010d' $TABLET_UID
-pid=`cat $VTDATAROOT/$tablet_dir/vttablet.pid`
+printf -v tablet_dir 'vt_%010d' "$TABLET_UID"
 
-kill $pid
-
-# Wait for vttablet to die.
-while ps -p $pid > /dev/null; do sleep 1; done
-
+stop_process "vttablet" "$VTDATAROOT/$tablet_dir/vttablet.pid"
 


### PR DESCRIPTION
## Description

Fix issue 13432 {1}.  At the same time, get rid of duplicate code in vtadmin-down.sh.

{1}: https://github.com/vitessio/vitess/issues/13432

The PR is organized in 2 commits for ease of understanding.  I would suggest a squash-merge.

## Related Issue(s)

Fixes: https://github.com/vitessio/vitess/issues/13432

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation not required

## Deployment Notes

N/A