### PR TITLE
docker/k8s: add bookworm builds

### DIFF
--- a/changelog/18.0/18.0.0/summary.md
+++ b/changelog/18.0/18.0.0/summary.md
@@ -16,6 +16,9 @@
     - [VTGate Vindex unknown parameters](#vtgate-vindex-unknown-parameters)
   - **[VTTablet](#vttablet)**
     - [VTTablet: New ResetSequences RPC](#vttablet-new-rpc-reset-sequences)
+  - **[Docker](#docker)**
+    - [Debian: Bookworm added and made default](#debian-bookworm)
+    - [Debian: Buster removed](#debian-buster)
 
 ## <a id="major-changes"/>Major Changes
 
@@ -76,3 +79,16 @@ Vitess upgrade process from an earlier version if you need to use such a workflo
 
 Any MoveTables or Migrate workflow that moves a sequence table should only be run after all vitess components have been
 upgraded, and no upgrade should be done while such a workflow is in progress.
+
+### <a id="docker"/>Docker
+
+#### <a id="debian-bookworm"/>Bookworm added and made default
+
+Bookworm was released on 2023-06-10, and will be the new default base container for Docker builds.
+Bullseye images will still be built and available as long as the OS build is current, tagged with the `-bullseye` suffix.
+
+#### <a id="debian-buster"/>Buster removed
+
+Buster LTS supports will stop in June 2024, and Vitess v18.0 will be supported through October 2024. 
+To prevent supporting a deprecated buster build for several months after June 2024, we are preemptively
+removing Vitess support.

--- a/docker/release.sh
+++ b/docker/release.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -ex
 
-vt_base_version='v16.0.0'
-debian_versions='buster  bullseye'
-default_debian_version='bullseye'
+vt_base_version='v18.0.0-SNAPSHOT'
+debian_versions='bullseye  bookworm'
+default_debian_version='bookworm'
 
 docker pull --platform linux/amd64 vitess/base:$vt_base_version
 


### PR DESCRIPTION
Pretty straightforward. This should auto-build with releases, but doesn't change the default yet.