### PR TITLE
[main] Upgrade-Downgrade Fix: Schema-initialization stuck on semi-sync ACKs while upgrading (#13411)

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -273,14 +273,6 @@ jobs:
         source build.env ; cd examples/backups
         ./take_backups.sh
 
-    # Stopping the tablets so we can perform the upgrade.
-    - name: Stop tablets
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 10
-      run: |
-        source build.env ; cd examples/backups
-        ./stop_tablets.sh
-
     # We upgrade: we swap binaries and use the version N of the tablet.
     - name: Upgrade - Swap binaries, use VTTablet N
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
@@ -299,9 +291,7 @@ jobs:
       timeout-minutes: 10
       run: |
         source build.env ; cd examples/backups
-        ./restart_tablets.sh
-        # give enough time to the tablets to restore the backup
-        sleep 90
+        ./upgrade_cluster.sh
 
     # We count the number of rows in every table to check that the restore step was successful.
     - name: Assert the number of rows in every table

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -276,14 +276,6 @@ jobs:
         source build.env ; cd examples/backups
         ./take_backups.sh
 
-    # Stopping the tablets so we can perform the upgrade.
-    - name: Stop tablets
-      if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-      timeout-minutes: 10
-      run: |
-        source build.env ; cd examples/backups
-        ./stop_tablets.sh
-
     # We upgrade: we swap binaries and use the version N of the tablet.
     - name: Upgrade - Swap binaries, use VTTablet N
       if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
@@ -302,9 +294,7 @@ jobs:
       timeout-minutes: 10
       run: |
         source build.env ; cd examples/backups
-        ./restart_tablets.sh
-        # give enough time to the tablets to restore the backup
-        sleep 90
+        ./upgrade_cluster.sh
 
     # We count the number of rows in every table to check that the restore step was successful.
     - name: Assert the number of rows in every table

--- a/examples/backups/restart_tablets.sh
+++ b/examples/backups/restart_tablets.sh
@@ -58,6 +58,6 @@ for i in 101 201 301; do
   exit 1
 done
 
-vtctldclient InitShardPrimary --force commerce/0 zone1-100
-vtctldclient InitShardPrimary --force customer/-80 zone1-200
-vtctldclient InitShardPrimary --force customer/80- zone1-300
+vtctldclient PlannedReparentShard commerce/0 --new-primary "zone1-100"
+vtctldclient PlannedReparentShard customer/-80 --new-primary "zone1-200"
+vtctldclient PlannedReparentShard customer/80- --new-primary "zone1-300"

--- a/examples/backups/upgrade_cluster.sh
+++ b/examples/backups/upgrade_cluster.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Copyright 2023 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this script brings up new tablets for the two new shards that we will
+# be creating in the customer keyspace and copies the schema
+
+source ../common/env.sh
+
+# Restart the replica tablets so that they come up with new vttablet versions
+for i in 101 102; do
+  echo "Shutting down tablet zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/vttablet-down.sh
+  echo "Shutting down mysql zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
+  echo "Removing tablet directory zone1-$i"
+  vtctlclient DeleteTablet -- --allow_primary=true zone1-$i
+  rm -Rf $VTDATAROOT/vt_0000000$i
+  echo "Starting tablet zone1-$i again"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh
+  CELL=zone1 KEYSPACE=commerce TABLET_UID=$i ../common/scripts/vttablet-up.sh
+done
+
+for i in 201 202; do
+  echo "Shutting down tablet zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/vttablet-down.sh
+  echo "Shutting down mysql zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
+  echo "Removing tablet directory zone1-$i"
+  vtctlclient DeleteTablet -- --allow_primary=true zone1-$i
+  rm -Rf $VTDATAROOT/vt_0000000$i
+  echo "Starting tablet zone1-$i again"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh
+  SHARD=-80 CELL=zone1 KEYSPACE=customer TABLET_UID=$i ../common/scripts/vttablet-up.sh
+done
+
+for i in 301 302; do
+  echo "Shutting down tablet zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/vttablet-down.sh
+  echo "Shutting down mysql zone1-$i"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-down.sh
+  echo "Removing tablet directory zone1-$i"
+  vtctlclient DeleteTablet -- --allow_primary=true zone1-$i
+  rm -Rf $VTDATAROOT/vt_0000000$i
+  echo "Starting tablet zone1-$i again"
+  CELL=zone1 TABLET_UID=$i ../common/scripts/mysqlctl-up.sh
+  SHARD=80- CELL=zone1 KEYSPACE=customer TABLET_UID=$i ../common/scripts/vttablet-up.sh
+done
+
+# Wait for all the replica tablets to be in the serving state before reparenting to them.
+totalTime=600
+for i in 101 201 301; do
+  while [ $totalTime -gt 0 ]; do
+    status=$(curl "http://$hostname:15$i/debug/status_details")
+    echo "$status" | grep "REPLICA: Serving" && break
+    totalTime=$((totalTime-1))
+    sleep 0.1
+  done
+done
+
+# Check that all the replica tablets have reached REPLICA: Serving state
+for i in 101 201 301; do
+  status=$(curl "http://$hostname:15$i/debug/status_details")
+  echo "$status" | grep "REPLICA: Serving" && continue
+  echo "tablet-$i did not reach REPLICA: Serving state. Exiting due to failure."
+  exit 1
+done
+
+# Promote the replica tablets to primary
+vtctldclient PlannedReparentShard commerce/0 --new-primary "zone1-101"
+vtctldclient PlannedReparentShard customer/-80 --new-primary "zone1-201"
+vtctldclient PlannedReparentShard customer/80- --new-primary "zone1-301"
+
+# Restart the old primary tablets so that they are on the latest version of vttablet too.
+echo "Restarting tablet zone1-100"
+CELL=zone1 TABLET_UID=100 ../common/scripts/vttablet-down.sh
+CELL=zone1 KEYSPACE=commerce TABLET_UID=100 ../common/scripts/vttablet-up.sh
+
+echo "Restarting tablet zone1-200"
+CELL=zone1 TABLET_UID=200 ../common/scripts/vttablet-down.sh
+SHARD=-80 CELL=zone1 KEYSPACE=customer TABLET_UID=200 ../common/scripts/vttablet-up.sh
+
+echo "Restarting tablet zone1-300"
+CELL=zone1 TABLET_UID=300 ../common/scripts/vttablet-down.sh
+SHARD=80- CELL=zone1 KEYSPACE=customer TABLET_UID=300 ../common/scripts/vttablet-up.sh

--- a/examples/common/scripts/vttablet-up.sh
+++ b/examples/common/scripts/vttablet-up.sh
@@ -54,7 +54,6 @@ vttablet \
  --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
  --pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
  --vtctld_addr http://$hostname:$vtctld_web_port/ \
- --disable_active_reparents \
  --throttler-config-via-topo --heartbeat_enable --heartbeat_interval=250ms --heartbeat_on_demand_duration=5s \
  > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR is a forward port of https://github.com/vitessio/vitess/pull/13411 to `main`.

When we introduced the schema-init-db code, we failed to realize that it would start doing writes as part of the code to change the tablet type. As part of the PRS process, we used to call `PromoteReplica` first, followed by calls to `SetReplicationSource`. 

When a user upgrades from v16 (/v15) to v17 (/v16), as part of `PromoteReplica` call, the schema-init realizes that there are schema diffs to apply and ends up writing to the database. The problem is that if semi-sync is enabled, all of these writes get blocked indefinitely. Eventually, `PromoteReplica` fails and this fails the entire `PRS` call.

In this PR we fix this issue, by altering the PRS flow slightly, where we call `SetReplicationSource` on all the replicas and `PromoteReplica` on the new primary in parallel. This allows `PromoteReplica` to be unblocked just as any semi-sync capable replica reparents to it.

As part of this PR, the upgrade-downgrade tests for manual backups has been augmented as well to start using semi-sync and to follow the correct steps to upgrade the cluser instead of just shutting down all the tablets and restarting all the tablets. Also, we call `PlannedReparentShard` now in the test instead of `InitShardPrimary` which has been long deprecated.

## Related Issue(s)
- Fixes #13426 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
