### PR TITLE
schema.Reload(): ignore column reading errors for views only, error for tables

### DIFF
--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -554,6 +554,7 @@ const (
 	ERIllegalValueForType          = ErrorCode(1367)
 	ERDataTooLong                  = ErrorCode(1406)
 	ErrWrongValueForType           = ErrorCode(1411)
+	ERNoSuchUser                   = ErrorCode(1449)
 	ERForbidSchemaChange           = ErrorCode(1450)
 	ERWrongValue                   = ErrorCode(1525)
 	ERDataOutOfRange               = ErrorCode(1690)

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -41,6 +41,14 @@ import (
 
 var autoIncr = regexp.MustCompile(` AUTO_INCREMENT=\d+`)
 
+type EmptyColumnsErr struct {
+	dbName, tableName, query string
+}
+
+func (e EmptyColumnsErr) Error() string {
+	return fmt.Sprintf("unable to get columns for table %s.%s using query %s", e.dbName, e.tableName, e.query)
+}
+
 // executeSchemaCommands executes some SQL commands. It uses the dba connection parameters, with credentials.
 func (mysqld *Mysqld) executeSchemaCommands(ctx context.Context, sql string) error {
 	params, err := mysqld.dbcfgs.DbaConnector().MysqlParams()
@@ -283,6 +291,10 @@ const (
 	GetFieldsQuery = "SELECT %s FROM %s WHERE 1 != 1"
 )
 
+// GetColumnsList returns the column names for a given table/view, using a query generating function.
+// Returned values:
+// - selectColumns: a string of comma delimited qualified names to be used in a SELECT query. e.g. "`id`, `name`, `val`"
+// - err: error
 func GetColumnsList(dbName, tableName string, exec func(string, int, bool) (*sqltypes.Result, error)) (string, error) {
 	var dbName2 string
 	if dbName == "" {
@@ -296,8 +308,8 @@ func GetColumnsList(dbName, tableName string, exec func(string, int, bool) (*sql
 		return "", err
 	}
 	if qr == nil || len(qr.Rows) == 0 {
-		err = fmt.Errorf("unable to get columns for table %s.%s using query %s", dbName, tableName, query)
-		log.Errorf("%s", fmt.Errorf("unable to get columns for table %s.%s using query %s", dbName, tableName, query))
+		err := &EmptyColumnsErr{dbName: dbName, tableName: tableName, query: query}
+		log.Errorf(err.Error())
 		return "", err
 	}
 	selectColumns := ""

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -309,7 +309,7 @@ func GetColumnsList(dbName, tableName string, exec func(string, int, bool) (*sql
 	}
 	if qr == nil || len(qr.Rows) == 0 {
 		err := &EmptyColumnsErr{dbName: dbName, tableName: tableName, query: query}
-		log.Errorf(err.Error())
+		log.Error(err.Error())
 		return "", err
 	}
 	selectColumns := ""

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -447,7 +447,7 @@ func TestOpenFailedDueToLoadTableErr(t *testing.T) {
 	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, "test_view"),
 		sqltypes.MakeTestResult(sqltypes.MakeTestFields("column_name", "varchar"), ""))
 	// rejecting the impossible query
-	db.AddRejectedQuery("SELECT * FROM `fakesqldb`.`test_view` WHERE 1 != 1", mysql.NewSQLErrorFromError(errors.New("ERROR 1449 (HY000): The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")))
+	db.AddRejectedQuery("SELECT * FROM `fakesqldb`.`test_view` WHERE 1 != 1", mysql.NewSQLErrorFromError(errors.New("The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")))
 
 	AddFakeInnoDBReadRowsResult(db, 0)
 	se := newEngine(10, 1*time.Second, 1*time.Second, 0, db)
@@ -458,7 +458,7 @@ func TestOpenFailedDueToLoadTableErr(t *testing.T) {
 	logs := tl.GetAllLogs()
 	logOutput := strings.Join(logs, ":::")
 	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the table: test_view")
-	assert.Contains(t, logOutput, "ERROR 1449 (HY000): The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")
+	assert.Contains(t, logOutput, "The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")
 }
 
 func TestExportVars(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -452,7 +452,7 @@ func TestOpenFailedDueToLoadTableErr(t *testing.T) {
 	AddFakeInnoDBReadRowsResult(db, 0)
 	se := newEngine(10, 1*time.Second, 1*time.Second, 0, db)
 	err := se.Open()
-	// failed load should not return any error, instead should be logged.
+	// failed load should return an error because of test_table
 	assert.ErrorContains(t, err, "Row count exceeded")
 
 	logs := tl.GetAllLogs()


### PR DESCRIPTION

## Description

Followup and refine to https://github.com/vitessio/vitess/pull/13421.

In https://github.com/vitessio/vitess/pull/13421 we ignore (log and continue) errors while reading columns for tables/views. This is too permissive and might cause undesired behavior down the road for code that uses the caches table data. An error reading table columns should remain an error and fail the `Reload()` operation. For views, we can indeed ignore such failure, for two reasons:

1. It is possible to have an invalid view definition in MySQL. So while highly undesired, this is a "valid" situation that we should accommodate.
2. None of our internal processes cares much about view columns (e.g. vreplication doesn't read from views).

So this PR only ignores the errors for views, and does error when failing to read table columns.

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/13421
- https://github.com/vitessio/vitess/issues/13422

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
