### PR TITLE
Misc Local Install improvements.

### DIFF
--- a/examples/common/scripts/etcd-up.sh
+++ b/examples/common/scripts/etcd-up.sh
@@ -21,6 +21,8 @@ source "$(dirname "${BASH_SOURCE[0]:-$0}")/../env.sh"
 cell=${CELL:-'test'}
 export ETCDCTL_API=2
 
+echo "Starting etcd..."
+
 # Check that etcd is not already running
 curl "http://${ETCD_SERVER}" > /dev/null 2>&1 && fail "etcd is already running. Exiting."
 
@@ -46,6 +48,6 @@ vtctl $TOPOLOGY_FLAGS VtctldCommand AddCellInfo \
   $cell
 set -e
 
-echo "etcd start done..."
+echo "etcd is running!"
 
 

--- a/examples/common/scripts/mysqlctl-up.sh
+++ b/examples/common/scripts/mysqlctl-up.sh
@@ -40,3 +40,5 @@ mysqlctl \
  --tablet_uid $uid \
  --mysql_port $mysql_port \
  $action
+
+echo -e "MySQL for tablet $alias is running!"

--- a/examples/common/scripts/vtgate-up.sh
+++ b/examples/common/scripts/vtgate-up.sh
@@ -24,7 +24,7 @@ grpc_port=15991
 mysql_server_port=15306
 mysql_server_socket_path="/tmp/mysql.sock"
 
-# Start vtgate.
+echo "Starting vtgate..."
 # shellcheck disable=SC2086
 vtgate \
   $TOPOLOGY_FLAGS \
@@ -45,7 +45,6 @@ vtgate \
 # Block waiting for vtgate to be listening
 # Not the same as healthy
 
-echo "Waiting for vtgate to be up..."
 while true; do
  curl -I "http://$hostname:$web_port/debug/status" >/dev/null 2>&1 && break
  sleep 0.1

--- a/examples/common/scripts/vtorc-up.sh
+++ b/examples/common/scripts/vtorc-up.sh
@@ -6,6 +6,7 @@ source "${script_dir}/../env.sh"
 log_dir="${VTDATAROOT}/tmp"
 port=16000
 
+echo "Starting vtorc..."
 vtorc \
   $TOPOLOGY_FLAGS \
   --logtostderr \

--- a/examples/common/scripts/vttablet-up.sh
+++ b/examples/common/scripts/vttablet-up.sh
@@ -67,3 +67,5 @@ done
 
 # check one last time
 curl -I "http://$hostname:$port/debug/status" || fail "tablet could not be started!"
+
+echo -e "vttablet for $alias is running!"

--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -42,13 +42,13 @@ CELL=zone1 ../common/scripts/vtctld-up.sh
 
 if vtctldclient GetKeyspace commerce > /dev/null 2>&1 ; then
 	# Keyspace already exists: we could be running this 101 example on an non-empty VTDATAROOT
-	vtctldclient --server localhost:15999 SetKeyspaceDurabilityPolicy --durability-policy=semi_sync commerce || fail "Failed to set keyspace durability policy on the commerce keyspace"
+	vtctldclient SetKeyspaceDurabilityPolicy --durability-policy=semi_sync commerce || fail "Failed to set keyspace durability policy on the commerce keyspace"
 else
 	# Create the keyspace with the sidecar database name and set the
 	# correct durability policy. Please see the comment above for
 	# more context on using a custom sidecar database name in your
 	# Vitess clusters.
-	vtctldclient --server localhost:15999 CreateKeyspace --sidecar-db-name="${SIDECAR_DB_NAME}" --durability-policy=semi_sync commerce || fail "Failed to create and configure the commerce keyspace"
+	vtctldclient CreateKeyspace --sidecar-db-name="${SIDECAR_DB_NAME}" --durability-policy=semi_sync commerce || fail "Failed to create and configure the commerce keyspace"
 fi
 
 # start vttablets for keyspace commerce

--- a/examples/local/401_teardown.sh
+++ b/examples/local/401_teardown.sh
@@ -33,8 +33,15 @@ for tablet in 100 200 300 400; do
 			printf -v alias '%s-%010d' 'zone1' $uid
 			echo "Shutting down tablet $alias"
 			CELL=zone1 TABLET_UID=$uid ../common/scripts/vttablet-down.sh
+   			# because MySQL takes time to stop, we do this in parallel
 			CELL=zone1 TABLET_UID=$uid ../common/scripts/mysqlctl-down.sh
 		done
+
+  		# without a sleep below, we can have the echo happen before the echo of mysqlctl-down.sh
+                sleep 2
+                echo "Waiting mysqlctl to stop..."
+                wait
+                echo "mysqlctls are stopped!"
 	fi
 done
 

--- a/examples/local/401_teardown.sh
+++ b/examples/local/401_teardown.sh
@@ -34,7 +34,7 @@ for tablet in 100 200 300 400; do
 			echo "Shutting down tablet $alias"
 			CELL=zone1 TABLET_UID=$uid ../common/scripts/vttablet-down.sh
    			# because MySQL takes time to stop, we do this in parallel
-			CELL=zone1 TABLET_UID=$uid ../common/scripts/mysqlctl-down.sh
+			CELL=zone1 TABLET_UID=$uid ../common/scripts/mysqlctl-down.sh &
 		done
 
   		# without a sleep below, we can have the echo happen before the echo of mysqlctl-down.sh


### PR DESCRIPTION
## Description

Misc improvements, one per commit:
- Make etcd-up.sh output consistent with vtctld-up.sh.
- Remove --server from vtctldclient in 101_initial_cluster.sh.
- Make mysqlctl-up.sh output consistent with vtctld-up.sh.
- Make vttablet-up.sh output consistent with vtctld-up.sh.
- Make vtorc-up.sh output consistent with vtctld-up.sh.
- Make vtgate-up.sh output consistent with vtctld-up.sh.
- Start mysqlctls in parallel in 101_initial_cluster.sh.
- Stop mysqlctls in parallel in 401_teardown.sh.

I have more ideas, but not more time for this PR, so this work will have to be continued by someone else.  Some ideas:
- add Access vtctld at <url>
- add Access vttablet at <url>
- remove --server from vtctldclient in utils.sh
- do not leak global variables PRIMARY_TABLET and _  in utils.sh
- add starting mysqlctl in parallel in other scripts

Some of these changes could be backported, I do not see how to add the "Backport to:" labels.  Backport notes:
- This will need a refactor for 17 backport, not sure how I should submit this: Remove --server from vtctldclient in 101_initial_cluster.sh.

Suggested changes, comments welcome (I might have to create an issue after all):
- Because `SIDECAR_DB_NAME` is only use once, merge the assignment with the usage, which will simplify "see the comment above".
- Replace the `vtctldclient ... || fail ...` pattern with `vtctldclient ... <NEWLINE> [[ $status -ne 0 ]] || fail ... which makes is easier to cut-and-paste the commands one by one if running things manually.  This is a little more code, but makes things easier to play with.
- Replace `echo "...$hostname..."` in vtgate-up.sh to be consistent with vtorc-up.sh (it is highly probably that the hostname shown is not usable anyway).

I tested on v17, but some of the scripts have been modified for v18, which I did not fully test.

## Related Issue(s)

Sorry, I am lazy and did not create an issue, which would make this improvement work much longer than it needs.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation is not required

## Deployment Notes

N/A