### PR TITLE
Viper migrations - go/acl go/mysql go/stats go/streamlog

### DIFF
--- a/go/mysql/auth_server_clientcert_test.go
+++ b/go/mysql/auth_server_clientcert_test.go
@@ -33,12 +33,6 @@ import (
 
 const clientCertUsername = "Client Cert"
 
-func init() {
-	// These tests do not invoke the servenv.Parse codepaths, so this default
-	// does not get set by the OnParseFor hook.
-	clientcertAuthMethod = string(MysqlClearPassword)
-}
-
 func TestValidCert(t *testing.T) {
 	th := &testHandler{}
 

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -324,7 +324,7 @@ func (c *Conn) getWriter() (w io.Writer, unget func()) {
 // startFlushTimer must be called while holding lock on bufMu.
 func (c *Conn) startFlushTimer() {
 	c.stopFlushTimer()
-	c.flushTimer = time.AfterFunc(mysqlServerFlushDelay, func() {
+	c.flushTimer = time.AfterFunc(mysqlServerFlushDelay.Get(), func() {
 		c.bufMu.Lock()
 		defer c.bufMu.Unlock()
 

--- a/go/stats/opentsdb/opentsdb.go
+++ b/go/stats/opentsdb/opentsdb.go
@@ -30,13 +30,17 @@ import (
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/viperutil"
 	"vitess.io/vitess/go/vt/servenv"
 )
 
-var openTsdbURI string
+var openTsdbURI = viperutil.Configure("stats.opentsdb.uri", viperutil.Options[string]{
+	FlagName: "opentsdb_uri",
+})
 
 func registerFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&openTsdbURI, "opentsdb_uri", openTsdbURI, "URI of opentsdb /api/put method")
+	fs.String("opentsdb_uri", openTsdbURI.Default(), "URI of opentsdb /api/put method")
+	viperutil.BindFlags(fs, openTsdbURI)
 }
 
 func init() {
@@ -64,7 +68,7 @@ func sendDataPoints(data []dataPoint) error {
 		return err
 	}
 
-	resp, err := http.Post(openTsdbURI, "application/json", bytes.NewReader(json))
+	resp, err := http.Post(openTsdbURI.Get(), "application/json", bytes.NewReader(json))
 	if err != nil {
 		return err
 	}
@@ -102,7 +106,7 @@ func Init(prefix string) {
 
 // InitWithoutServenv initializes the opentsdb without servenv
 func InitWithoutServenv(prefix string) {
-	if openTsdbURI == "" {
+	if openTsdbURI.Get() == "" {
 		return
 	}
 


### PR DESCRIPTION
## Description

This migrates the flags in the above subtrees to be viper-backed.

I have not made any of them Dynamic, but that is possible with minimal changes should we want to revisit that in the future.

## Related Issue(s)

#11456 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
