### PR TITLE
Backport v15: schema.Reload(): ignore column reading errors for views only, error for tables #13442

### DIFF
--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -536,6 +536,7 @@ const (
 	ERDataTooLong                  = 1406
 	ErrWrongValueForType           = 1411
 	ERWarnDataTruncated            = 1265
+	ERNoSuchUser                   = 1449
 	ERForbidSchemaChange           = 1450
 	ERDataOutOfRange               = 1690
 	ERInvalidJSONText              = 3140

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -41,6 +41,14 @@ import (
 
 var autoIncr = regexp.MustCompile(` AUTO_INCREMENT=\d+`)
 
+type EmptyColumnsErr struct {
+	dbName, tableName, query string
+}
+
+func (e EmptyColumnsErr) Error() string {
+	return fmt.Sprintf("unable to get columns for table %s.%s using query %s", e.dbName, e.tableName, e.query)
+}
+
 // executeSchemaCommands executes some SQL commands, using the mysql
 // command line tool. It uses the dba connection parameters, with credentials.
 func (mysqld *Mysqld) executeSchemaCommands(sql string) error {
@@ -287,6 +295,10 @@ const (
 	GetFieldsQuery = "SELECT %s FROM %s WHERE 1 != 1"
 )
 
+// GetColumnsList returns the column names for a given table/view, using a query generating function.
+// Returned values:
+// - selectColumns: a string of comma delimited qualified names to be used in a SELECT query. e.g. "`id`, `name`, `val`"
+// - err: error
 func GetColumnsList(dbName, tableName string, exec func(string, int, bool) (*sqltypes.Result, error)) (string, error) {
 	var dbName2 string
 	if dbName == "" {
@@ -300,8 +312,8 @@ func GetColumnsList(dbName, tableName string, exec func(string, int, bool) (*sql
 		return "", err
 	}
 	if qr == nil || len(qr.Rows) == 0 {
-		err = fmt.Errorf("unable to get columns for table %s.%s using query %s", dbName, tableName, query)
-		log.Errorf("%s", fmt.Errorf("unable to get columns for table %s.%s using query %s", dbName, tableName, query))
+		err := &EmptyColumnsErr{dbName: dbName, tableName: tableName, query: query}
+		log.Error(err.Error())
 		return "", err
 	}
 	selectColumns := ""

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -444,18 +444,16 @@ func TestOpenFailedDueToLoadTableErr(t *testing.T) {
 	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, "test_view"),
 		sqltypes.MakeTestResult(sqltypes.MakeTestFields("column_name", "varchar"), ""))
 	// rejecting the impossible query
-	db.AddRejectedQuery("SELECT * FROM `fakesqldb`.`test_view` WHERE 1 != 1", errors.New("The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)"))
+	db.AddRejectedQuery("SELECT * FROM `fakesqldb`.`test_view` WHERE 1 != 1", mysql.NewSQLErrorFromError(errors.New("The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")))
 
 	AddFakeInnoDBReadRowsResult(db, 0)
 	se := newEngine(10, 1*time.Second, 1*time.Second, db)
 	err := se.Open()
-	// failed load should not return any error, instead should be logged.
-	require.NoError(t, err)
+	// failed load should return an error because of test_table
+	assert.ErrorContains(t, err, "Row count exceeded")
 
 	logs := tl.GetAllLogs()
 	logOutput := strings.Join(logs, ":::")
-	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the table: test_table")
-	assert.Contains(t, logOutput, "Row count exceeded")
 	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the table: test_view")
 	assert.Contains(t, logOutput, "The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")
 }


### PR DESCRIPTION
Backport of https://github.com/vitessio/vitess/pull/13442 to v15