### PR TITLE
Remove excessive logging in VTOrc APIs

### DIFF
--- a/go/vt/vtorc/server/api.go
+++ b/go/vt/vtorc/server/api.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtorc/collection"
 	"vitess.io/vitess/go/vt/vtorc/discovery"
@@ -67,7 +66,6 @@ var (
 // ServeHTTP implements the http.Handler interface. This is the entry point for all the api commands of VTOrc
 func (v *vtorcAPI) ServeHTTP(response http.ResponseWriter, request *http.Request) {
 	apiPath := request.URL.Path
-	log.Infof("HTTP API Request received: %v", apiPath)
 	if err := acl.CheckAccessHTTP(request, getACLPermissionLevelForAPI(apiPath)); err != nil {
 		acl.SendError(response, err)
 		return


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Currently, whenever a VTOrc API is called, it gets logged with a message like - `HTTP API Request received: /debug/health`. Since the VTOp does a certain amount of API calls constantly, this log line very quickly starts polluting the logs. This PR removes this log line to resolve this problem.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
