### PR TITLE
`examples/compose`: fix `consul:latest` error w/`docker-compose up -d`

### DIFF
--- a/examples/compose/.env
+++ b/examples/compose/.env
@@ -7,7 +7,6 @@ CELL=local
 KEYSPACE=commerce
 DB=commerce
 
-VITESS_TAG:v14.0.5
 EXTERNAL_DB=0
 DB_HOST=external_db_host
 DB_PORT=3306

--- a/examples/compose/.env
+++ b/examples/compose/.env
@@ -7,6 +7,7 @@ CELL=local
 KEYSPACE=commerce
 DB=commerce
 
+VITESS_TAG:v14.0.5
 EXTERNAL_DB=0
 DB_HOST=external_db_host
 DB_PORT=3306

--- a/examples/compose/docker-compose.beginners.yml
+++ b/examples/compose/docker-compose.beginners.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   consul1:
-    image: consul:latest
+    image: hashicorp/consul:latest
     hostname: "consul1"
     ports:
       - "8400:8400"
@@ -9,7 +9,7 @@ services:
       - "8600:8600"
     command: "agent -server -bootstrap-expect 3 -ui -disable-host-node-id -client 0.0.0.0"
   consul2:
-    image: consul:latest
+    image: hashicorp/consul:latest
     hostname: "consul2"
     expose:
       - "8400"
@@ -19,7 +19,7 @@ services:
     depends_on:
       - consul1
   consul3:
-    image: consul:latest
+    image: hashicorp/consul:latest
     hostname: "consul3"
     expose:
       - "8400"

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   consul1:
     command: agent -server -bootstrap-expect 3 -ui -disable-host-node-id -client 0.0.0.0
     hostname: consul1
-    image: consul:latest
+    image: hashicorp/consul:latest
     ports:
     - 8400:8400
     - 8500:8500
@@ -16,7 +16,7 @@ services:
     - "8500"
     - "8600"
     hostname: consul2
-    image: consul:latest
+    image: hashicorp/consul:latest
   consul3:
     command: agent -server -retry-join consul1 -disable-host-node-id
     depends_on:
@@ -26,7 +26,7 @@ services:
     - "8500"
     - "8600"
     hostname: consul3
-    image: consul:latest
+    image: hashicorp/consul:latest
   external_db_host:
     build:
       context: ./external_db/mysql


### PR DESCRIPTION
## Description

This PR resolves errors pulling `consul:latest` in `examples/compose/docker-compose.yml`:
```bash
tvaillancourt@tvailla-ltmxctu compose % docker-compose up -d       
[+] Running 3/3
 ✘ consul2 Error                                                                                                                                                                                                2.1s 
 ✘ consul3 Error                                                                                                                                                                                                2.1s 
 ✘ consul1 Error                                                                                                                                                                                                2.1s 
Error response from daemon: manifest for consul:latest not found: manifest unknown: manifest unknown
```

This is due to [this deprecation notice on DockerHub](https://hub.docker.com/_/consul):
> Upcoming in Consul 1.16, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from [hashicorp/consul](https://hub.docker.com/r/hashicorp/consul) instead of [consul](https://hub.docker.com/_/consul). Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/consul.

It might be worth backporting this, as this is broken for at least v14+. We noticed this on v14.0.5+

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/13467

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
