### PR TITLE
Fix `TestGatewayBufferingWhileReparenting` flakiness

### DIFF
--- a/go/vt/vtgate/tabletgateway_flaky_test.go
+++ b/go/vt/vtgate/tabletgateway_flaky_test.go
@@ -185,6 +185,9 @@ func TestGatewayBufferingWhileReparenting(t *testing.T) {
 	hc.Broadcast(primaryTablet)
 	// set the serving type for the primary tablet false and broadcast it so that the buffering code registers this change
 	hc.SetServing(primaryTablet, false)
+	// We call the broadcast twice to ensure that the change has been processed by the keyspace event watcher.
+	// The second broadcast call is blocking until the first one has been processed.
+	hc.Broadcast(primaryTablet)
 	hc.Broadcast(primaryTablet)
 
 	// add a result to the sandbox connection of the new primary


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the flakiness in `TestGatewayBufferingWhileReparenting`. As reported in #13465, the test is flaky and results in an error saying that the state is inconsistent. 

The fix in this PR entails ensuring the state is consistent before running the query. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on the CI
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
