### PR TITLE
Fix logging by omitting the host and port in `SetReadOnly`

### DIFF
--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -258,8 +258,9 @@ func (mysqld *Mysqld) SetReadOnly(on bool) error {
 	case true:
 		newState = "ReadOnly"
 	}
-	log.Infof("SetReadOnly setting connection setting of %s:%d to : %s",
-		mysqld.dbcfgs.Host, mysqld.dbcfgs.Port, newState)
+	params, _ := mysqld.dbcfgs.DbaWithDB().MysqlParams()
+	log.Infof("SetReadOnly setting connection setting of %s:%d, socket:%s to : %s",
+		params.Host, params.Port, params.UnixSocket, newState)
 
 	query := "SET GLOBAL read_only = "
 	if on {

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -258,9 +258,7 @@ func (mysqld *Mysqld) SetReadOnly(on bool) error {
 	case true:
 		newState = "ReadOnly"
 	}
-	params, _ := mysqld.dbcfgs.DbaWithDB().MysqlParams()
-	log.Infof("SetReadOnly setting connection setting of %s:%d, socket:%s to : %s",
-		params.Host, params.Port, params.UnixSocket, newState)
+	log.Infof("SetReadOnly setting to : %s", newState)
 
 	query := "SET GLOBAL read_only = "
 	if on {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
It was noticed that we are getting logs like `SetReadOnly setting connection setting of :0 to : ReadWrite`. This is happening because vttablet is connected to mysql via a socket file, so the hostname and port are empty. 

This log message is on the vttablets and the knowledge of whether host port is used or whether socket is used to connect to mysql is not interesting.
Now the log looks like - `SetReadOnly setting to : ReadOnly`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
