### PR TITLE
viperutil: Remove potential cross site reflecting issue

### DIFF
--- a/go/viperutil/debug/handler.go
+++ b/go/viperutil/debug/handler.go
@@ -77,6 +77,6 @@ func HandlerFunc(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	default:
-		http.Error(w, fmt.Sprintf("unsupported config format %s", format), http.StatusBadRequest)
+		http.Error(w, "unsupported config format", http.StatusBadRequest)
 	}
 }


### PR DESCRIPTION
It's possible to inject HTML / Javascript in the format parameter which means you can do a self XSS. Not a huge immediately issue as it's only self XSS, but we should fix it nonetheless.

## Related Issue(s)

See https://github.com/vitessio/vitess/security/code-scanning/142

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required
