### PR TITLE
Fix remote VersionString API

### DIFF
--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package mysqlctld
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/mysqlctl/mysqlctlclient"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/vt/sidecardb"
@@ -101,6 +105,7 @@ func initCluster(shardNames []string, totalTabletsRequired int) error {
 			if err != nil {
 				return err
 			}
+			mysqlctldProcess.SocketFile = path.Join(clusterInstance.TmpDirectory, fmt.Sprintf("mysqlctld_%d.sock", tablet.TabletUID))
 			tablet.MysqlctldProcess = *mysqlctldProcess
 			err = tablet.MysqlctldProcess.Start()
 			if err != nil {
@@ -155,4 +160,12 @@ func TestAutoDetect(t *testing.T) {
 	// Reparent tablets, which requires flavor detection
 	err = clusterInstance.VtctlclientProcess.InitializeShard(keyspaceName, shardName, cell, primaryTablet.TabletUID)
 	require.Nil(t, err, "error should be nil")
+}
+
+func TestVersionString(t *testing.T) {
+	client, err := mysqlctlclient.New("unix", primaryTablet.MysqlctldProcess.SocketFile)
+	require.NoError(t, err)
+	version, err := client.VersionString(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, version)
 }

--- a/go/vt/mysqlctl/grpcmysqlctlclient/client.go
+++ b/go/vt/mysqlctl/grpcmysqlctlclient/client.go
@@ -116,8 +116,11 @@ func (c *client) VersionString(ctx context.Context) (string, error) {
 	var version string
 	err := c.withRetry(ctx, func() error {
 		r, err := c.c.VersionString(ctx, &mysqlctlpb.VersionStringRequest{})
+		if err != nil {
+			return err
+		}
 		version = r.Version
-		return err
+		return nil
 	})
 	return version, err
 }

--- a/go/vt/mysqlctl/grpcmysqlctlserver/server.go
+++ b/go/vt/mysqlctl/grpcmysqlctlserver/server.go
@@ -71,6 +71,15 @@ func (s *server) RefreshConfig(ctx context.Context, request *mysqlctlpb.RefreshC
 	return &mysqlctlpb.RefreshConfigResponse{}, s.mysqld.RefreshConfig(ctx, s.cnf)
 }
 
+// VersionString registers the Server for RPCs.
+func (s *server) VersionString(ctx context.Context, request *mysqlctlpb.VersionStringRequest) (*mysqlctlpb.VersionStringResponse, error) {
+	version, err := s.mysqld.GetVersionString(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &mysqlctlpb.VersionStringResponse{Version: version}, nil
+}
+
 // StartServer registers the Server for RPCs.
 func StartServer(s *grpc.Server, cnf *mysqlctl.Mycnf, mysqld *mysqlctl.Mysqld) {
 	mysqlctlpb.RegisterMysqlCtlServer(s, &server{cnf: cnf, mysqld: mysqld})


### PR DESCRIPTION
The remote API added in #13449 didn't actually implement the server as this was overlooked with the generated unimplemented server.

This adds the implementation and a test to exercise the remote path. 

## Related Issue(s)

This was broken in https://github.com/vitessio/vitess/pull/13449

Fixes #13485

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required