### PR TITLE
docker/mini: remove refs to orc configs

### DIFF
--- a/docker/mini/Dockerfile
+++ b/docker/mini/Dockerfile
@@ -31,16 +31,12 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY docker/mini/install_mini_dependencies.sh /vt/dist/install_mini_dependencies.sh
 RUN /vt/dist/install_mini_dependencies.sh
 
-COPY docker/mini/orchestrator-vitess-mini.conf.json /etc/orchestrator.conf.json
-RUN chown vitess:vitess /etc/orchestrator.conf.json
-
 COPY docker/mini/docker-entry /vt/dist/docker/mini/docker-entry
 COPY examples/common/scripts /vt/dist/scripts
 COPY examples/common/env.sh /vt/dist/scripts/env.sh
 COPY examples/common/lib/utils.sh /vt/dist/scripts/lib/utils.sh
 COPY docker/mini/vtctld-mini-up.sh /vt/dist/scripts/vtctld-mini-up.sh
 COPY docker/mini/vttablet-mini-up.sh /vt/dist/scripts/vttablet-mini-up.sh
-COPY docker/mini/orchestrator-up.sh /vt/dist/scripts/orchestrator-up.sh
 RUN echo "hostname=127.0.0.1" >> /vt/dist/scripts/env.sh
 RUN cat /vt/dist/scripts/env.sh | egrep "^alias" >> /etc/bash.bashrc
 


### PR DESCRIPTION
Signed-off-by: Amir Abushareb <yields@icloud.com>

## Description

During the cleanup in https://github.com/vitessio/vitess/pull/13327 seems like we removed some files but didn't update `docker/mini/Dockerfile`.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
