### PR TITLE
fix: error.as method usage to send pointer to the reference type expected

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -501,7 +501,7 @@ func (se *Engine) reload(ctx context.Context, includeStats bool) error {
 		table, err := LoadTable(conn, se.cp.DBName(), tableName, tableType, row[3].ToString())
 		if err != nil {
 			isView := strings.Contains(tableType, tmutils.TableView)
-			var emptyColumnsError mysqlctl.EmptyColumnsErr
+			var emptyColumnsError *mysqlctl.EmptyColumnsErr
 			if errors.As(err, &emptyColumnsError) && isView {
 				log.Warningf("Failed reading schema for the table: %s, error: %v", tableName, err)
 				continue

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -461,6 +461,35 @@ func TestOpenFailedDueToLoadTableErr(t *testing.T) {
 	assert.Contains(t, logOutput, "The user specified as a definer ('root'@'%') does not exist (errno 1449) (sqlstate HY000)")
 }
 
+// TestOpenFailedDueToEmptyColumnInView tests that schema engine load should not fail instead should log the failures for empty columns in view
+func TestOpenFailedDueToEmptyColumnInView(t *testing.T) {
+	tl := syslogger.NewTestLogger()
+	defer tl.Close()
+	db := fakesqldb.New(t)
+	defer db.Close()
+	schematest.AddDefaultQueries(db)
+	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
+		Fields: mysql.BaseShowTablesFields,
+		Rows: [][]sqltypes.Value{
+			mysql.BaseShowTablesRow("test_view", true, "VIEW"),
+		},
+	})
+
+	// adding column query for table_view
+	db.AddQueryPattern(fmt.Sprintf(mysql.GetColumnNamesQueryPatternForTable, "test_view"),
+		&sqltypes.Result{})
+
+	AddFakeInnoDBReadRowsResult(db, 0)
+	se := newEngine(10, 1*time.Second, 1*time.Second, 0, db)
+	err := se.Open()
+	require.NoError(t, err)
+
+	logs := tl.GetAllLogs()
+	logOutput := strings.Join(logs, ":::")
+	assert.Contains(t, logOutput, "WARNING:Failed reading schema for the table: test_view")
+	assert.Contains(t, logOutput, "unable to get columns for table fakesqldb.test_view")
+}
+
 func TestExportVars(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the use of `error.As` method to send the correct argument for matching.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- https://github.com/vitessio/vitess/pull/13442
- #13422 

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on the CI
