### PR TITLE
Remove `--disable_active_reparents` flag in vttablet-up.sh

### DIFF
--- a/examples/common/scripts/vttablet-up.sh
+++ b/examples/common/scripts/vttablet-up.sh
@@ -54,7 +54,6 @@ vttablet \
  --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
  --pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
  --vtctld_addr http://$hostname:$vtctld_web_port/ \
- --disable_active_reparents \
  --heartbeat_enable \
  --heartbeat_interval=250ms \
  --heartbeat_on_demand_duration=5s \


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

The upgrade-downgrade tests have become flaky with the changes in https://github.com/vitessio/vitess/pull/13246. In that PR `--disable-active-reparents` has been added to `vttablet-up.sh`. 

I see it has failed on main - https://github.com/vitessio/vitess/actions/runs/5551856255/jobs/10138489035

Adding `--disable_active_reparents` means that if the REPLICA tablet is selected for the backup, then it doesn't fix its own replication back again. So there is a 12.5% chance of success of this test to pass! (We have 3 shards, each having 3 tablets, PRIMARY, REPLICA and RDONLY, 50-50 chance you select REPLICA for running the backup).

This PR removes that flag.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
